### PR TITLE
fix(dashboard): guard the dialog focus trap's Escape against IME composition (#5420)

### DIFF
--- a/website/src/hooks/useDialogFocusTrap.imeGuard.test.tsx
+++ b/website/src/hooks/useDialogFocusTrap.imeGuard.test.tsx
@@ -18,12 +18,14 @@ import { useDialogFocusTrap } from './useDialogFocusTrap'
 function Harness({
   enabled = true,
   onEscape = () => {},
+  handleEscape = true,
 }: {
   enabled?: boolean
   onEscape?: () => void
+  handleEscape?: boolean
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  useDialogFocusTrap(ref, onEscape, enabled)
+  useDialogFocusTrap(ref, onEscape, enabled, handleEscape)
   return (
     <div ref={ref} role="dialog">
       <button data-testid="first">first</button>
@@ -197,5 +199,103 @@ describe('useDialogFocusTrap IME guard', () => {
     last.focus()
     fireEvent.keyDown(last, { key: 'Escape' })
     expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * IME guard on the Escape-dismisses path (#5420, the Escape half of the
+ * defect whose Tab half is pinned above). A CJK user pressing Escape to
+ * cancel an in-flight candidate list must not have that same keypress close
+ * the dialog and discard a part-filled form.
+ */
+describe('useDialogFocusTrap Escape IME guard', () => {
+  const esc = (target: Element, init: KeyboardEventInit & { keyCode?: number } = {}) =>
+    fireEvent.keyDown(target, { key: 'Escape', ...init })
+
+  it('declines a mid-composition Escape (native flag) without cancelling the IME cancel', () => {
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    const notPrevented = esc(last, { isComposing: true })
+    expect(onEscape).not.toHaveBeenCalled()
+    // The IME is consuming this key to cancel its own candidate; the guard
+    // must not preventDefault or the candidate cancellation itself breaks
+    // (claimKey's split: consume only where the browser would otherwise act).
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines a keyCode-229 Escape without cancelling the IME cancel', () => {
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    const notPrevented = esc(last, { keyCode: 229 })
+    expect(onEscape).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines the Escape landing in the post-composition window AND consumes it', () => {
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    // WebKit reports the keydown that follows a candidate commit/cancel as
+    // non-composing; only the tracked latch can identify it. Nothing live is
+    // cancelled, so the key is fully consumed rather than dismissing.
+    const notPrevented = esc(last)
+    expect(onEscape).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('dismisses again once the post-composition window has elapsed', () => {
+    // A guard that never released would make dialogs un-closable by keyboard,
+    // which is an accessibility regression as bad as the defect itself.
+    vi.useFakeTimers()
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    vi.advanceTimersByTime(60)
+    esc(last)
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers Escape dismissal from an abandoned composition when focus moves away', () => {
+    // No compositionend ever fires (OS-level IME cancel, focus stolen
+    // mid-composition). The focusout recovery resets the latch; without it
+    // every later Escape would be consumed for the dialog's lifetime — the
+    // un-closable dialog the release case above pins, on its other path.
+    const onEscape = vi.fn()
+    const { last } = mount({ onEscape })
+    last.focus()
+    fireEvent.compositionStart(last) // abandoned: no compositionEnd follows
+    last.blur()
+    last.focus()
+    esc(last)
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('never claims an Escape the caller owns (handleEscape=false), even mid-latch', () => {
+    // The claim lives INSIDE the handleEscape branch. `claimKey` stops
+    // propagation on the keys it declines, so a hoisted claim would swallow
+    // Escapes that must reach a caller's own bubble-phase listener (Modal,
+    // CommandBarOverlay pass handleEscape=false for nested-overlay handling).
+    const onEscape = vi.fn()
+    const bubbleListener = vi.fn()
+    const { last } = mount({ onEscape, handleEscape: false })
+    last.focus()
+    fireEvent.compositionStart(last)
+    fireEvent.compositionEnd(last)
+    window.addEventListener('keydown', bubbleListener)
+    try {
+      esc(last)
+      // Untouched: not dismissed by the hook, and still propagating to the
+      // bubble phase where the caller's own Escape handling lives.
+      expect(onEscape).not.toHaveBeenCalled()
+      expect(bubbleListener).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', bubbleListener)
+    }
   })
 })

--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -113,6 +113,15 @@ export function useDialogFocusTrap(
     if (!enabled) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && handleEscape) {
+        // An Escape the IME owns must not dismiss the dialog: the user is
+        // cancelling a candidate list, not their part-filled form. `claimKey`
+        // owns the whole decline (see its contract in useImeGuard.ts) — a
+        // mid-composition Escape keeps its default action so the IME can
+        // still cancel the candidate. The claim sits INSIDE this branch on
+        // purpose: `claimKey` stops propagation on the keys it declines, and
+        // a hoisted claim would swallow Escapes belonging to callers that own
+        // dismissal on bubble-phase listeners (`handleEscape = false`).
+        if (!imeLatchRef.current!.claimKey(e)) return
         onEscape()
         return
       }


### PR DESCRIPTION
## Problem / Motivation

`useDialogFocusTrap` installs a window-CAPTURE keydown listener whose Escape branch fired unconditionally — no `isComposing`, no `keyCode === 229`, no latch consumption. A CJK/IME user pressing Escape to cancel an in-flight candidate list had that same keypress close the entire dialog, discarding a part-filled form. The Tab branch directly below was already guarded (#5410 / PR #5421, which also landed all the latch infrastructure this fix consumes); this PR is the deliberately-deferred Escape half.

Closes #5420

## The fix (one line + placement)

Mirror the guarded Tab branch: claim the key through the shared IME latch inside the `handleEscape` branch —

```ts
if (e.key === 'Escape' && handleEscape) {
  if (!imeLatchRef.current!.claimKey(e)) return
  onEscape()
  return
}
```

`claimKey`'s existing contract (`useImeGuard.ts`) produces the required behaviour with no additions:
- Escape with `isComposing` / `keyCode === 229` is declined **without** `preventDefault`, so the IME still receives the key and cancels its candidate (swallowing it would break candidate cancellation, trading one bug for another).
- Escape inside the post-`compositionend` latch window is declined and consumed.
- The next Escape after the window closes the dialog normally.

**Placement is load-bearing:** `claimKey` calls `stopPropagation()` on keys it declines, so a claim hoisted above the branch would swallow Escapes that must reach the bubble-phase listeners of the two consumers that pass `handleEscape=false`. The claim sits inside the branch so the hook only ever claims keys it was actually going to act on — pinned by a dedicated test.

## Scope

The hook is the shared chokepoint: one edit fixes all six default-true consumers (DiagramLightbox, SideSheet, McpAppFrame, ConnectRepoModal, RefSheet, AddReposModal — verified against the tree).

**Known-unaddressed (deliberate):** three sibling sites, all tracked in #5481 — `Modal.tsx:67` and `apps/command-bar/CommandBarOverlay.tsx:118` pass `handleEscape=false` and own Escape on bubble-phase listeners interacting with nested-layer `preventDefault` semantics (each needs an independent decision), and `useListKeyboardNav.ts:157` (surfaced by the First Principles review) whose unconditional Escape branch holds the same latch yet dismisses unguarded — its fix interacts with the deliberate empty-list release ordering, so it gets its own review rather than a rider here.

**Documented behaviour boundary** (review advisory, settled `claimKey` trade-off, not a defect): inside the 50ms post-composition window the claim consumes Escape at window-capture, so a nested non-`useDialogFocusTrap` consumer (e.g. a search dropdown inside AddReposModal) does not see that one keypress; the next Escape reaches it normally. A composing Escape belongs to the IME, not to any handler.

## Tests (`useDialogFocusTrap.imeGuard.test.tsx`, +6)

- (a) mid-composition Escape (native flag) → `onEscape` NOT called, `preventDefault` NOT called
- (b) `keyCode === 229` Escape → same
- (c) Escape inside the post-compositionend window → NOT called, consumed
- (d) second Escape after the window → IS called (a guard that never releases would make dialogs un-closable by keyboard — an accessibility regression as bad as the defect)
- (e) `handleEscape=false` + latched: the hook never claims the key, propagation to bubble listeners preserved (pins the placement)
- (f) abandoned composition (no `compositionend`) + focusout recovery → Escape dismisses again (adopted from pre-push review)

Fail-before verified: with the hook change reverted, (a)/(b)/(c) fail; (d)/(e)/(f) pin the reverse properties.

## Verification

- `npx tsc -b` clean; `npx vitest run` 23287 passed / 1490 files (18/18 in the extended file)
- Backend isort/flake8/mypy/black-gate/brand-gate clean; full `python -m pytest`: 64915 passed, **1 failed = inherited main-red** `TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` (#5456, merge-skew of #5114×#5379, now also #4282: unaccounted `['feishu', 'whatsapp']` — repair PR #5457, evidence posted there). This diff is frontend-only (2 files) and cannot affect that test.
- **No UI pixels change** — hook-internal keyboard behaviour only, so no screenshots for this one.

## Review

Pre-push dual model-pinned review: GPT 5.6 Sol PASS (zero findings); Opus 5 PASS + 3 advisories (adopted the focusout-recovery test; trade-off documented above; follow-up #5481).
