### PR TITLE
fix: isolate dep-sync interpreter probe from caller CWD and env (#5436)

### DIFF
--- a/src/kiro_crew/dep_sync.py
+++ b/src/kiro_crew/dep_sync.py
@@ -370,16 +370,43 @@ def requires_python(repo: Path) -> str | None:
     return cfg.get("options", "python_requires").strip() or None
 
 
-def interpreter_version(target_py: Path) -> tuple[int, int, int] | None:
-    """``(major, minor, micro)`` of *target_py*, or ``None`` if it cannot be asked."""
-    proc = subprocess.run(
-        [str(target_py), "-c", "import sys;print('%d.%d.%d' % sys.version_info[:3])"],
+def _probe_interpreter(target_py: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Run *code* under *target_py*, isolated from the caller's CWD and env.
+
+    Every probe here asks a question about the VENV -- where it resolves this
+    package, which interpreter version it runs, what its console script
+    dispatches to -- so the answer must not depend on the process asking.
+    Without isolation it does, by two routes: ``python -c`` puts the child's
+    CWD at ``sys.path[0]``, so a caller running from a checkout's ``src/``
+    (the Dev Fleet backend does) makes ``find_spec`` resolve this package from
+    that directory for ANY target interpreter; and the child inherits
+    ``PYTHONPATH``, which shadows site-packages the same way.
+
+    ``-I`` closes both routes at once -- no CWD entry on ``sys.path``, no
+    ``PYTHONPATH``, no user-site -- while still honoring the venv's own
+    site-packages, where an editable install's ``.pth`` lives. Because ``-I``
+    implies ``-E``, an encoding request must ride the argv rather than the
+    environment: ``-X utf8`` pins the child's stdout to UTF-8 (matching the
+    decode below) where a ``PYTHONIOENCODING`` entry would be ignored,
+    keeping a non-ASCII checkout path from mangling -- or crashing -- the
+    answer on a non-UTF-8 locale. ``cwd`` is pinned to the interpreter's own
+    directory as well: it keeps the child's working directory valid even when
+    the caller's has been deleted, and a venv's script directory holds
+    executables, never an importable package.
+    """
+    return subprocess.run(
+        [str(target_py), "-I", "-X", "utf8", "-c", code],
         capture_output=True,
-        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         text=True,
         encoding="utf-8",
         errors="replace",
+        cwd=Path(target_py).parent,
     )
+
+
+def interpreter_version(target_py: Path) -> tuple[int, int, int] | None:
+    """``(major, minor, micro)`` of *target_py*, or ``None`` if it cannot be asked."""
+    proc = _probe_interpreter(target_py, "import sys;print('%d.%d.%d' % sys.version_info[:3])")
     if proc.returncode != 0:
         return None
     try:
@@ -434,6 +461,12 @@ def installed_package_origin(target_py: Path) -> str | None:
     what the installed dependencies will be imported alongside, so it is the thing
     worth checking.
 
+    Runs through :func:`_probe_interpreter`, so the answer describes the venv
+    rather than the caller: an unisolated probe resolves the package from the
+    calling process's CWD (or a ``PYTHONPATH`` entry) ahead of the venv's
+    site-packages, and the consumer then refuses a perfectly healthy venv as
+    "serving a different checkout".
+
     Returns ``None`` when the package cannot be located at all -- including when
     the interpreter itself cannot be run. That case is not theoretical: the caller
     resolved this path by a filesystem check, and a venv deleted between that check
@@ -447,14 +480,7 @@ def installed_package_origin(target_py: Path) -> str | None:
         "print(os.path.abspath(s.origin) if s and s.origin else '')"
     )
     try:
-        proc = subprocess.run(
-            [str(target_py), "-c", probe],
-            capture_output=True,
-            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
+        proc = _probe_interpreter(target_py, probe)
     except OSError:
         return None
     if proc.returncode != 0:
@@ -652,14 +678,7 @@ def installed_console_script_target(target_py: Path, script: str) -> str | None:
         "print(next((e.value for e in d.entry_points"
         f" if e.group=='console_scripts' and e.name=={script!r}), ''))"
     )
-    proc = subprocess.run(
-        [str(target_py), "-c", probe],
-        capture_output=True,
-        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    proc = _probe_interpreter(target_py, probe)
     if proc.returncode != 0:
         return None
     return proc.stdout.strip() or None

--- a/test/test_dep_sync.py
+++ b/test/test_dep_sync.py
@@ -936,6 +936,80 @@ def test_installed_package_origin_fails_closed_on_an_unrunnable_interpreter(tmp_
     assert dep_sync.venv_not_mapped_to(None, tmp_path) is not None
 
 
+def _decoy_package(tmp_path):
+    """A directory holding a decoy ``kiro_crew`` package, as a checkout's src/ does."""
+    decoy = tmp_path / "decoy-src"
+    (decoy / "kiro_crew").mkdir(parents=True)
+    (decoy / "kiro_crew" / "__init__.py").write_text("", encoding="utf-8")
+    return decoy
+
+
+def test_origin_probe_ignores_a_decoy_package_in_the_callers_cwd(tmp_path, monkeypatch):
+    """The probe describes the venv, never the caller's working directory.
+
+    The reproduction from the field: the caller (the Dev Fleet backend) runs
+    with its CWD inside a checkout's ``src/``, which contains ``kiro_crew/``.
+    An unisolated ``python -c`` puts that CWD at ``sys.path[0]``, so
+    ``find_spec`` resolves the decoy for ANY target interpreter and the guard
+    refuses a healthy venv. The probe's answer must not be the decoy.
+    """
+    decoy = _decoy_package(tmp_path)
+    monkeypatch.chdir(decoy)
+
+    origin = dep_sync.installed_package_origin(Path(sys.executable))
+
+    # Whatever this interpreter genuinely serves (an editable install, or no
+    # install at all -> None), it is not the package sitting in the caller's CWD.
+    assert origin is None or not origin.startswith(str(decoy))
+
+
+def test_origin_probe_ignores_pythonpath(tmp_path, monkeypatch):
+    """The second route to the same false positive: an inherited PYTHONPATH.
+
+    PYTHONPATH entries rank ahead of site-packages, so a decoy on the caller's
+    PYTHONPATH shadows the venv's own install exactly like the CWD does. The
+    probe runs the interpreter isolated, so the inherited value is ignored.
+    """
+    decoy = _decoy_package(tmp_path)
+    monkeypatch.setenv("PYTHONPATH", str(decoy))
+
+    origin = dep_sync.installed_package_origin(Path(sys.executable))
+
+    assert origin is None or not origin.startswith(str(decoy))
+
+
+def test_every_interpreter_probe_runs_isolated_with_a_neutral_cwd(tmp_path):
+    """All three venv probes share the isolation, not just the origin one.
+
+    ``interpreter_version`` and ``installed_console_script_target`` ask the
+    same kind of question of the same interpreter; a probe left unisolated
+    would re-open the CWD/PYTHONPATH route this module just closed.
+    """
+    target = tmp_path / "venv" / "bin" / "python"
+    target.parent.mkdir(parents=True)
+    seen = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch.object(dep_sync.subprocess, "run", side_effect=fake_run):
+        dep_sync.interpreter_version(target)
+        dep_sync.installed_package_origin(target)
+        dep_sync.installed_console_script_target(target, "kirocrew")
+
+    assert len(seen) == 3
+    for cmd, kwargs in seen:
+        assert cmd[0] == str(target)
+        assert cmd[1] == "-I", "probe must run the interpreter isolated"
+        assert cmd[2:4] == ["-X", "utf8"], (
+            "-I implies -E, so the UTF-8 pin must ride the argv -- an env "
+            "PYTHONIOENCODING is ignored and a non-ASCII path would come "
+            "back locale-mangled"
+        )
+        assert kwargs.get("cwd") == target.parent, "probe needs a neutral cwd"
+
+
 def test_sync_captures_pip_output_instead_of_writing_it_to_stderr(tmp_path, capsys):
     """pip's output must reach ``emit``, never the inherited stderr.
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -693,9 +693,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # spelled out inline before, with the target read from sys.executable and
         # the repo from the operator-configured checkout. Sandboxing it now would
         # refuse a step every platform has always run unsandboxed.
-        "dep_sync.py::interpreter_version",
-        "dep_sync.py::installed_console_script_target",
-        "dep_sync.py::installed_package_origin",
+        #
+        # The three interpreter probes (interpreter_version,
+        # installed_package_origin, installed_console_script_target) share one
+        # fixed-argv helper, _probe_interpreter, which is where their single
+        # spawn now lives: `<target python> -I -X utf8 -c <fixed probe>` with a
+        # neutral cwd, so the answer describes the venv instead of the caller.
+        "dep_sync.py::_probe_interpreter",
         "dep_sync.py::sync",
         "dep_sync.py::sync_or_reinstall",
         # Foreground last-resort restart (Make Live on hosts with no drivable


### PR DESCRIPTION
## Summary

Dev Fleet's **Pull + Build** on the primary checkout was refused whenever the live gateway points at a feature worktree, with an error incorrectly blaming the target venv (#5436).

Root cause: the dep-sync interpreter probes ran `python -c` with no `cwd=` and an inherited environment. `python -c` puts the child's CWD at `sys.path[0]`, ahead of the venv's site-packages — and the Dev Fleet app backend's CWD is the live worktree's `src/` directory — so `importlib.util.find_spec('kiro_crew')` resolved the worktree copy for **any** target interpreter. The consumer `venv_not_mapped_to` then refused a perfectly healthy venv as "serving a different checkout". An inherited `PYTHONPATH` produces the identical false positive by a second route.

## Change

- All three interpreter probes (`installed_package_origin`, `interpreter_version`, `installed_console_script_target`) now share one helper, `_probe_interpreter`, which runs the target interpreter with:
  - **`-I`** (isolated mode): no CWD `sys.path` entry, no `PYTHONPATH`, no user-site — while the venv's own site-packages and its editable `.pth` are still honored (`-I` implies `-s`, not `-S`).
  - **`-X utf8`** on the argv: `-I` implies `-E`, so a `PYTHONIOENCODING` env entry would be ignored; pinning UTF-8 via argv keeps a non-ASCII checkout path from coming back locale-mangled (or crashing the probe's `print`) on a non-UTF-8 locale — the same defect class by a third route.
  - **A neutral `cwd`** pinned to the interpreter's own directory: valid cross-OS (`bin/` on POSIX, `Scripts\` on Windows), survives a deleted caller CWD, and a venv's script directory holds executables, never an importable package.
- The guard `venv_not_mapped_to` is deliberately unchanged — only the probe feeding it now describes the venv instead of the caller.
- The spawn-audit allowlist keys spawn sites by innermost enclosing function, so its three per-probe entries collapse into the shared helper's single entry.

## Not in scope

The two `pip` subprocess sites in this module are deliberately untouched: they act on explicit argv targets and do not resolve the package by `sys.path`, so they are not in this defect class. No other `subprocess.run` site in the file probes an interpreter this way.

## Tests

Three regression tests in `test/test_dep_sync.py`:

1. **Decoy-CWD reproduction** (the exact field evidence from the issue): the probe runs with a CWD containing a decoy `kiro_crew/__init__.py` and must not report the decoy as origin.
2. **PYTHONPATH route**: a decoy on the caller's `PYTHONPATH` must be ignored the same way.
3. **All-probes argv pin**: every one of the three probes runs `-I -X utf8` with the neutral `cwd` (locks the shared helper's contract; fails on the pre-fix code where `cmd[1]` is `-c`).

Pre-push review: two model-pinned reviewer lanes (GPT + Opus mirrors of the CI review workflows). All findings adopted: the `-I`-implies-`-E` encoding gap (both lanes, independently) and the spawn-audit allowlist topology change (Opus). Local gates green on changed files: isort, flake8, mypy (0 issues in `dep_sync.py`), 70 tests passing across `test_dep_sync.py` + `test_spawn_audit.py`.

No linked UI change — backend-only fix, no screenshots.

Closes #5436
