### PR TITLE
fix(apps): guard the cron manifest against non-list and non-object JSON

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -1374,14 +1374,51 @@ def _deregister_crons(app_name: str) -> int:
 
 
 def load_app_cron_defs(app_name: str) -> list[dict[str, Any]]:
-    """Load persisted cron definitions for an app (used by CronService bridge)."""
+    """Load persisted cron definitions for an app (used by CronService bridge).
+
+    The return type is a promise to the caller, so it is enforced rather than
+    assumed. ``app-crons.json`` lives in the app's INSTALL directory, which is
+    ordinary user-writable state -- a hand-edit, a partial restore, or an app
+    that writes its own file can leave valid JSON that is not a list of
+    objects. That parses cleanly, so catching ``JSONDecodeError`` does not see
+    it, and the value flows into ``register_app_crons_with_service``'s
+    ``for d in defs: d.get("name", "")`` -- which raises ``AttributeError`` on
+    a string (iterating a JSON object yields its keys) and ``TypeError`` on a
+    scalar, from OUTSIDE the per-job ``try`` that makes one bad cron skippable.
+
+    Two levels, because they fail differently:
+
+    - a non-list top level is the whole file being wrong, and is treated
+      exactly like the unreadable case above -- no definitions, app enables
+      without crons.
+    - a non-object ENTRY is one bad row among good ones, and is skipped the
+      way an entry whose registration raises already is, so the remaining
+      crons still register.
+    """
     path = _app_crons_path(app_name)
     if not path.is_file():
         return []
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return []
+    if not isinstance(data, list):
+        logger.warning(
+            "App %s: cron manifest %s is not a JSON array (%s); ignoring it",
+            app_name,
+            path,
+            type(data).__name__,
+        )
+        return []
+    defs = [entry for entry in data if isinstance(entry, dict)]
+    if len(defs) != len(data):
+        logger.warning(
+            "App %s: cron manifest %s has %d entry/entries that are not JSON objects; skipping them",
+            app_name,
+            path,
+            len(data) - len(defs),
+        )
+    return defs
 
 
 async def register_app_crons_with_service(app_name: str, cron_service: Any) -> list[str]:

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -18,6 +18,7 @@ from hypothesis import strategies as st
 from kiro_crew import platform_compat
 from kiro_crew.apps.bridges import (
     RegistrationResult,
+    _app_crons_path,
     _deregister_agents,
     _deregister_crons,
     _deregister_mcp_servers,
@@ -615,6 +616,63 @@ class TestCronRegistration:
         defs = load_app_cron_defs("test-app")
         assert len(defs) == 1
         assert defs[0]["enabled"] is False
+
+    @pytest.mark.parametrize("payload", ["{}", '{"name": "x"}', "42", '"str"', "null", "true"])
+    def test_non_list_cron_manifest_is_ignored(self, payload, tmp_path, app_env):
+        """Valid JSON that is not an array yields no definitions, not a crash.
+
+        ``app-crons.json`` sits in the app's install directory, which is
+        ordinary user-writable state. A non-array parses cleanly, so the
+        ``JSONDecodeError`` guard never sees it and the value is returned
+        under a ``list[dict]`` annotation that promised otherwise.
+        """
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        _app_crons_path("test-app").write_text(payload, encoding="utf-8")
+
+        assert load_app_cron_defs("test-app") == []
+
+    def test_non_object_entries_are_skipped_and_the_rest_survive(self, tmp_path, app_env):
+        """One malformed row must not cost the good rows beside it.
+
+        Matches the disposition the registration loop already gives an entry
+        whose ``add_job`` raises: skip that one, keep going.
+        """
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        _app_crons_path("test-app").write_text(
+            json.dumps([{"name": "test-app/good", "every": 60}, "junk", 7, None, []]),
+            encoding="utf-8",
+        )
+
+        defs = load_app_cron_defs("test-app")
+        assert defs == [{"name": "test-app/good", "every": 60}]
+
+    def test_a_non_list_manifest_does_not_break_registration(self, tmp_path, app_env):
+        """The end-to-end shape: enabling the app must not raise.
+
+        ``register_app_crons_with_service`` reads ``d.get("name", "")`` OUTSIDE
+        its per-job ``try``, so before the guard a JSON object here raised
+        ``AttributeError`` (iterating an object yields its string keys) and a
+        scalar raised ``TypeError`` -- out of the app-enable path entirely.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from kiro_crew.apps.bridges import register_app_crons_with_service
+
+        src = _make_app_source(tmp_path)
+        install_app(src)
+        _app_crons_path("test-app").write_text(
+            json.dumps({"name": "test-app/refresh", "every": 60}), encoding="utf-8"
+        )
+
+        mock_sdk = MagicMock()
+        mock_sdk.list_jobs.return_value = []
+        with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
+            result = _run(register_app_crons_with_service("test-app", MagicMock()))
+
+        assert result == []
+        mock_sdk.add_job_async.assert_not_called()
 
     def test_deregister_crons(self, tmp_path, app_env):
         src = _make_app_source(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

`load_app_cron_defs` returns whatever `json.loads` produced, under an annotation that promises otherwise:

```python
def load_app_cron_defs(app_name: str) -> list[dict[str, Any]]:
    ...
    try:
        return json.loads(path.read_text(encoding="utf-8"))
    except (json.JSONDecodeError, OSError):
        return []
```

A cron manifest holding **valid JSON that is not an array of objects** parses cleanly, so the `JSONDecodeError` guard never sees it.

The wrong shape is not inert downstream. `register_app_crons_with_service` does:

```python
for d in defs:
    name = d.get("name", "")
```

— **outside** the per-job `try` that makes a single failing cron skippable. So the whole app-enable path raises: `AttributeError` on a JSON object (iterating one yields its string keys), `TypeError` on a scalar.

Reproduced on `origin/main` (`0b500677c`):

```
E   AttributeError: 'str' object has no attribute 'get'
src\kiro_crew\apps\bridges.py:1430: AttributeError
```

## Why it matters

`app-crons.json` lives in the app's **install directory** — ordinary user-writable state. A hand-edit, a partially-restored backup, or an app that writes its own file can leave it malformed, and nothing between there and the crash re-validates it.

The failure lands during app enable, and it is not confined to the bad app's crons: the exception escapes `register_app_crons_with_service` entirely, so it takes the enable with it. The unreadable case one line above was already handled gracefully — this is the same user-visible situation reaching a different outcome purely because the bytes happened to be parseable.

The shipped-builtin path (`_cron_defs_from_manifest`) is unaffected: it never reads this file.

## What changed (motivation → approach → change)

**Symptom** — `AttributeError`/`TypeError` out of the app-enable path.

**Root cause** — a parse-only guard used where a *shape* guard was needed; the annotation was assumed rather than enforced.

**Change** — enforce it, at two levels, because the two failures deserve different dispositions:

| Malformed shape | Disposition | Why |
|---|---|---|
| non-list top level (`{}`, `42`, `"str"`, `null`, `true`) | return `[]` | the whole file is wrong; treat it exactly like the unreadable case one line above — no definitions, app still enables |
| non-object **entry** inside a good list | skip that entry, keep the rest | one bad row among good ones; matches the disposition an entry whose `add_job` raises already gets |

Both log the app and the path. No signature change, no new dependency, and the shipped-builtin path is untouched.

Deliberately **not** hardened here: `_cron_defs_from_manifest`'s output, which comes from the immutable package manifest rather than user-writable state.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_non_list_cron_manifest_is_ignored` (parametrized over `{}`, `{"name": "x"}`, `42`, `"str"`, `null`, `true`) | every non-array top level yields no definitions |
| `test_non_object_entries_are_skipped_and_the_rest_survive` | `[{good}, "junk", 7, null, []]` → only the good entry |
| `test_a_non_list_manifest_does_not_break_registration` | the end-to-end shape: `register_app_crons_with_service` returns `[]` and arms nothing, instead of raising out of app enable |

**Red-before on pristine `origin/main` (`0b500677c`)** — the new tests copied into a clean checkout, no source change:

```
8 failed
  assert {} == []
  assert {'name': 'x'} == []
  assert 42 == []
  assert 'str' == []
  assert None == []
  assert True == []
  assert [{...}, 'junk', 7, None, []] == [{'every': 60, 'name': 'test-app/good'}]
  AttributeError: 'str' object has no attribute 'get'
```

After: `37 passed` for `-k cron` in `test/test_app_bridges.py`.

Gates: `flake8` · `isort --check-only` · `mypy src/kiro_crew/apps/bridges.py` (clean for this file) · `scripts/check_black_formatting.py` (2 files in scope, passed).

## Manual verification

N/A — unit coverage sufficient: the end-to-end test drives the real `register_app_crons_with_service` against a real on-disk manifest, which is exactly the path a user hits, and reproduces the original crash without the fix.

## Related Issues

The sibling counted in #5331's First Principles review and deferred there:

> Same except-only shape survives in the same file for a different file family: `load_app_cron_defs` (`src/kiro_crew/apps/bridges.py:1382`) returns whatever JSON parses, typed `list` — accepted-and-deferred, not this PR's root cause.

Continues #5316 (`cli_doctor.py` MCP section) and #5331 (three agent-spec consumers), which closed the agent-spec members of the same family; #5319 tracked that family.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: the contract is stated on the function itself; no user-facing docs describe this file's tolerance.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
