### PR TITLE
test: exempt whatsapp in the pre-turn roster ratchet

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -237,7 +237,11 @@ class TestPreTurnRatchet:
         # checks (wecom additionally clears attachments there and ingests
         # media before rotating), so folding them into the helper is a
         # behaviour change that needs its own review, not a rider here.
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom"}
+        # whatsapp has the same shape (its own is_busy/_handle_busy path,
+        # maybe_rotate, and awaiting-compact latch in transport_dispatch.py);
+        # it landed concurrently with this ratchet, so the roster gained a
+        # channel the list did not yet name. Migration tracked in #5456.
+        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Problem / Motivation

`TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` is red on main: #5114 (whatsapp channel) and #5379 (pre-turn one-owner refactor carrying the roster ratchet) merged concurrently, each green on its own base, leaving the roster with a channel the ratchet neither wires through `messaging.pre_turn` nor names exempt.

## Why it matters

Every open PR's Backend Tests shard 3 fails regardless of its diff (first seen on #5452), so the break blocks the whole review pipeline until main is fixed.

## What changed

whatsapp is added to the ratchet's exempt set with the same rationale as the existing weixin/wecom entries: its `transport_dispatch.py` runs its own pre-turn sequence (own `is_busy`/`_handle_busy` path, `maybe_rotate`, awaiting-compact latch), so folding it into the shared helper is a behaviour change that needs its own review, not a rider on a red-main fix. The exempt list is exactly the explicit-decision record the ratchet exists to force; the comment names the follow-up.

## Tests

`pytest test/test_messaging_pre_turn.py` -- 13 passed (was 1 failed / 6 passed on the class). One-line set change plus comment; no production code touched.

Closes #5456
