### PR TITLE
feat(approval): Add PendingDecision tool-approval frontend model

### DIFF
--- a/website/src/test/toolApproval.test.ts
+++ b/website/src/test/toolApproval.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import type { PendingDecision, ToolInvocationState } from '../types/toolApproval'
+import type { PendingApproval } from '../types/index'
+
+// Task 0 is a types + seam-confirmation task. These tests lock in:
+//   1. `PendingDecision` wraps the REAL `PendingApproval` event (no new wire
+//      field); if that wire shape drifts, `tsc` fails here.
+//   2. The resume identifier is `approval.request_id` — the id-scoped
+//      `api.resolveApproval` path, not a fabricated one.
+//   3. `ToolInvocationState` models the three reachable lifecycle phases, with
+//      `input-available` as the approvable moment.
+
+describe('PendingDecision model', () => {
+  it('wraps the real PendingApproval event (no new wire field)', () => {
+    // Typed as the existing wire shape — the compiler enforces the field set.
+    const approval: PendingApproval = {
+      tool: 'fs_write',
+      tool_input: '{"path":"/tmp/x","content":"hi"}',
+      tool_kind: 'edit',
+      request_id: 'req-123',
+    }
+
+    const pending: PendingDecision = {
+      slot: 'chat-1',
+      approval,
+      invocation: { state: 'input-available', input: JSON.parse(approval.tool_input) },
+    }
+
+    expect(pending.slot).toBe('chat-1')
+    // The resume identifier is request_id (id-scoped api.resolveApproval).
+    expect(pending.approval.request_id).toBe('req-123')
+    // The raw-input source is the verbatim event field.
+    expect(pending.approval.tool_input).toBe(approval.tool_input)
+    expect(pending.toolCallId).toBeUndefined()
+    expect(pending.invocation.state).toBe('input-available')
+  })
+
+  it('carries an optional tool_call_id for display/correlation when present', () => {
+    const approval: PendingApproval = {
+      tool: 'grep',
+      tool_input: '{"pattern":"foo"}',
+      tool_kind: 'read',
+      request_id: 'req-9',
+    }
+    const pending: PendingDecision = {
+      slot: 'chat-1',
+      approval,
+      toolCallId: 'tc-abc',
+      invocation: { state: 'input-available', input: { pattern: 'foo' } },
+    }
+    expect(pending.toolCallId).toBe('tc-abc')
+    // Even with a tool_call_id present, request_id remains the resume id.
+    expect(pending.approval.request_id).toBe('req-9')
+  })
+
+  it('models the three reachable lifecycle phases', () => {
+    const samples: ToolInvocationState[] = [
+      { state: 'input-available', input: {} },
+      { state: 'output-available', input: {}, output: {} },
+      { state: 'output-error', input: {}, error: 'TOOL_DENY' },
+    ]
+    expect(samples.map((s) => s.state)).toEqual([
+      'input-available',
+      'output-available',
+      'output-error',
+    ])
+    const errored = samples[2]
+    if (errored.state === 'output-error') expect(errored.error).toBe('TOOL_DENY')
+  })
+})

--- a/website/src/types/toolApproval.ts
+++ b/website/src/types/toolApproval.ts
@@ -1,0 +1,68 @@
+import type { PendingApproval } from './index'
+
+// Human-in-the-Loop Tool-Approval Layer — shared frontend model.
+//
+// A `PendingDecision` is the frontend view of one tool call paused at the
+// PreToolUse boundary, awaiting an operator's approve/reject. It adds NO new
+// backend wire field: it carries the existing `PendingApproval` event verbatim
+// (`approval`, from types/index.ts — `tool`, `tool_input`, `tool_kind`,
+// `request_id`) plus the two pieces of context the event itself does not hold:
+//   - slot        ← the chat slot the paused turn belongs to
+//   - toolCallId  ← `tool_call_id` when a tool-activity event carries it
+//                   (spread conditionally by useWebSocket.ts); optional, used for
+//                   display/correlation only. It is NOT the resume identifier.
+// Carrying `PendingApproval` (rather than re-spelling its fields) keeps the model
+// pinned to the real wire shape: if that shape drifts, `tsc` fails here.
+//
+// Resume identifier: `approval.request_id`. Plain approve/reject resolves through
+// the id-scoped `api.resolveApproval(request_id, action)` → POST
+// /api/approvals/<id>/<action> (ChatInput.tsx). The slot-scoped
+// `api.approveChatSlot(slot, …)` is used ONLY for trust grants, and downgrades to
+// `resolveApproval` for unattended sources — so this layer resumes by
+// `request_id`, never by inventing a new call. A stale/closed id is a no-op.
+//
+// `ToolInvocationState` mirrors the shape of the Vercel AI SDK `UIToolInvocation`
+// lifecycle as a STATE MODEL ONLY — a way to reason about the phases of one tool
+// call, NOT a claim that Kiro Crew's transport carries a typed `tool-<name>` part
+// stream (it does not; the transport is markdown + <mcwidget> opaque strings).
+
+/**
+ * The lifecycle phase of a single tool invocation.
+ *
+ * `input-available` is the approvable moment: the input is complete but the tool
+ * has not run. The approval card renders from this state; a decision moves it to
+ * `output-available` (executed) or `output-error` (rejected / failed).
+ *
+ * `input-streaming` is intentionally omitted: on this transport the pending
+ * event arrives with the input already complete, so there is no partial-args
+ * phase to model. Inputs/outputs are `unknown` here — Task 0 has no
+ * schema-matched consumer; a typed variant returns with Task 1's typed preview
+ * (`kit/tool-views`), the first caller that can name a concrete type.
+ */
+export type ToolInvocationState =
+  | { state: 'input-available'; input: unknown } // ← the approvable moment
+  | { state: 'output-available'; input: unknown; output: unknown }
+  | { state: 'output-error'; input: unknown; error: string }
+
+/**
+ * One tool call awaiting a human decision. Wraps the existing `PendingApproval`
+ * event (no new backend wire field) and the invocation lifecycle.
+ */
+export interface PendingDecision {
+  /** Chat slot the paused turn belongs to; scopes display/routing. */
+  slot: string
+  /**
+   * The verbatim backend approval event. `approval.request_id` is the resume
+   * identifier (`api.resolveApproval`); `approval.tool_input` is the ground-truth
+   * "show raw input" source; `approval.tool` is the display title.
+   */
+  approval: PendingApproval
+  /**
+   * `tool_call_id` when a tool-activity event carries it (spread conditionally by
+   * the backend). Optional; for display/correlation only — resume uses
+   * `approval.request_id`, not this. A missing id is never a re-issued call.
+   */
+  toolCallId?: string
+  /** The invocation lifecycle; at the approvable moment this is `input-available`. */
+  invocation: ToolInvocationState
+}


### PR DESCRIPTION
## Problem
The Human-in-the-Loop Tool-Approval Layer spec (merged in #5013, `.kiro/specs/tool-approval-layer/`) defines Task 0 as: establish the `PendingDecision` frontend model and confirm the resume seam. Until that shared model exists, the later tasks (rich preview, resume wiring, batch approval) have no typed contract to build against, and the seam the spec *assumed* (`approveChatSlot`) had not been checked against the real resume path.

## Why it matters
Getting the seam wrong is the expensive failure mode: a contributor who assumes the wrong resume call or invents a new backend event risks moving enforcement out of `on_tool_call` (a security regression) or widening the approval surface. Task 0's whole value is settling the contract in ONE place before Tasks 1–8 build on it.

## Fix (symptoms → root cause → change)
Symptom: no shared `PendingDecision` type, and the spec's assumed resume seam was unverified. Root cause: Task 0 was specced but not implemented, and its assumption (`approveChatSlot` "pins resume to the slot") turned out not to match the code. Change: add a types-only module that wraps the real wire event, and correct the seam.

- `website/src/types/toolApproval.ts` — `PendingDecision` carries the existing `PendingApproval` event **verbatim** (`approval: PendingApproval`, from `types/index.ts`), plus `slot` and an optional `toolCallId` (display/correlation only). Carrying the real event — rather than re-spelling `title`/`rawInput` — keeps the model pinned to the wire shape, so `tsc` fails if that shape drifts. `ToolInvocationState` is a non-generic 3-phase union (`input-available` = the approvable moment; `input-streaming` is omitted as unreachable on this transport). It mirrors the AI-SDK `UIToolInvocation` lifecycle **as a state model only**, not a transport claim.
- `website/src/test/toolApproval.test.ts` — 3 vitest cases: wrap a real `PendingApproval` (proving no new wire field, compiler-enforced), assert the optional `toolCallId`, and construct the three lifecycle phases.

**Resume seam, corrected against real code** (`website/src/components/ChatInput.tsx:806-813`, `website/src/api/client.ts:2410`): plain approve/reject resolves through the **id-scoped `api.resolveApproval(request_id, action)`** → `POST /api/approvals/<id>/<action>`. The slot-scoped `api.approveChatSlot(slot, …)` is used **only for trust grants**, and even downgrades to `resolveApproval` for unattended sources. So the resume identifier is `approval.request_id`, and no new call/wire field is introduced. Requirements 3.3, 3.4, 5.1, 6.4.

No runtime, backend, or dependency change. `ToolPreviewFrame` from `kit/tool-views` is a Task 1 dependency and is intentionally NOT imported here.

## Tests
`website/src/test/toolApproval.test.ts` (3 cases) — lock the wrap-the-real-`PendingApproval` mapping (compiler-enforced), the optional `toolCallId`, and the 3-phase union. Type correctness enforced by `tsc -b`.

## Manual verification
N/A — unit + type coverage sufficient; pure types module, no UI or runtime behavior. Local gates green: `tsc -b`, `vitest` (3/3), `eslint`.

## Follow-up (not in this PR)
Design Review + First Principles correctly note the **merged spec still names the old seam**: `.kiro/specs/tool-approval-layer/tasks.md` Task 3 routes decisions through `approveChatSlot`, and Task 0 / the design's field shape (`title`/`rawInput`, `<TIn,TOut>`, 4 phases) predate this correction. That is a change to already-merged spec files and belongs in its own docs PR — filed as follow-up so Tasks 1–8 build against the `request_id`/`resolveApproval` contract this PR verified, not the stale one.
