### PR TITLE
test(apps): keep the builtin-app strategy inside the app-name contract

### DIFF
--- a/test/test_builtin_app_optional_enable.py
+++ b/test/test_builtin_app_optional_enable.py
@@ -22,6 +22,7 @@ from kiro_crew.apps.manager import (
     register_builtin_apps,
     uninstall_app,
 )
+from kiro_crew.apps.manifest import app_name_error
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -134,8 +135,22 @@ def _no_disk_discovery(monkeypatch):
 # Strategies
 # ---------------------------------------------------------------------------
 
-# Generate valid kebab-case app names
-app_name_st = st.from_regex(r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}", fullmatch=True)
+# Generate valid kebab-case app names.
+#
+# The regex alone is not the admission contract. It happily produces `aux`,
+# `con`, `nul`, `com1`..`com9`, `lpt1`..`lpt9` and `system`, every one of which
+# `app_name_error` refuses -- the device stems because a directory of that name
+# cannot be created on Windows, `system` because it would shadow the
+# `system.*` notification channel namespace. A definition carrying one is not a
+# VALID builtin definition, so a strategy that emits one is out of contract and
+# the tests below, which assert the app registers, fail on it.
+#
+# Filtered through `app_name_error` itself rather than a copied exclusion list:
+# the contract gains names over time (it has already gained the device stems),
+# and a second copy here would silently stop matching it.
+app_name_st = st.from_regex(
+    r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}", fullmatch=True
+).filter(lambda name: app_name_error(name) is None)
 
 # Generate valid builtin app definitions
 valid_builtin_def_st = st.fixed_dictionaries({
@@ -148,6 +163,40 @@ valid_builtin_def_st = st.fixed_dictionaries({
     "defaultEnabled": st.booleans(),
     "tags": st.lists(st.text(min_size=1, max_size=10), max_size=3),
 })
+
+
+# ---------------------------------------------------------------------------
+# The strategy's own contract
+# ---------------------------------------------------------------------------
+
+
+@given(name=app_name_st)
+@settings(max_examples=200)
+def test_the_name_strategy_only_emits_admissible_names(name):
+    """Every name this module calls VALID must be one the app store admits.
+
+    The three property tests below register the generated definition and assert
+    the app is there afterwards. A name `app_name_error` refuses is skipped by
+    `register_builtin_apps` instead -- correctly, and with a warning -- so the
+    assertion fails on a definition that was never valid to begin with.
+    """
+    assert app_name_error(name) is None, f"strategy produced an inadmissible name: {name!r}"
+
+
+def test_the_filter_is_load_bearing():
+    """The bare regex admits refused names, so the filter is not decoration.
+
+    Without this, a later reader sees a `.filter` that never seems to reject
+    anything (the offending names are a vanishing fraction of the space, which
+    is exactly why the failure arrived as an intermittent Windows-shard flake
+    rather than a reproducible red) and removes it.
+    """
+    import re
+
+    bare = re.compile(r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}")
+    refused = [n for n in ("aux", "con", "nul", "com1", "lpt9", "system")
+               if bare.fullmatch(n) and app_name_error(n) is not None]
+    assert refused == ["aux", "con", "nul", "com1", "lpt9", "system"], refused
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

`test/test_builtin_app_optional_enable.py` builds its "valid builtin definition" from a bare regex:

```python
app_name_st = st.from_regex(r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}", fullmatch=True)
```

That regex is not the admission contract. It also produces `aux`, `con`, `nul`, `com1`..`com9`, `lpt1`..`lpt9` and `system` — every one of which `apps/manifest.py::app_name_error` refuses: the device stems because Windows reserves them, so a directory of that name cannot be created; `system` because it would shadow the `system.*` notification channel namespace.

`register_builtin_apps` validates before registering and skips an inadmissible definition with a warning. The three property tests then assert the app **is** registered:

```python
register_builtin_apps()
meta = _read_installed(app_def["name"])
assert meta is not None
```

So the failure is a definition that was never valid, not a store that lost it.

Observed on PR #5327's merge-ref run (job 97304347359) — a change confined to `src/kiro_crew/mcp_gateway/`, with no path to the app store. Hypothesis-random, so it can land on any PR's Windows shard.

## Why it matters

It is a **cross-PR CI flake**: an unrelated contributor's Windows shard goes red, and the failing test names an app store their diff never touches. The obvious readings — "the app store silently drops apps", or "reserved names are unhandled" — are both wrong, so the time cost is a wrong investigation before the right one.

It is also invisible on Linux, where the names are legal and the falsifying example never appears, so it only reproduces on the shard least likely to be re-run locally.

## What changed (motivation → approach → change)

**Symptom** — `assert None is not None` on the Windows shard, with `Falsifying example: app_def={'name': 'aux', ...}`.

**Root cause** — the strategy is out of contract. `aux` matches the regex and is refused by `app_name_error`, so the definition is skipped, correctly, by production code.

**Change** — filter the strategy through the contract function itself:

```python
app_name_st = st.from_regex(
    r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}", fullmatch=True
).filter(lambda name: app_name_error(name) is None)
```

Through `app_name_error`, **not** a copied exclusion list. The contract has already grown once — the device stems arrived with #2590 — and a second copy in a test module would silently stop matching it.

**Not the production side.** The issue offered two options; (a) "the app store should reject reserved names, fail loudly, not silently produce no meta" is already how `main` behaves. Verified on `0b500677c`:

```
Skipping invalid builtin app definition 'aux': app name 'aux' is not portable:
Windows reserves it as a device name, so the app directory is not safe to create there
```

So there is nothing to fix on that side, and this PR changes no production code.

## Tests

Two guards, added because the filter reads as decoration — the offending names are a vanishing fraction of the space, which is exactly why this arrived as an intermittent shard flake rather than a reproducible red, and the next reader has every reason to delete a `.filter` that never appears to reject anything.

| Test | Behavior locked in |
|---|---|
| `test_the_name_strategy_only_emits_admissible_names` | every name the strategy emits satisfies `app_name_error` — the property the three registration tests silently depend on |
| `test_the_filter_is_load_bearing` | the **bare** regex does admit `aux`, `con`, `nul`, `com1`, `lpt9`, `system`, so removing the filter reopens the flake |

**Red-before on pristine `origin/main` (`0b500677c`)**, with the falsifying value pinned as an explicit example rather than waited for:

```
E   Falsifying explicit example: test_builtin_apps_always_locked(
FAILED test/test_builtin_app_optional_enable.py::TestProperty3LifecycleLocked::test_builtin_apps_always_locked
  - assert None is not None
```

After: `28 passed` for the whole file on Windows. Gates: `flake8`, `isort --check-only`, `scripts/check_black_formatting.py` (1 file in scope, passed).

## Manual verification

N/A — unit coverage sufficient: the change is confined to a Hypothesis strategy, and the two guards assert its output against the production contract directly.

## Related Issues

Fixes #5454.

The contract this aligns to was introduced by #2590 (`WINDOWS_DEVICE_STEMS`, one definition in `constants.py`).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: test-only, no documented behaviour changes.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
