### PR TITLE
test: exempt whatsapp from the messaging pre-turn ratchet (#5448)

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -237,7 +237,13 @@ class TestPreTurnRatchet:
         # checks (wecom additionally clears attachments there and ingests
         # media before rotating), so folding them into the helper is a
         # behaviour change that needs its own review, not a rider here.
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom"}
+        # whatsapp is exempt on the same basis: its dispatcher runs its own
+        # pre-turn sequence with its own busy check (is_busy -> _handle_busy,
+        # then maybe_rotate). Unlike weixin/wecom there is no structural
+        # obstacle -- its _handle_busy mirrors webex's, so migration looks
+        # mechanical -- but it is still a behaviour change that gets its own
+        # review, not a rider in a main-red unblock (#5448).
+        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Problem / Motivation

`test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` fails on **every open PR's merge ref** since PR #5114 (WhatsApp channel) merged at 2026-08-24T00:57Z:

```
AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['whatsapp']
```

The test is a roster ratchet: it computes `rostered - set(_PRE_TURN_CHANNELS) - exempt`, where `rostered` comes from `builtin_channel_descriptors()` at runtime. `channels.py:60` now registers `whatsapp`, but the `exempt` set still listed only the six pre-WhatsApp channels. PR #5114's own CI passed because the roster scan only sees the new channel once it is on main's side of the merge ref.

## Why it matters

This is a repo-wide main-red: the `Backend Tests (3.10, 3)` shard (and its 3.12 sibling) is red for every open PR regardless of what it touches (observed on #5327, which only touches `src/kiro_crew/mcp_gateway/`). Every PR is blocked until this lands.

## What changed (motivation → approach → change)

- **Symptom**: ratchet names `['whatsapp']` as unaccounted.
- **Root cause**: a new rostered channel must be either migrated to `messaging.pre_turn` or explicitly exempted; #5114 did neither.
- **Change**: add `"whatsapp"` to the `exempt` set and extend the rationale comment above it, keeping the exemption an explicit, documented decision.

**Why exempt rather than migrate** (the two branches are not symmetric): the exempt-list's documented criterion for `weixin`/`wecom` is that their dispatchers run their own pre-turn steps with their own busy checks, so folding them into the helper is a behaviour change needing its own review. `src/kiro_crew/whatsapp/transport_dispatch.py` matches that shape today: its own busy check (`is_busy` → `_handle_busy`, L266-267), its own `maybe_rotate` (L270), its own two `clear_awaiting` sites (L180, L474). Per pre-push review (Opus 5), the comment states honestly that unlike `weixin`/`wecom` there is **no structural obstacle** — whatsapp's `_handle_busy` mirrors webex's, so migration looks mechanical — but it is still a behaviour change that gets its own review, not a rider in a main-red unblock.

The assertion itself is unchanged: the ratchet still forces every future channel to make this decision explicitly. No wildcard/auto-exempt escape was added.

## Tests

This change IS a test-file change; the lock-in is the ratchet itself.

**Fail-before** (main @ 1a1efe55c, worktree before the edit):

```
FAILED test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for
  - AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['whatsapp']
  - assert not {'whatsapp'}
1 failed, 12 passed, 40 warnings in 4.16s
```

**Pass-after** (same worktree, after the edit):

```
13 passed, 40 warnings in 3.26s
```

Full local gates: `isort` / `flake8` / `mypy` (1077 files, no issues) / CI-identical black gate / full `python -m pytest`: **64729 passed, 339 skipped, 6 xfailed, 0 failed** — establishing no other red is attributable to this diff.

## Manual verification

N/A — the ratchet test plus the full suite cover this one-file test change; there is no runtime behaviour change.

## Related Issues

Closes #5448

## Checklist

- [x] Single commit with a Conventional Commits title (`test: ...`)
- [x] Existing tests pass and new tests added for new functionality (ratchet re-armed; no new test needed)
- [x] Self-review completed; code follows project style guidelines (pre-push dual model review: GPT 5.6 PASS zero findings, Opus 5 PASS zero blocking)
- [ ] Documentation updated (N/A — test-file comment is the documentation)
- [x] No secrets, credentials, or internal references in the diff
