### PR TITLE
fix: guard useListKeyboardNav's choose keys against IME composition (#5340)

### DIFF
--- a/website/src/hooks/useImeGuard.ts
+++ b/website/src/hooks/useImeGuard.ts
@@ -1,27 +1,96 @@
 import { useRef, useEffect, type KeyboardEvent, type FocusEvent } from 'react'
 
 /**
+ * How long after `compositionend` an Enter keydown still belongs to the IME.
+ * On WebKit the keydown that commits a candidate arrives AFTER
+ * `compositionend` with `isComposing` already false, so the native flags alone
+ * cannot identify it — the tracked latch below outlives them by this window.
+ */
+const POST_COMPOSITION_MS = 50
+
+export interface ImeLatch {
+  onCompositionStart: () => void
+  onCompositionEnd: () => void
+  /** True while a composition is live or inside the post-composition window. */
+  isLatched: () => boolean
+  /** Clear the latch and any pending timer (stale-latch recovery). */
+  reset: () => void
+  /**
+   * Native-event twin of `useImeGuard().claimEnter`: take ownership of a key
+   * the caller has decided is a choose/submit key, and report whether to act.
+   * `true` = act on it (the caller consumes it as part of acting). `false` =
+   * the IME owns this keypress; the claim has already consumed it — always
+   * `stopPropagation()` (so it cannot fall through to the host composer), and
+   * `preventDefault()` only when both native signals are clear (the
+   * post-composition latch window, where the browser would otherwise act).
+   * A mid-composition key keeps its default action: the browser is consuming
+   * it for the candidate commit or candidate navigation itself, and
+   * cancelling that would eat the user's composition. Owning both halves in
+   * one place is the point — a call site re-spelling the split is the drift
+   * the `ImeEnterClaimRatchet` exists to prevent.
+   */
+  claimKey: (e: globalThis.KeyboardEvent) => boolean
+}
+
+/**
+ * The tracked half of the IME guard, framework-free so both event worlds share
+ * ONE latch spelling: `useImeGuard` layers it under React synthetic events, and
+ * native-event listeners (document-level keydown handlers, which never see a
+ * synthetic event and therefore cannot call `claimEnter`) consume it directly —
+ * `useListKeyboardNav` is the reference consumer. A private flag-and-timer copy
+ * in a native handler is exactly the drift the `ImeEnterClaimRatchet` pins.
+ *
+ * `latched` stays true from `compositionstart` until POST_COMPOSITION_MS after
+ * `compositionend`. The timer handle is cleared on every new
+ * `compositionstart`, so a stale timer cannot flip the latch back to false
+ * while a follow-up (back-to-back) composition is mid-flight.
+ */
+export function createImeLatch(): ImeLatch {
+  let latched = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const isLatched = () => latched
+  return {
+    onCompositionStart() {
+      clearTimeout(timer)
+      latched = true
+    },
+    onCompositionEnd() {
+      latched = true
+      timer = setTimeout(() => { latched = false }, POST_COMPOSITION_MS)
+    },
+    isLatched,
+    reset() {
+      clearTimeout(timer)
+      latched = false
+    },
+    claimKey(e: globalThis.KeyboardEvent) {
+      const composing = latched || e.isComposing || e.keyCode === 229
+      if (!composing) return true
+      if (!e.isComposing && e.keyCode !== 229) e.preventDefault()
+      e.stopPropagation()
+      return false
+    },
+  }
+}
+
+/**
  * Guard against IME composition Enter falsely triggering submit handlers.
  *
  * IME (Chinese/Japanese/Korean) sends a final Enter to commit the composition.
  * React's synthetic `isComposing` is sometimes false on that final Enter, so
  * this hook layers multiple guards:
  *
- *   1. `composingRef`              - true from compositionStart until 50ms
- *                                    after compositionEnd (timer-based)
+ *   1. the tracked latch (`createImeLatch`) - true from compositionStart until
+ *                                    50ms after compositionEnd (timer-based)
  *   2. `e.nativeEvent.isComposing` - native browser flag
  *   3. `e.keyCode === 229`         - "IME processing" keyCode some browsers
  *                                    emit while composition is in flight even
  *                                    after isComposing flips to false
  *
- * The 50ms guard is tracked via `setTimeout` whose handle is cleared on every
- * new `compositionStart` - prevents a stale timer from flipping composingRef
- * back to false while a follow-up (back-to-back) composition is mid-flight.
- *
  * **Sharing a single hook instance across multiple inputs:** If the hosting
  * component unmounts an input mid-composition (e.g. Escape cancels a rename
  * and removes the input from the tree), `compositionEnd` will never fire and
- * `composingRef` would stay true forever, blocking Enter on every input that
+ * the latch would stay set forever, blocking Enter on every input that
  * shares this hook. Recovery therefore ships WITH the tracking: the only
  * composition binding this hook exposes carries the blur reset, so a surface
  * cannot opt out of it by omission. That matters more now than it used to,
@@ -37,7 +106,7 @@ import { useRef, useEffect, type KeyboardEvent, type FocusEvent } from 'react'
  * remember that. It suppresses the default only where the browser would
  * otherwise act — both native signals clear — and leaves a keypress the IME is
  * itself consuming alone. The window this matters in is not hypothetical: the
- * `composingRef` timer above outlives the native signals by 50ms, and a fast
+ * latch timer above outlives the native signals by 50ms, and a fast
  * typist's send lands inside it.
  *
  * Usage (simple Enter/Escape inputs):
@@ -54,28 +123,20 @@ import { useRef, useEffect, type KeyboardEvent, type FocusEvent } from 'react'
  *   />
  */
 export function useImeGuard() {
-  const composingRef = useRef(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+  const latchRef = useRef<ImeLatch>()
+  if (!latchRef.current) latchRef.current = createImeLatch()
+  const latch = latchRef.current
 
   // Clear any pending post-composition timer when the host component unmounts.
-  // Prevents stale timer callbacks from writing to the ref after teardown.
-  useEffect(() => () => { clearTimeout(timerRef.current) }, [])
+  // Prevents stale timer callbacks from writing to the latch after teardown.
+  useEffect(() => () => { latch.reset() }, [latch])
 
-  const reset = () => {
-    clearTimeout(timerRef.current)
-    composingRef.current = false
-  }
+  const reset = () => latch.reset()
 
-  const onCompositionStart = () => {
-    clearTimeout(timerRef.current)
-    composingRef.current = true
-  }
-  const onCompositionEnd = () => {
-    composingRef.current = true
-    timerRef.current = setTimeout(() => { composingRef.current = false }, 50)
-  }
+  const onCompositionStart = () => latch.onCompositionStart()
+  const onCompositionEnd = () => latch.onCompositionEnd()
   const isComposing = (e: KeyboardEvent) =>
-    composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229
+    latch.isLatched() || e.nativeEvent.isComposing || e.keyCode === 229
 
   /**
    * Take ownership of an Enter the caller has already decided is a submit key,
@@ -107,7 +168,7 @@ export function useImeGuard() {
    *
    * The blur reset is not optional and not the caller's to remember. A composition
    * abandoned WITHOUT a `compositionend` — focus moves away mid-composition, the
-   * element unmounts, an OS-level IME cancel — leaves `composingRef` latched, and a
+   * element unmounts, an OS-level IME cancel — leaves the latch set, and a
    * latched guard declines every later Enter for the element's lifetime. Since
    * `claimEnter` also consumes those keypresses, a latched guard is SILENT: the
    * surface simply stops sending. So the recovery ships with the tracking, and a

--- a/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
+++ b/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { useListKeyboardNav, type UseListKeyboardNavOptions } from './useListKeyboardNav'
+
+/**
+ * IME guard on the Enter-chooses-row path (document-capture NATIVE keydown).
+ *
+ * This hook's listener receives native KeyboardEvents, so it cannot consume
+ * `useImeGuard`'s synthetic-only `claimEnter`; it shares the guard's tracked
+ * latch via `createImeLatch` instead. On WebKit the keydown that commits an
+ * IME candidate arrives AFTER `compositionend` with `isComposing` already
+ * false — unguarded, committing a candidate into a picker's filter query
+ * activated whatever row was highlighted (#5340).
+ */
+
+function Harness(props: Partial<UseListKeyboardNavOptions>) {
+  useListKeyboardNav({
+    open: true,
+    count: 3,
+    onChoose: () => {},
+    onClose: () => {},
+    ...props,
+  })
+  return <input data-testid="host-input" />
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+const enter = (init: KeyboardEventInit & { keyCode?: number } = {}) =>
+  fireEvent.keyDown(document, { key: 'Enter', ...init })
+
+describe('useListKeyboardNav IME guard', () => {
+  it('plain Enter still chooses the selected row (positive control)', () => {
+    const onChoose = vi.fn()
+    render(<Harness onChoose={onChoose} />)
+    const notPrevented = enter()
+    expect(onChoose).toHaveBeenCalledWith(0, false)
+    expect(notPrevented).toBe(false) // consumed by the choose path
+  })
+
+  it('declines a mid-composition Enter (native flag) without cancelling the commit', () => {
+    const onChoose = vi.fn()
+    render(<Harness onChoose={onChoose} />)
+    const notPrevented = enter({ isComposing: true })
+    expect(onChoose).not.toHaveBeenCalled()
+    // The browser is consuming this key for the candidate commit itself, so
+    // the guard must not cancel its default action (claimEnter's split).
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines a keyCode-229 Enter without cancelling the commit', () => {
+    const onChoose = vi.fn()
+    render(<Harness onChoose={onChoose} />)
+    const notPrevented = enter({ keyCode: 229 })
+    expect(onChoose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines the committing Enter in the post-composition window AND consumes it', () => {
+    const onChoose = vi.fn()
+    const { getByTestId } = render(<Harness onChoose={onChoose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    // WebKit reports the committing keydown as non-composing; only the
+    // tracked latch can identify it. Nothing live is cancelled, so the key is
+    // fully consumed rather than falling through to the host composer.
+    const notPrevented = enter()
+    expect(onChoose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('chooses again once the post-composition window has elapsed', () => {
+    vi.useFakeTimers()
+    const onChoose = vi.fn()
+    const { getByTestId } = render(<Harness onChoose={onChoose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    vi.advanceTimersByTime(60)
+    enter()
+    expect(onChoose).toHaveBeenCalledWith(0, false)
+  })
+
+  it('does not inherit a stale latch across a close/reopen', () => {
+    const onChoose = vi.fn()
+    const { getByTestId, rerender } = render(<Harness onChoose={onChoose} />)
+    // Abandoned mid-composition: no compositionend follows before close.
+    fireEvent.compositionStart(getByTestId('host-input'))
+    rerender(<Harness open={false} onChoose={onChoose} />)
+    rerender(<Harness onChoose={onChoose} />)
+    enter()
+    expect(onChoose).toHaveBeenCalledWith(0, false)
+  })
+
+  it('keeps releasing Enter to the host on an empty list, composing or not', () => {
+    // The empty-list release path has no claim on the keystroke and must stay
+    // untouched: the host composer carries its own IME guard.
+    const onChoose = vi.fn()
+    const onClose = vi.fn()
+    const { getByTestId } = render(
+      <Harness count={0} releaseKeysWhenEmpty onChoose={onChoose} onClose={onClose} />,
+    )
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    const notPrevented = enter()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onChoose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(true) // released, not consumed
+  })
+
+  it('keeps the latch armed across an unrelated prop change inside the window', () => {
+    // Consumers derive releaseKeysWhenEmpty from live query/fetch state, and
+    // the commit's own input event mutates that state right before the
+    // committing keydown arrives. The handler resubscribing on the prop
+    // change must not reset the latch (the composition effect is keyed on
+    // `open` alone).
+    const onChoose = vi.fn()
+    const { getByTestId, rerender } = render(<Harness onChoose={onChoose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    rerender(<Harness onChoose={onChoose} releaseKeysWhenEmpty />)
+    const notPrevented = enter()
+    expect(onChoose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('declines Tab during composition — Tab is the same choose dispatch', () => {
+    // IMEs use Tab to cycle the candidate list, and the hook's Tab branch is
+    // an unconditional onChoose otherwise.
+    const onChoose = vi.fn()
+    const { getByTestId } = render(<Harness onChoose={onChoose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(onChoose).not.toHaveBeenCalled()
+  })
+
+  it('recovers from an abandoned composition when focus moves away', () => {
+    // No compositionend ever fires (OS-level IME cancel, focus stolen
+    // mid-composition). Without the focusout recovery the latch would stay
+    // set and consume every later Enter for the rest of the open.
+    const onChoose = vi.fn()
+    const { getByTestId } = render(<Harness onChoose={onChoose} />)
+    const input = getByTestId('host-input')
+    input.focus()
+    fireEvent.compositionStart(input) // abandoned: no compositionEnd follows
+    input.blur()
+    enter()
+    expect(onChoose).toHaveBeenCalledWith(0, false)
+  })
+
+  it('leaves the Tab and modifier-Enter contracts unchanged', () => {
+    const onChoose = vi.fn()
+    render(<Harness onChoose={onChoose} />)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(onChoose).toHaveBeenLastCalledWith(0, false)
+    enter({ metaKey: true })
+    expect(onChoose).toHaveBeenLastCalledWith(0, true)
+  })
+
+  it('honors onAltEnter after the guard clears', () => {
+    const onChoose = vi.fn()
+    const onAltEnter = vi.fn(() => true)
+    render(<Harness onChoose={onChoose} onAltEnter={onAltEnter} />)
+    enter({ altKey: true })
+    expect(onAltEnter).toHaveBeenCalledWith(0)
+    expect(onChoose).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/hooks/useListKeyboardNav.ts
+++ b/website/src/hooks/useListKeyboardNav.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { createImeLatch } from './useImeGuard'
 
 /**
  * Shared list keyboard-navigation hook for picker-menu / palette surfaces
@@ -16,6 +17,10 @@ import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
  *    palette uses it to cycle category tabs) registers its own *window*-capture
  *    listener — which runs before this document-capture one — and calls
  *    `stopImmediatePropagation()` so this handler never sees the event.
+ *    Both choose keys are IME-guarded: while a composition is live or inside
+ *    the post-composition latch window (shared with `useImeGuard` via
+ *    `createImeLatch`), the key declines the choose and is consumed per
+ *    `claimKey`'s contract instead.
  *  - `Alt`/`Option`+`Enter`  — `onAltEnter(selected)` when provided; if it
  *    returns `true` the event is treated as handled.
  *  - `Escape`                — `onClose()`.
@@ -93,6 +98,19 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
   const onAltEnterRef = useRef(onAltEnter)
   onAltEnterRef.current = onAltEnter
 
+  // IME guard for the Enter-chooses-row path. This listener receives NATIVE
+  // KeyboardEvents (document capture), which `useImeGuard`'s synthetic-only
+  // `claimEnter` cannot consume — so it shares the guard's tracked latch via
+  // `createImeLatch` instead of hand-rolling a second spelling. On WebKit the
+  // keydown that commits an IME candidate arrives AFTER `compositionend` with
+  // `isComposing` already false; unguarded, committing a candidate into the
+  // filter query would activate whatever row is highlighted (switch project,
+  // insert a file/skill/slash command, dispatch a palette row) against
+  // half-composed text. The latch lives in a ref so `onKey` reads the live
+  // value without re-subscribing.
+  const imeLatchRef = useRef<ReturnType<typeof createImeLatch>>()
+  if (!imeLatchRef.current) imeLatchRef.current = createImeLatch()
+
   const move = useCallback((next: number) => {
     selectedRef.current = next
     setSelected(next)
@@ -141,6 +159,17 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
       }
       return
     }
+    // A choose key the IME owns must not activate the row. `claimKey` owns
+    // the whole decline (stopPropagation always; preventDefault only in the
+    // post-composition latch window where the browser would otherwise act) —
+    // see its contract in useImeGuard.ts. Covers Tab as well as Enter: IMEs
+    // use Tab to cycle the candidate list, and Tab is the same unconditional
+    // choose dispatch below. Deliberately after the empty-list block above,
+    // whose release path must stay untouched (the host composer carries its
+    // own IME guard).
+    if ((e.key === 'Enter' || e.key === 'Tab') && !imeLatchRef.current!.claimKey(e)) {
+      return
+    }
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       e.stopPropagation()
@@ -171,6 +200,45 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
       onChooseRef.current(selectedRef.current, false)
     }
   }, [move, wrap, releaseKeysWhenEmpty])
+
+  // Composition tracking + latch lifecycle, keyed on `open` ONLY. The keydown
+  // subscription below re-attaches whenever `onKey`'s identity changes (wrap /
+  // releaseKeysWhenEmpty — consumers derive the latter from live query/fetch
+  // state), and a latch reset riding along on that churn would clear the
+  // post-composition window at exactly the moment it matters: the commit's own
+  // input event mutates the query right before the committing keydown arrives.
+  // Same constraint useListboxKeyboard states for its guard ("no reset()
+  // firing mid-composition on unrelated re-renders").
+  useEffect(() => {
+    if (!open) return
+    const latch = imeLatchRef.current!
+    // A reopened surface must not inherit a latch stranded by a composition
+    // that ended (or was abandoned) while it was closed.
+    latch.reset()
+    // Composition tracking listens at document capture like the keydown
+    // listener itself: the filter input these surfaces pair with lives in the
+    // host (outside the menu), so element-scoped listeners have nothing
+    // reliable to attach to.
+    const onCompositionStart = () => latch.onCompositionStart()
+    const onCompositionEnd = () => latch.onCompositionEnd()
+    // Stranded-latch recovery, mirroring bindComposition's blur reset: a
+    // composition abandoned WITHOUT compositionend (focus moves off the input
+    // mid-composition, an OS-level IME cancel, the element unmounts) would
+    // otherwise leave the latch set — and a latched guard consumes what it
+    // declines, so the surface would silently stop responding to Enter/Tab.
+    const onRecover = () => latch.reset()
+    document.addEventListener('compositionstart', onCompositionStart, true)
+    document.addEventListener('compositionend', onCompositionEnd, true)
+    document.addEventListener('focusout', onRecover, true)
+    return () => {
+      document.removeEventListener('compositionstart', onCompositionStart, true)
+      document.removeEventListener('compositionend', onCompositionEnd, true)
+      document.removeEventListener('focusout', onRecover, true)
+      // Drop any pending post-composition timer with the listeners so a timer
+      // from the closing surface cannot fire into the next open.
+      latch.reset()
+    }
+  }, [open])
 
   useEffect(() => {
     if (!open) return

--- a/website/src/test/ImeEnterClaimRatchet.test.ts
+++ b/website/src/test/ImeEnterClaimRatchet.test.ts
@@ -136,6 +136,44 @@ function scanShadowedBindings(lines: string[]): number[] {
   return hits
 }
 
+/**
+ * A `compositionstart` subscription is the seed of a composition LATCH, and a
+ * latch hand-rolled beside a native handler is the second spelling this
+ * ratchet exists to prevent: its author re-derives the flag-and-timer
+ * semantics (the post-`compositionend` window, the stale-timer clear, the
+ * stranded-latch recovery) and reliably gets one of them wrong. So each
+ * subscription must feed the shared latch — `useImeGuard` for synthetic
+ * handlers, its `createImeLatch` factory for native ones (document-capture
+ * keydown listeners never see a synthetic event, so `claimEnter` is
+ * structurally unavailable to them; `useListKeyboardNav` is the reference
+ * consumer). The exemption is judged in a bounded window around EACH
+ * subscription, on comment-stripped lines: a whole-file test would let one
+ * sanctioned latch (or a mere comment mention) exempt every other
+ * subscription in the file. The window accepts either the shared-guard call
+ * itself or a handler delegating into a latch's own `onCompositionStart()`
+ * (both in-tree consumers wire it through a one-line arrow). A
+ * `compositionend`-only grace window (TerminalCompletion's xterm handler
+ * tracks a timestamp, not a latch) does not subscribe to `compositionstart`
+ * and stays out of scope — a structural distinction, not a pardoned file.
+ */
+const COMPOSITION_SUBSCRIBE = /addEventListener\(\s*['"]compositionstart['"]/
+const SHARED_LATCH = /\b(?:useImeGuard|createImeLatch)\(|\.onCompositionStart\(\)/
+const LATCH_WINDOW = 12
+
+function scanUnlatchedCompositionSubscribers(lines: string[]): number[] {
+  const code = lines.map(l => {
+    const t = l.trim()
+    return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') ? '' : l
+  })
+  const hits: number[] = []
+  code.forEach((line, i) => {
+    if (!COMPOSITION_SUBSCRIBE.test(line)) return
+    const windowLines = code.slice(Math.max(0, i - LATCH_WINDOW), i + LATCH_WINDOW + 1)
+    if (!windowLines.some(l => SHARED_LATCH.test(l))) hits.push(i + 1)
+  })
+  return hits
+}
+
 describe('IME Enter claim ratchet', () => {
   it('routes every Enter-submit branch through the guard', () => {
     const offenders: string[] = []
@@ -211,6 +249,26 @@ describe('IME Enter claim ratchet', () => {
     expect(offenders).toEqual([])
   })
 
+  it('never hand-rolls a composition latch beside a native handler', () => {
+    // A `compositionstart` subscription outside the guard module must feed the
+    // shared latch (`useImeGuard` / `createImeLatch`), never a private flag —
+    // the native-event twin of the one-line rule above. `useListKeyboardNav`
+    // shipped exactly the gap this pins: a document-capture Enter dispatch
+    // with no composition reference at all, which on WebKit activated the
+    // highlighted picker row with the keydown that committed an IME candidate.
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (rel === 'hooks/useImeGuard.ts') continue
+      const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
+      for (const n of scanUnlatchedCompositionSubscribers(lines)) {
+        offenders.push(`${rel}:${n}`)
+      }
+    }
+    // An entry here tracks composition with its own state. Consume
+    // `createImeLatch()` (native handlers) or `useImeGuard()` (synthetic).
+    expect(offenders).toEqual([])
+  })
+
   it('keeps every React handler off the raw composition flag', () => {
     // The Enter check above only sees the two on one line. `SearchableSelect` guarded
     // Enter with a bare `e.nativeEvent.isComposing` early-return one line ABOVE the
@@ -244,7 +302,11 @@ describe('IME Enter claim ratchet', () => {
     // the only place that can make that unreachable, so it must not hand out a
     // recovery-less binding for a caller to pick by mistake.
     const hook = readFileSync(join(SRC, 'hooks/useImeGuard.ts'), 'utf8')
-    const returned = /return \{([^}]*)\}/.exec(hook)?.[1] ?? ''
+    // Anchor on the hook itself: the file also exports the `createImeLatch`
+    // factory (the tracked latch shared with native-event consumers), whose
+    // own `return {` would otherwise be the first match.
+    const hookBody = hook.slice(hook.indexOf('export function useImeGuard'))
+    const returned = /return \{([^}]*)\}/.exec(hookBody)?.[1] ?? ''
     expect(returned).toContain('bindComposition')
     expect(returned.split(',').map(s => s.trim())).not.toContain('composition')
     // Every binding the hook returns carries onBlur.
@@ -346,5 +408,32 @@ describe('ratchet rule fixtures', () => {
           e.currentTarget.blur()
         }
       }}`))).toHaveLength(1)
+  })
+
+  it('flags a compositionstart subscription that feeds a private flag, not the shared latch', () => {
+    const handRolled = jsx(`
+      let composing = false
+      document.addEventListener('compositionstart', () => { composing = true }, true)
+      document.addEventListener('compositionend', () => { composing = false }, true)`)
+    expect(scanUnlatchedCompositionSubscribers(handRolled)).toHaveLength(1)
+    // The sanctioned shapes: the same subscription feeding the shared latch,
+    // via the factory call or a handler delegating into it.
+    expect(scanUnlatchedCompositionSubscribers(jsx(`
+      const latch = createImeLatch()
+      document.addEventListener('compositionstart', () => latch.onCompositionStart(), true)`))).toHaveLength(0)
+    expect(scanUnlatchedCompositionSubscribers(jsx(`
+      const onStart = () => imeRef.current.onCompositionStart()
+      el.addEventListener('compositionstart', onStart)`))).toHaveLength(0)
+    // A compositionend-only grace window (TerminalCompletion's xterm handler)
+    // is a timestamp, not a latch, and stays out of scope.
+    expect(scanUnlatchedCompositionSubscribers(jsx(`
+      ta.addEventListener('compositionend', done)`))).toHaveLength(0)
+    // The exemption is per subscription and ignores comments: a hand-rolled
+    // flag is still flagged when the sanctioned latch is merely mentioned in
+    // a nearby comment, or lives elsewhere in the same file beyond the window.
+    expect(scanUnlatchedCompositionSubscribers(jsx(`
+      // the shared guard is createImeLatch(), which this deliberately skips
+      let composing = false
+      document.addEventListener('compositionstart', () => { composing = true }, true)`))).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

`useListKeyboardNav` — the shared list-keyboard-navigation hook behind six picker surfaces (SkillPickerMenu, FilePickerMenu, SlashCommandMenu, CommandPalette, ProjectPicker's Recent tab, and SettingsSearch) — installs a document-level capture-phase `keydown` listener whose Enter and Tab branches call `onChoose(selected)` with no IME composition check at all, not even the native `isComposing` flag.

On WebKit the keydown that commits an IME candidate arrives **after** `compositionend` with `isComposing` already false. So a user composing Chinese/Japanese/Korean text into a picker's filter query commits a candidate and instead activates whatever row is highlighted: switching project, inserting a file / skill / slash command, or dispatching a palette row against half-composed text. IMEs also use Tab to cycle the candidate list, and Tab hits the same unconditional choose dispatch.

The earlier IME sweep (#5338) did not close this: that sweep's `useImeGuard.claimEnter` reads `e.nativeEvent.isComposing` and is therefore synthetic-only, while this listener receives native KeyboardEvents — a boundary `ImeEnterClaimRatchet.test.ts` documents deliberately. (Note: the issue counts five consumer surfaces; a re-grep at `7c36513a` found six — `SettingsSearch.tsx` also consumes the hook behind a filter input.)

## Why it matters

Every IME user (Chinese, Japanese, Korean input) hits this on every picker surface in the dashboard. The consequence is not cosmetic: a candidate commit silently switches the active project, inserts the wrong file into the composer, or fires a palette command the user never chose — destructive, surprising actions against half-composed text.

## What changed (motivation → approach → change)

Symptom → root cause: the native-event path has no composition tracking, and the existing guard's claim API is structurally unavailable to native handlers.

Approach: the issue named two acceptable shapes — (a) extract `useImeGuard`'s latch core into a shared factory, or (b) hand-roll internal tracking mirroring `useListboxKeyboard`'s #5338 guard. This PR takes **(a)**: option (b) alone would introduce a second hand-rolled latch spelling, which the ratchet's acceptance criteria forbid, and the extraction is small and leaves `useImeGuard`'s public surface untouched.

Changes:

- **`useImeGuard.ts`**: the flag-and-timer latch core moves into an exported, framework-free `createImeLatch()` factory; `useImeGuard` now consumes it (public surface unchanged). The latch also carries `claimKey(e)`, the native-event twin of `claimEnter`: it owns the whole decline — `stopPropagation()` always, `preventDefault()` only in the post-composition window where the browser would otherwise act — so no native call site re-spells the two-halves split.
- **`useListKeyboardNav.ts`**: one latch per hook instance; document capture-phase `compositionstart` / `compositionend` listeners feed it, plus a capture-phase `focusout` reset that recovers a latch stranded by a composition abandoned without `compositionend` (mirroring `bindComposition`'s blur recovery). Composition tracking is keyed on `open` **alone**, in its own effect, so a keydown-handler resubscription (`wrap` / `releaseKeysWhenEmpty` changing mid-window — consumers derive the latter from live query/fetch state) cannot reset a live latch. The Enter **and** Tab dispatches are guarded through `claimKey`; a reopened menu resets the latch; the empty-list `releaseKeysWhenEmpty` early-return, `onAltEnter`, and modifier contracts are unchanged.
- **`ImeEnterClaimRatchet.test.ts`**: a new tree rule pins the shape — every `compositionstart` subscription outside the guard module must feed the shared latch, judged per-subscription in a bounded window on comment-stripped lines (so one sanctioned latch cannot exempt a whole file), with fixtures proving the predicate matches the hand-rolled defect shape.

Root cause analysis credit: **@bolichen97**, who reported this as a First Principles review finding on #5338.

## Tests

- `website/src/hooks/useListKeyboardNav.imeGuard.test.tsx` (new, 12 cases): plain Enter still chooses and is consumed (positive control); mid-composition Enter declines without cancelling the candidate commit (native flag and keyCode 229 variants); the post-`compositionend` committing Enter declines AND is consumed; choose works again once the window elapses; the latch survives an unrelated prop change inside the window (the regression both reviewers flagged); Tab during composition declines; an abandoned composition recovers on focusout; no stale latch across close/reopen; empty-list release path unchanged while composing; Tab / modifier-Enter / `onAltEnter` contracts unchanged.
- `website/src/test/ImeEnterClaimRatchet.test.ts`: new tree scan (`never hand-rolls a composition latch beside a native handler`) + fixtures covering the hand-rolled flag shape, both sanctioned shapes, the `compositionend`-only grace window, and the comment-mention/window-scoping edge.

## Manual verification

N/A — hook-level unit coverage exercises the exact WebKit event sequence (composition events then a non-composing committing keydown) through real document-level dispatch; there is no rendered delta to inspect.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** behavior change inside a keyboard hook; no pixel changes on any surface.

## Related Issues

Fixes #5340

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, hook-internal behavior; doc comments updated in-file
- [x] No secrets, credentials, or internal references in the diff
