### PR TITLE
fix(test): account for feishu in the pre-turn roster, and stop credential env residue

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -363,6 +363,44 @@ def _isolate_launchd_paths(_xdg_config_root, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _no_credential_env_residue():
+    """Restore the credential env vars a test may have had INJECTED into it.
+
+    ``KiroCrewConfig.load_credentials()`` deliberately propagates every credential
+    it reads into ``os.environ`` with ``setdefault``, so a spawned child (sandboxed
+    agent, MCP server, cron subprocess) inherits it through ``Popen``'s default
+    ``env=os.environ.copy()``. Any test that points ``env_path()`` at a fabricated
+    ``.env`` therefore leaves those fake credentials in the WORKER's environment,
+    for every test that follows it.
+
+    The usual guard does not catch this, which is what makes it worth a floor:
+    ``monkeypatch.delenv(KEY, raising=False)`` on a key that is ABSENT records
+    nothing to undo, so a value written during the test is restored to nothing.
+
+    And the residue is not inert -- ``load_credentials`` lets ``os.environ`` WIN
+    over the file it just read, so the next test pointing at a different ``.env``
+    is answered with the previous test's token. Observed between
+    ``test_handlers_messaging_coverage.py`` and ``test_review_fixes.py``: a Slack
+    token from one file's temp ``.env`` silently satisfied the other's assertion,
+    and only when both landed in the same worker.
+
+    Bounded to the recognised credential keys, so this is two dict passes over
+    ~20 names per test and cannot mask an unrelated environment change.
+    """
+    from kiro_crew.config.loader import _CREDENTIAL_KEYS
+
+    before = {key: os.environ.get(key) for key in _CREDENTIAL_KEYS}
+    try:
+        yield
+    finally:
+        for key, value in before.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture(autouse=True)
 def _block_host_service_mutation(request, monkeypatch):
     """Fail loudly if a test really starts, stops, or reconfigures a service.
 

--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,21 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu is exempt for the same reason, and its own source says so: the
+        # busy check runs BEFORE `maybe_rotate` (rotating first would mint a
+        # generation and miss the in-flight turn), and the session key is
+        # re-derived afterwards because rotation retires the pre-rotation one.
+        # Its comments name WeCom as the shape it mirrors.
+        exempt = {
+            "telegram",
+            "discord",
+            "teams",
+            "slack",
+            "weixin",
+            "wecom",
+            "whatsapp",
+            "feishu",
+        }
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
Two failures a full local backend run surfaces on current main, neither of which CI
has reported. Both are deterministic once you know the trigger; one only shows when
two files share a worker.

no linked issue: found while re-verifying the local suite after #5366 and #5153.

## `feishu` is not accounted for in the pre-turn roster

`test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for`
fails deterministically:

```
AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['whatsapp']
```

**Why CI never said so.** The WhatsApp channel landed in
`1e042325e feat(channels): whatsapp channel with typed-reply tool approval (#5114)`,
and that commit's own CI run was **cancelled** by a newer push before the backend
shards finished. Nothing since has run a completed shard over it on main.

**Why exempt is the right answer, not migration.** The ratchet's contract is that
"not yet migrated" must be an *explicit decision*, and WhatsApp qualifies on exactly
the terms the six existing exemptions do — verified in `whatsapp/transport_dispatch.py`
rather than assumed:

- `_drive` runs **its own busy check** (routing to `_handle_busy`) before
  `maybe_rotate`, and
- it **re-derives the session key after** the rotation, because that key depends on
  whether the conversation is a group and whether the sender is the operator.

The shared helper owns neither of those, so folding WhatsApp into it is a behaviour
change that needs its own review — which is what the exempt list is for, and what
its own comment says.

## Credential env residue, which is a floor the conftest was missing

`test_review_fixes.py::TestEnvPermissions::test_env_permission_repair_is_posix_only`
passes alone and fails after `test_handlers_messaging_coverage.py`:

```
assert 'xoxb-1234567890-wxyz' == 'xoxb-test'
```

The chain, measured rather than inferred:

1. `load_credentials()` **deliberately** propagates every credential it reads into
   `os.environ` with `setdefault`, so a spawned child (sandboxed agent, MCP server,
   cron subprocess) inherits it via `Popen`'s default `env=os.environ.copy()`.
2. So a test pointing `env_path()` at a fabricated `.env` leaves those fake
   credentials in the **worker's** environment.
3. The usual guard misses it, which is what makes this worth a floor rather than a
   one-line test fix: `monkeypatch.delenv(KEY, raising=False)` on a key that is
   **absent** records nothing to undo, so a value written *during* the test is
   restored to nothing.
4. And the residue is not inert — `load_credentials` lets `os.environ` **win** over
   the file it just read. So the next test reading a different `.env` is answered
   with the previous test's token.

Confirmed at the failing test's setup: `SLACK_BOT_TOKEN='xoxb-1234567890-wxyz'`
already in the environment, with `env_path()` back to the real `~/.kiro/crew/.env`.
The first leaker is `TestConfigGetHandlers::test_slack_config_get_masks_the_tokens`,
found by bisecting with a `pytest_runtest_logfinish` hook.

The rootdir conftest — which already owns this floor for `KIROCREW_HOME`, the
`~/.kiro` bindings, the SEL dir and `tempfile`'s base — now snapshots and restores
the recognised credential keys per test. Bounded to `_CREDENTIAL_KEYS`, so it is two
dict passes over ~20 names and cannot mask an unrelated environment change.

<!-- no-visual-delta -->
**Why no screenshot:** nothing renders. The diff is the rootdir `conftest.py` and one
backend test module; no frontend file is touched.

## Verification

- Full local backend suite on macOS: **64,682 passed, 386 skipped, 6 xfailed, 0 failed**
  (was 2 failed before these two changes).
- The pair that collided now passes in one process: `276 passed`.
- Reverting the conftest restore reddens that pair again (`1 failed`), so the floor
  is guarded rather than incidental.
- black baseline, isort, flake8, brand and harness gates: pass.

## Rebased: the WhatsApp half landed upstream, Feishu took its place

While this PR was open, someone fixed the same ratchet for `whatsapp` on main
(#5448, as a main-red unblock). That conflict resolved to **main's version** — the
duplicate comment here is gone, and this PR no longer touches WhatsApp.

Rebasing then surfaced the next one: **`feishu`**, which landed since and trips the
identical assertion. It is exempt on terms its own source states rather than ones I
inferred — the busy check runs *before* `maybe_rotate` (rotating first would mint a
generation and miss the in-flight turn), the session key is re-derived afterwards
because rotation retires the pre-rotation one, and its comments name WeCom as the
shape it mirrors.

Worth naming as a pattern rather than a coincidence: this ratchet has now caught
three channels (`whatsapp`, `feishu`, and it will catch the next one) *after* they
reached main, because it only fires in a completed backend shard and main's runs are
routinely cancelled by the next push. The ratchet is doing its job; what is missing
is that nothing forces a completed run before the next merge. That is a CI-topology
question, deliberately not answered here.
