### PR TITLE
fix(channels): warn on every enabled-but-uncredentialed skip (#5418)

### DIFF
--- a/src/kiro_crew/messaging/registry.py
+++ b/src/kiro_crew/messaging/registry.py
@@ -4,7 +4,8 @@ One registry entry per channel carries the host's per-channel LIFECYCLE seams â€
 the members tuple, the start call, the shutdown gather. The other per-channel
 seams (the ``orch._<channel>_*`` hoist in ``slack/gateway.py``, the ``loader.py``
 config dataclass, the ``sandbox.py`` credential denylist, the
-``dashboard/state.py`` connected fields) are still hand-edited.
+``dashboard/state.py`` connected fields, the uncredentialed-skip probe table in
+``_start_channel_transports``) are still hand-edited.
 
 This module owns the TYPES and the LOOPS
 only â€” it must not import any channel package (``dispatch.py`` pins the

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -255,7 +255,7 @@ from kiro_crew.subagent_completion_meta import (
     wave_final_meta,
 )
 from kiro_crew.taskrunner import TaskRunner
-from kiro_crew.wecom.gateway import warn_if_wecom_uncredentialed
+from kiro_crew.wecom.gateway import warn_if_channel_uncredentialed
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import _ChatSlot
@@ -9516,11 +9516,66 @@ class GatewayOrchestrator:
         # The enabled-only gate below never calls a factory whose flag is
         # False — for a disabled and an enabled-but-uncredentialed channel
         # alike — so a factory-level skip-reason log can never be reached.
-        # Say WHY WeCom is being skipped here, at the decision point (issue
-        # #304). Runs after KIROCREW_READY, outside the boot-path window.
-        warn_if_wecom_uncredentialed(
-            self._cfg.wecom.enabled, self._wecom_bot_id, self._wecom_secret
+        # Say WHY each channel is being skipped here, at the decision point
+        # (issues #304, #5418). Runs after KIROCREW_READY, outside the
+        # boot-path window. Each row lists exactly the credential operands its
+        # _<channel>_enabled predicate reads: telegram folds in the
+        # deprecated-accounts stop (which already has its own warning at
+        # config-load time, so pointing at the token would misname the actual
+        # blocker), and teams deliberately omits the tenant id its predicate
+        # never reads. whatsapp/imessage enablement is config-only (no
+        # credential operand), so they have no row.
+        uncredentialed_probe_rows: tuple[
+            tuple[str, str, bool, tuple[tuple[str, str], ...]], ...
+        ] = (
+            (
+                "wecom",
+                "WeCom",
+                self._cfg.wecom.enabled,
+                (
+                    (CRED_WECOM_BOT_ID, self._wecom_bot_id),
+                    (CRED_WECOM_SECRET, self._wecom_secret),
+                ),
+            ),
+            (
+                "telegram",
+                "Telegram",
+                bool(self._cfg.telegram.enabled and not self._cfg.telegram.accounts),
+                ((CRED_TELEGRAM_BOT_TOKEN, self._telegram_bot_token),),
+            ),
+            (
+                "weixin",
+                "WeChat",
+                self._cfg.weixin.enabled,
+                (
+                    (CRED_WEIXIN_TOKEN, self._weixin_token),
+                    ("weixin.account_id", self._weixin_account_id),
+                ),
+            ),
+            (
+                "discord",
+                "Discord",
+                self._cfg.discord.enabled,
+                ((CRED_DISCORD_BOT_TOKEN, self._discord_bot_token),),
+            ),
+            (
+                "webex",
+                "Webex",
+                self._cfg.webex.enabled,
+                ((CRED_WEBEX_BOT_TOKEN, self._webex_bot_token),),
+            ),
+            (
+                "teams",
+                "Teams",
+                self._cfg.teams.enabled,
+                (
+                    (CRED_MICROSOFT_APP_ID, self._teams_app_id),
+                    (CRED_MICROSOFT_APP_PASSWORD, self._teams_app_password),
+                ),
+            ),
         )
+        for channel_type, settings_name, cfg_enabled, credentials in uncredentialed_probe_rows:
+            warn_if_channel_uncredentialed(channel_type, settings_name, cfg_enabled, credentials)
         loop = asyncio.get_running_loop()
         permitted = await loop.run_in_executor(
             maintenance_executor(),

--- a/src/kiro_crew/wecom/gateway.py
+++ b/src/kiro_crew/wecom/gateway.py
@@ -11,11 +11,13 @@ gateway.
 The turn itself runs on the shared ``TurnDriver`` (credential/exfil redaction +
 tool-approval ladder + SEL audit) via the dispatcher -- no hand-rolled loop.
 
-``warn_if_wecom_uncredentialed`` is the diagnostic companion: the channel
-registry's enabled-only gate never calls the factory when ``_wecom_enabled``
-is False, so ``_start_channel_transports`` logs the enabled-but-uncredentialed
+``warn_if_channel_uncredentialed`` is the diagnostic companion, generalized
+over every collapsed-flag channel (issue #5418): the channel registry's
+enabled-only gate never calls a factory when ``_<channel>_enabled`` is False,
+so ``_start_channel_transports`` logs each channel's enabled-but-uncredentialed
 skip reason through this helper at the start decision point, after
-``KIROCREW_READY`` (issue #304).
+``KIROCREW_READY``. ``warn_if_wecom_uncredentialed`` remains as the
+WeCom-shaped wrapper pinning the original contract (issue #304).
 """
 
 from __future__ import annotations
@@ -30,6 +32,8 @@ from kiro_crew.wecom.transport import WeComTransport
 from kiro_crew.wecom.transport_dispatch import WeComDispatcher
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from kiro_crew.slack.gateway import GatewayOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -58,36 +62,67 @@ def _allowed_userids(orch: "GatewayOrchestrator") -> list[str]:
     return out
 
 
-def warn_if_wecom_uncredentialed(cfg_enabled: bool, bot_id: str, secret: str) -> None:
-    """Log WHY WeCom will not start when enabled but missing credentials.
+def warn_if_channel_uncredentialed(
+    channel_type: str,
+    settings_name: str,
+    cfg_enabled: bool,
+    credentials: "Sequence[tuple[str, str]]",
+) -> None:
+    """Log WHY a channel will not start when enabled but missing credentials.
 
-    ``_wecom_enabled`` is computed as ``cfg.wecom.enabled AND bot_id AND
-    secret`` (see GatewayOrchestrator), which collapses "channel disabled" and
-    "channel enabled but uncredentialed" into one boolean -- and the channel
-    registry's enabled-only gate then skips :func:`maybe_start_wecom` entirely
-    for BOTH states, so no code inside the factory can ever report the
-    difference. This helper is therefore called by
+    Every ``_<channel>_enabled`` flag is computed as ``cfg.<channel>.enabled
+    AND <credential operands>`` (see GatewayOrchestrator), which collapses
+    "channel disabled" and "channel enabled but uncredentialed" into one
+    boolean -- and the channel registry's enabled-only gate then skips the
+    channel factory entirely for BOTH states, so no code inside a factory can
+    ever report the difference. This helper is therefore called by
     ``_start_channel_transports`` at the start decision point (after
-    ``KIROCREW_READY``, off the boot-path window), from the raw ingredients
-    the collapsed flag was computed from. When the operator enabled WeCom but
-    a credential is absent it
-    emits exactly one WARNING (visible at the default log level) naming the
+    ``KIROCREW_READY``, off the boot-path window), once per collapsed-flag
+    channel, from the raw ingredients each flag was computed from (issue
+    #5418, generalizing the WeCom fix from issue #304).
+
+    ``credentials`` holds ``(name, value)`` pairs for exactly the operands the
+    channel's enabled-flag predicate reads -- no more (a name that does not
+    gate the flag would send the operator to configure something that cannot
+    start the channel) and no fewer. When the operator enabled the channel but
+    at least one operand is absent, it emits exactly one WARNING (visible at
+    the default log level) on the channel's own gateway logger, naming the
     missing credential NAME(s), never values; when the channel is disabled, or
     fully credentialed, it stays completely silent.
     """
-    if not cfg_enabled or (bot_id and secret):
+    if not cfg_enabled or all(value for _, value in credentials):
         return
-    missing = " and ".join(
-        name for name, value in (("WECOM_BOT_ID", bot_id), ("WECOM_SECRET", secret)) if not value
-    )
+    missing = " and ".join(name for name, value in credentials if not value)
+    channel_logger = logging.getLogger(f"kiro_crew.{channel_type}.gateway")
     # The rule keys on the word "credential" in the format string; the call
-    # logs only the MISSING credential variable name(s) ("WECOM_BOT_ID",
-    # "WECOM_SECRET") and a static remediation hint — no credential value is
-    # in scope here, and the tests pin that present values never appear.
-    logger.warning(  # nosemgrep: python-logger-credential-disclosure
-        "wecom: enabled but not credentialed (missing %s) — skipping. "
-        "Set the missing credential(s) in the dashboard WeCom settings.",
+    # logs only the MISSING credential variable name(s) and a static
+    # remediation hint — no credential value is among the format arguments,
+    # and the tests pin that present values never appear.
+    channel_logger.warning(  # nosemgrep: python-logger-credential-disclosure
+        "%s: enabled but not credentialed (missing %s) — skipping. "
+        "Set the missing credential(s) in the dashboard %s settings.",
+        channel_type,
         missing,
+        settings_name,
+    )
+
+
+def warn_if_wecom_uncredentialed(cfg_enabled: bool, bot_id: str, secret: str) -> None:
+    """WeCom-shaped wrapper over :func:`warn_if_channel_uncredentialed`.
+
+    Preserves the public contract issue #304 introduced (pinned by
+    ``test_wecom_gateway.py::TestSkipReasonWarning``): exactly one WARNING on
+    this module's logger naming the missing credential name(s)
+    (``WECOM_BOT_ID`` / ``WECOM_SECRET``), values never logged, silence when
+    disabled or fully credentialed. Production routes through the
+    six-channel table in ``_start_channel_transports`` (issue #5418), which
+    feeds the generic helper the same ``(name, value)`` pairs.
+    """
+    warn_if_channel_uncredentialed(
+        "wecom",
+        "WeCom",
+        cfg_enabled,
+        (("WECOM_BOT_ID", bot_id), ("WECOM_SECRET", secret)),
     )
 
 
@@ -100,8 +135,8 @@ async def maybe_start_wecom(orch: "GatewayOrchestrator") -> "WeComClient | None"
 
     The enabled-but-uncredentialed diagnostic does NOT live here: the channel
     registry only calls this factory when ``_wecom_enabled`` is already true,
-    so the skip reason is logged by :func:`warn_if_wecom_uncredentialed` from
-    ``_start_channel_transports`` instead.
+    so the skip reason is logged by :func:`warn_if_channel_uncredentialed`
+    from ``_start_channel_transports`` instead.
     """
     if not getattr(orch, "_wecom_enabled", False):
         return None

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -7099,65 +7099,280 @@ class TestMandatoryUpdateOnWheelInstall:
         apply_called.assert_awaited_once()
 
 
-# ─── WeCom skip-reason warning on the PRODUCTION start path (issue #304) ─────
+# ─── Channel skip-reason warning on the PRODUCTION start path (#304, #5418) ──
 
 
-class TestWeComSkipReasonAtTransportStart:
+# One row per collapsed-flag channel the enabled-but-uncredentialed WARNING
+# covers: (channel_type, names the WARNING must carry, names it must NOT carry,
+# creds entries + cfg mutations that make the channel FULLY credentialed).
+# The name lists are spelled exactly as the warning must emit them, i.e. the
+# credential operands each _<channel>_enabled predicate actually reads.
+_UNCREDENTIALED_CHANNEL_ROWS = (
+    pytest.param(
+        "wecom",
+        ("WECOM_BOT_ID", "WECOM_SECRET"),
+        (),
+        {"WECOM_BOT_ID": "wecom-bot-value", "WECOM_SECRET": "wecom-secret-value"},
+        (),
+        id="wecom",
+    ),
+    pytest.param(
+        "telegram",
+        ("TELEGRAM_BOT_TOKEN",),
+        (),
+        {"TELEGRAM_BOT_TOKEN": "telegram-token-value"},
+        (),
+        id="telegram",
+    ),
+    pytest.param(
+        "weixin",
+        # account_id is not a secret (it comes from the QR setup flow) but the
+        # predicate reads it, so it is named like any other missing operand.
+        ("WEIXIN_TOKEN", "weixin.account_id"),
+        (),
+        {"WEIXIN_TOKEN": "weixin-token-value"},
+        (("weixin", "account_id", "weixin-account-value"),),
+        id="weixin",
+    ),
+    pytest.param(
+        "discord",
+        ("DISCORD_BOT_TOKEN",),
+        (),
+        {"DISCORD_BOT_TOKEN": "discord-token-value"},
+        (),
+        id="discord",
+    ),
+    pytest.param(
+        "webex",
+        ("WEBEX_BOT_TOKEN",),
+        (),
+        {"WEBEX_BOT_TOKEN": "webex-token-value"},
+        (),
+        id="webex",
+    ),
+    pytest.param(
+        "teams",
+        ("MICROSOFT_APP_ID", "MICROSOFT_APP_PASSWORD"),
+        # _teams_enabled never reads the tenant id, so the warning must not
+        # send the operator to a field that cannot start the channel.
+        ("MICROSOFT_APP_TENANT_ID",),
+        {
+            "MICROSOFT_APP_ID": "teams-app-id-value",
+            "MICROSOFT_APP_PASSWORD": "teams-password-value",
+        },
+        (),
+        id="teams",
+    ),
+)
+
+_UNCREDENTIALED_CHANNEL_TYPES = ("wecom", "telegram", "weixin", "discord", "webex", "teams")
+
+
+class TestChannelSkipReasonAtTransportStart:
     """The enabled-but-uncredentialed WARNING must fire on the real start path.
 
-    The channel registry's enabled-only gate never calls ``maybe_start_wecom``
-    when ``_wecom_enabled`` is False — for a disabled AND for an
-    enabled-but-uncredentialed channel alike — so a factory-level log can never
-    be reached in production. The skip reason is therefore logged by
+    The channel registry's enabled-only gate never calls a channel factory
+    when ``_<channel>_enabled`` is False — for a disabled AND for an
+    enabled-but-uncredentialed channel alike — so a factory-level log can
+    never be reached in production. The skip reason is therefore logged by
     ``_start_channel_transports`` at the decision point, which runs AFTER
-    ``KIROCREW_READY`` (outside the boot-path window). These pin that wiring;
-    the helper's message contract is pinned in ``test_wecom_gateway.py``.
+    ``KIROCREW_READY`` (outside the boot-path window), via the six-channel
+    table feeding ``warn_if_channel_uncredentialed``. These pin that wiring
+    for every collapsed-flag channel (issue #5418, generalizing the
+    WeCom-only class issue #304 introduced); the helper's message contract is
+    pinned in ``test_wecom_gateway.py``.
 
-    Every scenario here keeps ``_wecom_enabled`` False (and all other channels
-    config-off), so the registry starts nothing and no network is touched.
+    Rows that make a ``_<channel>_enabled`` flag True (fully-credentialed
+    cases) stub the governance gate to deny, so ``registry.start_channels``
+    skips every factory and no transport or network is ever touched; the
+    WARNING under test fires before either.
+
+    Capture is scoped to WARNING+: the wiring contract here is the
+    warning-level diagnostic (exactly one, or none), so an unrelated DEBUG/INFO
+    line some channel module may grow on the skip path must not flake these.
+    Helper-level COMPLETE silence (no records at any level) stays pinned in
+    ``test_wecom_gateway.py``.
     """
 
-    def _build(self, *, wecom_enabled: bool, creds: dict[str, str]) -> GatewayOrchestrator:
+    def _build(
+        self,
+        *,
+        creds: dict[str, str],
+        cfg_mut: tuple[tuple[str, str, object], ...] = (),
+    ) -> GatewayOrchestrator:
         cfg = KiroCrewConfig()
-        cfg.wecom.enabled = wecom_enabled
+        for section, attr, value in cfg_mut:
+            setattr(getattr(cfg, section), attr, value)
         with patch.object(cfg, "load_credentials", return_value=creds):
             return GatewayOrchestrator(cfg)
 
-    def _wecom_records(self, caplog) -> list[logging.LogRecord]:
-        return [r for r in caplog.records if r.name == "kiro_crew.wecom.gateway"]
+    async def _start(self, orch: GatewayOrchestrator, monkeypatch) -> None:
+        from kiro_crew.slack import gateway as gw
+
+        monkeypatch.setattr(gw, "_channel_transport_permitted", lambda member: False)
+        await orch._start_channel_transports()
+
+    def _channel_records(self, caplog) -> list[logging.LogRecord]:
+        names = {f"kiro_crew.{c}.gateway" for c in _UNCREDENTIALED_CHANNEL_TYPES}
+        return [r for r in caplog.records if r.name in names]
 
     @pytest.mark.asyncio
-    async def test_enabled_without_credentials_warns_at_default_level(self, caplog) -> None:
-        orch = self._build(wecom_enabled=True, creds={"KIROCREW_OWNER_ID": "U_OWNER"})
-        with caplog.at_level(logging.WARNING, logger="kiro_crew.wecom.gateway"):
-            await orch._start_channel_transports()
-        records = self._wecom_records(caplog)
-        assert len(records) == 1
-        assert records[0].levelno == logging.WARNING
-        msg = records[0].getMessage()
-        assert "WECOM_BOT_ID" in msg
-        assert "WECOM_SECRET" in msg
-
-    @pytest.mark.asyncio
-    async def test_a_partial_configuration_names_only_the_missing_credential(
-        self, caplog
+    @pytest.mark.parametrize(
+        "channel,names,forbidden,full_creds,full_cfg_mut", _UNCREDENTIALED_CHANNEL_ROWS
+    )
+    async def test_enabled_without_credentials_warns_at_default_level(
+        self, caplog, monkeypatch, channel, names, forbidden, full_creds, full_cfg_mut
     ) -> None:
         orch = self._build(
-            wecom_enabled=True,
-            creds={"KIROCREW_OWNER_ID": "U_OWNER", "WECOM_BOT_ID": "bot-1"},
+            creds={"KIROCREW_OWNER_ID": "U_OWNER"},
+            cfg_mut=((channel, "enabled", True),),
         )
-        with caplog.at_level(logging.WARNING, logger="kiro_crew.wecom.gateway"):
-            await orch._start_channel_transports()
-        records = self._wecom_records(caplog)
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        records = self._channel_records(caplog)
+        # Exactly one WARNING, on this channel's own gateway logger, and no
+        # cross-talk onto any sibling channel's logger.
         assert len(records) == 1
+        assert records[0].name == f"kiro_crew.{channel}.gateway"
+        assert records[0].levelno == logging.WARNING
         msg = records[0].getMessage()
-        assert "WECOM_SECRET" in msg
-        assert "WECOM_BOT_ID" not in msg
-        assert "bot-1" not in msg
+        for name in names:
+            assert name in msg
+        for name in forbidden:
+            assert name not in msg
 
     @pytest.mark.asyncio
-    async def test_a_disabled_channel_is_completely_silent(self, caplog) -> None:
-        orch = self._build(wecom_enabled=False, creds={"KIROCREW_OWNER_ID": "U_OWNER"})
-        with caplog.at_level(logging.DEBUG, logger="kiro_crew.wecom.gateway"):
-            await orch._start_channel_transports()
-        assert self._wecom_records(caplog) == []
+    @pytest.mark.parametrize(
+        "channel,creds,cfg_mut,named,not_named,present_values",
+        (
+            pytest.param(
+                "wecom",
+                {"WECOM_BOT_ID": "wecom-bot-value"},
+                (),
+                ("WECOM_SECRET",),
+                ("WECOM_BOT_ID",),
+                ("wecom-bot-value",),
+                id="wecom-secret-missing",
+            ),
+            pytest.param(
+                "weixin",
+                {"WEIXIN_TOKEN": "weixin-token-value"},
+                (),
+                ("weixin.account_id",),
+                ("WEIXIN_TOKEN",),
+                ("weixin-token-value",),
+                id="weixin-account-id-missing",
+            ),
+            pytest.param(
+                "weixin",
+                {},
+                (("weixin", "account_id", "weixin-account-value"),),
+                ("WEIXIN_TOKEN",),
+                ("weixin.account_id",),
+                ("weixin-account-value",),
+                id="weixin-token-missing",
+            ),
+            pytest.param(
+                "teams",
+                {"MICROSOFT_APP_ID": "teams-app-id-value"},
+                (),
+                ("MICROSOFT_APP_PASSWORD",),
+                ("MICROSOFT_APP_ID",),
+                ("teams-app-id-value",),
+                id="teams-password-missing",
+            ),
+        ),
+    )
+    async def test_a_partial_configuration_names_only_the_missing_credential(
+        self, caplog, monkeypatch, channel, creds, cfg_mut, named, not_named, present_values
+    ) -> None:
+        orch = self._build(
+            creds={"KIROCREW_OWNER_ID": "U_OWNER", **creds},
+            cfg_mut=((channel, "enabled", True), *cfg_mut),
+        )
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        records = self._channel_records(caplog)
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        for name in named:
+            assert name in msg
+        for name in not_named:
+            assert name not in msg
+        # Credential VALUES must never be logged, only the variable names.
+        for value in present_values:
+            assert value not in msg
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "channel,names,forbidden,full_creds,full_cfg_mut", _UNCREDENTIALED_CHANNEL_ROWS
+    )
+    async def test_a_disabled_channel_is_completely_silent(
+        self, caplog, monkeypatch, channel, names, forbidden, full_creds, full_cfg_mut
+    ) -> None:
+        # Even with every credential present: disabled means silence.
+        orch = self._build(
+            creds={"KIROCREW_OWNER_ID": "U_OWNER", **full_creds},
+            cfg_mut=full_cfg_mut,
+        )
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        assert self._channel_records(caplog) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "channel,names,forbidden,full_creds,full_cfg_mut", _UNCREDENTIALED_CHANNEL_ROWS
+    )
+    async def test_a_fully_credentialed_channel_is_silent(
+        self, caplog, monkeypatch, channel, names, forbidden, full_creds, full_cfg_mut
+    ) -> None:
+        orch = self._build(
+            creds={"KIROCREW_OWNER_ID": "U_OWNER", **full_creds},
+            cfg_mut=((channel, "enabled", True), *full_cfg_mut),
+        )
+        assert getattr(orch, f"_{channel}_enabled") is True  # flag really computed
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        assert self._channel_records(caplog) == []
+
+    @pytest.mark.asyncio
+    async def test_teams_tenant_id_is_not_a_credential_operand(
+        self, caplog, monkeypatch
+    ) -> None:
+        # The trap the table must not fall into: the tenant id sits in config
+        # right next to the two operands that count, but _teams_enabled never
+        # reads it — app id + password present with NO tenant is fully
+        # credentialed, so the probe must stay SILENT rather than send the
+        # operator to a field that does not gate the channel.
+        orch = self._build(
+            creds={
+                "KIROCREW_OWNER_ID": "U_OWNER",
+                "MICROSOFT_APP_ID": "teams-app-id-value",
+                "MICROSOFT_APP_PASSWORD": "teams-password-value",
+            },
+            cfg_mut=(("teams", "enabled", True),),
+        )
+        assert orch._teams_enabled is True
+        assert orch._teams_tenant_id == ""
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        assert self._channel_records(caplog) == []
+
+    @pytest.mark.asyncio
+    async def test_telegram_deprecated_accounts_suppress_the_warning(
+        self, caplog, monkeypatch
+    ) -> None:
+        # With telegram.accounts set the channel is stopped by DEPRECATED
+        # CONFIG, not by the missing token, and that state already has its own
+        # warning at config-load time — pointing the operator at
+        # TELEGRAM_BOT_TOKEN here would misname the actual blocker.
+        orch = self._build(
+            creds={"KIROCREW_OWNER_ID": "U_OWNER"},
+            cfg_mut=(
+                ("telegram", "enabled", True),
+                ("telegram", "accounts", {"legacy-bot": object()}),
+            ),
+        )
+        with caplog.at_level(logging.WARNING):
+            await self._start(orch, monkeypatch)
+        assert self._channel_records(caplog) == []


### PR DESCRIPTION
Closes #5418

## What broke

Six channels compute an `_<channel>_enabled` flag that collapses two distinct operator states into one boolean: "channel disabled" and "channel enabled but credentials missing". The channel registry's gate is enabled-only, so it never calls the channel factory in EITHER state — any factory-level log is unreachable in production. An operator who ticks a channel on and forgets its credentials gets zero diagnostic at any log level; the channel simply never starts.

PR #5412 fixed exactly one of the six (WeCom). The other five stayed silent — and weixin had **no** diagnostic at all after #5412 removed its dead factory-level INFO log.

## The fix

Generalize the merged WeCom pattern into **one table-driven check** at the existing call site in `_start_channel_transports` (after `KIROCREW_READY`, off the boot-path window — that placement was itself a review outcome on #5412):

- `warn_if_channel_uncredentialed(channel_type, settings_name, cfg_enabled, credentials)` in `wecom/gateway.py` emits **exactly one WARNING** per affected channel on that channel's own gateway logger (`kiro_crew.<channel>.gateway`), naming only the **missing credential NAME(s)**. Credential values are never among the format arguments — the `nosemgrep` exemption and the #5412 "present values never appear" test contract are preserved and extended to all six channels.
- `warn_if_wecom_uncredentialed` stays as a thin WeCom-shaped wrapper delegating to the generic helper, pinning the #304 contract — `test/test_wecom_gateway.py` is untouched.
- The table lists **exactly the credential operands each predicate reads**, derived from the six `_<channel>_enabled` definitions:

  | channel | names in the warning |
  |---|---|
  | wecom | `WECOM_BOT_ID`, `WECOM_SECRET` |
  | telegram | `TELEGRAM_BOT_TOKEN` |
  | weixin | `WEIXIN_TOKEN`, `weixin.account_id` (not a secret — QR setup value — but the predicate reads it) |
  | discord | `DISCORD_BOT_TOKEN` |
  | webex | `WEBEX_BOT_TOKEN` |
  | teams | `MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD` — **not** the tenant id, which the predicate never reads |

- **Telegram special case:** while the deprecated `telegram.accounts` map is set, the channel is stopped by deprecated config (which already has its own warning at config-load time), not by the missing token — the new warning is suppressed so the operator is pointed at the actual blocker. Pinned by a test.
- Registered the probe table in the `messaging/registry.py` docstring's hand-edited per-channel seam list, so channel authors adding a seventh channel find it.

Scope: log-only. No channel's start/skip decision changes; the enabled flags stay collapsed; no startup path migrates.

## Tests

`TestWeComSkipReasonAtTransportStart` becomes `TestChannelSkipReasonAtTransportStart`, parameterized over all six channels (26 tests):

- (a) enabled with everything missing → exactly one WARNING on that channel's logger naming every operand, no cross-talk onto sibling loggers; teams row additionally pins that `MICROSOFT_APP_TENANT_ID` is never named
- (b) partial configurations (wecom / weixin ×2 / teams) → only the missing operand is named, and **present values never appear** in the record
- (c) disabled → silent; fully credentialed → silent (governance gate stubbed to deny so no transport starts in tests)
- (d) the teams tenant-id trap and the telegram deprecated-accounts suppression, each pinned by an explicit test

Capture is scoped to WARNING+ (per pre-push review): the wiring contract is the warning-level diagnostic, so a future DEBUG line on some channel's skip path cannot flake these; helper-level complete silence stays pinned in `test_wecom_gateway.py`.

## Pre-push review (dual model-pinned)

- GPT 5.6 Sol: **PASS, zero findings** — verified all six name lists against the predicates, value non-disclosure, boot-path placement, unchanged lifecycle flow.
- Opus 5: **PASS + 5 advisories**, adopted 3:
  1. settings hint for weixin now says "WeChat" (the dashboard section's actual title in `loader.py` `_meta`)
  2. probe table registered in the registry docstring seam list
  3. silence assertions capture at WARNING+ instead of DEBUG
  
  Two documented as deliberate trade-offs: (i) `warn_if_wecom_uncredentialed` is production-unreachable (test-contract pin, delegating implementation so it cannot drift; folding it away means editing the #5412 contract tests — separate cleanup); (ii) warnings name the credential ENV-VAR spelling while values may come from `config.json` fields — consistent with the merged WeCom wording, and the "dashboard settings" hint covers the config path.

## Verified

- Local: isort / flake8 / mypy clean; `scripts/check_black_formatting.py` passes both ratchet directions; new tests 26/26; `test_wecom_gateway.py` 21/21 untouched-and-green; full backend pytest **64752 passed**.
- The single full-suite failure is the known main-red #5448 (`test_messaging_pre_turn` roster ratchet vs whatsapp, PRs #5114 × #5379 crossed in flight — repair PRs racing: #5457 / #5460 / #5466). Unrelated to this diff: fails identically without this commit; this PR touches neither the roster nor the pre-turn helper. Backend Tests on this PR's merge-ref will stay red until one repair merges; will re-trigger a fresh merge-ref run after that.

Known limitation: the probe table is hand-maintained — a seventh collapsed-flag channel must add a row (now discoverable via the registry seam list). A ratchet guard asserting predicate-operands ⊆ table is follow-up material.
