### PR TITLE
docs(spec): Address Design Review concerns on tool-approval-layer spec

### DIFF
--- a/.kiro/specs/tool-approval-layer/design.md
+++ b/.kiro/specs/tool-approval-layer/design.md
@@ -63,8 +63,35 @@ Tool executes (approved) or is skipped (rejected); agent turn continues
 | `website/src/components/ToolInputPreview.tsx` | The fallback preview and the "show raw input" surface. |
 | `website/src/components/ChatInput.tsx` (`approveChatSlot`) | **Unchanged** resume transport the layer reuses. |
 | `website/src/hooks/useWebSocket.ts` | Delivers the pending-decision + resume events (existing). |
-| `website/src/kit/tool-views/` (App Builder Kit) | Supplies `ToolPreviewFrame` / schema-matched typed previews. |
+| `website/src/kit/tool-views/` (App Builder Kit spec — **prerequisite, not built by this spec**) | Supplies `ToolPreviewFrame` / schema-matched typed previews. This spec **consumes** it and is sequenced after it (see "Dependency and sequencing" below, and Req 8). |
 | `website/src/types/index.ts` (`tool_input: string`) | The opaque input string a preview parses; no new wire field. |
+
+### Dependency and sequencing (Req 8)
+
+`ToolPreviewFrame` is **not defined or built by this spec.** It is owned by the separate
+App Builder Kit spec (`.kiro/specs/app-builder-kit/`), whose `kit/tool-views` module
+supplies `defineToolView` + `ToolPreviewFrame`. This spec is a **consumer** and is
+sequenced **after** that module ships (a hard prerequisite — Req 8.1). Task 0 verifies the
+module exists before Task 1 begins and fails closed if it does not (Req 8.3), rather than
+stubbing a local `ToolPreviewFrame` that would fork the App Builder Kit's contract.
+
+The **exact contract this spec depends on** (owned by App Builder Kit, restated here only
+so the boundary is legible — not redefined):
+
+```ts
+// from website/src/kit/tool-views/ (App Builder Kit spec)
+function ToolPreviewFrame(props: {
+  input: unknown                                  // the pending call's tool_input, parsed
+  onApprove: (decision: 'approve' | 'reject', pattern?: string) => void
+}): JSX.Element
+// (a) registered ToolViewDef schema matches input → typed preview
+// (b) no match → falls back to <ToolInputPreview> <pre>
+// (c) verbatim raw input is always one interaction away (Req 2.4)
+```
+
+If only the approval loop is wanted before `tool-views` ships, the Req 2.3 fallback (the
+existing `ToolInputPreview` `<pre>`) alone delivers Requirements 1, 3, 4, 5, 6 — the typed
+rich preview (Req 2.2) is the single capability gated on this dependency (Req 8.4).
 
 ## Components and Interfaces
 
@@ -122,9 +149,15 @@ onApprove(decision: 'approve' | 'reject', pattern?: string)
 
 Batch is a **UI affordance over the per-call resume**, not a new transport (Req 4.2).
 When N calls are pending in a slot, `ApprovalCard` renders a multi-select; submitting a
-batch iterates `approveChatSlot` per included call. A call the gate would deny is visibly
-excluded and never included in the batch set (Req 4.3–4.4) — the frontend cannot approve
-what the backend denies.
+batch iterates `approveChatSlot` per included call. **Exclusion is backend-driven, not
+predicted (Req 4.3–4.4, Req 6.1):** the frontend does not compute or forecast a gate
+verdict — it submits each selected call's resume, and if the `on_tool_call` gate rejects
+one at resume time, that call comes back rejected and the UI marks it excluded *after the
+fact*. Because Req 1.2 already keeps a `TOOL_DENY` call from ever becoming a pending
+decision, everything in a batch was `TOOL_ALLOW` when surfaced; an exclusion reflects a
+verdict that changed between surfacing and resume (e.g. governance state shifted), reported
+by the backend. The frontend never re-implements the gate — that would be exactly the
+parallel policy Req 6.1 forbids.
 
 ## Portable AI-SDK mapping (Requirement 5)
 
@@ -157,8 +190,9 @@ schema; a parse failure downgrades to `<pre>` (no throw).
   via the existing logger — it never blocks the operator from deciding.
 - A resume that references a stale/closed `toolCallId` is a no-op with a surfaced notice,
   never a re-issued call (Req 3.4).
-- A batch that includes a now-denied call excludes it and reports the exclusion; the
-  remaining approvals proceed.
+- A batch resume where the gate rejects one included call surfaces that call as excluded
+  *after the fact* (the backend reports the per-call rejection); the remaining approvals
+  proceed. The frontend does not pre-filter by predicting the verdict.
 - Enforcement errors (governance deny, sensitive-path) are owned by `on_tool_call` and its
   SEL audit — the layer surfaces the deny, it does not handle or suppress it.
 

--- a/.kiro/specs/tool-approval-layer/requirements.md
+++ b/.kiro/specs/tool-approval-layer/requirements.md
@@ -74,8 +74,8 @@ several pending calls at once, so that supervision scales past one-click-per-cal
 #### Acceptance Criteria
 1. WHERE more than one call is pending in a slot THE layer SHALL present them such that the operator can act on multiple pending decisions in one interaction.
 2. WHEN a batch decision is submitted THEN each included pending call SHALL resolve through the same per-call `approveChatSlot` path (batch is a UI affordance over the existing per-call resume, not a new transport).
-3. WHEN a batch approval includes a call the gate would deny THEN that call SHALL still be denied — batch approval SHALL NOT override the security gate.
-4. IF a batch spans calls of differing risk THEN a denied or ineligible call SHALL be visibly excluded from the batch rather than silently approved.
+3. WHEN a batch approval includes a call the gate rejects THEN that call SHALL still be denied — batch approval SHALL NOT override the security gate. The frontend does NOT predict the gate verdict (that would be the parallel policy Req 6.1 forbids); exclusion is **backend-driven** — each included call resolves through the same per-call `approveChatSlot` resume, and a call the `on_tool_call` gate rejects at that resume is reported back as excluded.
+4. WHERE a batch resume produces a per-call rejection from the gate THE rejected call SHALL be **surfaced as excluded after the fact** (marked rejected in the batch result), never silently approved. Because Req 1.2 already guarantees a `TOOL_DENY` call never becomes a pending decision, the only calls reaching a batch are `TOOL_ALLOW` at surfacing time; an exclusion here reflects a verdict that changed between surfacing and resume (e.g. governance state shifted), reported by the backend, not computed by the frontend.
 
 ### Requirement 5 — Portable AI-SDK lifecycle mapping
 
@@ -109,3 +109,22 @@ adopting it does not create review or build friction.
 2. WHEN layer code adds user-facing strings THEN the corresponding keys SHALL exist in all locale files (catalogParity).
 3. WHEN layer code is added THEN it SHALL NOT introduce copy/paste clones that fail the jscpd 0% threshold, and SHALL reuse `ApprovalCard`/`ToolInputPreview`/`ChatInput` rather than forking them.
 4. WHEN the existing approval flow is exercised THEN it SHALL show no regression versus its pre-change behavior (the auto-approve, deny, and single-approve paths keep working).
+
+### Requirement 8 — Dependency on the App Builder Kit tool-views, and sequencing
+
+**User Story:** As an implementer, I need the typed-preview dependency named and the build
+order stated, so that I do not start the core render task against a module that does not
+yet exist and end up inventing its contract ad hoc.
+
+**Context (verified against the codebase):** The rich preview (Req 2.2) is rendered by
+`ToolPreviewFrame`, which lives in `website/src/kit/tool-views/` — a module **defined by
+the separate App Builder Kit spec** (`.kiro/specs/app-builder-kit/`), NOT by this spec and
+NOT yet built. This spec consumes that module; it does not create it. Without stating the
+dependency and the minimal contract, Task 1 (the core render deliverable) blocks on an
+unbuilt module and an implementer would invent the preview contract.
+
+#### Acceptance Criteria
+1. WHEN this spec is scheduled THEN it SHALL be sequenced **after** the App Builder Kit spec's `tool-views` module (specifically `ToolPreviewFrame` + `defineToolView`) has shipped — this is a hard prerequisite, and Task 0 SHALL verify the module exists before Task 1 begins.
+2. WHERE `ToolPreviewFrame` is consumed THE contract THIS spec depends on SHALL be exactly: a component `ToolPreviewFrame({ input, onApprove })` that (a) renders a typed preview when a registered `ToolViewDef` schema matches `input`, (b) falls back to `ToolInputPreview` `<pre>` when none matches, and (c) exposes the verbatim raw input one interaction away (Req 2.4). This spec SHALL NOT redefine or extend that contract — the App Builder Kit spec owns it.
+3. IF the App Builder Kit `tool-views` module is NOT available when this spec is implemented THEN Task 0 SHALL fail closed and the work SHALL stop with that dependency named, rather than stubbing a local `ToolPreviewFrame` (which would fork the contract the jscpd/AGENTS conventions forbid).
+4. WHERE only the approval-loop portion is wanted before `tool-views` ships THE fallback path (Req 2.3, the existing `ToolInputPreview` `<pre>`) SHALL be sufficient to deliver Requirements 1, 3, 4, 5, 6 with no rich preview — the typed preview (Req 2.2) is the one capability gated on the dependency.

--- a/.kiro/specs/tool-approval-layer/tasks.md
+++ b/.kiro/specs/tool-approval-layer/tasks.md
@@ -2,17 +2,24 @@
 
 This plan enriches the render + resume steps of Kiro Crew's existing approval loop and
 documents the portable AI-SDK mapping. The backend enforcement gate (`on_tool_call`) is
-NOT modified. Depends on the App Builder Kit's `kit/tool-views` module for the typed
-preview components.
+NOT modified. **Prerequisite:** the App Builder Kit's `kit/tool-views` module
+(`ToolPreviewFrame` + `defineToolView`) must ship first — this spec is sequenced after it
+and Task 0 verifies it fail-closed (Req 8). The Req 2.3 `<pre>` fallback path can deliver
+Reqs 1/3/4/5/6 without the module; only the typed rich preview (Req 2.2) is gated on it.
 
-- [ ] 0. Establish the `PendingDecision` frontend model and confirm the resume seam
+- [ ] 0. Verify the tool-views prerequisite, then establish the `PendingDecision` frontend model
+  - **Prerequisite check (fail-closed, Req 8.1/8.3):** confirm the App Builder Kit
+    `website/src/kit/tool-views/` module exists and exports `ToolPreviewFrame` +
+    `defineToolView`. If it does not, STOP and report the dependency — do NOT stub a local
+    `ToolPreviewFrame` (that forks the App Builder Kit contract). The Req 2.3 `<pre>`
+    fallback path may proceed for Reqs 1/3/4/5/6 without it (Req 8.4).
   - Define `PendingDecision` (`slot`, `toolCallId`, `title`, `rawInput`, `invocation`) and
     the `ToolInvocationState` union in a shared types module, mirroring AI-SDK
     `UIToolInvocation` as a state model only.
   - Confirm (via reading `useWebSocket.ts` + `ChatInput.tsx`) that a `PendingDecision` can
     be assembled from the existing PreToolUse event with NO new backend wire field, and that
     `approveChatSlot(slot, action, extra)` already pins resume to the slot.
-  - _Requirements: 3.3, 3.4, 5.1, 6.4_
+  - _Requirements: 3.3, 3.4, 5.1, 6.4, 8.1, 8.3_
 
 - [ ] 1. Rich preview inside `ApprovalCard` (default view, with raw-input fallback)
   - Host `ToolPreviewFrame` (from `kit/tool-views`) inside `ApprovalCard`/`ToolInputPreview`.
@@ -36,7 +43,9 @@ preview components.
 - [ ] 4. Batch approval affordance
   - Render a multi-select when N calls are pending in a slot; submitting a batch iterates
     the per-call `approveChatSlot` resume (no new transport).
-  - Visibly exclude any call the gate would deny; never include it in the batch set.
+  - Surface any per-call rejection the gate returns at resume as excluded **after the fact**
+    (backend-driven, not predicted); never pre-filter by forecasting the verdict, and never
+    silently approve an excluded call.
   - _Requirements: 4.1, 4.2, 4.3, 4.4_
 
 - [ ] 5. Enforce the single-authority boundary
@@ -57,7 +66,7 @@ preview components.
   - Unit (vitest): each `PendingDecision` state; schema-match vs `<pre>` fallback;
     raw-input reveal; keyboard/ARIA.
   - Resume: approve/reject route with correct `slot`/`toolCallId`/`pattern`; stale id no-op.
-  - Batch: per-call resolution; denied call excluded.
+  - Batch: per-call resolution; a gate-rejected call surfaced as excluded after the fact.
   - Non-bypass: a `TOOL_DENY` never yields an approvable card.
   - Backend (pytest): reuse `test_dashboard_approval.py` / `test_auto_approve.py` /
     `test_approval_threading.py` to assert gate verdicts + SEL audit unchanged.


### PR DESCRIPTION
## Problem

PR #5013 landed the Human-in-the-Loop Tool-Approval Layer Kiro spec, but a Design Review verdict of **CONCERNS** on it flagged two real gaps that shipped to `main`:

1. The spec's load-bearing render dependency — `website/src/kit/tool-views/` / `ToolPreviewFrame` — is listed in the design's "verified paths" table but is **not built by this spec** and did not exist at review time. Task 1 (the core deliverable) blocks on an unbuilt, un-named module, so an implementer would invent the preview contract ad hoc.
2. Requirement 4.3–4.4 ("a call the gate would deny is visibly excluded from a batch") implies the **frontend can predict gate verdicts** — but Req 1.2 guarantees denied calls never become pending decisions and Req 6.1 forbids a parallel frontend policy. As written, 4.3–4.4 asked for exactly the second policy the spec prohibits.

## Why it matters

Both are one-way-door design concerns on a spec that is now the reference for building the feature. Left unaddressed, an implementer either invents a forked `ToolPreviewFrame` (violating the jscpd/AGENTS conventions) or builds a frontend verdict-predictor that duplicates the security gate — the exact thing the spec's single-authority principle exists to prevent.

## Fix (symptom → root cause → change)

**Symptom:** design references a module no spec owns; two requirements contradict the spec's own authority model.
**Root cause:** the dependency on the App Builder Kit's `kit/tool-views` was implied but never named or sequenced, and the batch-exclusion wording described a frontend-side prediction instead of the backend-driven reality.
**Change (docs-only, 3 files under `.kiro/specs/tool-approval-layer/`):**

- **Dependency + sequencing (Concern 1):**
  - New **Requirement 8** — "Dependency on the App Builder Kit tool-views, and sequencing": names `ToolPreviewFrame`/`kit/tool-views` as owned by the App Builder Kit spec, makes this spec sequenced *after* it (hard prerequisite), states the exact consumed contract, requires a fail-closed Task 0 check, and notes the `<pre>` fallback delivers Reqs 1/3/4/5/6 without the module.
  - `design.md`: boundary-table row now marks `kit/tool-views` as a prerequisite not built here; new "Dependency and sequencing" subsection restates the consumed `ToolPreviewFrame` contract.
  - `tasks.md`: Task 0 gains the fail-closed prerequisite check; header dependency note updated.
- **Backend-driven batch exclusion (Concern 2):**
  - `requirements.md` Req 4.3–4.4 reworded: the frontend does **not** predict the verdict; each included call resolves through the same per-call `approveChatSlot` resume, and a call the `on_tool_call` gate rejects at resume is surfaced as excluded **after the fact** — consistent with Req 1.2 / Req 6.1.
  - `design.md` Batch section + Error Handling and `tasks.md` Task 4 / Task 7 updated to match.

## Tests

N/A — documentation-only change (three `.kiro/specs/tool-approval-layer/*.md` files). No code, no runtime behavior.

## Manual verification

- Confirmed no one-word "KiroCrew" in added lines (Brand Name Gate expects "Kiro Crew").
- `push_guard.py --base main --require-single-on-base` → SAFE (single commit on fresh `origin/main`).

## Screenshots

N/A — no user-visible UI change.
