### PR TITLE
chore(cloud): pin the stock-port invariant and drop the dead dashboard_port plumbing

### DIFF
--- a/src/kiro_crew/cloud/ec2.py
+++ b/src/kiro_crew/cloud/ec2.py
@@ -432,7 +432,6 @@ def build_deploy_argv(
     allow_ssh_cidr: str = "",
     source_bucket: str = "",
     source_key: str = "",
-    dashboard_port: int = 0,
 ) -> list[str]:
     """Assemble the exact ``aws cloudformation deploy`` argv (also the dry-run output).
 
@@ -451,10 +450,6 @@ def build_deploy_argv(
         f"StackTag={tag}",
         f"PermissionsBoundaryArn={permissions_boundary_arn}",
     ]
-    # Only sent when the caller allocated one, so a direct deploy keeps the
-    # template default rather than being pinned by an implicit 0.
-    if dashboard_port:
-        overrides.append(f"DashboardPort={dashboard_port}")
     # Prefer the S3 source (private-repo safe); else pass git repo/ref fallback.
     if source_bucket:
         overrides.append(f"SourceBucket={source_bucket}")
@@ -493,7 +488,6 @@ def deploy(
     ref: str = "",
     allow_ssh_cidr: str = "",
     ship_source: Optional[bool] = None,
-    dashboard_port: int = 0,
     disable_rollback: bool = False,
     dry_run: bool = False,
     proc_sink: Optional[Any] = None,
@@ -546,7 +540,6 @@ def deploy(
             allow_ssh_cidr=allow_ssh_cidr,
             source_bucket="<auto>" if ship_source else "",
             source_key=f"{tag}/kirocrew-src.tar.gz" if ship_source else "",
-            dashboard_port=dashboard_port,
         )
         return DeployResult(
             tag=tag,
@@ -614,7 +607,6 @@ def deploy(
         allow_ssh_cidr=allow_ssh_cidr,
         source_bucket=source_bucket,
         source_key=source_key,
-        dashboard_port=dashboard_port,
     )
     # `cloudformation deploy` blocks until the stack settles (WaitCondition gates
     # on the gateway being healthy). "No changes" exits 0 with a message on reuse.

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -99,11 +99,12 @@ Parameters:
     MinValue: 1024
     MaxValue: 65535
     Description: >-
-      Port the crew's gateway listens on. The local tunnel MIRRORS this port
-      (the remote gateway only trusts CSRF/WebSocket Origins on its own
-      configured port), so every simultaneously-connected crew needs a distinct
-      value and it must not collide with the operator's own gateway port. The
-      launcher allocates one; 5476 is the default only for a direct deploy.
+      Port the crew's gateway listens on. The launcher registers the instance
+      with the registry's own stock remote-port default, so this Default must
+      equal DEFAULT_REMOTE_DASHBOARD_PORT in cloud/connect.py -- a test pins
+      the two together. Crews may share this value: the hub allocates its LOCAL
+      forward port independently, so simultaneously-connected crews do not
+      collide. Override only for a direct (non-launcher) deploy.
   AllowSshCidr:
     Type: String
     Default: ""
@@ -386,9 +387,9 @@ Resources:
       #   (the default clone-of-main path). install.sh stages website/dist ->
       #   src/kiro_crew/static/dist.
       # "systemd unit": a system-level unit so the gateway survives reboots
-      #   and runs as ec2-user. The local tunnel MIRRORS DashboardPort, so the
-      #   crew must listen on the launcher-allocated port, not the built-in
-      #   default -- hence the KIROCREW_PORT Environment line.
+      #   and runs as ec2-user. The registry records DashboardPort as the
+      #   instance's remote_port, so the gateway must listen on exactly this
+      #   parameter -- hence the KIROCREW_PORT Environment line.
       # Editing hazard: the whole UserData is ONE CloudFormation !Sub, so any
       #   dollar-brace token in the script -- even inside a bash comment -- is
       #   parsed as a Sub variable and breaks change-set creation. Use plain
@@ -583,7 +584,7 @@ Resources:
           WorkingDirectory=$RUN_HOME
           Environment=HOME=$RUN_HOME
           Environment=PATH=$RUN_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
-          # The local tunnel mirrors this launcher-allocated port.
+          # The registry records this port as the instance's remote_port.
           Environment=KIROCREW_PORT=${DashboardPort}
 
           [Install]

--- a/test/test_cloud_launch_job.py
+++ b/test/test_cloud_launch_job.py
@@ -406,6 +406,35 @@ class TestRealEngineGatewayPort:
         assert "dashboard_port" not in seen
         assert "remote_port" not in seen["reg"]
 
+    def test_the_template_default_and_the_registry_default_name_the_same_port(self):
+        """The invariant behind the no-override contract above.
+
+        Both ends resolve independently -- the stack binds the template's
+        ``DashboardPort`` Default, the registry records ``register_instance``'s
+        signature default -- so nothing at runtime checks they agree. A drift in
+        either literal ships crews whose tunnel forwards to a port nothing is
+        listening on, with every other test green. This is the one place the two
+        numbers are compared.
+        """
+        import re
+
+        from kiro_crew.cloud import ec2
+        from kiro_crew.cloud.connect import DEFAULT_REMOTE_DASHBOARD_PORT
+
+        text = ec2.load_template()
+        # The template carries CloudFormation short-form tags (!Sub), which a
+        # plain YAML load rejects, so read the parameter block textually. The
+        # match is anchored to the DashboardPort block's own indentation and
+        # guarded below so a template reshape fails loudly instead of matching
+        # some other parameter's Default.
+        m = re.search(
+            r"^  DashboardPort:\n(?:    \S.*\n)*?    Default: (\d+)\n",
+            text,
+            re.MULTILINE,
+        )
+        assert m, "DashboardPort parameter with a Default not found in the template"
+        assert int(m.group(1)) == DEFAULT_REMOTE_DASHBOARD_PORT
+
 
 class TestRealEnginePreflight:
     """The credentials gate that runs immediately before `provision`.


### PR DESCRIPTION
## Problem / Motivation

#5351 deleted `RealLaunchEngine._allocate_port` and left three tails, called out in its review and by the Design / First Principles lanes (tracked in #5450):

1. The same-port invariant became two unlinked literals. Before, one allocated value reached both ends of a crew by construction; now the stack binds the template's `DashboardPort` `Default: 5476` while the registry records `connect.py`'s `DEFAULT_REMOTE_DASHBOARD_PORT = 5476`, and nothing compares them.
2. The template still documented the deleted behavior ("every simultaneously-connected crew needs a distinct value", "The launcher allocates one", "the crew must listen on the launcher-allocated port").
3. `ec2.deploy` / `build_deploy_argv` kept a `dashboard_port` parameter chain whose only production caller was the line #5351 deleted.

## Why it matters

A future edit to either default ships crews whose tunnel forwards to a port nothing is listening on -- with every test green, since the merged test pins only the absence of overrides. The stale template text makes every reader reconstruct the dead local==remote rule, and the dead kwarg chain invites new callers of a mechanism the repo just paid to remove.

## What changed

- `test/test_cloud_launch_job.py`: new parity test in `TestRealEngineGatewayPort` reads the template's `DashboardPort` Default (textual, indentation-anchored -- the template's CloudFormation short-form tags reject a plain YAML load) and asserts equality with `DEFAULT_REMOTE_DASHBOARD_PORT`. Guarded so a template reshape fails loudly rather than matching another parameter.
- `src/kiro_crew/cloud/templates/kirocrew-ec2.yaml`: the `DashboardPort` description and both UserData comments now state the current rule -- both ends take the stock default, the hub allocates its local forward port independently, and the Default is pinned to the registry constant by a test. No `!Sub` variables touched.
- `src/kiro_crew/cloud/ec2.py`: `dashboard_port` removed from `deploy()` and `build_deploy_argv()` along with the `if dashboard_port:` override branch. The template parameter itself remains for direct (non-launcher) deploys.

## Tests

- `pytest test/test_cloud_launch_job.py test/test_cloud_ec2.py test/test_cloud_wizard.py` -- 148 passed.
- Mutation-verified in both drift directions: template Default 5476->5999 reddens the parity test (`assert 5999 == 5476`), constant 5476->5999 reddens it symmetrically (`assert 5476 == 5999`).
- flake8, isort, mypy clean on the changed Python files; black baseline gate passes (no new unformatted files).

Closes #5450
