### PR TITLE
fix(acp): execute slash commands natively on shared runtime (#4972)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -719,6 +719,55 @@ def _is_tool_interrupted_marker(chunk: str) -> bool:
     return chunk.strip() == _TOOL_INTERRUPTED_MARKER
 
 
+def format_command_result(result: dict) -> str:
+    """Extract displayable text from a commands/execute response.
+
+    Module-level (not a method) because both native slash-command paths need
+    it: AcpClient.stream_command (direct-spawn sessions) and
+    AcpSessionHandle.stream_command (shared-runtime sessions).
+
+    The output is two-pass redacted (URLs + credentials) HERE, in the shared
+    helper, so every present and future caller inherits the security control
+    (command output is backend-echoed text that reaches the dashboard) instead
+    of each call site re-discovering it. Call-site re-redaction stays
+    harmless — both passes are idempotent.
+    """
+    data = result.get("data")
+    message = result.get("message", "")
+    text = ""
+    # Structured data — format as readable JSON block
+    if isinstance(data, dict) and data:
+        # Filter out agent/model metadata (handled separately)
+        display = {k: v for k, v in data.items() if k not in ("agent", "model")}
+        if display:
+            block = json.dumps(display, indent=2)
+            text = (
+                f"{message}\n```json\n{block}\n```"
+                if message
+                else f"```json\n{block}\n```"
+            )
+    if not text:
+        text = message or ""
+    if text:
+        text, _ = redact_exfiltration_urls(text)
+        text, _ = redact_credentials(text)
+    return text
+
+
+def parse_slash_command(command: str) -> tuple[str, dict]:
+    """Parse ``/foo bar baz`` into TuiCommand ``(name, args)``.
+
+    Shared by AcpClient.stream_command and AcpSessionHandle.stream_command —
+    both send the OBJECT form (``{command, args}``) because kiro-cli 2.14.0
+    returns no response on the string form of ``_kiro.dev/commands/execute``.
+    """
+    parts = command.strip().split(None, 1)
+    name = parts[0].lstrip("/") if parts else command.lstrip("/")
+    value = parts[1] if len(parts) > 1 else None
+    args: dict = {"value": value} if value else {}
+    return name, args
+
+
 # Timeouts for session initialization steps
 _INIT_TIMEOUT = 240.0  # 4 min — MCP servers can be slow to initialize
 # set_mode/set_model: fire-and-forget.  kiro-cli accepts these commands
@@ -4256,7 +4305,7 @@ class AcpClient:
                 if extract_agent_from_result and isinstance(result, dict):
                     # commands/execute returns output in result fields,
                     # not via session/update chunks — yield as text.
-                    text = self._format_command_result(result)
+                    text = format_command_result(result)
                     if text:
                         yield AcpEvent(kind=EVENT_TEXT_CHUNK, text=text)
                     if not saw_agent_switch:
@@ -4620,7 +4669,7 @@ class AcpClient:
         self._cancelled = False
         await self.ensure_ready()
 
-        cmd_name, cmd_args = self._parse_slash_command(command)
+        cmd_name, cmd_args = parse_slash_command(command)
         req_id = await self._send_request(
             METHOD_COMMANDS_EXECUTE,
             {
@@ -4630,34 +4679,6 @@ class AcpClient:
         )
         async for event in self._dispatch_events(req_id, timeout, extract_agent_from_result=True):
             yield event
-
-    @staticmethod
-    def _format_command_result(result: dict) -> str:
-        """Extract displayable text from a commands/execute response."""
-        import json as _json
-
-        data = result.get("data")
-        message = result.get("message", "")
-        # Structured data — format as readable JSON block
-        if isinstance(data, dict) and data:
-            # Filter out agent/model metadata (handled separately)
-            display = {k: v for k, v in data.items() if k not in ("agent", "model")}
-            if display:
-                return (
-                    f"{message}\n```json\n{_json.dumps(display, indent=2)}\n```"
-                    if message
-                    else f"```json\n{_json.dumps(display, indent=2)}\n```"
-                )
-        return message or ""
-
-    @staticmethod
-    def _parse_slash_command(command: str) -> tuple[str, dict]:
-        """Parse ``/foo bar baz`` into TuiCommand ``(name, args)``."""
-        parts = command.strip().split(None, 1)
-        name = parts[0].lstrip("/") if parts else command.lstrip("/")
-        value = parts[1] if len(parts) > 1 else None
-        args: dict = {"value": value} if value else {}
-        return name, args
 
     async def cancel_session(self, grace_secs: float = 0.0) -> None:
         """Cancel the current in-flight operation via ACP session/cancel.

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -47,6 +47,8 @@ from kiro_crew.acp.client import (
     _is_safe_oauth_url,
     _is_tool_interrupted_marker,
     _raise_acp_error,
+    format_command_result,
+    parse_slash_command,
     prompt_timeout_for_ceiling,
     resolve_usable_model,
 )
@@ -66,6 +68,7 @@ from kiro_crew.acp.liveness import (
 from kiro_crew.acp.prompt_blocks import build_prompt_blocks
 from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
     EVENT_AGENT_SWITCHED,
     EVENT_CLEAR_STATUS,
     EVENT_COMPACTION_STATUS,
@@ -313,6 +316,20 @@ def _watchdog_evidence_class(evidence: str) -> str:
 # AcpClient's _CANCEL_GRACE_SECS floor without the process-kill (which is
 # impossible on a multiplexed runtime).
 _CANCEL_GRACE_SECS = 10.0
+# Commands that must stay on the PROMPT transport even where native
+# commands/execute is available: kiro-cli 2.14.0 exits rc=0 WITHOUT a response
+# on commands/execute for these (live-probe recorded in compact()'s docstring;
+# the probe covered the string form, and no probe exists for their object
+# form), and session.py's compaction flow additionally depends on watching
+# compaction status mid-PROMPT-stream. Routing them natively would leave the
+# dispatch loop draining an unanswered request until its deadline.
+_PROMPT_TRANSPORT_COMMANDS = frozenset({"compact", "help"})
+# Native command turns are bounded like send_command's 60s RPC wait, not like
+# a chat turn: commands/execute answers in well under a second, and neither
+# turn watchdog arms on a command turn (no text chunk streamed, no tool
+# dispatched), so an unanswered request would otherwise drain silently for the
+# full chat-turn ceiling (hours) while holding the session's turn slot.
+_COMMAND_TURN_TIMEOUT_SECS = 60.0
 # Post-compaction metadata grace: kiro-cli emits fresh _kiro.dev/metadata with
 # the real post-compaction contextUsagePercentage ~1s after the completed
 # status (live-probe confirmed). Mirrors AcpClient's constant.
@@ -637,6 +654,120 @@ class AcpSessionHandle:
         ``agent.chat_turn_timeout_secs`` so the transport wait follows a raised
         turn ceiling instead of cutting the turn at the 2h default underneath it.
         """
+
+        async def _build() -> tuple[str, dict[str, Any]]:
+            # Offloaded: the builder stats and reads image files (up to
+            # MAX_IMAGE_BYTES each) and base64-encodes them. Inline, that
+            # blocking I/O runs on the gateway loop and pauses every other
+            # session's streaming for the duration.
+            prompt_blocks = await asyncio.to_thread(
+                build_prompt_blocks,
+                message,
+                allow_image=self._runtime.supports_image_prompt,
+            )
+            return METHOD_PROMPT, {
+                "sessionId": self._session_id,
+                # An image reaches the model ONLY as an image block. Sending a
+                # local image path as a single text block would ship a
+                # filesystem path as prose (Slack, dashboard) and the model
+                # would never see the picture. Gated on the agent's advertised
+                # capability; when it is absent the path stays in the text as a
+                # tool-openable reference rather than being dropped.
+                "prompt": prompt_blocks,
+            }
+
+        # Explicit aclose in a finally: abandoning THIS wrapper (gen.aclose()
+        # at any yield) must finalize the inner turn generator NOW — its
+        # finally is what unmarks the turn and re-sets _turn_done. Left to the
+        # event loop's async-generator GC hook, the handle would read as
+        # turn-active until some later collection pass.
+        turn = self._run_turn(_build, timeout)
+        try:
+            async for event in turn:
+                yield event
+        finally:
+            await turn.aclose()
+
+    async def stream_command(
+        self, command: str, timeout: float | None = None
+    ) -> AsyncIterator[AcpEvent]:
+        """Execute a slash command natively and yield AcpEvents until it completes.
+
+        Sends ``_kiro.dev/commands/execute`` with the TuiCommand OBJECT form
+        (``{command, args}``) — kiro-cli 2.14.0 exits without a response on the
+        STRING form (see :meth:`compact`), so the object form is load-bearing —
+        and drains ``session/update`` events with the same turn discipline as
+        :meth:`prompt`. The command's own output arrives in the RESPONSE result
+        (message/data), not as update chunks, so the dispatch loop
+        surfaces it as a text chunk (``extract_command_result=True``). Mirrors
+        AcpClient.stream_command for the shared runtime.
+
+        Two carve-outs keep the PROMPT transport (delegate to :meth:`prompt`):
+
+        - ``_PROMPT_TRANSPORT_COMMANDS`` (/compact, /help) — kiro-cli 2.14.0
+          returns no response for these over commands/execute, and the
+          compaction flow (session.py, Slack !compact) depends on watching
+          ``compaction/status`` on the prompt stream.
+        - a non-kiro backend (KAS) — ``_kiro.dev/commands/execute`` is
+          kiro-cli-specific; KAS sessions keep degrading softly through
+          session/prompt instead of erroring on an unimplemented method.
+
+        The native turn is bounded at ``_COMMAND_TURN_TIMEOUT_SECS`` (matching
+        send_command's RPC wait) because neither turn watchdog arms on a
+        command turn; an explicit ``timeout`` still wins.
+        """
+        cmd_name, cmd_args = parse_slash_command(command)
+        # Positive capability gate: only the kiro harness implements
+        # _kiro.dev/commands/execute, so native execution requires
+        # acp_backend == ACP_BACKEND_KIRO — every other harness (KAS today,
+        # any harness added later) fails CLOSED onto the prompt transport
+        # instead of inheriting a kiro-only RPC (harness parity H5/H6).
+        native = (
+            self._runtime.acp_backend == ACP_BACKEND_KIRO
+            and cmd_name not in _PROMPT_TRANSPORT_COMMANDS
+        )
+        if not native:
+            async for event in self.prompt(command, timeout=timeout):
+                yield event
+            return
+
+        async def _build() -> tuple[str, dict[str, Any]]:
+            return METHOD_COMMANDS_EXECUTE, {
+                "sessionId": self._session_id,
+                "command": {"command": cmd_name, "args": cmd_args},
+            }
+
+        # Same deterministic finalization as prompt(): see the comment there.
+        turn = self._run_turn(
+            _build,
+            timeout if timeout is not None else _COMMAND_TURN_TIMEOUT_SECS,
+            extract_command_result=True,
+        )
+        try:
+            async for event in turn:
+                yield event
+        finally:
+            await turn.aclose()
+
+    async def _run_turn(
+        self,
+        build_request: Callable[[], Awaitable[tuple[str, dict[str, Any]]]],
+        timeout: float | None,
+        *,
+        extract_command_result: bool = False,
+    ) -> AsyncGenerator[AcpEvent, None]:
+        """Shared turn lifecycle for :meth:`prompt` and :meth:`stream_command`.
+
+        Owns the concurrent-turn guard, the per-turn state resets, the pre-turn
+        stale-frame drain, the request send, event dispatch, and turn-done
+        bookkeeping. ``build_request`` returns the JSON-RPC ``(method, params)``
+        to send; it runs BEFORE the turn is marked active (see the comment at
+        the send site below).
+
+        ``timeout=None`` (every dashboard turn) resolves from
+        ``agent.chat_turn_timeout_secs`` so the transport wait follows a raised
+        turn ceiling instead of cutting the turn at the 2h default underneath it.
+        """
         timeout = await _effective_prompt_timeout_async(timeout)
         # Guard against concurrent prompts on the same handle: a second call
         # would clear _turn_done and race on the shared _queue, corrupting
@@ -789,40 +920,21 @@ class AcpSessionHandle:
         # exception hierarchy. Re-raised unchanged, so cancellation still
         # propagates.
         try:
-            # Build the prompt blocks FIRST (the slow, cancellable part), then
-            # mark the turn active immediately before the write: a child
-            # permission frame read by the runtime between the write and the
-            # mark would otherwise be auto-answered as "between turns" even
-            # though this owner's turn had begun. Marking pre-build instead
-            # would claim an active turn during a long image-encoding stint
-            # in which nothing consumes the queue. The BaseException guard
-            # unmarks on any failure so a dead write cannot leave the session
-            # permanently routed-to.
-            _prompt_blocks = await asyncio.to_thread(
-                build_prompt_blocks,
-                message,
-                allow_image=self._runtime.supports_image_prompt,
-            )
+            # Build the request FIRST (for prompts, the slow, cancellable
+            # image-encoding part — see prompt()'s _build), then mark the turn
+            # active immediately before the write: a child permission frame
+            # read by the runtime between the write and the mark would
+            # otherwise be auto-answered as "between turns" even though this
+            # owner's turn had begun. Marking pre-build instead would claim an
+            # active turn during a long image-encoding stint in which nothing
+            # consumes the queue. The BaseException guard unmarks on any
+            # failure so a dead write cannot leave the session permanently
+            # routed-to.
+            _method, _params = await build_request()
             _mark = getattr(self._runtime, "mark_turn_active", None)
             if _mark is not None:
                 _mark(self._session_id, True)
-            req_id = await self._runtime.send_request(
-                METHOD_PROMPT,
-                {
-                    "sessionId": self._session_id,
-                    # An image reaches the model ONLY as an image block. Sending a
-                    # local image path as a single text block would ship a
-                    # filesystem path as prose (Slack, dashboard) and the model
-                    # would never see the picture. Gated on the agent's advertised
-                    # capability; when it is absent the path stays in the text as a
-                    # tool-openable reference rather than being dropped.
-                    # Offloaded (above): the builder stats and reads image files
-                    # (up to MAX_IMAGE_BYTES each) and base64-encodes them.
-                    # Inline, that blocking I/O runs on the gateway loop and
-                    # pauses every other session's streaming for the duration.
-                    "prompt": _prompt_blocks,
-                },
-            )
+            req_id = await self._runtime.send_request(_method, _params)
         except BaseException:
             self._turn_done.set()
             _mark = getattr(self._runtime, "mark_turn_active", None)
@@ -852,7 +964,9 @@ class AcpSessionHandle:
                         f"{redact_text(str(_n_title)[:4096])[:120]}"
                     ),
                 )
-            async for event in self._dispatch_events(req_id, timeout):
+            async for event in self._dispatch_events(
+                req_id, timeout, extract_command_result=extract_command_result
+            ):
                 # Park accounting. The consumer holds this event from here until
                 # it comes back for the next one, and that interval is CONSUMER
                 # time, not backend silence: the dispatch loop is suspended at
@@ -1708,11 +1822,20 @@ class AcpSessionHandle:
                 self._queue.put_nowait(_m)
 
     async def _dispatch_events(
-        self, req_id: int, timeout: float
+        self, req_id: int, timeout: float, *, extract_command_result: bool = False
     ) -> AsyncIterator[AcpEvent]:
-        """Core event dispatch loop. Yields AcpEvent objects from the session queue."""
+        """Core event dispatch loop. Yields AcpEvent objects from the session queue.
+
+        ``extract_command_result`` (commands/execute turns): the command's
+        output arrives in the RESPONSE result rather than as session/update
+        chunks — surface it as a text chunk before the terminal event.
+        """
         deadline = time.monotonic() + timeout
         last_data_ts = time.monotonic()
+        # Whether a native agent-switch notification already reported the
+        # switch this turn; guards the result-extracted fallback below from
+        # double-emitting EVENT_AGENT_SWITCHED (mirrors AcpClient).
+        saw_agent_switch = False
         # Consumer time already accounted for at the moment `last_data_ts` was
         # taken. The idle clocks below measure BACKEND silence, so any park that
         # happens after this point must be subtracted from them.
@@ -2021,6 +2144,29 @@ class AcpSessionHandle:
                         # Single-shot: the flag is consumed here so a later genuine
                         # cancel can never be misattributed to a stale probe.
                         self._stale_probe = False
+                    if extract_command_result and isinstance(result, dict):
+                        # commands/execute returns its output in the RESPONSE
+                        # result (message/data), not via session/update
+                        # chunks — surface it as a text chunk. The helper
+                        # two-pass redacts (URLs + credentials) before
+                        # returning: command output is backend-echoed text
+                        # that reaches the dashboard.
+                        text = format_command_result(result)
+                        if text:
+                            yield AcpEvent(kind=EVENT_TEXT_CHUNK, text=text)
+                        if not saw_agent_switch:
+                            data = result.get("data")
+                            if isinstance(data, dict) and data.get("agent"):
+                                agent_info = data["agent"]
+                                name = (
+                                    agent_info.get("name", "")
+                                    if isinstance(agent_info, dict)
+                                    else ""
+                                )
+                                if name:
+                                    yield AcpEvent(
+                                        kind=EVENT_AGENT_SWITCHED, text=name
+                                    )
                     self._last_stop_reason = reason
                     self._tool_dispatched = False
                     self._turn_done.set()
@@ -2150,6 +2296,7 @@ class AcpSessionHandle:
                 elif action == "clear":
                     yield AcpEvent(kind=EVENT_CLEAR_STATUS)
                 elif action == "agent_switched":
+                    saw_agent_switch = True
                     params = msg.params or {}
                     yield AcpEvent(kind=EVENT_AGENT_SWITCHED, text=params.get("agentName", ""))
                 elif action == "subagent_list":

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -281,9 +281,24 @@ class AcpSessionProvider(LLMProvider):
         return self._handle.supports_steer
 
     async def stream_command(self, command: str) -> AsyncIterator[LLMEvent]:
-        """Execute a slash command via prompt (kiro handles commands in-prompt)."""
-        async for event in self.stream(command):
-            yield event
+        """Execute a slash command natively via ``_kiro.dev/commands/execute``.
+
+        Routes through AcpSessionHandle.stream_command so kiro-cli executes the
+        command itself and returns its structured output deterministically —
+        no LLM round-trip. (Previously delegated to stream(), which sent the
+        command through session/prompt: a full model turn that summarized the
+        output instead of returning it.) The handle keeps /compact, /help, and
+        non-kiro backends (KAS) on the prompt transport — see its docstring.
+        Same exception translation as stream(): everything leaving this
+        surface stays within AcpError.
+        """
+        try:
+            async for event in self._handle.stream_command(command):
+                yield event
+        except AcpRuntimeDead as exc:
+            raise self._translate_dead(exc) from exc
+        except AcpRuntimeError as exc:
+            raise AcpError(str(exc)) from exc
 
     def _translate_dead(self, exc: AcpRuntimeDead) -> AcpProcessDied | AcpAuthRequired:
         """Map a shared-runtime death (AcpRuntimeDead — an AcpRuntimeError OUTSIDE

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -28,6 +28,8 @@ from kiro_crew.acp.client import (
     _resolve_vendored_claude_acp,
     _substitute_model_from_advisory,
     _vendored_claude_acp_roots,
+    format_command_result,
+    parse_slash_command,
 )
 from kiro_crew.acp.liveness import (
     VERDICT_DEAD,
@@ -5813,50 +5815,50 @@ class TestReadNewToolResultsSync:
 
 
 class TestFormatCommandResult:
-    """Tests for _format_command_result."""
+    """Tests for format_command_result."""
 
     def test_structured_data_with_message(self):
-        result = AcpClient._format_command_result({"data": {"key": "value"}, "message": "Done"})
+        result = format_command_result({"data": {"key": "value"}, "message": "Done"})
         assert "Done" in result
         assert "```json" in result
         assert '"key"' in result
 
     def test_structured_data_without_message(self):
-        result = AcpClient._format_command_result({"data": {"key": "val"}, "message": ""})
+        result = format_command_result({"data": {"key": "val"}, "message": ""})
         assert "```json" in result
         assert '"key"' in result
 
     def test_agent_model_filtered(self):
-        result = AcpClient._format_command_result(
+        result = format_command_result(
             {"data": {"agent": "x", "model": "y"}, "message": ""}
         )
         # Only agent/model → display is empty → falls through to message
         assert result == ""
 
     def test_message_only(self):
-        result = AcpClient._format_command_result({"message": "hello"})
+        result = format_command_result({"message": "hello"})
         assert result == "hello"
 
     def test_empty_result(self):
-        result = AcpClient._format_command_result({})
+        result = format_command_result({})
         assert result == ""
 
 
 class TestParseSlashCommand:
-    """Tests for _parse_slash_command."""
+    """Tests for parse_slash_command."""
 
     def test_simple_command(self):
-        name, args = AcpClient._parse_slash_command("/compact")
+        name, args = parse_slash_command("/compact")
         assert name == "compact"
         assert args == {}
 
     def test_command_with_value(self):
-        name, args = AcpClient._parse_slash_command("/agent planner")
+        name, args = parse_slash_command("/agent planner")
         assert name == "agent"
         assert args == {"value": "planner"}
 
     def test_command_with_multi_word_value(self):
-        name, args = AcpClient._parse_slash_command("/usage detailed view")
+        name, args = parse_slash_command("/usage detailed view")
         assert name == "usage"
         assert args == {"value": "detailed view"}
 

--- a/test/test_acp_session_handle_stream_command.py
+++ b/test/test_acp_session_handle_stream_command.py
@@ -1,0 +1,322 @@
+"""Tests for AcpSessionHandle.stream_command — native slash-command execution.
+
+The dashboard's shared-runtime sessions previously routed slash commands
+through session/prompt (a full LLM turn that *summarized* kiro-cli's output).
+stream_command sends ``_kiro.dev/commands/execute`` with the TuiCommand OBJECT
+form (``{command, args}`` — kiro-cli 2.14.0 returns no response on the string
+form) and drains session/update events with prompt()'s turn discipline, so the
+command's own structured output comes back deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.acp.session_handle import AcpRuntimeError, AcpSessionHandle
+from kiro_crew.acp.types import (
+    EVENT_AGENT_SWITCHED,
+    EVENT_COMPLETE,
+    EVENT_TEXT_CHUNK,
+    METHOD_AGENT_SWITCHED,
+    METHOD_COMMANDS_EXECUTE,
+    METHOD_SESSION_UPDATE,
+    JsonRpcMessage,
+)
+
+_REQ_ID = 7
+
+
+class _CommandRuntime:
+    """Runtime double for commands/execute turns.
+
+    ``send_request`` records the outbound frame and enqueues the scripted
+    session/update frames followed by the JSON-RPC response — AFTER the send,
+    so the pre-turn stale-frame drain cannot eat them. ``respond=False``
+    enqueues nothing, modelling kiro-cli's known no-response behavior.
+    """
+
+    def __init__(
+        self,
+        queue: asyncio.Queue,
+        response_result: dict[str, Any] | None = None,
+        updates: list[JsonRpcMessage] | None = None,
+        acp_backend: str = "",
+        respond: bool = True,
+    ) -> None:
+        self.pid = None
+        self.is_alive = MagicMock(return_value=True)
+        self.send_notification = AsyncMock()
+        self.supports_image_prompt = False
+        self.acp_backend = acp_backend
+        self.requests: list[tuple[str, dict]] = []
+        self.marks: list[tuple[str, bool]] = []
+        self._queue = queue
+        self._response_result = response_result if response_result is not None else {}
+        self._updates = updates or []
+        self._respond = respond
+        self._last_activity = time.monotonic()
+
+    def mark_turn_active(self, session_id: str, active: bool) -> None:
+        self.marks.append((session_id, active))
+
+    async def send_request(self, method: str, params: dict) -> int:
+        self.requests.append((method, params))
+        for frame in self._updates:
+            self._queue.put_nowait(frame)
+        if self._respond:
+            self._queue.put_nowait(JsonRpcMessage(id=_REQ_ID, result=self._response_result))
+        return _REQ_ID
+
+
+def _make(
+    response_result: dict[str, Any] | None = None,
+    updates: list[JsonRpcMessage] | None = None,
+    acp_backend: str = "",
+    respond: bool = True,
+) -> tuple[AcpSessionHandle, _CommandRuntime]:
+    queue: asyncio.Queue = asyncio.Queue()
+    rt = _CommandRuntime(
+        queue,
+        response_result=response_result,
+        updates=updates,
+        acp_backend=acp_backend,
+        respond=respond,
+    )
+    handle = AcpSessionHandle("sA", queue, rt)
+    return handle, rt
+
+
+async def _collect(handle: AcpSessionHandle, command: str) -> list:
+    return [ev async for ev in handle.stream_command(command, timeout=5.0)]
+
+
+# ── Request shape ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sends_object_form_without_args():
+    """A bare command goes out as the TuiCommand OBJECT form with empty args —
+    the string form returns no response on kiro-cli 2.14.0."""
+    handle, rt = _make(response_result={"message": "ok"})
+    await _collect(handle, "/tools")
+    assert rt.requests == [
+        (
+            METHOD_COMMANDS_EXECUTE,
+            {"sessionId": "sA", "command": {"command": "tools", "args": {}}},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sends_object_form_with_value_arg():
+    """``/agent foo`` carries the remainder as the ``value`` arg."""
+    handle, rt = _make(response_result={"message": "ok"})
+    await _collect(handle, "/agent foo")
+    method, params = rt.requests[0]
+    assert method == METHOD_COMMANDS_EXECUTE
+    assert params["command"] == {"command": "agent", "args": {"value": "foo"}}
+
+
+# ── Result extraction & completion ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_response_text_yielded_then_complete():
+    """The command's output lives in the RESPONSE result, not update chunks —
+    it must surface as a text chunk before the terminal event."""
+    handle, _ = _make(response_result={"message": "13 tools available"})
+    events = await _collect(handle, "/tools")
+    kinds = [ev.kind for ev in events]
+    assert kinds == [EVENT_TEXT_CHUNK, EVENT_COMPLETE]
+    assert events[0].text == "13 tools available"
+    # Turn bookkeeping: the handle is reusable afterwards.
+    assert handle._turn_done.is_set()
+    assert handle.is_turn_active is False
+
+
+@pytest.mark.asyncio
+async def test_structured_data_formatted_as_json_block():
+    """result.data renders as a readable JSON block (agent/model filtered)."""
+    handle, _ = _make(
+        response_result={
+            "message": "MCP servers",
+            "data": {"servers": ["a", "b"], "agent": {"name": "x"}},
+        }
+    )
+    events = await _collect(handle, "/mcp")
+    text_events = [ev for ev in events if ev.kind == EVENT_TEXT_CHUNK]
+    assert len(text_events) == 1
+    assert "MCP servers" in text_events[0].text
+    assert "```json" in text_events[0].text
+    assert '"servers"' in text_events[0].text
+    # agent metadata is filtered from the block (surfaced separately).
+    assert '"agent"' not in text_events[0].text
+
+
+@pytest.mark.asyncio
+async def test_empty_result_yields_only_complete():
+    """No message/data → no empty text chunk, just the terminal event."""
+    handle, _ = _make(response_result={})
+    events = await _collect(handle, "/tools")
+    assert [ev.kind for ev in events] == [EVENT_COMPLETE]
+
+
+@pytest.mark.asyncio
+async def test_result_text_is_credential_redacted():
+    """Command output is backend-echoed text that reaches the dashboard —
+    the two-pass redaction (URLs + credentials) must run on it, matching
+    send_command's auditable control at the same surface."""
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    handle, _ = _make(response_result={"message": f"key {secret} leaked"})
+    events = await _collect(handle, "/env")
+    text_events = [ev for ev in events if ev.kind == EVENT_TEXT_CHUNK]
+    assert len(text_events) == 1
+    assert secret not in text_events[0].text
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_extracted_from_result():
+    """A command result carrying data.agent (e.g. /agent) emits
+    EVENT_AGENT_SWITCHED so the dashboard's indicator updates."""
+    handle, _ = _make(
+        response_result={
+            "message": "switched",
+            "data": {"agent": {"name": "kirocrew"}},
+        }
+    )
+    events = await _collect(handle, "/agent kirocrew")
+    switches = [ev for ev in events if ev.kind == EVENT_AGENT_SWITCHED]
+    assert [ev.text for ev in switches] == ["kirocrew"]
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_not_duplicated_when_notification_arrived():
+    """When the native agent-switch notification already reported the switch,
+    the result-extracted fallback must not emit a second event."""
+    notification = JsonRpcMessage(
+        method=METHOD_AGENT_SWITCHED,
+        params={"sessionId": "sA", "agentName": "kirocrew"},
+    )
+    handle, _ = _make(
+        response_result={"data": {"agent": {"name": "kirocrew"}}},
+        updates=[notification],
+    )
+    events = await _collect(handle, "/agent kirocrew")
+    switches = [ev for ev in events if ev.kind == EVENT_AGENT_SWITCHED]
+    assert len(switches) == 1
+
+
+# ── Event draining ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drains_session_update_chunks_before_response():
+    """session/update frames emitted during command execution stream through
+    with prompt()'s dispatch logic, ahead of the response-extracted text."""
+    update = JsonRpcMessage(
+        method=METHOD_SESSION_UPDATE,
+        params={
+            "sessionId": "sA",
+            "update": {"sessionUpdate": "agent_message_chunk", "text": "streamed"},
+        },
+    )
+    handle, _ = _make(response_result={"message": "final"}, updates=[update])
+    events = await _collect(handle, "/tools")
+    texts = [ev.text for ev in events if ev.kind == EVENT_TEXT_CHUNK]
+    assert texts == ["streamed", "final"]
+    assert events[-1].kind == EVENT_COMPLETE
+
+
+# ── Turn discipline ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rejected_while_turn_active():
+    """A command during an active turn is refused, not interleaved — it shares
+    prompt()'s concurrent-turn guard on the same session queue."""
+    handle, _ = _make(response_result={"message": "ok"})
+    handle._turn_done.clear()  # a turn is in flight
+    with pytest.raises(AcpRuntimeError):
+        await _collect(handle, "/tools")
+
+
+@pytest.mark.asyncio
+async def test_turn_marked_active_and_released():
+    """The turn is marked active around the send and released at completion,
+    so shared-runtime frame routing sees the command like any other turn."""
+    handle, rt = _make(response_result={"message": "ok"})
+    await _collect(handle, "/tools")
+    assert rt.marks == [("sA", True), ("sA", False)]
+
+
+@pytest.mark.asyncio
+async def test_send_failure_keeps_handle_reusable():
+    """A send_request failure re-sets _turn_done and unmarks the turn — the
+    BaseException guard — so the handle is not wedged permanently active."""
+    handle, rt = _make()
+
+    async def _boom(method: str, params: dict) -> int:
+        raise AcpRuntimeError("broken pipe")
+
+    rt.send_request = _boom  # type: ignore[method-assign]
+    with pytest.raises(AcpRuntimeError):
+        await _collect(handle, "/tools")
+    assert handle._turn_done.is_set()
+    # Marked active before the (failed) write, unmarked by the guard.
+    assert rt.marks == [("sA", True), ("sA", False)]
+
+
+# ── Transport carve-outs & failure modes ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/compact", "/compact keep the design", "/help"])
+async def test_prompt_transport_commands_stay_on_prompt(command):
+    """/compact and /help keep the PROMPT transport: kiro-cli 2.14.0 returns
+    no response for them over commands/execute, and the compaction flow
+    (session.py, Slack !compact) watches compaction status on the prompt
+    stream — routing them natively would strand it until timeout."""
+    from kiro_crew.acp.types import METHOD_PROMPT
+
+    handle, rt = _make(response_result={"stopReason": "end_turn"})
+    events = await _collect(handle, command)
+    assert [m for m, _ in rt.requests] == [METHOD_PROMPT]
+    assert events[-1].kind == EVENT_COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_kas_backend_falls_back_to_prompt():
+    """_kiro.dev/commands/execute is kiro-cli-specific: a KAS shared-runtime
+    session must keep degrading softly through session/prompt instead of
+    erroring on an unimplemented method."""
+    from kiro_crew.acp.types import ACP_BACKEND_KAS, METHOD_PROMPT
+
+    handle, rt = _make(response_result={"stopReason": "end_turn"}, acp_backend=ACP_BACKEND_KAS)
+    events = await _collect(handle, "/tools")
+    assert [m for m, _ in rt.requests] == [METHOD_PROMPT]
+    assert events[-1].kind == EVENT_COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_no_response_terminates_at_timeout():
+    """An unanswered commands/execute request must terminate at the bounded
+    command timeout with a terminal event — not drain for the chat-turn
+    ceiling — and leave the handle reusable."""
+    handle, _ = _make(respond=False)
+    start = time.monotonic()
+    events = await _collect_with_timeout(handle, "/tools", timeout=0.5)
+    elapsed = time.monotonic() - start
+    assert events[-1].kind == EVENT_COMPLETE
+    assert events[-1].stop_reason == "timeout"
+    assert elapsed < 5.0
+    assert handle._turn_done.is_set()
+    assert handle.is_turn_active is False
+
+
+async def _collect_with_timeout(handle: AcpSessionHandle, command: str, timeout: float) -> list:
+    return [ev async for ev in handle.stream_command(command, timeout=timeout)]

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -238,23 +238,56 @@ class TestAcpSessionProviderStream:
         assert collected[2].kind == EVENT_COMPLETE
 
     @pytest.mark.asyncio
-    async def test_stream_command_delegates_to_stream(self):
+    async def test_stream_command_routes_through_handle_stream_command(self):
+        """Slash commands go through the handle's NATIVE commands/execute path,
+        never through prompt() — a prompt round-trip would hand the command to
+        the model, which summarizes kiro-cli's output instead of returning it
+        (issue #4972)."""
         handle = _make_handle()
-        events = [AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn")]
+        events = [
+            AcpEvent(kind=EVENT_TEXT_CHUNK, text="13 tools"),
+            AcpEvent(kind=EVENT_COMPLETE, stop_reason=""),
+        ]
+        seen_commands: list[str] = []
 
-        async def mock_prompt(msg):
+        async def mock_stream_command(command):
+            seen_commands.append(command)
             for e in events:
                 yield e
 
+        async def mock_prompt(msg):  # pragma: no cover — must never run
+            raise AssertionError("stream_command must not route through prompt()")
+            yield  # make it a generator
+
+        handle.stream_command = mock_stream_command
         handle.prompt = mock_prompt
         runtime = _make_runtime()
         provider = AcpSessionProvider(handle, runtime)
 
-        collected = []
-        async for event in provider.stream_command("/help"):
-            collected.append(event)
+        collected = [e async for e in provider.stream_command("/tools")]
 
-        assert len(collected) == 1
+        assert seen_commands == ["/tools"]
+        assert [e.kind for e in collected] == [EVENT_TEXT_CHUNK, EVENT_COMPLETE]
+        assert collected[0].text == "13 tools"
+
+    @pytest.mark.asyncio
+    async def test_stream_command_translates_runtime_dead(self):
+        """Runtime death mid-command stays inside the AcpError hierarchy
+        (AcpProcessDied), mirroring stream()'s translation."""
+
+        async def dead_stream_command(command):
+            raise AcpRuntimeDead("runtime died")
+            yield  # make it a generator
+
+        handle = _make_handle()
+        handle.stream_command = dead_stream_command
+        runtime = _make_runtime()
+        runtime.saw_not_logged_in = lambda: False
+        provider = AcpSessionProvider(handle, runtime)
+
+        with pytest.raises(AcpProcessDied):
+            async for _ in provider.stream_command("/tools"):
+                pass
 
 
 class TestAcpSessionProviderToolApproval:


### PR DESCRIPTION
## Problem / Motivation

Dashboard slash commands such as `/tools` and `/mcp` are slow and return a model-summarized answer (e.g. "13 tools available") instead of kiro-cli's structured native output.

Root cause: `chat_runner.py` dispatches slash commands via `client.stream_command`, but the dashboard's active provider is the shared-runtime `AcpSessionProvider`, whose `stream_command` just delegated to `self.stream(command)` — sending the command through `session/prompt`, a full LLM turn. The native path already existed only on the direct-spawn client (`AcpClient.stream_command` → `_kiro.dev/commands/execute`).

## Why it matters

Every dashboard user on a shared-runtime session (the default) pays a full model round-trip — seconds of latency plus token cost — for a command kiro-cli answers deterministically in milliseconds, and gets a lossy paraphrase instead of the real structured output. The output also varies run to run, so `/tools` and `/mcp` can't be trusted for debugging.

## What changed (motivation → approach → change)

Symptom: slow, summarized slash-command output → cause: the shared-runtime provider routes commands through a prompt turn → change: give the shared runtime the same native path the direct-spawn client already has.

- **`AcpSessionHandle.stream_command`** (new): sends `_kiro.dev/commands/execute` with the TuiCommand OBJECT form (`{command, args}` — the string form returns no response on kiro-cli 2.14.0) and drains `session/update` events with `prompt()`'s exact turn discipline. That discipline (concurrent-turn guard, per-turn resets, pre-turn stale-frame drain, BaseException unmark guard, park accounting, deterministic `aclose` finalization) is extracted verbatim into a shared `_run_turn` core; `prompt()` becomes a thin wrapper over it, so the two transports cannot drift.
- **`_dispatch_events`** gains `extract_command_result`: commands/execute returns its output in the RESPONSE result (`message`/`data`), not as update chunks, so the dispatch loop surfaces it as a text chunk plus an `EVENT_AGENT_SWITCHED` fallback (deduped against the native notification).
- **`AcpSessionProvider.stream_command`** routes through the new handle method with the same `AcpError`-hierarchy translation as `stream()`.
- **Three guards keep known-unfit paths safe:** `/compact` and `/help` stay on the PROMPT transport (kiro-cli 2.14.0 returns no response for them over commands/execute, and the compaction flow in `session.py` depends on watching `compaction/status` on the prompt stream); non-kiro backends (KAS) stay on the prompt transport (`_kiro.dev/commands/execute` is kiro-cli-specific); native command turns are bounded at 60s (matching `send_command`'s RPC wait) because neither turn watchdog arms on a command turn, so an unanswered request would otherwise drain for the chat-turn ceiling while holding the session's turn slot.
- **`format_command_result` / `parse_slash_command`** are promoted from `AcpClient` staticmethods to module level so both native paths share them, and the two-pass output redaction (`redact_exfiltration_urls` + `redact_credentials`) now lives inside `format_command_result` so every present and future caller inherits the security control.

## Tests

`test/test_acp_session_handle_stream_command.py` (new, 17 tests):
- object-form request shape (bare command and `value` arg)
- response text surfaced as a text chunk before the terminal event; structured `data` rendered as a JSON block with agent/model metadata filtered
- credential redaction of command output
- `EVENT_AGENT_SWITCHED` extracted from the result and deduped against the native notification
- session/update chunks drained ahead of the response-extracted text
- turn discipline: concurrent-turn rejection, mark/unmark bookkeeping, handle reusability after a send failure
- carve-outs: `/compact` (bare and with args) and `/help` go out as `session/prompt`; a KAS backend falls back to `session/prompt`
- an unanswered request terminates at the bounded timeout with a terminal `timeout` event and leaves the handle reusable

`test/test_acp_session_provider.py`: `stream_command` routes through the handle's native method (never `prompt()`), and `AcpRuntimeDead` mid-command translates to `AcpProcessDied`.

`test/test_acp_client.py`: the format/parse helper tests updated to the module-level functions.

Full backend suite run locally: 64,833 passed; the 92 failures + 2 errors are pre-existing host-environment issues (missing `gh`, path aliasing, sandbox constraints) in unrelated files, unchanged by this diff.

## Manual verification

N/A — unit coverage sufficient: the wire behavior this relies on (object-form commands/execute answering with `message`/`data`; string-form `/compact`//`/help` returning no response) is the same contract `AcpClient.stream_command` and `AcpSessionHandle.compact()` already ship on, and both carve-outs are locked by tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only transport change; no frontend files touched and no rendered pixel changes (command output already renders through the existing text-chunk pipeline).

## Related Issues

Closes #4972

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
