### PR TITLE
test: prune graduated channels from the pre-turn exempt set (#5461)

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -197,6 +197,31 @@ _SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
 #: Listing them here would assert a migration that has not happened.
 _PRE_TURN_CHANNELS = ("webex", "imessage")
 
+#: Rostered channels deliberately NOT on the shared helper. telegram, discord,
+#: teams and slack carry extra pre-turn work between the busy check and
+#: rotation; weixin and wecom run the same kind of steps from their
+#: ``handle_message`` with their own busy checks (wecom additionally clears
+#: attachments there and ingests media before rotating); whatsapp and feishu
+#: hand-roll the sequence in their dispatchers, and although whatsapp's busy
+#: handling mirrors webex's closely enough that migration looks mechanical,
+#: it is still a behaviour change -- so folding any of them into the helper
+#: is a separate, reviewed change. Both ratchet directions read this one set:
+#: joining it (a rostered channel must be accounted for) and leaving it (a
+#: migrated channel must be pruned) are each an explicit decision.
+_EXEMPT_CHANNELS = frozenset(
+    {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp", "feishu"}
+)
+
+
+def _calls_pre_turn_helper(path: pathlib.Path) -> bool:
+    """A call on a code line marks a migration; a comment merely naming the
+    helper (say, to explain why a channel deliberately avoids it) does not."""
+    return any(
+        "resolve_pre_turn(" in line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
 
 class TestPreTurnRatchet:
     @pytest.mark.parametrize("channel", _PRE_TURN_CHANNELS)
@@ -232,34 +257,42 @@ class TestPreTurnRatchet:
         """
         from kiro_crew.channels import builtin_channel_descriptors
 
-        # weixin and wecom are exempt for the same reason as the big four:
-        # their handle_message runs extra pre-turn steps with their own busy
-        # checks (wecom additionally clears attachments there and ingests
-        # media before rotating), so folding them into the helper is a
-        # behaviour change that needs its own review, not a rider here.
-        # whatsapp is exempt on the same basis: its dispatcher runs its own
-        # pre-turn sequence with its own busy check (is_busy -> _handle_busy,
-        # then maybe_rotate). Unlike weixin/wecom there is no structural
-        # obstacle -- its _handle_busy mirrors webex's, so migration looks
-        # mechanical -- but it is still a behaviour change that gets its own
-        # review, not a rider in a main-red unblock (#5448).
-        # feishu is exempt on the same basis as whatsapp: transport_dispatch
-        # runs its own is_busy -> _handle_busy (with a busy re-check) ->
-        # maybe_rotate sequence, so migrating it to the shared helper is a
-        # separately-reviewable behaviour change, not a rider in a main-red
-        # unblock (#5483).
-        exempt = {
-            "telegram",
-            "discord",
-            "teams",
-            "slack",
-            "weixin",
-            "wecom",
-            "whatsapp",
-            "feishu",
-        }
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
-        unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
+        unrostered = _EXEMPT_CHANNELS - rostered
+        assert not unrostered, (
+            "exempt entries naming channels no longer in the roster "
+            f"(prune them from _EXEMPT_CHANNELS): {sorted(unrostered)}"
+        )
+        unaccounted = rostered - set(_PRE_TURN_CHANNELS) - _EXEMPT_CHANNELS
         assert not unaccounted, (
             "channels neither using messaging.pre_turn nor listed exempt: " f"{sorted(unaccounted)}"
+        )
+
+    def test_exempt_channels_have_not_graduated(self) -> None:
+        """The reverse direction: an exempt entry asserts the channel still
+        hand-rolls its pre-turn sequence. Once any module in the channel's
+        package calls the shared helper, the entry is stale, and with nothing
+        forcing removal the set would silently accrete entries that no longer
+        describe anything. The channels host their pre-turn logic in different
+        modules (weixin and wecom drive it from ``handle_message``, slack's
+        busy check lives in its gateway), so the scan covers the whole package
+        rather than assuming one dispatch filename. The scan anchors on the
+        package directory matching the channel type, so that mapping is
+        asserted first: a renamed package must fail loudly here instead of
+        reading as never-migrated forever.
+        """
+        missing = {c for c in _EXEMPT_CHANNELS if not (_SRC / c).is_dir()}
+        assert not missing, (
+            "exempt channels without a package dir under src/kiro_crew "
+            f"(the graduation scan cannot see them): {sorted(missing)}"
+        )
+        graduated = {
+            channel
+            for channel in _EXEMPT_CHANNELS
+            if any(_calls_pre_turn_helper(path) for path in (_SRC / channel).rglob("*.py"))
+        }
+        assert not graduated, (
+            "channels in the exempt list already call resolve_pre_turn -- prune "
+            "them from _EXEMPT_CHANNELS (a migrated channel belongs in "
+            f"_PRE_TURN_CHANNELS instead): {sorted(graduated)}"
         )


### PR DESCRIPTION
## Problem / Motivation

`test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` ratchets in one direction only: a rostered channel must be in `_PRE_TURN_CHANNELS` or the exempt set. There is no reverse check that an exempt entry is still genuinely unmigrated. When an exempt channel is later migrated to `messaging.pre_turn`, its exempt entry becomes stale with nothing forcing removal, so the set silently accretes entries that no longer describe anything.

## Why it matters

The exempt list's whole value is that "not yet migrated" is an explicit, reviewed decision. A stale entry inverts that: it asserts a hand-rolled sequence that no longer exists, misleads the next person auditing migration progress, and — same defect class as the black-baseline "graduated entries" direction, which the black gate DOES enforce — grows unboundedly because no test ever goes red on it.

## What changed (motivation → approach → change)

Symptom → root cause: the ratchet encodes joining the exempt set but not leaving it. Approach: add the reverse assertion in the same test file, sharing one source of truth so the two directions cannot drift apart.

- Hoisted the exempt set to a module-level `_EXEMPT_CHANNELS` frozenset (previously function-local), read by both ratchet directions.
- New `test_exempt_channels_have_not_graduated`: fails when any exempt channel's package contains a call to `resolve_pre_turn(`. The scan covers the whole channel package rather than assuming one dispatch filename, because the exempt channels host their pre-turn logic in different modules (weixin/wecom drive it from `handle_message`; slack's busy check lives in its gateway with no rotation file at all). Matching skips comment lines via `_calls_pre_turn_helper`, so documenting *why* a channel avoids the helper cannot trip the ratchet.
- The scan anchors on `channel_type == package dir`, so that mapping is asserted first: a renamed package fails loudly instead of reading as never-migrated forever (a vacuous pass would be indistinguishable from a real one).
- `test_every_rostered_channel_is_accounted_for` additionally asserts `_EXEMPT_CHANNELS ⊆ rostered`, so an entry for a de-rostered channel is also forced out instead of surviving as a pre-approved exemption for whoever reuses the name.
- Failure messages name the complete two-step fix (prune from `_EXEMPT_CHANNELS`, migrated channels belong in `_PRE_TURN_CHANNELS`), so following the message cannot convert one red test into another.

Test-only change; no runtime behaviour change.

Note: main's #5453 reds are fully resolved and this branch is rebased on top of both unbreaks (whatsapp via #5460, feishu via #5484). This diff replaces main's in-function `exempt` set with the module-level `_EXEMPT_CHANNELS` carrying the same eight members; the test file is fully green.

## Tests

All new assertions are in the diff and were mutation-verified against unfixed code:
- adding a migrated channel (webex) to `_EXEMPT_CHANNELS` → `test_exempt_channels_have_not_graduated` fails;
- a comment line naming `resolve_pre_turn(` in an exempt channel → does NOT trip; a code-line call → trips;
- an exempt entry with no package dir → loud failure in both the dir-coverage assertion and the new unrostered assertion.

## Manual verification

N/A — unit coverage sufficient: the change is itself a test, and every assertion was empirically shown to bite via the mutations above.

## Related Issues

<!-- no-visual-delta -->
**Why no screenshot:** test-only backend change, nothing rendered.

Closes #5461

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff



