### PR TITLE
test: exempt feishu in the pre-turn roster ratchet (#5453)

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,20 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu likewise drives the busy-check/rotate/latch sequence inside
+        # its own dispatcher (is_busy -> maybe_rotate -> clear_awaiting), so
+        # migrating it onto the helper is a behaviour change that needs its
+        # own review.
+        exempt = {
+            "telegram",
+            "discord",
+            "teams",
+            "slack",
+            "weixin",
+            "wecom",
+            "whatsapp",
+            "feishu",
+        }
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Problem / Motivation

`main` is red on every platform: `test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` fails because the feishu channel (#4282) merged after #5379 wrote the ratchet's fixed exempt set. #5460 already exempted `whatsapp`, so against current main the remaining unaccounted channel is:

```
AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['feishu']
```

Every open PR inherits the failure through its merge ref (Backend Tests shards + Coverage Gate + PR Readiness).

(This PR originally exempted both `whatsapp` and `feishu`; after #5460 merged mid-flight it was rebased down to the remaining feishu gap.)

## Why it matters

Every open PR stays blocked on a test its diff never touched, burning CI and review capacity and masking real failures.

## What changed (motivation → approach → change)

Symptom: `feishu` is rostered but neither calls the `messaging.pre_turn` helper nor is named exempt. Root cause: the ratchet's exempt set is a fixed literal written before the channel landed. The ratchet offers exactly two outcomes for a rostered channel — migrated, or explicitly exempt. The feishu dispatcher hand-rolls the busy-check/rotate/latch sequence (`is_busy`/`maybe_rotate`/`clear_awaiting` in `src/kiro_crew/feishu/transport_dispatch.py`), the same shape the existing exemptions cover, so listing it in `_PRE_TURN_CHANNELS` would assert a migration that has not happened. The minimal unbreak names it exempt with a rationale comment, keeping "not yet migrated" an explicit decision; the set is also reflowed to one entry per line. Migrating feishu onto the helper is a behaviour change needing its own review and is deliberately out of scope.

## Tests

Test-only change. `test_every_rostered_channel_is_accounted_for` now passes against the current 10-channel roster while still catching any future rostered channel that is neither migrated nor exempt. Full file (13 tests) plus `test/test_channel_registry.py` verified locally after the rebase (33 passed).

## Manual verification

N/A — unit coverage sufficient: the change is a set literal inside the failing test itself; the test run is the verification.

<!-- no-visual-delta -->
**Why no screenshot:** test-only backend change, no UI surface.

## Related Issues

Closes #5453

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
