### PR TITLE
fix: SEL-audit Slack cron removals and one-shot auto-removal

### DIFF
--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -22,7 +22,7 @@ Each entry records:
 | `source` | Interface: `slack`, `dashboard`, `cli`, `cron`, `subagent`, `taskrunner`, `mcp`, `background`, `acp` (ACP-transport events, e.g. `tool_interrupted`), `token_auth` / `refresh_tokens` (dashboard auth), `host` (the `_host` sentinel — an in-process host action like app activation / workspace admission), `unknown` (empty/unrecognized session key, which must NOT be mis-tagged `slack`). This is a closed interface vocabulary — component attribution does not extend it; see `caller` below |
 | `operation` | Tool name or `METHOD /api/path` |
 | `tool_kind` | Tool category (`execute_bash`, `fs_write`, `mcp_core`, `mcp_cron`, etc.) |
-| `outcome` | `invoked`, `auto_approved`, `approved`, `rejected`, `denied`, `completed`, `failed`, `clamped`, `degraded` (a governance chokepoint failed OPEN) |
+| `outcome` | `invoked`, `auto_approved`, `approved`, `rejected`, `denied`, `completed`, `failed`, `clamped`, `degraded` (a governance chokepoint failed OPEN), `one_shot_completed` (a one-shot cron consumed by its own completion — an automated removal, not an operator delete) |
 | `resources` | Affected resources summary (redacted, then truncated to 500 chars — see `metadata`) |
 | `downstream_service` | MCP server name if applicable (`kirocrew-core`, `kirocrew-cron`, `internal-mcp`) |
 | `request_id` | ACP permission request ID |

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -2015,8 +2015,42 @@ class CronService:
                 break
         self._pending_removals.add(job_id)
 
-    def _drain_pending_removals_locked(self) -> None:
+    def audit_one_shot_removal(self, job_id: str, path: str) -> None:
+        """SEL-audit one automated one-shot removal. Call AFTER the store lock.
+
+        An automated removal with no human caller is exactly the delete an
+        operator cannot otherwise distinguish from data loss (issue #5408).
+        Emits the ``cron.remove`` shape PR #5405 introduces for the
+        dashboard/MCP/CLI single-delete paths (on base, the plural
+        ``cron.batch_delete`` is the only audited removal), with an
+        automated-actor identity and a ``one_shot_completed`` outcome.
+        ``source`` stays ``"cron"`` — the SEL spec treats ``source`` as a
+        constrained identity vocabulary (it skips redaction on that promise),
+        and ``"cron"`` is this module's established value — so the removal
+        path rides in ``resources`` as a ``path=`` discriminator instead.
+        Best-effort and exception-contained: the removal is already saved, so
+        audit unavailability must never break the caller. Never call while
+        holding ``_file_lock`` — the first ``sel()`` of a process constructs
+        the log and must not extend the store-lock hold.
+        """
+        try:
+            sel.sel().log_api_access(
+                caller="cron",
+                operation="cron.remove",
+                outcome="one_shot_completed",
+                source="cron",
+                resources=f"job_id={job_id} path={path}",
+            )
+        except Exception:
+            logger.warning(
+                "SEL audit for one-shot cron removal failed (job %s)", job_id, exc_info=True
+            )
+
+    def _drain_pending_removals_locked(self) -> list[str]:
         """Delete jobs queued via :meth:`defer_removal`. MUST hold the store lock.
+
+        Returns the ids actually removed (sorted, empty when nothing drained)
+        so the caller can SEL-audit them after releasing the store lock.
 
         Called from :meth:`_tick_scan_locked` (the timer tick's worker-thread
         transaction) inside its ``_file_lock`` block, so the delete+save is
@@ -2040,7 +2074,7 @@ class CronService:
         even an id deferred to the next tick from re-firing meanwhile.
         """
         if not self._pending_removals:
-            return
+            return []
         # Atomic claim-and-reset (see docstring) — do NOT split into a read
         # (``& present``) followed by ``.clear()``; an id added between those
         # two steps would be erased without ever being deleted from disk, so
@@ -2049,11 +2083,16 @@ class CronService:
         present = {j.id for j in self._jobs}
         to_remove = pending & present
         if not to_remove:
-            return
+            return []
         self._jobs = [j for j in self._jobs if j.id not in to_remove]
         self._save()
         for jid in to_remove:
             logger.info("Removed deferred one-shot cron job %s", jid)
+        # SEL audit is the CALLER's job (post-lock): this method runs inside
+        # the caller's ``_file_lock`` transaction, and the first ``sel()`` of a
+        # process constructs the log (trust-dir + HMAC key read), which must
+        # never extend the store-lock hold past the CronStoreBusy timeout.
+        return sorted(to_remove)
 
     def _remove_job_locked(self, job_id: str) -> bool:
         """Lock/reload/mutate/save core of :meth:`remove_job` (no timer work)."""
@@ -2697,12 +2736,18 @@ class CronService:
         the (re)arm back to the bound event loop thread-safely (see
         :meth:`_arm_timer`) — no caller-side drain is required.
         """
+        drained: list[str] = []
         try:
             with self._file_lock():
                 self._sync()
-                self._drain_pending_removals_locked()
+                drained = self._drain_pending_removals_locked()
         except CronStoreBusy:
             logger.debug("Cron timer tick: store busy, using in-memory snapshot")
+        # Post-lock on purpose: the emit must never extend the store-lock hold
+        # (see audit_one_shot_removal). Still on this worker thread, so the
+        # queue append cannot block the event loop either.
+        for jid in drained:
+            self.audit_one_shot_removal(jid, "cron_deferred_drain")
         return list(self._jobs)
 
     async def _on_timer(self) -> None:
@@ -3204,9 +3249,20 @@ class CronService:
             # the one-shot would destroy scheduled work that never got a chance to
             # run. Only the delete is suppressed: unlike a policy denial this needs
             # no operator action, so the job stays enabled and simply retries.
+            removed_one_shot = False
             if job.delete_after_run and not (job.fire_time_denied or job.run_never_started):
+                # Presence check keeps the audit honest: a Done-script one-shot
+                # already removed by the gateway path leaves nothing to delete
+                # here, and that path owns the audit record.
+                removed_one_shot = job.id in by_id
                 self._jobs = [j for j in self._jobs if j.id != job.id]
             self._save()
+        if removed_one_shot:
+            # The delete_after_run consume is an automated removal with no
+            # handler-level caller (issue #5408), so the emit lives with the
+            # removal. AFTER the lock: only a saved removal is recorded, and
+            # the sel call never extends the store-lock hold.
+            self.audit_one_shot_removal(job.id, "cron_run_complete")
 
     def _merge_terminal_state_locked(
         self,

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3024,17 +3024,32 @@ class GatewayOrchestrator:
                 logger.warning("Cron '%s' delivery failed: %s", job.name, notify_exc)
             if remove and delivered and self.cron_svc:
                 try:
-                    await self.cron_svc.remove_job_async(job.id)
+                    removed = await self.cron_svc.remove_job_async(job.id)
                 except CronStoreBusy:
                     # No caller to retry this fire-and-forget removal, so hand
                     # it to the service's deferred-removal queue: the job is
                     # disabled in memory immediately (can't re-fire) and the
                     # next timer tick drains it from disk under the store lock.
+                    # No audit here — whichever path lands the removal on disk
+                    # emits cron.remove: the deferred drain, or the run-merge
+                    # consume when a delete_after_run job's merge gets there
+                    # first.
                     self.cron_svc.defer_removal(job.id)
                     logger.warning(
                         "Cron '%s': store busy, queued one-shot removal for " "the next timer tick",
                         job.name,
                     )
+                else:
+                    if removed:
+                        # SEL audit: automated one-shot (Done) removal after
+                        # delivery (issue #5408). One owner for the record
+                        # shape: the service's helper emits the same
+                        # cron.remove event as the deferred-drain and
+                        # run-merge paths, best-effort and exception-contained
+                        # (audit unavailability never fails the delivery
+                        # callback). removed=False means another path already
+                        # deleted the job — that path owns the audit record.
+                        self.cron_svc.audit_one_shot_removal(job.id, "cron_gateway")
 
         async def _alert_cron_failure(job: CronJob, detail: str, *, denied: bool = False) -> None:
             """Tell the user WHY a script/command cron run failed or was denied.

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -2472,7 +2472,9 @@ async def maybe_handle_keyword_command(
 
     # ── Natural language cron: intercept wakeup patterns ──
     if cron_service:
-        cron_reply = await _handle_cron_command(text, cron_service, channel, reply_ts)
+        cron_reply = await _handle_cron_command(
+            text, cron_service, channel, reply_ts, user_id=user_id
+        )
         if cron_reply:
             await slack.post_message(channel, cron_reply, reply_ts)
             if conversation_log and not _is_slack_restricted(session_key):
@@ -4749,8 +4751,12 @@ def _build_approval_blocks(event: LLMEvent, is_dm: bool = True, source: str = ""
     return blocks
 
 
-async def _remove_all_jobs(cron_service: CronService) -> str:
-    """Remove all cron jobs and return a summary (event-loop-safe)."""
+async def _remove_all_jobs(cron_service: CronService, user_id: str) -> str:
+    """Remove all cron jobs and return a summary (event-loop-safe).
+
+    ``user_id`` is the Slack caller, threaded through for SEL audit
+    attribution (empty falls back to the surface name).
+    """
     jobs = cron_service.list_jobs(include_disabled=True)
     if not jobs:
         return "No cron jobs to remove."
@@ -4766,9 +4772,28 @@ async def _remove_all_jobs(cron_service: CronService) -> str:
     # "busy" reply as the single-job remove/pause/resume paths rather than
     # aborting the Slack message handler.
     try:
-        await cron_service.remove_jobs([j.id for j in jobs])
+        removed_ids, missing_ids = await cron_service.remove_jobs([j.id for j in jobs])
     except CronStoreBusy:
         return "⏳ Cron store busy — try again in a moment."
+    # SEL audit: the Slack plural path must leave the same cron.batch_delete
+    # record the dashboard's plural path already emits (MCP's cron_remove_all
+    # logs its own authz-scoped tool event instead) — after the jobs
+    # vanish from crons.json the trail is the only way to tell a deliberate
+    # remove-all from data loss. Best-effort and exception-contained: the
+    # first sel() of a process CONSTRUCTS the log and can raise, and the jobs
+    # are already removed — audit unavailability must not fail the command.
+    try:
+        sel().log_api_access(
+            caller=user_id or "slack",
+            operation="cron.batch_delete",
+            outcome="ok" if removed_ids else "failed",
+            source="slack",
+            resources=(
+                f"requested={[j.id for j in jobs]} deleted={removed_ids} failed={missing_ids}"
+            ),
+        )
+    except Exception:
+        logger.warning("SEL audit for Slack cron remove-all failed", exc_info=True)
     return f"✅ Removed {len(lines)} cron job(s):\n" + "\n".join(lines)
 
 
@@ -4806,7 +4831,7 @@ def _do_spawn(task: str, manager: SubagentManager, session_key: str = "") -> str
 
 
 async def _handle_cron_command(
-    text: str, cron_service: CronService, channel: str, thread_ts: str
+    text: str, cron_service: CronService, channel: str, thread_ts: str, user_id: str = ""
 ) -> str | None:
     """Handle cron keyword commands. Returns reply or None.
 
@@ -4814,6 +4839,10 @@ async def _handle_cron_command(
     event-loop-safe ``*_async`` variants instead of parking the Slack gateway
     loop on the store lock; a contended store yields a "busy, retry" reply
     rather than a stall.
+
+    ``user_id`` is the Slack caller, threaded through so the destructive
+    branches can attribute their SEL audit events to the human who issued
+    the command (per-caller identity, matching the dashboard/MCP/CLI paths).
     """
     t = text.strip().lower()
     parts = t.split()
@@ -4869,11 +4898,32 @@ async def _handle_cron_command(
 
     if action == "remove":
         if job_id == "all":
-            return await _remove_all_jobs(cron_service)
+            return await _remove_all_jobs(cron_service, user_id=user_id)
         try:
             removed = await cron_service.remove_job_async(job_id)
         except CronStoreBusy:
             return "⏳ Cron store busy — try again in a moment."
+        # SEL audit: single delete records the affected job and outcome, the
+        # same cron.remove shape PR #5405 introduces for the dashboard/MCP/CLI
+        # single-delete paths (on base, the plural cron.batch_delete is the
+        # only audited removal so far). Written only after the store mutation
+        # settled — a busy store returns above with no mutation to audit.
+        # Exception-contained: the first sel() of a process CONSTRUCTS the log
+        # and can raise, and the job is already removed — a completed delete
+        # must not surface as a crashed command because the audit trail is
+        # unavailable.
+        try:
+            sel().log_api_access(
+                caller=user_id or "slack",
+                operation="cron.remove",
+                outcome="allowed" if removed else "not_found",
+                source="slack",
+                resources=f"job_id={job_id}",
+            )
+        except Exception:
+            logger.warning(
+                "SEL audit for Slack cron remove failed (job %s)", job_id, exc_info=True
+            )
         if removed:
             return f"✅ Removed cron job `{job_id}`"
         return f"❌ Job `{job_id}` not found"

--- a/test/test_slack_cron_remove_audit.py
+++ b/test/test_slack_cron_remove_audit.py
@@ -1,0 +1,464 @@
+"""SEL audit for the remaining cron-removal paths (issue #5408).
+
+PR #5405 (in review) adds the ``cron.remove`` audit to the dashboard, MCP, and
+CLI single-delete paths; on base, the plural ``cron.batch_delete`` is the only
+audited removal. These tests lock in the same shapes for the paths neither
+covers:
+
+* Slack keyword ``cron remove <id>`` (``slack/handler.py``)
+* Slack ``cron remove all`` (the plural path, mirroring ``cron.batch_delete``)
+* the automated one-shot removal after delivery — the gateway's direct
+  Done removal, the deferred drain, and the ``delete_after_run`` consume in
+  ``_merge_job_result``
+
+Each path asserts both halves of the contract: the event is emitted on
+success, and the removal still succeeds when the audit raises (the first
+``sel()`` of a process constructs the log and can raise). The composite
+gateway-then-merge test locks the exactly-one-record invariant across paths.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.cron as cron_mod
+import kiro_crew.slack.handler as h
+from kiro_crew.cron import CronJob, CronSchedule, CronService, CronStoreBusy
+
+
+def _job(job_id: str = "j1", *, name: str = "nightly") -> CronJob:
+    return CronJob(
+        id=job_id,
+        name=name,
+        message="do the thing",
+        schedule=CronSchedule(kind="cron", cron_expr="0 9 * * *"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slack keyword `cron remove <id>`
+# ──────────────────────────────────────────────────────────────────────
+class TestSlackSingleRemoveAudit:
+    @pytest.mark.asyncio
+    async def test_remove_emits_sel_audit_with_caller(self):
+        svc = MagicMock()
+        svc.remove_job_async = AsyncMock(return_value=True)
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            out = await h._handle_cron_command("cron remove j1", svc, "C", "t", user_id="U123")
+        assert out is not None and "Removed cron job" in out
+        mock_sel.return_value.log_api_access.assert_called_once_with(
+            caller="U123",
+            operation="cron.remove",
+            outcome="allowed",
+            source="slack",
+            resources="job_id=j1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_remove_missing_audits_not_found(self):
+        svc = MagicMock()
+        svc.remove_job_async = AsyncMock(return_value=False)
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            out = await h._handle_cron_command("cron remove ghost", svc, "C", "t", user_id="U123")
+        assert out is not None and "not found" in out
+        kw = mock_sel.return_value.log_api_access.call_args.kwargs
+        assert kw["operation"] == "cron.remove"
+        assert kw["outcome"] == "not_found"
+        assert "ghost" in kw["resources"]
+
+    @pytest.mark.asyncio
+    async def test_caller_falls_back_to_surface_when_no_user(self):
+        svc = MagicMock()
+        svc.remove_job_async = AsyncMock(return_value=True)
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            await h._handle_cron_command("cron remove j1", svc, "C", "t")
+        assert mock_sel.return_value.log_api_access.call_args.kwargs["caller"] == "slack"
+
+    @pytest.mark.asyncio
+    async def test_busy_store_audits_nothing(self):
+        # A contended store means the delete never happened — no mutation to
+        # audit, matching the dashboard single-delete busy path.
+        svc = MagicMock()
+        svc.remove_job_async = AsyncMock(side_effect=CronStoreBusy())
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            out = await h._handle_cron_command("cron remove j1", svc, "C", "t", user_id="U123")
+        assert out is not None and "busy" in out
+        mock_sel.return_value.log_api_access.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_succeeds_when_audit_raises(self):
+        # The first sel() of a process constructs the log and can raise; the
+        # job is already removed by then, so the reply must still report the
+        # completed delete instead of crashing the Slack handler.
+        svc = MagicMock()
+        svc.remove_job_async = AsyncMock(return_value=True)
+        with patch(
+            "kiro_crew.slack.handler.sel",
+            side_effect=RuntimeError("SEL trust root unavailable"),
+        ):
+            out = await h._handle_cron_command("cron remove j1", svc, "C", "t", user_id="U123")
+        assert out is not None and "Removed cron job" in out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slack `cron remove all` (plural path)
+# ──────────────────────────────────────────────────────────────────────
+class TestSlackRemoveAllAudit:
+    @pytest.mark.asyncio
+    async def test_remove_all_emits_batch_audit(self):
+        svc = MagicMock()
+        svc.list_jobs.return_value = [_job("j1"), _job("j2")]
+        svc.remove_jobs = AsyncMock(return_value=(["j1", "j2"], []))
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            out = await h._remove_all_jobs(svc, user_id="U123")
+        assert "Removed 2 cron job(s)" in out
+        mock_sel.return_value.log_api_access.assert_called_once()
+        kw = mock_sel.return_value.log_api_access.call_args.kwargs
+        assert kw["caller"] == "U123"
+        assert kw["operation"] == "cron.batch_delete"
+        assert kw["outcome"] == "ok"
+        assert kw["source"] == "slack"
+        assert "j1" in kw["resources"] and "j2" in kw["resources"]
+
+    @pytest.mark.asyncio
+    async def test_remove_all_nothing_deleted_audits_failed(self):
+        # Every id vanished concurrently: no delete happened, and the audit
+        # outcome must say so — mirroring the dashboard cron.batch_delete rule.
+        svc = MagicMock()
+        svc.list_jobs.return_value = [_job("j1")]
+        svc.remove_jobs = AsyncMock(return_value=([], ["j1"]))
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            await h._remove_all_jobs(svc, user_id="U123")
+        assert mock_sel.return_value.log_api_access.call_args.kwargs["outcome"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_busy_store_audits_nothing(self):
+        svc = MagicMock()
+        svc.list_jobs.return_value = [_job("j1")]
+        svc.remove_jobs = AsyncMock(side_effect=CronStoreBusy())
+        with patch("kiro_crew.slack.handler.sel") as mock_sel:
+            out = await h._remove_all_jobs(svc, user_id="U123")
+        assert "busy" in out
+        mock_sel.return_value.log_api_access.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_all_succeeds_when_audit_raises(self):
+        svc = MagicMock()
+        svc.list_jobs.return_value = [_job("j1"), _job("j2")]
+        svc.remove_jobs = AsyncMock(return_value=(["j1", "j2"], []))
+        with patch(
+            "kiro_crew.slack.handler.sel",
+            side_effect=RuntimeError("SEL trust root unavailable"),
+        ):
+            out = await h._remove_all_jobs(svc, user_id="U123")
+        assert "Removed 2 cron job(s)" in out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# One-shot auto-removal: deferred drain + delete_after_run consume (cron.py)
+# ──────────────────────────────────────────────────────────────────────
+class _SelRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def log_api_access(self, **kw) -> None:
+        self.events.append(kw)
+
+    def log_tool_invocation(self, **kw) -> None:
+        self.events.append(kw)
+
+
+@pytest.fixture()
+def sel_recorder(monkeypatch):
+    """Replace cron.py's module-level ``sel`` module with a recorder."""
+    rec = _SelRecorder()
+    monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=lambda: rec))
+    return rec
+
+
+@pytest.fixture()
+def raising_sel(monkeypatch):
+    def _boom():
+        raise RuntimeError("SEL trust root unavailable")
+
+    monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=_boom))
+
+
+def _remove_events(rec: _SelRecorder) -> list[dict]:
+    return [e for e in rec.events if e.get("operation") == "cron.remove"]
+
+
+class TestDeferredDrainAudit:
+    def test_tick_drain_audits_each_removed_one_shot(self, tmp_path, sel_recorder):
+        # Through the real tick entry point: the drain removes under the lock
+        # and _tick_scan_locked emits the audit AFTER the lock releases.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("one-shot", "ping", at_ts=time.time() + 3600, delete_after_run=True)
+        svc.defer_removal(job.id)
+        svc._tick_scan_locked()
+        assert not [j for j in CronService(base_dir=tmp_path).list_jobs() if j.id == job.id]
+        removes = _remove_events(sel_recorder)
+        assert len(removes) == 1
+        assert removes[0]["caller"] == "cron"
+        assert removes[0]["outcome"] == "one_shot_completed"
+        assert removes[0]["source"] == "cron"
+        assert "path=cron_deferred_drain" in removes[0]["resources"]
+        assert f"job_id={job.id}" in removes[0]["resources"]
+
+    def test_drain_returns_removed_ids_for_the_caller_to_audit(self, tmp_path, sel_recorder):
+        # The locked core itself emits nothing (the first sel() of a process
+        # constructs the log and must not extend the store-lock hold); it
+        # returns the ids so the post-lock caller owns the emit.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("one-shot", "ping", at_ts=time.time() + 3600, delete_after_run=True)
+        svc.defer_removal(job.id)
+        with svc._file_lock():
+            drained = svc._drain_pending_removals_locked()
+            assert drained == [job.id]
+            assert not _remove_events(sel_recorder)  # no emit inside the lock
+
+    def test_drain_removes_even_when_audit_raises(self, tmp_path, raising_sel):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("one-shot", "ping", at_ts=time.time() + 3600, delete_after_run=True)
+        svc.defer_removal(job.id)
+        svc._tick_scan_locked()  # must not raise
+        assert not [j for j in CronService(base_dir=tmp_path).list_jobs() if j.id == job.id]
+
+    def test_already_removed_id_is_not_audited(self, tmp_path, sel_recorder):
+        # An id already deleted elsewhere leaves nothing to drain: no event
+        # may claim a delete that did not happen here.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("one-shot", "ping", at_ts=time.time() + 3600, delete_after_run=True)
+        svc.defer_removal(job.id)
+        svc.remove_job(job.id)
+        sel_recorder.events.clear()
+        svc._tick_scan_locked()
+        assert not _remove_events(sel_recorder)
+
+
+class TestMergeJobResultOneShotAudit:
+    def test_delete_after_run_consume_is_audited(self, tmp_path, sel_recorder):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("reminder", "ping", at_ts=time.time() - 5, delete_after_run=True)
+        job.last_run_ts = time.time()
+        job.last_status = "ok"
+        svc._merge_job_result(job)
+        assert not [
+            j
+            for j in CronService(base_dir=tmp_path).list_jobs(include_disabled=True)
+            if j.id == job.id
+        ]
+        removes = _remove_events(sel_recorder)
+        assert len(removes) == 1
+        assert removes[0]["caller"] == "cron"
+        assert removes[0]["outcome"] == "one_shot_completed"
+        assert removes[0]["source"] == "cron"
+        assert "path=cron_run_complete" in removes[0]["resources"]
+        assert f"job_id={job.id}" in removes[0]["resources"]
+
+    def test_recurring_job_merge_is_not_audited(self, tmp_path, sel_recorder):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("recurring", "ping", every_secs=3600)
+        job.last_run_ts = time.time()
+        job.last_status = "ok"
+        svc._merge_job_result(job)
+        assert not _remove_events(sel_recorder)
+        assert [
+            j
+            for j in CronService(base_dir=tmp_path).list_jobs(include_disabled=True)
+            if j.id == job.id
+        ]
+
+    def test_already_removed_one_shot_is_not_audited(self, tmp_path, sel_recorder):
+        # A Done-script one-shot the gateway already removed leaves nothing to
+        # consume here; the gateway path owns that audit record.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("reminder", "ping", at_ts=time.time() - 5, delete_after_run=True)
+        svc.remove_job(job.id)
+        sel_recorder.events.clear()
+        job.last_run_ts = time.time()
+        job.last_status = "ok"
+        svc._merge_job_result(job)
+        assert not _remove_events(sel_recorder)
+
+    def test_merge_survives_audit_raise(self, tmp_path, raising_sel):
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job("reminder", "ping", at_ts=time.time() - 5, delete_after_run=True)
+        job.last_run_ts = time.time()
+        job.last_status = "ok"
+        svc._merge_job_result(job)  # must not raise
+        assert not [
+            j
+            for j in CronService(base_dir=tmp_path).list_jobs(include_disabled=True)
+            if j.id == job.id
+        ]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# One-shot auto-removal: gateway direct Done removal (slack/gateway.py)
+# ──────────────────────────────────────────────────────────────────────
+def _make_gw():
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    gw = GatewayOrchestrator.__new__(GatewayOrchestrator)
+    gw.sessions = MagicMock()
+    gw.ctx_builder = MagicMock()
+    gw.slack = MagicMock()
+    gw.conv_log = None
+    gw.dashboard_state = MagicMock()
+    gw.dashboard_state.get_slot = MagicMock(return_value=None)
+    gw._owner_id = "U000"
+    gw.subagent_mgr = None
+    gw._cron_injecting = {}
+    gw._running_script_ids = set()
+    gw._no_crons = False
+    gw.cron_svc = MagicMock()
+    gw.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    gw.sessions.release = MagicMock()
+    gw.sessions.reset = AsyncMock()
+    gw.sessions.set_thread = AsyncMock()
+    gw.sessions.set_channel = AsyncMock()
+    gw.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+    gw.ctx_builder.hooks = MagicMock()
+    gw._interactive_approval = MagicMock(return_value="cb")
+    return gw
+
+
+def _make_script_job(**overrides):
+    defaults = dict(
+        id="sj1",
+        name="script-job",
+        message="CR-123",
+        schedule=CronSchedule(kind="every", every_secs=60),
+        script="~/.kirocrew/crons/monitor.py:run",
+    )
+    defaults.update(overrides)
+    return CronJob(**defaults)
+
+
+async def _run_done_callback(
+    gw, job, *, remove_result=True, remove_side_effect=None, real_svc=None
+):
+    """Drive the cron callback through the script Done path.
+
+    Pass ``real_svc`` (a CronService) to back the removal with the real store
+    instead of a MagicMock — the end-to-end tests need the job to actually
+    vanish from disk and the real audit helper to run.
+    """
+    captured_cb = None
+    recorder = MagicMock()
+
+    with (
+        patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+        patch(
+            "kiro_crew.slack.gateway.run_script_sandboxed",
+            return_value={"status": "done", "message": "all done"},
+        ),
+        patch("kiro_crew.slack.gateway.vet_job_at_fire_time", return_value=None),
+        patch("kiro_crew.slack.gateway.sel", return_value=recorder),
+    ):
+
+        def capture_cron(on_job=None, **kw):
+            nonlocal captured_cb
+            captured_cb = on_job
+            if real_svc is not None:
+                real_svc.start = AsyncMock()  # never arm a real timer in tests
+                return real_svc
+            svc = MagicMock()
+            svc.start = AsyncMock()
+            if remove_side_effect is not None:
+                svc.remove_job_async = AsyncMock(side_effect=remove_side_effect)
+            else:
+                svc.remove_job_async = AsyncMock(return_value=remove_result)
+            svc.defer_removal = MagicMock()
+            return svc
+
+        mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+
+        await gw._init_cron()
+        assert captured_cb is not None
+        result = await captured_cb(job)
+
+    return result, recorder
+
+
+class TestGatewayDoneRemovalAudit:
+    @pytest.mark.asyncio
+    async def test_done_removal_calls_the_shared_audit_helper(self):
+        # The gateway owns no emit of its own: the service helper is the one
+        # owner of the one-shot record shape, so the exactly-one-record
+        # invariant has a single point to depend on.
+        gw = _make_gw()
+        job = _make_script_job()
+        result, _ = await _run_done_callback(gw, job)
+        assert "all done" in (result or "")
+        gw.cron_svc.remove_job_async.assert_called_once_with("sj1")
+        gw.cron_svc.audit_one_shot_removal.assert_called_once_with("sj1", "cron_gateway")
+
+    @pytest.mark.asyncio
+    async def test_busy_store_defers_without_gateway_audit(self):
+        # On a busy store the removal has NOT happened yet: the deferred drain
+        # owns the audit when it lands on disk, so the gateway audits nothing.
+        gw = _make_gw()
+        job = _make_script_job()
+        await _run_done_callback(gw, job, remove_side_effect=CronStoreBusy("busy"))
+        gw.cron_svc.defer_removal.assert_called_once_with("sj1")
+        gw.cron_svc.audit_one_shot_removal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_already_removed_job_is_not_audited(self):
+        # remove_job_async=False means another path already deleted the job —
+        # that path owns the audit record; no event may claim this delete.
+        gw = _make_gw()
+        job = _make_script_job()
+        await _run_done_callback(gw, job, remove_result=False)
+        gw.cron_svc.audit_one_shot_removal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delivery_succeeds_when_audit_raises(self, tmp_path, raising_sel):
+        # End-to-end through the REAL service: the helper's exception
+        # containment means a broken SEL never fails the delivery callback or
+        # the removal itself.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(
+            "done-oneshot",
+            "ping",
+            every_secs=60,
+            script="~/.kirocrew/crons/monitor.py:run",
+        )
+        gw = _make_gw()
+        result, _ = await _run_done_callback(gw, job, real_svc=svc)
+        assert "all done" in (result or "")
+        assert not [j for j in CronService(base_dir=tmp_path).list_jobs() if j.id == job.id]
+
+    @pytest.mark.asyncio
+    async def test_gateway_then_merge_emits_exactly_one_record(self, tmp_path, sel_recorder):
+        # One Done delete_after_run job through BOTH removal paths in order:
+        # the gateway removes and audits (via the shared helper); the later
+        # run-merge finds the job gone and must NOT add a second cron.remove
+        # record. Locks the exactly-one-record invariant against a reorder
+        # that lets the merge win and double-count removals in the trail.
+        svc = CronService(base_dir=tmp_path)
+        job = svc.add_job(
+            "done-oneshot",
+            "ping",
+            every_secs=60,
+            delete_after_run=True,
+            script="~/.kirocrew/crons/monitor.py:run",
+        )
+        gw = _make_gw()
+        result, _ = await _run_done_callback(gw, job, real_svc=svc)
+        assert "all done" in (result or "")
+        removes = _remove_events(sel_recorder)
+        assert len(removes) == 1
+        assert "path=cron_gateway" in removes[0]["resources"]
+        assert not [j for j in CronService(base_dir=tmp_path).list_jobs() if j.id == job.id]
+        # Now the run-state merge runs for the same (already-removed) job.
+        job.last_run_ts = time.time()
+        job.last_status = "ok"
+        svc._merge_job_result(job)
+        assert len(_remove_events(sel_recorder)) == 1  # still exactly one

--- a/test/test_slack_handler_coverage.py
+++ b/test/test_slack_handler_coverage.py
@@ -828,14 +828,16 @@ class TestCronHelpers:
     async def test_remove_all_empty(self):
         svc = MagicMock()
         svc.list_jobs.return_value = []
-        assert await h._remove_all_jobs(svc) == "No cron jobs to remove."
+        assert await h._remove_all_jobs(svc, user_id="U1") == "No cron jobs to remove."
 
     @pytest.mark.asyncio
     async def test_remove_all_reports_each_job(self):
         svc = MagicMock()
         svc.list_jobs.return_value = [_job("j1"), _job("j2")]
-        svc.remove_jobs = AsyncMock()
-        out = await h._remove_all_jobs(svc)
+        # remove_jobs returns (removed_ids, missing_ids); _remove_all_jobs now
+        # unpacks it for the SEL batch audit.
+        svc.remove_jobs = AsyncMock(return_value=(["j1", "j2"], []))
+        out = await h._remove_all_jobs(svc, user_id="U1")
         assert "Removed 2 cron job(s)" in out and "`j1`" in out and "`j2`" in out
 
     @pytest.mark.asyncio
@@ -843,7 +845,7 @@ class TestCronHelpers:
         svc = MagicMock()
         svc.list_jobs.return_value = [_job()]
         svc.remove_jobs = AsyncMock(side_effect=CronStoreBusy())
-        assert "busy" in (await h._remove_all_jobs(svc))
+        assert "busy" in (await h._remove_all_jobs(svc, user_id="U1"))
 
     @pytest.mark.asyncio
     async def test_remove_all_via_cron_remove_all(self):


### PR DESCRIPTION
## Problem / Motivation

Three cron-job removal paths write no SEL (Security Event Log) record, so the job disappears from `crons.json` with no trail:

1. Slack keyword `cron remove <id>` — `slack/handler.py` calls `remove_job_async(job_id)` with no audit event.
2. Slack `cron remove all` — `_remove_all_jobs` calls `remove_jobs(...)` with no audit event, while the dashboard's plural path (`cron.batch_delete`) is audited.
3. Automatic one-shot removal after delivery — the `delete_after_run`/Done removal (gateway direct removal, the deferred drain in `cron.py`, and the `delete_after_run` consume in `_merge_job_result`) removes the job with no audit event.

An unattributed automated delete is exactly the case an operator cannot distinguish from data loss.

## Why it matters

After a job vanishes, the audit trail is the only way to tell a deliberate removal (who, when, which path) from accidental data loss or a compromise. The dashboard batch path already treats destructive cron actions as audit-worthy; leaving the Slack surface and the automation paths silent makes the trail systematically incomplete precisely where no human was watching.

## What changed (motivation → approach → change)

Symptom: removals reach the store through three call sites that never touch SEL. Root cause: auditing was added surface-by-surface (dashboard batch first, dashboard/MCP/CLI single-delete in-flight on PR #5405) and these surfaces were missed. Change: surface-level emits at each remaining call site, keeping per-caller identity rather than a service-level single audit point (which would lose caller attribution unless identity were threaded through):

- **Slack single remove** (`slack/handler.py`): emits `cron.remove` with the Slack caller identity (`caller=<user_id>`, `source="slack"`), outcome `allowed`/`not_found`, only after the store mutation settles; a busy store returns with no mutation and no event. The caller's `user_id` is threaded into `_handle_cron_command` as a defaulted parameter.
- **Slack remove-all** (`_remove_all_jobs`): emits `cron.batch_delete` matching the dashboard plural shape (`requested`/`deleted`/`failed` id lists, outcome `ok`/`failed`), attributed to the Slack caller.
- **One-shot auto-removal**: emits `cron.remove` with an automated-actor identity (`caller="cron"`) and outcome `one_shot_completed`, at whichever site actually lands the removal: the gateway's direct Done removal (`source="cron_gateway"`), the deferred drain (`source="cron_deferred_drain"`), or the `delete_after_run` consume in `_merge_job_result` (`source="cron_run_complete"`). Presence checks keep exactly one path owning each record. The drain's emit is deliberately hoisted to `_tick_scan_locked` AFTER the store lock releases — the first `sel()` of a process constructs the log and must never extend the store-lock hold — via a shared `_audit_one_shot_removal` helper used by both service-internal sites.

All emits are best-effort and exception-contained: audit unavailability never breaks a removal, and no event is written before the mutation settles, so no record can claim a delete that did not happen.

## Tests

`test/test_slack_cron_remove_audit.py` (new, 22 tests):

- Slack single remove: event emitted with caller attribution; `not_found` outcome; busy store emits nothing; removal still succeeds when the audit raises; caller falls back to `"slack"` when no user id.
- Slack remove-all: `cron.batch_delete` with id lists; `failed` outcome when nothing was deleted; busy store emits nothing; command still succeeds when the audit raises.
- Deferred drain: the real tick path (`_tick_scan_locked`) removes and audits post-lock; the locked core emits nothing inside the lock and returns the ids; drain survives an audit raise; an id already removed elsewhere is not audited.
- `_merge_job_result`: `delete_after_run` consume audited; recurring jobs not audited; already-removed one-shots not audited; merge survives an audit raise.
- Gateway Done removal: audit on success; busy defers with no gateway audit; `removed=False` emits nothing; delivery survives an audit raise; and a composite gateway-then-merge test locks the exactly-one-record invariant for a single deletion.

`test/test_slack_handler_coverage.py`: one existing test updated for the now-consumed `remove_jobs` return tuple.

## Manual verification

N/A — unit coverage sufficient: every changed line is a call-site emit or its test, and the tests drive the real `CronService` store and the real gateway callback path.

## Screenshots / video

N/A — backend-only change, no user-visible UI delta.

<!-- no-visual-delta -->
**Why no screenshot:** backend audit-logging only; no frontend paths touched.

## Related Issues

Closes #5408

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, call-site comments carry the design
- [x] No secrets, credentials, or internal references in the diff
