### PR TITLE
docs(spec): Align tool-approval-layer spec to verified resume seam

### DIFF
--- a/.kiro/specs/tool-approval-layer/design.md
+++ b/.kiro/specs/tool-approval-layer/design.md
@@ -12,8 +12,9 @@ It already exists in Kiro Crew as three cooperating pieces:
 2. **Render (frontend):** `components/ApprovalCard.tsx` + `components/ToolInputPreview.tsx`
    render a pending call as a card, currently as a raw `<pre>` args dump.
 3. **Resume (frontend → backend):** `components/ChatInput.tsx` submits the decision via
-   `api.approveChatSlot(slot, action, extra)`; the paused turn resumes with the tool
-   either executed or rejected.
+   the id-scoped `api.resolveApproval(request_id, action)` for plain approve/reject
+   (`api.approveChatSlot(slot, …)` is reserved for trust grants); the paused turn resumes
+   with the tool either executed or rejected.
 
 This design does NOT add a second policy. It (a) enriches the **render** step with a typed
 preview and a batch affordance, (b) documents the **resume** step against the AI-SDK
@@ -47,9 +48,9 @@ Agent turn
    ▼
 ┌──────────────────────────────────────────────┐
 │ onApprove(decision, pattern?) → ChatInput.tsx   │
-│   api.approveChatSlot(slot, action, extra)      │  (EXISTING transport)
+│   api.resolveApproval(request_id, action)       │  (EXISTING id-scoped path)
 └──────────────────────────────────────────────┘
-   │  resume the SAME interrupted invocation (slot + tool-call id)
+   │  resume the SAME interrupted invocation (by request_id)
    ▼
 Tool executes (approved) or is skipped (rejected); agent turn continues
 ```
@@ -61,7 +62,7 @@ Tool executes (approved) or is skipped (rejected); agent turn continues
 | `src/kiro_crew/hooks.py` (`on_tool_call`) | **Unchanged.** Sole policy authority; the layer reads its verdict. |
 | `website/src/components/ApprovalCard.tsx` | Hosts `ToolPreviewFrame` + the batch affordance. |
 | `website/src/components/ToolInputPreview.tsx` | The fallback preview and the "show raw input" surface. |
-| `website/src/components/ChatInput.tsx` (`approveChatSlot`) | **Unchanged** resume transport the layer reuses. |
+| `website/src/components/ChatInput.tsx` (`resolveApproval`) | **Unchanged** resume path the layer reuses (id-scoped by `request_id`; `approveChatSlot` is trust-grants only). |
 | `website/src/hooks/useWebSocket.ts` | Delivers the pending-decision + resume events (existing). |
 | `website/src/kit/tool-views/` (App Builder Kit spec — **prerequisite, not built by this spec**) | Supplies `ToolPreviewFrame` / schema-matched typed previews. This spec **consumes** it and is sequenced after it (see "Dependency and sequencing" below, and Req 8). |
 | `website/src/types/index.ts` (`tool_input: string`) | The opaque input string a preview parses; no new wire field. |
@@ -98,19 +99,20 @@ rich preview (Req 2.2) is the single capability gated on this dependency (Req 8.
 ### Pending-decision model (frontend, mirrors AI-SDK `UIToolInvocation`)
 
 ```ts
-// state model only — NOT a transport claim
-type ToolInvocationState<TIn, TOut> =
-  | { state: 'input-streaming';  input: Partial<TIn> }   // args still arriving
-  | { state: 'input-available';  input: TIn }            // ← the approvable moment
-  | { state: 'output-available'; input: TIn; output: TOut }
-  | { state: 'output-error';     input: TIn; error: string }
+// state model only — NOT a transport claim; input-streaming is omitted
+// (unreachable on this transport: the pending event arrives input-complete)
+type ToolInvocationState =
+  | { state: 'input-available';  input: unknown }               // ← the approvable moment
+  | { state: 'output-available'; input: unknown; output: unknown }
+  | { state: 'output-error';     input: unknown; error: string }
 
 interface PendingDecision {
   slot: string
-  toolCallId: string           // pins the resume to the SAME invocation (Req 3.4)
-  title: string                // display title/purpose from the PreToolUse event
-  rawInput: string             // verbatim tool_input — the "show raw input" source (Req 2.4)
-  invocation: ToolInvocationState<unknown, unknown>  // at 'input-available'
+  approval: PendingApproval    // the verbatim wire event (types/index.ts): carries
+                               // request_id (the resume id), tool, tool_input, tool_kind
+  toolCallId?: string          // optional; display/correlation only — resume uses
+                               // approval.request_id, not this
+  invocation: ToolInvocationState  // at 'input-available'
 }
 ```
 
@@ -125,37 +127,45 @@ body to `ToolPreviewFrame` (from `kit/tool-views`):
 
 - **Schema match** → typed rich preview (e.g. a diff, a table, a chart of the args).
 - **No match** → the existing `ToolInputPreview` `<pre>` (Req 2.3, non-regression).
-- **Always** → a collapsed "show raw input" control revealing the verbatim `rawInput`
+- **Always** → a collapsed "show raw input" control revealing the verbatim
+  `approval.tool_input`
   (Req 2.4). The rich preview is lossy by design; the raw string is the ground truth the
   operator can inspect before approving.
 
 Controls (approve / reject / optional pattern field) are keyboard operable with ARIA
 roles (Req 2.5).
 
-### Resume: `onApprove` → `approveChatSlot`
+### Resume: `onApprove` → `resolveApproval`
 
 The decision is passed straight to the existing callback:
 
 ```ts
 onApprove(decision: 'approve' | 'reject', pattern?: string)
-// → api.approveChatSlot(slot, decision, pattern)   (ChatInput.tsx, unchanged)
+// plain approve/reject → api.resolveApproval(approval.request_id, decision)  (ChatInput.tsx)
+// (trust grants only → approveChatSlot; unattended sources downgrade to resolveApproval)
 ```
 
-`toolCallId` + `slot` pin the resume to the interrupted invocation (Req 3.4). The optional
-`pattern` (e.g. an "always allow this shape" rule) is forwarded verbatim as `extra`
-(Req 3.5); it is a hint to the *next* `on_tool_call` evaluation, never a frontend policy.
+`approval.request_id` pins the resume to the interrupted invocation (Req 3.4). The optional
+`pattern` (e.g. an "always allow this shape" rule) is forwarded verbatim on the path that
+accepts it (Req 3.5); it is a hint to the *next* `on_tool_call` evaluation, never a frontend
+policy. The layer introduces no new approval API path (Req 3.3).
 
 ### Batch approval
 
 Batch is a **UI affordance over the per-call resume**, not a new transport (Req 4.2).
 When N calls are pending in a slot, `ApprovalCard` renders a multi-select; submitting a
-batch iterates `approveChatSlot` per included call. **Exclusion is backend-driven, not
-predicted (Req 4.3–4.4, Req 6.1):** the frontend does not compute or forecast a gate
-verdict — it submits each selected call's resume, and if the `on_tool_call` gate rejects
-one at resume time, that call comes back rejected and the UI marks it excluded *after the
-fact*. Because Req 1.2 already keeps a `TOOL_DENY` call from ever becoming a pending
-decision, everything in a batch was `TOOL_ALLOW` when surfaced; an exclusion reflects a
-verdict that changed between surfacing and resume (e.g. governance state shifted), reported
+batch iterates the slot-scoped `approveChatSlot(slot, mappedAction, { request_id })` per
+included call — NOT the bare id-scoped `resolveApproval`. `state.resolve_approval` matches a
+bare `request_id` across all slots with no session-identity check, so a connection-scoped id
+that collides in two slots could otherwise resolve the wrong slot's call; pinning the batch
+resume to the addressed slot removes that hazard (single approve/reject keeps `resolveApproval`
+— one owned id, no collision). **Exclusion is
+backend-driven, not predicted (Req 4.3–4.4, Req 6.1):** the frontend does not compute or
+forecast a gate verdict — it submits each selected call's resume, and if the `on_tool_call`
+gate rejects one at resume time, that call comes back rejected and the UI marks it excluded
+*after the fact*. Because Req 1.2 already keeps a `TOOL_DENY` call from ever becoming a
+pending decision, everything in a batch was `TOOL_ALLOW` when surfaced; an exclusion reflects
+a verdict that changed between surfacing and resume (e.g. governance state shifted), reported
 by the backend. The frontend never re-implements the gate — that would be exactly the
 parallel policy Req 6.1 forbids.
 
@@ -167,12 +177,12 @@ The portable shape is three steps; the table names what an adopter substitutes.
 |---|---|---|---|
 | Intercept | evaluate the call before it executes | `HookManager.on_tool_call` | a tool with no `execute`, or `prepareStep`/`onStepFinish` interruption |
 | Render | build a card from the invocation state | `ApprovalCard` + `ToolPreviewFrame` | render from `UIToolInvocation` at `input-available` |
-| Resume | apply the decision to the same invocation | `approveChatSlot(slot, action, extra)` | `addToolResult({ toolCallId, output })` + continued stream |
+| Resume | apply the decision to the same invocation | `resolveApproval(request_id, action)` | `addToolResult({ toolCallId, output })` + continued stream |
 
 **Explicit boundary (Req 5.3):** the *enforcement* (`on_tool_call`) and the *transport*
-(`approveChatSlot`) are Kiro-Crew-specific — an adopter swaps in their own. The *portable*
+(`resolveApproval` / `approveChatSlot`) are Kiro-Crew-specific — an adopter swaps in their own. The *portable*
 part is: intercept before execute, render a card from the invocation state, resume the
-same `toolCallId` on decision. **The AI-SDK `UIToolInvocation` union is reused as a state
+same invocation on decision. **The AI-SDK `UIToolInvocation` union is reused as a state
 model, not a transport claim (Req 5.4)** — Kiro Crew's chat transport is markdown +
 `<mcwidget>` opaque strings (`useBlockAssembler.ts`, `types/index.ts`), not a typed
 `tool-<name>` part stream, exactly as documented for the App Builder Kit tool-view encoding.
@@ -181,7 +191,7 @@ model, not a transport claim (Req 5.4)** — Kiro Crew's chat transport is markd
 
 The layer adds **no new backend wire field.** A `PendingDecision` is assembled on the
 frontend from the existing PreToolUse event (title, `tool_input` string) already delivered
-over `useWebSocket.ts`. The typed preview parses `rawInput` against a `kit/tool-views`
+over `useWebSocket.ts`. The typed preview parses `approval.tool_input` against a `kit/tool-views`
 schema; a parse failure downgrades to `<pre>` (no throw).
 
 ## Error Handling
@@ -199,9 +209,9 @@ schema; a parse failure downgrades to `<pre>` (no throw).
 ## Testing Strategy
 
 - **Unit (vitest):** `ApprovalCard` renders each `PendingDecision` state; schema-match vs
-  `<pre>` fallback; "show raw input" reveals verbatim `rawInput`; keyboard/ARIA on controls.
-- **Resume:** approve and reject each route through a mocked `onApprove`/`approveChatSlot`
-  with the correct `slot`/`toolCallId`/`pattern`; a stale `toolCallId` is a no-op.
+  `<pre>` fallback; "show raw input" reveals verbatim `approval.tool_input`; keyboard/ARIA on controls.
+- **Resume:** approve and reject each route through a mocked `onApprove`/`resolveApproval`
+  with the correct `request_id`/`pattern`; a stale `request_id` is a no-op.
 - **Batch:** multi-select resolves per-call; a denied call is excluded, not approved.
 - **Enforcement non-bypass:** a `TOOL_DENY` verdict never yields an approvable card and
   no operator affordance executes it (Req 6.1–6.2).

--- a/.kiro/specs/tool-approval-layer/tasks.md
+++ b/.kiro/specs/tool-approval-layer/tasks.md
@@ -7,25 +7,33 @@ NOT modified. **Prerequisite:** the App Builder Kit's `kit/tool-views` module
 and Task 0 verifies it fail-closed (Req 8). The Req 2.3 `<pre>` fallback path can deliver
 Reqs 1/3/4/5/6 without the module; only the typed rich preview (Req 2.2) is gated on it.
 
-- [ ] 0. Verify the tool-views prerequisite, then establish the `PendingDecision` frontend model
+- [x] 0. Verify the tool-views prerequisite, then establish the `PendingDecision` frontend model
   - **Prerequisite check (fail-closed, Req 8.1/8.3):** confirm the App Builder Kit
     `website/src/kit/tool-views/` module exists and exports `ToolPreviewFrame` +
     `defineToolView`. If it does not, STOP and report the dependency — do NOT stub a local
     `ToolPreviewFrame` (that forks the App Builder Kit contract). The Req 2.3 `<pre>`
     fallback path may proceed for Reqs 1/3/4/5/6 without it (Req 8.4).
-  - Define `PendingDecision` (`slot`, `toolCallId`, `title`, `rawInput`, `invocation`) and
-    the `ToolInvocationState` union in a shared types module, mirroring AI-SDK
-    `UIToolInvocation` as a state model only.
-  - Confirm (via reading `useWebSocket.ts` + `ChatInput.tsx`) that a `PendingDecision` can
-    be assembled from the existing PreToolUse event with NO new backend wire field, and that
-    `approveChatSlot(slot, action, extra)` already pins resume to the slot.
+  - Define `PendingDecision` (`slot`, `approval: PendingApproval`, optional `toolCallId`,
+    `invocation`) and the `ToolInvocationState` union in a shared types module. The model
+    WRAPS the existing `PendingApproval` wire type (`types/index.ts`) rather than re-spelling
+    its fields, so `tsc` pins it to the real event shape and it carries `request_id`.
+    `ToolInvocationState` is non-generic with three reachable phases
+    (`input-available` | `output-available` | `output-error`); `input-streaming` is omitted
+    as unreachable on this transport. It mirrors AI-SDK `UIToolInvocation` as a state model only.
+  - Confirmed (via reading `useWebSocket.ts` + `ChatInput.tsx`) that a `PendingDecision`
+    assembles from the existing PreToolUse event with NO new backend wire field, and that the
+    resume identifier is `approval.request_id`: plain approve/reject resolves through the
+    id-scoped `api.resolveApproval(request_id, action)` (`ChatInput.tsx`), NOT slot-scoped
+    `approveChatSlot` (which is used only for trust grants, and downgrades to `resolveApproval`
+    for unattended sources).
   - _Requirements: 3.3, 3.4, 5.1, 6.4, 8.1, 8.3_
+  - Shipped: PR #5413 (`feat/tal-pending-decision`), MERGED to main 2026-08-24.
 
 - [ ] 1. Rich preview inside `ApprovalCard` (default view, with raw-input fallback)
   - Host `ToolPreviewFrame` (from `kit/tool-views`) inside `ApprovalCard`/`ToolInputPreview`.
   - Render the typed preview when a schema matches the pending input; fall back to the
     existing `<pre>` when none matches.
-  - Add an always-present, collapsed "show raw input" control revealing verbatim `rawInput`.
+  - Add an always-present, collapsed "show raw input" control revealing verbatim `approval.tool_input`.
   - _Requirements: 2.1, 2.2, 2.3, 2.4_
 
 - [ ] 2. Keyboard + ARIA on the approval controls
@@ -34,15 +42,25 @@ Reqs 1/3/4/5/6 without the module; only the typed rich preview (Req 2.2) is gate
   - _Requirements: 2.5_
 
 - [ ] 3. Wire the resume path (approve / reject / pattern)
-  - Route the decision through the existing `onApprove(decision, pattern?)` →
-    `api.approveChatSlot(slot, action, extra)`; forward `pattern` verbatim as `extra`.
-  - Ensure resume targets the same `slot` + `toolCallId`; a stale/closed id is a no-op with
-    a surfaced notice, never a re-issued call.
+  - Route the decision through the existing `onApprove(decision, pattern?)`. Plain
+    approve/reject resolves via the id-scoped `api.resolveApproval(request_id, action)`
+    (`ChatInput.tsx`); the slot-scoped `api.approveChatSlot(slot, …)` is reserved for trust
+    grants (and downgrades to `resolveApproval` for unattended sources). Forward an approval
+    `pattern` verbatim on the path that accepts it. Do NOT introduce a new approval API path.
+  - Ensure resume targets the same invocation via `approval.request_id`; a stale/closed id is
+    a no-op with a surfaced notice, never a re-issued call.
   - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
 
 - [ ] 4. Batch approval affordance
   - Render a multi-select when N calls are pending in a slot; submitting a batch iterates
-    the per-call `approveChatSlot` resume (no new transport).
+    the per-call slot-scoped `approveChatSlot(slot, mappedAction, { request_id })` resume
+    (no new transport). **Batches MUST route through the slot-scoped path, not the bare
+    id-scoped `resolveApproval`:** `state.resolve_approval` matches a bare `request_id` across
+    ALL slots with no session-identity check (see its docstring), so if the same
+    connection-scoped id collides in two slots a bare-id resume could resolve the wrong slot's
+    call. `approveChatSlot` pins resolution to the addressed slot; the `request_id` rides in
+    `extra` to disambiguate within it. (Single approve/reject in Task 3 stays on id-scoped
+    `resolveApproval` — one owned id, no collision surface.)
   - Surface any per-call rejection the gate returns at resume as excluded **after the fact**
     (backend-driven, not predicted); never pre-filter by forecasting the verdict, and never
     silently approve an excluded call.
@@ -65,8 +83,12 @@ Reqs 1/3/4/5/6 without the module; only the typed rich preview (Req 2.2) is gate
 - [ ] 7. Tests — render, resume, batch, non-bypass
   - Unit (vitest): each `PendingDecision` state; schema-match vs `<pre>` fallback;
     raw-input reveal; keyboard/ARIA.
-  - Resume: approve/reject route with correct `slot`/`toolCallId`/`pattern`; stale id no-op.
-  - Batch: per-call resolution; a gate-rejected call surfaced as excluded after the fact.
+  - Resume: single approve/reject routes through id-scoped `resolveApproval` with the correct
+    `request_id` (a stale `request_id` is a no-op); an approval `pattern` is asserted on the
+    trust-grant `approveChatSlot(slot, …, { pattern })` branch, since `resolveApproval` carries
+    no `pattern`.
+  - Batch: per-call slot-scoped `approveChatSlot(slot, …, { request_id })` resolution; a
+    gate-rejected call surfaced as excluded after the fact.
   - Non-bypass: a `TOOL_DENY` never yields an approvable card.
   - Backend (pytest): reuse `test_dashboard_approval.py` / `test_auto_approve.py` /
     `test_approval_threading.py` to assert gate verdicts + SEL audit unchanged.


### PR DESCRIPTION
## Problem
The merged Human-in-the-Loop Tool-Approval Layer spec (`.kiro/specs/tool-approval-layer/`, from #5013) names a resume seam and model shape that turned out not to match the real code. Task 0 (PR #5413) verified against `ChatInput.tsx` that plain approve/reject resolves through the **id-scoped `api.resolveApproval(request_id, action)`** path — not the slot-scoped `approveChatSlot` the spec assumed — and shipped a `PendingDecision` that wraps the real `PendingApproval` wire type. The spec still tells Tasks 1–8 the old story.

## Why it matters
A contributor implementing Task 3 from the unamended spec would build the **wrong, wider** resume path (`approveChatSlot` is slot-scoped and carries an over-granting risk — it's exactly why `ChatInput` downgrades unattended sources to `resolveApproval`), and would model fields (`title`/`rawInput`, `<TIn,TOut>`, a 4th `input-streaming` phase) that the shipped type does not have. Task 0's whole value is settling the contract in one place; leaving the spec stale defeats it.

## Fix (symptoms → root cause → change)
Symptom: spec ↔ code divergence on the resume seam and model shape. Root cause: the spec predates the Task-0 verification. Change (docs-only, both files under `.kiro/specs/tool-approval-layer/`):

- **`design.md`** — corrected the Overview resume step, the architecture diagram, the boundary table (`ChatInput.tsx` row), the Resume section, the batch section, the portable-mapping table, the Data Models note, and the Testing section to the `api.resolveApproval(request_id, action)` seam (with `approveChatSlot` noted as trust-grants-only). Updated the model code block to wrap `PendingApproval`, drop the `<TIn,TOut>` generics, and use the three reachable `ToolInvocationState` phases (`input-streaming` removed as unreachable on this transport).
- **`tasks.md`** — Task 0 marked done (shipped in #5413) with the corrected shape; Tasks 3, 4, and the testing task re-pointed to `resolveApproval(request_id)`; the raw-input control references `approval.tool_input`.

## Tests
N/A — docs-only change (2 markdown files under `.kiro/specs/`). No code, tests, dependencies, CI, or config are touched.

## Manual verification
Verified against real code before editing: `api.resolveApproval` (`website/src/api/client.ts`) is the id-scoped path `POST /api/approvals/<id>/<action>`, and `ChatInput.tsx` routes plain approve/reject through it while reserving `approveChatSlot` for trust grants. Confirmed the diff is exactly the 2 spec files, single commit on fresh `origin/main`, no one-word brand usage in added lines.
