### PR TITLE
refactor: share one divergence counter across the update gates (#5205)

### DIFF
--- a/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
@@ -35,6 +35,7 @@ from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.papyrus.backend import procio, store
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.git_divergence import divergence_count_args, parse_divergence_counts
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     create_subprocess_limited,
@@ -585,13 +586,14 @@ async def status(project: Path) -> GitStatus:
     _c, remote_out, _e = await _git(["remote"], cwd=project)
 
     ahead = behind = 0
-    code, counts, _e = await _git(
-        ["rev-list", "--left-right", "--count", "HEAD...@{upstream}"], cwd=project
-    )
+    code, counts_out, _e = await _git(divergence_count_args("@{upstream}"), cwd=project)
     if code == 0:
-        parts = counts.strip().split()
-        if len(parts) == 2 and all(p.isdigit() for p in parts):
-            ahead, behind = int(parts[0]), int(parts[1])
+        # Display surface, not a gate: an unreadable count folds to 0/0 so the
+        # status panel still renders. The refusal policy for unreadable counts
+        # lives at the update gates, which act on the numbers.
+        parsed = parse_divergence_counts(counts_out)
+        if parsed is not None:
+            ahead, behind = parsed.ahead, parsed.behind
 
     changed = [line for line in porcelain.strip().splitlines() if line]
     return GitStatus(

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -44,6 +44,11 @@ from kiro_crew.embeddings import (
 )
 from kiro_crew.env import activate_mise
 from kiro_crew.frontend import build_frontend_sync, ensure_dev_dist_symlink
+from kiro_crew.git_divergence import (
+    UNREADABLE_UNPARSEABLE,
+    DivergenceUnreadable,
+    count_divergence_sync,
+)
 from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, hooks_config_from_config_dict
 from kiro_crew.instances import run_marker
@@ -1102,26 +1107,16 @@ def _update(force: bool = False) -> None:
         * ``"diverged"`` — ahead AND behind; resettable only under ``--force``.
         * ``"fast_forward"`` — behind and not ahead; nothing of its own to lose.
         """
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "--left-right", f"HEAD...origin/{branch}"],
-            cwd=proj,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            print(f"  ❌ Could not compare HEAD against origin/{branch}:")
-            print(f"     {result.stderr.strip() or result.stdout.strip()}")
+        counts = count_divergence_sync(proj, f"origin/{branch}")
+        if isinstance(counts, DivergenceUnreadable):
+            if counts.reason == UNREADABLE_UNPARSEABLE:
+                print(f"  ❌ Could not parse the commit counts against origin/{branch}:")
+                print(f"     {counts.detail!r}")
+            else:
+                print(f"  ❌ Could not compare HEAD against origin/{branch}:")
+                print(f"     {counts.detail}")
             return "unreadable", -1, -1
-        # ``--left-right`` with the three-dot range prints "<ahead>\t<behind>":
-        # left is reachable from HEAD only, right from origin/<branch> only.
-        try:
-            ahead_text, behind_text = result.stdout.split()
-            ahead, behind = int(ahead_text), int(behind_text)
-        except ValueError:
-            print(f"  ❌ Could not parse the commit counts against origin/{branch}:")
-            print(f"     {result.stdout.strip()!r}")
-            return "unreadable", -1, -1
+        ahead, behind = counts.ahead, counts.behind
         if behind == 0:
             return "up_to_date", ahead, behind
         if ahead > 0:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -29,6 +29,11 @@ from kiro_crew.config.loader import (
 from kiro_crew.dashboard.handlers._shared import read_capped_response
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.git_divergence import (
+    UNREADABLE_TIMEOUT,
+    DivergenceUnreadable,
+    count_divergence,
+)
 from kiro_crew.platform.update_capability import (
     CHECK_DEFERRED,
     CHECK_FAILED,
@@ -653,40 +658,14 @@ async def _check_git_checkout(proj: str, capability: UpdateCapability) -> None:
     # and the second is precisely the case with commits to lose. Only a checkout
     # that is behind and NOT ahead can be fast-forwarded, so only that one is
     # offered an update.
-    ahead = behind = 0
-    count = await asyncio.create_subprocess_exec(
-        "git",
-        "rev-list",
-        "--count",
-        "--left-right",
-        "HEAD...@{u}",
-        cwd=proj,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    try:
-        count_out, _ = await asyncio.wait_for(count.communicate(), timeout=10)
-    except asyncio.TimeoutError:
-        try:
-            count.kill()
-        except ProcessLookupError:
-            pass
-        await count.communicate()
+    counts = await count_divergence(proj, "@{u}")
+    if isinstance(counts, DivergenceUnreadable):
+        # A check that could not count must not answer "you are on the latest
+        # version" — the unattended auto-apply reads this verdict.
+        logger.warning("Could not count commits against upstream in %s (%s)", proj, counts.reason)
         _set_update_info(**base, check_status=CHECK_FAILED, error_code=ERR_GIT_READ_FAILED)
         return
-    if count.returncode != 0:
-        logger.warning("Could not count commits against upstream in %s", proj)
-        _set_update_info(**base, check_status=CHECK_FAILED, error_code=ERR_GIT_READ_FAILED)
-        return
-    # ``--left-right`` with the three-dot range prints "<ahead>\t<behind>": left
-    # is reachable from HEAD only, right from the upstream only.
-    try:
-        ahead_text, behind_text = count_out.decode(errors="replace").split()
-        ahead, behind = int(ahead_text), int(behind_text)
-    except ValueError:
-        logger.warning("Unparseable rev-list count in %s", proj)
-        _set_update_info(**base, check_status=CHECK_FAILED, error_code=ERR_GIT_READ_FAILED)
-        return
+    ahead, behind = counts.ahead, counts.behind
     # Fast-forwardable: behind, and carrying nothing of its own to lose.
     can_fast_forward = behind > 0 and ahead == 0
 
@@ -1337,32 +1316,15 @@ async def api_update_apply(request: web.Request) -> web.Response:
             },
             status=409,
         )
-    count = await asyncio.create_subprocess_exec(
-        "git",
-        "rev-list",
-        "--count",
-        "--left-right",
-        "HEAD...@{u}",
-        cwd=proj,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    try:
-        count_out, _ = await asyncio.wait_for(count.communicate(), timeout=10)
-    except asyncio.TimeoutError:
-        try:
-            count.kill()
-        except ProcessLookupError:
-            pass
-        await count.communicate()
-        return web.json_response(
-            {"error": "Timed out checking upstream distance", "code": "git_read_failed"},
-            status=500,
-        )
-    try:
-        ahead_text, behind_text = count_out.decode(errors="replace").split()
-        ahead, behind = int(ahead_text), int(behind_text)
-    except ValueError:
+    counts = await count_divergence(proj, "@{u}")
+    if isinstance(counts, DivergenceUnreadable):
+        if counts.reason == UNREADABLE_TIMEOUT:
+            return web.json_response(
+                {"error": "Timed out checking upstream distance", "code": "git_read_failed"},
+                status=500,
+            )
+        # A failed or unparseable count alike: the guard cannot read the
+        # distance, so it refuses rather than waving the pull through.
         logger.warning("Update refused: could not count commits against upstream in %s", proj)
         return web.json_response(
             {
@@ -1371,6 +1333,7 @@ async def api_update_apply(request: web.Request) -> web.Response:
             },
             status=409,
         )
+    ahead, behind = counts.ahead, counts.behind
     if ahead > 0 and behind > 0:
         logger.warning(
             "Update refused: checkout diverged from upstream (%d ahead, %d behind)", ahead, behind

--- a/src/kiro_crew/git_divergence.py
+++ b/src/kiro_crew/git_divergence.py
@@ -1,0 +1,186 @@
+"""Ahead/behind divergence counting against an upstream ref.
+
+Several gateway surfaces ask "how far is this checkout from its upstream"
+before acting on the answer, and two of them gate actions that are hard to
+undo: the CLI's hard-reset recovery path, and the update-check verdict that
+the unattended auto-apply path reads. Each surface previously re-derived the
+same fragile details by hand — the three-dot range, ``--left-right``'s
+left-is-ahead semantics, the two-token split, the ``int()`` conversion, the
+subprocess timeout, and what an unreadable result means — so the copies
+agreeing was luck rather than structure. This module is the one owner of the
+COUNTING. Every caller keeps its own POLICY about what the counts mean,
+because the surfaces intentionally disagree: the update check offers only a
+fast-forward, the apply precondition refuses only true divergence, the CLI
+refuses to reset even an ahead-only checkout, and the papyrus status panel
+merely displays the distance.
+
+The one property no caller may lose: **failure is never (0, 0)**. A count
+that cannot be read returns :class:`DivergenceUnreadable`, a distinct type,
+because ``(0, 0)`` also means "in sync" and a sentinel pair would silently
+convert a fail-closed gate into a fail-open one. Callers decide explicitly
+what an unreadable count means for them; the gates guarding destructive
+actions refuse.
+
+Three call shapes are deliberate, not redundancy:
+
+* :func:`count_divergence` — async, for handlers running on the event loop.
+* :func:`count_divergence_sync` — blocking, for the one-shot ``kirocrew
+  update`` CLI path that runs with no event loop.
+* :func:`divergence_count_args` + :func:`parse_divergence_counts` — the raw
+  argv and the parser, for a caller that must spawn through its own hardened
+  runner (papyrus routes every git call through its sandbox chokepoint with
+  config-override pins, and counting through this module's spawns would
+  bypass that). The primitives keep the fragile details here even when the
+  spawn cannot be.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+#: Wall-clock ceiling for the count. ``rev-list`` walks local objects only —
+#: no network — so this bounds a wedged filesystem or a pathological repo,
+#: not a slow remote.
+DIVERGENCE_TIMEOUT_SEC = 10.0
+
+#: ``DivergenceUnreadable.reason`` values. Callers that present failures
+#: differently (an HTTP surface mapping a timeout to a different status than
+#: a bad count; the CLI choosing which message to print) branch on these
+#: rather than re-deriving the failure class.
+UNREADABLE_TIMEOUT = "timeout"
+UNREADABLE_GIT_FAILED = "git_failed"
+UNREADABLE_UNPARSEABLE = "unparseable"
+
+
+@dataclass(frozen=True)
+class DivergenceCounts:
+    """How far HEAD is from the upstream, in commits, both directions."""
+
+    #: Commits reachable from HEAD only — local work the upstream lacks.
+    ahead: int
+    #: Commits reachable from the upstream only — remote work HEAD lacks.
+    behind: int
+
+
+@dataclass(frozen=True)
+class DivergenceUnreadable:
+    """The count could not be determined.
+
+    A distinct type rather than a sentinel pair: gates that guard destructive
+    actions must refuse on an unreadable count, and a result the caller
+    cannot read ``.ahead`` off makes "treat failure as in sync"
+    unrepresentable rather than merely discouraged.
+    """
+
+    #: One of the ``UNREADABLE_*`` constants.
+    reason: str
+    #: Operator-facing context: git's own error text, or the unparseable
+    #: output. Empty when the failure carries no message worth printing.
+    detail: str = ""
+
+
+def divergence_count_args(upstream: str) -> list[str]:
+    """The ``git`` arguments (without the binary) that count HEAD vs *upstream*.
+
+    The three-dot range with ``--count --left-right`` prints
+    ``"<ahead>\\t<behind>"``: left counts commits reachable from HEAD only,
+    right those reachable from *upstream* only. *upstream* is a caller choice
+    because the surfaces genuinely differ — ``@{u}``/``@{upstream}`` where
+    the tracked upstream is the comparison, ``origin/<branch>`` where the
+    exact ref a reset targets is.
+    """
+    return ["rev-list", "--count", "--left-right", f"HEAD...{upstream}"]
+
+
+def parse_divergence_counts(output: str) -> DivergenceCounts | None:
+    """Parse ``rev-list --count --left-right`` output, ``None`` when unreadable.
+
+    Exactly two whitespace-separated integer tokens are accepted. Anything
+    else — an empty read, an error message, a truncated line — is ``None``,
+    never a pair of zeros.
+    """
+    try:
+        ahead_text, behind_text = output.split()
+        return DivergenceCounts(int(ahead_text), int(behind_text))
+    except ValueError:
+        return None
+
+
+async def count_divergence(
+    repo: str | Path, upstream: str, *, timeout: float = DIVERGENCE_TIMEOUT_SEC
+) -> DivergenceCounts | DivergenceUnreadable:
+    """Count HEAD's divergence from *upstream* in *repo*, off the event loop.
+
+    stderr is discarded: the async callers are HTTP handlers whose responses
+    carry their own machine-readable codes, so git's message has no reader.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            *divergence_count_args(upstream),
+            cwd=repo,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        # The spawn itself failed — git not on PATH, the repo path gone, or a
+        # permission refusal. Naming it keeps "failure is DivergenceUnreadable"
+        # exhaustive: without this, spawn errors would be a third, unnamed
+        # exit that every caller degrades through differently.
+        return DivergenceUnreadable(UNREADABLE_GIT_FAILED, detail=str(exc))
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.communicate()
+        return DivergenceUnreadable(UNREADABLE_TIMEOUT, detail=f"timed out after {timeout:g}s")
+    if proc.returncode != 0:
+        return DivergenceUnreadable(UNREADABLE_GIT_FAILED)
+    text = out.decode(errors="replace")
+    counts = parse_divergence_counts(text)
+    if counts is None:
+        return DivergenceUnreadable(UNREADABLE_UNPARSEABLE, detail=text.strip())
+    return counts
+
+
+def count_divergence_sync(
+    repo: str | Path, upstream: str, *, timeout: float = DIVERGENCE_TIMEOUT_SEC
+) -> DivergenceCounts | DivergenceUnreadable:
+    """Blocking :func:`count_divergence`, for CLI paths with no event loop.
+
+    Never call this from a coroutine or an event-loop callback — the gateway
+    runs everything on one loop, and a blocked loop freezes every session.
+    stderr IS captured here: the sync caller is an operator at a terminal,
+    and git's own message is the most useful thing to show them.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *divergence_count_args(upstream)],
+            cwd=repo,
+            capture_output=True,
+            timeout=timeout,
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired:
+        return DivergenceUnreadable(UNREADABLE_TIMEOUT, detail=f"timed out after {timeout:g}s")
+    except OSError as exc:
+        # Same exhaustiveness as the async path: a spawn failure (git missing,
+        # repo path gone, permissions) is an unreadable count, not a traceback.
+        return DivergenceUnreadable(UNREADABLE_GIT_FAILED, detail=str(exc))
+    if result.returncode != 0:
+        return DivergenceUnreadable(
+            UNREADABLE_GIT_FAILED,
+            detail=result.stderr.strip() or result.stdout.strip(),
+        )
+    counts = parse_divergence_counts(result.stdout)
+    if counts is None:
+        return DivergenceUnreadable(UNREADABLE_UNPARSEABLE, detail=result.stdout.strip())
+    return counts

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1110,6 +1110,59 @@ class TestUpdateGitPath:
         assert "Already up to date" in capsys.readouterr().out
         assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
 
+    def test_ahead_only_checkout_is_never_reset(self, monkeypatch, git_checkout, capsys) -> None:
+        """The CLI is the strictest surface: ahead-only has nothing to pull.
+
+        ``origin/<branch>`` is an ancestor of HEAD here, so a reset could only
+        REMOVE the local commits — refused even though the tree content
+        differs from the upstream.
+        """
+        stub = _GitStub()
+        stub.rev_list_out = "2\t0\n"  # 2 ahead, 0 behind
+        monkeypatch.setattr(subprocess, "run", stub)
+        cli_server._update()
+        out = capsys.readouterr().out
+        assert "Already up to date!" in out
+        assert "2 local commit(s) ahead" in out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_diverged_checkout_refuses_without_force(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+        stub.rev_list_out = "3\t2\n"  # 3 ahead, 2 behind — diverged
+        monkeypatch.setattr(subprocess, "run", stub)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "diverged" in out
+        assert "kirocrew update --force" in out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_diverged_checkout_resets_under_force(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        stub = _GitStub()
+        stub.rev_list_out = "3\t2\n"  # 3 ahead, 2 behind — diverged
+        monkeypatch.setattr(subprocess, "run", stub)
+        cli_server._update(force=True)
+        out = capsys.readouterr().out
+        assert "--force: discarding 3 local commit(s)" in out
+        assert any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_unreadable_divergence_refuses_the_reset(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """Fail closed: a guard that cannot count must not wave the reset through."""
+        stub = _GitStub(rev_list=128)
+        monkeypatch.setattr(subprocess, "run", stub)
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "Could not compare HEAD against origin/main" in capsys.readouterr().out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
     def test_local_changes_prompt_and_abort_leaves_tree_alone(
         self, monkeypatch, git_checkout, capsys
     ) -> None:

--- a/test/test_git_divergence.py
+++ b/test/test_git_divergence.py
@@ -1,0 +1,300 @@
+"""The shared ahead/behind divergence counter (``kiro_crew.git_divergence``).
+
+Four surfaces act on this count and two of them gate hard-to-undo actions
+(the CLI hard reset, the unattended auto-apply's check verdict), so the
+contract under test here is safety-relevant: the counting details live in
+ONE place, and a count that cannot be read is a distinct failure value —
+never ``(0, 0)``, which also means "in sync" and would silently turn a
+fail-closed gate into a fail-open one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import git_divergence
+from kiro_crew.git_divergence import (
+    DIVERGENCE_TIMEOUT_SEC,
+    UNREADABLE_GIT_FAILED,
+    UNREADABLE_TIMEOUT,
+    UNREADABLE_UNPARSEABLE,
+    DivergenceCounts,
+    DivergenceUnreadable,
+    count_divergence,
+    count_divergence_sync,
+    divergence_count_args,
+    parse_divergence_counts,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestArgs:
+    def test_three_dot_range_owns_the_fragile_spelling(self) -> None:
+        assert divergence_count_args("@{u}") == [
+            "rev-list",
+            "--count",
+            "--left-right",
+            "HEAD...@{u}",
+        ]
+
+    def test_upstream_spelling_is_a_caller_choice(self) -> None:
+        """Both real spellings stay reachable: the callers genuinely differ."""
+        assert divergence_count_args("origin/main")[-1] == "HEAD...origin/main"
+        assert divergence_count_args("@{upstream}")[-1] == "HEAD...@{upstream}"
+
+
+class TestParse:
+    def test_left_is_ahead_right_is_behind(self) -> None:
+        assert parse_divergence_counts("3\t219\n") == DivergenceCounts(ahead=3, behind=219)
+
+    def test_any_whitespace_split_is_accepted(self) -> None:
+        """``--left-right --count`` prints a tab, but the split is not brittle."""
+        assert parse_divergence_counts("2 1") == DivergenceCounts(ahead=2, behind=1)
+
+    @pytest.mark.parametrize(
+        "junk",
+        ["", "garbage\n", "1\n", "1\t2\t3\n", "a\tb\n", "3.5\t2\n", "fatal: bad revision\n"],
+    )
+    def test_junk_is_none_never_zeros(self, junk: str) -> None:
+        assert parse_divergence_counts(junk) is None
+
+
+class _FakeProc:
+    """A scripted ``asyncio`` subprocess: one (returncode, stdout) result."""
+
+    def __init__(self, rc: int, out: bytes, *, hang: bool = False) -> None:
+        self.returncode = rc
+        self._out = out
+        self._hang = hang
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang and not self.killed:
+            await asyncio.sleep(30)
+        return (self._out, b"")
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class TestAsyncCount:
+    def _patch(self, monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> list[tuple[str, ...]]:
+        calls: list[tuple[str, ...]] = []
+
+        async def _exec(*args: str, **kwargs: object) -> _FakeProc:
+            calls.append(tuple(args))
+            return proc
+
+        monkeypatch.setattr(git_divergence.asyncio, "create_subprocess_exec", _exec)
+        return calls
+
+    def test_success_returns_the_pair(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._patch(monkeypatch, _FakeProc(0, b"2\t5\n"))
+        result = asyncio.run(count_divergence("/repo", "@{u}"))
+        assert result == DivergenceCounts(ahead=2, behind=5)
+        assert calls == [("git", "rev-list", "--count", "--left-right", "HEAD...@{u}")]
+
+    def test_nonzero_exit_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, _FakeProc(128, b""))
+        result = asyncio.run(count_divergence("/repo", "@{u}"))
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_GIT_FAILED
+
+    def test_unparseable_output_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, _FakeProc(0, b"garbage\n"))
+        result = asyncio.run(count_divergence("/repo", "@{u}"))
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_UNPARSEABLE
+        assert result.detail == "garbage"
+
+    def test_spawn_failure_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """git missing from PATH (or the repo path gone) is a count failure,
+        not a traceback for every caller to degrade through differently."""
+
+        async def _exec(*args: str, **kwargs: object) -> _FakeProc:
+            raise FileNotFoundError("git: command not found")
+
+        monkeypatch.setattr(git_divergence.asyncio, "create_subprocess_exec", _exec)
+        result = asyncio.run(count_divergence("/repo", "@{u}"))
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_GIT_FAILED
+        assert "git" in result.detail
+
+    def test_timeout_kills_the_child_and_is_unreadable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProc(0, b"0\t0\n", hang=True)
+        self._patch(monkeypatch, proc)
+        result = asyncio.run(count_divergence("/repo", "@{u}", timeout=0.05))
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_TIMEOUT
+        assert proc.killed
+
+
+class TestSyncCount:
+    def _patch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        rc: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        timeout: bool = False,
+    ) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        def _run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(list(argv))
+            if timeout:
+                raise subprocess.TimeoutExpired(argv, DIVERGENCE_TIMEOUT_SEC)
+            return subprocess.CompletedProcess(argv, rc, stdout, stderr)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        return calls
+
+    def test_success_returns_the_pair(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._patch(monkeypatch, stdout="0\t7\n")
+        result = count_divergence_sync("/repo", "origin/main")
+        assert result == DivergenceCounts(ahead=0, behind=7)
+        assert calls == [["git", "rev-list", "--count", "--left-right", "HEAD...origin/main"]]
+
+    def test_nonzero_exit_carries_gits_own_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The CLI prints git's message, so the failure must carry it."""
+        self._patch(monkeypatch, rc=128, stderr="fatal: bad revision\n")
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_GIT_FAILED
+        assert result.detail == "fatal: bad revision"
+
+    def test_nonzero_exit_falls_back_to_stdout_detail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch(monkeypatch, rc=1, stdout="something odd\n")
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.detail == "something odd"
+
+    def test_unparseable_output_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, stdout="garbage\n")
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_UNPARSEABLE
+
+    def test_spawn_failure_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise FileNotFoundError("git: command not found")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_GIT_FAILED
+
+    def test_timeout_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, timeout=True)
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert result.reason == UNREADABLE_TIMEOUT
+
+
+class TestFailureIsNeverInSync:
+    """The single most important property of the shared counter.
+
+    ``(0, 0)`` means "in sync". Two of the callers gate hard-to-undo actions
+    on that answer, so a failure that surfaced as a zero pair would convert
+    their fail-closed refusal into a silent go-ahead. Every failure mode must
+    therefore come back as :class:`DivergenceUnreadable` — a type with no
+    ``ahead``/``behind`` to read — and never as a counts value.
+    """
+
+    def test_no_async_failure_mode_reads_as_in_sync(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        failures = [
+            _FakeProc(128, b""),  # git failed
+            _FakeProc(0, b""),  # empty output
+            _FakeProc(0, b"garbage\n"),  # unparseable
+            _FakeProc(0, b"0\t0\n", hang=True),  # timeout (even with clean output)
+        ]
+        for proc in failures:
+
+            async def _exec(*args: str, _proc: _FakeProc = proc, **kwargs: object) -> _FakeProc:
+                return _proc
+
+            monkeypatch.setattr(git_divergence.asyncio, "create_subprocess_exec", _exec)
+            result = asyncio.run(count_divergence("/repo", "@{u}", timeout=0.05))
+            assert isinstance(result, DivergenceUnreadable)
+            assert not isinstance(result, DivergenceCounts)
+            assert not hasattr(result, "ahead")
+
+    def test_no_sync_failure_mode_reads_as_in_sync(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        shapes: list[dict[str, object]] = [
+            {"rc": 128, "stdout": ""},
+            {"rc": 0, "stdout": ""},
+            {"rc": 0, "stdout": "garbage\n"},
+        ]
+        for shape in shapes:
+
+            def _run(
+                argv: list[str], _shape: dict[str, object] = shape, **kwargs: object
+            ) -> subprocess.CompletedProcess[str]:
+                return subprocess.CompletedProcess(
+                    argv, int(_shape["rc"]), str(_shape["stdout"]), ""
+                )
+
+            monkeypatch.setattr(subprocess, "run", _run)
+            result = count_divergence_sync("/repo", "origin/main")
+            assert isinstance(result, DivergenceUnreadable)
+            assert not hasattr(result, "ahead")
+
+        def _boom(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(argv, DIVERGENCE_TIMEOUT_SEC)
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        result = count_divergence_sync("/repo", "origin/main")
+        assert isinstance(result, DivergenceUnreadable)
+        assert not hasattr(result, "ahead")
+
+
+class TestNoHandRolledCopies:
+    """A future consumer must go through the shared counter, not re-roll it.
+
+    The tripwire greps the one spelling the helper owns — ``--left-right`` —
+    which is what every historical copy used and what a copy-paste of any of
+    them reintroduces. A from-scratch reimplementation via two one-directional
+    ``rev-list --count`` calls or ``status -sb`` parsing is outside its reach
+    on purpose: widening the pattern would flag legitimate one-directional
+    counts (the doctor's behind-only readout) and grow the allowlist, and a
+    guard with a broad allowlist reads as protection while permitting the
+    regression. That class stays a review concern.
+    """
+
+    # The ONLY files allowed to spell ``--left-right`` by hand. Keep this list
+    # explicit and short: a broad allowlist reads as protection while
+    # permitting the regression this guard exists to catch.
+    _ALLOWED = {
+        # The owner.
+        Path("src/kiro_crew/git_divergence.py"),
+        # A standalone skill script shipped to users' machines; it must stay
+        # dependency-free, so it cannot import the shared module.
+        Path("src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/preflight.py"),
+    }
+
+    def test_no_new_hand_rolled_divergence_count(self) -> None:
+        offenders: list[str] = []
+        for path in sorted((_REPO_ROOT / "src" / "kiro_crew").rglob("*.py")):
+            rel = path.relative_to(_REPO_ROOT)
+            if rel in self._ALLOWED:
+                continue
+            if "--left-right" in path.read_text(encoding="utf-8"):
+                offenders.append(str(rel))
+        assert not offenders, (
+            "Hand-rolled ahead/behind divergence count outside the shared "
+            "helper. Route the counting through kiro_crew.git_divergence "
+            "(count_divergence / count_divergence_sync, or "
+            "divergence_count_args + parse_divergence_counts for a caller "
+            "with its own hardened spawn path) instead of re-rolling "
+            "`rev-list --left-right`:\n  " + "\n  ".join(offenders)
+        )

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -804,15 +804,8 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
         "cli_server.py::_update",
-        # Nested helper inside ``_update``, keyed separately because the audit
-        # keys by function name. Same class as its enclosing function, already
-        # allowlisted above: a read-only ``git rev-list --count --left-right
-        # HEAD...origin/<branch>`` on the install's own checkout, run on the
-        # one-shot ``kirocrew update`` path. Fixed argv with no shell; the only
-        # interpolated value is the branch name ``git rev-parse --abbrev-ref
-        # HEAD`` just reported, and it sits after the ``origin/`` prefix so it
-        # cannot become an option. Nothing agent-supplied, nothing written.
-        "cli_server.py::_divergence_verdict",
+        # (_divergence_verdict removed — its counting now delegates to the
+        # git_divergence module, allowlisted below, and spawns nothing itself.)
         "cli_server.py::_update_wheel",
         "cli_setup.py::_setup_electron",
         # Cursor Motion overlay renderer: `<this interpreter> -m
@@ -943,6 +936,20 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "frontend.py::_npm_build_and_stage_locked",
         "frontend.py::build_frontend_async",
         "frontend.py::build_frontend_sync",
+        # The shared ahead/behind divergence count: a read-only ``git rev-list
+        # --count --left-right HEAD...<upstream>`` fixed list-argv (no shell)
+        # run against the install's own checkout. Callers pass the repo path
+        # (KIROCREW_PROJECT_DIR, an operator environment value) and the
+        # upstream spelling — a literal ``@{u}`` or ``origin/<branch>`` where
+        # <branch> is git's own ``rev-parse --abbrev-ref HEAD`` output sitting
+        # after the ``origin/`` prefix so it cannot become an option. Nothing
+        # agent-supplied, nothing written; same trust profile as the update
+        # surfaces it serves (``_check_git_checkout`` / ``api_update_apply`` /
+        # ``_update`` above). The papyrus status caller does NOT spawn through
+        # these: it reuses only the argv/parse primitives and keeps its own
+        # sandbox-routed runner.
+        "git_divergence.py::count_divergence",
+        "git_divergence.py::count_divergence_sync",
         "instances/diagnostics.py::_run_ok",
         "instances/diagnostics.py::_run_stdout",
         "instances/ssh_tunnel_manager.py::start",

--- a/test/test_update_check_install_aware.py
+++ b/test/test_update_check_install_aware.py
@@ -630,6 +630,34 @@ class TestGitCheckoutStillWorks:
         assert info["check_status"] == "failed"
         assert info["managed_by"] == "git"
 
+    @pytest.mark.parametrize(
+        "rev_list_result",
+        [
+            (128, b""),  # rev-list itself failed
+            (0, b"garbage\n"),  # output that is not two integer counts
+        ],
+        ids=["git_failed", "unparseable"],
+    )
+    def test_an_unreadable_commit_distance_fails_the_check(
+        self, _git_install, monkeypatch, rev_list_result
+    ):
+        """A check that could not count must not answer "up to date".
+
+        The unattended auto-apply reads this verdict, so an unreadable
+        distance surfacing as ``update_available: False`` with a clean status
+        would be a silently wrong answer, and one surfacing as available
+        would offer a pull the guard never validated.
+        """
+        self._git_script(
+            monkeypatch,
+            [(0, b""), (0, b"aaaa\n"), (0, b"bbbb\n"), rev_list_result],
+        )
+        asyncio.run(updates._do_update_check())
+        info = updates.get_update_info()
+        assert info["check_status"] == "failed"
+        assert info["error_code"] == "git_read_failed"
+        assert not info["update_available"]
+
     def test_missing_upstream_is_reported_not_up_to_date(self, _git_install, monkeypatch):
         self._git_script(
             monkeypatch,

--- a/test/test_update_git_guard.py
+++ b/test/test_update_git_guard.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 import subprocess
 
+import pytest
+
 from kiro_crew.dashboard.handlers import updates
 
 
@@ -187,6 +189,64 @@ class TestUpdateCheckGitGuard:
         resp = asyncio.run(updates.api_update_apply(_Req()))
         assert resp.status == 409
         assert json.loads(resp.body)["code"] == "git_fetch_failed"
+        assert not any("pull" in c for c in calls)
+
+    @pytest.mark.parametrize(
+        "rev_list_result",
+        [
+            (128, b""),  # rev-list itself failed (e.g. the upstream ref is gone)
+            (0, b"garbage\n"),  # output that is not two integer counts
+        ],
+        ids=["git_failed", "unparseable"],
+    )
+    def test_apply_fails_closed_when_the_distance_is_unreadable(
+        self, monkeypatch, tmp_path, rev_list_result
+    ):
+        # The diverged refusal above only works if the guard can COUNT. A
+        # distance it cannot read must refuse too — never read as "in sync"
+        # and wave the pull through.
+        _init_repo(tmp_path)
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_capability.running_from_checkout",
+            lambda root, **kw: True,
+        )
+
+        async def _no_provider():
+            return None
+
+        monkeypatch.setattr("kiro_crew.platform.update_provider.apply_policy_update", _no_provider)
+        monkeypatch.setattr(updates, "update_blocked_reason", lambda url: None)
+
+        calls: list[tuple[str, ...]] = []
+        # git status --porcelain (clean), pre-guard git fetch, then rev-list.
+        outputs = [(0, b""), (0, b""), rev_list_result]
+
+        class _Proc:
+            def __init__(self, rc: int, out: bytes) -> None:
+                self.returncode = rc
+                self._out = out
+
+            async def communicate(self):
+                return (self._out, b"")
+
+        async def _fake_exec(*args, **kwargs):
+            calls.append(tuple(str(a) for a in args))
+            rc, out = outputs.pop(0) if outputs else (0, b"")
+            return _Proc(rc, out)
+
+        monkeypatch.setattr(updates.asyncio, "create_subprocess_exec", _fake_exec)
+
+        class _State:
+            def push_refresh(self, kind: str) -> None:
+                pass
+
+        class _Req:
+            app = {"state": _State()}
+
+        resp = asyncio.run(updates.api_update_apply(_Req()))
+        assert resp.status == 409
+        assert json.loads(resp.body)["code"] == "git_read_failed"
         assert not any("pull" in c for c in calls)
 
     def test_the_apply_pull_is_fast_forward_only(self):


### PR DESCRIPTION
Closes #5205

## What

One ahead/behind divergence computation was independently hand-rolled at four call sites, and two of them gate hard-to-undo actions (the CLI's hard-reset recovery path; the update-check verdict the unattended auto-apply reads). The four copies agreeing was luck, not structure.

`kiro_crew.git_divergence` now owns the **counting only** — the three-dot range, `--left-right`'s left-is-ahead semantics, the two-token split, the `int()` conversion, the subprocess timeout, and what an unreadable result means. **Policy stays at each caller**, because the surfaces intentionally disagree:

| Surface | Policy (unchanged) |
|---|---|
| update CHECK (`_check_git_checkout`) | fast-forward-only: `behind > 0 and ahead == 0` |
| POST `/api/update` precondition | diverged-only: `ahead > 0 and behind > 0` → 409 `checkout_diverged` |
| CLI `_divergence_verdict` | strictest: `behind == 0` refuses the reset even when ahead; diverged needs `--force` |
| papyrus status | display: unreadable folds to 0/0, no gate |

Failure is an explicit `DivergenceUnreadable` (reason + detail) — a type with no `ahead`/`behind` to read — never `(0, 0)`, which also means "in sync" and would silently turn the fail-closed gates fail-open. That property has its own dedicated test class (`TestFailureIsNeverInSync`).

Three call shapes are deliberate: `count_divergence` (async, event-loop callers), `count_divergence_sync` (the no-event-loop CLI path), and the `divergence_count_args` + `parse_divergence_counts` primitives for papyrus, which **keeps its sandbox-routed `_git` runner** (config-override pins) — counting through this module's spawns would bypass its chokepoint.

The fifth site, `builtin_skills/kirocrew-dev/prepare-pr/scripts/preflight.py`, is deliberately untouched: it ships as a standalone dependency-free skill script (guard test allowlists exactly it and the helper).

## Behaviour deltas (all in previously-unreachable or failure corners, all fail-closed)

1. **POST precondition `rc != 0` is now explicit.** Previously there was no returncode check — a failed `rev-list` produced empty stdout, which fell into the `ValueError` parse branch and *coincidentally* reached the same 409. Same reachable outcome, no longer by luck.
2. **CLI timeout is a clean refusal.** Previously `subprocess.run(..., timeout=10)` had no `TimeoutExpired` handler, so a wedged repo escaped `_update` as a traceback. Now it classifies as `unreadable` → printed refusal → `exit 1`.
3. **Spawn failure (git missing, repo path gone) is `DivergenceUnreadable`,** not an exception each caller degrades through differently (bare aiohttp 500 without the handler's `code` field; CLI traceback). Adopted from pre-push review.
4. **CLI rev-list decode pinned UTF-8** (`UTF8_TEXT`) instead of locale `text=True`, per the repo's git-decoding rule; Windows-only difference.
5. **papyrus parse acceptance** is nominally wider (`int()` vs `isdigit()`), unreachable for real `rev-list` output; argv order normalized to `--count --left-right` (git accepts both). Display fold-to-zero preserved.

## Tests

- New `test/test_git_divergence.py`: argv/parse contract, all failure modes on both entry points, the dedicated failure-is-never-in-sync class, and a tripwire that no new hand-rolled `--left-right` count appears outside the helper + the excluded preflight script (allowlist is exactly those two paths; the docstring states the tripwire's scope honestly).
- Policy pins added at each surface: CLI ahead-only never reset / diverged refuses without `--force` / diverged resets under `--force` / unreadable refuses; apply-precondition 409 `git_read_failed` on failed and unparseable counts; check-path `CHECK_FAILED`+`git_read_failed` on both.
- `test/test_spawn_audit.py`: `cli_server.py::_divergence_verdict` entry removed (no longer spawns); `git_divergence.py::count_divergence{,_sync}` allowlisted with the same trust profile as the update surfaces they serve.

## Verification

- Local gates: `check_black_formatting.py`, `check_subprocess_encoding.py`, isort, flake8, mypy (1078 files), brand, harness-parity — all green.
- Full backend pytest: **64757 passed**; the single failure (`test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for`) reproduces identically on clean base `main@1a1efe55c` via stash-control — pre-existing main-red #5448, not this diff.
- **CI shard-3 reds (3.10/3.12/Windows) + Coverage Gate are that same inherited main-red**, log-confirmed: `AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['feishu', 'whatsapp']`. This PR's merge-ref predates the whatsapp exemption (#5460, merged 04:04Z), and feishu (rostered by #4282) is still unexempted on current main — the complete fix is #5469. Once it merges, a zero-diff amend will refresh the merge-ref here. Every other check is green, including all five review bots (round 1).
- Pre-push dual model-pinned review: GPT 5.6 Sol **PASS** (zero findings); Opus 5 **PASS** + 4 advisories — High (black-ratchet new-offender) verified real and fixed, Medium (spawn `OSError` gap) adopted with tests, two Lows documented above.

