### PR TITLE
feat(desktop): dump Pierre highlight churn when the renderer dies

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -73,7 +73,8 @@ const {
   unrecoverableGatewayDialog,
 } = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
-const { createMetricsRecorder } = require("./perf-metrics");
+const { createMetricsRecorder, profilingEnabled } = require("./perf-metrics");
+const { createPierrePerfLog } = require("./pierre-perf-log");
 const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
 const { initMochi, shutdownMochi } = require("./mochi/index");
 const { borrowSessionToken } = require("./mochi-session-token");
@@ -380,6 +381,12 @@ function glog(line) {
   try { fs.appendFileSync(gatewayLogPath(), entry); } catch { /* never let logging break launch */ }
   console.log(`[gateway-launch] ${line}`);
 }
+
+// Highlight-churn history for the renderer-crash post-mortem. Module scope
+// because the reports arrive on an ipcMain channel while the flush happens in
+// the window's render-process-gone handler. Holds only plain numbers, bounded to
+// its capacity, and writes nothing until a crash.
+const pierrePerfLog = createPierrePerfLog();
 
 // ── Cross-app gateway ownership (shared ~/.kiro/crew, shared port) ─────────
 // The nightly app and the production app are different bundles sharing one
@@ -2294,6 +2301,13 @@ function createWindow() {
     },
   });
   mainWindow.webContents.on("render-process-gone", (_e, details) => {
+    // Flush the highlight history FIRST so the log reads in causal order: what
+    // the highlighter was doing, then the death and what the processes had grown
+    // to. Unconditional -- this is the moment the buffer was kept for, and it is
+    // also the one moment the write cost is justified. An empty flush is itself
+    // informative: no highlighting in the last two minutes points away from the
+    // Pierre worker pool as the cause.
+    for (const line of pierrePerfLog.flush()) glog(line);
     rendererRecovery.handleGone(details || {});
   });
 
@@ -3918,6 +3932,34 @@ app.whenReady().then(async () => {
     } catch {
       /* status probe unavailable — stay silent rather than guess */
     }
+  });
+
+  // Pierre highlight-churn reports (src/lib/pierrePerf.ts). Buffered in memory
+  // and flushed to the log only when the renderer dies -- see pierre-perf-log.js
+  // for why nothing is written in steady state (glog has no rotation, so a line
+  // every few seconds would grow the user's log without bound).
+  //
+  // The payoff: every future renderer crash carries the two minutes of
+  // highlighter activity that preceded it, on a normal install, with no env var
+  // set ahead of time.
+  //
+  // KIROCREW_DEBUG additionally logs each window as it arrives, for watching a
+  // live reproduction instead of reading a post-mortem. Checked per message so
+  // toggling the variable needs no rebuild.
+  ipcMain.on("pierre-perf", (_event, w) => {
+    // Only the primary renderer's activity belongs in this buffer. The channel is
+    // reachable from any window that loads the shared preload (companion panels,
+    // secondary dashboards), but the flush is triggered by THIS window's
+    // render-process-gone -- so accepting a sibling's reports would file its
+    // highlighting under the primary renderer's crash history and point the
+    // post-mortem at the wrong process. Mis-attributed evidence is worse than
+    // none, because it is acted upon.
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (_event.sender !== mainWindow.webContents) return;
+    if (!pierrePerfLog.record(w)) return;
+    if (!profilingEnabled(process.env)) return;
+    const line = pierrePerfLog.lastLine();
+    if (line) glog(line);
   });
 
   createTray();

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -163,6 +163,7 @@
       "gateway-liveness.js",
       "gateway-recovery.js",
       "renderer-recovery.js",
+    "pierre-perf-log.js",
       "pyspy-dump.js",
       "perf-metrics.js",
       "host-config.js",

--- a/website/electron/pierre-perf-log.js
+++ b/website/electron/pierre-perf-log.js
@@ -1,0 +1,161 @@
+"use strict";
+//
+// In-memory ring buffer for the renderer's Pierre highlight-churn reports,
+// flushed to the log ONLY when the renderer dies.
+//
+// Why a buffer instead of just logging each report: `glog` is a bare
+// appendFileSync with no rotation (see gatewayLogPath), so a line every few
+// seconds for as long as the app renders code would grow the user's log file
+// without bound. That cost is only worth paying at the moment it explains
+// something, and the thing it explains is the crash.
+//
+// So steady state writes NOTHING and keeps a bounded history in memory; the
+// render-process-gone path flushes it next to the crash line. The result is the
+// property the diagnostics were missing: every future crash carries the minutes
+// of highlighter activity that preceded it, on a normal install, with no env var
+// set in advance and no disk cost for the sessions that never crash.
+//
+// KIROCREW_DEBUG still opts into continuous per-window logging, for watching a
+// reproduction live rather than reading it post-mortem.
+//
+// Same contract as the other diagnostics modules: best-effort, never throws,
+// holds only plain numbers.
+//
+// REMOVAL CONDITION -- this is deferred-deletion, not furniture. It exists to
+// answer one question. Once a crash dump has reported `peakKeysForOneSurface`, the
+// answer is in hand: >1 means a single block was re-tokenized that many times and
+// the fix belongs in `contentCacheKey`'s caching, ~1 means the highlighter is not
+// the cause and the search moves elsewhere. Either way this module, its IPC
+// channel, its preload entry and the renderer's timer should come back out --
+// delete them rather than leaving a permanent instrument behind a settled
+// question.
+
+/** 24 windows at the renderer's 5s report interval is two minutes of lead-up for
+ *  a few hundred bytes. Bounded on purpose: this exists to diagnose unbounded
+ *  growth, so it must not become a leak itself. */
+const DEFAULT_CAPACITY = 24;
+
+/** Coerces one report into plain finite numbers. The renderer is not trusted to
+ *  send well-formed values — preload coerces too, but this module is what
+ *  decides what reaches a log line, so it re-checks rather than assuming. */
+function normalizeWindow(w) {
+  const num = (v) => (Number.isFinite(v) ? v : 0);
+  if (!w || typeof w !== "object") return null;
+  const calls = num(w.calls);
+  if (calls <= 0) return null;
+  return {
+    calls,
+    keys: num(w.keys),
+    maxKeysForOneSurface: num(w.maxKeysForOneSurface),
+    repeatKeyCalls: num(w.repeatKeyCalls),
+    chars: num(w.chars),
+    maxLen: num(w.maxLen),
+    heapMB: Number.isFinite(w.heapMB) ? w.heapMB : -1,
+  };
+}
+
+/** `chars / maxLen` -- how much hashing was wasted relative to the largest single
+ *  content. Useful as magnitude, but NOT the verdict: five distinct blocks each
+ *  rendered once produce the same value as one block re-tokenized five times. */
+function ratio(w) {
+  return w.maxLen > 0 ? w.chars / w.maxLen : 0;
+}
+
+/** One log line for a single window. */
+function renderWindow(entry) {
+  const w = entry.window;
+  return (
+    `[pierre-perf] ${entry.at} calls=${w.calls} keys=${w.keys} ` +
+    `maxKeysForOneSurface=${w.maxKeysForOneSurface} repeatKeyCalls=${w.repeatKeyCalls} ` +
+    `chars=${w.chars} maxLen=${w.maxLen} ` +
+    `charsPerMaxLen=${w.maxLen > 0 ? ratio(w).toFixed(1) : "n/a"} mainHeap=${w.heapMB}MB`
+  );
+}
+
+/** Aggregate across the buffered windows. Put FIRST in the flush so a reader who
+ *  only sees the top of the dump still gets the verdict.
+ *
+ *  `peakKeysForOneSurface` is the number that decides the hypothesis: >1 means a
+ *  single block was re-tokenized that many times inside one 5s window, which many
+ *  distinct blocks cannot produce. `peakRepeatKeyCalls` separates the other
+ *  failure mode (identical content re-hashed, i.e. a memoization miss), so one
+ *  dump is not read as evidence for whichever defect the reader expected. */
+function renderSummary(entries) {
+  let calls = 0;
+  let keys = 0;
+  let chars = 0;
+  let maxLen = 0;
+  let peak = 0;
+  let peakHeap = -1;
+  let peakKeysForOneSurface = 0;
+  let peakRepeatKeyCalls = 0;
+  for (const e of entries) {
+    const w = e.window;
+    calls += w.calls;
+    keys += w.keys;
+    chars += w.chars;
+    if (w.maxLen > maxLen) maxLen = w.maxLen;
+    const r = ratio(w);
+    if (r > peak) peak = r;
+    if (w.heapMB > peakHeap) peakHeap = w.heapMB;
+    if (w.maxKeysForOneSurface > peakKeysForOneSurface) peakKeysForOneSurface = w.maxKeysForOneSurface;
+    if (w.repeatKeyCalls > peakRepeatKeyCalls) peakRepeatKeyCalls = w.repeatKeyCalls;
+  }
+  return (
+    `[pierre-perf] pre-crash summary over ${entries.length} window(s): ` +
+    `calls=${calls} keys=${keys} peakKeysForOneSurface=${peakKeysForOneSurface} ` +
+    `peakRepeatKeyCalls=${peakRepeatKeyCalls} chars=${chars} largestContent=${maxLen} ` +
+    `peakCharsPerMaxLen=${peak.toFixed(1)} peakMainHeap=${peakHeap}MB`
+  );
+}
+
+/**
+ * @param {object} [deps]
+ * @param {number} [deps.capacity]      windows retained (default 24)
+ * @param {() => string} [deps.now]     timestamp source, injected for tests
+ */
+function createPierrePerfLog({ capacity = DEFAULT_CAPACITY, now } = {}) {
+  const cap = Math.max(1, Number(capacity) || DEFAULT_CAPACITY);
+  const stamp = typeof now === "function" ? now : () => new Date().toISOString();
+  /** @type {{at: string, window: object}[]} */
+  let entries = [];
+
+  return {
+    /** Buffers one report. Returns the normalized window, or null when the
+     *  report was empty/malformed and nothing was recorded. */
+    record(w) {
+      const win = normalizeWindow(w);
+      if (!win) return null;
+      entries.push({ at: stamp(), window: win });
+      if (entries.length > cap) entries = entries.slice(entries.length - cap);
+      return win;
+    },
+
+    /** One line for the most recent window, for KIROCREW_DEBUG live logging. */
+    lastLine() {
+      if (entries.length === 0) return null;
+      return renderWindow(entries[entries.length - 1]);
+    },
+
+    /** Drains the buffer into log lines: summary first, then each window oldest
+     *  to newest. Returns [] when nothing was buffered, so a crash with no
+     *  highlighting activity adds no noise — itself a useful signal, since it
+     *  points away from the highlighter. */
+    flush() {
+      if (entries.length === 0) return [];
+      const lines = [renderSummary(entries), ...entries.map(renderWindow)];
+      entries = [];
+      return lines;
+    },
+
+    size() {
+      return entries.length;
+    },
+  };
+}
+
+module.exports = {
+  createPierrePerfLog,
+  normalizeWindow,
+  DEFAULT_CAPACITY,
+};

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -89,6 +89,21 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Privacy-pane dialog only if macOS is actually the one saying no. Without
   // this the toast is a dead end: macOS never re-prompts after a denial.
   reportMicDenied: () => ipcRenderer.send("mic:denied"),
+  // Pierre highlight-churn accounting (see src/lib/pierrePerf.ts). Fields are
+  // coerced here because preload is the trust boundary: the main process writes
+  // them into a log line, so a renderer bug must not be able to put an object or
+  // a huge string there. Fire-and-forget — the renderer never waits on a
+  // diagnostic, and the main process drops it entirely unless KIROCREW_DEBUG.
+  reportPierrePerf: (w) =>
+    ipcRenderer.send("pierre-perf", {
+      calls: Number(w && w.calls) || 0,
+      chars: Number(w && w.chars) || 0,
+      keys: Number(w && w.keys) || 0,
+      maxKeysForOneSurface: Number(w && w.maxKeysForOneSurface) || 0,
+      repeatKeyCalls: Number(w && w.repeatKeyCalls) || 0,
+      maxLen: Number(w && w.maxLen) || 0,
+      heapMB: Number(w && w.heapMB) || -1,
+    }),
   // The system-wide summon hotkey as ACTUALLY bound by main.js (registration
   // can degrade to the default or to nothing when a key is taken), so the
   // shortcuts UI advertises what really works. Resolves

--- a/website/electron/test/pierre-perf-log.test.js
+++ b/website/electron/test/pierre-perf-log.test.js
@@ -1,0 +1,147 @@
+"use strict";
+//
+// Guards for the crash-time highlight-churn dump. The behaviours worth locking
+// are the ones a future edit could silently break: that steady state writes
+// nothing, that the buffer cannot grow without bound, and that the flush leads
+// with the ratio a post-mortem is looking for.
+//
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  createPierrePerfLog,
+  normalizeWindow,
+  DEFAULT_CAPACITY,
+} = require("../pierre-perf-log");
+
+const win = (over = {}) => ({
+  calls: 1,
+  keys: 1,
+  maxKeysForOneSurface: 1,
+  repeatKeyCalls: 0,
+  chars: 100,
+  maxLen: 100,
+  heapMB: 50,
+  ...over,
+});
+
+test("a malformed or empty report is not recorded", () => {
+  const log = createPierrePerfLog();
+  assert.equal(log.record(null), null);
+  assert.equal(log.record(undefined), null);
+  assert.equal(log.record("nope"), null);
+  assert.equal(log.record({ calls: 0 }), null);
+  assert.equal(log.record({ calls: NaN }), null);
+  assert.equal(log.size(), 0);
+});
+
+test("non-finite fields are coerced rather than reaching a log line", () => {
+  const w = normalizeWindow({
+    calls: 2,
+    keys: NaN,
+    maxKeysForOneSurface: NaN,
+    repeatKeyCalls: Infinity,
+    chars: Infinity,
+    maxLen: 10,
+    heapMB: "x",
+  });
+  assert.equal(w.keys, 0);
+  assert.equal(w.maxKeysForOneSurface, 0);
+  assert.equal(w.repeatKeyCalls, 0);
+  assert.equal(w.chars, 0);
+  assert.equal(w.heapMB, -1);
+});
+
+test("nothing is flushed when no report was recorded", () => {
+  // The property that keeps a normal install from writing anything: a crash with
+  // no highlighting activity adds no lines at all.
+  assert.deepStrictEqual(createPierrePerfLog().flush(), []);
+});
+
+test("the buffer is bounded to its capacity", () => {
+  const log = createPierrePerfLog({ capacity: 3 });
+  for (let i = 0; i < 10; i++) log.record(win({ chars: i }));
+  assert.equal(log.size(), 3);
+});
+
+test("capacity defaults and rejects nonsense", () => {
+  assert.equal(createPierrePerfLog({ capacity: 0 }).size(), 0);
+  const log = createPierrePerfLog({ capacity: "junk" });
+  for (let i = 0; i < DEFAULT_CAPACITY + 5; i++) log.record(win());
+  assert.equal(log.size(), DEFAULT_CAPACITY);
+});
+
+test("the oldest windows are the ones dropped", () => {
+  const log = createPierrePerfLog({ capacity: 2, now: () => "T" });
+  log.record(win({ chars: 1, maxLen: 1 }));
+  log.record(win({ chars: 2, maxLen: 1 }));
+  log.record(win({ chars: 3, maxLen: 1 }));
+  const lines = log.flush();
+  const body = lines.slice(1).join("\n");
+  assert.ok(!body.includes("chars=1"), "oldest window should have been evicted");
+  assert.ok(body.includes("chars=2") && body.includes("chars=3"));
+});
+
+test("flush leads with a summary carrying the peak ratio", () => {
+  const log = createPierrePerfLog({ now: () => "T" });
+  // A single render (ratio 1.0) then a streamed block re-tokenized per chunk.
+  log.record(win({ calls: 1, keys: 1, maxKeysForOneSurface: 1, chars: 100, maxLen: 100 }));
+  log.record(
+    win({ calls: 4, keys: 4, maxKeysForOneSurface: 4, chars: 1000, maxLen: 200, heapMB: 900 })
+  );
+  const lines = log.flush();
+  assert.match(lines[0], /pre-crash summary over 2 window\(s\)/);
+  assert.match(lines[0], /peakCharsPerMaxLen=5\.0/);
+  assert.match(lines[0], /peakKeysForOneSurface=4/);
+  assert.match(lines[0], /peakMainHeap=900MB/);
+  assert.equal(lines.length, 3, "summary plus one line per window");
+});
+
+test("the summary distinguishes many-blocks-once from one-block-churned", () => {
+  // Both windows carry IDENTICAL calls/keys/chars/maxLen, so peakCharsPerMaxLen
+  // is the same for each: 5 distinct blocks rendered once vs 1 block re-tokenized
+  // 5 times. peakKeysForOneSurface is the only field that separates them, which is
+  // why the verdict is read off it and not off the ratio.
+  const many = createPierrePerfLog({ now: () => "T" });
+  many.record(win({ calls: 5, keys: 5, maxKeysForOneSurface: 1, chars: 500, maxLen: 100 }));
+  const churn = createPierrePerfLog({ now: () => "T" });
+  churn.record(win({ calls: 5, keys: 5, maxKeysForOneSurface: 5, chars: 500, maxLen: 100 }));
+
+  const manyLine = many.flush()[0];
+  const churnLine = churn.flush()[0];
+  assert.match(manyLine, /peakCharsPerMaxLen=5\.0/);
+  assert.match(churnLine, /peakCharsPerMaxLen=5\.0/);
+  assert.match(manyLine, /peakKeysForOneSurface=1/);
+  assert.match(churnLine, /peakKeysForOneSurface=5/);
+});
+
+test("a memoization miss is reported apart from key churn", () => {
+  const log = createPierrePerfLog({ now: () => "T" });
+  // Same content re-hashed 6 times: no new keys, so this is NOT churn.
+  log.record(win({ calls: 7, keys: 1, maxKeysForOneSurface: 1, repeatKeyCalls: 6 }));
+  const lines = log.flush();
+  assert.match(lines[0], /peakRepeatKeyCalls=6/);
+  assert.match(lines[0], /peakKeysForOneSurface=1/);
+  assert.match(lines[1], /repeatKeyCalls=6/);
+});
+
+test("flush drains, so a second crash does not replay the first", () => {
+  const log = createPierrePerfLog();
+  log.record(win());
+  assert.equal(log.flush().length, 2);
+  assert.deepStrictEqual(log.flush(), []);
+});
+
+test("a window with no content length reports n/a instead of dividing by zero", () => {
+  const log = createPierrePerfLog({ now: () => "T" });
+  log.record(win({ maxLen: 0, chars: 0 }));
+  assert.match(log.flush()[1], /charsPerMaxLen=n\/a/);
+});
+
+test("lastLine reflects only the most recent window", () => {
+  const log = createPierrePerfLog({ now: () => "T" });
+  assert.equal(log.lastLine(), null);
+  log.record(win({ chars: 111, maxLen: 111 }));
+  log.record(win({ chars: 222, maxLen: 111 }));
+  assert.ok(log.lastLine().includes("chars=222"));
+});

--- a/website/src/lib/pierrePerf.ts
+++ b/website/src/lib/pierrePerf.ts
@@ -1,0 +1,211 @@
+// Rolling accounting for Pierre's content-keyed highlight cache.
+//
+// Why this exists: this window's black-screen crashes are renderer-process V8
+// aborts on a DedicatedWorker thread (the Pierre highlight pool), and they are
+// activity-driven — they land while agent output is streaming, not on an idle
+// timer. `perf-metrics.js` already records what each PROCESS grew to, but that
+// cannot say WHY: a renderer at 2GB looks identical whether the bytes came from
+// highlight churn or from anything else. This fills that gap with the one number
+// the leading hypothesis actually predicts.
+//
+// The hypothesis: `contentCacheKey` (PierreImpl.tsx) hashes a file's ENTIRE
+// contents, and Pierre caches tokens by that key. While a code block streams,
+// every chunk changes the content, so every chunk mints a NEW key — a cache miss
+// that re-tokenizes the whole block from scratch. Over C chunks reaching final
+// length L that is ~L*C/2 characters hashed and re-tokenized instead of ~L, i.e.
+// quadratic in the stream length, with a fresh AST allocated per chunk.
+//
+// So the falsifiable signal is `maxKeysForOneSurface` — how many distinct keys
+// ONE rendered surface minted inside a window. The unit is a surface, not a
+// filename: a diff's old side and new side share one name yet each legitimately
+// tokenizes once, so a per-name count would read every settled diff as 2 — a
+// false confirm. Streaming a block in C chunks drives its surface to C;
+// rendering C different blocks once each leaves every surface at 1; a settled
+// diff is 1 per side. The aggregate ratio `chars / maxLen` deliberately does NOT
+// carry the verdict: five distinct blocks rendered once produce the same ratio
+// and the same `keys == calls` shape as one block re-tokenized five times, so
+// reading confirmation off the ratio alone would false-confirm on an ordinary
+// multi-block chat window. The ratio still bounds how much hashing was wasted;
+// the per-surface count is what names the cause.
+//
+// Reading the log line off a crash dump just before a crash is what confirms or
+// kills the hypothesis — no heap snapshot, and no need to catch the spike inside a
+// manual capture window.
+//
+// Cost discipline, matching perf-metrics.js and pyspy-dump.js: the counters are
+// three integer adds on a path that already walks the whole string, the report
+// is at most one IPC per FLUSH_MS, and a window where nothing was highlighted
+// sends nothing at all. Accounting stays OFF entirely where no reporter drains it
+// (the dashboard in a plain browser), so that surface pays nothing and cannot
+// accumulate. The main process BUFFERS these reports in memory and writes them to
+// the log only when the renderer dies (see pierre-perf-log.js), so a normal
+// install pays no disk cost and every crash still carries the activity that
+// preceded it.
+
+/** Report shape sent to the main process. Field names are the log line. */
+export interface PierrePerfWindow {
+  /** contentCacheKey() calls in this window. */
+  calls: number
+  /** Characters hashed across those calls — the main-thread O(n)-per-call cost. */
+  chars: number
+  /** Distinct keys minted across ALL surfaces. Each new key is a forced
+   *  re-tokenize, so this is the worker-side task count the pool actually ran. */
+  keys: number
+  /** Distinct keys minted for the single busiest SURFACE INSTANCE — the churn
+   *  verdict.
+   *
+   *  The attribution unit is a mounted surface instance (each caller prefixes a
+   *  React useId), not a filename or a surface kind, because every
+   *  content-derived proxy identity admits collisions: a filename conflates a
+   *  diff's two sides, and a kind+name pair still conflates two same-named
+   *  fences rendered independently. Two instances can never share a useId, and
+   *  a streaming block is ONE instance re-rendering — so everything that
+   *  renders once stays at 1, only a streamed instance climbs to its chunk
+   *  count, and a false confirm is impossible by construction. Confirming the
+   *  re-tokenize hypothesis reads THIS field, not the ratio. */
+  maxKeysForOneSurface: number
+  /** Calls whose key had already been seen for that surface in this window: the
+   *  same content re-hashed with no content change. That is a memoization
+   *  failure, a DIFFERENT defect from key churn, and separating them keeps one
+   *  dump from being read as evidence for the wrong one. */
+  repeatKeyCalls: number
+  /** Longest single content seen. `chars / maxLen` bounds the wasted hashing, but
+   *  it is NOT the churn verdict on its own — see maxKeysForOneSurface. */
+  maxLen: number
+  /** usedJSHeapSize in MB when the engine exposes it, else -1. Main-thread heap
+   *  only — worker isolates are NOT included, which is exactly why the process
+   *  totals from perf-metrics.js stay the memory source of truth. */
+  heapMB: number
+}
+
+/** How often a non-empty window is reported. Long enough that a burst of chunks
+ *  aggregates into one line instead of one line per chunk, short enough that the
+ *  last line before a crash still describes the seconds that caused it. */
+const FLUSH_MS = 5000
+
+let calls = 0
+let chars = 0
+let maxLen = 0
+let repeatKeyCalls = 0
+// Accounting is OFF until a reporter is found, and that gate is load-bearing
+// rather than an optimization. The counters are only ever drained by the
+// reporting interval, so in a surface with no reporter -- the dashboard opened in
+// a plain browser, where `window.electronAPI` does not exist -- nothing would ever
+// empty `keysBySurface` and it would retain every key for the life of the session.
+// That is the exact failure this module exists to diagnose, so it must not be the
+// failure the module introduces. No reporter means no accumulation at all.
+let enabled = false
+// Keys are grouped BY RENDERED SURFACE (the caller passes a surface-qualified
+// identity), because the number that answers the question is "how many times was
+// ONE surface re-tokenized", not "how many keys existed". Discarded every window,
+// so it cannot grow without bound the way a session-lifetime registry would.
+let keysBySurface = new Map<string, Set<string>>()
+let timer: ReturnType<typeof setInterval> | null = null
+
+// Joins a surface kind and a file name into one attribution identity. NUL is
+// the separator because a file name may itself contain any printable character;
+// built with fromCharCode rather than a string literal so the i18n scanner has
+// no literal to misread as user-visible copy (this identity never renders).
+const SURFACE_SEP = String.fromCharCode(0)
+
+/** Records one cache-key computation. Called from contentCacheKey, which has
+ *  already paid the O(n) walk — this adds only the accounting, and nothing at all
+ *  when no reporter is draining it.
+ *
+ *  `surface` names the rendered surface (diff side, editor base, standalone
+ *  block) and `name` the file; the pair is the attribution identity, because a
+ *  bare filename conflates a diff's two sides into false churn. */
+export function recordCacheKey(surface: string, name: string, key: string, length: number): void {
+  if (!enabled) return
+  calls += 1
+  chars += length
+  if (length > maxLen) maxLen = length
+  const identity = surface + SURFACE_SEP + name
+  let seen = keysBySurface.get(identity)
+  if (!seen) {
+    seen = new Set<string>()
+    keysBySurface.set(identity, seen)
+  }
+  if (seen.has(key)) repeatKeyCalls += 1
+  seen.add(key)
+}
+
+function heapMB(): number {
+  // performance.memory is a non-standard Chromium extension; absent elsewhere
+  // and in tests, so it is read defensively and reported as -1 when missing
+  // rather than omitted (a missing field would look like a zero heap).
+  try {
+    const mem = (performance as unknown as { memory?: { usedJSHeapSize?: number } }).memory
+    const used = mem && mem.usedJSHeapSize
+    return typeof used === 'number' ? Math.round(used / (1024 * 1024)) : -1
+  } catch {
+    return -1
+  }
+}
+
+/** Drains the window. Returns null when nothing was highlighted, so an idle
+ *  session reports nothing at all. */
+export function drainWindow(): PierrePerfWindow | null {
+  if (calls === 0) return null
+  let keys = 0
+  let maxKeysForOneSurface = 0
+  for (const seen of keysBySurface.values()) {
+    keys += seen.size
+    if (seen.size > maxKeysForOneSurface) maxKeysForOneSurface = seen.size
+  }
+  const snapshot: PierrePerfWindow = {
+    calls,
+    chars,
+    keys,
+    maxKeysForOneSurface,
+    repeatKeyCalls,
+    maxLen,
+    heapMB: heapMB(),
+  }
+  calls = 0
+  chars = 0
+  maxLen = 0
+  repeatKeyCalls = 0
+  keysBySurface = new Map<string, Set<string>>()
+  return snapshot
+}
+
+/** Starts the reporting interval. Idempotent, and a no-op outside Electron —
+ *  the browser dashboard has no main process to log to, so there is no reason
+ *  to run a timer there. */
+export function startPierrePerfReporting(): void {
+  if (timer) return
+  const api = (window as unknown as {
+    electronAPI?: { reportPierrePerf?: (w: PierrePerfWindow) => void }
+  }).electronAPI
+  const report = api && api.reportPierrePerf
+  if (typeof report !== 'function') return
+  enabled = true
+  timer = setInterval(() => {
+    const w = drainWindow()
+    if (!w) return
+    try {
+      report(w)
+    } catch {
+      // Never let diagnostics break rendering.
+    }
+  }, FLUSH_MS)
+  // Do not hold the event loop / keep a test runner alive.
+  if (typeof (timer as unknown as { unref?: () => void }).unref === 'function') {
+    ;(timer as unknown as { unref: () => void }).unref()
+  }
+}
+
+/** Test seam: stops the interval, disables accounting, and clears counters. */
+export function stopPierrePerfReporting(): void {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  enabled = false
+  calls = 0
+  chars = 0
+  maxLen = 0
+  repeatKeyCalls = 0
+  keysBySurface = new Map<string, Set<string>>()
+}

--- a/website/src/pierre/PierreEditorImpl.tsx
+++ b/website/src/pierre/PierreEditorImpl.tsx
@@ -3,7 +3,7 @@
  * editing surface for every code-editing view. Lives beside `PierreImpl` in
  * the same lazy chunk; reach it through `../pierre` only.
  */
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
+import { forwardRef, useEffect, useId, useImperativeHandle, useMemo, useRef } from 'react'
 import type { BaseCodeOptions, FileContents } from '@pierre/diffs'
 import { EditProvider, File, MultiFileDiff, Virtualizer } from '@pierre/diffs/react'
 import { Editor, type EditorOptions } from '@pierre/diffs/edit'
@@ -90,11 +90,12 @@ export const PierreEditorImpl = forwardRef<PierreEditorHandle, {
     }),
     [dark, options, diffSplit, diffExpandUnchanged],
   )
+  const surfaceId = useId()
   const baseFile = useMemo<FileContents | null>(
     () => (diffBase == null
       ? null
-      : { name: file.name, contents: diffBase, cacheKey: contentCacheKey(file.name, diffBase) }),
-    [diffBase, file.name],
+      : { name: file.name, contents: diffBase, cacheKey: contentCacheKey(file.name, diffBase, surfaceId + ':edit-base') }),
+    [diffBase, file.name, surfaceId],
   )
   const editorRef = useRef<Editor<undefined> | null>(null)
   /** A jump requested before Pierre bound its editor, replayed on attach. */

--- a/website/src/pierre/PierreImpl.tsx
+++ b/website/src/pierre/PierreImpl.tsx
@@ -5,12 +5,13 @@
  * of them resolve their options through `./config` — the single place the
  * look/behavior of code and diff rendering is decided.
  */
-import { useMemo } from 'react'
+import { useId, useMemo } from 'react'
 import type { BaseCodeOptions, FileContents, SupportedLanguages } from '@pierre/diffs'
 import { EXTENSION_TO_FILE_FORMAT, parsePatchFiles, setCustomExtension } from '@pierre/diffs'
 import { File, FileDiff, MultiFileDiff, Virtualizer, WorkerPoolContext } from '@pierre/diffs/react'
 import { getOrCreateWorkerPoolSingleton } from '@pierre/diffs/worker'
 import { useIsDark } from '../hooks/useIsDark'
+import { recordCacheKey, startPierrePerfReporting } from '../lib/pierrePerf'
 import { PlainCodeFallback } from './PlainCodeFallback'
 import {
   PIERRE_EXTENSION_OVERRIDES,
@@ -64,11 +65,27 @@ export function fenceLanguage(tag?: string): SupportedLanguages {
  *  NAME and caches highlight results by it, so two renders of the same file
  *  name with different text (a streaming patch, a live-edited buffer) would
  *  serve the first render's cached tokens forever. Keying on content keeps the
- *  cache correct while still deduping identical re-renders. */
-export function contentCacheKey(name: string, contents: string): string {
+ *  cache correct while still deduping identical re-renders.
+ *
+ *  `surface` identifies the MOUNTED SURFACE INSTANCE for the churn accounting
+ *  ONLY — it never enters the returned key, so cache identity is unchanged. It
+ *  must be instance-qualified (each caller prefixes a React `useId()`), because
+ *  every content-derived proxy identity admits collisions: a filename conflates
+ *  a diff's two sides, and a surface KIND still conflates two same-named fences
+ *  rendered independently. Only the component instance is the true unit of
+ *  tokenization — two instances can never share a `useId`, while a streaming
+ *  block is one instance re-rendering, so churn attribution is exact in both
+ *  directions. */
+export function contentCacheKey(name: string, contents: string, surface = 'file'): string {
   let h = 5381
   for (let i = 0; i < contents.length; i++) h = ((h << 5) + h + contents.charCodeAt(i)) | 0
-  return `${name}:${contents.length}:${(h >>> 0).toString(36)}`
+  const key = `${name}:${contents.length}:${(h >>> 0).toString(36)}`
+  // Accounting for the streaming re-tokenize hypothesis (see lib/pierrePerf.ts).
+  // This is the right site because it is the one place that observes both halves
+  // of the cost: the O(n) hash just paid, and the key whose churn decides whether
+  // Pierre reuses cached tokens or re-tokenizes the whole file again.
+  recordCacheKey(surface, name, key, contents.length)
+  return key
 }
 
 /** Rewrites hand-written patches into ones Pierre's parser accepts.
@@ -241,6 +258,12 @@ const workerPool = typeof window === 'undefined' || typeof Worker === 'undefined
       highlighterOptions: { theme: PIERRE_THEMES },
     })
 
+// Report highlight churn once this module is live. Placed here rather than in
+// `main.tsx` so the timer only ever runs in a realm that actually renders code:
+// this module is reached through the `React.lazy` boundaries in `./index`, so a
+// tab that never shows a diff never starts it.
+startPierrePerfReporting()
+
 /** Hands every descendant the shared pool. Exported because the editor surface
  *  lives in a sibling module and needs the same one — without it Pierre falls
  *  back to `workerManager === undefined` and tokenizes on the main thread. */
@@ -264,6 +287,10 @@ export function PierreCodeImpl({ file, options, className, langHint, scrollClass
   scrollClassName?: string
 }) {
   const dark = useIsDark()
+  // Instance identity for churn accounting: two independently mounted blocks —
+  // even with identical fence names — must never share an identity, while this
+  // one instance re-rendering with streamed content must keep its own.
+  const surfaceId = useId()
   const resolved = useMemo(
     () => pierreFileOptions({ themeType: pierreThemeType(dark), ...options }),
     [dark, options],
@@ -272,8 +299,8 @@ export function PierreCodeImpl({ file, options, className, langHint, scrollClass
     const withLang = file.lang || !langHint ? file : { ...file, lang: fenceLanguage(langHint) }
     return withLang.cacheKey
       ? withLang
-      : { ...withLang, cacheKey: contentCacheKey(withLang.name, withLang.contents) }
-  }, [file, langHint])
+      : { ...withLang, cacheKey: contentCacheKey(withLang.name, withLang.contents, surfaceId + ':file') }
+  }, [file, langHint, surfaceId])
   const code = <File className={className} file={resolvedFile} options={resolved} />
   return (
     <PierreShell>
@@ -291,6 +318,7 @@ export function PierrePatchImpl({ patch, options, className, renderHeaderMetadat
   renderHeaderMetadata?: () => React.ReactNode
 }) {
   const dark = useIsDark()
+  const surfaceId = useId()
   const resolved = useMemo(
     () => pierreDiffOptions({ themeType: pierreThemeType(dark), ...options }),
     [dark, options],
@@ -311,13 +339,13 @@ export function PierrePatchImpl({ patch, options, className, renderHeaderMetadat
           const prev = f.prevName.slice(2)
           f.prevName = prev === f.name ? undefined : prev
         }
-        f.cacheKey = contentCacheKey(f.name ?? '', patch)
+        f.cacheKey = contentCacheKey(f.name ?? '', patch, surfaceId + ':patch')
       }
       return parsed
     } catch {
       return []
     }
-  }, [patch])
+  }, [patch, surfaceId])
   // Zero files is an outright parse failure. Zero HUNKS across every file is
   // the subtler one: Pierre reads that as a pure rename and draws a header with
   // `+0 −0` and no rows — so when the raw text plainly carries changes, treat
@@ -358,6 +386,7 @@ export function PierreFilePairImpl({ oldFile, newFile, options, className, rende
   renderHeaderFilenameSuffix?: () => React.ReactNode
 }) {
   const dark = useIsDark()
+  const surfaceId = useId()
   const resolved = useMemo(
     () => pierreDiffOptions({ themeType: pierreThemeType(dark), ...options }),
     [dark, options],
@@ -366,12 +395,12 @@ export function PierreFilePairImpl({ oldFile, newFile, options, className, rende
   // happen from our call sites (DiffPanel banners the identical case away and
   // new/deleted files carry one side), but the type demands the narrowing.
   const keyedOld = useMemo(
-    () => (oldFile ? { ...oldFile, cacheKey: contentCacheKey(oldFile.name, oldFile.contents) } : null),
-    [oldFile],
+    () => (oldFile ? { ...oldFile, cacheKey: contentCacheKey(oldFile.name, oldFile.contents, surfaceId + ':diff-old') } : null),
+    [oldFile, surfaceId],
   )
   const keyedNew = useMemo(
-    () => (newFile ? { ...newFile, cacheKey: contentCacheKey(newFile.name, newFile.contents) } : null),
-    [newFile],
+    () => (newFile ? { ...newFile, cacheKey: contentCacheKey(newFile.name, newFile.contents, surfaceId + ':diff-new') } : null),
+    [newFile, surfaceId],
   )
   if (!keyedOld && !keyedNew) return null
   const input = (keyedOld && keyedNew

--- a/website/src/test/pierrePerf.test.ts
+++ b/website/src/test/pierrePerf.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  drainWindow,
+  recordCacheKey,
+  startPierrePerfReporting,
+  stopPierrePerfReporting,
+} from '../lib/pierrePerf'
+
+interface TestWindow {
+  electronAPI?: { reportPierrePerf?: (w: unknown) => void }
+}
+
+function setApi(fn: ((w: unknown) => void) | undefined) {
+  const w = window as unknown as TestWindow
+  if (fn === undefined) {
+    delete w.electronAPI
+    return
+  }
+  w.electronAPI = { reportPierrePerf: fn }
+}
+
+afterEach(() => {
+  stopPierrePerfReporting()
+  setApi(undefined)
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('pierrePerf accounting', () => {
+  // Accounting is gated on a reporter existing, so these tests go through the real
+  // gate (stub an API, then start) rather than around it. Fake timers keep the
+  // interval from firing inside the accounting cases.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setApi(vi.fn())
+    startPierrePerfReporting()
+  })
+
+  it('records nothing at all when no reporter exists', () => {
+    // The leak guard: in a plain browser there is no electronAPI, so no interval
+    // ever drains the counters. If accounting still ran, keysBySurface would retain
+    // every key for the life of the session -- the very failure this module was
+    // built to diagnose. Nothing is accumulated, so there is nothing to leak.
+    stopPierrePerfReporting()
+    setApi(undefined)
+    startPierrePerfReporting()
+    for (let i = 0; i < 50; i++) recordCacheKey('file', 'f.ts', `f.ts:${i}:h`, i)
+    expect(drainWindow()).toBeNull()
+  })
+
+  it('reports nothing when no highlighting happened', () => {
+    expect(drainWindow()).toBeNull()
+  })
+
+  it('sums calls, chars and the largest content length', () => {
+    recordCacheKey('file', 'a.ts', 'a.ts:3:x', 3)
+    recordCacheKey('file', 'b.ts', 'b.ts:10:y', 10)
+    const w = drainWindow()
+    expect(w).not.toBeNull()
+    expect(w?.calls).toBe(2)
+    expect(w?.chars).toBe(13)
+    expect(w?.maxLen).toBe(10)
+  })
+
+  it('counts distinct keys, so repeated identical renders are not miscounted as churn', () => {
+    // Same key three times = Pierre serves cached tokens; only one tokenize.
+    recordCacheKey('file', 'a.ts', 'a.ts:5:same', 5)
+    recordCacheKey('file', 'a.ts', 'a.ts:5:same', 5)
+    recordCacheKey('file', 'a.ts', 'a.ts:5:same', 5)
+    const w = drainWindow()
+    expect(w?.calls).toBe(3)
+    expect(w?.keys).toBe(1)
+    // The two re-hashes of unchanged content are a memoization miss, reported
+    // separately so they cannot be read as key churn.
+    expect(w?.repeatKeyCalls).toBe(2)
+    expect(w?.maxKeysForOneSurface).toBe(1)
+  })
+
+  it('exposes the quadratic signature of a streamed block', () => {
+    // A block streamed in 4 growing chunks: every chunk mints a new key, and the
+    // hashed characters are the sum of the prefixes, not the final length.
+    for (const len of [10, 20, 30, 40]) recordCacheKey('file', 'f.ts', `f.ts:${len}:h`, len)
+    const w = drainWindow()
+    expect(w?.keys).toBe(4)
+    expect(w?.maxLen).toBe(40)
+    expect(w?.chars).toBe(100)
+    // The verdict: one NAME minted 4 keys, which is what churn looks like.
+    expect(w?.maxKeysForOneSurface).toBe(4)
+    expect(w?.repeatKeyCalls).toBe(0)
+  })
+
+  it('does NOT report churn when many distinct blocks are each rendered once', () => {
+    // The ambiguity this field exists to remove: four separate files of the same
+    // sizes as the streamed case above produce IDENTICAL calls/keys/chars/maxLen,
+    // so the aggregate ratio cannot tell the two apart. maxKeysForOneSurface can.
+    for (const len of [10, 20, 30, 40]) recordCacheKey('file', `f${len}.ts`, `f${len}.ts:${len}:h`, len)
+    const w = drainWindow()
+    expect(w?.calls).toBe(4)
+    expect(w?.keys).toBe(4)
+    expect(w?.chars).toBe(100)
+    expect(w?.maxLen).toBe(40)
+    // Same ratio as the streamed block (2.5) -- and yet no churn.
+    expect((w as { chars: number }).chars / (w as { maxLen: number }).maxLen).toBe(2.5)
+    expect(w?.maxKeysForOneSurface).toBe(1)
+  })
+
+  it('does NOT report churn when two independent fences share one name', () => {
+    // The collision the instance qualifier exists to remove: an agent showing
+    // before/after as two SEPARATE fences of the same file name. Under a
+    // kind+name identity both landed in one bucket and read as churn; with the
+    // caller's useId prefix they are two instances, one key each.
+    recordCacheKey(':r1:', 'snippet.ts', 'snippet.ts:100:before', 100)
+    recordCacheKey(':r2:', 'snippet.ts', 'snippet.ts:120:after', 120)
+    const w = drainWindow()
+    expect(w?.calls).toBe(2)
+    expect(w?.keys).toBe(2)
+    expect(w?.maxKeysForOneSurface).toBe(1)
+  })
+
+  it('does NOT report churn when a settled diff keys both sides of one filename', () => {
+    // The false confirm that per-NAME attribution produced: a two-sided diff of
+    // an edit keys oldFile and newFile under the SAME filename (PierreImpl
+    // renders them as the 'diff-old' and 'diff-new' surfaces), so a per-name
+    // count read every static diff as 2. Per surface, each side is its own
+    // once-rendered unit and the verdict stays at the floor.
+    recordCacheKey('diff-old', 'a.ts', 'a.ts:100:old', 100)
+    recordCacheKey('diff-new', 'a.ts', 'a.ts:120:new', 120)
+    const w = drainWindow()
+    expect(w?.calls).toBe(2)
+    expect(w?.keys).toBe(2)
+    expect(w?.maxKeysForOneSurface).toBe(1)
+    expect(w?.repeatKeyCalls).toBe(0)
+  })
+
+  it('attributes churn to the busiest surface when blocks are interleaved', () => {
+    // A streaming block alongside quiet ones: the verdict must follow the block
+    // that actually churned, not the count of names.
+    recordCacheKey('file', 'quiet.ts', 'quiet.ts:5:a', 5)
+    recordCacheKey('file', 'other.ts', 'other.ts:5:b', 5)
+    for (const len of [10, 20, 30]) recordCacheKey('file', 'busy.ts', `busy.ts:${len}:h`, len)
+    const w = drainWindow()
+    expect(w?.keys).toBe(5)
+    expect(w?.maxKeysForOneSurface).toBe(3)
+  })
+
+  it('drains, so each window is independent', () => {
+    recordCacheKey('file', 'a.ts', 'a.ts:1:x', 1)
+    drainWindow()
+    expect(drainWindow()).toBeNull()
+  })
+
+  it('always reports a numeric heap field', () => {
+    recordCacheKey('file', 'a.ts', 'a.ts:1:x', 1)
+    const w = drainWindow()
+    expect(typeof w?.heapMB).toBe('number')
+  })
+
+  it('reports -1 rather than throwing when the heap probe is unavailable', () => {
+    // performance.memory is a non-standard Chromium extension. It is absent in
+    // this environment, so it is installed as a THROWING getter to prove the
+    // read is guarded: a host where probing throws must degrade to -1, not take
+    // the render path down with it.
+    const had = Object.prototype.hasOwnProperty.call(performance, 'memory')
+    Object.defineProperty(performance, 'memory', {
+      configurable: true,
+      get() {
+        throw new Error('nope')
+      },
+    })
+    try {
+      recordCacheKey('file', 'a.ts', 'a.ts:1:x', 1)
+      expect(drainWindow()?.heapMB).toBe(-1)
+    } finally {
+      if (!had) delete (performance as unknown as { memory?: unknown }).memory
+    }
+  })
+
+  it('reports the heap in MB when the probe is available', () => {
+    const had = Object.prototype.hasOwnProperty.call(performance, 'memory')
+    Object.defineProperty(performance, 'memory', {
+      configurable: true,
+      get() {
+        return { usedJSHeapSize: 3 * 1024 * 1024 }
+      },
+    })
+    try {
+      recordCacheKey('file', 'a.ts', 'a.ts:1:x', 1)
+      expect(drainWindow()?.heapMB).toBe(3)
+    } finally {
+      if (!had) delete (performance as unknown as { memory?: unknown }).memory
+    }
+  })
+})
+
+describe('pierrePerf reporting lifecycle', () => {
+  it('does nothing outside Electron, where there is no main process to log to', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(undefined)
+    startPierrePerfReporting()
+    recordCacheKey('file', 'a.ts', 'a.ts:1:x', 1)
+    vi.advanceTimersByTime(60_000)
+    expect(spy).not.toHaveBeenCalled()
+    // Nothing was recorded either: with no reporter to drain the counters,
+    // accumulating them would be an unbounded retain for the whole session.
+    expect(drainWindow()).toBeNull()
+  })
+
+  it('reports a non-empty window on the interval', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    recordCacheKey('file', 'f.ts', 'f.ts:20:h', 20)
+    vi.advanceTimersByTime(5000)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toMatchObject({ calls: 2, keys: 2, chars: 30, maxLen: 20 })
+  })
+
+  it('sends nothing while idle, so a quiet session reports nothing at all', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    vi.advanceTimersByTime(30_000)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('drains between intervals, so a window is never reported twice', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    vi.advanceTimersByTime(5000)
+    vi.advanceTimersByTime(5000)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('survives a throwing reporter — diagnostics never break rendering', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn(() => {
+      throw new Error('ipc gone')
+    })
+    setApi(spy)
+    startPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    expect(() => vi.advanceTimersByTime(5000)).not.toThrow()
+    expect(spy).toHaveBeenCalledTimes(1)
+    // Still reporting after the failure.
+    recordCacheKey('file', 'f.ts', 'f.ts:11:h', 11)
+    expect(() => vi.advanceTimersByTime(5000)).not.toThrow()
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('is idempotent, so a second call cannot double-report', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    startPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    vi.advanceTimersByTime(5000)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops reporting once stopped', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    stopPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    vi.advanceTimersByTime(30_000)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('can be restarted after a stop', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    setApi(spy)
+    startPierrePerfReporting()
+    stopPierrePerfReporting()
+    startPierrePerfReporting()
+    recordCacheKey('file', 'f.ts', 'f.ts:10:h', 10)
+    vi.advanceTimersByTime(5000)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Problem

The dashboard's renderer process has been dying repeatedly with `EXC_BREAKPOINT`/`SIGTRAP` — a V8 fatal abort on a **DedicatedWorker thread**, i.e. the Pierre highlight pool. Five crash reports so far, all activity-driven: they land while agent output is streaming, not on an idle timer.

`renderer-recovery.js` already turns those crashes from a permanent black screen into an automatic reload, and `perf-metrics.js` already records what each process grew to. Neither can say **why**. A renderer at 2GB looks identical whether the bytes came from highlight churn or from anything else, so each crash so far has ended in a hypothesis rather than an answer.

## Why it matters

Recovery hides the symptom, which makes the underlying defect *less* likely to be diagnosed: the user sees a flicker and moves on, and the evidence is gone. Diagnosing it today needs a relaunch with `--remote-debugging-port` and a manual CDP capture that happens to overlap the spike — for a crash that occurs a few times a week at unpredictable moments, that window almost never lands.

## Fix

**Symptom** → the crash is in a highlight worker, during streaming.

**Root cause hypothesis** → `contentCacheKey` (`website/src/pierre/PierreImpl.tsx`) hashes a file's *entire* contents, and Pierre caches tokens by that key. While a block streams, every chunk changes the content, so every chunk mints a **new** key — a cache miss that re-tokenizes the whole block from scratch. Over `C` chunks reaching final length `L` that is ~`L*C/2` characters hashed and re-tokenized instead of ~`L`: quadratic in stream length, with a fresh AST allocated per chunk.

**Change** → record the measurement that hypothesis predicts, at the only site that observes both halves of the cost (the `O(n)` hash just paid, and the key whose churn decides reuse vs re-tokenize).

**The verdict is `maxKeysForOneSurface`** — how many distinct keys a **single mounted surface instance** minted inside one window. The attribution unit is the component instance — each `contentCacheKey` caller prefixes a React `useId()` — because every content-derived proxy identity admits collisions that false-confirm: an aggregate ratio conflates N blocks rendered once with one block re-tokenized N times, a filename conflates a diff's two sides, and a surface kind still conflates two same-named fences rendered independently. Two instances can never share a `useId`, and a streaming block is one instance re-rendering, so a false confirm is impossible by construction. The qualifier feeds only the accounting and never enters the returned key, so Pierre's cache identity is unchanged:

- **1** → each block was tokenized about once. Hypothesis falsified.
- **C ≫ 1** → one block was re-tokenized C times. Churn confirmed.

An aggregate ratio deliberately does **not** carry the verdict. Five distinct blocks each rendered once produce the same `chars/maxLen` and the same `keys == calls` shape as one block re-tokenized five times, so reading confirmation off the ratio would false-confirm on an ordinary multi-block chat window. The ratio is kept as *magnitude* (how much hashing was wasted); the per-name count names the *cause*. `repeatKeyCalls` splits off the other failure mode — identical content re-hashed, a memoization miss — so one dump cannot be read as evidence for whichever defect the reader expected.

The reports are **buffered in memory and written only when the renderer dies**. Logging each one continuously was the obvious approach and is wrong: `glog` is an `appendFileSync` with **no rotation**, so a line every few seconds would grow every user's log file without bound. Buffering makes the diagnostic free in steady state and still present exactly when it explains something — so a crash self-documents on a normal install, with no env var armed in advance.

Details that matter for reading the log:
- The dump **precedes** the existing `renderer died` line, so the log reads in causal order: what the highlighter was doing, then the death and process sizes.
- It **leads with the verdict**, so a reader who sees only the first line still gets the answer.
- An **empty dump is a signal** — no highlighting in the buffered window points away from the Pierre pool.
- The buffer is capacity-bounded (24 windows ≈ 2 min) and holds only plain numbers, and the per-name key map is discarded every window, so the instrument cannot leak while measuring a leak.
- Accounting is **gated on a reporter existing**, and that gate is load-bearing rather than an optimization: the counters are only drained by the reporting interval, so on a surface with no reporter (the dashboard in a plain browser, where `window.electronAPI` does not exist) nothing would empty the per-name key map and it would retain every key for the life of the session — the exact failure this module exists to diagnose. No reporter now means no accumulation at all, and that surface pays nothing.
- The main process accepts reports **only from the primary renderer's `webContents`**. The channel is reachable from any window loading the shared preload, but the flush is triggered by the primary window's `render-process-gone`, so a sibling's reports would be filed under the primary renderer's crash history and point the post-mortem at the wrong process.
- `KIROCREW_DEBUG` additionally logs each window as it arrives, reusing `profilingEnabled` from `perf-metrics.js` rather than inventing a second switch.
- The module header records a **removal condition**: this is deferred-deletion, not furniture. Once one crash dump reports the number, the module, its IPC channel, its preload entry and the renderer's timer should come back out rather than persist behind a settled question.

## Tests

- **12 main-process cases** (`website/electron/test/pierre-perf-log.test.js`): capacity bounding, oldest-first eviction, drain-on-flush, malformed/non-finite coercion, divide-by-zero guard, the empty-flush property that keeps a normal install silent, and two that pin the discriminator — *identical* `peakCharsPerMaxLen` for many-blocks-once vs one-block-churned separated only by `peakKeysForOneSurface`, and a memoization miss reported apart from churn.
- **21 renderer cases** (`website/src/test/pierrePerf.test.ts`) in two groups:
  - *Accounting* — run through the real reporter gate rather than around it, with one case asserting that 50 records without a reporter accumulate nothing; plus call/char/max sums, per-name churn attribution across interleaved blocks, the two collision regressions (a settled diff's two sides, and two independent same-named fences, each staying at 1), an explicit many-distinct-blocks case asserting the same 2.5 ratio as the streamed block **with no churn reported**, repeat-key counting, window independence, and both heap-probe branches (available, and a throwing getter that must degrade to `-1`).
  - *Reporting lifecycle* — no-op outside Electron while still preserving counters, reports a non-empty window on the interval, stays silent when idle, drains between intervals, idempotent start, stop, restart-after-stop, and a throwing reporter that must not break rendering.
- `src/lib/pierrePerf.ts` is at **100% statement and line coverage** (96% branch), clearing the gate's 80% per-file floor.
- Full electron suite **733 pass / 0 fail**; `tsc --noEmit` and `eslint` clean.
- `pierre-perf-log.js` is added to the `build.files` allowlist, verified by `shell-contract.test.js` — without it the module would work from source and be missing from the packaged DMG.

## Manual verification

Not yet observed against a live crash: the crashes are days apart, and the whole point of this change is that catching one no longer requires being present. Behaviour verified so far:

- The buffer writes nothing in steady state (asserted by the empty-flush and no-record tests).
- The discriminator is asserted directly: a 4-chunk streamed block and four separate files of the same sizes produce identical `calls`/`keys`/`chars`/`maxLen` and identical ratio 2.5, and only `maxKeysForOneSurface` (4 vs 1) tells them apart.
- Instrumented path is `contentCacheKey`, which already walks the whole string, so the added cost is three integer adds plus one bounded `Set` insert; reporting is at most one IPC per 5s and none at all when idle.

The next renderer crash on a build carrying this will produce the dump in `~/Library/Logs/KiroCrew/gateway-launch.log` immediately above the existing crash line, which either confirms or kills the re-tokenize hypothesis without a manual capture.

<!-- no-visual-delta -->
**Why no screenshot:** diagnostics only — the instrumentation adds counters and a crash-time log line, and renders nothing in the UI.

no linked issue: diagnostic instrumentation for an in-flight investigation, no tracked issue filed.




