### PR TITLE
test: exempt feishu from the messaging pre-turn ratchet

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,21 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu is exempt on the same basis as whatsapp: transport_dispatch
+        # runs its own is_busy -> _handle_busy (with a busy re-check) ->
+        # maybe_rotate sequence, so migrating it to the shared helper is a
+        # separately-reviewable behaviour change, not a rider in a main-red
+        # unblock (#5483).
+        exempt = {
+            "telegram",
+            "discord",
+            "teams",
+            "slack",
+            "weixin",
+            "wecom",
+            "whatsapp",
+            "feishu",
+        }
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## What is the problem?

test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for fails on the current main tip: the feishu channel (#4282) landed neither wired through messaging.pre_turn nor listed in the ratchet's exempt set.

## Why this issue matters to the user

The backend test suites run only on pull_request merge refs, never on main pushes, so main carries this red invisibly and EVERY open PR inherits a failing Backend Tests shard 3 (observed on Linux 3.10, 3.12 and Windows) plus the Coverage Gate / PR Readiness aggregates -- no PR can go green until this is fixed.

## How our fix solves it

Symptom: the ratchet's roster diff reports ['feishu'] unaccounted. Root cause: #4282 added feishu to builtin_channel_descriptors() without making the pre-turn decision the ratchet exists to force. Fix: add feishu to the exempt set with a VERIFIED rationale -- its transport_dispatch runs its own pre-turn sequence with its own busy check (is_busy -> _handle_busy with a busy re-check, then maybe_rotate), matching the documented whatsapp/webex criterion, so migrating it to the shared helper is a separately-reviewable behaviour change rather than a rider in a main-red unblock. Identical in shape to #5460, which fixed the same gap for whatsapp one commit earlier. The assertion is unchanged: future channels still must decide explicitly.

## What tests we did

test/test_messaging_pre_turn.py 13/13 green locally (was 12 passed + 1 failed on pristine main); flake8 and black clean on the file. One-line set change plus comment; no runtime code touched.

## Any other suggestions on the work

Migrating feishu (and whatsapp) to the shared messaging.pre_turn helper looks mechanical and would shrink the exempt list -- worth a follow-up after #5379's single-owner refactor settles.

Closes #5483