### PR TITLE
fix(session): read agent specs through the hardened, size-capped gate

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -240,7 +240,13 @@ send time.
   JSON appearing bumps the dir mtime) AND a TTL (`_AGENT_MODEL_CACHE_TTL`, for
   in-place edits that leave the dir mtime unchanged). Without invalidation an
   early `"auto"` miss (agent JSON not yet present) would be pinned forever, so a
-  later create/edit of the agent config would never be observed.
+  later create/edit of the agent config would never be observed. The scan reads
+  each spec through `agent_discovery._read_agent_spec`, the hardened reader that
+  module documents as the one reader for both agent scopes: `~/.kiro/agents` is
+  user-writable and shared with kiro-cli, so the read is size-capped and refuses
+  a link resolving onto a sensitive target rather than resolving a model out of
+  whatever the link names. A refused spec is skipped like a malformed one, so
+  the resolution falls through to `"auto"` exactly as an absent spec does.
 - **Idle cleanup**: expires sessions after `session.timeout_secs` (default
   60min). Never expires `BACKGROUND_KEY`. Dashboard per-tab sessions
   (`dashboard:{slot_key}`) idle-expire like any other session.

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -106,7 +106,7 @@ from kiro_crew.acp.types import (
 )
 from kiro_crew.acp_backends import selectable_backends
 from kiro_crew.agent import kiro_agents_dir_path
-from kiro_crew.agent_discovery import spec_model
+from kiro_crew.agent_discovery import _read_agent_spec, spec_model
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     CONTEXT_WARN_MARGIN_PCT,
@@ -2723,12 +2723,14 @@ class SessionManager:
 
         model = "auto"
         try:
-            import json as _json
-
             for af in kiro_agents_dir_path().glob("*.json"):
-                try:
-                    ad = _json.loads(af.read_text(encoding="utf-8"))
-                except (ValueError, OSError):
+                # The hardened, size-capped reader, same as every other spec
+                # read: the agents directory is user-writable and shared with
+                # other tools, and this result is cached and served to
+                # ``/api/sessions/context``. It also supplies the malformed- and
+                # non-object-JSON skip this loop needs.
+                ad = _read_agent_spec(af)
+                if ad is None:
                     continue
                 if ad.get("name") == agent or af.stem == agent:
                     # Coerced, not raw: this method is annotated ``-> str`` and

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2464,6 +2464,67 @@ class TestContextInfo:
         assert result == "auto"
         assert isinstance(result, str)
 
+    def test_resolve_agent_model_refuses_an_oversized_spec(self, tmp_path, monkeypatch):
+        """The scan reads through the hardened, size-capped reader.
+
+        ``~/.kiro/agents`` is user-writable and shared with kiro-cli, so an
+        oversized "agent config" there must be refused rather than slurped into
+        memory — and this resolution is CACHED and served to
+        ``/api/sessions/context``, so it is not a rare corner.
+
+        Exercised with a LOWERED cap rather than a real 50 MB fixture; the
+        property is that the cap is consulted, not its value. Paired with the
+        A-side below so the refusal cannot pass by breaking every read.
+        """
+        import json
+
+        from kiro_crew import hooks
+
+        if hasattr(SessionManager, "_agent_model_cache"):
+            SessionManager._agent_model_cache.clear()
+        monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+        (tmp_path / "big.json").write_text(
+            json.dumps({"name": "big", "model": "pinned-by-oversized", "pad": "x" * 1024})
+        )
+
+        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path):
+            assert SessionManager._resolve_agent_model("big") == "auto"
+
+    def test_resolve_agent_model_still_reads_a_spec_under_the_same_cap(self, tmp_path, monkeypatch):
+        """A-side of the cap test above: a normal spec still resolves."""
+        import json
+
+        from kiro_crew import hooks
+
+        if hasattr(SessionManager, "_agent_model_cache"):
+            SessionManager._agent_model_cache.clear()
+        monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+        (tmp_path / "small.json").write_text(
+            json.dumps({"name": "small", "model": "pinned-by-small"})
+        )
+
+        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path):
+            assert SessionManager._resolve_agent_model("small") == "pinned-by-small"
+
+    def test_resolve_agent_model_refuses_a_link_to_a_sensitive_target(self, tmp_path, monkeypatch):
+        """A spec that is a symlink resolving onto a sensitive target is refused,
+        so the model is not resolved out of whatever the link names."""
+        import json
+
+        from kiro_crew import agent_discovery
+
+        if hasattr(SessionManager, "_agent_model_cache"):
+            SessionManager._agent_model_cache.clear()
+        target = tmp_path / "protected.json"
+        target.write_text(json.dumps({"model": "leaked-value"}))
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "linked.json").symlink_to(target)
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+
+        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", agents):
+            assert SessionManager._resolve_agent_model("linked") == "auto"
+
 
 class TestWarmPoolInternals:
     """Tests for _fill_warm_pool, _claim_from_pool, _drain_and_claim."""


### PR DESCRIPTION
## Problem / Motivation

`SessionManager._resolve_agent_model` (`src/kiro_crew/session.py`) globs `~/.kiro/agents/*.json` and reads each spec with a plain `json.loads(af.read_text(encoding="utf-8"))`. That bypasses `agent_discovery._read_agent_spec` — the reader `agent_discovery` documents as **the one reader for both agent scopes** — which goes through `hooks.safe_read_file_bytes` and therefore applies the size cap and refuses a symlink whose resolved target is sensitive, non-UTF-8 bytes, AppleDouble sidecars, and JSON that is not an object.

`~/.kiro/agents` is user-writable and shared with kiro-cli, so both properties were reachable:

1. **No size cap** — an oversized file there was read whole into memory by whatever asked for a session's model.
2. **A link was followed onto a sensitive target** — a planted `linked.json` resolved the model out of whatever the link named.

## Why it matters

This resolution is **cached** at class level (`_agent_model_cache`) and served to `/api/sessions/context`, so a value read through the unhardened path was retained and handed to an HTTP consumer rather than recomputed and discarded. `agent_discovery._read_agent_spec` is the reader that module documents as the one hardened reader for agent specs, and this was a cached, API-served resolution path still bypassing it. Other hand-rolled `json.loads(read_text)` reads of the same directory remain elsewhere (e.g. `agent.py`, `chat_persistence.py`, `handlers/agents.py`, `handlers/mcp.py`) — migrating them is tracked as a follow-up (see the issue linked in comments), not bundled here.

It is also the site most easily missed: it does not import from `config/loader.py`, so a fix scoped to the loader by module leaves it behind.

A side effect worth declaring: routing this path through the hardened reader means sensitive-path refusals on this scan now emit SEL audit entries, which the old raw read never did.

## What changed (motivation → approach → change)

**Symptom:** an oversized or symlinked spec in `~/.kiro/agents` decided a session's model, uncapped and unrefused.

**Root cause:** one of the spec reads was hand-rolled instead of going through the module's documented single reader.

**Change:** route the scan through `agent_discovery._read_agent_spec` and drop the local `json` import — that reader also supplies the malformed- and non-object-JSON skip this loop was hand-rolling, so the `try`/`except (ValueError, OSError)` around the parse becomes a `None` check.

A refused spec stays **non-fatal** and is skipped exactly like a malformed one, so the scan falls through to `"auto"` as an absent spec already does. Nothing fails closed.

The reader's symlink policy is adopted **whole** rather than tightened into a blanket refusal. This caller only reads, so refusing a benign link would break specs kept outside the agents directory and linked in — and it would recreate the same surface disagreement in the opposite direction.

`docs/system-specs/modules/session.md` is updated in the same commit, on the bullet that documents this cache.

## Tests

Three tests in `test/test_session.py::TestContextInfo`, each locking in one property:

| Test | Locks in |
|---|---|
| `test_resolve_agent_model_refuses_an_oversized_spec` | the cap is consulted — an oversized spec resolves to `"auto"`, not to its `model` |
| `test_resolve_agent_model_still_reads_a_spec_under_the_same_cap` | **A-side**: a normal spec under the same lowered cap still resolves, so the refusal cannot pass by breaking every read |
| `test_resolve_agent_model_refuses_a_link_to_a_sensitive_target` | a link resolving onto a sensitive target yields `"auto"`, not the target's value |

The cap tests use a **lowered** `hooks.MAX_FILE_BYTES` rather than a real 50 MB fixture: the property under test is that the cap is consulted, not its value.

**Verified the tests actually catch the defect.** With the source change reverted and the tests unchanged:

```
FAILED test_resolve_agent_model_refuses_an_oversized_spec
    - AssertionError: assert 'pinned-by-oversized' == 'auto'
FAILED test_resolve_agent_model_refuses_a_link_to_a_sensitive_target
    - AssertionError: assert 'leaked-value' == 'auto'
2 failed, 4 passed
```

The A-side passes in both directions, as it must.

## Manual verification

N/A — unit coverage sufficient. Both properties are file-shaped and fully observable from the resolver's return value; there is no integration path or UI surface involved.

## Test run

- The 57 test files that reference `_resolve_agent_model`, `KIRO_AGENTS_DIR`, `_read_agent_spec`, or `kiro_agents_dir`: **5449 passed, 23 skipped, 0 failed**
- `mypy --platform linux src/kiro_crew`: **no issues in 1049 source files**
- `flake8`, `isort --check-only`, `scripts/check_black_formatting.py`, `scripts/docs-lint.sh`, `scripts/check_brand_name.py`, `scripts/check_harness_parity.py`, `scripts/check_changelog_history.py`: all clean

Both touched files are listed in `.github/black-baseline.txt`; `black --diff` leaves every line this PR adds untouched, so no baseline-wide reformat is bundled in.

## Related Issues

Fixes #5422

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/session.md`, same commit)
- [x] No secrets, credentials, or internal references in the diff

