### PR TITLE
fix(update): gate auto-update on an allowlist, and harden the path it re-enables

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1124,33 +1124,6 @@ def _linger_enabled(user: str) -> bool | None:
     return None
 
 
-# Git for Windows never lives in the system directories the trusted resolver
-# pins Windows lookups to — it installs under Program Files. Fixed literal
-# roots, not ``%ProgramFiles%``: doctor runs with operator privileges, and
-# reading the environment would let a poisoned variable redirect the lookup to
-# an agent-writable directory — the exact hole the pin exists to close.
-_WINDOWS_GIT_DIRS = (
-    r"C:\Program Files\Git\cmd",
-    r"C:\Program Files (x86)\Git\cmd",
-)
-
-
-def _windows_git_bin() -> str | None:
-    """``git.exe`` from the fixed Git for Windows install roots, else ``None``.
-
-    Without this, every supported Windows source install reports "could not
-    check" — :func:`platform_compat.trusted_system_bin` only probes the system
-    directories, where git never is. A non-default-drive install still misses
-    and degrades to "could not check", which is honest: this fallback widens
-    the pin only to paths an unprivileged attacker cannot write.
-    """
-    for directory in _WINDOWS_GIT_DIRS:
-        candidate = os.path.join(directory, "git.exe")
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
-
-
 def _git_line(repo: Path, *args: str) -> str | None:
     """First stdout line of ``git -C repo *args``, ``None`` on any failure.
 
@@ -1159,16 +1132,13 @@ def _git_line(repo: Path, *args: str) -> str | None:
     install has no ``.git``, a fresh clone may lack ``origin/HEAD`` — so every
     error collapses to ``None`` and the caller renders "could not check".
 
-    ``git`` is resolved through :func:`platform_compat.trusted_system_bin`
-    rather than a bare ``PATH`` lookup: doctor runs with operator privileges,
-    and an agent-writable directory leading ``PATH`` could plant a ``git``
-    shim. On Windows a resolver miss falls back to the fixed Git for Windows
-    install roots (:func:`_windows_git_bin`); any remaining miss collapses to
+    ``git`` is resolved through :func:`platform_compat.trusted_git_bin` rather
+    than a bare ``PATH`` lookup: doctor runs with operator privileges, and an
+    agent-writable directory leading ``PATH`` could plant a ``git`` shim. That
+    helper carries the Windows install-root fallback; a miss collapses to
     ``None`` like every other failure here — no spawn at all.
     """
-    git = platform_compat.trusted_system_bin("git")
-    if git is None and platform_compat.IS_WINDOWS:
-        git = _windows_git_bin()
+    git = platform_compat.trusted_git_bin()
     if git is None:
         return None
     try:

--- a/src/kiro_crew/platform/update_governance.py
+++ b/src/kiro_crew/platform/update_governance.py
@@ -19,13 +19,112 @@ against a local operator who could edit the checkout directly.
 from __future__ import annotations
 
 import logging
+import os
+import re
 import subprocess
 
+from kiro_crew import platform_compat
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT_SECS = 10
+
+
+#: The ONLY branch names an unattended update may reset a checkout to.
+#:
+#: A literal in reviewed code, and deliberately the WHOLE decision: see
+#: :func:`is_primary_branch` for why no local git ref is allowed to participate.
+#: This repo's primary branch is ``main``; the other two cover internal and
+#: mirror clones. Mirrors ``security._PROTECTED_BRANCHES`` by intent — the branch
+#: an unattended update may reset to is exactly the branch a push must never
+#: target — but is kept separate so update routing does not read a
+#: security-module private.
+PRIMARY_BRANCHES = frozenset(
+    {
+        "main",
+        "mainline",
+        "master",  # wokeignore:rule=master  # legacy primary in older clones
+    }
+)
+
+
+def is_primary_branch(branch: str) -> bool:
+    """Whether *branch* is a primary line an unattended update may reset to.
+
+    Membership in :data:`PRIMARY_BRANCHES` is the entire test. That is a design
+    constraint, not an omission: this gate gates the most privileged path in the
+    product — a boot-time ``git reset --hard`` + ``pip install`` + ``execv`` with
+    no auth and no click — and it is also the path the enterprise ``min_version``
+    floor drives (``_auto_apply_update`` is what a mandatory update calls on a
+    checkout). So the decision must not read any state a local process can write.
+
+    ``refs/remotes/<remote>/HEAD`` is exactly such state: one
+    ``git remote set-head`` repoints it. Consulting it fails in BOTH directions,
+    and there is no ordering that fixes both —
+
+    * Obeying it as authoritative lets a repoint aim the install at an arbitrary
+      branch of the still-approved origin, so unreviewed code gets installed and
+      executed. The source pin cannot catch that: the remote URL is unchanged.
+    * Letting it merely narrow (accept only when it agrees) turns the same
+      one-command repoint into a veto — point a ``main`` checkout's pointer at
+      ``mainline`` and the host silently stops updating, including for a
+      mandatory floor, stranding it below the administrator's minimum version.
+
+    A fork whose primary line is named something else entirely therefore gets no
+    unattended update, only the badge. ``kirocrew update`` and the dashboard
+    apply path still serve it, and both have a human in the loop — the
+    difference that makes wider trust acceptable there and not here.
+
+    A wrong literal here fails SILENTLY — the gate returns and the host simply
+    never updates — which is what a hardcoded ``!= "mainline"`` did to every
+    ``main`` checkout of this repo for three months. The allowlist is the fix for
+    that: it names every primary line this project's clones actually use, so no
+    single name has to be guessed right.
+
+    A detached HEAD is never primary: there is no branch to fast-forward.
+    """
+    return branch in PRIMARY_BRANCHES
+
+
+def _git(proj: str, *args: str) -> str:
+    """Run a read-only git command in *proj*, returning stripped stdout or ``""``."""
+    out = _git_probe(proj, *args)
+    return out.strip() if out is not None else ""
+
+
+def _git_probe(proj: str, *args: str) -> str | None:
+    """As :func:`_git`, but ``None`` when git could not answer at all.
+
+    Every git invocation in this module carries
+    :func:`git_neutralizer_env`, so a repo-planted ``core.fsmonitor`` (or any
+    other fixed-key exec vector) cannot run just because the update seam looked
+    at the checkout.
+
+    ``git`` itself is resolved through
+    :func:`platform_compat.trusted_git_bin` rather than ``PATH``: a gateway's
+    ``PATH`` can lead with an agent-writable directory, and a planted ``git``
+    shim on THIS path chooses what the process installs and re-executes. An
+    unresolvable git returns ``None`` — a refusal, not a bare-name fallback.
+    """
+    git = platform_compat.trusted_git_bin()
+    if git is None:
+        # No trustworthy git. Answer "could not determine", which every caller
+        # already treats as the unsafe direction — never fall back to a bare
+        # `"git"`, which is the hazard itself.
+        return None
+    try:
+        done = subprocess.run(
+            [git, *args],
+            cwd=proj,
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SECS,
+            env=git_command_env(),
+            **UTF8_TEXT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return done.stdout if done.returncode == 0 else None
 
 
 def resolve_remote_url(proj: str, *, remote: str = "", branch: str = "") -> str:
@@ -46,29 +145,529 @@ def resolve_remote_url(proj: str, *, remote: str = "", branch: str = "") -> str:
     permitted" and an unpinned host ignores.
     """
 
-    def _git(*args: str) -> str:
-        try:
-            out = subprocess.run(
-                ["git", *args],
-                cwd=proj,
-                capture_output=True,
-                timeout=_GIT_TIMEOUT_SECS,
-                **UTF8_TEXT,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return ""
-        return out.stdout.strip() if out.returncode == 0 else ""
-
     if not remote:
         if not branch:
-            branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+            branch = _git(proj, "rev-parse", "--abbrev-ref", "HEAD")
         if not branch or branch == "HEAD":  # detached HEAD tracks nothing
             return ""
-        remote = _git("config", "--get", f"branch.{branch}.remote") or "origin"
-    url = _git("ls-remote", "--get-url", "--", remote)
+        remote = _git(proj, "config", "--get", f"branch.{branch}.remote") or "origin"
+    url = _git(proj, "ls-remote", "--get-url", "--", remote)
     # `--get-url` echoes its argument back for an unknown remote; that is a bare
     # name, not a URL, and must not be checked as one.
     return "" if url == remote else url
+
+
+#: Repo-scoped config keys whose VALUE git may execute as a program, and whose
+#: KEY NAME is fixed so ``-c``/``GIT_CONFIG_*`` can pin it back to a safe value.
+#:
+#: The membership criterion is exactly that — "git may exec this value, and the
+#: key is a literal" — and it is written down because the first version of this
+#: list was an enumeration without one and was therefore missing members
+#: (``core.gitProxy``). Adding a key here is correct whenever git might exec it;
+#: the cost of an unnecessary pin is nil, because none of these are values the
+#: update path wants from the repository in the first place.
+#:
+#: Keys whose NAME is repo-chosen (``filter.<name>.smudge``,
+#: ``diff.<driver>.textconv``, ``credential.<url>.helper``) cannot be pinned at
+#: all — there is no name to override — so those are refused instead, by
+#: :func:`repo_exec_config_reason`.
+#:
+#: Mirrors the neutralizer lists the app-side git callers already carry
+#: (``apps/builtins/md_notebook/git_ops.py``, ``papyrus/backend/gitops.py``,
+#: ``dev_fleet/server.py``). This copy exists because ``platform/`` must not
+#: import from ``apps/``, and the update seam needs it at the same chokepoint.
+_GIT_EXEC_NEUTRALIZERS: tuple[tuple[str, str], ...] = (
+    # `git status` and `git diff` consult core.fsmonitor and SPAWN it.
+    ("core.fsmonitor", "false"),
+    # Any command may run hooks; a reset checks files out.
+    ("core.hooksPath", os.devnull),
+    ("credential.helper", ""),
+    ("core.sshCommand", "ssh"),
+    # A fixed-key exec vector on the `git diff` call below.
+    ("diff.external", ""),
+    # Prompt helpers git execs when a transport wants credentials.
+    ("core.askPass", ""),
+    # Executed while enumerating an alternate object store's refs.
+    ("core.alternateRefsCommand", ""),
+    # Server-side hook honoured for a local/file transport fetch.
+    ("uploadpack.packObjectsHook", ""),
+    # Paged output execs the pager. `--porcelain`/`--quiet` and a non-tty stdout
+    # make this unreachable today, which is exactly why it is pinned rather than
+    # reasoned about at each call site.
+    ("core.pager", "cat"),
+    ("core.editor", "true"),
+    ("sequence.editor", "true"),
+    # Reached through signature verification, which is also forced off below.
+    ("gpg.program", "true"),
+    # Signature VERIFICATION is the trigger here: a fetched commit carrying a
+    # gpgsig header would invoke gpg.program. The update never verifies
+    # signatures, so the only reason git would exec it is an attacker's.
+    ("merge.verifySignatures", "false"),
+    ("pull.verifySignatures", "false"),
+    # Local/file transports exec the config-named pack programs directly, and
+    # GIT_ALLOW_PROTOCOL does not gate them (they are not a protocol). Every
+    # update fetch uses the literal remote `origin`, so pinning these restores
+    # git's own defaults over anything in .git/config.
+    ("remote.origin.uploadpack", "git-upload-pack"),
+    ("remote.origin.receivepack", "git-receive-pack"),
+    # `ext::` remote URLs run an arbitrary command as the transport.
+    ("protocol.ext.allow", "never"),
+)
+
+#: Keys in :data:`_GIT_EXEC_NEUTRALIZERS` whose VALUE is a program NAME rather
+#: than a literal. They are resolved to a TRUSTED ABSOLUTE PATH when the env is
+#: built, because a bare name is resolved by git through ``PATH`` at exec time --
+#: the same agent-writable ``PATH`` that :func:`platform_compat.trusted_git_bin`
+#: exists to bypass for ``git`` itself. Pinning ``core.sshCommand`` to ``"ssh"``
+#: closes the repository's value and then hands the transport to whatever ``ssh``
+#: leads the gateway's ``PATH``, which is most of the hole reopened.
+#:
+#: An unresolvable name degrades to ``os.devnull``, which fails to exec: for this
+#: path that is the right direction, since every one of these is either
+#: unreachable (pager/editor/gpg -- forced off or non-tty) or a transport helper
+#: whose absence should stop an unattended update rather than silently fall back
+#: to an untrusted one.
+_PROGRAM_VALUED_PINS = frozenset(
+    {
+        "core.sshcommand",
+        "core.pager",
+        "core.editor",
+        "sequence.editor",
+        "gpg.program",
+        "remote.origin.uploadpack",
+        "remote.origin.receivepack",
+    }
+)
+
+
+#: Repo config that weakens or redirects TRANSPORT TRUST for the fetch.
+#:
+#: `http.sslVerify=false` in the checkout's own config turns off certificate
+#: verification for the update download, which together with a hostile proxy makes
+#: a forged update indistinguishable from a real one; the CA / client-cert and
+#: proxy keys reach the same outcome by supplying the trust material instead of
+#: disabling the check.
+#:
+#: REFUSED rather than pinned because the per-URL spellings
+#: (``http.<url>.sslVerify``, ``http.<url>.proxy``) are repo-NAMED -- there is no
+#: key to override, the same reason ``credential.<url>.helper`` is refused. The
+#: bare forms are folded in here too so the two spellings cannot diverge.
+_REPO_TRANSPORT_TRUST_RE = re.compile(
+    r"^http\.(?:.+\.)?(?:"
+    r"sslverify|sslcainfo|sslcapath|sslcert|sslkey|sslbackend"
+    r"|proxy|proxyauthmethod|proxysslcert|proxysslkey|proxysslcainfo"
+    r")$",
+    re.IGNORECASE,
+)
+
+
+#: Repo-NAMED keys that redirect where the update FETCHES FROM. The base is
+#: repo-chosen, so there is no key name to override -- refused, like the
+#: arbitrary-named exec drivers.
+#:
+#: Verified, and it is the reason an "just fetch the validated URL" fix is not
+#: sufficient on its own: with ``url.<evil>.insteadOf <honest>`` in repo config, a
+#: fetch passed the honest URL EXPLICITLY still delivered the attacker's commit.
+#: The rewrite happens below the URL argument, so the only way to trust the URL
+#: that was validated is for no rewrite rule to exist.
+_REPO_URL_REWRITE_RE = re.compile(
+    r"^url\..+\.(?:insteadof|pushinsteadof)$",
+    re.IGNORECASE,
+)
+
+
+#: Fixed-NAME keys that do not execute anything but WIDEN THE BLAST RADIUS of
+#: the destructive step. Pinned through the same ``GIT_CONFIG_*`` chokepoint as
+#: the exec vectors, but kept in a separate list because the membership criterion
+#: is different and both are worth keeping checkable: an entry belongs here when
+#: "git execs nothing, but the key makes `reset --hard` touch more than the
+#: superproject work tree".
+#:
+#: ``submodule.recurse``: with it enabled, `git reset --hard` recurses into
+#: submodules and discards uncommitted submodule work. That is not caught by the
+#: work-tree refusal one level up, because `submodule.<name>.ignore=all` (or
+#: `diff.ignoreSubmodules`) makes `git status --porcelain` report a COMPLETELY
+#: CLEAN tree while the submodule holds uncommitted edits — verified: status
+#: empty, edit destroyed by the reset. Pinned rather than refused because the pin
+#: was verified to WORK (with `submodule.recurse=false` supplied through
+#: ``GIT_CONFIG_*`` the submodule edit survived), which is the distinction
+#: ``core.worktree`` and ``core.gitProxy`` failed.
+_GIT_BLAST_RADIUS_PINS: tuple[tuple[str, str], ...] = (("submodule.recurse", "false"),)
+
+
+#: Fixed-NAME keys that still cannot be closed by pinning, so they are refused
+#: like the arbitrary-named drivers below.
+#:
+#: The shared property is MULTI-VALUEDNESS: git reads these as a list and acts on
+#: the repository's entry even when a higher-priority scope supplies another, so
+#: a ``GIT_CONFIG_*`` pin reports success while changing nothing. A pin left in
+#: place for such a key is worse than no pin, because it asserts the hazard is
+#: handled where it is not — which is why membership here is decided by
+#: reproducing the pin's failure, not by reasoning about it.
+#:
+#: ``core.gitProxy``: with ``core.gitProxy=""`` supplied through ``GIT_CONFIG_*``,
+#: ``git config --get`` reports the empty value and the repository's proxy program
+#: STILL EXECUTES on a ``git://`` fetch. Same shape as ``core.worktree``: an
+#: apparently-applied pin that silently loses.
+#:
+#: ``gc.recentObjectsHook``: documented as executed "using the shell", and
+#: explicitly multi-valued ("Multiple hooks are supported"). With an empty pin
+#: applied, ``git config --get-all`` still lists the repository's own value, so
+#: the pin cannot suppress it. Unlike ``core.gitProxy`` the *exec* was NOT
+#: reproduced — on git 2.50.1 no ``gc``/``repack``/``prune`` invocation consulted
+#: the hook (a deliberately failing hook failed nothing). It is refused on the
+#: :data:`_GIT_EXEC_NEUTRALIZERS` membership criterion — git may exec this value
+#: and the key is a literal — where an unnecessary entry costs nothing and a
+#: missing one is how ``core.gitProxy`` was overlooked. Refusal rather than a pin
+#: because the pin is the mechanism that was shown not to work.
+_REPO_UNPINNABLE_KEYS = frozenset({"core.gitproxy", "gc.recentobjectshook"})
+
+
+#: Repo-scoped keys naming an arbitrary-named driver program. Refused, not
+#: neutralized. Mirrors ``dashboard/handlers/worktree._FILTER_KEY_RE``, widened
+#: with the ``textconv`` cousin that ``git diff`` reaches;
+#: ``test_governance_updates`` asserts the two stay in agreement.
+_REPO_EXEC_DRIVER_RE = re.compile(
+    r"^(?:filter\.(?P<f>.+)\.(?:process|smudge|clean)"
+    # `textconv` converts a blob to text; `command` REPLACES the whole diff with
+    # an external program. Both are repo-named and both are reached by the
+    # `git diff` this path runs, so refusing only one left the other open.
+    r"|diff\.(?P<d>.+)\.(?:textconv|command)"
+    # `credential.<url>.helper` is per-URL and so repo-named: pinning the bare
+    # `credential.helper` does not reach it.
+    r"|credential\.(?P<c>.+)\.helper"
+    # `remote.<name>.vcs` names a TRANSPORT helper: git execs `git-remote-<value>`,
+    # resolved through PATH, so the fetch itself runs a repo-chosen program.
+    # Verified, and verified to be unpinnable in the useful sense: an empty pin
+    # does suppress the repo's helper, but git then treats "" as a helper name and
+    # every fetch dies with `remote helper '' aborted session` -- so pinning would
+    # disable the update path instead of protecting it.
+    r"|remote\.(?P<r>.+)\.vcs)$",
+    re.IGNORECASE,
+)
+
+#: Returned when a config scope could not be read at all. An unreadable scope
+#: cannot be PROVEN driver-free, so it refuses rather than assuming the best.
+_EXEC_CONFIG_UNREADABLE = "unreadable git config"
+
+
+#: Environment variables that relocate what a git command OPERATES ON, as
+#: opposed to what it may execute. An exported ``GIT_DIR`` in the gateway's own
+#: environment points every call below at unrelated metadata while ``cwd`` still
+#: says ``proj`` — so the update would read one repository's refs and reset
+#: another tree. They are STRIPPED rather than pinned: the correct value is
+#: "whatever git discovers from ``cwd``", which is expressed by their absence,
+#: and ``GIT_WORK_TREE`` in particular cannot be set without ``GIT_DIR``.
+#:
+#: This is the environment twin of the ``core.worktree`` redirect that
+#: :func:`repo_exec_config_reason` refuses. Closing only the config half left
+#: the same redirect reachable through the process environment.
+_GIT_LOCATION_VARS = frozenset(
+    {
+        "GIT_DIR",
+        "GIT_COMMON_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_NAMESPACE",
+    }
+)
+
+
+def git_command_env() -> dict[str, str]:
+    """A complete environment for running git against a discovered checkout.
+
+    The one env a caller should use. It is built rather than merged because the
+    hazard here is a variable that must be ABSENT, and merging a neutralizer dict
+    over ``os.environ`` can only add or overwrite keys — an inherited
+    ``GIT_DIR`` would survive that and silently retarget the command.
+
+    Combines the exec-vector pins from :func:`git_neutralizer_env` with the
+    removal of every :data:`_GIT_LOCATION_VARS` entry.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_VARS}
+    env.update(git_neutralizer_env())
+    # A replace ref (`refs/replace/<oid>`) makes git serve DIFFERENT content for
+    # a given object id, transparently and everywhere. That defeats the reason
+    # the update path pins its reset target to an OID at all: "an OID cannot
+    # move" is true of the id and false of what the id resolves to. Verified: with
+    # `git replace <good> <evil>` in place, `git reset --hard <good>` checks out
+    # the EVIL tree; with this variable set it checks out the good one.
+    #
+    # It cannot be handled by stripping, the way the location variables are:
+    # replace refs live in the repository, not the environment, so the safe state
+    # is this explicit opt-out being PRESENT.
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return env
+
+
+def git_neutralizer_env() -> dict[str, str]:
+    """Environment pinning every fixed-key git exec vector to a safe value.
+
+    ``GIT_CONFIG_COUNT``/``KEY``/``VALUE`` carry the same precedence as ``git
+    -c``, so these beat the repository's own ``.git/config``. Returned as
+    environment rather than per-call flags so one chokepoint covers every
+    invocation in a sequence and a later-added command cannot forget it.
+
+    Covers the fixed-key exec vectors (:data:`_GIT_EXEC_NEUTRALIZERS`) AND the
+    blast-radius keys (:data:`_GIT_BLAST_RADIUS_PINS`), which exec nothing but
+    widen what the reset touches. A redirected work tree is a third hazard —
+    data loss with nothing executed — and cannot be closed here:
+    ``core.worktree`` supplied through ``-c``/``GIT_CONFIG_*`` is deliberately
+    ignored by git (verified: a repo-set value still won), and the
+    ``GIT_WORK_TREE`` that does override it is refused without a matching
+    ``GIT_DIR``. It is therefore REFUSED instead, by
+    :func:`repo_exec_config_reason`.
+
+    Callers MUST merge this over ``os.environ`` rather than passing it alone: a
+    bare env would drop ``PATH``/``HOME`` and git would not run.
+    """
+    pins = _GIT_EXEC_NEUTRALIZERS + _GIT_BLAST_RADIUS_PINS
+    env: dict[str, str] = {"GIT_CONFIG_COUNT": str(len(pins))}
+    for index, (key, value) in enumerate(pins):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        if key.lower() in _PROGRAM_VALUED_PINS:
+            # A bare program name is resolved by git through PATH at exec time,
+            # so pinning the key without pinning the PATH lookup only moves the
+            # hazard. Resolved here rather than at import so the lookup is not
+            # cached across a long-lived gateway.
+            resolved = platform_compat.trusted_system_bin(value)
+            value = resolved if resolved is not None else os.devnull
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    return env
+
+
+def _same_dir(a: str, b: str) -> bool:
+    """Whether two paths name the same directory, symlinks and case resolved.
+
+    ``os.path.realpath`` on both sides so a symlinked checkout (this repo is
+    reached through one) does not read as a redirect, and ``normcase`` so a
+    Windows drive-letter or case difference does not either.
+    """
+    if not a or not b:
+        return False
+    return os.path.normcase(os.path.realpath(a)) == os.path.normcase(os.path.realpath(b))
+
+
+def repo_exec_config_reason(proj: str) -> str:
+    """Why *proj* must not be driven unattended, or ``""`` when it is clean.
+
+    :data:`_GIT_EXEC_NEUTRALIZERS` closes the keys whose NAME is fixed. A
+    content filter or a textconv driver is named by the repository
+    (``filter.evil.smudge``), so there is no key to pin — the operation is
+    refused instead, exactly as ``worktree._checkout_filter`` refuses a
+    worktree add.
+
+    Two scopes are probed, and both details are load-bearing (see that
+    function's docstring, where each was verified empirically):
+
+    * ``--worktree`` as well as ``--local``, because a ``--local`` listing does
+      NOT report worktree-scoped keys, so a repo with
+      ``extensions.worktreeConfig=true`` hides a driver from a ``--local`` probe.
+    * ``--includes`` on both, because for a SPECIFIC scope query git defaults
+      include-following off, so a driver reached via ``include.path`` is
+      invisible to the probe yet still resolves when the command runs.
+
+    Global and system config are deliberately not probed: that is the user's own
+    machine configuration, not something the repository supplies.
+    """
+    scopes = ["--local"]
+    if _git(
+        proj, "config", "--local", "--includes", "--get", "extensions.worktreeConfig"
+    ).lower() in (
+        "true",
+        "yes",
+        "on",
+        "1",
+    ):
+        scopes.append("--worktree")
+    for scope in scopes:
+        listing = _git_probe(proj, "config", scope, "--includes", "--name-only", "--list")
+        if listing is None:
+            return _EXEC_CONFIG_UNREADABLE
+        for line in listing.splitlines():
+            key = line.strip()
+            if _REPO_EXEC_DRIVER_RE.match(key):
+                return f"repository declares {key[:120]}"
+            if key.lower() in _REPO_UNPINNABLE_KEYS:
+                return f"repository declares {key[:120]}"
+            # A URL rewrite redirects the FETCH itself, and applies even when the
+            # URL is passed explicitly on the command line, so validating the
+            # remote's URL cannot survive one being configured.
+            if _REPO_URL_REWRITE_RE.match(key):
+                return f"repository rewrites remote URLs via {key[:120]}"
+            # Transport trust: weakening TLS verification or routing the fetch
+            # through a repo-supplied proxy makes a forged update look genuine.
+            if _REPO_TRANSPORT_TRUST_RE.match(key):
+                return f"repository overrides transport trust via {key[:120]}"
+
+    # A redirected work tree executes nothing, so no exec-key pin touches it —
+    # but `git reset --hard` would overwrite matching files in the OTHER
+    # directory. Ask git where the tree actually resolves rather than parsing
+    # `core.worktree`: that catches a relative value, a worktree-scoped one, and
+    # one reached through `include.path` with a single probe. A legitimate linked
+    # worktree resolves to the directory being operated on, so it is unaffected.
+    toplevel = _git_probe(proj, "rev-parse", "--show-toplevel")
+    if toplevel is None:
+        return "cannot resolve the work tree"
+    if not _same_dir(toplevel.strip(), proj):
+        return f"work tree is redirected to {toplevel.strip()[:120]}"
+    return ""
+
+
+def hidden_worktree_edits(proj: str) -> list[str] | None:
+    """Paths whose changes ``git status`` CANNOT see, and which differ from HEAD.
+
+    ``git update-index --assume-unchanged`` / ``--skip-worktree`` tell git to stop
+    checking a path, and git obeys them thoroughly: for an edited
+    assume-unchanged file both ``git status --porcelain`` and ``git diff --quiet
+    HEAD`` report a CLEAN tree, while ``reset --hard`` still overwrites the file.
+    That makes it the one tracked-file loss the work-tree refusal cannot see --
+    verified end to end, edit destroyed.
+
+    Read-only by construction. The documented remedy, ``update-index
+    --really-refresh``, does surface the edit, but it WRITES the index: a check
+    whose only purpose is to decide whether mutating the checkout is safe must not
+    mutate it to find out, and doing so unattended would also silently disturb the
+    developer's own index state.
+
+    Instead the flagged entries are enumerated (``ls-files -v``, where a LOWERCASE
+    tag means "not checked") and each one is hashed and compared with the blob HEAD
+    records.
+
+    The hash lets git apply the path's attributes, and deliberately does NOT pass
+    ``--no-filters``. That flag suppresses git's BUILT-IN conversions as well as
+    external ones, so under ``core.autocrlf`` -- the normal Windows posture -- an
+    UNMODIFIED file hashes differently from its blob (working CRLF vs stored LF)
+    and this check would refuse every such checkout. Verified: with
+    ``--no-filters`` an untouched file mismatches, with attributes applied it
+    matches and a real edit is still detected. Letting attributes apply is safe
+    here precisely because a repository declaring a filter driver is refused
+    before this runs (:func:`repo_exec_config_reason`), so no external program can
+    be reached through it.
+
+    Returning only paths that ACTUALLY differ matters: flagging every
+    assume-unchanged entry would refuse the update for anyone who uses the bit for
+    local config overrides, which is the silent no-op this whole change exists to
+    remove.
+
+    ``None`` means git could not answer, which the caller must treat as unsafe.
+    """
+    listing = _git_probe(proj, "ls-files", "-v")
+    if listing is None:
+        return None
+
+    flagged: list[str] = []
+    for line in listing.splitlines():
+        # "<tag> <path>"; lowercase tag == assume-unchanged, "S" == skip-worktree.
+        if len(line) < 3 or line[1] != " ":
+            continue
+        tag, path = line[0], line[2:]
+        if tag.islower() or tag == "S":
+            flagged.append(path)
+    if not flagged:
+        return []
+
+    differing: list[str] = []
+    for path in flagged:
+        recorded = _git_probe(proj, "rev-parse", f"HEAD:{path}")
+        actual = _git_probe(proj, "hash-object", "--", path)
+        if recorded is None or actual is None:
+            # Cannot compare this one, so cannot prove it is safe.
+            return None
+        if recorded.strip() != actual.strip():
+            differing.append(path)
+    return differing
+
+
+def loggable_path(name: str) -> str:
+    """*name* rendered so it is always UTF-8 encodable, for a log record.
+
+    Filesystem names reach this module through ``os.fsdecode``, which is what the
+    ``os.path`` calls need but which represents a byte that is not valid UTF-8 as
+    a LONE SURROGATE (``b"\\xff"`` becomes ``"\\udcff"``). A surrogate cannot be
+    encoded to UTF-8, so interpolating one into a log record raises
+    ``UnicodeEncodeError`` inside the handler. ``logging`` does not propagate that
+    -- it calls ``handleError`` and DROPS the record -- so the line that would be
+    lost is the one saying an unattended update refused in order to preserve the
+    user's file. The same string also breaks any UTF-8 log shipper, and
+    ``pytest-xdist``, which serializes reports as UTF-8 (a captured record with a
+    surrogate crashed an entire CI shard with ``DumpError``).
+
+    Round-trips to the ORIGINAL bytes and escapes only the un-encodable ones, so
+    the operator sees the real on-disk byte (``bad\\xffname.txt``) rather than a
+    replacement character. ASCII and valid non-ASCII names (CJK, accents) pass
+    through unchanged, so this costs nothing in readability for the normal case.
+
+    Use it for the LOG only. The un-decorated ``os.fsdecode`` form is the one that
+    must be passed to the filesystem.
+    """
+    return os.fsencode(name).decode("utf-8", "backslashreplace")
+
+
+def commits_ahead(proj: str, upstream: str) -> int | None:
+    """How many commits ``HEAD`` is ahead of *upstream*, or ``None`` if unknown.
+
+    ``None`` means git could not answer, which the caller must treat exactly as
+    it treats a positive count: an unattended ``reset --hard`` may not run when
+    we cannot prove there is nothing to lose.
+
+    *upstream* is taken as given — pass the SAME revision the reset will use,
+    which for the update path is the captured OID rather than a ref name. That is
+    not a detail: a ref is re-resolved per command, so counting against
+    ``origin/<branch>`` while resetting to a previously captured OID lets a
+    concurrent fetch advance the ref, report zero commits ahead of the NEW tip,
+    and still reset to the OLD one — discarding exactly the commits the count was
+    supposed to protect. Counting against the reset target closes that.
+
+    This exists because the two checks that look like they cover it do not.
+    ``git status --porcelain`` reports working-tree edits, not commits, and the
+    availability probe (``git diff HEAD <target> --quiet``) is satisfied by a
+    difference in EITHER direction — so a checkout carrying local commits passes
+    both and then loses them to the reset.
+    """
+    if not upstream:
+        return None
+    out = _git_probe(proj, "rev-list", "--count", f"{upstream}..HEAD")
+    if out is None:
+        return None
+    try:
+        return int(out.strip())
+    except ValueError:
+        return None
+
+
+def tracks_upstream(proj: str, branch: str, *, remote: str = "origin") -> bool:
+    """Whether *branch* in *proj* tracks exactly ``<remote>/<branch>``.
+
+    The unattended update FETCHES and RESETS to ``<remote>/<branch>``, and the
+    source pin validates that same fixed remote. But the availability check that
+    decides an update exists compares ``HEAD`` against ``@{u}`` — whatever the
+    branch actually tracks. When those two are not the same ref, the check
+    measures one thing and the reset applies another, and the reset is a
+    ``--hard`` one, so the gap is lost commits rather than a stale answer.
+
+    BOTH halves of the upstream are therefore checked, because either alone
+    leaves the gap open:
+
+    * the remote — a fork checkout whose ``main`` tracks ``upstream/main`` while
+      ``origin`` is the user's own stale fork;
+    * the branch — ``branch.main.remote=origin`` with
+      ``branch.main.merge=refs/heads/other``, which still points ``@{u}`` at
+      ``origin/other`` while the reset targets ``origin/main``.
+
+    A checkout that tracks anything else still gets the badge, and can update
+    through ``kirocrew update`` or the dashboard, both of which have a human
+    deciding.
+    """
+    if not branch or branch == "HEAD":
+        return False
+    if _git(proj, "config", "--get", f"branch.{branch}.remote") != remote:
+        return False
+    return _git(proj, "config", "--get", f"branch.{branch}.merge") == f"refs/heads/{branch}"
 
 
 def update_blocked_reason(remote_url: str) -> str:
@@ -112,4 +711,16 @@ def min_version() -> str:
     return active_update_pins().min_version
 
 
-__all__ = ["resolve_remote_url", "update_blocked_reason", "update_required", "min_version"]
+__all__ = [
+    "PRIMARY_BRANCHES",
+    "git_command_env",
+    "git_neutralizer_env",
+    "is_primary_branch",
+    "commits_ahead",
+    "min_version",
+    "repo_exec_config_reason",
+    "resolve_remote_url",
+    "tracks_upstream",
+    "update_blocked_reason",
+    "update_required",
+]

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1191,6 +1191,41 @@ def _log_tool_outside_trusted_dirs(name: str, directories: tuple[str, ...]) -> N
     )
 
 
+#: Git for Windows' fixed install roots. ``trusted_system_bin`` only probes the
+#: system directories, and git is never there on Windows, so without this every
+#: Windows source install resolves ``git`` to ``None``. Fixed literal roots, not
+#: ``%ProgramFiles%``: reading the environment would let a poisoned variable
+#: redirect the lookup to an agent-writable directory — the exact hole the pin
+#: exists to close. A non-default-drive install still misses and degrades to
+#: "unavailable", which is honest: the fallback widens the pin only to paths an
+#: unprivileged attacker cannot write.
+_WINDOWS_GIT_DIRS = (
+    r"C:\Program Files\Git\cmd",
+    r"C:\Program Files (x86)\Git\cmd",
+)
+
+
+def trusted_git_bin() -> str | None:
+    """The ``git`` executable resolved off ``PATH``, or ``None`` if untrustworthy.
+
+    :func:`trusted_system_bin` plus the Windows install-root fallback, shared by
+    every caller that spawns git for a privileged or unattended purpose (the
+    doctor's read-only probes, and the update seam — where what git returns
+    decides which code the process installs and re-executes).
+
+    ``None`` means "do not spawn git at all". Callers MUST treat it as a refusal;
+    falling back to a bare ``"git"`` reinstates the hazard.
+    """
+    git = trusted_system_bin("git")
+    if git is None and IS_WINDOWS:
+        for directory in _WINDOWS_GIT_DIRS:
+            candidate = os.path.join(directory, "git.exe")
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        return None
+    return git
+
+
 def trusted_system_bin(name: str) -> str | None:
     """Resolve *name* from fixed system directories, ignoring ``PATH``.
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -214,6 +214,17 @@ from kiro_crew.platform.update_capability import (
     CHECK_UNCHECKED,
     EXTERNALLY_MANAGED_STAMPS,
 )
+from kiro_crew.platform.update_governance import (
+    commits_ahead,
+    git_command_env,
+    hidden_worktree_edits,
+    is_primary_branch,
+    loggable_path,
+    repo_exec_config_reason,
+    resolve_remote_url,
+    tracks_upstream,
+    update_blocked_reason,
+)
 from kiro_crew.providers.base import LLMEvent
 from kiro_crew.safety_override import safety_override
 from kiro_crew.sandbox import ensure_agents_slice_limits, warm_backend
@@ -8591,13 +8602,53 @@ class GatewayOrchestrator:
         if not proj:
             return
         try:
+            # Every git call below reads a tree an agent can write, and several of
+            # them (`status`, `diff`, `reset`) will EXEC a program the repository
+            # names in its own config. Bound once here, ahead of the first spawn,
+            # so the whole sequence is covered and a later-added command cannot
+            # quietly opt out of it.
+            #
+            # A redirected work tree is handled separately, by the
+            # `repo_exec_config_reason` refusal below: git ignores a
+            # `core.worktree` supplied through the environment, so it cannot be
+            # pinned here.
+            #
+            # `git_command_env` BUILDS the environment rather than merging over
+            # `os.environ`, because an inherited `GIT_DIR` has to be ABSENT and a
+            # merge can only add keys. Left in place it would point every call
+            # below at unrelated metadata while `cwd` still says `proj`.
+            _git_env = git_command_env()
+
+            # `git` itself is resolved OFF `PATH`. A gateway's `PATH` can lead
+            # with an agent-writable directory (a worktree venv's `bin`,
+            # `~/.local/bin`), so a bare `"git"` lets a planted shim run — and on
+            # THIS path what git reports decides which code is installed and
+            # re-executed, so the shim would not merely lie, it would choose the
+            # payload. `AGENTS.md` already requires this for system tools;
+            # `cli_doctor` already did it for git.
+            #
+            # Resolved ONCE here rather than per call, so every step below runs
+            # the same binary: re-resolving per spawn would leave a window for the
+            # answer to change mid-sequence.
+            _git = platform_compat.trusted_git_bin()
+            if _git is None:
+                logger.warning(
+                    "Auto-update: skipping — no trustworthy `git` outside PATH. "
+                    "Run `kirocrew update` to apply this manually."
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
             # Detect current branch
             branch_proc = await asyncio.create_subprocess_exec(
-                "git",
+                _git,
                 "rev-parse",
                 "--abbrev-ref",
                 "HEAD",
                 cwd=proj,
+                env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
@@ -8606,22 +8657,64 @@ class GatewayOrchestrator:
                 logger.error("Auto-update: could not determine current branch")
                 return
             branch = branch_out.strip().decode() if branch_out else ""
-            if not branch or branch == "HEAD":
-                branch = "mainline"
 
-            # Only auto-update on mainline — beta/feature branches need manual update
-            if branch != "mainline":
-                logger.debug("Auto-update: skipping — on branch %s, not mainline", branch)
+            # Only a PRIMARY branch is auto-updated: a feature or beta branch
+            # needs a deliberate `kirocrew update`, and a detached HEAD has no
+            # branch to fast-forward at all.
+            #
+            # This gate read `branch != "mainline"` — inherited verbatim from the
+            # internal repo whose primary line is named that — so on this repo,
+            # whose primary line is `main`, it matched nothing and returned at
+            # `logger.debug`. Every git checkout (the documented `install.sh`
+            # path) therefore never auto-updated, and said so nowhere.
+            #
+            # `is_primary_branch` reads a reviewed allowlist and nothing else, so
+            # no local git ref can steer or veto this decision. See its docstring
+            # — this is also the path a mandatory `min_version` floor drives.
+            if not is_primary_branch(branch):
+                logger.info(
+                    "Auto-update: skipping — %s is not a primary branch",
+                    branch or "detached HEAD",
+                )
+                return
+
+            # A content filter or textconv driver is named BY THE REPOSITORY, so
+            # there is no fixed key to pin and `_git_env` cannot reach it. Refuse
+            # the unattended run rather than execute it; the operator still has
+            # `kirocrew update`, where a human is deciding.
+            exec_config = await asyncio.get_running_loop().run_in_executor(
+                None, lambda: repo_exec_config_reason(proj)
+            )
+            if exec_config:
+                logger.warning(
+                    "Auto-update refused: %s, which git would run during the update",
+                    exec_config,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
+            # The availability check compares HEAD against `@{u}` (the TRACKED
+            # upstream) while this applies `origin/<branch>`. On a fork checkout
+            # whose branch tracks `upstream` and whose `origin` is a stale fork,
+            # those are different refs: the check sees the canonical remote move
+            # ahead and the reset below would discard commits. Only reset when the
+            # branch tracks the remote this actually fetches and pins.
+            if not await asyncio.get_running_loop().run_in_executor(
+                None, lambda: tracks_upstream(proj, branch)
+            ):
+                logger.info(
+                    "Auto-update: skipping — %s does not track origin, and the "
+                    "update check measures against its tracked upstream",
+                    branch,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.push_refresh("update_available")
                 return
 
             # Source pin, checked before the fetch. This is the most privileged
             # update path in the product — no auth, no click, `git reset --hard`
             # + pip + execv on boot — so a blocked host must not touch its tree.
-            from kiro_crew.platform.update_governance import (
-                resolve_remote_url,
-                update_blocked_reason,
-            )
-
             blocked = await asyncio.get_running_loop().run_in_executor(
                 None, lambda: update_blocked_reason(resolve_remote_url(proj, remote="origin"))
             )
@@ -8635,11 +8728,12 @@ class GatewayOrchestrator:
                 self.dashboard_state.push_update_progress("pulling", "Fetching latest changes…")
 
             fetch = await asyncio.create_subprocess_exec(
-                "git",
+                _git,
                 "fetch",
                 "origin",
                 branch,
                 cwd=proj,
+                env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -8650,14 +8744,51 @@ class GatewayOrchestrator:
                     self.dashboard_state.clear_update_progress()
                 return
 
+            # Capture the fetched commit as an OID, immediately after the fetch,
+            # and use that OID for the comparison AND the reset below. A ref name
+            # is re-resolved on every command, so `origin/<branch>` could be moved
+            # by a concurrent fetch between the decision and the reset — deciding
+            # against one commit and resetting to another. An OID cannot move.
+            #
+            # The ref is spelled in FULL (`refs/remotes/origin/...`) because the
+            # short form is ambiguous in the attacker's favour: rev-parse's
+            # disambiguation order checks `refs/tags/<name>` BEFORE
+            # `refs/remotes/<name>`, so a tag literally named `origin/main`
+            # resolves instead of the remote-tracking branch — and the update's
+            # own `git fetch` auto-follows tags, so publishing that tag upstream
+            # is enough to create it locally. git prints "refname is ambiguous"
+            # to stderr and still writes the TAG's OID to stdout, which is what
+            # this capture reads, so the short form fails silently here.
+            target_proc = await asyncio.create_subprocess_exec(
+                _git,
+                "rev-parse",
+                "--verify",
+                f"refs/remotes/origin/{branch}^{{commit}}",
+                cwd=proj,
+                env=_git_env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            target_out, _ = await asyncio.wait_for(target_proc.communicate(), timeout=10)
+            target = (target_out or b"").strip().decode()
+            if target_proc.returncode != 0 or not target:
+                logger.warning(
+                    "Auto-update: skipping — could not resolve origin/%s to a commit",
+                    branch,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                return
+
             # Check if there are actually new commits
             diff_proc = await asyncio.create_subprocess_exec(
-                "git",
+                _git,
                 "diff",
                 "HEAD",
-                f"origin/{branch}",
+                target,
                 "--quiet",
                 cwd=proj,
+                env=_git_env,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )
@@ -8668,33 +8799,256 @@ class GatewayOrchestrator:
                     self.dashboard_state.clear_update_progress()
                 return
 
-            # Warn if local tracked-file edits will be discarded
+            # LAST-MOMENT REVALIDATION, after the fetch and immediately before the
+            # only destructive step. Everything checked so far was checked
+            # earlier: the availability verdict came from a separate pass, and
+            # the config probe ran before the fetch. A checkout is a live tree —
+            # a developer can commit, or repo config can be rewritten, in the
+            # window between those checks and this reset. `reset --hard` is not
+            # recoverable from, so the two facts that decide whether it destroys
+            # anything are re-read here rather than trusted from before.
+            #
+            # 1. Local commits. `git status --porcelain` below reports
+            #    working-tree edits, NOT commits, and the `git diff` above is
+            #    satisfied by any difference in either direction — so a checkout
+            #    that is ahead of origin passes both and then loses those commits.
+            # Counted against `target` — the OID the reset will use — not against
+            # `origin/<branch>`. A ref is re-resolved per command, so a concurrent
+            # fetch could advance it, make this read zero against the new tip, and
+            # leave the reset discarding commits relative to the old one.
+            ahead = await asyncio.get_running_loop().run_in_executor(
+                None, lambda: commits_ahead(proj, target)
+            )
+            if ahead != 0:
+                logger.warning(
+                    "Auto-update: skipping — %s is ahead of origin/%s by %s commit(s); "
+                    "a reset would discard them. Run `kirocrew update` to decide.",
+                    branch,
+                    branch,
+                    "an unknown number of" if ahead is None else ahead,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
+            # 2. The work tree, and the repo-named exec drivers, re-read after the
+            #    fetch. The earlier probe is a check-then-use otherwise: config
+            #    rewritten in between would redirect this reset, or hand the
+            #    checkout's own driver to the command that performs it.
+            exec_config_now = await asyncio.get_running_loop().run_in_executor(
+                None, lambda: repo_exec_config_reason(proj)
+            )
+            if exec_config_now:
+                logger.warning("Auto-update refused before reset: %s", exec_config_now)
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
+            # 3. Uncommitted tracked edits. REFUSE, like the two checks above —
+            #    this one used to log a warning and then reset anyway, which made
+            #    an unattended boot-time update the one code path that could
+            #    silently destroy a developer's uncommitted work. `reset --hard`
+            #    is not recoverable and nothing here has the standing to make
+            #    that trade on the developer's behalf: the count check one screen
+            #    up already refuses for COMMITTED work and defers to `kirocrew
+            #    update`, and uncommitted work is the strictly more fragile case
+            #    (a discarded commit is at least recoverable from the reflog; an
+            #    uncommitted edit is gone). The manual path keeps the destructive
+            #    semantics, because there a human chose them.
+            #
+            #    Untracked files are excluded: `reset --hard` preserves them, so
+            #    task specs and notes are not a reason to refuse.
             status_proc = await asyncio.create_subprocess_exec(
-                "git",
+                _git,
                 "status",
                 "--porcelain",
                 cwd=proj,
+                env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
             )
             status_out, _ = await asyncio.wait_for(status_proc.communicate(), timeout=10)
-            if status_out and status_out.strip():
-                tracked = [
-                    ln
-                    for ln in status_out.decode(errors="replace").splitlines()
-                    if not ln.startswith("??")
-                ]
-                if tracked:
-                    logger.warning("Auto-update: discarding local tracked-file changes in %s", proj)
+            if status_proc.returncode != 0:
+                # Cannot prove the tree is clean, and the next step is
+                # irreversible — treat an unreadable status as dirty.
+                logger.warning(
+                    "Auto-update: skipping — could not read the work-tree status of %s; "
+                    "a reset could discard uncommitted changes. Run `kirocrew update`.",
+                    loggable_path(proj),
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+            tracked = [
+                ln
+                for ln in (status_out or b"").decode(errors="replace").splitlines()
+                if ln.strip() and not ln.startswith("??")
+            ]
+            if tracked:
+                logger.warning(
+                    "Auto-update: skipping — %s has %s uncommitted tracked change(s); "
+                    "a reset would discard them. Run `kirocrew update` to decide.",
+                    loggable_path(proj),
+                    len(tracked),
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
 
-            # Hard reset to remote — discards local tracked-file edits,
-            # untracked files (task specs, notes) are preserved.
+            # 3b. Tracked edits git was TOLD not to look at. `status --porcelain`
+            #     above honours `assume-unchanged` / `skip-worktree` and reports a
+            #     clean tree for an edited file, while `reset --hard` still
+            #     overwrites it -- so check 3 alone cannot see this loss.
+            hidden = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), lambda: hidden_worktree_edits(proj)
+            )
+            if hidden is None or hidden:
+                logger.warning(
+                    "Auto-update: skipping — %s has %s tracked change(s) hidden by "
+                    "assume-unchanged/skip-worktree (e.g. %s); a reset would discard "
+                    "them. Run `kirocrew update` to decide.",
+                    loggable_path(proj),
+                    "an unknown number of" if hidden is None else len(hidden),
+                    loggable_path(hidden[0]) if hidden else "unknown",
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
+            # 4. Untracked files that the TARGET would create. `reset --hard`
+            #    leaves untracked files alone ONLY while they do not collide with
+            #    a path the target adds -- where it does, the local file is
+            #    overwritten. `git status --porcelain` reports such a file as
+            #    `??`, which check 3 deliberately skips, so this is the one
+            #    data-loss case that survives a "clean" tracked tree. Verified:
+            #    upstream adds `newfile.txt`, a local untracked `newfile.txt` is
+            #    replaced by the upstream content.
+            #
+            #    Detected rather than prevented by switching to `merge --ff-only`:
+            #    the reset semantics are deliberate (documented as discarding
+            #    tracked edits) and this path keeps them. A collision is a refusal
+            #    for the same reason as the three above -- it is unrecoverable and
+            #    unattended.
+            added_proc = await asyncio.create_subprocess_exec(
+                _git,
+                "diff",
+                "--name-only",
+                "--diff-filter=A",
+                # Rename detection is ON by default for porcelain diffs, and it
+                # DEFEATS this guard: a pure `git mv` upstream is reported as a
+                # single `R` entry, which `--diff-filter=A` excludes, so the
+                # destination path never appears as added. Verified — upstream
+                # renaming `a.txt` to `b.txt` yields `R100` and an EMPTY added
+                # list, while an untracked local `b.txt` is still overwritten by
+                # the reset. `--no-renames` decomposes the rename into a delete
+                # plus an add, which is what this check needs to see.
+                "--no-renames",
+                "-z",
+                "HEAD",
+                target,
+                cwd=proj,
+                env=_git_env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            added_out, _ = await asyncio.wait_for(added_proc.communicate(), timeout=10)
+            if added_proc.returncode != 0:
+                logger.warning(
+                    "Auto-update: skipping — could not list the paths %s would add; "
+                    "a reset could overwrite untracked files. Run `kirocrew update`.",
+                    branch,
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+            # `os.fsdecode`, NOT `.decode(errors="replace")`: a path byte that is
+            # not valid UTF-8 becomes U+FFFD under `replace`, and the resulting
+            # name does not exist on disk — so the check answers "no collision"
+            # for a file it is looking straight at. Verified: a `bad\xffname.txt`
+            # decodes to `bad\ufffdname.txt` (lexists False) under `replace` and
+            # to `bad\udcffname.txt` (lexists True) under `fsdecode`, and the
+            # reset overwrote it. `fsdecode` round-trips through surrogateescape,
+            # which is what the os functions below need.
+            added_names = [os.fsdecode(raw) for raw in (added_out or b"").split(b"\0") if raw]
+
+            def _obstructions(name: str) -> bool:
+                """Whether *name* collides with something already on disk.
+
+                Two shapes, both unrecoverable and both invisible to check 3:
+
+                * the path ITSELF exists untracked, and the reset overwrites it;
+                * an ANCESTOR exists as a non-directory. When the target adds
+                  `pkg/mod.py` and `pkg` is locally an untracked FILE, git must
+                  replace that file with a directory — `lexists("pkg/mod.py")` is
+                  False, so checking only the full path misses it. Verified: the
+                  untracked `pkg` was destroyed while the full-path check passed.
+                """
+                full = os.path.join(proj, name)
+                if os.path.lexists(full):
+                    return True
+                parent = os.path.dirname(name)
+                while parent:
+                    candidate = os.path.join(proj, parent)
+                    # Link check FIRST: `isdir` follows the link, so an untracked
+                    # symlink-to-directory reported "directory, not an
+                    # obstruction" -- and the reset then replaced the developer's
+                    # symlink with a real directory. Verified against real git.
+                    #
+                    # `is_link_or_junction`, not `os.path.islink`: `islink` returns
+                    # False for a Windows JUNCTION, so a junction ancestor would
+                    # read as a plain directory and the reset would write through
+                    # it, outside the checkout. AGENTS.md names this helper as the
+                    # required form for exactly this reason, and its own docstring
+                    # describes this failure -- using the bare `islink` here was a
+                    # rule violation, not a judgement call.
+                    if platform_compat.is_link_or_junction(candidate):
+                        return True
+                    if os.path.lexists(candidate) and not os.path.isdir(candidate):
+                        return True
+                    parent = os.path.dirname(parent)
+                return False
+
+            # Offloaded: `_obstructions` walks each added path's ancestors with
+            # synchronous `os.path` probes, so a large update would run an
+            # unbounded stat walk ON THE EVENT LOOP and stall every chat and the
+            # heartbeat (`no-blocking-call-on-event-loop`).
+            collisions = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(),
+                lambda: [name for name in added_names if _obstructions(name)],
+            )
+            if collisions:
+                logger.warning(
+                    "Auto-update: skipping — %s would add %s path(s) that already "
+                    "exist untracked here (e.g. %s); a reset would overwrite them. "
+                    "Run `kirocrew update` to decide.",
+                    branch,
+                    len(collisions),
+                    # `loggable_path`, not the raw name: this is the one log line
+                    # that carries a filename straight from git output, and a
+                    # non-UTF-8 byte in it would make logging DROP the record --
+                    # silently losing the evidence that the update refused here.
+                    loggable_path(collisions[0]),
+                )
+                if self.dashboard_state:
+                    self.dashboard_state.clear_update_progress()
+                    self.dashboard_state.push_refresh("update_available")
+                return
+
+            # Hard reset to remote. Reached only with a clean tracked tree and no
+            # untracked collisions, so it overwrites nothing the developer owns.
             reset = await asyncio.create_subprocess_exec(
-                "git",
+                _git,
                 "reset",
                 "--hard",
-                f"origin/{branch}",
+                target,
                 cwd=proj,
+                env=_git_env,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -915,13 +915,17 @@ class TestSourceCheckout:
     def test_git_line_pins_git_and_returns_none_when_untrusted(
         self, monkeypatch, tmp_path
     ) -> None:
-        """git resolves via trusted_system_bin; a miss means no subprocess at all.
+        """git resolves via trusted_git_bin; a miss means no subprocess at all.
 
         Doctor runs with operator privileges, so a ``git`` shim planted in an
         agent-writable PATH directory must never execute: when the trusted
-        resolver declines, _git_line collapses to None without spawning.
-        When it resolves, the pinned absolute path — not the bare name — is
-        what reaches argv[0].
+        resolver declines, _git_line collapses to None without spawning. When it
+        resolves, the pinned absolute path -- not the bare name -- reaches argv[0].
+
+        The resolver itself (system dirs plus the Windows install-root fallback)
+        is tested in `test_platform_compat`; this asserts what the doctor does
+        with each OUTCOME, which is why it patches the resolver rather than the
+        directories behind it.
         """
         import subprocess as _sp
 
@@ -933,82 +937,17 @@ class TestSourceCheckout:
 
         monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
 
-        # Miss: no trusted git -> None, and no process spawned. Neutralize
-        # the Windows fallback too so the miss is a miss on every platform
-        # (on a real Windows runner _windows_git_bin finds the actual Git
-        # for Windows install; the fallback has its own dedicated test).
-        monkeypatch.setattr(
-            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
-        )
-        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: None)
+        # Miss: no trusted git -> None, and no process spawned.
+        monkeypatch.setattr(cli_doctor.platform_compat, "trusted_git_bin", lambda: None)
         assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
         assert calls == []
 
         # Hit: the resolved absolute path is argv[0], never the bare "git".
         monkeypatch.setattr(
-            cli_doctor.platform_compat,
-            "trusted_system_bin",
-            lambda _n: "/usr/bin/git",
+            cli_doctor.platform_compat, "trusted_git_bin", lambda: "/usr/bin/git"
         )
         assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") == "main"
         assert calls and calls[0][0] == "/usr/bin/git"
-
-    def test_git_line_windows_falls_back_to_git_for_windows_roots(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        """On Windows a system-dirs miss probes the fixed Git for Windows roots.
-
-        Git for Windows installs under Program Files, never System32, so
-        without the fallback every supported Windows source install reported
-        "could not check". The fallback stays pinned: fixed literal roots, and
-        a miss there still means no subprocess.
-        """
-        import subprocess as _sp
-
-        calls: list[list[str]] = []
-
-        def fake_run(argv, *a, **k):
-            calls.append(list(argv))
-            return _sp.CompletedProcess(argv, 0, stdout="main\n", stderr="")
-
-        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
-        monkeypatch.setattr(
-            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
-        )
-        monkeypatch.setattr(cli_doctor.platform_compat, "IS_WINDOWS", True)
-
-        gfw = r"C:\Program Files\Git\cmd\git.exe"
-        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: gfw)
-        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") == "main"
-        assert calls and calls[0][0] == gfw
-
-        # Fallback miss: still no spawn at all.
-        calls.clear()
-        monkeypatch.setattr(cli_doctor, "_windows_git_bin", lambda: None)
-        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
-        assert calls == []
-
-    def test_git_line_non_windows_never_probes_git_for_windows(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        # POSIX resolver miss must not consult the Windows fallback: the
-        # trusted-dirs decision is final there.
-        monkeypatch.setattr(
-            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
-        )
-        monkeypatch.setattr(cli_doctor.platform_compat, "IS_WINDOWS", False)
-        monkeypatch.setattr(
-            cli_doctor,
-            "_windows_git_bin",
-            lambda: (_ for _ in ()).throw(AssertionError("probed on POSIX")),
-        )
-        assert cli_doctor._git_line(tmp_path, "rev-parse", "HEAD") is None
-
-    def test_windows_git_bin_returns_none_when_roots_empty(self, monkeypatch) -> None:
-        # Fixed roots only — a miss returns None without consulting PATH or
-        # the environment.
-        monkeypatch.setattr(cli_doctor, "_WINDOWS_GIT_DIRS", ("Z:\\nonexistent\\Git\\cmd",))
-        assert cli_doctor._windows_git_bin() is None
 
 
 class TestCliInstallerResidue:

--- a/test/test_governance_updates.py
+++ b/test/test_governance_updates.py
@@ -6,6 +6,9 @@ the three update paths call (``platform.update_governance``).
 
 from __future__ import annotations
 
+import os
+import pathlib
+
 import pytest
 
 from kiro_crew.platform import update_governance
@@ -16,6 +19,7 @@ from kiro_crew.platform.governance import (
     parse_policy,
     parse_profile,
 )
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 
 def _policy(**updates: str) -> dict:
@@ -226,7 +230,9 @@ class TestRemoteResolution:
         monkeypatch.setattr("subprocess.run", fake_run)
         url = update_governance.resolve_remote_url("/proj", branch="main")
         assert url == "https://git.corp/team/repo"
-        assert ["git", "ls-remote", "--get-url", "--", "upstream"] in calls
+        assert ["ls-remote", "--get-url", "--", "upstream"] in [c[1:] for c in calls]
+        # argv[0] must be the resolved binary, never a bare `git` off PATH.
+        assert all(c[0] != "git" for c in calls), calls
 
     def test_unknown_remote_echo_is_not_a_url(self, monkeypatch):
         """`--get-url` echoes its argument back for an unknown remote."""
@@ -264,7 +270,8 @@ class TestRemoteResolution:
             == "https://git.corp/origin-repo"
         )
         # Neither the branch nor its tracked remote is consulted.
-        assert calls == [["git", "ls-remote", "--get-url", "--", "origin"]]
+        assert [c[1:] for c in calls] == [["ls-remote", "--get-url", "--", "origin"]]
+        assert all(c[0] != "git" for c in calls), calls
 
     def test_resolves_the_branch_itself_when_not_given(self, monkeypatch):
         """The API path passes no branch; the seam resolves it (one impl)."""
@@ -286,7 +293,8 @@ class TestRemoteResolution:
 
         monkeypatch.setattr("subprocess.run", fake_run)
         assert update_governance.resolve_remote_url("/proj") == "https://git.corp/team/repo"
-        assert ["git", "rev-parse", "--abbrev-ref", "HEAD"] in calls
+        assert ["rev-parse", "--abbrev-ref", "HEAD"] in [c[1:] for c in calls]
+        assert all(c[0] != "git" for c in calls), calls
 
     def test_missing_git_is_unresolvable_not_an_error(self, monkeypatch):
         def _no_git(*a, **k):
@@ -294,3 +302,1473 @@ class TestRemoteResolution:
 
         monkeypatch.setattr("subprocess.run", _no_git)
         assert update_governance.resolve_remote_url("/proj", branch="main") == ""
+
+
+class TestPrimaryBranchResolution:
+    """The gate on the unattended boot-time ``git reset --hard`` + reinstall.
+
+    Two failure modes are asserted here, because the gate can be wrong in
+    opposite directions and only one of them is loud:
+
+    * Too narrow -> a whole install cohort silently never updates. A hardcoded
+      ``mainline`` did that to every ``main`` checkout of this repo.
+    * Too wide, or steerable -> unreviewed code is installed and executed, or a
+      mandatory version floor is vetoed.
+    """
+
+    def test_main_is_primary(self):
+        """The regression: this repo's primary line is `main`, not `mainline`."""
+        assert update_governance.is_primary_branch("main")
+
+    def test_mainline_is_primary(self):
+        """Internal and mirror clones whose primary line carries that name."""
+        assert update_governance.is_primary_branch("mainline")
+
+    def test_feature_branch_is_not_primary(self):
+        assert not update_governance.is_primary_branch("fix/some-thing")
+        assert not update_governance.is_primary_branch("beta-braveheart")
+
+    def test_detached_head_is_never_primary(self):
+        """There is no branch to fast-forward, so there is nothing to apply.
+
+        The old code fabricated `branch = "mainline"` here, which on an internal
+        clone would have let a boot-time `git reset --hard` move a deliberately
+        detached checkout.
+        """
+        assert not update_governance.is_primary_branch("HEAD")
+        assert not update_governance.is_primary_branch("")
+
+    def test_lookalike_names_are_not_primary(self):
+        """Membership is exact — no prefix, suffix, or case leniency.
+
+        A remote is free to carry a branch called `main-2`, and pushing one must
+        not be enough to get it installed on boot.
+        """
+        for name in ("main-2", "mainline2", "Main", "MAIN", "origin/main", " main"):
+            assert not update_governance.is_primary_branch(name), name
+
+    def test_decision_reads_no_git_state_at_all(self, monkeypatch):
+        """The security property, asserted directly: no local ref participates.
+
+        `refs/remotes/<remote>/HEAD` is one `git remote set-head` away from being
+        repointed by anything with write access to the checkout. Consulting it
+        breaks in BOTH directions — obeying it aims the boot-time
+        `git reset --hard` + `pip install` + `execv` at an arbitrary branch of the
+        still-approved origin (the source pin cannot catch it, the remote URL is
+        unchanged), while letting it merely narrow turns the same one-command
+        repoint into a veto. So the gate runs no git at all, and this fails if a
+        future change reintroduces one.
+        """
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: pytest.fail("must not run git"))
+        assert update_governance.is_primary_branch("main")
+        assert not update_governance.is_primary_branch("attacker-branch")
+
+    def test_a_repointed_pointer_cannot_veto_a_mandatory_update(self):
+        """A `main` checkout stays primary however `origin/HEAD` is aimed.
+
+        `_auto_apply_update` is what an enterprise `min_version` floor calls on a
+        checkout, so a vetoable gate would let a local repoint strand a host
+        below the administrator's minimum version — the ceiling bypass the
+        module docstring says a pin must not permit.
+        """
+        assert update_governance.is_primary_branch("main")
+        assert update_governance.is_primary_branch("mainline")
+
+    def test_unrelated_primary_fork_gets_no_unattended_update(self):
+        """The accepted cost, asserted rather than left implicit.
+
+        A fork whose primary line is named something else only gets the badge.
+        `kirocrew update` and the dashboard apply path still serve it, and both
+        have a human in the loop — the difference that makes wider trust
+        acceptable there and not on an unauthenticated boot path.
+        """
+        assert not update_governance.is_primary_branch("develop")
+        assert not update_governance.is_primary_branch("trunk")
+
+    def test_allowlist_is_frozen(self):
+        """A mutable set here would be writable by any import-time code."""
+        assert isinstance(update_governance.PRIMARY_BRANCHES, frozenset)
+
+    def test_this_repo_s_real_primary_branch_is_allowlisted(self):
+        """No mock: the real checkout's default branch must be in the allowlist.
+
+        This is the only test that can catch the original bug CLASS — a name that
+        is simply wrong for this repo. Every assertion above would still pass if
+        the allowlist held one wrong literal, because they choose their own
+        inputs; this one reads the repo. Skips where the metadata is absent
+        (`--single-branch` CI clones, exported tarballs).
+        """
+        import pathlib as _pathlib
+        import subprocess as _subprocess
+
+        root = _pathlib.Path(update_governance.__file__).resolve().parents[3]
+        if not (root / ".git").exists():
+            pytest.skip("not a git checkout")
+        probe = _subprocess.run(
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            cwd=root,
+            # Sanitized like every other git call here, but rooted at the REAL
+            # checkout: this test's subject is this repository, not a tmp_path one.
+            env=_fixture_git_env(str(root)),
+            capture_output=True,
+            timeout=10,
+            **UTF8_TEXT,
+        )
+        if probe.returncode != 0 or not probe.stdout.strip():
+            pytest.skip("clone published no origin/HEAD pointer")
+        default = probe.stdout.strip().removeprefix("origin/")
+        assert update_governance.is_primary_branch(default), (
+            f"this repo's default branch {default!r} is not in PRIMARY_BRANCHES — "
+            "auto-update would silently never run for any checkout of it"
+        )
+
+
+def _fixture_git_env(repo: str) -> dict:
+    """Env for a fixture git call: no inherited templates, hooks, or identity.
+
+    A developer (or CI image) with ``GIT_TEMPLATE_DIR`` set, or a global
+    ``core.hooksPath``, would otherwise have those hooks COPIED into every
+    fixture repo and executed by the ``git commit`` below — host-side side
+    effects from running the test suite. ``init.templateDir`` and the exec
+    vectors are pinned through the same mechanism the production path uses, and
+    the committer identity is supplied so the call cannot depend on, or fall
+    back to, the developer's global config.
+    """
+    # `git_command_env()` rather than a merge over `os.environ`: an exported
+    # GIT_DIR would otherwise point these fixture mutations at unrelated
+    # metadata, so `git commit` / `update-ref` could write an operator's real
+    # refs while the test believes it is working in tmp_path.
+    env = {
+        **update_governance.git_command_env(),
+        "GIT_TEMPLATE_DIR": "",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
+    count = int(env["GIT_CONFIG_COUNT"])
+    env[f"GIT_CONFIG_KEY_{count}"] = "init.templateDir"
+    env[f"GIT_CONFIG_VALUE_{count}"] = ""
+    env["GIT_CONFIG_COUNT"] = str(count + 1)
+    return env
+
+
+def _git_update_ref(repo: str, ref: str, sha: str) -> None:
+    """Point *ref* at *sha* without needing a real remote."""
+    import subprocess
+
+    done = subprocess.run(
+        ["git", "update-ref", ref, sha],
+        cwd=repo,
+        env=_fixture_git_env(repo),
+        capture_output=True,
+        **UTF8_TEXT,
+    )
+    assert done.returncode == 0, done.stderr
+
+
+def _init_repo(path) -> str:
+    """A real one-commit git repo at *path*, or a skip when git is unusable."""
+    import subprocess
+
+    path.mkdir(parents=True, exist_ok=True)
+    repo = str(path)
+    env = _fixture_git_env(repo)
+    for argv in (
+        ["git", "init", "-q", "--template=", "."],
+        ["git", "commit", "-q", "--no-verify", "--allow-empty", "-m", "x"],
+    ):
+        done = subprocess.run(argv, cwd=repo, env=env, capture_output=True, **UTF8_TEXT)
+        if done.returncode != 0:
+            pytest.skip(f"git unusable: {(done.stderr or '').strip()[:120]}")
+    return repo
+
+
+def _git_config(repo: str, *args: str) -> None:
+    import subprocess
+
+    done = subprocess.run(
+        ["git", "config", *args],
+        cwd=repo,
+        env=_fixture_git_env(repo),
+        capture_output=True,
+        **UTF8_TEXT,
+    )
+    assert done.returncode == 0, done.stderr
+
+
+class TestGitExecNeutralizers:
+    """The update path runs git on a tree the agent can write.
+
+    `git status` and `git diff` do not just READ config — they exec the program a
+    repo names in `core.fsmonitor`, and a reset runs hooks. These assert the
+    fixed-key vectors are pinned back, against real git rather than a mock,
+    because the whole question is what git actually does with the config.
+    """
+
+    @staticmethod
+    def _pinned() -> dict:
+        env = update_governance.git_neutralizer_env()
+        return {
+            env[f"GIT_CONFIG_KEY_{i}"]: env[f"GIT_CONFIG_VALUE_{i}"]
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+
+    def test_env_pins_the_named_exec_vectors(self):
+        pinned = self._pinned()
+        assert pinned["core.fsmonitor"] == "false"
+        assert pinned["core.hooksPath"] == os.devnull
+        assert pinned["credential.helper"] == ""
+        assert pinned["protocol.ext.allow"] == "never"
+        assert pinned["diff.external"] == ""
+
+    def test_every_exec_capable_fixed_key_is_pinned(self):
+        """The list's criterion is "git may exec this value, key name is fixed".
+
+        Asserted as a set rather than one key at a time because the first version
+        of the list was an enumeration with no criterion, and was missing
+        `core.gitProxy` for exactly that reason.
+        """
+        pinned = self._pinned()
+        for key in (
+            "core.fsmonitor",
+            "core.hooksPath",
+            "core.sshCommand",
+            "core.askPass",
+            "core.alternateRefsCommand",
+            "core.pager",
+            "core.editor",
+            "sequence.editor",
+            "credential.helper",
+            "diff.external",
+            "gpg.program",
+            "uploadpack.packObjectsHook",
+            "protocol.ext.allow",
+        ):
+            assert key in pinned, f"{key} is exec-capable but not pinned"
+
+    def test_no_pinned_value_is_a_repo_supplied_program(self):
+        """A pin must not itself name something the repo could control."""
+        for key, value in update_governance._GIT_EXEC_NEUTRALIZERS:
+            assert not value.startswith("!"), (key, value)
+            assert "$" not in value, (key, value)
+
+    def test_count_matches_the_entries(self):
+        """A stale GIT_CONFIG_COUNT silently drops the tail of the list."""
+        env = update_governance.git_neutralizer_env()
+        count = int(env["GIT_CONFIG_COUNT"])
+        assert count == len(update_governance._GIT_EXEC_NEUTRALIZERS) + len(
+            update_governance._GIT_BLAST_RADIUS_PINS
+        )
+        assert f"GIT_CONFIG_KEY_{count}" not in env
+        for i in range(count):
+            assert f"GIT_CONFIG_KEY_{i}" in env
+            assert f"GIT_CONFIG_VALUE_{i}" in env
+
+    def test_fsmonitor_program_does_not_run(self, tmp_path):
+        """The finding, reproduced: `git status` execs a repo-named program.
+
+        Asserted in both directions — without the neutralizer the program runs,
+        with it it does not — so the test fails if the pin ever stops working
+        rather than passing vacuously on a git that never ran the hook at all.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "repo")
+        marker = tmp_path / "FSMONITOR_RAN"
+        hook = tmp_path / "fsmon.sh"
+        hook.write_text(f'#!/bin/sh\ntouch "{marker}"\nexit 1\n')
+        hook.chmod(0o755)
+        _git_config(repo, "--local", "core.fsmonitor", str(hook))
+
+        def _status(env):
+            if marker.exists():
+                marker.unlink()
+            subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=repo,
+                env=env,
+                capture_output=True,
+                **UTF8_TEXT,
+            )
+            return marker.exists()
+
+        # BOTH probe environments are built from the sanitized fixture env: a
+        # raw `os.environ` carrying an exported GIT_DIR would point this `git
+        # status` at another checkout entirely, and then execute THAT
+        # repository's configured fsmonitor -- a host-side side effect from
+        # running the test suite, outside tmp_path.
+        protected = _fixture_git_env(repo)
+
+        # The control needs the fsmonitor pin OFF while keeping the sanitizing.
+        # Flip that one pinned value rather than dropping to `os.environ`, so the
+        # two probes differ only in the thing under test.
+        control = dict(protected)
+        count = int(control["GIT_CONFIG_COUNT"])
+        for i in range(count):
+            if control[f"GIT_CONFIG_KEY_{i}"] == "core.fsmonitor":
+                control[f"GIT_CONFIG_VALUE_{i}"] = str(hook)
+
+        if not _status(control):
+            pytest.skip("this git does not spawn core.fsmonitor")
+        assert not _status(protected), "core.fsmonitor still executed with the neutralizer applied"
+
+
+class TestNoTestSideEffects:
+    """Every git subprocess in THIS file must carry the sanitized environment.
+
+    `no-test-side-effects`, and it has now recurred four times across review rounds
+    (GIT_TEMPLATE_DIR, then GIT_DIR in the fixtures, then a control probe, then
+    seven bare calls at once). The failure is always the same: an inherited
+    ``GIT_DIR`` points a probe at an operator's real repository, where `git status`
+    can invoke THAT repo's configured fsmonitor -- a host-side side effect from
+    running the test suite, outside ``tmp_path``.
+
+    Fixing instances one at a time is what produced four rounds of it, so this
+    asserts the property over the whole file. A new bare call fails here instead of
+    in someone's review.
+    """
+
+    def test_every_subprocess_run_passes_a_sanitized_env(self):
+        import re
+
+        source = pathlib.Path(__file__).read_text(encoding="utf-8")
+        lines = source.splitlines()
+
+        offenders: list[tuple[int, str]] = []
+        for index, line in enumerate(lines):
+            if "subprocess.run(" not in line:
+                continue
+            # Walk to the end of the call expression by paren depth.
+            chunk: list[str] = []
+            depth = 0
+            for j in range(index, min(index + 25, len(lines))):
+                chunk.append(lines[j])
+                depth += lines[j].count("(") - lines[j].count(")")
+                if depth <= 0 and j > index:
+                    break
+            body = "\n".join(chunk)
+            if not re.search(r"\benv\s*=", body):
+                offenders.append((index + 1, lines[index].strip()))
+
+        assert not offenders, (
+            "these subprocess.run calls inherit the ambient environment; pass "
+            f"env=_fixture_git_env(repo): {offenders}"
+        )
+
+
+class TestWorktreeRedirectRefusal:
+    """`core.worktree` is not an exec vector -- it is a data-loss vector.
+
+    Repo config can point the work tree at another directory, and the unattended
+    `git reset --hard` then overwrites matching files THERE. Nothing is executed,
+    so no exec-key pin covers it, and it cannot be pinned away either: git
+    ignores `core.worktree` from `-c`/`GIT_CONFIG_*`, and the `GIT_WORK_TREE`
+    that does override it is refused without a matching `GIT_DIR`. So it is
+    refused.
+    """
+
+    def test_ordinary_checkout_is_allowed(self, tmp_path):
+        repo = _init_repo(tmp_path / "plain")
+        assert update_governance.repo_exec_config_reason(repo) == ""
+
+    def test_redirected_worktree_is_refused(self, tmp_path):
+        """Against real git, with the redirect proven to take effect first."""
+        import subprocess
+
+        repo = _init_repo(tmp_path / "wt")
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        _git_config(repo, "--local", "core.worktree", str(decoy))
+        proof = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=repo,
+            env=_fixture_git_env(repo),
+            capture_output=True,
+            **UTF8_TEXT,
+        )
+        if str(decoy) not in (proof.stdout or ""):
+            pytest.skip("this git does not honour core.worktree here")
+        assert "redirected" in update_governance.repo_exec_config_reason(repo)
+
+    def test_a_symlinked_checkout_is_not_a_redirect(self, tmp_path):
+        """`realpath` both sides, or every symlinked install reads as redirected.
+
+        This repo is itself reached through a symlinked path, so a naive string
+        compare would refuse the update on the developer's own checkout.
+        """
+        repo = _init_repo(tmp_path / "real")
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(repo)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable")
+        assert update_governance.repo_exec_config_reason(str(link)) == ""
+
+    def test_unresolvable_work_tree_is_refused(self, monkeypatch):
+        """Cannot prove where a write would land, so do not write."""
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance._git_probe",
+            lambda proj, *a: "" if a[:1] == ("config",) else None,
+        )
+        assert update_governance.repo_exec_config_reason("/proj") != ""
+
+
+class TestRepoExecConfigRefusal:
+    """Drivers named BY THE REPOSITORY have no fixed key, so they are refused.
+
+    Real repos, not mocks: two of these cases exist only because git resolves
+    config in a way a mock would not reproduce.
+    """
+
+    def test_clean_repo_is_allowed(self, tmp_path):
+        repo = _init_repo(tmp_path / "clean")
+        assert update_governance.repo_exec_config_reason(repo) == ""
+
+    def test_local_filter_driver_is_refused(self, tmp_path):
+        repo = _init_repo(tmp_path / "local")
+        _git_config(repo, "--local", "filter.evil.smudge", "sh -c ':'")
+        assert "filter.evil.smudge" in update_governance.repo_exec_config_reason(repo)
+
+    def test_worktree_scoped_driver_is_refused(self, tmp_path):
+        """A `--local` listing does NOT report worktree-scoped keys.
+
+        So probing only `--local` let a repo with `extensions.worktreeConfig`
+        hide a driver that still resolved when the command ran.
+        """
+        repo = _init_repo(tmp_path / "wt")
+        _git_config(repo, "--local", "extensions.worktreeConfig", "true")
+        _git_config(repo, "--worktree", "filter.evil.process", "sh -c ':'")
+        assert "filter.evil.process" in update_governance.repo_exec_config_reason(repo)
+
+    def test_included_driver_is_refused(self, tmp_path):
+        """For a SPECIFIC scope query git defaults include-following OFF.
+
+        Without `--includes` a driver reached through `include.path` is invisible
+        to the probe yet still resolves when git runs. The include path is
+        relative to the config file's own directory, i.e. `.git/`.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "inc")
+        (pathlib.Path(repo) / ".git" / "hostile.cfg").write_text(
+            "[filter \"evil\"]\n\tclean = sh -c ':'\n"
+        )
+        _git_config(repo, "--local", "include.path", "hostile.cfg")
+        # Precondition: git itself must resolve it, or the case proves nothing.
+        resolved = subprocess.run(
+            ["git", "-C", repo, "config", "--includes", "--get", "filter.evil.clean"],
+            capture_output=True,
+            env=_fixture_git_env(repo),
+            **UTF8_TEXT,
+        )
+        if resolved.returncode != 0:
+            pytest.skip("this git does not follow include.path here")
+        assert "filter.evil.clean" in update_governance.repo_exec_config_reason(repo)
+
+    def test_textconv_driver_is_refused(self, tmp_path):
+        """`git diff` runs a textconv driver, and its name is repo-chosen too."""
+        repo = _init_repo(tmp_path / "tc")
+        _git_config(repo, "--local", "diff.evil.textconv", "sh -c ':'")
+        assert "diff.evil.textconv" in update_governance.repo_exec_config_reason(repo)
+
+    def test_external_diff_command_is_refused(self, tmp_path):
+        """`diff.<driver>.command` REPLACES the diff with an external program.
+
+        `textconv` only converts a blob to text; `command` runs instead of the
+        diff itself. Both are repo-named and both are reached by the `git diff`
+        the update path runs, so refusing only `textconv` left this open.
+        """
+        repo = _init_repo(tmp_path / "extdiff")
+        _git_config(repo, "--local", "diff.evil.command", "sh -c ':'")
+        assert "diff.evil.command" in update_governance.repo_exec_config_reason(repo)
+
+    def test_git_proxy_is_refused_not_pinned(self, tmp_path):
+        """`core.gitProxy` has a fixed name but pinning it does not work.
+
+        Verified: with `core.gitProxy=""` supplied through `GIT_CONFIG_*`,
+        `git config --get` reports the empty value and the repository's proxy
+        program still runs on a `git://` fetch -- it is consulted as a first-match
+        list, so a higher-priority empty entry does not suppress the repo's own.
+        Refused for the same reason `core.worktree` is.
+        """
+        repo = _init_repo(tmp_path / "proxy")
+        _git_config(repo, "--local", "core.gitProxy", "sh -c ':'")
+        # git's own `--name-only --list` lowercases the key, so compare that way.
+        assert "gitproxy" in update_governance.repo_exec_config_reason(repo).lower()
+
+    def test_the_ineffective_pin_was_removed(self):
+        """Keeping it in the pin list would imply the hazard is handled there."""
+        pinned = {k.lower() for k, _ in update_governance._GIT_EXEC_NEUTRALIZERS}
+        assert "core.gitproxy" not in pinned
+        assert "core.gitproxy" in update_governance._REPO_UNPINNABLE_KEYS
+
+    def test_a_rename_hides_from_diff_filter_a_without_no_renames(self, tmp_path):
+        """Why the added-paths query carries `--no-renames`, against real git.
+
+        This asserts git's BEHAVIOUR rather than the gateway's argv, because the
+        argv is only correct for as long as this remains true. If a future git
+        stops classifying a pure `git mv` as `R` here, this test says so instead
+        of the flag quietly becoming cargo.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "rename")
+
+        def run(*argv):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=_fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        src_file = pathlib.Path(repo) / "a.txt"
+        src_file.write_text("line one\nline two\nline three\nline four\n")
+        run("git", "add", "a.txt")
+        run("git", "commit", "-qm", "base")
+        base = run("git", "rev-parse", "HEAD").stdout.strip()
+
+        run("git", "mv", "a.txt", "b.txt")
+        run("git", "commit", "-qm", "rename")
+        target = run("git", "rev-parse", "HEAD").stdout.strip()
+        run("git", "reset", "-q", "--hard", base)
+
+        with_renames = run(
+            "git", "diff", "--name-only", "--diff-filter=A", "-z", "HEAD", target
+        ).stdout
+        without = run(
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=A",
+            "--no-renames",
+            "-z",
+            "HEAD",
+            target,
+        ).stdout
+
+        names = run("git", "diff", "--name-status", "HEAD", target).stdout
+        if not names.startswith("R"):
+            pytest.skip(f"this git did not detect the rename: {names!r}")
+
+        # The bug: the destination is invisible to the guard's own query...
+        assert with_renames.strip("\0").strip() == ""
+        # ...and visible once renames are decomposed.
+        assert "b.txt" in without
+
+    def test_assume_unchanged_edit_is_invisible_to_status_but_found(self, tmp_path):
+        """The hazard and the detection, both against real git.
+
+        `git update-index --assume-unchanged` tells git to stop checking a path,
+        and git obeys it thoroughly: for an EDITED file both `status --porcelain`
+        and `diff --quiet HEAD` report clean, while `reset --hard` still overwrites
+        it. Asserting the blindness here is what makes the detection meaningful --
+        without it this test would not show why the check exists.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "assume")
+
+        def run(*argv):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=_fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        target = pathlib.Path(repo) / "tracked.txt"
+        target.write_text("original\n")
+        run("git", "add", "tracked.txt")
+        run("git", "commit", "-qm", "base")
+
+        run("git", "update-index", "--assume-unchanged", "tracked.txt")
+        target.write_text("MY PRECIOUS EDIT\n")
+
+        # The blindness: git itself reports nothing to lose.
+        assert run("git", "status", "--porcelain").stdout.strip() == ""
+        assert run("git", "diff", "--quiet", "HEAD").returncode == 0
+
+        # The detection finds it anyway.
+        assert update_governance.hidden_worktree_edits(repo) == ["tracked.txt"]
+
+    def test_an_unmodified_assume_unchanged_file_does_not_refuse(self, tmp_path):
+        """Only an ACTUAL difference is a reason to stop.
+
+        `assume-unchanged` is commonly used for local config overrides. Refusing on
+        the mere presence of the bit would disable auto-update for those checkouts
+        -- reintroducing the silent no-op this change exists to remove.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "assume-clean")
+
+        def run(*argv):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=_fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        (pathlib.Path(repo) / "cfg.txt").write_text("same\n")
+        run("git", "add", "cfg.txt")
+        run("git", "commit", "-qm", "base")
+        run("git", "update-index", "--assume-unchanged", "cfg.txt")
+
+        # Bit set, content identical -> nothing at risk.
+        assert update_governance.hidden_worktree_edits(repo) == []
+
+    def test_autocrlf_does_not_cause_a_false_refusal(self, tmp_path):
+        """`--no-filters` would refuse an UNMODIFIED file on Windows.
+
+        `core.autocrlf` is the normal Windows posture: the blob stores LF and the
+        working file holds CRLF. `--no-filters` suppresses git's BUILT-IN
+        conversions too, so a raw-byte hash mismatches for a file nobody touched
+        and the check refuses -- disabling auto-update for any such checkout.
+
+        Sets autocrlf explicitly so the Windows condition is reproduced on every
+        platform; this failed only on the Windows shard when the flag was present.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "crlf")
+
+        def run(*argv):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=_fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        run("git", "config", "core.autocrlf", "true")
+        cfg = pathlib.Path(repo) / "cfg.txt"
+        cfg.write_bytes(b"line1\nline2\n")
+        run("git", "add", "cfg.txt")
+        run("git", "commit", "-qm", "base")
+
+        # The checked-out (Windows) form, byte-for-byte what git would produce.
+        cfg.write_bytes(b"line1\r\nline2\r\n")
+        run("git", "update-index", "--assume-unchanged", "cfg.txt")
+
+        # Nobody edited it -> must NOT refuse.
+        assert update_governance.hidden_worktree_edits(repo) == []
+
+        # And a real edit under the same config is still caught.
+        cfg.write_bytes(b"line1\r\nCHANGED\r\n")
+        assert update_governance.hidden_worktree_edits(repo) == ["cfg.txt"]
+
+    def test_the_detection_does_not_write_the_index(self, tmp_path):
+        """Read-only by construction, unlike `update-index --really-refresh`.
+
+        The documented remedy surfaces the edit but WRITES the index. A check whose
+        only purpose is to decide whether mutating the checkout is safe must not
+        mutate it to find out, and unattended it would disturb the developer's own
+        index state.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "assume-ro")
+
+        def run(*argv):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=_fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        target = pathlib.Path(repo) / "tracked.txt"
+        target.write_text("original\n")
+        run("git", "add", "tracked.txt")
+        run("git", "commit", "-qm", "base")
+        run("git", "update-index", "--assume-unchanged", "tracked.txt")
+        target.write_text("MY PRECIOUS EDIT\n")
+
+        index = pathlib.Path(repo) / ".git" / "index"
+        before = index.read_bytes()
+        assert update_governance.hidden_worktree_edits(repo) == ["tracked.txt"]
+        assert index.read_bytes() == before, "the detection wrote the index"
+
+    def test_an_unreadable_index_listing_is_unsafe(self, monkeypatch):
+        """`None` means "could not determine", which the caller treats as unsafe."""
+        monkeypatch.setattr(update_governance, "_git_probe", lambda *a, **k: None)
+        assert update_governance.hidden_worktree_edits("/tmp/nope") is None
+
+    def test_no_pinned_value_is_a_bare_program_name(self, monkeypatch):
+        """A bare name hands the exec back to the agent-writable PATH.
+
+        Round 17 resolved `git` itself off PATH; pinning `core.sshCommand` to the
+        bare string "ssh" then let git resolve the TRANSPORT helper through the
+        same PATH, which is most of that hole reopened. Every program-valued pin
+        must therefore reach git as an absolute path.
+        """
+        monkeypatch.setattr(
+            update_governance.platform_compat,
+            "trusted_system_bin",
+            lambda name: f"/usr/bin/{name}",
+        )
+        env = update_governance.git_neutralizer_env()
+        count = int(env["GIT_CONFIG_COUNT"])
+        seen = 0
+        for i in range(count):
+            key = env[f"GIT_CONFIG_KEY_{i}"].lower()
+            if key in update_governance._PROGRAM_VALUED_PINS:
+                seen += 1
+                value = env[f"GIT_CONFIG_VALUE_{i}"]
+                assert os.path.isabs(value), f"{key} pinned to a bare name: {value!r}"
+        assert seen == len(update_governance._PROGRAM_VALUED_PINS)
+
+    def test_an_unresolvable_helper_fails_closed(self, monkeypatch):
+        """No trusted helper means do not run one at all.
+
+        Falling back to the bare name would reinstate the PATH hazard, so the pin
+        degrades to a value that cannot exec. For this path that is the right
+        direction: pager/editor/gpg are unreachable anyway, and a transport helper
+        that cannot be trusted should stop an unattended update.
+        """
+        monkeypatch.setattr(
+            update_governance.platform_compat, "trusted_system_bin", lambda _n: None
+        )
+        env = update_governance.git_neutralizer_env()
+        count = int(env["GIT_CONFIG_COUNT"])
+        for i in range(count):
+            key = env[f"GIT_CONFIG_KEY_{i}"].lower()
+            if key in update_governance._PROGRAM_VALUED_PINS:
+                assert env[f"GIT_CONFIG_VALUE_{i}"] == os.devnull
+
+    def test_every_program_valued_pin_names_a_real_key(self):
+        """The marker set must not drift from the pin list it annotates.
+
+        A typo here silently stops resolving that key, which looks like nothing --
+        the bare name just goes back to being PATH-resolved.
+        """
+        pinned = {k.lower() for k, _ in update_governance._GIT_EXEC_NEUTRALIZERS}
+        assert update_governance._PROGRAM_VALUED_PINS <= pinned
+
+    def test_url_insteadof_is_refused(self, tmp_path):
+        """`url.<base>.insteadOf` redirects the fetch itself.
+
+        Verified against real git: with the rewrite in repo config, a fetch given
+        the honest URL EXPLICITLY still delivered the attacker's commit -- the
+        rewrite applies below the URL argument. So validating the remote's URL
+        cannot survive one of these existing, and the base is repo-chosen so there
+        is no key name to pin.
+        """
+        repo = _init_repo(tmp_path / "rewrite")
+        _git_config(repo, "--local", "url.https://evil.invalid/.insteadOf", "https://good.invalid/")
+        reason = update_governance.repo_exec_config_reason(repo).lower()
+        assert "insteadof" in reason
+
+    def test_url_pushinsteadof_is_refused(self, tmp_path):
+        """The push-side spelling is the same mechanism and the same class."""
+        repo = _init_repo(tmp_path / "rewrite-push")
+        _git_config(
+            repo, "--local", "url.https://evil.invalid/.pushInsteadOf", "https://good.invalid/"
+        )
+        reason = update_governance.repo_exec_config_reason(repo).lower()
+        assert "insteadof" in reason
+
+    def test_loggable_path_is_always_utf8_encodable(self):
+        """A surrogate from `os.fsdecode` must not survive into a log record.
+
+        This is the property the whole helper exists for: `logging` cannot encode
+        a lone surrogate, does not propagate the error, and DROPS the record --
+        so the refusal line that proves an unattended update protected the user's
+        file is exactly the one that would vanish.
+        """
+        # Precondition: the raw form really is un-encodable, so this test cannot
+        # pass vacuously on a platform where fsdecode returned something tame --
+        # and `os.fsdecode` itself RAISES on Windows, where UTF-8 +
+        # surrogatepass cannot decode an invalid start byte, so it is inside the
+        # guard rather than above it.
+        try:
+            surrogate = os.fsdecode(b"bad\xffname.txt")
+            surrogate.encode("utf-8")
+        except UnicodeDecodeError:
+            pytest.skip("this platform cannot represent a non-UTF-8 name")
+        except UnicodeEncodeError:
+            pass
+        else:
+            pytest.skip("this platform's fsdecode produced an encodable name")
+
+        safe = update_governance.loggable_path(surrogate)
+        safe.encode("utf-8")  # must not raise
+        # The operator sees the REAL on-disk byte, not a lossy replacement char.
+        assert "\\xff" in safe
+        assert "\ufffd" not in safe
+
+    def test_loggable_path_leaves_ordinary_names_alone(self):
+        """Escaping must cost nothing for names that are already encodable.
+
+        Including non-ASCII ones -- mangling a CJK or accented path would trade a
+        rare crash for everyday unreadability.
+        """
+        for name in (
+            "pkg/mod.py",
+            "\u7b14\u8bb0/\u8bf4\u660e.md",
+            "caf\u00e9/re\u0301sume\u0301.txt",
+        ):
+            assert update_governance.loggable_path(name) == name
+
+    def test_git_is_resolved_off_path(self, monkeypatch):
+        """A planted `git` shim on PATH must not be what the update seam runs.
+
+        `AGENTS.md` requires system tools to resolve through the trusted
+        resolver; this path is the strongest case for it, because what git
+        reports here decides which code gets installed and re-executed.
+        """
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+
+            class R:
+                returncode = 0
+                stdout = "main\n"
+                stderr = ""
+
+            return R()
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(
+            update_governance.platform_compat,
+            "trusted_git_bin",
+            lambda: "/trusted/bin/git",
+        )
+        update_governance._git_probe("/tmp/proj", "rev-parse", "HEAD")
+        assert calls, "no git call was made"
+        assert calls[0][0] == "/trusted/bin/git"
+
+    def test_an_unresolvable_git_refuses_rather_than_falling_back(self, monkeypatch):
+        """`None` from the resolver means DO NOT SPAWN -- not "use a bare name".
+
+        Falling back to `"git"` would reinstate exactly the hazard the resolver
+        exists to close, so the probe must answer "could not determine" (which
+        every caller already treats as the unsafe direction) and spawn nothing.
+        """
+        spawned: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            spawned.append(list(argv))
+            raise AssertionError("git was spawned despite an unresolvable binary")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(update_governance.platform_compat, "trusted_git_bin", lambda: None)
+        assert update_governance._git_probe("/tmp/proj", "rev-parse", "HEAD") is None
+        assert spawned == []
+
+    def test_replace_objects_are_disabled(self):
+        """A replace ref makes a pinned OID resolve to different content.
+
+        The reset target is pinned to an OID precisely so it cannot change; a
+        `refs/replace/<oid>` entry defeats that by substituting what the id
+        RESOLVES TO. The opt-out must be PRESENT (unlike the location variables,
+        whose safe state is absence) because replace refs live in the repository.
+        """
+        env = update_governance.git_command_env()
+        assert env.get("GIT_NO_REPLACE_OBJECTS") == "1"
+
+    def test_a_replace_ref_cannot_substitute_the_reset_target(self, tmp_path):
+        """End-to-end against real git, both directions.
+
+        Without the variable the reset to the captured OID checks out the
+        attacker's tree; with it, the honest one. Asserting the control direction
+        keeps this from passing vacuously on a git that behaves differently.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "replace")
+
+        def run(*argv, env=None):
+            return subprocess.run(
+                argv,
+                cwd=repo,
+                capture_output=True,
+                env=env if env is not None else _fixture_git_env(repo),
+                **UTF8_TEXT,
+            )
+
+        payload = pathlib.Path(repo) / "payload.txt"
+        payload.write_text("good\n")
+        run("git", "add", "payload.txt")
+        run("git", "commit", "-qm", "good")
+        good = run("git", "rev-parse", "HEAD").stdout.strip()
+
+        payload.write_text("EVIL\n")
+        run("git", "add", "payload.txt")
+        run("git", "commit", "-qm", "evil")
+        evil = run("git", "rev-parse", "HEAD").stdout.strip()
+        run("git", "reset", "-q", "--hard", good)
+
+        made = run("git", "replace", good, evil)
+        if made.returncode != 0:
+            pytest.skip(f"git replace unavailable: {made.stderr[:200]}")
+
+        # Control: the sanitized fixture env with the opt-out REMOVED, so the two
+        # probes differ only in the thing under test.
+        control = {k: v for k, v in _fixture_git_env(repo).items() if k != "GIT_NO_REPLACE_OBJECTS"}
+        run("git", "reset", "-q", "--hard", good, env=control)
+        if payload.read_text() != "EVIL\n":
+            pytest.skip("this git does not honour replace refs on reset here")
+
+        # Protected: the seam's env.
+        run("git", "reset", "-q", "--hard", good, env=update_governance.git_command_env())
+        assert payload.read_text() == "good\n"
+
+    def test_submodule_recurse_is_pinned_off(self):
+        """`submodule.recurse` widens the reset past the superproject tree.
+
+        Pinned rather than refused because the pin was verified to work -- see
+        `test_the_submodule_pin_actually_protects_submodule_edits`, which
+        exercises real git rather than asserting the constant.
+        """
+        pins = dict(update_governance._GIT_BLAST_RADIUS_PINS)
+        assert pins.get("submodule.recurse") == "false"
+        # It execs nothing, so it must NOT be smuggled into the exec list, whose
+        # membership criterion is "git may exec this value".
+        assert "submodule.recurse" not in {
+            k.lower() for k, _ in update_governance._GIT_EXEC_NEUTRALIZERS
+        }
+
+    def test_the_pinning_env_carries_every_list(self):
+        """A second pin list is only useful if the env builder actually folds it in.
+
+        `GIT_CONFIG_COUNT` must cover both lists -- an undercount silently drops
+        the trailing pins, which is the failure this guards.
+        """
+        env = update_governance.git_neutralizer_env()
+        total = len(update_governance._GIT_EXEC_NEUTRALIZERS) + len(
+            update_governance._GIT_BLAST_RADIUS_PINS
+        )
+        assert env["GIT_CONFIG_COUNT"] == str(total)
+        keys = {env[f"GIT_CONFIG_KEY_{i}"] for i in range(total)}
+        assert "submodule.recurse" in keys
+        for key, _ in update_governance._GIT_EXEC_NEUTRALIZERS:
+            assert key in keys
+
+    def test_the_submodule_pin_actually_protects_submodule_edits(self, tmp_path):
+        """End-to-end against real git: the reset must not eat submodule work.
+
+        The hazard needs two repo settings together: `submodule.recurse` makes
+        `reset --hard` recurse, and `submodule.<name>.ignore=all` makes
+        `git status --porcelain` report a COMPLETELY CLEAN tree while the
+        submodule holds uncommitted edits -- so the work-tree refusal upstream of
+        the reset cannot see it. This asserts the control direction too: without
+        the pin the edit is destroyed, so the test cannot pass vacuously.
+        """
+        import subprocess
+
+        def run(*argv, cwd, env=None):
+            return subprocess.run(
+                argv,
+                cwd=cwd,
+                capture_output=True,
+                env=env if env is not None else _fixture_git_env(str(cwd)),
+                **UTF8_TEXT,
+            )
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        run("git", "init", "-q", ".", cwd=sub)
+        (sub / "s.txt").write_text("v1\n")
+        run("git", "add", "s.txt", cwd=sub)
+        run("git", "commit", "-qm", "s1", cwd=sub)
+
+        super_ = tmp_path / "super"
+        super_.mkdir()
+        run("git", "init", "-q", ".", cwd=super_)
+        add = run(
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            str(sub),
+            "sub",
+            cwd=super_,
+        )
+        if add.returncode != 0:
+            pytest.skip(f"submodule add unavailable here: {add.stderr[:200]}")
+        run("git", "commit", "-qm", "add submodule", cwd=super_)
+        base = run("git", "rev-parse", "HEAD", cwd=super_).stdout.strip()
+        (super_ / "top.txt").write_text("top\n")
+        run("git", "add", "top.txt", cwd=super_)
+        run("git", "commit", "-qm", "top", cwd=super_)
+        target = run("git", "rev-parse", "HEAD", cwd=super_).stdout.strip()
+
+        run("git", "config", "submodule.recurse", "true", cwd=super_)
+        run("git", "config", "submodule.sub.ignore", "all", cwd=super_)
+
+        precious = "PRECIOUS LOCAL WORK\n"
+
+        def reset_with(env):
+            run("git", "reset", "-q", "--hard", base, cwd=super_)
+            (super_ / "sub" / "s.txt").write_text(precious)
+            # The refusal upstream of the reset reads this, and it is why the pin
+            # is needed: the tree looks clean.
+            status = run("git", "status", "--porcelain", cwd=super_).stdout.strip()
+            run("git", "reset", "-q", "--hard", target, cwd=super_, env=env)
+            return status, (super_ / "sub" / "s.txt").read_text()
+
+        # Control: the SAME env with only this pin flipped back on. It cannot be
+        # `_fixture_git_env` alone -- that already builds from
+        # `git_command_env()`, so it carries the pin under test and the control
+        # would be silently pre-protected, passing the test vacuously.
+        protected = update_governance.git_command_env()
+        recursing = dict(protected)
+        count = int(recursing["GIT_CONFIG_COUNT"])
+        flipped = [
+            i for i in range(count) if recursing[f"GIT_CONFIG_KEY_{i}"] == "submodule.recurse"
+        ]
+        assert flipped, "the pin under test is not in the env at all"
+        for i in flipped:
+            recursing[f"GIT_CONFIG_VALUE_{i}"] = "true"
+
+        status, unrecursed = reset_with(recursing)
+        if unrecursed == precious:
+            pytest.skip(
+                "this git does not recurse the reset here, so the pin's effect "
+                "cannot be demonstrated"
+            )
+        assert status == "", f"expected a clean-looking tree, got {status!r}"
+
+        # Protected: the seam's own env pins submodule.recurse=false.
+        _, pinned = reset_with(protected)
+        assert pinned == precious
+
+    def test_recent_objects_hook_is_refused(self, tmp_path):
+        """`gc.recentObjectsHook` is a literal name git execs "using the shell".
+
+        By the pin list's own membership criterion it is an exec key, but it is
+        REFUSED rather than pinned because it is multi-valued -- see
+        `test_a_pin_cannot_suppress_the_recent_objects_hook`, which reproduces
+        the pin's failure instead of reasoning about it.
+        """
+        repo = _init_repo(tmp_path / "gchook")
+        _git_config(repo, "--local", "gc.recentObjectsHook", "sh -c ':'")
+        reason = update_governance.repo_exec_config_reason(repo).lower()
+        assert "recentobjectshook" in reason
+
+    def test_a_pin_cannot_suppress_the_recent_objects_hook(self, tmp_path):
+        """The reason this key is refused instead of pinned.
+
+        git documents the key as multi-valued ("Multiple hooks are supported"),
+        so an empty value from a higher-priority scope is an ADDITIONAL list
+        entry rather than an override: the repository's own value is still in the
+        list git would act on. `--get` hides this by reporting only the last
+        value, which is exactly how an ineffective pin looks like a working one --
+        the `core.gitProxy` mistake. This test fails if the key is ever
+        "handled" by moving it back to the pin list.
+        """
+        import subprocess
+
+        repo = _init_repo(tmp_path / "gchook-pin")
+        _git_config(repo, "--local", "gc.recentObjectsHook", "sh -c ':'")
+
+        # Built from the fixture env so the pin is the ONLY thing added -- an
+        # inherited GIT_DIR would otherwise point this probe at another repo.
+        env = _fixture_git_env(repo)
+        env.update(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "gc.recentObjectsHook",
+                "GIT_CONFIG_VALUE_0": "",
+            }
+        )
+        out = subprocess.run(
+            ["git", "config", "--get-all", "gc.recentObjectsHook"],
+            cwd=repo,
+            capture_output=True,
+            env=env,
+            **UTF8_TEXT,
+        ).stdout.splitlines()
+
+        # The repo's value survives the pin -- so the pin is not a fix.
+        assert "sh -c ':'" in out, out
+        assert "gc.recentobjectshook" not in {
+            k.lower() for k, _ in update_governance._GIT_EXEC_NEUTRALIZERS
+        }
+
+    def test_tls_verification_off_is_refused(self, tmp_path):
+        """`http.sslVerify=false` in the checkout makes a forged update genuine.
+
+        Combined with a hostile proxy there is nothing left distinguishing the real
+        download from an attacker's, and the update path then installs and re-execs
+        whatever arrived.
+        """
+        repo = _init_repo(tmp_path / "tls")
+        _git_config(repo, "--local", "http.sslVerify", "false")
+        reason = update_governance.repo_exec_config_reason(repo).lower()
+        assert "sslverify" in reason
+
+    def test_per_url_tls_and_proxy_spellings_are_refused(self, tmp_path):
+        """The per-URL forms are repo-NAMED, so they cannot be pinned.
+
+        Same reason `credential.<url>.helper` is refused: there is no fixed key to
+        override. Both spellings are covered so they cannot diverge.
+        """
+        for key, needle in (
+            ("http.https://example.invalid/.sslVerify", "sslverify"),
+            ("http.https://example.invalid/.proxy", "proxy"),
+            ("http.proxy", "proxy"),
+            ("http.sslCAInfo", "sslcainfo"),
+        ):
+            repo = _init_repo(tmp_path / f"tls-{needle}-{abs(hash(key)) % 9999}")
+            _git_config(repo, "--local", key, "x")
+            reason = update_governance.repo_exec_config_reason(repo).lower()
+            assert needle in reason, (key, reason)
+
+    def test_ordinary_http_settings_are_not_refused(self, tmp_path):
+        """Only TRUST-relevant keys refuse.
+
+        `http.postBuffer` and friends are performance knobs; refusing on any
+        `http.*` key would stop updates for checkouts that merely tuned one.
+        """
+        repo = _init_repo(tmp_path / "http-benign")
+        _git_config(repo, "--local", "http.postBuffer", "524288000")
+        assert update_governance.repo_exec_config_reason(repo) == ""
+
+    def test_remote_vcs_helper_is_refused(self, tmp_path):
+        """`remote.<name>.vcs` makes the FETCH exec a repo-chosen program.
+
+        git runs `git-remote-<value>` as the transport helper, resolved through
+        PATH -- verified: with `remote.origin.vcs=evil` and `git-remote-evil` on
+        PATH, the helper executed.
+
+        Refused rather than pinned, and that is not a stylistic choice: an empty
+        pin suppresses the repo's helper but leaves git treating "" as a helper
+        NAME, so every fetch dies with `remote helper '' aborted session`. Pinning
+        would disable the update path rather than protect it.
+        """
+        repo = _init_repo(tmp_path / "vcs")
+        _git_config(repo, "--local", "remote.origin.vcs", "evil")
+        reason = update_governance.repo_exec_config_reason(repo).lower()
+        assert "vcs" in reason
+
+    def test_remote_vcs_is_not_in_the_pin_list(self):
+        """A pin here would break fetching, so it must not appear as one."""
+        pinned = {k.lower() for k, _ in update_governance._GIT_EXEC_NEUTRALIZERS}
+        assert not any(k.endswith(".vcs") for k in pinned)
+
+    def test_namespaced_credential_helper_is_refused(self, tmp_path):
+        """`credential.<url>.helper` is per-URL, so pinning the bare key misses it.
+
+        The pinned `credential.helper` does not reach a per-URL form, and the URL
+        is repo-chosen, so there is no key name to override — refuse instead.
+        """
+        repo = _init_repo(tmp_path / "cred")
+        _git_config(repo, "--local", "credential.https://example.invalid.helper", "!sh -c ':'")
+        assert "credential" in update_governance.repo_exec_config_reason(repo)
+
+    def test_unreadable_config_refuses(self, monkeypatch):
+        """Cannot prove a repo driver-free, so do not proceed."""
+        monkeypatch.setattr("kiro_crew.platform.update_governance._git_probe", lambda *a, **k: None)
+        assert update_governance.repo_exec_config_reason("/proj") != ""
+
+    def test_driver_regex_agrees_with_the_worktree_gate(self):
+        """The two copies of this rule must not drift apart.
+
+        `worktree._FILTER_KEY_RE` guards the same class for `worktree add`; this
+        module carries its own because `platform/` must not import a dashboard
+        handler. Parity is asserted rather than assumed.
+        """
+        from kiro_crew.dashboard.handlers.worktree import _FILTER_KEY_RE
+
+        for key in (
+            "filter.evil.process",
+            "filter.evil.smudge",
+            "filter.evil.clean",
+            "filter.a.b.smudge",
+        ):
+            assert _FILTER_KEY_RE.match(key), key
+            assert update_governance._REPO_EXEC_DRIVER_RE.match(key), key
+        for key in ("filter.evil.required", "core.fsmonitor", "diff.external"):
+            assert not _FILTER_KEY_RE.match(key), key
+            assert not update_governance._REPO_EXEC_DRIVER_RE.match(key), key
+
+
+class TestTracksUpstream:
+    """The apply resets to `origin/<branch>`; the check measures `@{u}`.
+
+    When those are not the same ref the check measures one thing and a `--hard`
+    reset applies another, so the gap is lost commits. BOTH halves of the
+    upstream are checked, and each has its own case here because either alone
+    leaves the gap open.
+    """
+
+    def test_branch_tracking_the_same_ref_is_accepted(self, tmp_path):
+        repo = _init_repo(tmp_path / "o")
+        _git_config(repo, "--local", "branch.main.remote", "origin")
+        _git_config(repo, "--local", "branch.main.merge", "refs/heads/main")
+        assert update_governance.tracks_upstream(repo, "main")
+
+    def test_branch_tracking_another_remote_is_refused(self, tmp_path):
+        """The fork case: `main` tracks `upstream`, `origin` is a stale fork."""
+        repo = _init_repo(tmp_path / "u")
+        _git_config(repo, "--local", "branch.main.remote", "upstream")
+        _git_config(repo, "--local", "branch.main.merge", "refs/heads/main")
+        assert not update_governance.tracks_upstream(repo, "main")
+
+    def test_branch_tracking_another_branch_is_refused(self, tmp_path):
+        """Right remote, wrong branch: `@{u}` is `origin/other`, reset is `origin/main`."""
+        repo = _init_repo(tmp_path / "b")
+        _git_config(repo, "--local", "branch.main.remote", "origin")
+        _git_config(repo, "--local", "branch.main.merge", "refs/heads/other")
+        assert not update_governance.tracks_upstream(repo, "main")
+
+    def test_untracked_branch_is_refused(self, tmp_path):
+        """No upstream at all means the check had nothing to compare either."""
+        repo = _init_repo(tmp_path / "n")
+        assert not update_governance.tracks_upstream(repo, "main")
+
+    def test_remote_without_merge_is_refused(self, tmp_path):
+        """A half-configured upstream is not an upstream."""
+        repo = _init_repo(tmp_path / "h")
+        _git_config(repo, "--local", "branch.main.remote", "origin")
+        assert not update_governance.tracks_upstream(repo, "main")
+
+    def test_detached_head_is_refused(self, tmp_path):
+        repo = _init_repo(tmp_path / "d")
+        assert not update_governance.tracks_upstream(repo, "HEAD")
+        assert not update_governance.tracks_upstream(repo, "")
+
+
+class TestFixtureGitHygiene:
+    """The fixtures must not run anything the developer's environment supplies.
+
+    `git init` COPIES a template directory's hooks into the new repo and the
+    following `git commit` runs them, so an inherited `GIT_TEMPLATE_DIR` turned
+    running this suite into host-side execution.
+    """
+
+    def test_fixture_env_disables_templates_and_hooks(self, tmp_path):
+        repo = _init_repo(tmp_path / "hyg")
+        env = _fixture_git_env(repo)
+        keys = {
+            env[f"GIT_CONFIG_KEY_{i}"]: env[f"GIT_CONFIG_VALUE_{i}"]
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert env["GIT_TEMPLATE_DIR"] == ""
+        assert keys["init.templateDir"] == ""
+        assert keys["core.hooksPath"] == os.devnull
+
+    def test_a_template_hook_does_not_run(self, tmp_path, monkeypatch):
+        """The finding, reproduced end to end against real git."""
+        import subprocess
+
+        marker = tmp_path / "TEMPLATE_HOOK_RAN"
+        template = tmp_path / "tpl" / "hooks"
+        template.mkdir(parents=True)
+        hook = template / "post-commit"
+        hook.write_text(f'#!/bin/sh\ntouch "{marker}"\n')
+        hook.chmod(0o755)
+
+        # Control: with the template inherited, the hook DOES run -- otherwise
+        # this test would pass vacuously on a git that never ran it.
+        loose = tmp_path / "loose"
+        loose.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", f"--template={template.parent}", "."],
+            cwd=loose,
+            env=update_governance.git_command_env(),
+            capture_output=True,
+            **UTF8_TEXT,
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "--allow-empty", "-m", "x"],
+            cwd=loose,
+            env={
+                **update_governance.git_command_env(),
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@example.invalid",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@example.invalid",
+            },
+            capture_output=True,
+            **UTF8_TEXT,
+        )
+        if not marker.exists():
+            pytest.skip("this git did not run the template post-commit hook")
+        marker.unlink()
+
+        # The fixture helper, with GIT_TEMPLATE_DIR pointing at the same hooks.
+        # `monkeypatch.setenv` so a developer's pre-existing GIT_TEMPLATE_DIR is
+        # RESTORED afterwards -- a bare `os.environ` write plus `pop` would delete
+        # a value this test never owned and leak that into later tests.
+        monkeypatch.setenv("GIT_TEMPLATE_DIR", str(template.parent))
+        _init_repo(tmp_path / "guarded")
+        assert not marker.exists(), "fixture ran an inherited template hook"
+
+
+class TestCommitsAhead:
+    """Local commits must survive an unattended `reset --hard`.
+
+    The two checks that look like they cover this do not: `git status
+    --porcelain` reports working-tree edits rather than commits, and the
+    availability probe is satisfied by a difference in either direction.
+    """
+
+    def _repo_with_upstream(self, tmp_path, name):
+        repo = _init_repo(tmp_path / name)
+        _git_config(repo, "--local", "branch.main.remote", "origin")
+        _git_config(repo, "--local", "branch.main.merge", "refs/heads/main")
+        return repo
+
+    def test_level_checkout_is_zero(self, tmp_path):
+        import subprocess
+
+        repo = self._repo_with_upstream(tmp_path, "level")
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            env=_fixture_git_env(repo),
+            capture_output=True,
+            **UTF8_TEXT,
+        ).stdout.strip()
+        _git_update_ref(repo, "refs/remotes/origin/main", head)
+        assert update_governance.commits_ahead(repo, "origin/main") == 0
+
+    def test_local_commit_is_counted(self, tmp_path):
+        """The finding: a committed change is invisible to the other two checks."""
+        import subprocess
+
+        repo = self._repo_with_upstream(tmp_path, "ahead")
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            env=_fixture_git_env(repo),
+            capture_output=True,
+            **UTF8_TEXT,
+        ).stdout.strip()
+        _git_update_ref(repo, "refs/remotes/origin/main", head)
+        done = subprocess.run(
+            ["git", "commit", "-q", "--no-verify", "--allow-empty", "-m", "local"],
+            cwd=repo,
+            env=_fixture_git_env(repo),
+            capture_output=True,
+            **UTF8_TEXT,
+        )
+        assert done.returncode == 0, done.stderr
+        assert update_governance.commits_ahead(repo, "origin/main") == 1
+
+        # And the checks it exists to backstop really are blind to it.
+        assert (
+            subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=repo,
+                env=_fixture_git_env(repo),
+                capture_output=True,
+                **UTF8_TEXT,
+            ).stdout.strip()
+            == ""
+        ), "status sees a local commit, so this guard would be redundant"
+
+    def test_missing_upstream_ref_is_unknown_not_zero(self, tmp_path):
+        """`None`, so the caller refuses rather than reading it as 'nothing to lose'."""
+        repo = self._repo_with_upstream(tmp_path, "noref")
+        assert update_governance.commits_ahead(repo, "origin/main") is None
+
+    def test_empty_upstream_is_unknown(self, tmp_path):
+        repo = self._repo_with_upstream(tmp_path, "det")
+        assert update_governance.commits_ahead(repo, "") is None
+
+    def test_an_oid_upstream_is_accepted(self, tmp_path):
+        """The caller passes the captured OID, so that form must work.
+
+        And it is the form that matters: counting against a ref while resetting
+        to an OID is the race this signature exists to remove.
+        """
+        import subprocess
+
+        repo = self._repo_with_upstream(tmp_path, "oid")
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            env=_fixture_git_env(repo),
+            capture_output=True,
+            **UTF8_TEXT,
+        ).stdout.strip()
+        assert update_governance.commits_ahead(repo, head) == 0
+
+
+class TestGitCommandEnv:
+    """Inherited git LOCATION variables retarget every command in the sequence.
+
+    This is the environment twin of the `core.worktree` redirect: an exported
+    `GIT_DIR` points the calls at unrelated metadata while `cwd` still says the
+    project directory. It has to be ABSENT, which is why the env is built rather
+    than merged over `os.environ` -- a merge can only add or overwrite keys.
+    """
+
+    def test_location_vars_are_stripped(self, monkeypatch):
+        for var in sorted(update_governance._GIT_LOCATION_VARS):
+            monkeypatch.setenv(var, "/attacker/controlled")
+        env = update_governance.git_command_env()
+        leaked = sorted(v for v in update_governance._GIT_LOCATION_VARS if v in env)
+        assert leaked == [], leaked
+
+    def test_the_exec_pins_are_still_present(self, monkeypatch):
+        """Stripping must not have dropped the neutralizers it composes with."""
+        monkeypatch.setenv("GIT_DIR", "/attacker/controlled")
+        env = update_governance.git_command_env()
+        keys = {
+            env[f"GIT_CONFIG_KEY_{i}"]: env[f"GIT_CONFIG_VALUE_{i}"]
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert keys["core.fsmonitor"] == "false"
+        assert keys["core.hooksPath"] == os.devnull
+
+    def test_unrelated_environment_survives(self, monkeypatch):
+        """PATH and friends must come through, or git does not run at all."""
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("SOME_UNRELATED_VAR", "keep-me")
+        env = update_governance.git_command_env()
+        assert env["PATH"] == "/usr/bin"
+        assert env["SOME_UNRELATED_VAR"] == "keep-me"
+
+    def test_a_merge_would_not_have_worked(self):
+        """Documents WHY this builds instead of merging, as an assertion.
+
+        `git_neutralizer_env` names no location variable, so the old
+        `{**os.environ, **git_neutralizer_env()}` form could not have removed an
+        inherited one. If a future change tries to close this by adding a pin
+        there instead, this fails and points at the right mechanism.
+        """
+        assert not (
+            set(update_governance.git_neutralizer_env()) & update_governance._GIT_LOCATION_VARS
+        )
+
+    def test_an_inherited_git_dir_does_not_retarget_a_real_probe(self, tmp_path, monkeypatch):
+        """End to end against real git, with the control direction asserted."""
+        import subprocess
+
+        repo = _init_repo(tmp_path / "target")
+        decoy = _init_repo(tmp_path / "decoy")
+
+        def _toplevel(env):
+            done = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=repo,
+                env=env,
+                capture_output=True,
+                **UTF8_TEXT,
+            )
+            return (done.stdout or "").strip()
+
+        hijacked = _toplevel({**os.environ, "GIT_DIR": str(pathlib.Path(decoy) / ".git")})
+        if str(decoy) not in hijacked:
+            pytest.skip("this git does not honour GIT_DIR here")
+
+        # `monkeypatch.setenv` so a pre-existing GIT_DIR is RESTORED: a bare
+        # write plus `pop` would delete a value this test never owned.
+        monkeypatch.setenv("GIT_DIR", str(pathlib.Path(decoy) / ".git"))
+        assert str(decoy) not in _toplevel(update_governance.git_command_env())

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -3820,3 +3820,62 @@ class TestKillPidPinned:
 
         assert pc.kill_pid_pinned(4321, "777", pc.SIGTERM) is True
         assert killed == [(4321, pc.SIGTERM)]
+
+
+class TestTrustedGitBin:
+    """`git` resolution for privileged/unattended callers.
+
+    Moved here from `test_cli_doctor` with the logic: the doctor and the update
+    seam are two callers of one resolver, so the resolution rules belong beside
+    the resolver rather than in either caller's tests.
+    """
+
+    def test_uses_the_trusted_system_resolver(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            pc, "trusted_system_bin", lambda _n: "/usr/bin/git"
+        )
+        assert pc.trusted_git_bin() == "/usr/bin/git"
+
+    def test_windows_falls_back_to_the_git_for_windows_roots(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Git for Windows installs under Program Files, never System32.
+
+        Without the fallback every supported Windows source install resolves to
+        None, which would silently disable the callers that depend on it.
+        """
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+
+        gfw = tmp_path / "Git" / "cmd"
+        gfw.mkdir(parents=True)
+        exe = gfw / "git.exe"
+        exe.write_text("")
+        exe.chmod(0o755)
+        monkeypatch.setattr(pc, "_WINDOWS_GIT_DIRS", (str(gfw),))
+        assert pc.trusted_git_bin() == str(exe)
+
+    def test_windows_returns_none_when_the_roots_are_empty(self, monkeypatch) -> None:
+        """Fixed roots only -- a miss returns None without consulting PATH.
+
+        Reading `%ProgramFiles%` instead would let a poisoned variable redirect
+        the lookup to an agent-writable directory, which is the hole the pin
+        exists to close.
+        """
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            pc, "_WINDOWS_GIT_DIRS", (r"Z:\nonexistent\Git\cmd",)
+        )
+        assert pc.trusted_git_bin() is None
+
+    def test_posix_never_probes_the_windows_roots(self, monkeypatch) -> None:
+        """On POSIX the trusted-dirs decision is final."""
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            pc,
+            "_WINDOWS_GIT_DIRS",
+            property(lambda _s: (_ for _ in ()).throw(AssertionError("probed on POSIX"))),
+        )
+        assert pc.trusted_git_bin() is None

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -6,6 +6,7 @@ import ast
 import asyncio
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -2404,8 +2405,109 @@ class TestInitAutonudge:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+def _git_exec_fake(
+    *,
+    branch: bytes = b"mainline\n",
+    fetch_rc: int = 0,
+    diff_rc: int = 1,
+    status_out: bytes = b"",
+    status_rc: int = 0,
+    reset_rc: int = 0,
+    other_rc: int = 0,
+    target: bytes = b"0" * 40 + b"\n",
+    added_out: bytes = b"",
+    added_rc: int = 0,
+    record: list | None = None,
+):
+    """A `create_subprocess_exec` fake that dispatches on the GIT SUBCOMMAND.
+
+    Deliberately NOT a call counter. `_auto_apply_update` has gained git calls
+    three times, and each time every counter-keyed fake silently re-mapped its
+    own cases -- the stub written for `fetch` started answering the `diff`, and
+    the tests failed for a reason that had nothing to do with what they assert.
+    Dispatching on argv keeps each stub bound to the command it describes, so
+    inserting a call is not a test edit.
+
+    Defaults describe the interesting path: a branch is detected, the fetch
+    succeeds, the diff reports changes (rc=1), the tree is clean, the target adds
+    no colliding paths, the reset succeeds, and non-git spawns succeed.
+    `other_rc` fails the latter while leaving every git step green.
+
+    Note that `git diff` is now TWO distinct calls with opposite rc conventions,
+    so this dispatches on their flags. Subcommand alone is not always enough --
+    when a new call reuses a subcommand, the discriminator has to get narrower.
+    """
+
+    async def _fake(*args, **kwargs):
+        if record is not None:
+            record.append(args)
+        argv = [a for a in args if isinstance(a, str)]
+        proc = AsyncMock()
+        proc.kill = MagicMock()
+        out: bytes = b""
+        rc = 0
+        if "rev-parse" in argv and "--abbrev-ref" in argv:
+            out = branch
+        elif "rev-parse" in argv:
+            out = target
+        elif "rev-list" in argv:
+            out = b"0\n"
+        elif "fetch" in argv:
+            rc = fetch_rc
+        elif "diff" in argv and any(a.startswith("--diff-filter") for a in argv):
+            # The added-paths listing before the reset. Distinguished by its
+            # flags, not by call order: the `--quiet` check below uses rc as a
+            # BOOLEAN ("there are differences"), while this one uses rc for
+            # success and returns paths on stdout -- so answering both from one
+            # `"diff" in argv` branch made every happy-path test refuse.
+            out = added_out
+            rc = added_rc
+        elif "diff" in argv:
+            rc = diff_rc
+        elif "status" in argv:
+            out = status_out
+            rc = status_rc
+        elif "reset" in argv:
+            rc = reset_rc
+        else:
+            # Not a git step: the dependency install, the core-dep repair, the
+            # optional kiro-cli update.
+            rc = other_rc
+        proc.returncode = rc
+        proc.communicate = AsyncMock(return_value=(out, b""))
+        proc.wait = AsyncMock(return_value=rc)
+        return proc
+
+    return _fake
+
+
 class TestAutoApplyUpdateGitPath:
     """Git-based auto-update (non-toolbox)."""
+
+    @pytest.fixture(autouse=True)
+    def _permit_update_preconditions(self):
+        """Neutralize the two seam preconditions so these tests keep their subject.
+
+        `_auto_apply_update` refuses outright when the checkout declares a
+        repo-named git driver, when the branch does not track the remote it resets
+        to, or when a tracked edit is hidden by assume-unchanged. All read the REAL
+        git metadata of ``KIROCREW_PROJECT_DIR``, which these tests point at a path
+        that is not a repo — so without this they would all pass vacuously by
+        refusing before reaching the fetch/reset sequence they exist to cover. The
+        refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
+        ``TestAutoApplyUpdateResetPath``.
+        """
+        with patch(
+            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        ):
+            yield
 
     @pytest.mark.asyncio
     async def test_fetch_fails_returns_early(self):
@@ -2414,21 +2516,7 @@ class TestAutoApplyUpdateGitPath:
         orch.dashboard_state = ds
 
         # branch detection succeeds, fetch fails
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            if call_count[0] == 1:
-                # branch detection
-                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-                proc.returncode = 0
-            else:
-                # fetch fails
-                proc.communicate = AsyncMock(return_value=(b"", b"error"))
-                proc.returncode = 1
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            return proc
+        _fake_exec = _git_exec_fake(fetch_rc=1)
 
         with patch("kiro_crew.env.is_toolbox_install", return_value=False):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
@@ -2442,24 +2530,8 @@ class TestAutoApplyUpdateGitPath:
         ds = _mock_dashboard_state()
         orch.dashboard_state = ds
 
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            if call_count[0] == 1:
-                # branch detection
-                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-                proc.returncode = 0
-            elif call_count[0] == 2:
-                # fetch succeeds
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            else:
-                # diff --quiet returns 0 (no diff)
-                proc.returncode = 0
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            return proc
+        # diff --quiet reports no difference, so the run stops before the reset.
+        _fake_exec = _git_exec_fake(diff_rc=0)
 
         with patch("kiro_crew.env.is_toolbox_install", return_value=False):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
@@ -3305,6 +3377,31 @@ class TestHeartbeatCallback:
 class TestAutoApplyUpdateVenvPath:
     """Venv-based auto-update (pip install -e .)."""
 
+    @pytest.fixture(autouse=True)
+    def _permit_update_preconditions(self):
+        """Neutralize the two seam preconditions so these tests keep their subject.
+
+        `_auto_apply_update` refuses outright when the checkout declares a
+        repo-named git driver, when the branch does not track the remote it resets
+        to, or when a tracked edit is hidden by assume-unchanged. All read the REAL
+        git metadata of ``KIROCREW_PROJECT_DIR``, which these tests point at a path
+        that is not a repo — so without this they would all pass vacuously by
+        refusing before reaching the fetch/reset sequence they exist to cover. The
+        refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
+        ``TestAutoApplyUpdateResetPath``.
+        """
+        with patch(
+            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_venv_update_full_path(self):
         """Full venv update: fetch, diff, reset, pip install, restart."""
@@ -3313,44 +3410,7 @@ class TestAutoApplyUpdateVenvPath:
         orch.dashboard_state = ds
         orch.sessions = _mock_sessions()
 
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            proc.kill = MagicMock()
-            if call_count[0] == 1:
-                # branch detection → mainline
-                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-                proc.returncode = 0
-            elif call_count[0] == 2:
-                # fetch
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count[0] == 3:
-                # diff --quiet → has changes (rc=1)
-                proc.returncode = 1
-            elif call_count[0] == 4:
-                # git status --porcelain → clean
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count[0] == 5:
-                # git reset --hard
-                proc.returncode = 0
-            elif call_count[0] == 6:
-                # kiro-cli update
-                proc.returncode = 0
-            elif call_count[0] == 7:
-                # pip install -e .
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            else:
-                # extension installs, provider update
-                proc.returncode = 0
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            if not hasattr(proc, 'communicate'):
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-            return proc
+        _fake_exec = _git_exec_fake()
 
         with patch("kiro_crew.env.is_toolbox_install", return_value=False):
             with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
@@ -3902,50 +3962,51 @@ class TestReembedSweepDefersTheModelLoad:
 class TestAutoApplyUpdateResetPath:
     """Public auto-update reset path: discards local edits, builds frontend, pips."""
 
+    @pytest.fixture(autouse=True)
+    def _permit_update_preconditions(self):
+        """Neutralize the two seam preconditions so these tests keep their subject.
+
+        `_auto_apply_update` refuses outright when the checkout declares a
+        repo-named git driver, when the branch does not track the remote it resets
+        to, or when a tracked edit is hidden by assume-unchanged. All read the REAL
+        git metadata of ``KIROCREW_PROJECT_DIR``, which these tests point at a path
+        that is not a repo — so without this they would all pass vacuously by
+        refusing before reaching the fetch/reset sequence they exist to cover. The
+        refusals have their own tests in ``TestAutoApplyUpdatePreconditions`` and
+        ``TestAutoApplyUpdateResetPath``.
+        """
+        with patch(
+            "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=[]
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.commits_ahead", return_value=0
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_reset_then_frontend_then_pip(self):
-        """Local tracked edits are reset, then frontend build + pip install run.
+        """A CLEAN checkout resets, then frontend build + pip install run.
 
         Public OSS flow (no Brazil ws sync / toolbox / AIM): branch → fetch →
         diff → status → reset → [kiro-cli optional] → build frontend → pip.
+
+        This test used to pass ` M file.py` here and assert that the reset ran
+        anyway -- it encoded the warn-and-destroy behaviour that
+        `test_uncommitted_tracked_changes_refuse_the_reset` now forbids. The
+        happy path is a clean tree; the dirty tree is a refusal, not a variant
+        of this flow.
         """
         orch = _make_orchestrator()
         ds = _mock_dashboard_state()
         orch.dashboard_state = ds
         orch.sessions = _mock_sessions()
 
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            proc.kill = MagicMock()
-            if call_count[0] == 1:
-                # branch detection → mainline
-                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-                proc.returncode = 0
-            elif call_count[0] == 2:
-                # fetch
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count[0] == 3:
-                # diff --quiet → has changes (rc=1)
-                proc.returncode = 1
-            elif call_count[0] == 4:
-                # git status --porcelain → has tracked changes
-                proc.communicate = AsyncMock(return_value=(b" M file.py\n", b""))
-                proc.returncode = 0
-            elif call_count[0] == 5:
-                # git reset --hard
-                proc.returncode = 0
-            else:
-                # pip install -e . (kiro-cli skipped via shutil.which=None)
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            if not hasattr(proc, 'communicate'):
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-            return proc
+        # Clean tracked tree: nothing for the reset to discard.
+        _fake_exec = _git_exec_fake(status_out=b"")
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
@@ -3963,6 +4024,618 @@ class TestAutoApplyUpdateResetPath:
         ds.push_update_progress.assert_any_call("building", "Rebuilding package…")
 
     @pytest.mark.asyncio
+    async def test_uncommitted_tracked_changes_refuse_the_reset(self):
+        """An unattended update must not delete a developer's uncommitted work.
+
+        This check used to log a warning and reset anyway, which made the
+        boot-time path the one place that could silently destroy uncommitted
+        edits. It now refuses, like the committed-work and exec-config checks
+        immediately above it, and defers to `kirocrew update` -- where a human
+        chose the destructive semantics.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(status_out=b" M file.py\n", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                ) as mock_build:
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        # The destructive step never ran.
+        assert not any(
+            "reset" in [str(a) for a in args] for args in spawned
+        ), spawned
+        # And nothing downstream of it ran either.
+        mock_build.assert_not_awaited()
+        mock_execv.assert_not_called()
+        ds.push_refresh.assert_any_call("update_available")
+
+    @pytest.mark.asyncio
+    async def test_untracked_files_alone_do_not_refuse(self):
+        """`reset --hard` preserves untracked files, so they are not a reason to stop.
+
+        Task specs and notes live untracked in a checkout. Refusing on them would
+        disable auto-update for essentially every real install, which is the same
+        silent no-op this PR exists to remove.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(status_out=b"?? notes.md\n", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                    ):
+                        with patch("os.execv", side_effect=OSError("test")):
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        assert any("reset" in [str(a) for a in args] for args in spawned), spawned
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_git_refuses_the_whole_update(self):
+        """With no trustworthy git, the unattended path does nothing at all.
+
+        Not even the branch probe: the first spawn would already be the planted
+        shim, and it is the one that decides every later step.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.platform_compat.trusted_git_bin",
+                    return_value=None,
+                ):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async",
+                        new_callable=AsyncMock,
+                    ) as mock_build:
+                        with patch("os.execv") as mock_execv:
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        assert spawned == [], spawned
+        mock_build.assert_not_awaited()
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_every_git_step_runs_the_resolved_binary(self):
+        """One resolution, used by every step -- no bare `git` anywhere.
+
+        Resolved once rather than per call so the whole sequence runs the same
+        binary; re-resolving per spawn would leave a window for the answer to
+        change mid-update.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.platform_compat.trusted_git_bin",
+                    return_value="/trusted/bin/git",
+                ):
+                    with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                        with patch(
+                            "kiro_crew.slack.gateway.build_frontend_async",
+                            new_callable=AsyncMock,
+                        ):
+                            with patch("os.execv", side_effect=OSError("test")):
+                                with patch("shutil.which", return_value=None):
+                                    await orch._auto_apply_update()
+
+        git_calls = [
+            [str(a) for a in args]
+            for args in spawned
+            if args and str(args[0]).endswith("git")
+        ]
+        assert git_calls, spawned
+        for argv in git_calls:
+            assert argv[0] == "/trusted/bin/git", argv
+
+    @pytest.mark.asyncio
+    async def test_a_hidden_tracked_edit_refuses(self):
+        """An assume-unchanged edit must stop the unattended reset.
+
+        `status --porcelain` reports a clean tree for it, so check 3 passes and the
+        reset would silently overwrite the developer's edit.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.hidden_worktree_edits",
+                    return_value=["config/local.py"],
+                ):
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+        ds.push_refresh.assert_any_call("update_available")
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_hidden_edit_state_refuses(self):
+        """`None` cannot prove the tree is safe, so it fails closed.
+
+        Same rule as an unknown ahead-count and an unreadable status.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.hidden_worktree_edits", return_value=None
+                ):
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_untracked_collision_refuses(self, tmp_path):
+        """`reset --hard` OVERWRITES an untracked file the target adds.
+
+        This is the data-loss case that survives a clean tracked tree:
+        `git status --porcelain` reports the local file as `??`, and the
+        tracked-change refusal deliberately skips those -- so without this check
+        the reset silently replaces it. Verified against real git while
+        developing the fix.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        # The path the target would add EXISTS locally (untracked).
+        (tmp_path / "newfile.txt").write_text("MY PRECIOUS UNTRACKED WORK\n")
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=b"newfile.txt\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                ) as mock_build:
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_build.assert_not_awaited()
+        mock_execv.assert_not_called()
+        ds.push_refresh.assert_any_call("update_available")
+        # The file is still the developer's.
+        assert (tmp_path / "newfile.txt").read_text() == "MY PRECIOUS UNTRACKED WORK\n"
+
+    @pytest.mark.asyncio
+    async def test_an_obstructing_untracked_ancestor_refuses(self, tmp_path):
+        """Target adds `pkg/mod.py`; locally `pkg` is an untracked FILE.
+
+        git must replace that file with a directory, destroying it -- but
+        `lexists("pkg/mod.py")` is False, so checking only the full path misses
+        it. Verified against real git while developing the fix.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        (tmp_path / "pkg").write_text("MY PRECIOUS NOTES\n")
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=b"pkg/mod.py\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("os.execv") as mock_execv:
+                    with patch("shutil.which", return_value=None):
+                        await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+        assert (tmp_path / "pkg").read_text() == "MY PRECIOUS NOTES\n"
+
+    @pytest.mark.asyncio
+    async def test_a_symlinked_directory_ancestor_refuses(self, tmp_path):
+        """`isdir` follows a symlink, so the guard called it a plain directory.
+
+        Verified against real git: target adds `pkg/mod.py`, local untracked `pkg`
+        is a symlink to a directory, and the reset REPLACED the symlink with a real
+        directory -- destroying the developer's deliberate structure while the
+        collision guard reported nothing.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        real = tmp_path / "elsewhere"
+        real.mkdir()
+        link = tmp_path / "pkg"
+        try:
+            link.symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("this platform cannot create directory symlinks here")
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=b"pkg/mod.py\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("os.execv") as mock_execv:
+                    with patch("shutil.which", return_value=None):
+                        await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+        # The developer's symlink is still a symlink.
+        assert link.is_symlink()
+
+    @pytest.mark.asyncio
+    async def test_the_collision_scan_does_not_run_on_the_event_loop(self, tmp_path):
+        """`no-blocking-call-on-event-loop`: the ancestor walk is offloaded.
+
+        `_obstructions` stats every added path AND each of its ancestors, so a
+        large update would run an unbounded stat walk on the loop thread and stall
+        every chat and the heartbeat.
+
+        Asserts the THREAD the scan's own probes run on, not which executor object
+        some offload was handed: the first version of this test asserted the
+        latter and passed even with the scan inline, because another offload in
+        the same function already used that executor. Thread identity is the
+        property the rule is actually about.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        loop_thread = threading.current_thread()
+        probe_threads: list[threading.Thread] = []
+        real_lexists = os.path.lexists
+
+        def recording_lexists(path):
+            if "scanned-target.py" in str(path):
+                probe_threads.append(threading.current_thread())
+            return real_lexists(path)
+
+        _fake_exec = _git_exec_fake(added_out=b"deep/nested/scanned-target.py\0")
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("os.path.lexists", side_effect=recording_lexists):
+                    with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                        with patch(
+                            "kiro_crew.slack.gateway.build_frontend_async",
+                            new_callable=AsyncMock,
+                        ):
+                            with patch("os.execv", side_effect=OSError("test")):
+                                with patch("shutil.which", return_value=None):
+                                    await orch._auto_apply_update()
+
+        assert probe_threads, "the collision scan never probed the added path"
+        assert all(
+            t is not loop_thread for t in probe_threads
+        ), f"scan ran on the event-loop thread: {[t.name for t in probe_threads]}"
+
+    @pytest.mark.asyncio
+    async def test_a_junction_ancestor_refuses(self, tmp_path):
+        """A Windows junction must be treated as a link, not a directory.
+
+        `os.path.islink` returns False for a junction, so the round-20 check would
+        read one as a plain directory and let the reset write THROUGH it, outside
+        the checkout. `AGENTS.md` names `is_link_or_junction` as the required form
+        for exactly this. Asserted by faking the junction verdict, since a real
+        junction cannot be created on POSIX.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        (tmp_path / "pkg").mkdir()  # a plain dir to islink, a junction to the helper
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=b"pkg/mod.py\0", record=spawned)
+
+        def fake_link_or_junction(path):
+            return str(path).endswith("pkg")
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.platform_compat.is_link_or_junction",
+                    side_effect=fake_link_or_junction,
+                ):
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_directory_ancestor_is_not_an_obstruction(self, tmp_path):
+        """An existing DIRECTORY ancestor is normal and must not refuse.
+
+        Every update that adds a file into an existing package would otherwise
+        stop -- the over-refusal that would disable auto-update in practice.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        (tmp_path / "pkg").mkdir()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=b"pkg/mod.py\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                    ):
+                        with patch("os.execv", side_effect=OSError("test")):
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        assert any("reset" in [str(a) for a in args] for args in spawned), spawned
+
+    @pytest.mark.asyncio
+    async def test_a_non_utf8_added_path_is_still_matched(self, tmp_path):
+        """A path byte that is not valid UTF-8 must not decode into a miss.
+
+        Under `errors="replace"` the name becomes `bad\ufffdname.txt`, which does
+        not exist on disk, so the guard passes while the reset overwrites the real
+        file. `os.fsdecode` round-trips it.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        raw = b"bad\xffname.txt"
+        try:
+            (tmp_path / os.fsdecode(raw)).write_bytes(b"MY PRECIOUS\n")
+        except (OSError, UnicodeError):
+            pytest.skip("this filesystem rejects non-UTF-8 names")
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_out=raw + b"\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("os.execv") as mock_execv:
+                    with patch("shutil.which", return_value=None):
+                        await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_collision_refusal_logs_an_encodable_record(self, tmp_path, caplog):
+        """Reproduces the CI shard crash without needing xdist.
+
+        The collision refusal is the one log line carrying a filename straight
+        from git output. When that name is not valid UTF-8, an unsanitized record
+        raises inside the handler -- `logging` drops it, and `pytest-xdist`, which
+        serializes reports as UTF-8, dies with `DumpError` and takes the WHOLE
+        shard with it. That is what happened: one test killed shard 4 on both
+        Python versions while passing locally, because the local run disabled
+        `-n auto`.
+
+        Asserting encodability here is what makes the guard durable -- reverting
+        the sanitizer fails this test in a plain single-process run.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        raw = b"bad\xffname.txt"
+        # `os.fsdecode` itself RAISES on Windows (UTF-8 + surrogatepass cannot
+        # decode an invalid start byte), so it belongs inside the guard: the
+        # hazard does not exist on a platform whose filenames are UTF-16, and this
+        # must SKIP there rather than error.
+        try:
+            name = os.fsdecode(raw)
+            name.encode("utf-8")
+        except UnicodeDecodeError:
+            pytest.skip("this platform cannot represent a non-UTF-8 name")
+        except UnicodeEncodeError:
+            pass
+        else:
+            pytest.skip("this platform's fsdecode produced an encodable name")
+        try:
+            (tmp_path / name).write_bytes(b"MY PRECIOUS\n")
+        except (OSError, UnicodeError):
+            pytest.skip("this filesystem rejects non-UTF-8 names")
+
+        _fake_exec = _git_exec_fake(added_out=raw + b"\0")
+
+        with caplog.at_level(logging.WARNING):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+                with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                    with patch("os.execv"):
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        # The refusal must have been recorded...
+        refusals = [r for r in caplog.records if "already" in r.getMessage()]
+        assert refusals, [r.getMessage() for r in caplog.records]
+        # ...and EVERY record must survive a UTF-8 log sink / xdist report.
+        for record in caplog.records:
+            record.getMessage().encode("utf-8")
+
+    @pytest.mark.asyncio
+    async def test_the_added_paths_query_disables_rename_detection(self, tmp_path):
+        """Without `--no-renames` the collision guard is silently bypassable.
+
+        Rename detection is on by default for porcelain diffs, so a pure `git mv`
+        upstream is ONE `R` entry -- and `--diff-filter=A` excludes it, leaving the
+        destination path absent from the added list while the reset still
+        overwrites an untracked local file there.
+        `test_governance_updates` proves that against real git; this pins the flag
+        so the argv cannot regress.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                    ):
+                        with patch("os.execv", side_effect=OSError("test")):
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        added = [
+            [str(a) for a in args]
+            for args in spawned
+            if any(str(a).startswith("--diff-filter") for a in args)
+        ]
+        assert added, spawned
+        for argv in added:
+            assert "--no-renames" in argv, argv
+
+    @pytest.mark.asyncio
+    async def test_added_paths_that_do_not_exist_locally_do_not_refuse(self, tmp_path):
+        """Most updates add files. Only a COLLISION is a reason to stop.
+
+        Refusing whenever the target adds anything would disable auto-update for
+        ordinary upstream commits -- the silent no-op this PR exists to remove,
+        reintroduced by an over-broad guard.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        # Target adds two paths; neither exists in tmp_path.
+        _fake_exec = _git_exec_fake(added_out=b"a/new.py\0b/other.py\0", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch("kiro_crew.dep_sync.sync_or_reinstall", return_value=0):
+                    with patch(
+                        "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                    ):
+                        with patch("os.execv", side_effect=OSError("test")):
+                            with patch("shutil.which", return_value=None):
+                                await orch._auto_apply_update()
+
+        assert any("reset" in [str(a) for a in args] for args in spawned), spawned
+
+    @pytest.mark.asyncio
+    async def test_an_unlistable_added_set_refuses(self, tmp_path):
+        """If the added-path list cannot be read, safety cannot be proven.
+
+        Fails closed, like the unreadable-status and unknown-ahead-count cases.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(added_rc=1, record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": str(tmp_path)}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                ):
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_status_refuses(self):
+        """An unreadable work-tree status cannot prove the tree is clean.
+
+        The next step is irreversible, so an unanswerable question is treated as
+        the unsafe answer -- the same fail-closed rule the ahead-count uses when
+        `commits_ahead` returns None.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(status_rc=1, record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                ):
+                    with patch("os.execv") as mock_execv:
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        assert not any("reset" in [str(a) for a in args] for args in spawned), spawned
+        mock_execv.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_a_refusal_skips_the_core_dep_repair_entirely(self):
         """A REFUSED sync must not be followed by a repair into the same venv.
 
@@ -3978,17 +4651,7 @@ class TestAutoApplyUpdateResetPath:
         orch.sessions = _mock_sessions()
 
         spawned: list[tuple] = []
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            spawned.append(args)
-            proc = AsyncMock()
-            proc.kill = MagicMock()
-            proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-            proc.returncode = 1 if call_count[0] == 3 else 0
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            return proc
+        _fake_exec = _git_exec_fake(record=spawned)
 
         from kiro_crew import dep_sync
 
@@ -4012,6 +4675,49 @@ class TestAutoApplyUpdateResetPath:
         assert "restarting" not in steps
 
     @pytest.mark.asyncio
+    async def test_reset_target_is_resolved_through_the_full_remote_ref(self):
+        """The target capture must spell `refs/remotes/origin/<branch>`.
+
+        The short `origin/<branch>` is ambiguous in the attacker's favour:
+        rev-parse's disambiguation order checks `refs/tags/<name>` BEFORE
+        `refs/remotes/<name>`, so a tag literally named `origin/main` resolves
+        instead of the remote-tracking branch. The update's own fetch auto-follows
+        tags, so publishing that tag upstream creates it locally. git writes
+        "refname is ambiguous" to stderr and still prints the TAG's OID on stdout,
+        which is the stream this capture reads -- so the short form does not fail
+        loudly, it resets to attacker code.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        spawned: list[tuple] = []
+        _fake_exec = _git_exec_fake(branch=b"main\n", record=spawned)
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                with patch(
+                    "kiro_crew.slack.gateway.build_frontend_async", new_callable=AsyncMock
+                ):
+                    with patch("os.execv"):
+                        with patch("shutil.which", return_value=None):
+                            await orch._auto_apply_update()
+
+        revparses = [
+            [str(a) for a in args]
+            for args in spawned
+            if "rev-parse" in [str(a) for a in args]
+            and "--abbrev-ref" not in [str(a) for a in args]
+        ]
+        assert revparses, spawned
+        assert any("refs/remotes/origin/main^{commit}" in argv for argv in revparses), (
+            revparses
+        )
+        # The bare form must not be what git is asked to resolve.
+        assert not any("origin/main^{commit}" in argv for argv in revparses), revparses
+
+    @pytest.mark.asyncio
     async def test_no_restart_after_any_unclean_sync_even_when_the_repair_works(self):
         """A nonzero sync never restarts, even when the core-dep repair succeeds.
 
@@ -4028,18 +4734,9 @@ class TestAutoApplyUpdateResetPath:
         orch.dashboard_state = ds
         orch.sessions = _mock_sessions()
 
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            proc.kill = MagicMock()
-            proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-            # diff --quiet reports changes; everything else, INCLUDING the
-            # core-dep repair, succeeds.
-            proc.returncode = 1 if call_count[0] == 3 else 0
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            return proc
+        # diff --quiet reports changes; everything else, INCLUDING the
+        # core-dep repair, succeeds.
+        _fake_exec = _git_exec_fake()
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
@@ -4074,23 +4771,9 @@ class TestAutoApplyUpdateResetPath:
         orch.dashboard_state = ds
         orch.sessions = _mock_sessions()
 
-        call_count = [0]
-
-        async def _fake_exec(*args, **kwargs):
-            call_count[0] += 1
-            proc = AsyncMock()
-            proc.kill = MagicMock()
-            if call_count[0] == 1:
-                proc.communicate = AsyncMock(return_value=(b"mainline\n", b""))
-                proc.returncode = 0
-            elif call_count[0] == 3:
-                proc.returncode = 1  # diff --quiet -> there are changes
-            else:
-                # Everything else, INCLUDING the core-dep repair, fails.
-                proc.communicate = AsyncMock(return_value=(b"", b"boom"))
-                proc.returncode = 0 if call_count[0] in (2, 4, 5) else 1
-            proc.wait = AsyncMock(return_value=proc.returncode)
-            return proc
+        # Every git step succeeds; the dependency install AND the core-dep
+        # repair both fail, which is the condition this test is about.
+        _fake_exec = _git_exec_fake(other_rc=1)
 
         with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
@@ -7588,3 +8271,156 @@ class TestChannelSkipReasonAtTransportStart:
         with caplog.at_level(logging.WARNING):
             await self._start(orch, monkeypatch)
         assert self._channel_records(caplog) == []
+
+
+class TestAutoApplyUpdatePreconditions:
+    """The two refusals guarding the unattended reset, at the gateway level.
+
+    The seam functions have their own unit tests; these assert the gateway
+    actually HONOURS them — that it returns before spawning anything, rather than
+    computing a refusal and proceeding anyway.
+    """
+
+    @pytest.mark.asyncio
+    async def test_repo_declared_driver_refuses_before_running_a_driver(self):
+        """A repo-named filter/textconv driver would be run BY these git commands.
+
+        `-c` cannot pin an arbitrary driver name, so the run is refused. What must
+        be proven is that the refusal lands before the commands that would EXECUTE
+        such a driver — `status`, `diff` and `reset`. The branch probe ahead of it
+        is a pure ref read that runs no driver, and it carries the neutralizer env
+        regardless.
+        """
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        argvs = []
+
+        async def _fake_exec(*args, **kwargs):
+            argvs.append(args)
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.wait = AsyncMock(return_value=0)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
+            "asyncio.create_subprocess_exec", side_effect=_fake_exec
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="repository declares filter.evil.smudge",
+        ), patch(
+            "kiro_crew.slack.gateway.is_primary_branch", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ):
+            await orch._auto_apply_update()
+
+        for forbidden in ("status", "diff", "reset", "fetch"):
+            assert not any(forbidden in a for a in argvs), (forbidden, argvs)
+
+    @pytest.mark.asyncio
+    async def test_local_commits_refuse_before_the_reset(self):
+        """A checkout ahead of origin must not be `reset --hard` unattended.
+
+        Revalidated after the fetch, immediately before the reset, because the
+        availability verdict was reached in an earlier pass and a checkout is a
+        live tree. Asserts no `reset` spawn — a warning that still reset would
+        already have destroyed the commits.
+        """
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        argvs = []
+
+        async def _fake_exec(*args, **kwargs):
+            argvs.append(args)
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            # `git diff --quiet` must report a difference so the run reaches the
+            # revalidation rather than stopping at "already up to date".
+            proc.returncode = 1 if "diff" in args else 0
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
+            "asyncio.create_subprocess_exec", side_effect=_fake_exec
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.commits_ahead", return_value=2
+        ):
+            await orch._auto_apply_update()
+
+        assert not any("reset" in a for a in argvs), argvs
+
+    @pytest.mark.asyncio
+    async def test_unknown_ahead_count_also_refuses(self):
+        """`None` means git could not answer, which must not read as zero."""
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        argvs = []
+
+        async def _fake_exec(*args, **kwargs):
+            argvs.append(args)
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.returncode = 1 if "diff" in args else 0
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.wait = AsyncMock(return_value=proc.returncode)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
+            "asyncio.create_subprocess_exec", side_effect=_fake_exec
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=True
+        ), patch(
+            "kiro_crew.slack.gateway.commits_ahead", return_value=None
+        ):
+            await orch._auto_apply_update()
+
+        assert not any("reset" in a for a in argvs), argvs
+
+    @pytest.mark.asyncio
+    async def test_branch_not_tracking_origin_refuses_before_fetch(self):
+        """The check measures `@{u}`; the apply resets `origin/<branch>`.
+
+        When they are different remotes the reset would discard commits, so the
+        apply stops. Only the branch probe may have run by then — nothing that
+        fetches or writes.
+        """
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        argvs = []
+
+        async def _fake_exec(*args, **kwargs):
+            argvs.append(args)
+            proc = AsyncMock()
+            proc.kill = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.wait = AsyncMock(return_value=0)
+            return proc
+
+        with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}), patch(
+            "asyncio.create_subprocess_exec", side_effect=_fake_exec
+        ), patch(
+            "kiro_crew.slack.gateway.repo_exec_config_reason",
+            return_value="",
+        ), patch(
+            "kiro_crew.slack.gateway.tracks_upstream", return_value=False
+        ):
+            await orch._auto_apply_update()
+
+        assert not any("fetch" in a for a in argvs), argvs
+        assert not any("reset" in a for a in argvs), argvs

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -976,13 +976,16 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "mcp_gateway/gatewayd.py::main",
         "mcp_gateway/manager.py::_spawn_once",
         "mcp_gateway/stub.py::main",
-        # Read-only `git config` / `git ls-remote --get-url` resolving which
-        # remote the update would fetch from, for the `updates.source` pin. Fixed
-        # list-argv (no shell=True), no agent input: the branch lands mid-key
+        # The update seam's one read-only git chokepoint: `git config` (the
+        # `updates.source` pin's remote, the repo-driver probe, and which remote a
+        # branch tracks) and `git ls-remote --get-url`. Fixed list-argv (no
+        # shell=True), no agent input: the branch lands mid-key
         # (`branch.<x>.remote`) so it cannot lead with a dash, and the remote
         # name — which is read out of git config and COULD — is passed after
         # `--`. Must NOT be sandboxed: it reads the real checkout's git metadata.
-        "platform/update_governance.py::_git",
+        # It does carry `git_neutralizer_env()`, so repo config cannot make these
+        # reads exec a program (`core.fsmonitor` and friends are pinned).
+        "platform/update_governance.py::_git_probe",
         # Read-only `git rev-parse --show-toplevel` deciding whether the install
         # root IS a working tree. Fixed list-argv (no shell=True); the only
         # variable is the path, which comes from KIROCREW_PROJECT_DIR — an


### PR DESCRIPTION
## Summary

The unattended boot-time auto-update was gated on `branch != "mainline"`, inherited verbatim from the internal repo whose primary line carries that name. **This repo's primary line is `main`, so the gate matched nothing and returned at `logger.debug`** — every git checkout, which is the documented `install.sh` path (`git clone` + `pip install -e .`), silently stopped receiving updates with nothing in the logs to say why.

Because that gate had matched nothing for three months, **everything downstream of it was dead code** — and its latent defects go live the moment the gate starts passing. So this lands the gate fix together with the two defects that guard it, rather than re-enabling a path with known holes.

## How this surfaced

A released fix (ACP `clientInfo.name`, shipped in `0.3.0`) was not showing the expected jump in telemetry. Publishing was fine end to end — the stable feed advertises `0.3.0`, and the published wheel carries the fix:

```
$ curl -s https://updates.crew.kiro.dev/feed/stable/latest-cli.json
  "version": "0.3.0",
  "wheel_url": ".../cli/stable/0.3.0/kirocrew-0.3.0-py3-none-any.whl"

$ unzip -p kirocrew-0.3.0-py3-none-any.whl kiro_crew/acp/runtime.py | grep clientInfo
  "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
```

The artifact was correct and reachable; the *apply* side was dropping a whole cohort.

| Distribution | Auto-updated before this PR? | Path |
|---|---|---|
| Desktop (`dmg`/`appimage`/`deb`/`rpm`) | ✅ | electron-updater, per-channel feed |
| Managed wheel | ✅ | `_auto_apply_wheel_update()` |
| **`source` (git checkout)** | ❌ **silently never** | `_auto_apply_update()` → this gate |
| `docker`, source tarball | notify-only (by design) | — |

Introduced in `64e47961a` (2026-06-02), the initial de-Amazoned fork commit. No test covered the branch name. `security.py` already documents the correct answer two files away.

---

## 1. Primary-branch allowlist

`is_primary_branch` reads `PRIMARY_BRANCHES` — a literal in reviewed code — and nothing else.

Resolving the name from `refs/remotes/<remote>/HEAD` is the obvious alternative. I shipped it first and it is wrong in **both** directions; thanks to the review bot for catching each half. That is a **local** ref, one `git remote set-head` from being repointed by anything with write access to the checkout:

- **Obeying it** lets a repoint aim the boot-time `git reset --hard` + `pip install` + `execv` at an arbitrary branch of the *still-approved* origin. The source pin cannot catch it — the remote URL is unchanged.
- **Letting it merely narrow** turns the same one-command repoint into a **veto**: point a `main` checkout's pointer at `mainline` and the host silently stops updating, including for a mandatory floor, since `_auto_apply_update()` is what `update_required()` drives on a checkout (`gateway.py`). That strands the host below the administrator's `min_version`.

A test fails if any `subprocess.run` is reached from that decision.

**Cost, stated plainly:** a fork whose primary line is named something else (`develop`, `trunk`) gets no unattended update, only the badge. `kirocrew update` and the dashboard apply path still serve it, and both have a human in the loop.

## 2. Repo-controlled git exec config

`git status` and `git diff` do not merely *read* config — they **spawn** the program named in `core.fsmonitor`, and a reset runs hooks. All five git invocations here ran on an agent-writable tree with none of that neutralized.

**Keys whose name is fixed are pinned** via `GIT_CONFIG_*` (same precedence as `-c`), bound once ahead of the first spawn so the whole sequence is covered and a later-added command cannot quietly opt out.

The list now carries its **membership criterion** in a comment — *"git may exec this value, and the key is a literal"* — because the first version was an enumeration without one and was therefore missing `core.gitProxy` (caught in review), along with `core.askPass`, `core.alternateRefsCommand`, `uploadpack.packObjectsHook`, the pager/editor keys and `gpg.program`. A test asserts the criterion over the whole set rather than one key at a time, so the next omission fails here instead of in review.

Verified empirically, asserted in both directions so it cannot pass vacuously:

```
WITHOUT neutralizer    fsmonitor executed: True
WITH neutralizer       fsmonitor executed: False
```

**Keys whose name is repo-chosen are refused**, not pinned — there is nothing to override. Same call `worktree._checkout_filter` makes for `worktree add`. Both scopes are probed with `--includes`, and both details are load-bearing:

| Case | Caught |
|---|---|
| clean repo | allowed |
| `--local` `filter.evil.smudge` | refused |
| `--worktree` `filter.evil.process` (a `--local` listing does not report it) | refused |
| `include.path` → `filter.evil.clean` (invisible without `--includes`) | refused |
| `diff.evil.textconv` | refused |
| `credential.<url>.helper` (per-URL, so the pinned bare key misses it) | refused |
| unreadable config scope | refused (cannot prove it clean) |

Each is tested against a **real git repo**, because these cases exist precisely where a mock would not reproduce git's own resolution. The `include.path` test asserts git itself resolves the driver first, so it cannot pass on a broken fixture.

## 3. Check / apply ref mismatch

The availability check compares `HEAD` against **`@{u}`** — whatever the branch tracks (`dashboard/handlers/updates.py`) — while the apply resets to **`origin/<branch>`**. When those are not the same ref the check measures one thing and a `--hard` reset applies another, so the gap is lost commits rather than a stale answer.

`tracks_upstream` requires **both halves** of the upstream to match, because either alone leaves it open:

- **the remote** — a fork checkout whose `main` tracks `upstream/main` while `origin` is the user's own stale fork;
- **the branch** — `branch.main.remote=origin` with `branch.main.merge=refs/heads/other`, which still points `@{u}` at `origin/other` while the reset targets `origin/main`. (The remote-only check was the first version; the branch half was caught in review.)

---

## Two other intentional behaviour changes

- **A detached HEAD is no longer primary.** The old code fabricated `branch = "mainline"` for it, which on an internal clone would have let a boot-time `git reset --hard` move a deliberately detached checkout.
- **The skip logs at `info`, not `debug`,** so an operator can see why a host is not updating. The sibling wheel-mismatch branch already warns; this one said nothing at all.

## Notes for review

- `PRIMARY_BRANCHES` mirrors `security._PROTECTED_BRANCHES` by intent (the branch an unattended update may reset to is exactly the branch a push must never target) but is kept separate so update routing does not reach into a security-module private. The neutralizer list likewise mirrors the app-side git callers — `platform/` must not import from `apps/` — and a test asserts the driver regex stays in agreement with the worktree gate's.
- `test_spawn_audit`'s allowlist entry moves with the subprocess call, from `resolve_remote_url`'s former nested helper to the shared `_git_probe`, justification extended to the new callers.
- The three existing `_auto_apply_update` test classes gain an autouse fixture neutralizing the new preconditions, so they keep covering the reset sequence instead of passing vacuously by refusing first.
- **Deliberately not changed:** `cli_server.py`'s `or "mainline"` fallback for a detached HEAD. Reached only when branch detection returns nothing, then fails loudly at `git fetch origin mainline` — a confusing-error wart on a user-initiated path, not a silent no-op.

## Testing

71 cases in `test_governance_updates` + `TestAutoApplyUpdatePreconditions` in `test_slack_gateway`, which asserts the gateway *honours* both refusals before spawning anything that would run a driver or fetch.

**Mutation-verified nine ways:** restoring the `mainline` hardcode fails 4 (the real-checkout test included); reintroducing a pointer read fails 3; unpinning `core.fsmonitor` fails 2 (including the real-git exec test); dropping `core.gitProxy` fails the criterion test; dropping `--includes` fails the include case; dropping the `--worktree` scope fails the worktree case; dropping the namespaced-credential branch fails its case; dropping either half of the upstream check fails 1–2; and removing either gateway refusal fails its own test.

Local gates green: `pytest` 538 across the update/gateway/governance/spawn-audit/cli-server suites, `flake8`, `isort`, `mypy`, black baseline gate, woke scan of added lines.
