### PR TITLE
fix: offload vector store init off the event loop in kirocrew run (#5389)

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1548,7 +1548,9 @@ async def _run_task(args: argparse.Namespace) -> None:
         embedding_dim=cfg.memory.embedding_dim,
         decay_rates=cfg.memory.decay_rates or None,
     )
-    vector_memory.init()
+    # CALLER CONTRACT (vector_memory.py): async callers offload init() — the
+    # Windows path shells out to icacls and would freeze the loop for seconds.
+    await asyncio.to_thread(vector_memory.init)
     # Embeddings are always-on: wire the factory; bind embed_fn when the model
     # is already present. Deliberately NO download kick here — `kirocrew run`
     # is a one-shot CLI and must not start a 610MB download it will abandon at

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -973,13 +973,11 @@ class VectorMemoryStore:
         #
         # CALLER CONTRACT: an async caller must offload this. The Windows path shells
         # out to icacls, so calling ``init()`` directly on an event loop freezes it
-        # for seconds. ``eval.runner`` and ``slack.gateway`` offload via
-        # ``asyncio.to_thread``; ``dashboard/handlers/memory.py``'s standalone
-        # fallback routes through ``_get_vector_store_async``, which offloads the
-        # init-bearing path (#5221). ONE inline async caller remains:
-        # ``cli_server._run_task`` inits at one-shot CLI startup, before the loop
-        # serves anything concurrent, so the freeze has nothing to stall — tracked
-        # in #5389.
+        # for seconds. All async callers now offload: ``eval.runner``,
+        # ``slack.gateway`` and ``cli_server._run_task`` via ``asyncio.to_thread``
+        # (#5389); ``dashboard/handlers/memory.py``'s standalone fallback routes
+        # through ``_get_vector_store_async``, which offloads the init-bearing
+        # path (#5221).
         self._restrict_memory_files()
 
         # Load persisted FAISS index (or rebuild from SQLite embeddings)

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -924,6 +924,57 @@ class TestRunTask:
         assert vector.embed_fn_factory is None
         assert "Embedding model changed" in capsys.readouterr().err
 
+    def test_vector_init_is_offloaded_off_the_event_loop(
+        self, taskrunner_env, tmp_path, monkeypatch
+    ) -> None:
+        """``VectorMemoryStore.init()`` must honour its caller contract (#5389):
+        the Windows path shells out to icacls, so an async caller offloads it
+        via ``asyncio.to_thread`` instead of freezing the loop. Ordering is
+        asserted too: init must COMPLETE before ``_run_task`` wires the embed
+        hooks (a fire-and-forget offload would reorder them). The sibling
+        ``MemoryStore.init()`` (cheap mkdir+seed) carries no contract and is
+        deliberately not pinned to either thread here."""
+        import threading
+
+        events: list = []
+        init_threads: dict = {}
+
+        class _ThreadRecordingVector(_FakeVectorStore):
+            def init(self) -> None:
+                init_threads["vector"] = threading.current_thread()
+                events.append("init")
+                super().init()
+
+            @property
+            def embed_fn_factory(self):
+                return self.__dict__.get("_eff")
+
+            @embed_fn_factory.setter
+            def embed_fn_factory(self, value) -> None:
+                # First post-init wiring step in _run_task: recording it turns
+                # "init completed before first use" into an observed ordering.
+                events.append("wired")
+                self.__dict__["_eff"] = value
+
+        def _vector(**kw):
+            store = _ThreadRecordingVector(**kw)
+            taskrunner_env["vector"] = store
+            return store
+
+        monkeypatch.setattr(cli_server, "VectorMemoryStore", _vector)
+        taskrunner_env["install_runner"](_Result("completed"))
+        args = argparse.Namespace(
+            spec=str(_spec(tmp_path)), no_test=False, fresh=False, timeout=0, name=""
+        )
+        asyncio.run(cli_server._run_task(args))
+
+        # Offloaded: init ran in a worker thread, not on the loop thread.
+        assert init_threads["vector"] is not threading.current_thread()
+        assert taskrunner_env["vector"].inited is True
+        # Awaited, not fire-and-forget: init completed BEFORE the embed hooks
+        # were wired (the first use that follows it in _run_task).
+        assert events.index("init") < events.index("wired")
+
 
 # --------------------------------------------------------------------------
 # _update — git checkout path

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -2925,6 +2925,161 @@ class TestDbLockGuard:
         assert "S.good" not in flagged
 
 
+class TestAsyncInitOffloadGuard:
+    """AST guard for the #5206 caller contract: an ``async def`` must never
+    call ``VectorMemoryStore.init()`` inline — the Windows path shells out to
+    icacls, so an inline call freezes the event loop for seconds. Async
+    callers offload via ``asyncio.to_thread`` / ``run_in_executor`` (which
+    take the callable UNCALLED, so they never trip this guard).
+
+    The contract was prose-only and drifted three times before #5389 closed
+    the last inline caller; this test makes the next drift a CI failure
+    instead of a code-review catch. Same shape as ``TestDbLockGuard``,
+    including the seeded-violation self-test that keeps the guard armed.
+    """
+
+    @classmethod
+    def _find_inline_async_inits(cls, tree, where: str = "") -> list[str]:
+        """Return a violation per direct ``<store>.init()`` call whose nearest
+        enclosing function is ``async def``, where ``<store>`` is a name or
+        ``self.<attr>`` assigned from ``VectorMemoryStore(...)`` in the same
+        module. Shared by the real guard and its self-test below."""
+        import ast
+
+        def _is_store_ctor(node: object) -> bool:
+            return isinstance(node, ast.Call) and (
+                (isinstance(node.func, ast.Name) and node.func.id == "VectorMemoryStore")
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "VectorMemoryStore"
+                )
+            )
+
+        # Pass 1: collect module-local bindings created from the constructor.
+        store_names: set = set()
+        store_attrs: set = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                value = node.value
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                if value is not None and _is_store_ctor(value):
+                    for target in targets:
+                        if isinstance(target, ast.Name):
+                            store_names.add(target.id)
+                        elif isinstance(target, ast.Attribute) and isinstance(
+                            target.value, ast.Name
+                        ):
+                            store_attrs.add(target.attr)
+
+        # Pass 2: flag direct .init() calls on those bindings inside async defs.
+        violations: list[str] = []
+
+        class Visitor(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.name_stack: list = []
+                self.async_stack: list = []
+
+            def visit_ClassDef(self, node) -> None:
+                self.name_stack.append(node.name)
+                self.generic_visit(node)
+                self.name_stack.pop()
+
+            def _visit_func(self, node, is_async: bool) -> None:
+                self.name_stack.append(node.name)
+                self.async_stack.append(is_async)
+                self.generic_visit(node)
+                self.async_stack.pop()
+                self.name_stack.pop()
+
+            def visit_FunctionDef(self, node) -> None:
+                self._visit_func(node, is_async=False)
+
+            def visit_AsyncFunctionDef(self, node) -> None:
+                self._visit_func(node, is_async=True)
+
+            def visit_Call(self, node: ast.Call) -> None:
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "init"
+                    and self.async_stack
+                    and self.async_stack[-1]
+                ):
+                    receiver = func.value
+                    hit = (
+                        isinstance(receiver, ast.Name) and receiver.id in store_names
+                    ) or (
+                        isinstance(receiver, ast.Attribute)
+                        and receiver.attr in store_attrs
+                        and isinstance(receiver.value, ast.Name)
+                    )
+                    if hit:
+                        loc = ".".join(self.name_stack) or "<module>"
+                        violations.append(
+                            f"{where}line {node.lineno} ({loc}): VectorMemoryStore.init() "
+                            "called inline in an async function — offload it via "
+                            "`await asyncio.to_thread(<store>.init)` (caller contract, "
+                            "vector_memory.py init docs, #5206/#5389)"
+                        )
+                self.generic_visit(node)
+
+        Visitor().visit(tree)
+        return violations
+
+    def test_no_async_function_calls_init_inline(self) -> None:
+        import ast
+        import inspect
+        from pathlib import Path as _Path
+
+        import kiro_crew
+
+        pkg_root = _Path(inspect.getfile(kiro_crew)).parent
+        violations: list = []
+        for py in sorted(pkg_root.rglob("*.py")):
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+            rel = py.relative_to(pkg_root.parent)
+            violations.extend(self._find_inline_async_inits(tree, where=f"{rel}:"))
+        assert not violations, "inline async VectorMemoryStore.init() call(s):\n" + "\n".join(
+            violations
+        )
+
+    def test_guard_catches_a_seeded_violation(self) -> None:
+        """The guard must fail on a seeded inline call and stay quiet on the
+        offloaded / sync forms — otherwise a refactor that breaks its binding
+        or async tracking would silently disarm it."""
+        import ast
+
+        seeded = ast.parse(
+            "store = VectorMemoryStore()\n"
+            "class S:\n"
+            "    def __init__(self):\n"
+            "        self.vm = VectorMemoryStore()\n"
+            "    async def bad(self):\n"
+            "        store.init()\n"
+            "    async def bad_attr(self):\n"
+            "        self.vm.init()\n"
+            "    async def good(self):\n"
+            "        await asyncio.to_thread(store.init)\n"
+            "    def sync_ok(self):\n"
+            "        store.init()\n"
+            "    async def outer(self):\n"
+            "        def helper():\n"
+            "            store.init()\n"
+            "        await asyncio.to_thread(helper)\n"
+        )
+        violations = self._find_inline_async_inits(seeded)
+        # `bad` and `bad_attr` call init inline on the loop; `good` passes the
+        # callable uncalled; `sync_ok` is a sync function; `helper` is a sync
+        # function that runs at call time (inside to_thread).
+        assert len(violations) == 2
+        flagged = "\n".join(violations)
+        assert "(S.bad)" in flagged
+        assert "(S.bad_attr)" in flagged
+        assert "S.good" not in flagged
+        assert "S.sync_ok" not in flagged
+        assert "S.outer" not in flagged
+
+
 @pytest.mark.xdist_group("vector_memory_concurrency")
 class TestReaderConcurrency1947:
     """Stress the readers that ran UNLOCKED on the shared connection before


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

`cli_server._run_task` (the one-shot `kirocrew run` startup path) calls `VectorMemoryStore.init()` inline in an `async def`, violating the caller contract established by #5206: the Windows path of `init()` shells out to `icacls` up to ~11 times via `_restrict_memory_files()` (plus large sync file IO in `load_faiss_index()`), freezing the event loop for seconds. After PR #5371 fixed the dashboard sibling (#5221), this was the last inline async caller — the contract comment in `vector_memory.py` named it explicitly.

## Why it matters

Harm today is bounded (nothing concurrent is served at CLI startup), so this is contract hygiene rather than an outage fix — but every inline caller left standing is precedent for the next one, and this class of drift is exactly how #5389 accumulated three violating call sites after #5206 wrote the contract. Closing the last one lets the contract state "all async callers offload" and makes it mechanically enforceable.

## What changed (motivation → approach → change)

Symptom: an inline `vector_memory.init()` in an `async def`. Root cause: the call predates the #5206 caller contract and was never migrated. Change, mirroring the compliant siblings (`eval/runner.py`, `slack/gateway.py`):

- `src/kiro_crew/cli_server.py` — `_run_task` now runs `await asyncio.to_thread(vector_memory.init)`. The neighboring `MemoryStore.init()` is untouched: it is a cheap mkdir+seed with no offload contract. Cross-thread safety holds — the store connects with `check_same_thread=False` and serializes statements on `_db_lock`.
- `src/kiro_crew/vector_memory.py` — the contract comment no longer names a remaining inline caller: all async callers now offload (`eval.runner`, `slack.gateway`, `cli_server._run_task` via `asyncio.to_thread`; the dashboard fallback via `_get_vector_store_async`, #5221).
- `test/test_vector_memory.py` — new `TestAsyncInitOffloadGuard`, an AST guard (same shape as `TestDbLockGuard`, seeded-violation self-test included) that fails CI if any `async def` under `src/kiro_crew/**` calls `.init()` inline on a `VectorMemoryStore` binding. The contract is now enforced mechanically, not by prose.

## Tests

- `test_vector_init_is_offloaded_off_the_event_loop` (`test/test_cli_server_more_coverage.py`): asserts `init()` runs on a worker thread, not the loop thread, and that it **completes before** `_run_task`'s first post-init use (the embed-hook wiring) — so a fire-and-forget refactor would fail it. Verified to FAIL against the pre-fix code and pass with the fix.
- `TestAsyncInitOffloadGuard::test_no_async_function_calls_init_inline`: repo-wide AST scan; zero inline async callers.
- `TestAsyncInitOffloadGuard::test_guard_catches_a_seeded_violation`: the guard itself stays armed (flags inline name/attr calls; ignores `to_thread`-wrapped, sync, and call-time helper forms).

## Manual verification

N/A — unit coverage sufficient: the change is a single-call offload with behavior pinned by the ordering assertion; `isort`/`flake8`/`mypy` and the affected test files (709 tests) pass locally.

## Related Issues

Closes #5389

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (async offload + contract comment + tests); no rendered UI is touched.
