### PR TITLE
test: exempt feishu from the messaging pre-turn ratchet (#5483)

### DIFF
--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -243,7 +243,13 @@ class TestPreTurnRatchet:
         # obstacle -- its _handle_busy mirrors webex's, so migration looks
         # mechanical -- but it is still a behaviour change that gets its own
         # review, not a rider in a main-red unblock (#5448).
-        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
+        # feishu is exempt on the same basis as whatsapp: its dispatcher runs
+        # its own pre-turn sequence with its own busy check (is_busy ->
+        # _handle_busy, then maybe_rotate). There is no structural obstacle to
+        # a later migration -- its _handle_busy mirrors webex's -- but folding
+        # it into the helper is a behaviour change that gets its own review,
+        # not a rider in a main-red unblock (#5483).
+        exempt = {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp", "feishu"}
         rostered = {d.channel_type for d in builtin_channel_descriptors()}
         unaccounted = rostered - set(_PRE_TURN_CHANNELS) - exempt
         assert not unaccounted, (


### PR DESCRIPTION
## Problem / Motivation

The pre-turn ratchet test fails on the current `main` tip (`71134ec3`):

```
AssertionError: channels neither using messaging.pre_turn nor listed exempt: ['feishu']
```

`builtin_channel_descriptors()` rosters `feishu` (`src/kiro_crew/channels.py:62`), but it appears in neither of the two lists the ratchet accepts: it is not in `_PRE_TURN_CHANNELS` (`test/test_messaging_pre_turn.py:198`, `("webex", "imessage")`) and it is not in the exempt set (`test/test_messaging_pre_turn.py:246`).

## Why it matters

The backend suites run only on `pull_request` merge refs, never on pushes to `main`, so `main` carries this failure invisibly — and every open PR inherits a red Backend Tests shard 3 (Linux 3.10 and Windows). This is the third instance of one cross-merge class: the ratchet arrived in #5379 after `feishu` (#4282) and `whatsapp` (#5114) had merged against bases that predated it. The whatsapp half was #5448, fixed by PR #5460.

## What changed (motivation → approach → change)

Symptom: shard 3 red on every PR → root cause: `feishu` rostered but unaccounted for in the ratchet → change: add `"feishu"` to the exempt set with a recorded rationale, following the #5448/#5460 whatsapp precedent exactly.

**Why exemption rather than migration:** `feishu`'s dispatcher has the same shape whatsapp's did — it runs its own pre-turn sequence rather than the shared `resolve_pre_turn`:

- `src/kiro_crew/feishu/transport_dispatch.py:134-135` — its own busy check (`is_busy` → `_handle_busy`)
- `src/kiro_crew/feishu/transport_dispatch.py:143` — its own `maybe_rotate(...)`
- `src/kiro_crew/feishu/transport_dispatch.py:128` and `:366` — its own `clear_awaiting(route)`
- `src/kiro_crew/feishu/transport_dispatch.py:234-238` — `_handle_busy` re-checks `is_busy`, mirroring webex's

There is no structural obstacle to a later migration, but folding feishu into `resolve_pre_turn` is a behaviour change that deserves its own review with its own tests, not a rider inside a main-red unblock. The migration is **deliberately deferred**; the rationale comment in the exempt list records this with a reference to #5483. Exempting keeps "not yet migrated" an explicit, commented decision — exactly what the ratchet exists to force.

`feishu` is intentionally NOT added to `_PRE_TURN_CHANNELS`: the three parametrized `TestPreTurnRatchet` tests would then run against a dispatcher that fails two of them, converting one red into two.

## Tests

- `test/test_messaging_pre_turn.py::TestPreTurnRatchet::test_every_rostered_channel_is_accounted_for` — the previously failing selector, now green; its assertion enumerates the full rostered set, so a green run also proves no other channel became newly unaccounted for.
- Whole file green: 13 passed.
- Full backend suite run locally: no failures attributable to this diff (remaining failures reproduce identically on base `71134ec3` — environment-specific: AF_UNIX path length, host core-count assumptions).

## Manual verification

N/A — unit coverage sufficient: the change is one element in a test-file exempt set plus its rationale comment; the ratchet test itself is the verification.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no user-visible UI surface is touched.

## Related Issues

Fixes #5483

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test rationale comment carries the record
- [x] No secrets, credentials, or internal references in the diff
