### PR TITLE
fix(tests): sample only admissible app names in builtin tests (#5454)

### DIFF
--- a/test/test_builtin_app_optional_enable.py
+++ b/test/test_builtin_app_optional_enable.py
@@ -8,6 +8,8 @@ Tests correctness properties from the design document:
 """
 from __future__ import annotations
 
+import re
+
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
@@ -22,6 +24,8 @@ from kiro_crew.apps.manager import (
     register_builtin_apps,
     uninstall_app,
 )
+from kiro_crew.apps.manifest import app_name_error
+from kiro_crew.constants import WINDOWS_DEVICE_STEMS
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -134,8 +138,17 @@ def _no_disk_discovery(monkeypatch):
 # Strategies
 # ---------------------------------------------------------------------------
 
-# Generate valid kebab-case app names
-app_name_st = st.from_regex(r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}", fullmatch=True)
+# Generate app names the admission contract actually accepts. The kebab-case
+# grammar alone still reaches Windows reserved device stems (``aux``, ``con``,
+# ``nul``, ``com1``…), which ``app_name_error`` refuses on every platform, so
+# ``register_builtin_apps`` would skip the definition and ``_read_installed``
+# would return None — a domain error in the strategy, not a bug in the store.
+# The exclusion is delegated to ``app_name_error`` rather than restated, so the
+# sampling domain cannot drift away from what production admits.
+_APP_NAME_GRAMMAR = r"[a-z][a-z0-9]{1,8}(-[a-z][a-z0-9]{1,5}){0,2}"
+app_name_st = st.from_regex(_APP_NAME_GRAMMAR, fullmatch=True).filter(
+    lambda name: app_name_error(name) is None
+)
 
 # Generate valid builtin app definitions
 valid_builtin_def_st = st.fixed_dictionaries({
@@ -148,6 +161,23 @@ valid_builtin_def_st = st.fixed_dictionaries({
     "defaultEnabled": st.booleans(),
     "tags": st.lists(st.text(min_size=1, max_size=10), max_size=3),
 })
+
+
+def test_strategy_cannot_sample_an_inadmissible_app_name() -> None:
+    """Deterministic guard for the sampling domain.
+
+    ``aux`` is kebab-case and inside the grammar's length range, so the regex
+    alone still reaches it — and registration refuses it on every platform, so
+    a strategy that samples it asserts on an impossible state (Hypothesis lands
+    on it intermittently, surfacing as a Windows-shard flake). Production must
+    keep refusing the name first; the strategy filter then keeps it out of the
+    domain by delegating to the same contract.
+    """
+    assert re.fullmatch(
+        _APP_NAME_GRAMMAR, "aux"
+    ), "grammar no longer reaches the name under test"
+    assert app_name_error("aux") is not None, "production must refuse it first"
+    assert app_name_error("aux-tools") is None, "ordinary names stay in the domain"
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +479,76 @@ class TestValidateBuiltinApp:
         }
         errors = _validate_builtin_app(app)
         assert any("unsafe" in e for e in errors)
+
+    @pytest.mark.parametrize("name", sorted(WINDOWS_DEVICE_STEMS))
+    def test_windows_device_stem_rejected_on_all_platforms(self, name):
+        """Builtins are registered from a dict, never through ``AppManifest``,
+        so the reserved-stem refusal has to hold at this door too — otherwise a
+        name the manifest path refuses would be admitted here and the store's
+        write would silently produce no meta on Windows."""
+        app = {
+            "name": name,
+            "version": "1.0.0",
+            "displayName": "Device",
+            "description": "Reserved stem",
+            "author": "x",
+        }
+        errors = _validate_builtin_app(app)
+        assert any("not portable" in e for e in errors), (name, errors)
+
+    @pytest.mark.parametrize("name", ["AUX", "Con", "aux.txt", "nul."])
+    def test_device_stem_variants_refused_by_the_grammar(self, name):
+        """Windows reserves the stem case-insensitively and with any extension
+        (``AUX``, ``aux.txt``, ``nul.``). These variants never reach the stem
+        comparison because the kebab-case grammar refuses uppercase and dots
+        first — so the assertion pins the rule that actually fires, not the
+        stem check the names merely resemble."""
+        app = {
+            "name": name,
+            "version": "1.0.0",
+            "displayName": "Device",
+            "description": "Reserved stem variant",
+            "author": "x",
+        }
+        errors = _validate_builtin_app(app)
+        assert any("kebab-case" in e for e in errors), (name, errors)
+
+    def test_reserved_name_produces_no_meta_and_no_crash(
+        self, app_home, monkeypatch, caplog
+    ):
+        """End-to-end at the registration boundary: a reserved name is skipped
+        loudly (validation error + warning log) before any write, so no partial
+        state lands on disk and other apps are unaffected."""
+        import logging
+
+        import kiro_crew.apps.manager as mgr
+
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [
+            {
+                "name": "aux",
+                "version": "1.0.0",
+                "displayName": "Aux",
+                "description": "Reserved",
+                "author": "x",
+            },
+            {
+                "name": "good-app",
+                "version": "1.0.0",
+                "displayName": "Good App",
+                "description": "A valid sibling",
+                "author": "x",
+            },
+        ])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.apps.manager"):
+            count = register_builtin_apps()
+
+        assert "aux" in caplog.text, "the skip must be operator-visible"
+        assert count == 1, "the valid sibling still registers"
+        assert _read_installed("good-app") is not None
+        assert _read_installed("aux") is None
+        assert not app_dir("aux").exists()
 
     def test_existing_builtins_all_valid(self):
         """The shipped builtin apps must all pass validation."""


### PR DESCRIPTION
## Problem / Motivation

`test/test_builtin_app_optional_enable.py::TestProperty3LifecycleLocked::test_builtin_apps_always_locked` (and its two sibling property tests) fail intermittently on the Backend Tests (Windows) shard when Hypothesis draws an app named `aux`: `assert meta is not None` → `None is not None`. The failure lands on unrelated PRs (observed on #5327's merge-ref run, a PR touching only `mcp_gateway/`) because Hypothesis's search is randomized.

## Why it matters

An intermittent red on a shared CI shard taxes every open PR: authors re-run jobs, misattribute the failure to their own diff, and lose trust in the Windows shards. The flake fires on any PR regardless of surface.

## What changed (motivation → approach → change)

Symptom: `_read_installed()` returns `None` after `register_builtin_apps()` for names like `aux`. Root cause: production already refuses Windows reserved device stems (`con prn aux nul com1..9 lpt1..9`) on **all** platforms — #2590 added `UNPORTABLE_APP_NAMES` to `app_name_error()`, the single app-name contract, and `_validate_builtin_app()` funnels through it — so `register_builtin_apps()` skips such a definition with a warning and no meta is ever written. The test file's Hypothesis strategy, however, still generated those names: the strategy was sampling a state production deliberately makes impossible. This is the issue's option (a) already implemented at the store; what remained was the strategy reconciliation the issue's scope also names.

The change is test-only:

- Filter the name strategy through `app_name_error(name) is None`, delegating the exclusion to the production contract instead of restating the reserved set (the established pattern in `test/test_lifecycle_hooks.py::_app_names`), and hoist the grammar to a single `_APP_NAME_GRAMMAR` constant shared with the guard test.
- Add a deterministic domain guard (`test_strategy_cannot_sample_an_inadmissible_app_name`) pinning that the grammar still reaches `aux`, production refuses it first, and ordinary names stay in the domain — so the flake class cannot silently return if the grammar or contract drifts.
- Add parametrized rejection coverage at the builtin-registration door, which admits apps from a dict and never routes through `AppManifest`: every `WINDOWS_DEVICE_STEMS` name is refused as "not portable" by `_validate_builtin_app` on all platforms; case/extension variants (`AUX`, `aux.txt`, `nul.`) are refused by the kebab-case grammar before the stem check (the assertion pins the rule that actually fires); and an end-to-end test locks the loud-skip contract — warning log emitted, no meta, no directory, and a valid sibling definition still registers.

No production change: the write-boundary guard the issue asks for landed in #2590; this PR closes the remaining gap that kept the issue's observable symptom alive.

## Tests

- `test_strategy_cannot_sample_an_inadmissible_app_name` — domain guard: grammar reaches `aux`, `app_name_error` refuses it, `aux-tools` stays admissible.
- `test_windows_device_stem_rejected_on_all_platforms[con|prn|aux|nul|com1..9|lpt1..9]` — all 22 stems refused at the builtin door with the "not portable" error.
- `test_device_stem_variants_refused_by_the_grammar[AUX|Con|aux.txt|nul.]` — variants refused by the kebab-case rule that actually fires.
- `test_reserved_name_produces_no_meta_and_no_crash` — end-to-end: warning logged, `count == 1` (valid sibling registers), no meta and no directory for `aux`.
- Mutation-verified: neutering `UNPORTABLE_APP_NAMES` makes 24 of the new/guard tests fail; restoring it turns the file green (54 passed).

## Manual verification

N/A — unit coverage sufficient: the flake mechanism (`register_builtin_apps` skipping `aux` → `meta is None`) was reproduced directly against the store before the fix, and the strategy filter removes the only path that reached it.

## Related Issues

Closes #5454

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** test-only backend change; no frontend paths touched.
