### PR TITLE
fix(dashboard): bound the initial slot-detail load to one page

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1092,8 +1092,10 @@ export const fetchHistory = createAsyncThunk(
   },
 )
 
-/** Rows to request per older-history page. */
-const OLDER_PAGE_LIMIT = 100
+/** Rows for the initial slot-open page and each older-history page. One size
+ *  for both keeps the scrollback walk uniform: the first page a slot opens
+ *  with is simply page one of the same pagination `loadOlderMessages` runs. */
+export const OLDER_PAGE_LIMIT = 100
 
 // Aborts the in-flight older-history fetch, or null when none is running.
 // Module-level because switchSlot must reach a fetch it did not start.
@@ -1258,8 +1260,11 @@ function retainServerTotal(state: ChatState, key: string, total: number | undefi
 }
 
 async function fetchSlotDetail(key: string, limit?: number) {
-  // A limit takes the handler's most-recent-N slice, all a background pane shows.
-  // Omit the arg when unbounded so existing callers keep their one-argument shape.
+  // A limit takes the handler's most-recent-N slice. `undefined` keeps the
+  // unbounded shape, which two callers still need: refreshSlot replaces the
+  // active transcript in place (a bound would shrink history the user already
+  // paged in), and a STREAMING warm/switch fetch (the server's limit slices raw
+  // chunk rows). Omit the arg when unbounded so those keep the one-argument shape.
   const d = await (limit === undefined ? api.chatSlotDetail(key) : api.chatSlotDetail(key, limit))
   type QueueItem = string | { content: string; id: string }
   return { key, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
@@ -1303,12 +1308,26 @@ function seedContextUsage(
 
 export const switchSlot = createAsyncThunk(
   'chat/switchSlot',
-  async (key: string, { dispatch }) => {
+  async (key: string, { dispatch, getState }) => {
     // Safe unconditionally: this fetch resets the pane's messages and cursor, so
     // any older page still in flight is superseded even when the key is unchanged.
     _abortLoadOlder?.()
     dispatch(markSlotRead(key))
-    return fetchSlotDetail(key)
+    // Bounded to the page size so opening a long session costs one page, not the
+    // whole chained transcript; `loadOlderMessages` walks back from the cursor
+    // this fetch returns. Unbounded while the slot is streaming, for the same
+    // reason warmSlotCache and ChatPane's hydrate are: the server's limit slices
+    // RAW rows, and a streaming response is many chunk rows that only collapse
+    // afterwards -- bounding it would keep just the tail.
+    // `slotRun` and not `selectSlotStreamState`: switchSlot.pending has already
+    // assigned `activeSlot = key` by the time this body runs, so that selector
+    // would always take its active-slot branch and report `slotState`, which
+    // still describes the OUTGOING slot. `slotRun` is keyed per slot, so it
+    // answers for the incoming one. Guarded because a partial preloaded state
+    // can omit `slotRun` entirely, and throwing here would skip the fetch.
+    const state = (getState() as { chat: ChatState }).chat
+    const streaming = (state.slotRun?.[key]?.state ?? 'idle') !== 'idle'
+    return fetchSlotDetail(key, streaming ? undefined : OLDER_PAGE_LIMIT)
   },
 )
 

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -1272,7 +1272,7 @@ describe('chatSlice thunks', () => {
     await Promise.resolve()
 
     // The peer's transcript is still in flight...
-    expect(apiMock.chatSlotDetail).toHaveBeenCalledWith('peer')
+    expect(apiMock.chatSlotDetail).toHaveBeenCalledWith('peer', expect.any(Number))
     // ...yet the tab is already gone and focus already moved.
     expect(root(store).dashboard.slots.map(s => s.key)).not.toContain('doomed')
     expect(chat(store).activeSlot).toBe('peer')

--- a/website/src/test/OverviewPromptsTabCoverage.test.tsx
+++ b/website/src/test/OverviewPromptsTabCoverage.test.tsx
@@ -298,7 +298,7 @@ describe('PromptsTab slot picker', () => {
     const { store } = await openPicker([slot({ key: 'chat/7', title: 'Seven' })])
     fireEvent.click(screen.getByRole('button', { name: 'Seven' }))
     expect(store.getState().chat.pendingInput).toBe('@hello')
-    await waitFor(() => expect(mockApi.chatSlotDetail).toHaveBeenCalledWith('chat/7'))
+    await waitFor(() => expect(mockApi.chatSlotDetail).toHaveBeenCalledWith('chat/7', expect.any(Number)))
     expect(mockNavigate).toHaveBeenCalledWith('/chat?autoSend=1')
     expect(mockNavigate).not.toHaveBeenCalledWith('/chat?autoSend=1&newSession=1')
   })

--- a/website/src/test/chatSlice.switchSlotBound.test.ts
+++ b/website/src/test/chatSlice.switchSlotBound.test.ts
@@ -1,0 +1,132 @@
+/** `switchSlot` must bound its initial fetch instead of pulling the whole
+ *  chained transcript.
+ *
+ *  Opening a slot resets the pane's messages and cursor, so the first page is
+ *  simply page one of the same pagination `loadOlderMessages` runs — bounded to
+ *  `OLDER_PAGE_LIMIT`, with `has_more`/`next_before` from the response seeding
+ *  the cursor the older-page walk starts from. The bound must never make older
+ *  history unreachable: a truncating first page that could not page back would
+ *  be worse than the unbounded fetch it replaces.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+import { api } from '../api/client'
+import chatReducer, { OLDER_PAGE_LIMIT, loadOlderMessages, switchSlot } from '../store/chatSlice'
+
+vi.mock('../api/client')
+
+function makeStore(extra: Record<string, unknown> = {}) {
+  const base = chatReducer(undefined, { type: '@@INIT' })
+  return configureStore({
+    reducer: { chat: chatReducer },
+    preloadedState: { chat: { ...base, ...extra } },
+  })
+}
+
+const msg = (content: string, ts: string, mid: string) =>
+  ({ role: 'assistant', content, cls: '', ts, meta: { mid } })
+
+const mockDetail = (value: Record<string, unknown>) =>
+  (api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue(
+    { messages: [], running: false, has_more: false, total: 0, queue: [], ...value },
+  )
+
+describe('switchSlot initial load bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('bounds the slot-open fetch to the older-page limit', async () => {
+    mockDetail({})
+    const store = makeStore()
+    await store.dispatch(switchSlot('slot-a') as never)
+    expect(api.chatSlotDetail).toHaveBeenCalledWith('slot-a', OLDER_PAGE_LIMIT)
+    // The backend clamps limit to [1, 500]; a value outside that range would
+    // either 400 or silently shrink, so the constant must stay inside it.
+    expect(OLDER_PAGE_LIMIT).toBeGreaterThan(0)
+    expect(OLDER_PAGE_LIMIT).toBeLessThanOrEqual(500)
+  })
+
+  // The bound is only acceptable because the remainder stays reachable: the
+  // bounded response's cursor must arm loadOlderMessages, not strand it.
+  it('seeds the older-paging cursor from the bounded first page', async () => {
+    mockDetail({
+      messages: [msg('newest window', '2026-08-23T10:00:00Z', 'm-2')],
+      has_more: true,
+      next_before: 250,
+      total: 251,
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('slot-a') as never)
+    const st = store.getState().chat
+    expect(st.slotHasMore).toBe(true)
+    expect(st.slotOldestIndex).toBe(250)
+    // And the walk actually starts from that cursor.
+    mockDetail({ messages: [], has_more: false, next_before: 0, total: 251 })
+    await store.dispatch(loadOlderMessages() as never)
+    expect(api.chatSlotDetail).toHaveBeenLastCalledWith(
+      'slot-a', OLDER_PAGE_LIMIT, 250, expect.anything(),
+    )
+  })
+
+  it('older paging walks the bounded first page back to the oldest message', async () => {
+    mockDetail({
+      messages: [msg('newer', '2026-08-23T10:00:00Z', 'm-2')],
+      has_more: true,
+      next_before: 1,
+      total: 2,
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('slot-a') as never)
+    mockDetail({
+      messages: [msg('oldest', '2026-08-23T09:00:00Z', 'm-1')],
+      has_more: false,
+      next_before: 0,
+      total: 2,
+    })
+    await store.dispatch(loadOlderMessages() as never)
+    const st = store.getState().chat
+    expect(st.messages.map(m => m.content)).toEqual(['oldest', 'newer'])
+    // The walk terminates: nothing older is claimed once the head is reached.
+    expect(st.slotHasMore).toBe(false)
+    expect(st.slotOldestIndex).toBe(0)
+  })
+
+  it('loads a slot shorter than the limit whole, with no earlier-page claim', async () => {
+    mockDetail({
+      messages: [
+        msg('one', '2026-08-23T09:00:00Z', 'm-1'),
+        msg('two', '2026-08-23T10:00:00Z', 'm-2'),
+        msg('three', '2026-08-23T11:00:00Z', 'm-3'),
+      ],
+      has_more: false,
+      next_before: 0,
+      total: 3,
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('slot-a') as never)
+    const st = store.getState().chat
+    expect(st.messages.map(m => m.content)).toEqual(['one', 'two', 'three'])
+    expect(st.slotHasMore).toBe(false)
+    expect(st.slotOldestIndex).toBe(0)
+  })
+
+  // Same guard as warmSlotCache and ChatPane's hydrate: the server's limit
+  // slices RAW rows, and a streaming response is many chunk rows that only
+  // collapse afterwards — bounding it would keep just the tail.
+  it('switches to a streaming slot unbounded', async () => {
+    mockDetail({ running: true })
+    const store = makeStore({ slotRun: { 'slot-a': { state: 'streaming' } } })
+    await store.dispatch(switchSlot('slot-a') as never)
+    expect(api.chatSlotDetail).toHaveBeenCalledWith('slot-a')
+  })
+
+  it('switches to an idle slot bounded', async () => {
+    mockDetail({})
+    const store = makeStore({ slotRun: { 'slot-a': { state: 'idle' } } })
+    await store.dispatch(switchSlot('slot-a') as never)
+    expect(api.chatSlotDetail).toHaveBeenCalledWith('slot-a', OLDER_PAGE_LIMIT)
+  })
+})

--- a/website/src/test/chatSlice.warmSlotCacheBound.test.ts
+++ b/website/src/test/chatSlice.warmSlotCacheBound.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 
 import { api } from '../api/client'
-import chatReducer, { PANE_HYDRATE_LIMIT, appendSlotMessage, hydrateSlotMessages, refreshSlot, switchSlot, warmSlotCache } from '../store/chatSlice'
+import chatReducer, { OLDER_PAGE_LIMIT, PANE_HYDRATE_LIMIT, appendSlotMessage, hydrateSlotMessages, refreshSlot, switchSlot, warmSlotCache } from '../store/chatSlice'
 
 vi.mock('../api/client')
 
@@ -49,12 +49,13 @@ describe('warmSlotCache hydrate bound', () => {
     expect(api.chatSlotDetail).not.toHaveBeenCalled()
   })
 
-  // Control: the bound is for background panes only. The active slot renders the
-  // full transcript and pages through it, so bounding these would truncate it.
-  it('leaves the active-slot paths unbounded', async () => {
+  // Control: a refresh replaces the active transcript in place, so a bound
+  // would shrink history the user already paged in. switchSlot resets the
+  // pane's cursor, so IT pages: one bounded first page, older pages on demand.
+  it('leaves the in-place refresh unbounded while the slot open pages', async () => {
     const store = makeStore('active-slot')
     await store.dispatch(switchSlot('active-slot') as never)
-    expect(api.chatSlotDetail).toHaveBeenLastCalledWith('active-slot')
+    expect(api.chatSlotDetail).toHaveBeenLastCalledWith('active-slot', OLDER_PAGE_LIMIT)
     await store.dispatch(refreshSlot('active-slot') as never)
     expect(api.chatSlotDetail).toHaveBeenLastCalledWith('active-slot')
   })


### PR DESCRIPTION
Opening a slot fetched the entire chained transcript. `switchSlot` now requests one page instead.

## The report is partly stale

Worth stating up front, since it changes what the fix had to be. The issue quotes a `// No limit → backend returns all chained history` comment that is **already gone from main**, and frames the fix as moving the UI onto a different data path. That is not what was missing. The paging machinery already existed and was already plumbed through:

- `OLDER_PAGE_LIMIT`, `next_before`, `has_more` and `total` are all wired up.
- Sibling callers already pass bounds — `ChatPane`'s hydrate, and `useSceneInteraction`.

Only the primary slot-open path was still unbounded. So this adds an explicit initial bound and nothing more.

## What changed

`switchSlot` asks for `OLDER_PAGE_LIMIT` rows. The first page a slot opens with is simply page one of the same pagination `loadOlderMessages` already runs, so the existing constant is reused rather than a second magic number introduced beside it.

**The bound is only acceptable because the remainder stays reachable.** The bounded response's `next_before` / `has_more` seed the cursor the older-page walk starts from, and a test asserts that seeding directly rather than assuming it. A truncating first page that could not page back would be worse than the unbounded fetch it replaces. A second assertion pins `OLDER_PAGE_LIMIT` inside the backend's `[1, 500]` clamp, so the constant cannot drift outside the range the handler accepts.

## Two paths stay unbounded, deliberately

- **`refreshSlot`** replaces the active transcript in place, so a bound would shrink history the user had already paged in.
- **A streaming slot**, because the server's limit slices *raw chunk rows*, which only collapse into messages afterwards. Bounding mid-stream would keep just the tail.

That streaming check reads `slotRun` rather than the `selectSlotStreamState` selector, which looks like the obvious choice but is the wrong one here: `switchSlot.pending` assigns `activeSlot = key` before the thunk body runs, so the selector would always take its active-slot branch and report `slotState` — which still describes the *outgoing* slot. `slotRun` is keyed per slot, so it answers for the incoming one. The lookup is guarded (`slotRun?.[key]`) because a partial preloaded state can omit `slotRun` entirely, and throwing there would skip the fetch rather than merely misjudge the bound.

## Verification

- `typecheck` + `lint` clean.
- Full website suite: **1487 files, 23188 tests pass** (Node 24, matching CI).
- The 6 `ChatPage.*` test files that this change initially regressed were confirmed passing on a clean baseline first, then re-confirmed after the fix, so the guard is checked against the failure it addresses rather than assumed.

No screenshots: this changes how much history one fetch asks for, with no visual delta.

Closes #2809
