### PR TITLE
fix: drop an app's conversation pointers when it is uninstalled

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -658,6 +658,44 @@ lifecycle lock and the one step that can safely refuse runs FIRST:
 3. Backend stop and resource deregistration (gateway-managed only).
 4. Dependency cleanup (see §11).
 5. File removal, preserving `data/` unless the caller asked to purge.
+6. Resume pointers dropped for every conversation the app owned, on success only.
+
+Step 6 exists because an app's slot key is often DETERMINISTIC — one slot per object
+it tracks, named after that object — and `session.py` resumes a slot's previous
+kiro-cli conversation by that key. Correct while the app is installed; wrong once it
+is gone, since a reinstall would open the same key and resume a transcript from the
+previous installation.
+
+Ownership is read from each conversation's own metadata line, which every save —
+including the save that closes a tab — stamps with `app`. It has to be a record that
+outlives the tab: a closed app slot is the mainline state before an uninstall, and
+both live `_ChatSlot._app` and `open_slots.json` are gone by then (the latter tracks
+tabs to REOPEN, while the resume pointer deliberately survives close). The scan is
+scoped to session-map keys that still hold a sid, so the index is exactly as wide as
+the problem.
+
+Who performs the write differs by path, because `SessionMap`'s rule 3 makes a
+throwaway instance READ-ONLY — two instances that loaded `_data` independently do not
+merge, each write being a whole-file rewrite of one snapshot:
+
+- **In-gateway** (the uninstall route) clears through the LIVE map via
+  `SessionManager.discard_conversation`, which also tears the live session down, so a
+  still-open tab of the uninstalled app cannot re-record a sid on its next turn. It
+  runs INSIDE `app_lifecycle_lock`, because a step of the uninstall released before
+  the clear lands lets a concurrent reinstall be serving the same slot key again —
+  and the pointer dropped is then the new installation's.
+- **Gateway-less** (`kirocrew app uninstall`) writes through its own `SessionMap`
+  while HOLDING `GatewayLock` across the scan and the write, and declines when it
+  cannot take it. Asking whether a gateway is up cannot establish this: one starting
+  between the question and the write lands in exactly the excluded case. Holding the
+  lock the gateway itself takes makes the exclusion real both ways. Cost: a gateway
+  starting inside that window is refused as by any other holder.
+
+Deliberately NOT part of step 3: deregistration also runs on **disable**, and App
+Store Sync is a disable/enable pair, so clearing there would discard every
+long-lived conversation's accumulated context on every sync. `clear_sid`, not
+`delete` — the entry keeps its Slack linkage and the dropped value is stashed as
+`discarded_sid`.
 
 The lock spans the script deliberately: the script may itself be destructive, so
 holding the lock across it stops a racing enable or update from starting a

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -50,8 +50,11 @@ from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable, lookup_cron_folde
 from kiro_crew.cron_script import resolve_script_path
 from kiro_crew.env import emit_env
 from kiro_crew.executors import maintenance_executor
+from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
+from kiro_crew.history import ConversationLog
 from kiro_crew.platform.governance import may_skip_gate_now, strip_ungoverned_auto_approve
 from kiro_crew.sel import sel
+from kiro_crew.session_map import SessionMap
 
 logger = logging.getLogger(__name__)
 
@@ -2781,10 +2784,131 @@ def reconcile_enabled_app_resources() -> dict[str, int]:
     return counts
 
 
+def app_conversation_keys(app_name: str) -> list[str]:
+    """Session keys that still hold a resume pointer and belong to *app_name*.
+
+    A slot key an app chooses is often DETERMINISTIC — one slot per object it tracks,
+    named after that object — so the next slot created under that name is the same
+    key, and ``session.py``'s ``resume_sid = self._session_map.get(key)`` hands it the
+    previous conversation. That is correct while the app is installed: it is how a
+    long-lived per-object conversation keeps what it has learned about that object.
+    It stops being correct once the app is gone: reinstall it, open the same object,
+    and the first turn resumes a conversation from the previous installation — a
+    transcript from code that no longer exists.
+
+    Ownership is read from the record that already outlives the tab: every save
+    writes ``app`` into the conversation's metadata line, and closing a tab is a
+    save. Live ``_ChatSlot._app`` cannot answer here (the CLI path has no gateway,
+    and a closed slot is gone from a running one), and ``open_slots.json`` cannot
+    either — it tracks tabs to REOPEN, so a closed slot leaves it while the resume
+    pointer deliberately stays. A closed app slot is the mainline state before an
+    uninstall, so sourcing ownership from open tabs would miss the common case.
+
+    Scoped to keys that still have a sid, which makes this index exactly as wide as
+    the problem: a pointer exists only if a conversation was started, and starting
+    one writes the metadata line this reads. Reading the session map through a
+    throwaway instance is sound because nothing here writes — the class's rule 3
+    forbids a detached WRITE, and the callers below each clear through the writer
+    their own process owns.
+
+    Returns keys sorted for stable logs. Never raises: an uninstall the user asked
+    for does not fail over bookkeeping.
+    """
+    if not app_name:
+        return []
+    try:
+        log = ConversationLog()
+        owned = [
+            key
+            for key in SessionMap().mapped_sids_by_key()
+            if log.get_metadata(key).get("app") == app_name
+        ]
+        return sorted(owned)
+    except Exception:  # noqa: BLE001 — bookkeeping must not fail an uninstall
+        logger.warning("resolving %r's conversation keys failed", app_name, exc_info=True)
+        return []
+
+
+def discard_app_session_pointers(app_name: str) -> int:
+    """Drop the resume pointer of every conversation this app owned. CLI PATH ONLY.
+
+    Called by the UNINSTALL paths only, and deliberately NOT from
+    :func:`deregister_app`: that runs on **disable** too (the CLI's disable action,
+    the disable route, and the enable/update reconcile), and disable is how an app
+    is routinely restarted — App Store Sync is a disable/enable pair. Clearing
+    pointers there would discard the accumulated context of every long-lived
+    conversation the app owns, on every sync.
+
+    ``clear_sid``, not ``delete``: the entry also carries the Slack thread/channel
+    linkage and the reverse index built from it, so dropping the whole row would
+    silently unlink a mirrored session. The cleared value is stashed as
+    ``discarded_sid``, so this is diagnosable and reversible by hand — the native
+    conversation itself is untouched on disk.
+
+    **Holds the gateway lock across the whole scan and write, and that is the
+    mechanism, not a courtesy.** This writes through a throwaway ``SessionMap``,
+    which is only sound when no other instance holds the file: a running gateway
+    keeps a long-lived map whose ``_data`` loaded at startup and whose every write
+    rewrites the whole file from that snapshot, so two writers do not merge — the
+    loser's rows vanish. Writing anyway would both fail to drop the pointer (the
+    live map's next write restores it) and drop whatever that map recorded since
+    this process read, costing an unrelated session its sid or its channel link.
+    Merely *asking* whether a gateway is up cannot establish that: a gateway
+    starting between the question and the write lands in exactly the case the
+    question was meant to exclude. Taking the same lock the gateway takes makes the
+    exclusion real in both directions — while we hold it no gateway can start, and
+    if one is already up we cannot take it and decline instead. Doing nothing is
+    the pre-existing behaviour; corrupting a stranger's session is not.
+
+    The cost is stated rather than hidden: a gateway attempting to start inside this
+    window is refused as it would be by any other holder. The window is one scan
+    plus one write, and the alternative is losing another session's row.
+
+    The in-gateway route does not come through here at all — it clears through the
+    live map, inside the app lifecycle lock.
+
+    Returns the number of pointers dropped, or 0 when it declined.
+    """
+    try:
+        with GatewayLock(config_dir()):
+            keys = app_conversation_keys(app_name)
+            if not keys:
+                return 0
+            smap = SessionMap()
+            # ``clear_sid`` reports whether it dropped anything, so the count is
+            # conversations orphaned by THIS uninstall rather than keys looked at.
+            cleared = sum(1 for key in keys if smap.clear_sid(key))
+            # Durable BEFORE the lock is released. Off-loop writes are inline today,
+            # so this is belt and braces — but the ordering is the invariant, not a
+            # property inherited from being off the loop, which a later refactor
+            # could change without noticing this depends on it.
+            smap.flush()
+    except GatewayLockError:
+        logger.info(
+            "Left %s's conversation pointers in place: a gateway owns session_map.json "
+            "and a second writer would drop rows it has not flushed yet",
+            app_name,
+        )
+        return 0
+    except Exception:  # noqa: BLE001 — bookkeeping must not fail an uninstall
+        logger.warning("session pointer cleanup for %r failed", app_name, exc_info=True)
+        return 0
+    if cleared:
+        logger.info(
+            "Dropped %d resume pointer(s) for %s so a reinstall starts fresh",
+            cleared,
+            app_name,
+        )
+    return cleared
+
+
 def deregister_app(app_name: str) -> RegistrationResult:
     """Deregister all resources for an app.
 
     Removes symlinks and cron manifests.  Does not remove the app directory.
+
+    Does NOT touch session resume pointers — see
+    :func:`discard_app_session_pointers` for why that belongs to uninstall alone.
     """
     result = RegistrationResult()
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -38,6 +38,7 @@ from kiro_crew.apps.backend import (
 )
 from kiro_crew.apps.bridges import (
     RegistrationResult,
+    app_conversation_keys,
     deregister_app,
     deregister_app_crons_from_service,
     register_app,
@@ -1087,6 +1088,10 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     # Cost: a concurrent same-app lifecycle op waits up to the onUninstall
     # timeout — acceptable, since those ops genuinely conflict and the lock is
     # per-app (other apps are unaffected).
+    #
+    # Counted inside the lock (Step 6) but reported after it, so it is bound
+    # before the block that fills it.
+    dropped = 0
     async with app_lifecycle_lock(name):
         # A retained startup hook still owns the old app's AppContext. Bound the
         # wait and refuse the uninstall if it remains live; deleting files or
@@ -1335,6 +1340,46 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
             result = await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), lambda: uninstall_app(name, keep_data=keep_data)
             )
+
+        # Step 6: drop the resume pointer of every conversation the app owned.
+        #
+        # INSIDE the lifecycle lock, and that is the point: this is a step of the
+        # uninstall, not an epilogue to it. Outside, a concurrent reinstall could
+        # take the lock the moment we release it and be serving the SAME slot key
+        # again while our scan is still running — and the pointer we then clear is
+        # the new installation's, not the dead one's. The lock is keyed on the app
+        # name, so it serializes exactly the reinstall that would collide.
+        #
+        # On success only: a failed uninstall leaves nothing changed, so a
+        # still-installed app keeps the pointers its slots are still entitled to
+        # resume. Not in `deregister_app` (Step 3) — that also runs on disable, and
+        # App Store Sync is a disable/enable pair.
+        #
+        # Cleared through the LIVE session map (`discard_conversation`), never a
+        # throwaway `SessionMap`: this gateway holds a long-lived map whose `_data`
+        # loaded at startup and whose every write rewrites the whole file from that
+        # snapshot, so a detached write here would be undone by the next unrelated
+        # mutation — restoring the very pointer we just dropped — and would take
+        # whatever the live map had not flushed with it (`SessionMap`'s rule 3).
+        # `discard_conversation` also tears the live session down, which is what
+        # stops a still-open tab of the uninstalled app from re-recording a sid on
+        # its next turn and silently undoing this.
+        if result.ok:
+            sessions = getattr(request.app.get("state"), "sessions", None)
+            if sessions is not None:
+                # Resolution reads every mapped session's metadata line off disk;
+                # off the loop so a large history does not park the gateway.
+                owned = await asyncio.get_running_loop().run_in_executor(
+                    None, app_conversation_keys, name
+                )
+                for key in owned:
+                    try:
+                        await sessions.discard_conversation(key)
+                        dropped += 1
+                    except Exception:  # noqa: BLE001 — bookkeeping must not fail an uninstall
+                        logger.warning(
+                            "could not drop the resume pointer for %r", key, exc_info=True
+                        )
     if not result.ok:
         sel().log_api_access(
             caller="dashboard",
@@ -1352,6 +1397,9 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     # leftover tabs UNDISMISSABLE -- `notify_slot_closed` returns False when the
     # hook raises and `api_chat_slot_delete` refuses the close on that.
     forget_app_hooks(name)
+
+    if dropped:
+        uninstall_log.append(f"Dropped {dropped} conversation pointer(s)")
 
     # Step 6: Clean up workspace (each registry app has its own workspace)
     if is_registry_source(info.get("source", "")):

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -30,6 +30,7 @@ from kiro_crew.agent import reset_agent_model
 from kiro_crew.apps.bridges import (
     deregister_app,
     deregister_app_crons_from_service,
+    discard_app_session_pointers,
     register_app,
     register_app_crons_with_service,
 )
@@ -940,7 +941,15 @@ def _handle_app(args: argparse.Namespace) -> None:
         keep_data = not getattr(args, "purge_data", False)
         result = uninstall_app(args.name, keep_data=keep_data)
         if result.ok:
+            # AFTER success, matching this function's trust-grant reasoning: a
+            # failed uninstall leaves nothing changed, so a still-installed app
+            # keeps the pointers its slots are still entitled to resume. Returns
+            # 0 and says why when a gateway holds the lock — it owns
+            # session_map.json single-writer, so this process must not write it.
+            dropped = discard_app_session_pointers(args.name)
             print(f"✅ {result.message}")
+            if dropped:
+                print(f"   dropped {dropped} conversation pointer(s) — a reinstall starts fresh")
         else:
             print(f"❌ {result.error}", file=sys.stderr)
             sys.exit(1)

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -962,7 +962,7 @@ class SessionMap:
         return entry.get("provider", "")
 
     @_guarded
-    def clear_sid(self, key: str) -> None:
+    def clear_sid(self, key: str) -> bool:
         """Clear the stored session ID without removing the entry.
 
         Used on provider switch (the SID is incompatible with the new
@@ -970,12 +970,20 @@ class SessionMap:
         is stashed as ``discarded_sid`` so the operation is diagnosable and
         manually reversible — the native conversation still exists on disk;
         only the pointer to it is dropped.
+
+        Returns whether a pointer was actually dropped, so a caller clearing a
+        SET of keys can report how many conversations it orphaned without a
+        second lookup. ``get`` is the wrong probe for that: it gates on the
+        transcript file existing and prunes stale entries as a side effect, so
+        it answers "is this resumable" rather than "is a pointer recorded".
         """
         entry = self._data.get(canonical_key(key))
         if entry and entry.get("sid"):
             entry["discarded_sid"] = entry["sid"]
             entry["sid"] = ""
             self._save()
+            return True
+        return False
 
     def get_discarded_sid(self, key: str) -> str:
         """Return the last sid dropped by :meth:`clear_sid`, or ''."""

--- a/test/test_app_slot_ownership.py
+++ b/test/test_app_slot_ownership.py
@@ -1,0 +1,241 @@
+"""Uninstalling an app drops its conversations' resume pointers.
+
+The bug: a slot key an app chooses is often DETERMINISTIC — one slot per object it
+tracks, named after that object. ``session.py``'s
+``resume_sid = self._session_map.get(key)`` therefore hands the next slot under that
+name the PREVIOUS conversation, which is correct while the app is installed and wrong
+once it is gone: reinstall, open the same object, and the first turn resumes a
+transcript from code that no longer exists.
+
+Two things decide whether a fix works, and each has its own load-bearing negative.
+
+**Where ownership is read from.** It must outlive the tab, because a closed app slot
+is the mainline state before an uninstall — the user closes it, then uninstalls.
+``_ChatSlot._app`` dies with the gateway and a closed slot leaves ``_slots`` in a
+running one; ``open_slots.json`` is no better, since it tracks tabs to REOPEN and a
+closed slot leaves it at the next flush while the resume pointer deliberately stays.
+The record that already survives both is the conversation's own metadata line, which
+every save — including the save that closes a tab — stamps with ``app``.
+
+**Who does the writing.** ``SessionMap``'s rule 3: a throwaway instance is READ-ONLY,
+because two instances that loaded ``_data`` independently do not merge — each write
+is a whole-file rewrite of one snapshot. So the in-gateway path clears through the
+LIVE map, and the gateway-less CLI path refuses outright while a gateway is up rather
+than drop rows that map has not flushed.
+
+The third negative is the disable path: ``deregister_app`` runs on disable too, and
+App Store Sync is a disable/enable pair, so cleaning up there would discard every
+long-lived conversation's accumulated context on every sync.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from kiro_crew.apps import bridges
+from kiro_crew.gateway_lock import GatewayLock
+from kiro_crew.history import transcript_stem
+from kiro_crew.session_map import SessionMap
+
+APP = "acme-app"
+OWNED = "dashboard:acme-run-abc"
+OWNED2 = "dashboard:acme-run-def"
+MINE = "dashboard:chat-1-mine"
+
+
+def _seed_transcript(tmp_path: pathlib.Path, key: str, *, app: str = "", closed: bool = False):
+    """Write the metadata line a real save would write for *key*.
+
+    Only the first line matters here: ownership is read from the metadata line, so
+    this is the same shape ``chat_persistence`` emits (``app`` present only when the
+    slot has an owner, exactly as it writes it).
+    """
+    meta: dict = {"_type": "metadata", "created_at": "2026-01-01T00:00:00Z"}
+    if app:
+        meta["app"] = app
+        meta["origin"] = "app"
+    if closed:
+        meta["closed"] = True
+    sessions = tmp_path / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / f"{transcript_stem(key)}.jsonl").write_text(
+        json.dumps(meta) + "\n", encoding="utf-8"
+    )
+
+
+def _stored_sid(tmp_path: pathlib.Path, key: str) -> str:
+    """The sid recorded for *key*, read straight off disk.
+
+    Not ``SessionMap.get``: that answers "is this resumable" — it stats the
+    transcript file and prunes stale rows as a side effect — while these tests are
+    about what is RECORDED.
+    """
+    raw = json.loads((tmp_path / "session_map.json").read_text(encoding="utf-8"))
+    return str((raw.get(key) or {}).get("sid") or "")
+
+
+def test_ownership_is_recovered_from_the_conversation_s_own_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    smap = SessionMap()
+    smap.set(OWNED, "sid-app", provider="acp")
+    smap.set(MINE, "sid-mine", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+    _seed_transcript(tmp_path, MINE)
+
+    assert bridges.app_conversation_keys(APP) == [OWNED], (
+        "ownership must come from the metadata line; a user's own tab has no app "
+        "and must not be swept up with the app's"
+    )
+
+
+def test_a_slot_the_user_closed_before_uninstalling_is_still_found(tmp_path, monkeypatch):
+    """The regression that killed the previous approach.
+
+    Sourcing ownership from live slots or from ``open_slots.json`` finds nothing
+    here — there is no live state at all and the tab is closed — while the resume
+    pointer is deliberately preserved across close. This is the MAINLINE state
+    before an uninstall, not an edge case: the user closes the tab, then uninstalls.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    SessionMap().set(OWNED, "sid-app", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP, closed=True)
+
+    assert bridges.app_conversation_keys(APP) == [OWNED]
+
+
+def test_another_app_s_conversations_are_left_alone(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    smap = SessionMap()
+    smap.set(OWNED, "sid-app", provider="acp")
+    smap.set(OWNED2, "sid-other", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+    _seed_transcript(tmp_path, OWNED2, app="other-app")
+
+    assert bridges.app_conversation_keys(APP) == [OWNED]
+    assert bridges.app_conversation_keys("other-app") == [OWNED2]
+    assert bridges.app_conversation_keys("never-installed") == []
+
+
+def test_only_conversations_that_still_hold_a_pointer_are_listed(tmp_path, monkeypatch):
+    """The index is exactly as wide as the problem: no sid, nothing to resume.
+
+    ``OWNED2`` here is a row that EXISTS but has already had its pointer dropped —
+    what ``clear_sid`` leaves behind, and what a poisoned-conversation escalation
+    produces in the wild. Listing it would report a drop that did not happen.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    smap = SessionMap()
+    smap.set(OWNED, "sid-app", provider="acp")
+    smap.set(OWNED2, "sid-gone", provider="acp")
+    smap.clear_sid(OWNED2)
+    _seed_transcript(tmp_path, OWNED, app=APP)
+    _seed_transcript(tmp_path, OWNED2, app=APP)
+
+    assert bridges.app_conversation_keys(APP) == [OWNED]
+
+
+def test_the_cli_path_drops_the_pointer_when_no_gateway_owns_the_map(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    smap = SessionMap()
+    smap.set(OWNED, "sid-app", provider="acp")
+    smap.set(MINE, "sid-mine", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+    _seed_transcript(tmp_path, MINE)
+
+    assert bridges.discard_app_session_pointers(APP) == 1
+
+    assert _stored_sid(tmp_path, OWNED) == "", (
+        "the app's conversation pointer must be gone, or a reinstall resumes a "
+        "transcript from the previous installation"
+    )
+    assert _stored_sid(tmp_path, MINE) == "sid-mine", "an unowned session must be untouched"
+
+
+def test_the_cli_path_declines_while_a_gateway_owns_the_map(tmp_path, monkeypatch):
+    """A detached write here would be worse than doing nothing.
+
+    A running gateway holds a long-lived map whose ``_data`` loaded at startup;
+    every write rewrites the whole file from that snapshot. So this process's write
+    would be undone by the live map's next mutation (restoring the pointer) AND
+    would drop whatever that map recorded since this process read — costing an
+    unrelated session its sid or its channel link. Leaving the pointer is the
+    pre-existing behaviour; corrupting a stranger's session is not.
+
+    The lock is really HELD here, not stubbed. That is what makes this a test of
+    mutual exclusion rather than of a question asked before acting — a gateway
+    starting between such a question and the write would walk straight into the
+    case the question was meant to exclude.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    SessionMap().set(OWNED, "sid-app", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+
+    with GatewayLock(tmp_path):  # stands in for a running gateway
+        assert bridges.discard_app_session_pointers(APP) == 0
+
+    assert _stored_sid(tmp_path, OWNED) == "sid-app"
+
+
+def test_the_cleared_pointer_stays_diagnosable(tmp_path, monkeypatch):
+    """``clear_sid``, not ``delete``: the entry (and its Slack linkage) survives and
+    the dropped value is stashed, so this is reversible by hand."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    SessionMap().set(OWNED, "sid-app", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+
+    bridges.discard_app_session_pointers(APP)
+
+    assert SessionMap().get_discarded_sid(OWNED) == "sid-app"
+
+
+def test_deregister_does_NOT_drop_pointers(tmp_path, monkeypatch):
+    """The one that matters. ``deregister_app`` runs on DISABLE — the CLI's disable
+    action, the disable route, and the enable/update reconcile — and App Store Sync
+    is a disable/enable pair. Clearing pointers there would discard every long-lived
+    conversation's accumulated context on every sync."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    SessionMap().set(OWNED, "sid-app", provider="acp")
+    _seed_transcript(tmp_path, OWNED, app=APP)
+
+    bridges.deregister_app(APP)
+
+    assert _stored_sid(tmp_path, OWNED) == "sid-app", (
+        "disable must preserve the conversation; App Store Sync disables and "
+        "re-enables, and a long-lived per-object conversation would lose its "
+        "accumulated context on every sync"
+    )
+
+
+def test_the_in_gateway_path_clears_inside_the_lock_via_the_live_map(tmp_path):
+    """Two invariants of the in-gateway path, pinned where they are easy to undo.
+
+    It must clear through the LIVE map (``sessions.discard_conversation``) — a
+    throwaway instance's write is reversed by the live map's next mutation and takes
+    unflushed rows with it (``SessionMap``'s rule 3), and it also tears the live
+    session down so a still-open tab cannot re-record a sid on its next turn.
+
+    And it must run INSIDE ``app_lifecycle_lock``: outside it, a concurrent reinstall
+    of the same app can take that lock the moment this handler releases it and be
+    serving the same slot key again before the clear lands, so the pointer dropped
+    is the NEW installation's.
+    """
+    src = (
+        pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "apps" / "routes.py"
+    ).read_text(encoding="utf-8")
+    handler = src.split("async def handle_uninstall_app", 1)[1].split("\nasync def ", 1)[0]
+
+    assert "discard_conversation(" in handler, "the in-gateway path must use the live map"
+    assert "discard_app_session_pointers" not in handler, (
+        "that helper writes under the gateway lock this very process holds, so it "
+        "would decline; the in-gateway path must use the live map"
+    )
+
+    lock_open = handler.index("async with app_lifecycle_lock(name):")
+    # The lock body is indented past its ``async with``; the first line back at that
+    # statement's own indent ends the block.
+    lock_end = handler.index("\n    if not result.ok:", lock_open)
+    assert lock_open < handler.index("discard_conversation(") < lock_end, (
+        "the clear must run inside the lifecycle lock — outside it a concurrent "
+        "reinstall can be serving the same slot key before the clear lands"
+    )


### PR DESCRIPTION
## What

Uninstalling an app now drops the resume pointer of every conversation it owned, so a
reinstall starts fresh instead of resuming the previous installation's transcript.

## Why

An app's slot key is often DETERMINISTIC — one slot per object it tracks, named after
that object — so `session.py`'s `resume_sid = self._session_map.get(key)` hands the
next slot under that name the previous kiro-cli conversation. That is correct while
the app is installed: it is how a long-lived per-object conversation keeps what it has
learned about that object. It stops being correct once the app is gone — reinstall it,
open the same object, and the first turn resumes a transcript from code that no longer
exists.

## Where ownership is read from

Each conversation's own metadata line, which every save — **including the save that
closes a tab** — stamps with the owning app.

It has to be a record that outlives the tab, because a closed app slot is the
*mainline* state before an uninstall (the user closes it, then uninstalls). Live
`_ChatSlot._app` is gone by then, and `open_slots.json` is no better: it tracks tabs
to REOPEN, so a closed slot leaves it at the next flush while `SessionManager.remove`
deliberately preserves the resume pointer.

The scan is scoped to session-map keys that still hold a sid, which makes the index
exactly as wide as the problem: a pointer exists only if a conversation was started,
and starting one writes the line this reads.

## Who does the writing

`SessionMap`'s rule 3 makes a throwaway instance READ-ONLY — two instances that loaded
`_data` independently do not merge, since each write is a whole-file rewrite of one
snapshot. So the two paths differ:

**In-gateway (uninstall route)** clears through the live map via
`SessionManager.discard_conversation`. A detached write would be reversed by the live
map's next mutation and would take rows it has not flushed with it;
`discard_conversation` additionally tears the live session down, so a still-open tab
cannot re-record a sid and silently undo this. It runs **inside
`app_lifecycle_lock`** — this is a step of the uninstall, not an epilogue, and outside
the lock a concurrent reinstall can take it and be serving the same slot key again
before the clear lands, making the dropped pointer the *new* installation's.

**Gateway-less (`kirocrew app uninstall`)** writes its own `SessionMap` while
**holding `GatewayLock`** across the scan and the write, and declines when it cannot
take it. Merely asking whether a gateway is up cannot establish the exclusion: one
starting between the question and the write lands in exactly the case the question was
meant to rule out. Taking the lock the gateway itself takes makes it real both ways —
while we hold it no gateway can start, and if one is already up we decline. The write
is flushed before release, so durability-before-unlock is an invariant rather than a
property inherited from off-loop writes happening to be inline.

## The load-bearing negative

Not hung off `deregister_app`, even though both uninstall paths call it. That also runs
on **disable** — and App Store Sync is a disable/enable pair, so cleaning up there
would discard every long-lived conversation's accumulated context on every sync.
`test_deregister_does_NOT_drop_pointers` pins it, because moving the call there is
exactly the "simplification" someone will later reach for.

`clear_sid`, not `delete`: the entry also carries the Slack thread/channel linkage and
the reverse index built from it, so dropping the row would silently unlink a mirrored
session. The dropped value is stashed as `discarded_sid`, so this is diagnosable and
reversible by hand; the transcript itself is untouched.

## Costs, stated rather than hidden

- A gateway attempting to start inside the CLI path's lock window is refused as it
  would be by any other holder. The window is one scan plus one write; the alternative
  is losing an unrelated session's row.
- A conversation whose transcript has been deleted while its session-map row survives
  is not found, so it keeps its pointer. Narrower than what a tab-snapshot source
  missed, and it fails toward the pre-existing behaviour.

## Verification

- 9 tests, **8/8 mutations caught** — including "source ownership from live slots"
  (turns the closed-slot test red), "downgrade the lock hold to a probe", "move the
  cleanup back outside the lifecycle lock", "delete instead of `clear_sid`", "move the
  cleanup back into `deregister_app`", and "revert the in-gateway path to the
  throwaway-map helper".
- The gateway-up test really holds `GatewayLock` rather than stubbing a predicate, so
  it tests mutual exclusion instead of a sampled answer.
- Empirically checked against a real data home before choosing the source: the
  metadata line recovers ownership for 12 conversations across 3 apps, 6 of them
  `closed=True` — the population a tab snapshot cannot see.
- `flake8` / `mypy` (1083 files) / `isort` / black gate / `docs-lint.sh` clean;
  895 passed across every touched module's existing tests.
- `app-kit-platform.md` records uninstall step 6, the ownership source, and both
  writer paths in the same commit.

**Why no screenshot:** backend and CLI only — no user-visible frontend surface changes.
