### PR TITLE
fix(dashboard): guard list Escape during IME composition

### DIFF
--- a/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
+++ b/website/src/hooks/useListKeyboardNav.imeGuard.test.tsx
@@ -33,6 +33,9 @@ afterEach(() => {
 const enter = (init: KeyboardEventInit & { keyCode?: number } = {}) =>
   fireEvent.keyDown(document, { key: 'Enter', ...init })
 
+const escape = (init: KeyboardEventInit & { keyCode?: number } = {}) =>
+  fireEvent.keyDown(document, { key: 'Escape', ...init })
+
 describe('useListKeyboardNav IME guard', () => {
   it('plain Enter still chooses the selected row (positive control)', () => {
     const onChoose = vi.fn()
@@ -141,6 +144,37 @@ describe('useListKeyboardNav IME guard', () => {
     fireEvent.compositionEnd(input)
     fireEvent.keyDown(document, { key: 'Tab' })
     expect(onChoose).not.toHaveBeenCalled()
+  })
+
+  it('declines a mid-composition Escape without cancelling the IME candidate dismissal', () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+    const notPrevented = escape({ isComposing: true })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(true)
+  })
+
+  it('declines the committing Escape in the post-composition window AND consumes it', () => {
+    const onClose = vi.fn()
+    const { getByTestId } = render(<Harness onClose={onClose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    const notPrevented = escape()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(notPrevented).toBe(false)
+  })
+
+  it('closes again once the post-composition window has elapsed', () => {
+    vi.useFakeTimers()
+    const onClose = vi.fn()
+    const { getByTestId } = render(<Harness onClose={onClose} />)
+    const input = getByTestId('host-input')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    vi.advanceTimersByTime(60)
+    escape()
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('recovers from an abandoned composition when focus moves away', () => {

--- a/website/src/hooks/useListKeyboardNav.ts
+++ b/website/src/hooks/useListKeyboardNav.ts
@@ -26,7 +26,8 @@ import { createImeLatch } from './useImeGuard'
  *    before acting on a choose-class key.
  *  - `Alt`/`Option`+`Enter`  — `onAltEnter(selected)` when provided; if it
  *    returns `true` the event is treated as handled.
- *  - `Escape`                — `onClose()`.
+ *  - `Escape`                — `onClose()`, unless the shared IME latch owns
+ *                              the key for candidate dismissal.
  *
  * The selection is mirrored into {@link selectedRef} so callbacks captured in
  * effects can read the live value without re-subscribing, matching the
@@ -114,7 +115,7 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
   const onAltEnterRef = useRef(onAltEnter)
   onAltEnterRef.current = onAltEnter
 
-  // IME guard for the Enter-chooses-row path. This listener receives NATIVE
+  // IME guard for the hook's keyboard actions. This listener receives NATIVE
   // KeyboardEvents (document capture), which `useImeGuard`'s synthetic-only
   // `claimEnter` cannot consume — so it shares the guard's tracked latch via
   // `createImeLatch` instead of hand-rolling a second spelling. On WebKit the
@@ -155,6 +156,11 @@ export function useListKeyboardNav(opts: UseListKeyboardNavOptions): ListKeyboar
   const onKey = useCallback((e: KeyboardEvent) => {
     const n = countRef.current
     if (e.key === 'Escape') {
+      // Escape dismisses an IME candidate list too. Let the shared latch own
+      // that key while composition is live and in WebKit's short
+      // post-composition window, so cancelling a candidate does not also close
+      // the picker and discard the user's query.
+      if (!imeLatchRef.current!.claimKey(e)) return
       e.preventDefault()
       e.stopPropagation()
       onCloseRef.current()


### PR DESCRIPTION
## Problem / Motivation

`useListKeyboardNav` already tracks native IME composition for choose-class keys, but its Escape branch bypasses that latch. Pressing Escape to dismiss an IME candidate list can therefore also close the surrounding picker and discard the query.

## Why it matters

Users composing CJK text can lose the picker they are interacting with during a normal IME cancellation flow. WebKit's short post-composition event window makes the same double action possible immediately after `compositionend`.

## What changed (motivation → approach → change)

Route Escape through the hook's existing shared native-event IME latch before preventing propagation or invoking `onClose`. The latch now declines Escape while composition is live and during its post-composition window, then permits normal closing after that window expires.

This is only the third mechanical sibling discussed in #5481; it does not change the Modal or CommandBar consumers named by that issue.

## Tests

- Added coverage for live-composition Escape, WebKit-style post-composition Escape consumption, and positive recovery after 60 ms.
- Red-before proof: the two new guarded paths failed while the existing 18 tests passed.
- `npx vitest run src/hooks/useListKeyboardNav.imeGuard.test.tsx` — 20 passed.
- `npm run typecheck` — passed.
- Focused ESLint — 0 errors (one pre-existing test-harness accessibility warning).

## Manual verification

N/A — native keyboard-event unit coverage exercises both IME timing paths and the normal close control.

## Screenshots / video

<!-- no-visual-delta -->
N/A — this changes keyboard event ownership without changing rendered UI.

## Related Issues

Refs #5481

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable; the hook contract comment was updated in code)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template states that exact CLA wording is pending OSPO.