### PR TITLE
fix: isolate edit rewind from discarded context

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -605,7 +605,6 @@ test/test_dashboard.py
 test/test_dashboard_approval.py
 test/test_dashboard_approval_window.py
 test/test_dashboard_branding.py
-test/test_dashboard_chat_rewind.py
 test/test_dashboard_config_gitlab_hosts.py
 test/test_dashboard_cron_approval.py
 test/test_dashboard_cron_batch_delete_handler.py

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -378,6 +378,24 @@ re-inject the cancelled user prompt and partial assistant output. This is
 necessary because kiro-cli discards cancelled turns from its own ACP
 conversation log, so the LLM has no memory of the interrupted request.
 
+### Edit rewind context boundary
+
+Dashboard Edit + Send replaces the ACP session and rebuilds context from the
+retained canonical history. The discarded suffix is excluded from session
+replay, stop recovery, and persisted-history context; stable memory, rules,
+skills, and project context remain available.
+
+The native conversation is discarded before the retained history rewrite, and
+the cleared resume pointer is flushed durably before the rewrite is committed,
+so a gateway restart cannot resurrect the discarded native session. If the
+rewrite fails -- or the slot was concurrently rebound to another transcript
+while it was in flight -- Edit + Send returns a 503 and restores the dashboard
+slot, but it cannot restore the discarded native session; a later turn
+cold-starts from the original persisted history instead of resuming it.
+App-authenticated requests may rewind only a slot's own dashboard session:
+a channel-linked slot is refused, because its effective session is a
+conversation the app does not own.
+
 ### Eager Respawn
 
 After a hard kill, `_eager_respawn(key)` calls `get_or_create(key)` in a background task so the next user message finds a warm session. On failure, logs at debug and does nothing — the next message triggers `get_or_create` again via the normal path.

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1204,
+    "missing_code": 1202,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1540,
+  "_compliant": 1559,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -46,7 +46,7 @@
       "missing_code": 4
     },
     "dashboard/chat_rewind.py": {
-      "missing_code": 15
+      "missing_code": 13
     },
     "dashboard/chat_slack.py": {
       "missing_code": 9

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -12,21 +12,22 @@ orphaned kiro-cli session file is deleted so it does not pollute
 Contract:
 - ``POST /api/chat/slots/{slot}/rewind``
 - Body: ``{at_message_index: int, content: str}`` (or ``{ts, content}``)
-- Truncates ``slot.messages[:at_message_index]``, kills + removes the
-  current ACP session for the slot, deletes the orphaned kiro-cli session
-  file (best-effort), persists the truncated history, and re-runs from
-  the edited prompt against a fresh ACP session.
+- Prepares and persists the truncated history before replacing the live slot,
+  discards the current ACP conversation, deletes the orphaned kiro-cli session
+  file (best-effort), and re-runs from the edited prompt against a fresh ACP
+  session.
 """
 
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
-from kiro_crew.dashboard.chat_runner import _run_chat
+from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.chat_utils import (
     effective_session_key,
     slot_history_key,
@@ -78,7 +79,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     request_app = request.get("app", "")
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     # App ownership check — mirror fork's contract so apps can't rewind
     # slots they don't own.
@@ -94,7 +95,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
             )
             # 404 (not 403): indistinguishable from a missing slot —
             # anti-enumeration (CWE-204); true reason logged via SEL above.
-            return web.json_response({"error": "not found"}, status=404)
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     try:
         body = await request.json()
@@ -197,6 +198,30 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
         # Capture orphan info before any mutation, so we can clean up the
         # kiro-cli session file even if the swap path errors out partway.
         session_key = effective_session_key(slot)
+
+        # An app may rewind only the slot's OWN dashboard session. An
+        # app-owned slot can carry a channel link (``linked_session_key``),
+        # and ``session_key`` then addresses a foreign channel conversation
+        # -- rewinding through it would clear the native identity of a
+        # session the app does not own. Same 404-not-403 shape as the
+        # ownership check above (anti-enumeration); SEL records the truth.
+        if request_app and getattr(slot, "linked_session_key", ""):
+            sel().log_api_access(
+                caller=request_app,
+                operation="chat.slot_rewind",
+                outcome="denied",
+                source="app_isolation",
+                resources=f"slot={name}",
+                error="app cannot rewind a channel-linked slot",
+            )
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+        # The transcript this rewind was authorized against. A concurrent
+        # rebinding (a cron injection re-linking the slot) moves the slot to
+        # another transcript while the boundaries below are pending; the
+        # commit re-checks this key so the edit can never land on state it
+        # never read.
+        expected_history_key = slot_history_key(slot)
         orphan_kiro_session_id = ""
         if state.sessions is not None:
             try:
@@ -204,68 +229,75 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
             except Exception:
                 logger.debug("rewind: failed to read session_map", exc_info=True)
 
-        # Truncate slot messages to the snapshot — everything from the
-        # edited message onward is discarded (intentional, by design).
-        del slot.messages[index:]
-        slot.invalidate_source_links()
-        slot._dirty = True
-        slot._resumed_count = 0
-        # Window was truncated → next save MUST be the archive-safe rewrite path.
-        # If the inline save below fails, the flag keeps the flush loop on the
-        # rewrite path so the dropped tail is still archived.
-        slot._pending_rewrite = True
+        # Prepare the prospective state on a copy. The dirty-slot flush can run
+        # while either durable boundary below is pending, so exposing a truncated
+        # live window here could make a rejected edit permanent.
+        prospective_slot = copy.copy(slot)
+        prospective_slot.messages = list(slot.messages[:index])
+        prospective_slot._queue = []
+        prospective_slot._pending = list(slot._pending)
+        prospective_slot._question_pending = dict(slot._question_pending)
+        prospective_slot._on_question_retired = None
+        prospective_slot.event = asyncio.Event()
+        if prospective_slot._pending:
+            prospective_slot.event.set()
+        prospective_slot._dirty = True
+        prospective_slot._resumed_count = 0
+        prospective_slot._pending_rewrite = True
 
-        # Swap the ACP session: kill current process AND delete the
-        # session_map entry so the next get_or_create cold-starts a fresh
-        # kiro-cli session. ``remove`` (vs ``reset``) is the right call —
-        # we want a clean slate, not a session/load resume.
-        if state.sessions is not None:
-            try:
-                await state.sessions.remove(session_key)
-            except Exception:
-                logger.warning(
-                    "rewind: failed to remove ACP session for %s",
-                    session_key,
-                    exc_info=True,
-                )
+        # The backing queue belongs to the discarded suffix too. Entries that
+        # arrive AFTER this snapshot (a send diverted to the queue by the
+        # reservation below) are not part of it and must survive the commit.
+        discarded_queue = list(slot._queue)
+        discarded_queue_ids = {item["id"] for item in discarded_queue}
 
-        # Best-effort cleanup of the orphaned kiro-cli session JSONL so it
-        # does not show up in ``kiro-cli chat -l`` or the resume picker.
-        if orphan_kiro_session_id:
-            await _delete_orphan_kiro_session(orphan_kiro_session_id)
-
-        # Append the edited prompt to slot history so the truncated +
-        # edited state is what gets persisted and what the freshly-spawned
-        # ACP session sees on its first prompt.
+        # Build the user row through the slot's normal append path without
+        # publishing it to the live slot before persistence succeeds.
         redacted_content, _ = redact_exfiltration_urls(content)
         redacted_content, _ = redact_credentials(redacted_content)
-        slot.append("user", redacted_content, "msg msg-u")
+        prospective_slot.append("user", redacted_content, "msg msg-u")
+        msgs_snapshot = list(prospective_slot.messages)
+        retired_question_ids = [
+            question_id
+            for question_id in slot._question_pending
+            if question_id not in prospective_slot._question_pending
+        ]
 
-        try:
-            msgs_snapshot = list(slot.messages)
-            await asyncio.to_thread(_save_slot_to_history, state, slot, msgs_snapshot)
-        except Exception:
-            logger.warning("rewind: failed to persist truncated history", exc_info=True)
+        # Reserve the slot BEFORE the awaits below. ``slot.running`` derives
+        # from ``slot.task``, and the send path is not serialized on
+        # ``slot._lock``: without a live task, a send arriving while either
+        # durable boundary is pending observes an idle slot, appends its row
+        # to ``slot.messages`` and dispatches a competing turn -- which the
+        # commit below would then erase. Publishing the dispatch task here
+        # (no await between the idle check above and this assignment) makes
+        # such a send take the queue path instead; the entry is not in
+        # ``discarded_queue``, so the commit preserves it and the replacement
+        # turn's own teardown drain delivers it. On abort the task starts the
+        # next queued turn itself, so a diverted send is never stranded.
+        dispatch_ready = asyncio.Event()
+        dispatch_commit = False
 
-        sel().log_api_access(
-            caller=request_app or "dashboard",
-            operation="chat.rewind",
-            outcome="allowed",
-            source="dashboard",
-            resources=(
-                f"slot={slot.key},at_index={index},"
-                f"orphan_kiro_session={orphan_kiro_session_id or 'none'}"
-            ),
-        )
+        async def _rewind_dispatch() -> None:
+            await dispatch_ready.wait()
+            if dispatch_commit:
+                await _run_chat(
+                    state,
+                    slot,
+                    redacted_content,
+                    _directive_user_origin=not bool(request_app),
+                )
+                return
+            # Rewind rejected. A send diverted to the queue by this
+            # reservation has no drain trigger of its own (no turn ran), so
+            # hand it to the canonical successor dispatch, which re-validates
+            # holds before starting anything. Entries that were already
+            # queued before the rewind keep waiting for their own trigger.
+            if any(entry["id"] not in discarded_queue_ids for entry in slot._queue):
+                if await _start_next_queued_turn(state, slot):
+                    return
+            state.push_slots_update()
 
-        task = asyncio.create_task(
-            _run_chat(
-                state,
-                slot,
-                redacted_content,
-                _directive_user_origin=not bool(request_app),
-            )
-        )
+        task = asyncio.create_task(_rewind_dispatch())
         slot.task = task
         state._background_tasks.add(task)
         task.add_done_callback(state._background_tasks.discard)
@@ -275,6 +307,232 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 logger.error("rewind _run_chat failed for %s", slot.key, exc_info=t.exception())
 
         task.add_done_callback(_on_done)
+
+        # Durably clear the native resume sid before committing the edited
+        # history. A failure leaves the original branch intact and dispatches
+        # no replacement turn.
+        try:
+            if state.sessions is not None:
+                try:
+                    # ``skip_if_busy``: an inbound channel turn (a Slack reply
+                    # on the linked session) holds the session semaphore while
+                    # ``slot.running`` reads False, so the idle check above
+                    # cannot see it -- an unconditional discard would tear
+                    # down its provider mid-reply. The refusal is atomic with
+                    # the busy probe inside the lifecycle service.
+                    discarded = await state.sessions.discard_conversation(
+                        session_key, skip_if_busy=True
+                    )
+                except Exception:
+                    logger.warning(
+                        "rewind: failed to discard ACP conversation for %s",
+                        session_key,
+                        exc_info=True,
+                    )
+                    state.push_slots_update()
+                    return web.json_response(
+                        {
+                            "error": "could not prepare edited conversation; retry the edit",
+                            "code": "rewind_prepare_failed",
+                        },
+                        status=503,
+                    )
+                if not discarded:
+                    state.push_slots_update()
+                    return web.json_response(
+                        {
+                            "error": "the session is busy with another reply; retry the edit",
+                            "code": "rewind_session_busy",
+                        },
+                        status=409,
+                    )
+                try:
+                    # The sid clear lands in the session map's debounced
+                    # writer; a gateway exit before that write would reload
+                    # the old sid on restart and resurrect the discarded
+                    # conversation. Force the durability point HERE,
+                    # endpoint-side, so the shared discard keeps its existing
+                    # semantics for its other callers (chat_runner, channel
+                    # handlers), which tolerate the debounce.
+                    await state.sessions.aflush()
+                except Exception:
+                    logger.warning(
+                        "rewind: failed to flush the cleared resume sid for %s",
+                        session_key,
+                        exc_info=True,
+                    )
+                    state.push_slots_update()
+                    return web.json_response(
+                        {
+                            "error": "could not prepare edited conversation; retry the edit",
+                            "code": "rewind_prepare_failed",
+                        },
+                        status=503,
+                    )
+
+            def _commit_live_state() -> None:
+                """Adopt the prepared state on the live slot (synchronous).
+
+                Shared by the normal success path and the cancellation path
+                below: once the destructive rewrite has landed on disk, this
+                is the only thing that keeps live state matching it. No await
+                inside, so it is atomic on the event loop.
+                """
+                slot.messages = prospective_slot.messages
+                # Remove only the entries captured in the pre-await snapshot:
+                # an entry queued while the boundaries were pending belongs to
+                # the NEW timeline and must survive for the teardown drain.
+                slot._queue[:] = [
+                    entry for entry in slot._queue if entry["id"] not in discarded_queue_ids
+                ]
+                slot._pending = prospective_slot._pending
+                slot._question_pending = prospective_slot._question_pending
+                slot.invalidate_source_links()
+                slot._dirty = True
+                slot._resumed_count = 0
+                slot._pending_rewrite = prospective_slot._pending_rewrite
+                slot.total_messages = prospective_slot.total_messages
+                slot._disk_window_len = prospective_slot._disk_window_len
+                slot._disk_meta_created_at = prospective_slot._disk_meta_created_at
+                slot._disk_meta_observed = prospective_slot._disk_meta_observed
+                slot._disk_tail_ts = prospective_slot._disk_tail_ts
+                slot._frozen_prefix_cache = prospective_slot._frozen_prefix_cache
+                if slot._pending:
+                    slot.event.set()
+                else:
+                    slot.event.clear()
+                if retired_question_ids and callable(slot._on_question_retired):
+                    try:
+                        slot._on_question_retired(slot.key, retired_question_ids)  # type: ignore[operator]
+                    except Exception:
+                        logger.debug(
+                            "rewind: question-retirement announcement failed for slot %s",
+                            slot.key,
+                            exc_info=True,
+                        )
+                # Other open clients render queue cards from WebSocket events
+                # rather than this slot's optimistic edit.
+                for item in discarded_queue:
+                    state.broadcast_ws("queue_cancel", {"slot": slot.key, "queue_id": item["id"]})
+                sel().log_api_access(
+                    caller=request_app or "dashboard",
+                    operation="chat.rewind",
+                    outcome="allowed",
+                    source="dashboard",
+                    resources=(
+                        f"slot={slot.key},at_index={index},"
+                        f"orphan_kiro_session={orphan_kiro_session_id or 'none'}"
+                    ),
+                )
+
+            # The worker thread cannot be interrupted: once the rewrite starts
+            # it WILL finish, whether or not this handler is still alive. A
+            # client disconnect cancels the handler task, and a bare await
+            # here would then abandon a completed destructive rewrite --
+            # persisted history rewound, live state stale, edited prompt never
+            # dispatched. Shield the save; on cancellation, wait for the
+            # worker's real outcome and complete the matching commit (and let
+            # the reserved dispatch task run the edited prompt) before
+            # propagating the cancellation.
+            save_task = asyncio.ensure_future(
+                asyncio.to_thread(
+                    _save_slot_to_history,
+                    state,
+                    slot,
+                    msgs_snapshot,
+                    expected_history_key=expected_history_key,
+                )
+            )
+            try:
+                saved = await asyncio.shield(save_task)
+            except asyncio.CancelledError:
+                landed = False
+                try:
+                    landed = bool(await save_task)
+                except Exception:
+                    landed = False
+                if landed and slot_history_key(slot) == expected_history_key:
+                    _commit_live_state()
+                    dispatch_commit = True
+                    logger.info(
+                        "rewind: request cancelled after the rewrite landed for %s; "
+                        "committed live state and dispatching the edited prompt",
+                        slot.key,
+                    )
+                raise
+            except Exception:
+                logger.warning("rewind: failed to persist truncated history", exc_info=True)
+                state.push_slots_update()
+                return web.json_response(
+                    {
+                        "error": "could not save edited conversation; retry the edit",
+                        "code": "rewind_save_failed",
+                    },
+                    status=503,
+                )
+            if not saved:
+                # The save's own guards refused the write (the session was
+                # permanently deleted, or the slot was rebound to another
+                # transcript, while the write awaited its lock). Nothing was
+                # persisted, so reporting success here would dispatch a turn
+                # from state that exists only in memory.
+                logger.warning(
+                    "rewind: history save refused for %s (concurrent delete or rebind)",
+                    slot.key,
+                )
+                state.push_slots_update()
+                return web.json_response(
+                    {
+                        "error": "could not save edited conversation; retry the edit",
+                        "code": "rewind_save_failed",
+                    },
+                    status=503,
+                )
+
+            # Both irreversible boundaries succeeded. Before adopting the
+            # prepared state, confirm the slot still routes to the transcript
+            # this rewind was authorized against: a concurrent rebinding (a
+            # cron injection re-linking the slot mid-persistence) hydrates the
+            # slot with ANOTHER conversation's state, and a late commit here
+            # would silently replace it. The prospective copy froze the old
+            # routing, so the save-side ``expected_history_key`` guard cannot
+            # see the live slot move -- this loop-side check is the one that
+            # can. No await between this check and the mutations below.
+            if slot_history_key(slot) != expected_history_key:
+                logger.warning(
+                    "rewind: slot %s was rebound to another transcript during "
+                    "persistence; refusing the commit",
+                    slot.key,
+                )
+                state.push_slots_update()
+                return web.json_response(
+                    {
+                        "error": "the conversation changed while saving; retry the edit",
+                        "code": "rewind_slot_rebound",
+                    },
+                    status=503,
+                )
+
+            # The prepared state is now the live slot state. Keep the queue
+            # cancellation and source-link invalidation with this commit
+            # rather than leaking them during either await above.
+            _commit_live_state()
+            # BEFORE the await below: a cancellation landing during the
+            # best-effort cleanup would otherwise abort the reserved dispatch
+            # after the commit already happened, stranding a persisted edited
+            # prompt that never runs.
+            dispatch_commit = True
+
+            # Best-effort cleanup of the orphaned kiro-cli session JSONL so it
+            # does not show up in ``kiro-cli chat -l`` or the resume picker.
+            # After the commit (and skipped on the cancellation path): purely
+            # cosmetic, kiro-cli's own GC reclaims the file eventually.
+            if orphan_kiro_session_id:
+                await _delete_orphan_kiro_session(orphan_kiro_session_id)
+        finally:
+            # Wake the reserved dispatch task on every exit: it runs the
+            # replacement turn on commit and the queue handoff on abort.
+            dispatch_ready.set()
 
     state.push_slots_update()
     return web.json_response({"ok": True, "at_message_index": index + disk_older})

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -100,6 +100,8 @@ def _make_state(tmp_path, **kwargs):
     """Create a DashboardState with mocked services and real ConversationLog."""
     sessions = MagicMock(count=0)
     sessions.remove = AsyncMock()
+    sessions.discard_conversation = AsyncMock()
+    sessions.aflush = AsyncMock()
     sessions.recycle_background = AsyncMock()
     sessions.get_pid = MagicMock(return_value=None)
     # Real in-memory Slack-link store rather than bare MagicMocks. The unlink

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -7963,7 +7963,7 @@ class TestRuntimeWiring:
         build_message_calls: list[dict] = []
 
         def mock_build_message(self_ctx, text, is_new, session_key=None, **kwargs):
-            build_message_calls.append({"text": text, "kwargs": kwargs})
+            build_message_calls.append({"text": text, "session_key": session_key, "kwargs": kwargs})
             return text, MagicMock(action=None, text="")
 
         # Mock config loading
@@ -8001,14 +8001,34 @@ class TestRuntimeWiring:
 
         state = _make_state(tmp_path, context_builder=ctx_builder)
 
-        # Create a slot with an agent
+        # Create a slot with retained history, then verify a cold start replays it.
         slot = state.get_or_create_slot("mem-test", agent="oncall")
+        conversation_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conversation_log.init()
+        await asyncio.to_thread(
+            conversation_log.append, "dashboard:mem-test", "user", "frozen retained question"
+        )
+        await asyncio.to_thread(
+            conversation_log.append,
+            "dashboard:mem-test",
+            "assistant",
+            "frozen retained answer",
+        )
+        await asyncio.to_thread(
+            conversation_log.append, "dashboard:mem-test", "user", "test message"
+        )
+        ctx_builder.conversation_log = conversation_log
+        state.conversation_log = conversation_log
+        slot.append("user", "retained question", "msg msg-u")
+        slot.append("assistant", "retained answer", "msg msg-a")
+        slot.append("user", "test message", "msg msg-u")
 
         # Mock session manager to return a mock client
         mock_client = MagicMock()
         mock_client.stream = MagicMock(return_value=AsyncIterator([]))
         state.sessions.get_or_create = AsyncMock(return_value=(mock_client, True, False))
         state.sessions.get_pid = MagicMock(return_value=None)
+        state.sessions.consume_replay_suppression = MagicMock(return_value=False)
 
         # Import and run _run_chat
         from kiro_crew.dashboard.chat import _run_chat
@@ -8018,6 +8038,10 @@ class TestRuntimeWiring:
         # Verify build_message was called with memory_store
         assert len(build_message_calls) == 1
         assert build_message_calls[0]["kwargs"].get("memory_store") == "oncall-mem"
+        assert build_message_calls[0]["session_key"] == "dashboard:mem-test"
+        replay = build_message_calls[0]["kwargs"].get("compressed_history")
+        assert "frozen retained question" in replay
+        assert "frozen retained answer" in replay
 
     @pytest.mark.asyncio
     async def test_run_chat_forwards_and_clears_the_reinjection_flag(self, tmp_path, monkeypatch):

--- a/test/test_dashboard_chat_rewind.py
+++ b/test/test_dashboard_chat_rewind.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -59,11 +60,423 @@ class TestRewindSlot:
         roles = [m["role"] for m in slot.messages]
         assert roles == ["user"]
         assert slot.messages[0]["content"] == "edited first question"
-        # ACP session was reset
-        state.sessions.remove.assert_called_once_with("dashboard:src")
+        # The replacement must not resume the discarded native conversation.
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:src", skip_if_busy=True
+        )
+        state.sessions.remove.assert_not_awaited()
         # Cleanup runs
         if slot.task:
             slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_discards_queued_successors(self, tmp_path):
+        """Queued work from the discarded suffix must not run afterwards."""
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        queue_id = slot.queue_append("discarded queued prompt")
+        slot.append("queued", "discarded queued prompt", json.dumps({"queue_id": queue_id}))
+        slot.drain()
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        with patch.object(state, "broadcast_ws") as broadcast:
+            app = _make_app(state)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+                assert resp.status == 200
+
+        assert slot.queue_depth == 0
+        assert all(message["role"] != "queued" for message in slot.messages)
+        broadcast.assert_any_call("queue_cancel", {"slot": "src", "queue_id": queue_id})
+        assert not any(call.args[0] == "queue_pop" for call in broadcast.call_args_list)
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_failed_save_keeps_live_and_persisted_branch_during_flush(
+        self, tmp_path, monkeypatch
+    ):
+        """A flush pending beside a rejected rewrite must save the original window."""
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        queue_id = slot.queue_append("discarded queued prompt")
+        slot.append("queued", "discarded queued prompt", json.dumps({"queue_id": queue_id}))
+        slot.drain()
+        state.sessions._session_map.get = MagicMock(return_value="")
+        original_messages = list(slot.messages)
+        original_queue = list(slot._queue)
+        slot._question_pending = {"question-1": {"blocking": False}}
+        retired = MagicMock()
+        slot._on_question_retired = retired
+        slot._dirty = True
+
+        save_started = threading.Event()
+        fail_save = threading.Event()
+
+        def _wait_then_fail(_state, saved_slot, _messages, **kwargs):
+            # The save goes through the LIVE slot so its own
+            # expected_history_key guard can see a concurrent rebind; the
+            # candidate window travels as the explicit messages snapshot and
+            # the live slot is not mutated before the commit.
+            assert saved_slot is slot
+            assert kwargs.get("expected_history_key")
+            assert slot._question_pending == {"question-1": {"blocking": False}}
+            retired.assert_not_called()
+            save_started.set()
+            fail_save.wait()
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind._save_slot_to_history", _wait_then_fail
+        )
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            request_task = asyncio.create_task(
+                client.post(
+                    "/api/chat/slots/src/rewind",
+                    json={"at_message_index": 0, "content": "edited first question"},
+                )
+            )
+            try:
+                await asyncio.wait_for(asyncio.to_thread(save_started.wait), timeout=1)
+                await asyncio.to_thread(state.flush_slot_now, slot)
+                fail_save.set()
+                resp = await request_task
+            finally:
+                fail_save.set()
+                if not request_task.done():
+                    await request_task
+
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_save_failed"
+
+        persisted = state.conversation_log.read_messages("dashboard:src")
+        assert [(m["role"], m["content"]) for m in persisted] == [
+            (m["role"], m["content"]) for m in original_messages if m["role"] != "queued"
+        ]
+        assert slot.messages == original_messages
+        assert slot._queue == original_queue
+        assert slot._question_pending == {"question-1": {"blocking": False}}
+        retired.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rewind_rejects_when_the_boundary_cannot_be_saved(self, tmp_path, monkeypatch):
+        """A failed rewrite must not start a replacement from stale disk state."""
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        def _fail_save(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_rewind._save_slot_to_history", _fail_save)
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_save_failed"
+
+        assert slot.messages == original_messages
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:src", skip_if_busy=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_rewind_rejects_when_the_native_boundary_cannot_be_saved(self, tmp_path):
+        """A failed resume-sid write must leave the old branch in place."""
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        state.sessions.discard_conversation = AsyncMock(side_effect=OSError("map write failed"))
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_prepare_failed"
+
+        assert slot.messages == original_messages
+
+    @pytest.mark.asyncio
+    async def test_rewind_rejects_when_the_save_is_refused(self, tmp_path, monkeypatch):
+        """A save refused by its own guards (returns False) must 503, not dispatch.
+
+        ``_save_slot_to_history`` returns ``False`` without writing when the
+        session was permanently deleted or the slot was rebound while the
+        write awaited its lock; reporting success would dispatch a turn from
+        state that was never persisted.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_rewind._save_slot_to_history",
+            MagicMock(return_value=False),
+        )
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_save_failed"
+
+        assert slot.messages == original_messages
+
+    @pytest.mark.asyncio
+    async def test_rewind_reserves_the_slot_and_keeps_concurrent_queue_entries(
+        self, tmp_path, _mock_run_chat
+    ):
+        """A send arriving during the awaited boundaries queues and survives.
+
+        The reservation makes ``slot.running`` read True while the durable
+        boundaries are pending, so a concurrent send takes the queue path
+        instead of starting a competing turn -- and the commit removes only
+        the pre-await snapshot, never the entry that arrived during it.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        discarded_id = slot.queue_append("discarded queued prompt")
+        state.sessions._session_map.get = MagicMock(return_value="")
+        observed: dict = {}
+
+        async def _discard(key, **kwargs):
+            # Runs inside the awaited boundary: the reservation must already
+            # be visible, and a producer can still reach the queue.
+            observed["running"] = slot.running
+            observed["arrived_id"] = slot.queue_append("queued during rewind")
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 200
+
+        assert observed["running"] is True
+        queued_ids = [entry["id"] for entry in slot._queue]
+        assert observed["arrived_id"] in queued_ids
+        assert discarded_id not in queued_ids
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_app_cannot_reach_a_channel_linked_session(self, tmp_path):
+        """An app-owned slot with a channel link must not rewind through it.
+
+        ``effective_session_key`` resolves a linked slot to the channel's own
+        session, so an app rewind would clear the native identity of a
+        conversation the app does not own. Denied with the same 404 shape as
+        the ownership check (anti-enumeration).
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        slot._app = "some-app"
+        slot.linked_session_key = "slack:1234567890.123"
+        original_messages = list(slot.messages)
+
+        from aiohttp import web as _web
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.dashboard.chat_rewind import api_chat_slot_rewind
+
+        app = _make_app(state)
+        fake_request = make_mocked_request(
+            "POST",
+            "/api/chat/slots/src/rewind",
+            match_info={"slot": "src"},
+            app=app,
+        )
+        fake_request["app"] = "some-app"  # owns the slot, but the slot is linked
+
+        async def _json():
+            return {"at_message_index": 0, "content": "x"}
+
+        fake_request.json = _json  # type: ignore[method-assign]
+        try:
+            resp = await api_chat_slot_rewind(fake_request)
+        except _web.HTTPException as exc:
+            resp = exc
+        assert resp.status == 404
+        assert slot.messages == original_messages
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rewind_rejects_when_the_sid_flush_fails(self, tmp_path):
+        """The cleared resume sid must be durable before the commit.
+
+        ``discard_conversation`` lands the sid clear in the session map's
+        debounced writer; the endpoint forces the durability point and a
+        flush failure takes the same 503 path as a failed discard.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        state.sessions.aflush = AsyncMock(side_effect=OSError("map write failed"))
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "rewind_prepare_failed"
+
+        assert slot.messages == original_messages
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:src", skip_if_busy=True
+        )
+        state.sessions.aflush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rewind_refuses_the_commit_when_the_slot_is_rebound(self, tmp_path):
+        """A slot rebound to another transcript mid-save must not be replaced.
+
+        A cron injection can re-link the slot (and hydrate it with another
+        conversation's state) while the history write is in flight; the
+        commit re-checks the history key and refuses instead of overwriting
+        the injected state.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        async def _rebinding_discard(key, **kwargs):
+            # Runs inside the awaited boundary: the slot moves to another
+            # transcript while the rewind persists.
+            slot.linked_session_key = "slack:9876543210.999"
+            return True
+
+        state.sessions.discard_conversation = AsyncMock(side_effect=_rebinding_discard)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 503
+            # Two fences cover different windows: the save's own
+            # expected_history_key guard (rewind_save_failed) catches a rebind
+            # visible at write time; the commit-side re-check
+            # (rewind_slot_rebound) catches one landing after the save
+            # returned. Either refusal is correct -- the point is that the
+            # commit never happens.
+            assert (await resp.json())["code"] in {
+                "rewind_save_failed",
+                "rewind_slot_rebound",
+            }
+
+        assert slot.messages == original_messages
+        if slot.task:
+            slot.task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rewind_refuses_while_a_channel_turn_holds_the_session(self, tmp_path):
+        """A busy session (inbound channel reply in flight) must 409, not discard.
+
+        An inbound channel turn holds the session semaphore while
+        ``slot.running`` reads False, so the idle check cannot see it; the
+        discard is asked with ``skip_if_busy`` and its refusal surfaces as a
+        retryable 409 with the slot untouched.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        original_messages = list(slot.messages)
+        state.sessions._session_map.get = MagicMock(return_value="")
+        state.sessions.discard_conversation = AsyncMock(return_value=False)
+
+        app = _make_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/slots/src/rewind",
+                json={"at_message_index": 0, "content": "edited first question"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "rewind_session_busy"
+
+        assert slot.messages == original_messages
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:src", skip_if_busy=True
+        )
+        state.sessions.aflush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rewind_cancelled_mid_save_still_commits_the_landed_rewrite(
+        self, tmp_path, monkeypatch, _mock_run_chat
+    ):
+        """A client disconnect during the save must not abandon the rewrite.
+
+        The worker thread finishes the destructive rewrite regardless of the
+        handler's fate; on cancellation the handler waits for the worker's
+        outcome, commits the live state to match the persisted one, and the
+        reserved dispatch task still runs the edited prompt.
+        """
+        state = _make_state(tmp_path)
+        slot = _populate_slot(state)
+        state.sessions._session_map.get = MagicMock(return_value="")
+
+        save_started = threading.Event()
+        release = threading.Event()
+
+        def _gated_save(*_args, **_kwargs):
+            save_started.set()
+            release.wait()
+            return True
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_rewind._save_slot_to_history", _gated_save)
+
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.dashboard.chat_rewind import api_chat_slot_rewind
+
+        app = _make_app(state)
+        fake_request = make_mocked_request(
+            "POST", "/api/chat/slots/src/rewind", match_info={"slot": "src"}, app=app
+        )
+        fake_request["app"] = ""
+
+        async def _json():
+            return {"at_message_index": 0, "content": "edited first question"}
+
+        fake_request.json = _json  # type: ignore[method-assign]
+        handler_task = asyncio.create_task(api_chat_slot_rewind(fake_request))
+        await asyncio.wait_for(asyncio.to_thread(save_started.wait), timeout=2)
+        handler_task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await handler_task
+
+        # The commit landed: truncated window plus the edited user row.
+        assert [m["content"] for m in slot.messages] == ["edited first question"]
+        # The reserved dispatch task still runs the edited prompt.
+        for _ in range(50):
+            if _mock_run_chat.await_count:
+                break
+            await asyncio.sleep(0.02)
+        _mock_run_chat.assert_awaited_once()
+        assert _mock_run_chat.await_args.args[2] == "edited first question"
 
     @pytest.mark.asyncio
     async def test_rewind_middle_user_message_keeps_prior_turns(self, tmp_path):
@@ -86,7 +499,9 @@ class TestRewindSlot:
         assert slot.messages[0]["content"] == "first question"
         assert slot.messages[1]["content"] == "first answer"
         assert slot.messages[2]["content"] == "edited second question"
-        state.sessions.remove.assert_called_once_with("dashboard:src")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:src", skip_if_busy=True
+        )
         if slot.task:
             slot.task.cancel()
 
@@ -345,7 +760,8 @@ class TestRewindSlot:
         from kiro_crew.dashboard.chat_rewind import api_chat_slot_rewind
 
         fake_request = make_mocked_request(
-            "POST", "/api/chat/slots/src/rewind",
+            "POST",
+            "/api/chat/slots/src/rewind",
             match_info={"slot": "src"},
             app=app,
         )


### PR DESCRIPTION
## Problem / Motivation

Edit + Send visually rewound a dashboard conversation, but the next turn could still receive the discarded suffix through native ACP session resume, generic session-history reconstruction, or queued successors.

## Why it matters

Editing a prompt must create a real conversation boundary: the replacement turn may use only the retained prefix and revised prompt, including after a process restart or in another open client.

## What changed (motivation → approach → change)

The rewind request is now one-shot and is built only from the retained slot prefix. It clears the native conversation identity durably before saving the rewritten history, rejects the request if that boundary cannot be persisted, removes queued successors, and notifies other clients to remove their stale queue cards.

## Tests

- `pytest -q test/test_dashboard_chat_rewind.py test/test_session.py -k "rewind or TestDiscardConversation"` — 30 passed
- `pytest -q test/test_context.py test/test_dashboard_chat.py -k "rewind or build_session_context or build_message"` — 11 passed
- Exact changed-module `mypy` — passed
- Dashboard Vitest — 1,483 files / 23,130 tests passed
- `npm run build` — passed
- Full backend suite: 62,926 passed, 226 failures, 204 skipped, 6 xfailed. The failures are pre-existing app-composition failures concentrated in `ops_mission_control`, with none in changed paths.

`npm run check` exits non-zero after its passing dashboard suite because this Linux install lacks optional Electron packages required by unrelated Electron contract tests (`electron`, `electron-updater`, `electron-store`, and `app-builder-lib`).

## Manual verification

The focused endpoint tests cover durable-boundary failure, native-session discard, retained-prefix reconstruction, and queue removal. The local gateway deployment is queued after this PR; manual Edit + Send verification remains appropriate for a live dashboard session.

<!-- no-visual-delta -->
**Why no screenshot:** No rendered UI changed; this fixes prompt/session state assembly.

## Related Issues

no linked issue: no existing issue matches this bug fix

## Pattern harvest

Rule candidate: review-prompt
Pattern: a destructive edit that removes content in one layer while the data stays reachable through a parallel replay channel (native session resume, history reconstruction, queued successors) -- every replay path must be cleared, durably, before the replacement is dispatched.

## Checklist

- [x] Rebased on current `main`
- [x] Ran focused backend coverage and exact-module type checks
- [x] Ran dashboard tests and production build
- [x] Recorded unrelated full-suite and Electron-environment failures
