### PR TITLE
fix(dialog): guard six hand-rolled Tab traps against IME composition

### DIFF
--- a/website/src/components/AgentImportFlow.test.tsx
+++ b/website/src/components/AgentImportFlow.test.tsx
@@ -277,6 +277,26 @@ describe('AgentImportFlow', () => {
     expect(document.activeElement).toBe(focusable[focusable.length - 1])
   })
 
+  it('declines a boundary Tab that belongs to an IME composition', async () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition (issue class of the shared
+    // hook's own guard).
+    mockSuccessfulRequests()
+    renderWithProviders(<AgentImportFlow initialOpen onComplete={vi.fn()} />)
+
+    const dialog = await screen.findByRole('dialog', { name: 'Import agent setup' })
+    const heading = await within(dialog).findByRole('heading', { name: 'Choose sources' })
+    await waitFor(() => expect(heading).toHaveFocus())
+
+    fireEvent.compositionStart(heading)
+    fireEvent.compositionEnd(heading)
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+    // Declined: focus stays where it was instead of wrapping to the last button.
+    expect(document.activeElement).toBe(heading)
+  })
+
   it('waits for completion state to persist before calling onComplete', async () => {
     mockSuccessfulRequests()
     let resolveState: ((value: { ok: boolean }) => void) | undefined

--- a/website/src/components/AgentImportFlow.tsx
+++ b/website/src/components/AgentImportFlow.tsx
@@ -22,6 +22,7 @@ import {
   type AgentImportSource,
 } from '../api/client'
 import { fmtList } from '../i18n/format'
+import { useDocumentImeLatch } from '../hooks/useImeGuard'
 import { Btn, SendBtn } from './ui'
 import OnboardingChapterShell, {
   OnboardingShellContext,
@@ -147,6 +148,12 @@ export default function AgentImportFlow({
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const previousInitialOpenRef = useRef(initialOpen)
   const initializedScanGenerationRef = useRef<number | null>(null)
+  // Shared IME latch for the Tab trap below: a Tab that lands during an IME
+  // composition (or its post-`compositionend` window) is choosing a candidate,
+  // not leaving the field, so the trap must decline it instead of yanking
+  // focus and aborting the composition (`useDialogFocusTrap` is the reference
+  // consumer of the same seam).
+  const imeLatch = useDocumentImeLatch(open)
 
   const scanQuery = useQuery({
     queryKey: ['agent-import-scan', scanGeneration],
@@ -320,19 +327,25 @@ export default function AgentImportFlow({
       const first = focusable[0]
       const last = focusable[focusable.length - 1]
       const activeIndex = focusable.indexOf(document.activeElement as HTMLElement)
-      if (event.shiftKey && (activeIndex <= 0)) {
-        event.preventDefault()
-        last.focus()
-      } else if (!event.shiftKey && (activeIndex < 0 || activeIndex === focusable.length - 1)) {
-        event.preventDefault()
-        first.focus()
-      }
+      const wrapsBackward = event.shiftKey && activeIndex <= 0
+      const wrapsForward = !event.shiftKey && (activeIndex < 0 || activeIndex === focusable.length - 1)
+      // A mid-dialog Tab is the browser's to move, so it is also not the
+      // trap's to claim — claiming it would consume legitimate navigation
+      // inside the post-composition latch window.
+      if (!wrapsBackward && !wrapsForward) return
+      // A Tab the IME owns must not cycle focus — the user is choosing a
+      // candidate, not leaving the field. `claimKey` owns the whole decline;
+      // it must run before the preventDefault() and focus move so the IME
+      // keeps the key (see its contract in useImeGuard.ts).
+      if (!imeLatch.claimKey(event)) return
+      event.preventDefault()
+      ;(wrapsBackward ? last : first).focus()
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
     // `skipAll` intentionally follows the current mutation state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, completionMutation.isPending, applyMutation.isPending, skipAllMutation.isPending])
+  }, [open, completionMutation.isPending, applyMutation.isPending, skipAllMutation.isPending, imeLatch])
 
   if (!open) return null
 

--- a/website/src/components/ArtifactPanel.tsx
+++ b/website/src/components/ArtifactPanel.tsx
@@ -12,6 +12,7 @@ import { useFileArtifactComments } from './FileArtifactComments'
 import { formatArtifactCommentsMessage } from './CommentOverlay'
 import { copyToClipboard } from '../utils/clipboard'
 import { api } from '../api/client'
+import { useDocumentImeLatch } from '../hooks/useImeGuard'
 import type { Artifact } from '../types'
 
 import { i18nT } from '../i18n/t'
@@ -107,6 +108,12 @@ export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSub
   const fsPreviewRef = useRef<HTMLDivElement>(null)
   const fsScrollRef = useRef<HTMLDivElement>(null)
   const [fullscreen, setFullscreen] = useState(false)
+  // Shared IME latch for the full-screen preview's Tab trap: a Tab that lands
+  // during an IME composition (or its post-`compositionend` window) is
+  // choosing a candidate, not leaving the field, so the trap must decline it
+  // instead of yanking focus and aborting the composition
+  // (`useDialogFocusTrap` is the reference consumer of the same seam).
+  const fsImeLatch = useDocumentImeLatch(fullscreen)
 
   // Live artifact — authoritative for kind/name/content once loaded. Seeded
   // with what handleArtifactOpen captured so the panel renders immediately.
@@ -335,7 +342,27 @@ export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSub
     {fullscreen && createPortal(
       <div className="fixed inset-0 z-[9999] bg-bg flex flex-col" role="dialog" aria-modal="true" aria-label={i18nT('components.artifactPanel.full_screen_artifact_preview')}
         ref={el => { if (el && !el.dataset.focused) { el.dataset.focused = '1'; const first = el.querySelector<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])'); first?.focus() } }}
-        onKeyDown={e => { if (e.key === 'Tab') { const focusable = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])'); if (focusable.length === 0) return; const first = focusable[0], last = focusable[focusable.length - 1]; if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus() } } else { if (document.activeElement === last) { e.preventDefault(); first.focus() } } } }}>
+        onKeyDown={e => {
+          if (e.key !== 'Tab') return
+          const focusable = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])')
+          if (focusable.length === 0) return
+          const first = focusable[0], last = focusable[focusable.length - 1]
+          const wrapsBackward = e.shiftKey && document.activeElement === first
+          const wrapsForward = !e.shiftKey && document.activeElement === last
+          // A mid-dialog Tab is the browser's to move, and not the trap's to
+          // claim. A boundary Tab the IME owns must not cycle focus — the user
+          // is choosing a candidate, not leaving the field — so `claimKey`
+          // (native-event contract in useImeGuard.ts) runs before the
+          // preventDefault() and focus move.
+          if (!wrapsBackward && !wrapsForward) return
+          // `claimKey` consumes the native event (document/window listeners),
+          // but React 17+ checks the SYNTHETIC propagation flag when walking
+          // component ancestors — stop that half too so a declined Tab cannot
+          // trigger an ancestor's own keyboard handling.
+          if (!fsImeLatch.claimKey(e.nativeEvent)) { e.stopPropagation(); return }
+          e.preventDefault()
+          ;(wrapsBackward ? last : first).focus()
+        }}>
         {/* Header — pl-20 clears macOS traffic-light buttons */}
         <div className="flex items-center justify-between pl-20 pr-6 h-12 shrink-0 border-b border-border">
           <span className="flex items-center gap-2 min-w-0">

--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -217,7 +217,7 @@ interface Props {
 
 import { PierreFilePair, type PierreEditorHandle, type RevealTarget } from '../pierre'
 import { i18nT } from '../i18n/t'
-import { useImeGuard } from '../hooks/useImeGuard'
+import { useDocumentImeLatch, useImeGuard } from '../hooks/useImeGuard'
 
 /**
  * File types that render through a dedicated viewer instead of a text editor.
@@ -945,6 +945,12 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
   const [refreshing, setRefreshing] = useState(false)
   const [hintDismissed, setHintDismissed] = useState(() => localStorage.getItem(HINT_KEY) === '1')
   const [fullscreen, setFullscreen] = useState(false)
+  // Shared IME latch for the full-screen preview's Tab trap: a Tab that lands
+  // during an IME composition (or its post-`compositionend` window) is
+  // choosing a candidate, not leaving the field, so the trap must decline it
+  // instead of yanking focus and aborting the composition
+  // (`useDialogFocusTrap` is the reference consumer of the same seam).
+  const fsImeLatch = useDocumentImeLatch(fullscreen)
   const fileName = filePath.split('/').pop() || filePath
   // Artifact + knowledge state power the header star/knowledge toggles and
   // the ⋯ menu's Snapshot entry (same query cache as the OverflowMenu's own
@@ -1722,7 +1728,27 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <div className="fixed inset-0 z-[9999] bg-bg flex flex-col" role="dialog" aria-modal="true" aria-label={i18nT('components.markdownPanel.full_screen_file_preview')}
         ref={el => { if (el && !el.dataset.focused) { el.dataset.focused = '1'; const first = el.querySelector<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])'); first?.focus() } }}
-        onKeyDown={e => { if (e.key === 'Tab') { const focusable = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])'); if (focusable.length === 0) return; const first = focusable[0], last = focusable[focusable.length - 1]; if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus() } } else { if (document.activeElement === last) { e.preventDefault(); first.focus() } } } }}>
+        onKeyDown={e => {
+          if (e.key !== 'Tab') return
+          const focusable = e.currentTarget.querySelectorAll<HTMLElement>('button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])')
+          if (focusable.length === 0) return
+          const first = focusable[0], last = focusable[focusable.length - 1]
+          const wrapsBackward = e.shiftKey && document.activeElement === first
+          const wrapsForward = !e.shiftKey && document.activeElement === last
+          // A mid-dialog Tab is the browser's to move, and not the trap's to
+          // claim. A boundary Tab the IME owns must not cycle focus — the user
+          // is choosing a candidate, not leaving the field — so `claimKey`
+          // (native-event contract in useImeGuard.ts) runs before the
+          // preventDefault() and focus move.
+          if (!wrapsBackward && !wrapsForward) return
+          // `claimKey` consumes the native event (document/window listeners),
+          // but React 17+ checks the SYNTHETIC propagation flag when walking
+          // component ancestors — stop that half too so a declined Tab cannot
+          // trigger an ancestor's own keyboard handling.
+          if (!fsImeLatch.claimKey(e.nativeEvent)) { e.stopPropagation(); return }
+          e.preventDefault()
+          ;(wrapsBackward ? last : first).focus()
+        }}>
 
         {/* Header — pl-20 clears macOS traffic-light buttons */}
         <div className="flex items-center justify-between pl-20 pr-6 h-12 shrink-0 border-b border-border">

--- a/website/src/components/OnboardingFlow.tsx
+++ b/website/src/components/OnboardingFlow.tsx
@@ -12,7 +12,7 @@ import { capRoleOther, clampRoleOther } from '../lib/userProfile'
 import { ROLE_SLUGS, TECH_SLUGS } from '../lib/profileOptions'
 
 import { i18nT } from '../i18n/t'
-import { useImeGuard } from '../hooks/useImeGuard'
+import { useDocumentImeLatch, useImeGuard } from '../hooks/useImeGuard'
 /**
  * First-run onboarding flow (5 steps) — the Customize chapter plus the feature
  * tour. It is the LAST of the three first-run chapters: Import setup runs first,
@@ -158,6 +158,13 @@ export default function OnboardingFlow({
   // Which dialog step already received its initial focus (see the trap effect).
   // Reset on close so reopening focuses again.
   const initialFocusKeyRef = useRef('')
+  // Shared IME latch for the modal-step Tab trap below (steps 1-2 only, like
+  // the trap itself): a Tab that lands during an IME composition (or its
+  // post-`compositionend` window) is choosing a candidate, not leaving the
+  // field, so the trap must decline it instead of yanking focus and aborting
+  // the composition (`useDialogFocusTrap` is the reference consumer of the
+  // same seam).
+  const imeLatch = useDocumentImeLatch(open && step <= 2)
 
   // ── Step-2 profile state ──────────────────────────────────────────────────
   const [role, setRole] = useState('')
@@ -444,19 +451,25 @@ export default function OnboardingFlow({
       if (items.length === 0) return
       const first = items[0]
       const last = items[items.length - 1]
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault()
-        last.focus()
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault()
-        first.focus()
-      }
+      const wrapsBackward = e.shiftKey && document.activeElement === first
+      const wrapsForward = !e.shiftKey && document.activeElement === last
+      // A mid-dialog Tab is the browser's to move, so it is also not the
+      // trap's to claim — claiming it would consume legitimate navigation
+      // inside the post-composition latch window.
+      if (!wrapsBackward && !wrapsForward) return
+      // A Tab the IME owns must not cycle focus — the user is choosing a
+      // candidate, not leaving the field. `claimKey` owns the whole decline;
+      // it must run before the preventDefault() and focus move so the IME
+      // keeps the key (see its contract in useImeGuard.ts).
+      if (!imeLatch.claimKey(e)) return
+      e.preventDefault()
+      ;(wrapsBackward ? last : first).focus()
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
     // shellHost?.sectionSlot: in host mode the dialog mounts a pass after the
     // flow opens, so re-run once it exists to install the trap + initial focus.
-  }, [open, step, skipAll, savingProfile, dialogRef, shellHost?.sectionSlot])
+  }, [open, step, skipAll, savingProfile, dialogRef, shellHost?.sectionSlot, imeLatch])
 
   if (!open) return null
 

--- a/website/src/components/PrivacyChapter.cov80.test.tsx
+++ b/website/src/components/PrivacyChapter.cov80.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../test/helpers'
 import PrivacyChapter from './PrivacyChapter'
 import { api } from '../api/client'
@@ -78,6 +78,28 @@ describe('PrivacyChapter Tab trap', () => {
     ring[0].focus()
     fireEvent.keyDown(document, { key: 'ArrowDown' })
     expect(document.activeElement).toBe(ring[0])
+  })
+
+  it('declines a boundary Tab that belongs to an IME composition', async () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition (issue class of the shared
+    // hook's own guard).
+    renderWithProviders(<PrivacyChapter open onContinue={vi.fn()} />)
+    // Wait for the toggle to leave its loading-disabled state so the ring
+    // holds more than one member — a one-element ring wraps onto itself and
+    // cannot distinguish a decline from a wrap.
+    const toggle = await screen.findByRole('switch', { name: 'Send anonymous usage heartbeat' })
+    await waitFor(() => expect(toggle).toBeEnabled())
+    const ring = focusables()
+    expect(ring.length).toBeGreaterThan(1)
+    const last = ring[ring.length - 1]
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(ring[0])
   })
 
   it('the trap is torn down when the chapter closes', async () => {

--- a/website/src/components/PrivacyChapter.tsx
+++ b/website/src/components/PrivacyChapter.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef } from 'react'
 import { SendBtn } from './ui'
+import { useDocumentImeLatch } from '../hooks/useImeGuard'
 import OnboardingChapterShell, { OnboardingShellContext } from './OnboardingChapterShell'
 import { setupChapterAside } from './AgentImportFlow'
 import {
@@ -47,6 +48,12 @@ export default function PrivacyChapter({
   const localDialogRef = useRef<HTMLDivElement>(null)
   const dialogRef = shellHost?.dialogRef ?? localDialogRef
   const headingRef = useRef<HTMLHeadingElement>(null)
+  // Shared IME latch for the Tab trap below: a Tab that lands during an IME
+  // composition (or its post-`compositionend` window) is choosing a candidate,
+  // not leaving the field, so the trap must decline it instead of yanking
+  // focus and aborting the composition (`useDialogFocusTrap` is the reference
+  // consumer of the same seam).
+  const imeLatch = useDocumentImeLatch(open)
 
   // Move focus to the heading on open, then trap Tab inside the dialog
   // (website/AGENTS.md modal a11y). Escape is NOT wired: this chapter cannot be
@@ -66,19 +73,25 @@ export default function PrivacyChapter({
       const first = focusable[0]
       const last = focusable[focusable.length - 1]
       const activeIndex = focusable.indexOf(document.activeElement as HTMLElement)
-      if (event.shiftKey && activeIndex <= 0) {
-        event.preventDefault()
-        last.focus()
-      } else if (!event.shiftKey && (activeIndex < 0 || activeIndex === focusable.length - 1)) {
-        event.preventDefault()
-        first.focus()
-      }
+      const wrapsBackward = event.shiftKey && activeIndex <= 0
+      const wrapsForward = !event.shiftKey && (activeIndex < 0 || activeIndex === focusable.length - 1)
+      // A mid-dialog Tab is the browser's to move, so it is also not the
+      // trap's to claim — claiming it would consume legitimate navigation
+      // inside the post-composition latch window.
+      if (!wrapsBackward && !wrapsForward) return
+      // A Tab the IME owns must not cycle focus — the user is choosing a
+      // candidate, not leaving the field. `claimKey` owns the whole decline;
+      // it must run before the preventDefault() and focus move so the IME
+      // keeps the key (see its contract in useImeGuard.ts).
+      if (!imeLatch.claimKey(event)) return
+      event.preventDefault()
+      ;(wrapsBackward ? last : first).focus()
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
     // shellHost?.sectionSlot: in host mode the content is portaled a pass after
     // open, so re-run once the slot exists to install the trap + initial focus.
-  }, [open, dialogRef, shellHost?.sectionSlot])
+  }, [open, dialogRef, shellHost?.sectionSlot, imeLatch])
 
   if (!open) return null
 

--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -4,8 +4,8 @@
 // An aria-modal dialog that lets focus wander behind the overlay would let
 // keyboard users activate obscured controls, so every dialog needs the same
 // three pieces. They live here rather than being re-implemented per dialog.
-import { useEffect, useRef, type RefObject } from 'react'
-import { createImeLatch } from './useImeGuard'
+import { useEffect, type RefObject } from 'react'
+import { useDocumentImeLatch } from './useImeGuard'
 
 /** Focusable descendants of a dialog, in DOM order, skipping disabled ones. */
 export const FOCUSABLE =
@@ -61,53 +61,14 @@ export function useDialogFocusTrap(
   // IME guard for the Tab-cycles-focus path. This listener receives NATIVE
   // KeyboardEvents (window capture), which `useImeGuard`'s synthetic-only
   // `claimEnter` cannot consume — so it shares the guard's tracked latch via
-  // `createImeLatch` instead of hand-rolling a second spelling
-  // (`useListKeyboardNav` is the reference consumer). IMEs use Tab to cycle
-  // the candidate list, and on WebKit the keydown that commits a candidate
-  // arrives AFTER `compositionend` with `isComposing` already false —
-  // unguarded, a Tab composed into a dialog input that happens to be the
-  // last (or first) focusable element yanks focus and aborts the
-  // composition. The latch lives in a ref so the keydown handler reads the
-  // live value without re-subscribing.
-  const imeLatchRef = useRef<ReturnType<typeof createImeLatch>>()
-  if (!imeLatchRef.current) imeLatchRef.current = createImeLatch()
-
-  // Composition tracking + latch lifecycle, keyed on `enabled` ONLY. The
-  // keydown effect below re-attaches whenever a dep changes identity (callers
-  // routinely pass an inline `onEscape`), and a latch reset riding along on
-  // that churn would clear the post-composition window at exactly the moment
-  // it matters: the commit's own input event re-renders the host right before
-  // the committing keydown arrives. Same constraint `useListKeyboardNav`
-  // states for its guard.
-  useEffect(() => {
-    if (!enabled) return
-    const latch = imeLatchRef.current!
-    // A re-enabled trap must not inherit a latch stranded by a composition
-    // that ended (or was abandoned) while an inner dialog owned the keyboard.
-    latch.reset()
-    // Composition tracking listens at document capture like
-    // `useListKeyboardNav`'s: the composing input is anywhere inside the
-    // dialog, so element-scoped listeners have nothing reliable to attach to.
-    const onCompositionStart = () => latch.onCompositionStart()
-    const onCompositionEnd = () => latch.onCompositionEnd()
-    // Stranded-latch recovery: a composition abandoned WITHOUT compositionend
-    // (focus moves off the input mid-composition, an OS-level IME cancel)
-    // would otherwise leave the latch set — and a latched guard consumes the
-    // Tabs it declines, so the trap would silently stop cycling for the
-    // dialog's lifetime.
-    const onRecover = () => latch.reset()
-    document.addEventListener('compositionstart', onCompositionStart, true)
-    document.addEventListener('compositionend', onCompositionEnd, true)
-    document.addEventListener('focusout', onRecover, true)
-    return () => {
-      document.removeEventListener('compositionstart', onCompositionStart, true)
-      document.removeEventListener('compositionend', onCompositionEnd, true)
-      document.removeEventListener('focusout', onRecover, true)
-      // Drop any pending post-composition timer with the listeners so a timer
-      // from a disabled trap cannot fire into the next enablement.
-      latch.reset()
-    }
-  }, [enabled])
+  // `useDocumentImeLatch` (which owns the document-capture composition
+  // tracking, the enabled-keyed reset, and the stranded-latch recovery).
+  // IMEs use Tab to cycle the candidate list, and on WebKit the keydown that
+  // commits a candidate arrives AFTER `compositionend` with `isComposing`
+  // already false — unguarded, a Tab composed into a dialog input that
+  // happens to be the last (or first) focusable element yanks focus and
+  // aborts the composition.
+  const imeLatch = useDocumentImeLatch(enabled)
 
   useEffect(() => {
     if (!enabled) return
@@ -137,11 +98,11 @@ export function useDialogFocusTrap(
       // latch window where the browser would otherwise act) — see its
       // contract in useImeGuard.ts. It must run before the preventDefault()
       // and focus move so the IME keeps the key.
-      if (!imeLatchRef.current!.claimKey(e)) return
+      if (!imeLatch.claimKey(e)) return
       e.preventDefault()
       ;(wrapsBackward ? lastEl : firstEl).focus()
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
-  }, [containerRef, onEscape, enabled, handleEscape])
+  }, [containerRef, onEscape, enabled, handleEscape, imeLatch])
 }

--- a/website/src/hooks/useImeGuard.documentLatch.test.tsx
+++ b/website/src/hooks/useImeGuard.documentLatch.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { useDocumentImeLatch } from './useImeGuard'
+import type { ImeLatch } from './useImeGuard'
+
+/**
+ * The document-tracked IME latch shared by every focus-boundary Tab trap
+ * (`useDialogFocusTrap` plus the dialogs and inline traps that hand-roll the
+ * same shape). These tests pin the seam itself — the tracking lifecycle, the
+ * post-composition window, the stranded-latch recovery, and the
+ * enabled-keyed reset — so each consuming site only needs a wiring test.
+ */
+
+function Harness({
+  enabled = true,
+  expose,
+}: {
+  enabled?: boolean
+  expose: (latch: ImeLatch) => void
+}) {
+  expose(useDocumentImeLatch(enabled))
+  return <input data-testid="field" aria-label="composition host" />
+}
+
+function mount(enabled = true) {
+  let latch!: ImeLatch
+  const utils = render(<Harness enabled={enabled} expose={(l) => { latch = l }} />)
+  return { ...utils, latch: () => latch, field: utils.getByTestId('field') }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useDocumentImeLatch', () => {
+  it('latches on a composition anywhere in the document', () => {
+    const { latch, field } = mount()
+    expect(latch().isLatched()).toBe(false)
+    fireEvent.compositionStart(field)
+    expect(latch().isLatched()).toBe(true)
+  })
+
+  it('stays latched through the post-composition window', () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — only the tracked
+    // window can identify it.
+    const { latch, field } = mount()
+    fireEvent.compositionStart(field)
+    fireEvent.compositionEnd(field)
+    expect(latch().isLatched()).toBe(true)
+  })
+
+  it('unlatches once the post-composition window elapses', () => {
+    vi.useFakeTimers()
+    const { latch, field } = mount()
+    fireEvent.compositionStart(field)
+    fireEvent.compositionEnd(field)
+    vi.advanceTimersByTime(60)
+    expect(latch().isLatched()).toBe(false)
+  })
+
+  it('recovers from an abandoned composition on focusout', () => {
+    // No compositionend ever fires (OS-level IME cancel, focus stolen
+    // mid-composition). Without the recovery the latch would stay set and
+    // consume every later boundary Tab for the surface's lifetime.
+    const { latch, field } = mount()
+    field.focus()
+    fireEvent.compositionStart(field)
+    expect(latch().isLatched()).toBe(true)
+    field.blur()
+    expect(latch().isLatched()).toBe(false)
+  })
+
+  it('does not track while disabled', () => {
+    const { latch, field } = mount(false)
+    fireEvent.compositionStart(field)
+    expect(latch().isLatched()).toBe(false)
+  })
+
+  it('does not inherit a stale latch across a disable/re-enable', () => {
+    let latch!: ImeLatch
+    const expose = (l: ImeLatch) => { latch = l }
+    const { rerender, getByTestId } = render(<Harness enabled expose={expose} />)
+    fireEvent.compositionStart(getByTestId('field'))
+    expect(latch.isLatched()).toBe(true)
+    rerender(<Harness enabled={false} expose={expose} />)
+    rerender(<Harness enabled expose={expose} />)
+    expect(latch.isLatched()).toBe(false)
+  })
+
+  it('claimKey declines and consumes a latched key, accepts a clear one', () => {
+    const { latch, field } = mount()
+    fireEvent.compositionStart(field)
+    fireEvent.compositionEnd(field)
+    // Post-composition window: both native signals read clear, so the claim
+    // consumes the key (preventDefault + stopPropagation) and declines.
+    const latched = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true, bubbles: true })
+    expect(latch().claimKey(latched)).toBe(false)
+    expect(latched.defaultPrevented).toBe(true)
+    latch().reset()
+    const clear = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true, bubbles: true })
+    expect(latch().claimKey(clear)).toBe(true)
+    expect(clear.defaultPrevented).toBe(false)
+  })
+})

--- a/website/src/hooks/useImeGuard.ts
+++ b/website/src/hooks/useImeGuard.ts
@@ -74,6 +74,62 @@ export function createImeLatch(): ImeLatch {
 }
 
 /**
+ * Document-tracked IME latch for NATIVE keydown handlers that trap Tab at a
+ * dialog's focus boundary (`useDialogFocusTrap` and the hand-rolled traps that
+ * share its shape). Those listeners receive native KeyboardEvents, which the
+ * synthetic-only `useImeGuard().claimEnter` cannot consume — so they share the
+ * tracked latch through this hook instead of each re-implementing the
+ * flag-and-timer semantics (the drift the `ImeEnterClaimRatchet` pins).
+ *
+ * Composition tracking listens at DOCUMENT capture: the composing input is
+ * anywhere inside the dialog, so element-scoped listeners have nothing
+ * reliable to attach to.
+ *
+ * `enabled` keys the tracking lifecycle and nothing else, so the latch
+ * survives the host's own re-renders: the commit's input event re-renders the
+ * host right before the committing keydown arrives, and a latch reset riding
+ * along on that churn would clear the post-composition window at exactly the
+ * moment it matters. A re-enabled latch does NOT inherit state from its
+ * disabled span — a composition that ended (or was abandoned) while the latch
+ * was off would otherwise strand it.
+ *
+ * Stranded-latch recovery ships with the tracking: a composition abandoned
+ * WITHOUT `compositionend` (focus moves off the input mid-composition, an
+ * OS-level IME cancel) would otherwise leave the latch set — and a latched
+ * guard consumes the keys it declines, so the trap would silently stop
+ * cycling for the dialog's lifetime. `focusout` at document capture is the
+ * recovery signal.
+ *
+ * The returned latch is identity-stable for the host's lifetime (it lives in
+ * a ref), so listing it in an effect dependency array never re-runs the
+ * effect.
+ */
+export function useDocumentImeLatch(enabled = true): ImeLatch {
+  const latchRef = useRef<ImeLatch>()
+  if (!latchRef.current) latchRef.current = createImeLatch()
+  const latch = latchRef.current
+  useEffect(() => {
+    if (!enabled) return
+    latch.reset()
+    const onCompositionStart = () => latch.onCompositionStart()
+    const onCompositionEnd = () => latch.onCompositionEnd()
+    const onRecover = () => latch.reset()
+    document.addEventListener('compositionstart', onCompositionStart, true)
+    document.addEventListener('compositionend', onCompositionEnd, true)
+    document.addEventListener('focusout', onRecover, true)
+    return () => {
+      document.removeEventListener('compositionstart', onCompositionStart, true)
+      document.removeEventListener('compositionend', onCompositionEnd, true)
+      document.removeEventListener('focusout', onRecover, true)
+      // Drop any pending post-composition timer with the listeners so a timer
+      // from a disabled span cannot fire into the next enablement.
+      latch.reset()
+    }
+  }, [enabled, latch])
+  return latch
+}
+
+/**
  * Guard against IME composition Enter falsely triggering submit handlers.
  *
  * IME (Chinese/Japanese/Korean) sends a final Enter to commit the composition.

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -43,7 +43,7 @@ import { useSessionActions } from '../hooks/useSessionActions'
 import { useAutoGrowTextarea } from '../hooks/useAutoGrowTextarea'
 import { useChatPopouts } from '../hooks/useChatPopouts'
 import { platformShortcut } from '../utils/platform'
-import { useImeGuard } from '../hooks/useImeGuard'
+import { useDocumentImeLatch, useImeGuard } from '../hooks/useImeGuard'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { usePointerDrag } from '../hooks/usePointerDrag'
 import { safeSetItem } from '../utils/safeStorage'
@@ -2089,6 +2089,12 @@ function ChatSidebar({
   // together with the onKeyDown (Escape + Tab-trap) on the popover, this makes the
   // portaled overlay fully keyboard-operable.
   const columnPopoverRef = useRef<HTMLDivElement>(null)
+  // Shared IME latch for the popover's Tab trap: a Tab that lands during an
+  // IME composition (or its post-`compositionend` window) is choosing a
+  // candidate, not leaving the field, so the trap must decline it instead of
+  // yanking focus and aborting the composition (`useDialogFocusTrap` is the
+  // reference consumer of the same seam).
+  const columnPopoverImeLatch = useDocumentImeLatch(columnEditId !== null)
   const closeColumnPopover = useCallback((colId: string) => {
     setColumnEditId(null)
     requestAnimationFrame(() => document.querySelector<HTMLElement>(`[data-testid="column-edit-${colId}"]`)?.focus())
@@ -5326,8 +5332,22 @@ function ChatSidebar({
                         const f = Array.from(root.querySelectorAll<HTMLElement>('a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])'))
                         if (f.length === 0) return
                         const first = f[0], last = f[f.length - 1]
-                        if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus() }
-                        else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus() }
+                        const wrapsBackward = e.shiftKey && document.activeElement === first
+                        const wrapsForward = !e.shiftKey && document.activeElement === last
+                        // A mid-popover Tab is the browser's to move, and not the trap's
+                        // to claim. A boundary Tab the IME owns must not cycle focus —
+                        // the user is choosing a candidate, not leaving the field —
+                        // so `claimKey` (native-event contract in useImeGuard.ts) runs
+                        // before the preventDefault() and focus move.
+                        if (!wrapsBackward && !wrapsForward) return
+                        // `claimKey` consumes the native event (document/window
+                        // listeners), but React 17+ checks the SYNTHETIC propagation
+                        // flag when walking component ancestors — stop that half too
+                        // so a declined Tab cannot trigger an ancestor's own
+                        // keyboard handling.
+                        if (!columnPopoverImeLatch.claimKey(e.nativeEvent)) { e.stopPropagation(); return }
+                        e.preventDefault()
+                        ;(wrapsBackward ? last : first).focus()
                       }}>
                       <div className="flex items-center justify-between mb-1">
                         <span className="text-[11px] font-semibold text-muted uppercase tracking-wider">{i18nT('pages.chatSidebar.column_filter')}</span>

--- a/website/src/test/ArtifactPanelCoverage.test.tsx
+++ b/website/src/test/ArtifactPanelCoverage.test.tsx
@@ -494,6 +494,26 @@ describe('ArtifactPanel', () => {
       expect(document.activeElement).toBe(focusable[1])
     })
 
+    it('declines a boundary Tab that belongs to an IME composition', async () => {
+      // On WebKit the keydown that commits a candidate arrives AFTER
+      // compositionend with `isComposing` already false — unguarded, the trap
+      // would yank focus and abort the composition (issue class of the shared
+      // hook's own guard).
+      renderPanel()
+      await screen.findByText(NAME)
+      const dialog = await enterFullscreen()
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      last.focus()
+      fireEvent.compositionStart(last)
+      fireEvent.compositionEnd(last)
+      fireEvent.keyDown(dialog, { key: 'Tab' })
+      expect(document.activeElement).toBe(last)
+      expect(document.activeElement).not.toBe(first)
+    })
+
     it('navigates to the full artifact page from the overlay header', async () => {
       renderPanel()
       await screen.findByText(NAME)

--- a/website/src/test/ChatSidebar.boardColumnTagFilter.test.tsx
+++ b/website/src/test/ChatSidebar.boardColumnTagFilter.test.tsx
@@ -169,4 +169,37 @@ describe('board column tag filter', () => {
       expect(keys).toContain(JSON.stringify(['tag-columns']))
     })
   })
+
+  it('popover Tab trap wraps a boundary Tab but declines one an IME composition owns', async () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition (issue class of the shared
+    // hook's own guard).
+    const { container } = renderSidebar()
+    fireEvent.click(container.querySelector(`[data-testid="column-edit-${COL_FILTERED}"]`)!)
+    const popover = await waitFor(() => {
+      const el = document.querySelector(`[data-column-popover="${COL_FILTERED}"]`)
+      expect(el).toBeTruthy()
+      return el as HTMLElement
+    })
+    const focusable = Array.from(popover.querySelectorAll<HTMLElement>(
+      'a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])',
+    ))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    expect(focusable.length).toBeGreaterThan(1)
+
+    // Positive control: a plain boundary Tab still wraps.
+    last.focus()
+    fireEvent.keyDown(popover, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    // A boundary Tab inside the post-composition window is declined.
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    fireEvent.keyDown(popover, { key: 'Tab' })
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+  })
 })

--- a/website/src/test/MarkdownPanelCoverage.test.tsx
+++ b/website/src/test/MarkdownPanelCoverage.test.tsx
@@ -676,6 +676,26 @@ describe('MarkdownPanel — fullscreen overlay', () => {
     expect(document.activeElement).toBe(last)
   })
 
+  it('declines a boundary Tab that belongs to an IME composition', async () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition (issue class of the shared
+    // hook's own guard).
+    const dialog = await goFullscreen()
+    const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]),textarea,input,a[href],select,[tabindex]:not([tabindex="-1"])',
+    ))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+  })
+
   it('carries the editing toolbar into the overlay', async () => {
     mountPanel({ content: 'edited body', savedBaseline: 'disk body' })
     fireEvent.click(screen.getByText('View Source'))

--- a/website/src/test/OnboardingFlow.test.tsx
+++ b/website/src/test/OnboardingFlow.test.tsx
@@ -351,6 +351,37 @@ describe('OnboardingFlow — About You step', () => {
     expect(input).toHaveFocus()
   })
 
+  it('wraps a boundary Tab, but declines one that belongs to an IME composition', () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition (issue class of the shared
+    // hook's own guard).
+    renderWithProviders(<OnboardingFlow initialOpen onComplete={vi.fn()} />)
+    advanceToStep2()
+    const dialog = screen.getByRole('dialog')
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter(el => !el.hasAttribute('disabled'))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    expect(focusable.length).toBeGreaterThan(1)
+
+    // Positive control: a plain boundary Tab still wraps.
+    last.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    // A boundary Tab inside the post-composition window is declined.
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(last)
+    expect(document.activeElement).not.toBe(first)
+  })
+
   it('re-seats focus inside the dialog when the save freeze lifts', async () => {
     // Every step-2 control is disabled during the save, so the browser drops
     // focus to <body>. On the failed-save path the modal stays open, and


### PR DESCRIPTION
## Problem / Motivation

Six dialogs hand-roll their own focus-wrapping Tab keydown handlers instead of using the shared `useDialogFocusTrap` hook. Each is a second spelling of the same interceptor -- a focus-wrapping Tab handler holding no composition state -- so each still aborts an in-flight IME composition when Tab lands at a focus boundary. This is the defect class already fixed for the shared hook: IMEs use Tab to cycle the candidate list, and on WebKit the keydown that commits a candidate arrives AFTER `compositionend` with `isComposing` already false, so only a tracked latch can identify it.

## Why it matters

A CJK user composing text in a dialog input that happens to sit at the focus ring's boundary loses their composition mid-word: the trap consumes the candidate-cycling Tab, yanks focus, and the composition aborts. Reachability today differs by site -- the two full-screen previews (ArtifactPanel, MarkdownPanel: editor/comment textareas can occupy a ring boundary) and OnboardingFlow step 2 are live repro surfaces, while PrivacyChapter and AgentImportFlow currently hold no composable field and the ChatSidebar popover's input sits mid-ring. All six are converted anyway: the guard is what makes that safety structural instead of an accident of each dialog's current layout.

## What changed (motivation → approach → change)

Symptom: a boundary Tab during (or in the 50ms window after) an IME composition moves focus and aborts the composition at six dialogs. Root cause: each site re-implements the Tab wrap with no composition state, and the shared guard lived inline in `useDialogFocusTrap` where the sites could not reach it. Change:

- `useDialogFocusTrap`'s document-tracked latch lifecycle (composition tracking at document capture, enabled-keyed reset, stranded-latch `focusout` recovery) is extracted into `useDocumentImeLatch` in `useImeGuard.ts`; the shared hook now consumes it, deduplicating the only prior spelling.
- Each of the six sites (`AgentImportFlow`, `PrivacyChapter`, `OnboardingFlow` modal steps, the `ChatSidebar` column popover, the `ArtifactPanel` and `MarkdownPanel` full-screen previews) takes the same latch, enabled exactly when its trap is live, and gates its boundary-Tab wrap on `claimKey`: a Tab the IME owns is declined and consumed instead of moving focus. Mid-dialog Tabs are never claimed, and non-composing wrap behavior is unchanged at every site (verified predicate-by-predicate in review).
- On the three React-synthetic sites a declined Tab also stops synthetic propagation, since the native `stopPropagation` inside `claimKey` does not set React's own flag.
- Full hook adoption deliberately does not fit these sites (the alternative considered): the three effect-based dialogs own their focus-in/restore and Escape semantics (the hook's mount-time focus effect is not gated by `enabled`), and the other three are element-scoped traps -- the latch-fallback path the issue itself names.
- One deliberate semantic delta, consistent with the shared hook's contract: a MID-composition boundary Tab (native flag set) is declined without `preventDefault`, because the browser is consuming that key for the IME itself -- so the trap defers rather than wraps for that keystroke.
- Escape semantics are untouched; #5420 tracks that half of the handler family separately.

## Tests

- New hook-level suite `useImeGuard.documentLatch.test.tsx` (7 cases) pins the seam: document-capture tracking, the post-composition window, elapse, `focusout` recovery, disabled-span behavior, enable-reset, and `claimKey`'s decline/consume split.
- One wiring test per converted site pins that a boundary Tab inside the post-composition window is declined (no focus move) -- each mutation-verified: bypassing that site's `claimKey` gate reddens exactly its test. Existing wrap tests at four sites (plus new positive controls at OnboardingFlow and the ChatSidebar popover) pin the unchanged non-composing behavior.
- Full local gates: `tsc -b` clean; vitest 1491/1491 files green; eslint 656 warnings (ceiling 664, zero new on touched files); jscpd clean; production build green; i18n and brand gates green. Electron node:test shows 15 host-environment failures byte-identical on the pristine base (MacUpdater suites on Linux), not introduced here.

## Manual verification

N/A -- unit coverage sufficient: the guard's only observable behavior (boundary Tab declined during the latch window, wrap preserved otherwise) is pinned per site by the wiring tests, and the latch lifecycle by the hook suite. There is no visual surface to inspect.

## Related Issues

Closes #5427

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- no spec documents these hooks; N/A
- [x] No secrets, credentials, or internal references in the diff
