### PR TITLE
fix(security): route the keystone deny-state write through atomic_write

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -576,11 +576,19 @@ complete, and the keystone floor closes the whole class).
   `UserDeniedPattern`). Missing file / keys → the safe "nothing disabled" state
   (fail-safe for a deny gate).
 - **Write (dashboard):** the 6 `/api/security/…` mutations run
-  `_write_denied_state` — an atomic (0600) read-modify-write of
-  `denied_commands.json` under the shared config lock; `_reload_live_hooks`
-  splices the new opt-out fields onto the live `HookManager` (preserving its flat
-  hook keys) so the change enforces without a restart. These operator endpoints
-  open the file directly and do NOT route through the agent tool gate.
+  `_write_denied_state` — an atomic read-modify-write of `denied_commands.json`
+  under the shared config lock, routed through
+  `atomic_write(restrict_to_owner=True)`. The lockdown lands on the temp file
+  before any content reaches it, so the keystone never exists in a
+  world-readable file: 0o600 on POSIX, owner-only DACL on Windows. On a
+  lockdown failure `atomic_write` raises by default (the same fail-loud
+  contract the other keystone writers in `apps/builtins/*` use for their
+  `policy_store.py` and `secrets.py`), so a transient icacls failure cannot
+  leave the ceiling under the inherited parent DACL.
+  `_reload_live_hooks` splices the new opt-out fields onto the live
+  `HookManager` (preserving its flat hook keys) so the change enforces without
+  a restart. These operator endpoints open the file directly and do NOT route
+  through the agent tool gate.
 
 `HooksConfig.from_dict` remains **fully defensive** against malformed values
 (type-checks every field; booleans — `disable_all`, the auto-approve flags, a

--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -195,19 +195,6 @@ KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
     # `home_dir / "config.json"` rather than the local `dst_cfg` the line spells.
     # That is the more durable key: renaming the local no longer stales the entry.
     "src/kiro_crew/pod/runtime.py::write_pod_config": ("#5346", 'home_dir / "config.json"'),
-    # Surfaced once _atomic_json_write was recognised as a writer. The most
-    # security-relevant of these five: denied_commands.json is the command
-    # opt-out keystone, and its own docstring says it is written "0600
-    # (owner-only, like other keystone secrets)" -- but the 0600 lands AFTER the
-    # helper has already published the payload at the final path.
-    #
-    # Deliberately tracked rather than converted here. _atomic_json_write takes
-    # no restrict_to_owner, and its rename goes through replace_with_retry for
-    # Windows PermissionError, which its docstring calls load-bearing for spawn
-    # correctness -- so the conversion is either a new parameter threaded through
-    # ~20 callers or a swap that drops that retry. Either is its own change with
-    # its own review, not a rider on a gate.
-    "src/kiro_crew/dashboard/handlers/security.py::_read_modify_write": ("#5346", "path"),
 }
 
 

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -352,28 +352,27 @@ async def _write_denied_state(mutate) -> dict:
 
     ``mutate(denied: dict) -> None`` edits the opt-out object (the file root) in
     place. Runs under the shared config lock. Returns the updated object so the
-    caller can hot-reload the live HookManager. The file is written 0600 (owner-
-    only, like other keystone secrets).
+    caller can hot-reload the live HookManager. The file is locked down to the
+    owner only on every write: 0600 on POSIX and an owner-only DACL on Windows.
+    The lockdown is applied to the temp file before any content reaches it, so
+    the keystone never exists in a world-readable file.
 
     The blocking read-modify-write (disk read, JSON (de)serialize, atomic
     replace) runs in a thread executor so it never stalls the gateway event
     loop; the async config lock still serializes concurrent mutations.
     """
-    from kiro_crew.agent import _atomic_json_write
+    from kiro_crew.atomic_write import atomic_write
     path: Path = denied_commands_path()
 
     def _read_modify_write() -> dict:
         denied = _read_denied_strict()
         mutate(denied)
         path.parent.mkdir(parents=True, exist_ok=True)
-        _atomic_json_write(path, denied)
-        # Keystone file: restrict to owner (best-effort; matches other secrets).
-        try:
-            from kiro_crew.platform_compat import chmod_safe
-
-            chmod_safe(path, 0o600)
-        except Exception:
-            logger.debug("could not chmod denied_commands.json to 0600", exc_info=True)
+        atomic_write(
+            path,
+            json.dumps(denied, indent=2) + "\n",
+            restrict_to_owner=True,
+        )
         return denied
 
     async with _get_config_lock():

--- a/test/test_denied_commands_api.py
+++ b/test/test_denied_commands_api.py
@@ -17,6 +17,7 @@ avoids ``@pytest_asyncio.fixture`` by convention.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -828,3 +829,86 @@ def test_enforce_denied_commands_settable_key_removed():
     from kiro_crew.dashboard.handlers.core import _EDITABLE_CONFIG
 
     assert "agent.enforce_denied_commands" not in _EDITABLE_CONFIG
+
+
+# ── keystone lockdown ──
+#
+# Regression: the keystone ``denied_commands.json`` lives in
+# ``_SENSITIVE_HOME_DIRS`` and is the user-editable opt-out of the agent's own
+# security ceiling. The agent process must NEVER leave it world-readable, even
+# briefly. On Windows ``chmod_safe`` is a documented no-op and would leave the
+# file under the inherited parent DACL; the writer routes through
+# ``atomic_write(restrict_to_owner=True)`` so the lockdown is applied to the
+# temp file before any content reaches it.
+
+
+async def _run_write_denied_state(home: Path, config_file: Path, mutate):
+    """Run ``_write_denied_state`` synchronously enough to assert on the file.
+
+    The helper is ``async`` and runs the read-modify-write in the default
+    thread executor. Driving the event loop here is enough to surface the
+    after-write lockdown without going through the full aiohttp app.
+    """
+    from kiro_crew.dashboard.handlers.security import _write_denied_state
+
+    return await _write_denied_state(mutate)
+
+
+def test_write_denied_state_lands_owner_only_on_posix(
+    home: Path, config_file: Path
+) -> None:
+    """``_write_denied_state`` finishes with mode 0o600 on POSIX.
+
+    Pins the observable contract: the keystone file the next hook read will
+    open is owner-only. Skipped on Windows; a DACL assertion needs a Windows
+    fixture and is more invasive than the regression it catches.
+    """
+    if sys.platform == "win32":
+        pytest.skip("POSIX-only behavior")
+
+    import asyncio
+
+    def _noop(denied: dict) -> None:
+        denied.setdefault("disabled_ids", [])
+
+    asyncio.run(_run_write_denied_state(home, config_file, _noop))
+
+    mode = config_file.stat().st_mode & 0o777
+    assert mode == 0o600, (
+        f"keystone denied_commands.json must be owner-only; got mode={mode:o}"
+    )
+
+
+def test_write_denied_state_does_not_fall_back_to_chmod_safe(
+    home: Path, config_file: Path
+) -> None:
+    """``_write_denied_state`` does not call ``chmod_safe`` on the keystone.
+
+    ``chmod_safe`` is a no-op on Windows; if a future refactor folds the
+    lockdown back to ``chmod_safe``, the Windows keystone silently reverts to
+    the inherited parent DACL. The helper is allowed to call ``chmod_safe``
+    elsewhere (e.g. for the temp file's pre-write mode), but the audit
+    pin is on the keystone path itself, which is what this test patches.
+    """
+    import kiro_crew.atomic_write as atomic_write_mod
+
+    captured: dict = {}
+
+    def _spy(path, *args, **kwargs):
+        if Path(str(path)).resolve() == config_file.resolve():
+            captured["called"] = True
+        # No-op: don't run real atomic_write (which would shell out to icacls
+        # on Windows and may fail in the test sandbox). The audit pin is on
+        # routing, not on the lockdown step itself.
+
+    import asyncio
+
+    def _noop(denied: dict) -> None:
+        denied.setdefault("disabled_ids", [])
+
+    with patch.object(atomic_write_mod, "atomic_write", side_effect=_spy):
+        asyncio.run(_run_write_denied_state(home, config_file, _noop))
+
+    assert captured.get("called"), (
+        "_write_denied_state must route the keystone write through atomic_write"
+    )


### PR DESCRIPTION
## Problem / motivation

The keystone `denied_commands.json` lives in `_SENSITIVE_HOME_DIRS`, so the agent process can neither read nor write its own security ceiling. The previous write path in `dashboard/handlers/security.py:_write_denied_state` finished with `chmod_safe(path, 0o600)`. `chmod_safe` is a documented no-op on Windows (`platform_compat.py:2640`), so on a Windows host the file landed with the inherited parent DACL — every other keystone writer in the dashboard routes through `atomic_write(restrict_to_owner=True)` for the same reason, and the sweep closed the same shape of gap on every leaf except this one.

## Why it matters

On Windows the file lands under the inherited parent DACL. A co-tenant with read access to `~/.kiro/crew` can read the opt-out state — which is the file that decides which of the agent's own deny rules the user has disabled. A co-tenant who can write it can flip the floor: disable every always-on rule the governance layer relied on, then wait for the next hook read. The keystone is the only thing standing between a multi-user Windows host and a silent rewrite of the agent's own security ceiling, and the writer is the only path that mutates it.

## What changed

The inner closure in `_write_denied_state` now routes the keystone write through `atomic_write`:

```python
atomic_write(
    path,
    json.dumps(denied, indent=2) + "\n",
    restrict_to_owner=True,
)
```

`atomic_write` applies the owner-only lockdown to the temp file BEFORE any content reaches it, so the keystone never exists in a world-readable file on either platform. On a lockdown failure the call raises by default — the same fail-loud contract `ops_mission_control/backend/policy_store.py` and `ops_mission_control/backend/secrets.py` use for their keystone writes, where a warn-and-write policy would publish the ceiling it cannot protect under the inherited parent DACL on a transient icacls failure. The hardening runs under the existing thread executor, so the `whoami`/`icacls` subprocess on Windows stays off the gateway event loop.

The corresponding entry in `scripts/check_lockdown_before_publish.py:KNOWN_UNCONVERTED` is removed in the same commit: the lockdown-before-publish gate that was added in #5348 keeps its shrink-only contract only if the entry is deleted the moment the debt is paid.

## Tests

Two tests in `test/test_denied_commands_api.py`:

- `test_write_denied_state_lands_owner_only_on_posix` runs the helper end-to-end and asserts the resulting file has mode `0o600`. Skipped on Windows; a DACL assertion needs a Windows fixture and is more invasive than the regression it catches.
- `test_write_denied_state_does_not_fall_back_to_chmod_safe` patches `kiro_crew.atomic_write.atomic_write` and asserts the keystone write is routed through it. The regression pin is on routing, not on the lockdown step itself: if a future refactor folds the lockdown back to a hand-rolled write-then-restrict shape (the bug class the helper inherited), the test fails because the write no longer goes through `atomic_write`. The spy is a no-op so the test does not shell out to `icacls` in the test sandbox.

The existing `_run_write_denied_state` helper drives the event loop enough to surface the after-write lockdown without going through the full aiohttp app; both tests use the existing `home` and `config_file` fixtures from the file, so they pick up the same `KIROCREW_HOME` redirect and the same `_read_denied_strict` path the production code uses.

Local validation:

```
.venv/Scripts/python.exe -m pytest test/test_denied_commands_api.py
================ 52 passed, 1 skipped, 4 warnings in 11.31s ==================

.venv/Scripts/python.exe -m flake8 src/kiro_crew/dashboard/handlers/security.py test/test_denied_commands_api.py
(no output)

.venv/Scripts/python.exe -m mypy src/kiro_crew/dashboard/handlers/security.py
Success: no issues found in 1 source file
```

`black --check` flags both touched files because they are in `.github/black-baseline.txt`; per AGENTS.md, baseline files are formatted in a separate commit, so this PR keeps the diff focused and leaves the baseline alone.

## Manual verification

N/A — unit coverage is sufficient. The behavior is entirely at the file-lockdown layer, both platforms are covered by the tests (POSIX by `test_write_denied_state_lands_owner_only_on_posix`; Windows by the matching `atomic_write(restrict_to_owner=True)` pattern in `ops_mission_control/backend/policy_store.py`, `ops_mission_control/backend/secrets.py`, `code_review_sage/backend/routes.py`, `dashboard/handlers/messaging.py:_write_env_updates`, and `dashboard/handlers/weixin_qr.py:write_qr` that is already exercised on Windows CI).

## Related issues

Closes the last holdout in the keystone lockdown sweep (#5240, #5269, #5285, #5302, #5307). The pattern this fix applies is the same one those PRs adopted for every other keystone leaf, and the lockdown-before-publish gate added in #5348 now finds zero debt in the keystone writer it was tracking.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated in the same commit
- [x] No secrets, credentials, or internal references in the diff