### PR TITLE
test: exempt feishu from the messaging pre-turn ratchet

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,10 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu is exempt on the same basis: its dispatcher hand-rolls the
+        # same is_busy -> maybe_rotate sequence around its event routing, and
+        # it landed concurrently with that unblock so it missed the roster.
+        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp", "feishu"}
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Summary

main is still red on `test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` — now with `feishu` unaccounted. The whatsapp exemption (#5448, merged as `06612aea8`) unblocked half of it, but the Feishu channel (#4282) merged concurrently with that unblock, so the roster ratchet fails again and every PR inherits the red via its merge ref. Verified on `71134ec31` (current main HEAD): the test fails with `['feishu']` on an unmodified checkout.

## Fix

Rebased onto current main; this PR is now feishu-only. Feishu's dispatcher hand-rolls the same `is_busy` -> `maybe_rotate` sequence as the existing exemptions (`feishu/transport_dispatch.py`, no `resolve_pre_turn` call), so the correct accounting is the explicit exempt entry the ratchet prescribes. Migrating it onto the shared helper remains its own reviewable change.

## Testing

- `test/test_messaging_pre_turn.py` 13/13 pass on this branch (fails 1 on unmodified main).
- flake8 + isort clean on the touched file.
