### PR TITLE
fix(chat): offer only resolvable decisions on collapsed tool rows (#5434)

### DIFF
--- a/website/src/app-sdk/ChatEmbed.tsx
+++ b/website/src/app-sdk/ChatEmbed.tsx
@@ -180,7 +180,10 @@ function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSe
         {messages.length === 0 && !running && (
           <div className="text-center text-muted text-[13px] py-10">{i18nT('appSdk.chatEmbed.session_ready_type_a_message_to_start')}</div>
         )}
-        <ChatMessageList messages={messages} running={running} onApprove={approve} />
+        {/* canTrust: this embed's approve routes through the slot approve
+            endpoint (above), which records standing trust — the one mount
+            allowed to offer the tier (#5434). */}
+        <ChatMessageList messages={messages} running={running} onApprove={approve} canTrust />
         <div ref={endRef} />
       </div>
 

--- a/website/src/app-sdk/ChatMessageList.tsx
+++ b/website/src/app-sdk/ChatMessageList.tsx
@@ -28,6 +28,13 @@ export interface ChatMessageListProps {
   running: boolean
   contentWidth?: string
   onApprove?: (approvalId: string, decision: string) => void
+  /** Offer the standing-trust tier on pending-approval rows. FAIL-CLOSED: set it
+   *  only when `onApprove` routes to an endpoint that RECORDS standing trust
+   *  (the slot approve endpoint carries the decision verbatim). Hosts resolving
+   *  through the one-shot `resolveApproval` endpoint must leave it unset — that
+   *  path has no trust verb, so a Trust offer there overstates the grant
+   *  (#5400, #5434). */
+  canTrust?: boolean
   onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
   /** Optional host-injected renderer for tool messages (role 'tool'/'tool_call'/
    *  'tool_result'). Lets a Redux-connected host (e.g. the dashboard's split-view
@@ -57,6 +64,7 @@ const ChatMessageList = memo(function ChatMessageList({
   running,
   contentWidth = '900px',
   onApprove,
+  canTrust,
   onFileOpen,
   renderTool,
   hideCardOwnedOAuth = false,
@@ -198,6 +206,7 @@ const ChatMessageList = memo(function ChatMessageList({
           permissionMeta={lastPerm?.meta}
           pendingPermCount={unresolvedPerms.length}
           onApprove={handleApprove}
+          canTrust={canTrust}
         >
           {/* Grouped messages (thinking, permission) return null from renderMessage
               intentionally — CollapsibleToolGroup handles their display via its
@@ -206,7 +215,7 @@ const ChatMessageList = memo(function ChatMessageList({
         </CollapsibleToolGroup>
       </div>
     )
-  }, [renderMessage, running, messages.length, contentWidth, onApprove])
+  }, [renderMessage, running, messages.length, contentWidth, onApprove, canTrust])
 
   // Render a DisplayItem (single, group, or turn)
   const renderDisplayItem = useCallback((item: DisplayItem, i: number) => {

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4460,8 +4460,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [])
 
   const approve = useCallback(async (action: string) => { if (activeSlot) await api.approveChatSlot(activeSlot, action) }, [activeSlot])
+  // Approvals dismissed through this mapping resolve via the ONE-SHOT
+  // `api.resolveApproval` endpoint, which has no trust verb: it can honor
+  // exactly `approve` or `reject`, and the next identical call prompts again.
+  // Any UI feeding this path must offer only those decisions — a Trust
+  // affordance here would claim a standing grant the backend never records
+  // (#5400 on the spawn-approval card, #5434 on the collapsed tool row).
   const toApiDecision = (action: string): 'approve' | 'reject' =>
-    action === 'approved' || action === 'trust' ? 'approve' : 'reject'
+    action === 'approved' ? 'approve' : 'reject'
   const dismissApproval = useCallback((aid: string, decision?: string) => {
     dispatch(resolveByApprovalId({ id: aid, decision }))
     const n = store.getState().notifications.items.find(x => x.approval_id === aid)

--- a/website/src/pages/chat/CollapsibleToolGroup.tsx
+++ b/website/src/pages/chat/CollapsibleToolGroup.tsx
@@ -17,8 +17,18 @@ interface CollapsibleToolGroupProps {
   permissionMeta?: Record<string, unknown>
   /** Number of pending permission messages in this group (shown as indicator when > 1). */
   pendingPermCount?: number
-  /** Callback for approve/trust/reject — same as PermissionMessage.onApprove. */
+  /** Callback for approve/reject (and trust, only when `canTrust`) — same as PermissionMessage.onApprove. */
   onApprove?: (decision: string) => void | Promise<void>
+  /**
+   * Offer the standing-trust tier. FAIL-CLOSED: leave unset unless this mount's
+   * `onApprove` routes to an endpoint that actually RECORDS standing trust
+   * (POST /api/chat/slots/{slot}/approve carries the decision verbatim).
+   * The common resolve path — ChatPage's `toApiDecision` into the one-shot
+   * `api.resolveApproval` — has no trust verb, so offering Trust there (or
+   * labelling a decision "Trusted") overstates the grant: the next identical
+   * call prompts again (#5400 on the spawn card, #5434 on this row).
+   */
+  canTrust?: boolean
   /** Callback to open the Activity Viewer. */
   onViewActivity?: () => void
   /** Whether the Activity Viewer is currently open. */
@@ -44,7 +54,7 @@ function extractPreview(meta?: Record<string, unknown>): string {
 }
 
 /** Collapsible row that wraps tool/thinking/permission messages — always collapsed unless autoExpand. */
-const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExpand, disclosureKey, hasPermission, isRunning, children, permissionMeta, pendingPermCount, onApprove, onViewActivity, activityOpen }: CollapsibleToolGroupProps) {
+const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExpand, disclosureKey, hasPermission, isRunning, children, permissionMeta, pendingPermCount, onApprove, canTrust, onViewActivity, activityOpen }: CollapsibleToolGroupProps) {
   const [expanded, setExpanded] = useRowDisclosure(disclosureKey, !!autoExpand)
   const userToggled = useRef(false)
   const [submitting, setSubmitting] = useState(false)
@@ -63,6 +73,10 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
     wasRunning.current = !!isRunning
   }, [isRunning, setExpanded])
 
+  // The 'trust' entries are reachable only from a `canTrust` mount (see the
+  // prop's contract above): a mount resolving through the one-shot
+  // `api.resolveApproval` endpoint never offers the Trust button, so it can
+  // never wear a "Trusted" label it did not earn (#5400, #5434).
   const decisionLabel: Record<string, ReactNode> = { approved: <><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.approved')}</>, trust: <><Handshake className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.trusted')}</>, rejected: <><Ban className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.rejected')}</> }
   const labelNode = localResolved
     ? (decisionLabel[localResolved] || <><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.resolved')}</>)
@@ -126,7 +140,7 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
       {needsAttention && !expanded && onApprove && (
         <div className="mt-1 ml-4 pl-3 flex gap-2 flex-wrap">
           <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('approved') }}><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.approve')}</button>
-          <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('trust') }}><Handshake className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.trust')}</button>
+          {canTrust && <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('trust') }}><Handshake className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.trust')}</button>}
           <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-danger hover:border-danger transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('rejected') }}><Ban className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.reject')}</button>
         </div>
       )}

--- a/website/src/test/ChatEmbed.test.tsx
+++ b/website/src/test/ChatEmbed.test.tsx
@@ -16,12 +16,13 @@ interface MockChatMessageListProps {
   messages: unknown[]
   running: boolean
   onApprove?: (approvalId: string, decision: string) => void
+  canTrust?: boolean
 }
 
 vi.mock('./ChatMessageList', () => ({
-  default: ({ messages, running, onApprove }: MockChatMessageListProps) => (
+  default: ({ messages, running, onApprove, canTrust }: MockChatMessageListProps) => (
     <div data-testid="chat-message-list" data-count={messages.length} data-running={String(running)}
-      data-can-approve={String(!!onApprove)}>
+      data-can-approve={String(!!onApprove)} data-can-trust={String(!!canTrust)}>
       {onApprove && (
         <>
           <button data-testid="mock-approve" onClick={() => onApprove('appr-1', 'approved')}>approve</button>
@@ -34,9 +35,9 @@ vi.mock('./ChatMessageList', () => ({
 
 // Mock ChatMessageList from the correct path (ChatEmbed imports from ./ChatMessageList)
 vi.mock('../app-sdk/ChatMessageList', () => ({
-  default: ({ messages, running, onApprove }: MockChatMessageListProps) => (
+  default: ({ messages, running, onApprove, canTrust }: MockChatMessageListProps) => (
     <div data-testid="chat-message-list" data-count={messages.length} data-running={String(running)}
-      data-can-approve={String(!!onApprove)}>
+      data-can-approve={String(!!onApprove)} data-can-trust={String(!!canTrust)}>
       {onApprove && (
         <>
           <button data-testid="mock-approve" onClick={() => onApprove('appr-1', 'approved')}>approve</button>
@@ -488,6 +489,10 @@ describe('ChatEmbed approvals', () => {
       renderWithProviders(<ChatEmbed slotKey="slot-1" />)
       await vi.advanceTimersByTimeAsync(0)
     })
+    // The embed must DECLARE the trust tier: CollapsibleToolGroup is fail-closed
+    // and only renders the Trust button on a canTrust mount (#5434). Dropping
+    // the flag would silently remove Trust from every embedded approval row.
+    expect(screen.getByTestId('chat-message-list').dataset.canTrust).toBe('true')
     await act(async () => {
       screen.getByTestId('mock-trust').click()
       await vi.advanceTimersByTimeAsync(0)

--- a/website/src/test/ChatMessageList.test.tsx
+++ b/website/src/test/ChatMessageList.test.tsx
@@ -22,14 +22,15 @@ vi.mock('../pages/chat/UserMessage', () => ({
 }))
 
 vi.mock('../pages/chat/CollapsibleToolGroup', () => ({
-  default: ({ children, count, hasPermission, pendingPermCount }: {
-    children?: ReactNode; count?: number; hasPermission?: boolean; pendingPermCount?: number
+  default: ({ children, count, hasPermission, pendingPermCount, canTrust }: {
+    children?: ReactNode; count?: number; hasPermission?: boolean; pendingPermCount?: number; canTrust?: boolean
   }) => (
     <div
       data-testid="collapsible-tool-group"
       data-count={count}
       data-has-permission={String(hasPermission)}
       data-pending-perm-count={pendingPermCount}
+      data-can-trust={String(!!canTrust)}
     >
       {children}
     </div>
@@ -273,6 +274,25 @@ describe('ChatMessageList', () => {
       // All permissions are resolved, so has-permission should be false
       expect(group.getAttribute('data-has-permission')).toBe('false')
       expect(group.getAttribute('data-pending-perm-count')).toBe('0')
+    })
+
+    it('threads canTrust to the group, and withholds it by default (#5434)', () => {
+      const msgs: ChatMessage[] = [
+        msg('user', 'Run a command'),
+        msg('thinking', 'Analyzing...'),
+        msg('permission', 'Allow read access?', { meta: { approval_id: 'a1' } }),
+        msg('assistant', 'Here you go.'),
+      ]
+      // Fail-closed default: a host that says nothing gets no Trust tier —
+      // most hosts resolve through the one-shot resolveApproval endpoint,
+      // which has no trust verb (#5400, #5434).
+      const { unmount } = render(<ChatMessageList messages={msgs} running={false} onApprove={() => {}} />)
+      expect(screen.getByTestId('collapsible-tool-group').getAttribute('data-can-trust')).toBe('false')
+      unmount()
+
+      // A host whose onApprove records standing trust declares it explicitly.
+      render(<ChatMessageList messages={msgs} running={false} onApprove={() => {}} canTrust />)
+      expect(screen.getByTestId('collapsible-tool-group').getAttribute('data-can-trust')).toBe('true')
     })
 
     it('groups at end of messages list are flushed', () => {

--- a/website/src/test/ChatPage.collapsedGroupTrust.test.tsx
+++ b/website/src/test/ChatPage.collapsedGroupTrust.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Source contract for #5434: ChatPage's CollapsibleToolGroup mounts must not
+ * declare the standing-trust tier.
+ *
+ * Both mounts resolve approvals through `toApiDecision` into the one-shot
+ * `api.resolveApproval` endpoint, which has no trust verb. The group component
+ * is fail-closed (`canTrust` opt-in), so the regression this pins is someone
+ * flipping `canTrust` on a ChatPage mount: the Trust button would render, and
+ * with `toApiDecision` narrowed to `'approved' -> approve, else reject`, a
+ * user's Trust click would resolve as a SILENT DENIAL — worse than the silent
+ * one-shot approve #5434 removed.
+ *
+ * Why a source contract and not a render test: these mounts are currently
+ * unreachable — `groupDisplayItems` skips `permission` rows entirely (the
+ * pinned ApprovalBar owns them) and nothing else is GROUPABLE, so no transcript
+ * can mount the group from ChatPage. That latency is exactly why the defect had
+ * to be fixed by inspection (#5434), and why the pin must read the source
+ * rather than the DOM. The component's own rendering of the decision set is
+ * covered behaviorally in CollapsibleToolGroupCov80.test.tsx; the app-sdk
+ * threading in ChatMessageList.test.tsx and ChatEmbed.test.tsx.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = readFileSync(resolve(__dirname, '../pages/ChatPage.tsx'), 'utf-8')
+
+/** Every `<CollapsibleToolGroup ...>` opening tag's attribute block. */
+function mountAttributeBlocks(src: string): string[] {
+  const blocks: string[] = []
+  const open = /<CollapsibleToolGroup\b/g
+  let m: RegExpExecArray | null
+  while ((m = open.exec(src))) {
+    // The attribute block ends at the first `>` that is not inside a brace
+    // expression — track brace depth so `onApprove={(() => {...})()}` and
+    // arrow bodies do not end the scan early.
+    let depth = 0
+    for (let i = m.index; i < src.length; i++) {
+      const ch = src[i]
+      if (ch === '{') depth++
+      else if (ch === '}') depth--
+      else if (ch === '>' && depth === 0) {
+        blocks.push(src.slice(m.index, i + 1))
+        break
+      }
+    }
+  }
+  return blocks
+}
+
+describe('ChatPage CollapsibleToolGroup mounts (#5434 contract)', () => {
+  const mounts = mountAttributeBlocks(source)
+
+  it('finds the mounts (fail-closed: a rename or refactor must re-establish this contract)', () => {
+    // Exactly the two known mounts. If this count changes, re-verify the new
+    // mount set's resolve paths and update this contract deliberately.
+    expect(mounts).toHaveLength(2)
+  })
+
+  it('no mount declares canTrust — their resolve path is the one-shot resolveApproval', () => {
+    for (const block of mounts) {
+      // toApiDecision maps anything but 'approved' to 'reject', so a canTrust
+      // mount here would turn a user's Trust click into a silent denial.
+      expect(block).not.toMatch(/\bcanTrust\b/)
+      // And the mounts stay latent as shipped: hasPermission is the literal
+      // false. Flipping it truthy arms the approval row — legitimate, but the
+      // author doing so must re-read the toApiDecision constraint comment.
+      expect(block).toContain('hasPermission={false}')
+    }
+  })
+})

--- a/website/src/test/CollapsibleToolGroupCov80.test.tsx
+++ b/website/src/test/CollapsibleToolGroupCov80.test.tsx
@@ -54,9 +54,38 @@ describe('CollapsibleToolGroup header label', () => {
 describe('CollapsibleToolGroup approval dispatch', () => {
   const cases: [string, string][] = [
     [T('approve'), T('approved')],
-    [T('trust'), T('trusted')],
     [T('reject'), T('rejected')],
   ]
+
+  it('offers only the decisions its resolve path honors — Approve / Reject, no Trust (#5434)', () => {
+    renderWithProviders(
+      <CollapsibleToolGroup count={1} hasPermission permissionMeta={{ tool_input: 'zzq --run' }} onApprove={() => {}}>
+        <div>zzq-child</div>
+      </CollapsibleToolGroup>,
+    )
+    // This row resolves through ChatPage's toApiDecision into the one-shot
+    // resolveApproval endpoint, which has no trust verb — offering a Trust
+    // tier here would overstate the grant, because the next identical call
+    // prompts again (#5400 on the spawn card, #5434 on this row).
+    const actionButtons = screen.getAllByRole('button').slice(1) // [0] is the header toggle
+    expect(actionButtons.map(b => b.textContent?.trim())).toEqual([T('approve'), T('reject')])
+    expect(screen.queryByText(T('trust'))).not.toBeInTheDocument()
+  })
+
+  it('offers the Trust tier only on a canTrust mount, and reports the trust decision verbatim (#5434)', async () => {
+    const onApprove = vi.fn()
+    renderWithProviders(
+      <CollapsibleToolGroup count={1} hasPermission canTrust permissionMeta={{ tool_input: 'zzq --run' }} onApprove={onApprove}>
+        <div>zzq-child</div>
+      </CollapsibleToolGroup>,
+    )
+    const actionButtons = screen.getAllByRole('button').slice(1)
+    expect(actionButtons.map(b => b.textContent?.trim())).toEqual([T('approve'), T('trust'), T('reject')])
+
+    fireEvent.click(screen.getByText(T('trust')))
+    await waitFor(() => expect(onApprove).toHaveBeenCalledWith('trust'))
+    expect(screen.getByText(T('trusted'))).toBeInTheDocument()
+  })
 
   for (const [buttonLabel, resolvedLabel] of cases) {
     it(`${buttonLabel} reports its decision and shows the resolved label`, async () => {
@@ -69,7 +98,7 @@ describe('CollapsibleToolGroup approval dispatch', () => {
       fireEvent.click(screen.getByText(buttonLabel))
 
       await waitFor(() => expect(onApprove).toHaveBeenCalledTimes(1))
-      expect(onApprove.mock.calls[0][0]).toBe(resolvedLabel.toLowerCase() === 'trusted' ? 'trust' : resolvedLabel.toLowerCase())
+      expect(onApprove.mock.calls[0][0]).toBe(resolvedLabel.toLowerCase())
       expect(screen.getByText(resolvedLabel)).toBeInTheDocument()
       // The approval affordances are gone once resolved.
       expect(screen.queryByText(T('approve'))).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary

`CollapsibleToolGroup` offered a **Trust** decision on its inline approval row (and could label a decision "Trusted"), while the resolve path behind both `ChatPage` mounts — `toApiDecision` into the one-shot `api.resolveApproval` — has no trust verb: a trust click was silently downgraded to a one-shot approve, claiming a standing grant the backend never records. Same class as #5400 / PR #5433 (spawn-approval card), third surface after #5202/#5203. Latent today (`hasPermission={false}` on both mounts), fixed while still unreachable.

**Why not a blanket removal (divergence from #5433's shape, same principle):** this component has one mount whose resolve path DOES honor trust — app-sdk `ChatEmbed` routes decisions verbatim through `POST /api/chat/slots/{slot}/approve`, a deliberate, test-pinned behavior ("sends Trust as trust, not as a plain approve"). Removing Trust outright would regress that live surface, and its `ChatMessageList` mock would keep vitest green while the real button vanished. So #5433's principle — *offer only verbs the resolve path honors* — is applied **per mount**:

- `CollapsibleToolGroup` gains a **fail-closed `canTrust` prop**; the Trust button renders only when the mount declares it.
- `ChatMessageList` threads `canTrust` (default withheld; added to the `renderItem` memo deps); `ChatEmbed` declares it.
- `ChatPage`'s mounts stay one-shot: `toApiDecision` no longer maps a stray `'trust'` to `'approve'` (fails safe to reject) and carries a comment naming the constraint, as #5434 suggests.

## Testing

- `CollapsibleToolGroupCov80.test.tsx`: default mount offers exactly Approve/Reject (mutation-verified: re-adding an ungated Trust button fails it); `canTrust` mount offers Approve/Trust/Reject and reports `trust` verbatim.
- `ChatMessageList.test.tsx`: `canTrust` threads through and is withheld by default (mutation-verified: dropping the thread fails it).
- `ChatEmbed.test.tsx`: the embed declares `canTrust` (mutation-verified: dropping the declaration fails it) — pins the anti-regression for the one legitimate Trust surface.
- `ChatPage.collapsedGroupTrust.test.tsx` (new): source contract that neither ChatPage mount declares `canTrust` (mutation-verified). A render test is impossible by construction: `groupDisplayItems` skips `permission` rows entirely (the pinned ApprovalBar owns them), so no transcript can mount these groups — the same latency that made #5434 an inspection finding.
- Local gates: `npx tsc -b` clean; full `npx vitest run` 23284 passed / 0 failed.
- Pre-push review lanes: GPT (gpt-5.6-sol) PASS, no findings. Opus (claude-opus-5) PASS, 0 blocking; adopted A1 (ChatPage mount pin) and A3 (catalog-key assertion), declined A2 (fail-closed default on the no-approval_id edge branch is deliberate), A4/A5 informational — filed as follow-up issues.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** no reachable rendered state changes. Both ChatPage mounts pass `hasPermission={false}` (the approval row never renders there — verified unreachable by construction, see the new contract test), and ChatEmbed — the only production surface that renders the row — keeps its exact Approve/Trust/Reject set via `canTrust`.

Closes #5434
