### PR TITLE
fix(config): resync generated baseline after agent.session_control (#5424)

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -51,6 +51,7 @@
         "chat_turn_timeout_secs": 7200,
         "session_start_timeout_secs": 90,
         "tool_approval_timeout_secs": 600,
+        "session_control": false,
         "subagent_cost_gb": 0.5,
         "subagent_cpu_cost_cores": 1.0,
         "subagent_auto_max": 32,
@@ -661,6 +662,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 600
+    },
+    {
+      "path": "agent.session_control",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Session Control",
+      "help": "Let one chat session open a new session, and stop or read another session of yours. No session writes into another session's conversation: reading returns a transcript tail, stopping cancels an in-flight turn, and a created session starts empty for you to type into. Off by default: the three tools ride on a server you may already have assigned for other work, so reaching another session waits for you to grant it here rather than arriving with an upgrade. Sessions can only reach peers in the same workspace; incognito, app-scoped and scheduled sessions are never addressable.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
     },
     {
       "path": "agent.subagent_cost_gb",


### PR DESCRIPTION
## What

Mechanical resync of `config-baseline.json` via `python scripts/generate_config_baseline.py` — no manual edits. Adds the `agent.session_control` entry (15 lines) that commit `39a5b9b2d` (PR #2435) introduced into the schema without regenerating the baseline.

Closes #5424

## Why this is urgent

`TestCommittedBaselineParity::test_committed_snapshot_matches_generator` fails deterministically on current main, reddening Backend Tests shard 1 (3.10 / 3.12 / Windows) on **every open PR's merge-ref CI** — every PR appears red through no fault of its own.

## Verification

- Reproduced the failure on a pristine main worktree (`e4c260ebb`): 1 failed
- After the resync: `test/test_config_baseline.py` full suite passes (parity 3 passed, generator unit tests green)
- Diff is generator output only: one new baseline entry for `agent.session_control` + its `defaultValue: false` in the defaults block

## Related

- Open PR #4260 is a stale resync from an earlier drift (2026-08-18) and does not contain this field
- Discovered while driving PR #5412 (issue #304) to green
