### PR TITLE
fix: route palette window-capture Tab/Alt+Enter through the IME latch (#5396)

### DIFF
--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -69,6 +69,8 @@ const H = vi.hoisted(() => {
     indices: [] as number[],
     groupLabel: 'Current',
     onActivate: onActivateRecent,
+    // Optional preview hook; the Alt+Enter IME-guard test installs a spy here.
+    onAltActivate: undefined as (() => void) | undefined,
   }
   const allProvider = { id: 'all', label: 'All', icon: null, search: vi.fn(async () => [allResult]) }
   const sessionsProvider = {
@@ -93,12 +95,15 @@ const H = vi.hoisted(() => {
   const settingsProvider = { id: 'settings', label: 'Settings', icon: null, search: vi.fn(() => []) }
   const appsProvider = { id: 'apps', label: 'Apps', icon: null, search: vi.fn(async () => []) }
   // Stable return for the mocked keyboard-nav hook (constant identities avoid
-  // re-render loops in the palette's effects).
+  // re-render loops in the palette's effects). `claimKey` defaults to "not
+  // composing" so the keyboard tests exercise the palette's own branches; the
+  // IME-guard test flips it per call.
   const navReturn = {
     selected: 0,
     setSelected: vi.fn(),
     selectedRef: { current: 0 },
     itemRefs: { current: [] as (HTMLElement | null)[] },
+    claimKey: vi.fn(() => true),
   }
   const nav = {
     current: null as null | {
@@ -512,6 +517,56 @@ describe('CommandPalette — keyboard & activation', () => {
     // Scope chip adopted: placeholder narrows and the sessions provider serves.
     expect(await screen.findByPlaceholderText('Search sessions…')).toBeInTheDocument()
     expect(await screen.findByText('Session Result')).toBeInTheDocument()
+  })
+
+  it('a Tab the IME guard declines does not adopt the scope or clear the query', async () => {
+    render(<CommandPalette open onClose={vi.fn()} />, { wrapper })
+    await screen.findByText('Recent Session')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search everywhere' }), { target: { value: 'sess' } })
+    expect(await screen.findByText('Sessions')).toBeInTheDocument() // the hint label
+
+    // The shared hook's latch declines the key (composition live, or the
+    // committing keydown inside the post-composition window): the palette's
+    // window-capture branch must bail out before adopting the scope hint and
+    // wiping the half-composed query.
+    H.navReturn.claimKey.mockClear()
+    H.navReturn.claimKey.mockReturnValueOnce(false)
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Tab' })
+    })
+    expect(H.navReturn.claimKey).toHaveBeenCalledTimes(1)
+    expect(screen.queryByPlaceholderText('Search sessions…')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Search everywhere' })).toHaveValue('sess')
+
+    // Once the latch clears, the same Tab adopts the scope as before.
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Tab' })
+    })
+    expect(await screen.findByPlaceholderText('Search sessions…')).toBeInTheDocument()
+  })
+
+  it('an Alt+Enter the IME guard declines does not fire the preview', async () => {
+    const onAltActivate = vi.fn()
+    H.recentResult.onAltActivate = onAltActivate
+    try {
+      render(<CommandPalette open onClose={vi.fn()} />, { wrapper })
+      await screen.findByText('Recent Session')
+
+      H.navReturn.claimKey.mockReturnValueOnce(false)
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Enter', altKey: true })
+      })
+      expect(onAltActivate).not.toHaveBeenCalled()
+
+      // Guard clear: the same chord previews the selected row.
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Enter', altKey: true })
+      })
+      expect(onAltActivate).toHaveBeenCalledTimes(1)
+    } finally {
+      H.recentResult.onAltActivate = undefined
+    }
   })
 
   it('a leading sigil ($) instantly scopes to Skills and strips the sigil', async () => {

--- a/website/src/components/CommandPalette.tsx
+++ b/website/src/components/CommandPalette.tsx
@@ -61,7 +61,9 @@ import { useVisualViewport } from '../hooks/useVisualViewport'
  * shared hook, this component registers a *window*-phase capture listener:
  * window-capture fires before document-capture, so it can
  * `stopImmediatePropagation()` those two keys before the hook's document-level
- * listener sees them.
+ * listener sees them. Because that ordering also bypasses the hook's IME
+ * guard, both intercepted branches consult the hook's shared latch (its
+ * returned `claimKey`) before acting, declining keys the IME owns.
  *
  * Highlighting renders matched indices as React `<strong>` nodes split out of
  * the title — never `dangerouslySetInnerHTML` (`frontend-security` lint rule).
@@ -398,7 +400,7 @@ export default function CommandPalette({
     [dispatchEnter],
   )
 
-  const { selected, setSelected, selectedRef, itemRefs } = useListKeyboardNav({
+  const { selected, setSelected, selectedRef, itemRefs, claimKey } = useListKeyboardNav({
     open,
     count: results.length,
     wrap: true,
@@ -423,10 +425,21 @@ export default function CommandPalette({
   // way the palette needs: Tab (cycle category) and ⌥/Alt+Enter (preview).
   // window-capture runs before the hook's document-capture listener, so
   // stopImmediatePropagation here keeps the hook from also acting on them.
+  // Outranking the hook also outranks its IME guard, so each choose-class
+  // branch consults the hook's own latch first via `claimKey`: a Tab the IME
+  // owns (candidate-list navigation, or the committing keydown inside the
+  // post-composition window) must not adopt the scope hint and wipe the
+  // half-composed query. A declined key is already consumed per `claimKey`'s
+  // contract — stopPropagation keeps it from the hook's document listener,
+  // and preventDefault fires only where the browser would otherwise act.
+  // Backspace is not a choose-class key (the IME consumes its own Backspace
+  // mid-composition, and the composing text keeps `queryRef` non-empty, so
+  // the branch stays inert), and needs no guard.
   useEffect(() => {
     if (!open) return
     const onWinKey = (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
+        if (!claimKey(e)) return
         e.preventDefault()
         e.stopImmediatePropagation()
         // Prefix + Tab adopts the hinted scope (clearing the query); Shift+Tab
@@ -443,6 +456,7 @@ export default function CommandPalette({
         e.stopImmediatePropagation()
         setScope(null)
       } else if (e.key === 'Enter' && e.altKey && !e.metaKey && !e.ctrlKey) {
+        if (!claimKey(e)) return
         e.preventDefault()
         e.stopImmediatePropagation()
         const r = resultsRef.current
@@ -453,7 +467,7 @@ export default function CommandPalette({
     }
     window.addEventListener('keydown', onWinKey, true)
     return () => window.removeEventListener('keydown', onWinKey, true)
-  }, [open, selectedRef])
+  }, [open, selectedRef, claimKey])
 
   if (!open) return null
 

--- a/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
+++ b/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, fireEvent, cleanup } from '@testing-library/react'
+import { useEffect } from 'react'
 import { useListKeyboardNav, type UseListKeyboardNavOptions } from './useListKeyboardNav'
 
 /**
@@ -172,5 +173,118 @@ describe('useListKeyboardNav IME guard', () => {
     enter({ altKey: true })
     expect(onAltEnter).toHaveBeenCalledWith(0)
     expect(onChoose).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * A host-level WINDOW-capture interceptor (the palette's Tab / Alt+Enter
+ * takeover) deliberately outranks the hook's document-capture listener, so it
+ * bypasses the guard above along with the dispatch. The hook returns its
+ * instance `claimKey` so such an interceptor declines through the SAME
+ * tracked latch; this harness mirrors the palette's shape (claim first,
+ * consume-and-act on true, bail on false).
+ */
+function InterceptorHarness(props: Partial<UseListKeyboardNavOptions> & {
+  onTabAction: () => void
+  onAltAction?: () => void
+}) {
+  const { onTabAction, onAltAction, ...opts } = props
+  const { claimKey } = useListKeyboardNav({
+    open: true,
+    count: 3,
+    onChoose: () => {},
+    onClose: () => {},
+    ...opts,
+  })
+  useEffect(() => {
+    const onWinKey = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        if (!claimKey(e)) return
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onTabAction()
+      } else if (e.key === 'Enter' && e.altKey) {
+        if (!claimKey(e)) return
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onAltAction?.()
+      }
+    }
+    window.addEventListener('keydown', onWinKey, true)
+    return () => window.removeEventListener('keydown', onWinKey, true)
+  }, [claimKey, onTabAction, onAltAction])
+  return <input data-testid="host-input" aria-label="host input" />
+}
+
+describe('claimKey for a window-capture interceptor', () => {
+  it('a plain Tab reaches the interceptor and never the hook (positive control)', () => {
+    const onTabAction = vi.fn()
+    const onChoose = vi.fn()
+    render(<InterceptorHarness onTabAction={onTabAction} onChoose={onChoose} />)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(onTabAction).toHaveBeenCalledTimes(1)
+    // stopImmediatePropagation: the hook's document listener never chooses.
+    expect(onChoose).not.toHaveBeenCalled()
+  })
+
+  it('declines the committing Tab in the post-composition window AND consumes it', () => {
+    const onTabAction = vi.fn()
+    const onChoose = vi.fn()
+    const { getByTestId } = render(
+      <InterceptorHarness onTabAction={onTabAction} onChoose={onChoose} />,
+    )
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    // WebKit reports the committing keydown as non-composing; only the shared
+    // latch identifies it. The decline is fully consumed: preventDefault
+    // (nothing live to cancel) and stopPropagation (the hook's own document
+    // listener must not see a key the host already claimed).
+    const notPrevented = fireEvent.keyDown(document, { key: 'Tab' })
+    expect(onTabAction).not.toHaveBeenCalled()
+    expect(onChoose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('declines a mid-composition Tab without cancelling the IME candidate navigation', () => {
+    const onTabAction = vi.fn()
+    const { getByTestId } = render(<InterceptorHarness onTabAction={onTabAction} />)
+    fireEvent.compositionStart(getByTestId('host-input'))
+    const notPrevented = fireEvent.keyDown(document, { key: 'Tab', isComposing: true })
+    expect(onTabAction).not.toHaveBeenCalled()
+    // The browser is consuming Tab for the candidate list itself.
+    expect(notPrevented).toBe(true)
+  })
+
+  it('intercepts again once the post-composition window has elapsed', () => {
+    vi.useFakeTimers()
+    const onTabAction = vi.fn()
+    const { getByTestId } = render(<InterceptorHarness onTabAction={onTabAction} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    vi.advanceTimersByTime(60)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(onTabAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('declines a latched Alt+Enter preview through the same latch, then intercepts once it clears', () => {
+    vi.useFakeTimers()
+    const onTabAction = vi.fn()
+    const onAltAction = vi.fn()
+    const { getByTestId } = render(
+      <InterceptorHarness onTabAction={onTabAction} onAltAction={onAltAction} />,
+    )
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    enter({ altKey: true })
+    expect(onAltAction).not.toHaveBeenCalled()
+    // Positive control: past the post-composition window the same chord
+    // reaches the interceptor, so the decline above pins the latch and not
+    // an interceptor that declines everything.
+    vi.advanceTimersByTime(60)
+    enter({ altKey: true })
+    expect(onAltAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/website/src/hooks/useListKeyboardNav.ts
+++ b/website/src/hooks/useListKeyboardNav.ts
@@ -20,7 +20,10 @@ import { createImeLatch } from './useImeGuard'
  *    Both choose keys are IME-guarded: while a composition is live or inside
  *    the post-composition latch window (shared with `useImeGuard` via
  *    `createImeLatch`), the key declines the choose and is consumed per
- *    `claimKey`'s contract instead.
+ *    `claimKey`'s contract instead. A host interceptor that outranks this
+ *    listener bypasses that guard along with the dispatch, so it must consult
+ *    the same latch through the returned {@link ListKeyboardNav.claimKey}
+ *    before acting on a choose-class key.
  *  - `Alt`/`Option`+`Enter`  — `onAltEnter(selected)` when provided; if it
  *    returns `true` the event is treated as handled.
  *  - `Escape`                — `onClose()`.
@@ -78,6 +81,19 @@ export interface ListKeyboardNav {
   selectedRef: MutableRefObject<number>
   /** Per-row element refs; assign with `ref={el => { itemRefs.current[i] = el }}`. */
   itemRefs: MutableRefObject<(HTMLElement | null)[]>
+  /**
+   * The hook's IME-guard claim, for a HOST-LEVEL interceptor that outranks the
+   * hook's own document-capture listener (the window-capture Tab takeover the
+   * `onChoose` doc describes). Such an interceptor acts on choose-class keys
+   * BEFORE the hook's guarded dispatch can decline them, so it must consult
+   * the SAME tracked latch: call this first in each intercepted choose branch
+   * and bail out on `false` — the claim has already consumed the decline per
+   * `claimKey`'s contract in useImeGuard.ts (stopPropagation always,
+   * preventDefault only where the browser would otherwise act). A private
+   * latch in the host is the drift the `ImeEnterClaimRatchet` pins; this is
+   * the sanctioned spelling.
+   */
+  claimKey: (e: globalThis.KeyboardEvent) => boolean
 }
 
 export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboardNav {
@@ -254,5 +270,13 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
     move(next)
   }, [move])
 
-  return { selected, setSelected: setSelectedSynced, selectedRef, itemRefs }
+  // Stable delegate onto the instance latch, so a host's window-capture
+  // interceptor consults the same composition tracking as the hook's own
+  // choose dispatch (see the ListKeyboardNav.claimKey contract).
+  const claimKey = useCallback(
+    (e: globalThis.KeyboardEvent) => imeLatchRef.current!.claimKey(e),
+    [],
+  )
+
+  return { selected, setSelected: setSelectedSynced, selectedRef, itemRefs, claimKey }
 }


### PR DESCRIPTION

## Problem / Motivation

Typing with a CJK IME into the Command Palette query and pressing Tab mid-composition adopts the category scope hint and wipes the half-composed query -- and the keypress the IME needed for its own candidate-list navigation is cancelled out from under it. Alt+Enter has the same hole: it can fire the preview against half-composed text.

This is the same defect class as #5340, on the one surface whose host-level interceptor deliberately outranks the guarded shared hook: the palette registers a *window*-capture keydown listener for Tab (cycle/adopt category scope) and Alt+Enter (preview) that runs before `useListKeyboardNav`'s document-capture listener and calls `stopImmediatePropagation()`, so the IME composition guard added to the hook in #5393 never sees those keys here.

## Why it matters

Every CJK-IME user of the palette is affected: composing a query and pressing Tab (a key IMEs routinely use to cycle candidates) silently destroys their input and drops them into a scope they did not choose. The guard shipped for every other picker surface; the palette -- the most prominent one -- remained the gap.

## What changed (motivation -> approach -> change)

Symptom: window-capture Tab/Alt+Enter act during composition. Root cause: the palette's interceptor outranks the hook's document-capture listener *and therefore also its IME guard* -- the ordering that makes the Tab takeover work is exactly what bypasses the protection. The fix keeps the documented window-capture-outranks-document-capture ordering and instead brings the guard to the interceptor:

- `useListKeyboardNav` now returns `claimKey` -- a stable delegate onto the hook instance's existing `createImeLatch`, the same latch its own choose dispatch consults (composition tracking for it was already wired at document capture). A host interceptor and the hook can no longer disagree about who owns a keypress.
- The palette's window-capture Tab and Alt+Enter branches call `if (!claimKey(e)) return` before acting -- one check per branch, inheriting `claimKey`'s documented prevent/stop split: mid-composition keys keep their default action (the IME is consuming them), post-composition-window keys are fully consumed, and a declined key is `stopPropagation()`ed so it cannot fall through to the hook's document listener either.
- The Backspace branch is not a choose key and stays unguarded (the composing text keeps the query non-empty, so the branch is inert during composition).

Consuming the hook's instance latch (rather than the palette creating its own `createImeLatch`) avoids a second set of composition listeners and a second source of truth -- and stays inside the `ImeEnterClaimRatchet`'s sanctioned spellings.

One deliberate behavior change: a mid-composition Tab is no longer `preventDefault`'d (previously every Tab while the palette was open was unconditionally prevented). This matches `claimKey`'s contract -- cancelling the default there risks eating the candidate commit/navigation the browser is consuming the key for -- and is the same accepted decline the hook's own choose path already ships.

## Tests

`useListKeyboardNav.imeGuard.test.tsx` -- new `claimKey for a window-capture interceptor` block with a harness mirroring the palette's shape (claim first, consume-and-act on true):
- plain Tab reaches the interceptor and never the hook (positive control for the takeover ordering),
- the committing Tab inside the post-composition window is declined AND fully consumed,
- a mid-composition Tab is declined without cancelling the IME's default action,
- the interceptor works again once the window elapses,
- a latched Alt+Enter is declined, then intercepted once the latch clears.

`CommandPalette.test.tsx` -- wiring tests against the mocked hook: a declined `claimKey` leaves the scope hint unadopted and the query intact (then the same Tab adopts once the guard clears), and a declined Alt+Enter does not fire the preview. Both mutation-verified: removing the palette's Tab guard reds the Tab test; neutering the hook's `claimKey` delegate reds the interceptor declines.

Full local gates: `npx tsc -b`, full `vitest run` (23,178 passed), eslint (repo-wide 660 warnings, under the 664 ratchet; no new warnings on touched files), `ImeEnterClaimRatchet` 14/14, brand + harness-parity + scrub gates, backend isort/flake8/mypy (diff is frontend-only; the 4 mypy notes are the pre-existing boto3-stub drift in untouched files).

## Manual verification

N/A -- the defect and fix are keyboard-event ordering, fully exercised by the window-capture interceptor harness; there is no visual delta to screenshot (keyboard-guard change only).

Pre-push review fleet: GPT lane and Opus lane both NO BLOCKING FINDINGS. Two advisory test-hardening suggestions were folded in (exact call-count assertion; Alt+Enter positive control). One advisory residual-class finding -- `useDialogFocusTrap`'s window-capture Tab handler has no composition reference, though it does not outrank any guarded listener today -- is filed separately as a follow-up issue rather than widening this diff.

Closes #5396
