### PR TITLE
fix(dashboard): guard the dialog focus trap's Tab handler against IME composition (#5410)

### DIFF
--- a/website/src/hooks/useDialogFocusTrap.imeGuard.test.tsx
+++ b/website/src/hooks/useDialogFocusTrap.imeGuard.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { useRef } from 'react'
+import { useDialogFocusTrap } from './useDialogFocusTrap'
+
+/**
+ * IME guard on the Tab-cycles-focus path (window-capture NATIVE keydown).
+ *
+ * The trap's listener receives native KeyboardEvents, so it cannot consume
+ * `useImeGuard`'s synthetic-only `claimEnter`; it shares the guard's tracked
+ * latch via `createImeLatch` instead. IMEs use Tab to cycle the candidate
+ * list, and on WebKit the keydown that commits a candidate arrives AFTER
+ * `compositionend` with `isComposing` already false — unguarded, a Tab
+ * composed into a dialog input that is the last focusable element yanked
+ * focus and aborted the composition (#5410, same class as #5340/#5396).
+ */
+
+function Harness({
+  enabled = true,
+  onEscape = () => {},
+}: {
+  enabled?: boolean
+  onEscape?: () => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  useDialogFocusTrap(ref, onEscape, enabled)
+  return (
+    <div ref={ref} role="dialog">
+      <button data-testid="first">first</button>
+      <input data-testid="middle" aria-label="middle input" />
+      <input data-testid="last" aria-label="dialog input" />
+    </div>
+  )
+}
+
+/**
+ * The trap filters focusable candidates on `offsetParent !== null`, and the
+ * test DOM has no layout engine so every element reports null. Pin a
+ * non-null offsetParent on the dialog's focusables so the trap sees them.
+ */
+function layOut(...els: HTMLElement[]) {
+  for (const el of els) {
+    Object.defineProperty(el, 'offsetParent', {
+      get: () => document.body,
+      configurable: true,
+    })
+  }
+}
+
+function mount(props: Parameters<typeof Harness>[0] = {}) {
+  const utils = render(<Harness {...props} />)
+  const first = utils.getByTestId('first')
+  const middle = utils.getByTestId('middle')
+  const last = utils.getByTestId('last')
+  layOut(first, middle, last)
+  return { ...utils, first, middle, last }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+const tab = (target: Element, init: KeyboardEventInit & { keyCode?: number } = {}) =>
+  fireEvent.keyDown(target, { key: 'Tab', ...init })
+
+describe('useDialogFocusTrap IME guard', () => {
+  it('plain Tab on the last focusable still wraps to the first (positive control)', () => {
+    const { first, last } = mount()
+    last.focus()
+    const notPrevented = tab(last)
+    expect(document.activeElement).toBe(first)
+    expect(notPrevented).toBe(false) // consumed by the trap
+  })
+
+  it('plain Shift+Tab on the first focusable still wraps to the last', () => {
+    const { first, last } = mount()
+    first.focus()
+    const notPrevented = tab(first, { shiftKey: true })
+    expect(document.activeElement).toBe(last)
+    expect(notPrevented).toBe(false)
+  })
+
+  it('declines a mid-composition Tab (native flag) without cancelling the commit', () => {
+    const { first, last } = mount()
+    last.focus()
+    const notPrevented = tab(last, { isComposing: true })
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+    // The browser is consuming this key for candidate navigation itself, so
+    // the guard must not cancel its default action (claimKey's split).
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines a keyCode-229 Tab without cancelling the commit', () => {
+    const { last } = mount()
+    last.focus()
+    const notPrevented = tab(last, { keyCode: 229 })
+    expect(document.activeElement).toBe(last)
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines the committing Tab in the post-composition window AND consumes it', () => {
+    const { first, last } = mount()
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    // WebKit reports the committing keydown as non-composing; only the
+    // tracked latch can identify it. Nothing live is cancelled, so the key
+    // is fully consumed rather than acted on by the trap.
+    const notPrevented = tab(last)
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+    expect(notPrevented).toBe(false)
+  })
+
+  it('declines a post-composition Shift+Tab the same way', () => {
+    const { first, last } = mount()
+    first.focus()
+    fireEvent.compositionStart(first)
+    fireEvent.compositionEnd(first)
+    tab(first, { shiftKey: true })
+    expect(document.activeElement).toBe(first)
+    expect(document.activeElement).not.toBe(last)
+  })
+
+  it('traps again once the post-composition window has elapsed', () => {
+    vi.useFakeTimers()
+    const { first, last } = mount()
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    vi.advanceTimersByTime(60)
+    tab(last)
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('keeps the latch armed across an unrelated re-render inside the window', () => {
+    // Callers routinely pass an inline `onEscape`, so the keydown effect
+    // re-attaches on every host re-render — and the commit's own input event
+    // re-renders the host right before the committing keydown arrives. The
+    // resubscription must not reset the latch (the composition effect is
+    // keyed on `enabled` alone).
+    const { first, last, rerender } = mount()
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    rerender(<Harness onEscape={() => {}} />)
+    tab(last)
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+  })
+
+  it('does not inherit a stale latch across a disable/re-enable', () => {
+    // Abandoned mid-composition while an inner dialog owned the keyboard:
+    // no compositionend ever follows.
+    const { first, last, rerender } = mount()
+    last.focus()
+    fireEvent.compositionStart(last)
+    rerender(<Harness enabled={false} />)
+    rerender(<Harness enabled />)
+    last.focus()
+    tab(last)
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('recovers from an abandoned composition when focus moves away', () => {
+    // No compositionend ever fires (OS-level IME cancel, focus stolen
+    // mid-composition). Without the focusout recovery the latch would stay
+    // set and consume every later Tab for the dialog's lifetime.
+    const { first, last } = mount()
+    last.focus()
+    fireEvent.compositionStart(last) // abandoned: no compositionEnd follows
+    last.blur()
+    last.focus()
+    tab(last)
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('leaves a mid-dialog Tab untouched inside the post-composition window', () => {
+    // The trap only consumes boundary Tabs; a Tab on a mid-dialog field is
+    // the browser's to move, so the guard must not claim it — claiming would
+    // consume legitimate navigation for 50ms after every composition.
+    const { middle } = mount()
+    middle.focus()
+    fireEvent.compositionStart(middle)
+    fireEvent.compositionEnd(middle)
+    const notPrevented = tab(middle)
+    // Released: neither prevented nor redirected by the trap.
+    expect(notPrevented).toBe(true)
+    expect(document.activeElement).toBe(middle)
+  })
+
+  it('leaves Escape dismissal unaffected by the guard wiring', () => {
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    fireEvent.keyDown(last, { key: 'Escape' })
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+})

--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -4,7 +4,8 @@
 // An aria-modal dialog that lets focus wander behind the overlay would let
 // keyboard users activate obscured controls, so every dialog needs the same
 // three pieces. They live here rather than being re-implemented per dialog.
-import { useEffect, type RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
+import { createImeLatch } from './useImeGuard'
 
 /** Focusable descendants of a dialog, in DOM order, skipping disabled ones. */
 export const FOCUSABLE =
@@ -57,6 +58,57 @@ export function useDialogFocusTrap(
     return () => restoreTo?.focus?.({ preventScroll: true })
   }, [containerRef])
 
+  // IME guard for the Tab-cycles-focus path. This listener receives NATIVE
+  // KeyboardEvents (window capture), which `useImeGuard`'s synthetic-only
+  // `claimEnter` cannot consume — so it shares the guard's tracked latch via
+  // `createImeLatch` instead of hand-rolling a second spelling
+  // (`useListKeyboardNav` is the reference consumer). IMEs use Tab to cycle
+  // the candidate list, and on WebKit the keydown that commits a candidate
+  // arrives AFTER `compositionend` with `isComposing` already false —
+  // unguarded, a Tab composed into a dialog input that happens to be the
+  // last (or first) focusable element yanks focus and aborts the
+  // composition. The latch lives in a ref so the keydown handler reads the
+  // live value without re-subscribing.
+  const imeLatchRef = useRef<ReturnType<typeof createImeLatch>>()
+  if (!imeLatchRef.current) imeLatchRef.current = createImeLatch()
+
+  // Composition tracking + latch lifecycle, keyed on `enabled` ONLY. The
+  // keydown effect below re-attaches whenever a dep changes identity (callers
+  // routinely pass an inline `onEscape`), and a latch reset riding along on
+  // that churn would clear the post-composition window at exactly the moment
+  // it matters: the commit's own input event re-renders the host right before
+  // the committing keydown arrives. Same constraint `useListKeyboardNav`
+  // states for its guard.
+  useEffect(() => {
+    if (!enabled) return
+    const latch = imeLatchRef.current!
+    // A re-enabled trap must not inherit a latch stranded by a composition
+    // that ended (or was abandoned) while an inner dialog owned the keyboard.
+    latch.reset()
+    // Composition tracking listens at document capture like
+    // `useListKeyboardNav`'s: the composing input is anywhere inside the
+    // dialog, so element-scoped listeners have nothing reliable to attach to.
+    const onCompositionStart = () => latch.onCompositionStart()
+    const onCompositionEnd = () => latch.onCompositionEnd()
+    // Stranded-latch recovery: a composition abandoned WITHOUT compositionend
+    // (focus moves off the input mid-composition, an OS-level IME cancel)
+    // would otherwise leave the latch set — and a latched guard consumes the
+    // Tabs it declines, so the trap would silently stop cycling for the
+    // dialog's lifetime.
+    const onRecover = () => latch.reset()
+    document.addEventListener('compositionstart', onCompositionStart, true)
+    document.addEventListener('compositionend', onCompositionEnd, true)
+    document.addEventListener('focusout', onRecover, true)
+    return () => {
+      document.removeEventListener('compositionstart', onCompositionStart, true)
+      document.removeEventListener('compositionend', onCompositionEnd, true)
+      document.removeEventListener('focusout', onRecover, true)
+      // Drop any pending post-composition timer with the listeners so a timer
+      // from a disabled trap cannot fire into the next enablement.
+      latch.reset()
+    }
+  }, [enabled])
+
   useEffect(() => {
     if (!enabled) return
     const onKey = (e: KeyboardEvent) => {
@@ -72,16 +124,22 @@ export function useDialogFocusTrap(
       const firstEl = items[0]
       const lastEl = items[items.length - 1]
       const active = document.activeElement
-      if (!e.shiftKey && active === lastEl) {
-        e.preventDefault()
-        firstEl.focus()
-      } else if (e.shiftKey && (active === firstEl || active === container)) {
-        e.preventDefault()
-        lastEl.focus()
-      } else if (!container.contains(active)) {
-        e.preventDefault()
-        firstEl.focus()
-      }
+      const wrapsForward = !e.shiftKey && active === lastEl
+      const wrapsBackward = e.shiftKey && (active === firstEl || active === container)
+      const refocuses = !wrapsForward && !wrapsBackward && !container.contains(active)
+      // A mid-dialog Tab is the browser's to move, not the trap's — so it is
+      // also not the trap's to claim: claiming it would consume legitimate
+      // navigation inside the post-composition latch window.
+      if (!wrapsForward && !wrapsBackward && !refocuses) return
+      // A Tab the IME owns must not cycle focus — the user is choosing a
+      // candidate, not leaving the field. `claimKey` owns the whole decline
+      // (stopPropagation always; preventDefault only in the post-composition
+      // latch window where the browser would otherwise act) — see its
+      // contract in useImeGuard.ts. It must run before the preventDefault()
+      // and focus move so the IME keeps the key.
+      if (!imeLatchRef.current!.claimKey(e)) return
+      e.preventDefault()
+      ;(wrapsBackward ? lastEl : firstEl).focus()
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)


### PR DESCRIPTION
## Problem / Motivation

`useDialogFocusTrap` installs a window-capture keydown listener that traps Tab / Shift+Tab to cycle focus within a dialog, with no IME composition reference. When a user composes text with an IME (Chinese/Japanese/Korean) into a dialog input that happens to be the last (or first) focusable element and presses Tab to cycle/accept a candidate, the trap calls `preventDefault()` and yanks focus — aborting the in-progress composition. Same defect class as #5340 / #5396, reached through a different host-level interceptor.

## Why it matters

Every IME user typing into a dialog form (Add Repos, Connect Repo, ref sheets, modals) whose input sits at a focus boundary loses their in-flight composition the moment they touch Tab — a data-destroying interruption on the normal path for CJK input, in a dashboard that ships in 12 languages.

## What changed (motivation → approach → change)

Symptom: a composing Tab is treated as trap navigation. Root cause: the trap's native window-capture handler holds no composition state, and on WebKit the keydown that commits a candidate arrives AFTER `compositionend` with `isComposing` already false, so native flags alone cannot identify it. Change — mirror the already-landed latch pattern rather than inventing a new mechanism:

- `useDialogFocusTrap` now holds the shared tracked latch (`createImeLatch` from `useImeGuard.ts`, the same helper `useListKeyboardNav` uses) in a per-instance ref.
- `compositionstart` / `compositionend` / `focusout` are wired at document capture in an effect keyed on `enabled` ONLY — deliberately not the keydown effect, whose deps (callers routinely pass an inline `onEscape`) churn identity every render; a latch reset riding that churn would clear the post-composition window at exactly the moment it matters. This matches `useListKeyboardNav`'s wiring and its stated constraint. `focusout` recovery + reset-on-re-enable prevent a stranded latch from silently eating Tabs after an abandoned composition.
- The Tab branch computes the boundary predicates first and calls `claimKey(e)` only on Tabs the trap would actually consume (forward wrap, backward wrap, refocus-from-outside), before any `preventDefault()`/focus move. A mid-dialog Tab is the browser's to move, so it is also not the trap's to claim — claiming it would consume legitimate navigation for 50ms after every composition (caught by the pre-push Opus review lane; fixed with a pinning test).

Non-IME Tab cycling behavior is byte-for-byte equivalent: same predicates, same targets, same `preventDefault` sites.

## Tests

New `website/src/hooks/useDialogFocusTrap.imeGuard.test.tsx` (12 tests), mirroring `useListKeyboardNav.imeGuard.test.tsx`:

- Positive controls: plain Tab wraps last→first, Shift+Tab wraps first→last (regression pins for the existing suite-less hook), Escape dismissal unaffected.
- Declines a mid-composition Tab (native flag) and a keyCode-229 Tab without cancelling the candidate commit (no `preventDefault`).
- Declines and consumes the committing Tab inside the post-`compositionend` latch window (forward and Shift+Tab), and traps again once the window elapses (fake timers).
- Latch survives an unrelated host re-render inside the window (the inline-`onEscape` churn case).
- No stale latch across a disable/re-enable cycle (stacked dialogs) and after an abandoned composition recovered via `focusout`.
- A mid-dialog Tab inside the latch window is released untouched (the trap has no claim on it).

Mutation-verified: with the production change reverted, 5 of the guard tests fail; positive controls stay green.

## Manual verification

N/A — unit coverage sufficient: the defect and fix are entirely keyboard-event semantics exercised directly by the tests; there is no rendered surface to inspect.

<!-- no-visual-delta -->
**Why no screenshot:** keyboard-only behavioral fix inside an event handler; nothing renders differently.

## Related Issues

Closes #5410

Follow-up filed: #5420 — the same handler's Escape branch dismisses the dialog on the Escape that cancels an IME composition (pre-existing, surfaced as an Opus advisory; distinct semantics, needs its own contract).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, hook-internal behavior documented in code comments
- [x] No secrets, credentials, or internal references in the diff
