### PR TITLE
fix(test): exempt feishu in the pre-turn ratchet

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,21 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu (landed in #4282, hours after whatsapp) follows the same
+        # in-handler pattern (own is_busy -> _handle_busy flow) and is exempt
+        # on the same basis. Per #5379's own body, feishu adopting the helper
+        # is the decided follow-up now that #4282 has landed, so this entry
+        # is expected to be temporary.
+        exempt = {
+            "telegram",
+            "discord",
+            "teams",
+            "slack",
+            "weixin",
+            "wecom",
+            "whatsapp",
+            "feishu",
+        }
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Problem / Motivation

`main` is still red after #5460: `test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` now fails with

```
AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['feishu']
```

#5460 exempted `whatsapp`, but the Feishu channel (#4282) landed hours later, also in parallel with the pre-turn ratchet (#5379) — rostered, not wired to `messaging.pre_turn`, and not in the exempt set. Every branch rebased onto current main inherits the red, and the fork AI-review pipeline (which gates on CI) keeps skipping on affected fork PRs.

*(This PR originally exempted both channels; rebased onto main after #5460 merged, so the remaining diff is feishu-only.)*

## Why it matters

Every open PR rebased onto main still fails Backend Tests shard 3 on all matrices, Coverage Gate fails closed behind it, and fork PRs get no review verdicts. The pipeline stays blocked until the feishu half lands.

## What changed (motivation → approach → change)

Symptom: the ratchet reports `feishu` unaccounted. Root cause: crossed merges — the ratchet's roster snapshot predates the channel. The test's own docstring defines the remedy for "not yet migrated": name the channel in the exempt list with a recorded reason.

Feishu follows the same in-handler pattern the existing exemptions document: its transport dispatch runs its own `is_busy` → `_handle_busy` flow (`src/kiro_crew/feishu/transport_dispatch.py`). One extra fact recorded in the comment: #5379's own body says feishu adopts the helper as a follow-up once #4282 lands — which it now has — so this exempt entry is expected to be temporary and the migration is the decided direction, not an open question. Test-only change; no production code is touched.

## Tests

- `test/test_messaging_pre_turn.py` — the full file passes (13 tests). The ratchet test itself is the change: it accounts for every rostered channel again, and will correctly fail on the next channel that lands unwired and unexempted.

## Manual verification

N/A — unit coverage sufficient: the change is to the test's own exempt data, and the full test file passing is the verification.

## Related Issues

no linked issue: the whatsapp-framed tracker #5448 was closed with #5460; the feishu remainder is documented here and in #5469's thread rather than a fresh issue that would outlive the fix.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
