### PR TITLE
refactor(feishu): use the shared pre-turn sequence

### DIFF
--- a/src/kiro_crew/feishu/transport_dispatch.py
+++ b/src/kiro_crew/feishu/transport_dispatch.py
@@ -24,7 +24,6 @@ Dependency direction is ``feishu -> messaging`` (allowed).
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.feishu.client import CHAT_GROUP
@@ -44,6 +43,7 @@ from kiro_crew.messaging.link import (
     build_dm_session_key,
     seed_generation,
 )
+from kiro_crew.messaging.pre_turn import resolve_pre_turn
 from kiro_crew.safety_override import safety_override
 
 if TYPE_CHECKING:
@@ -129,26 +129,19 @@ class FeishuDispatcher:
             await self._handle_compact(inbound)
             return
 
-        # ── Mid-turn concurrency: steer or queue prompt ────────────────────
-        session_key = self._session_key(route)
-        if self.sessions.is_busy(session_key):
-            await self._handle_busy(inbound, session_key)
-            return
-
-        # Idle/daily rotation, AFTER the busy check: rotating first could
-        # mint a new generation and miss the in-flight turn on the current
-        # key. Also records activity, which is what makes idle detection
-        # work at all -- a dispatcher that never calls this leaves
-        # last_active frozen and silently ignores both settings.
-        self._conv.maybe_rotate(
-            route,
-            time.time(),
+        # Busy check, then rotation, then a re-derived key -- the ordering and
+        # the reasons it matters live in messaging.pre_turn.
+        session_key = await resolve_pre_turn(
+            conv=self._conv,
+            sessions=self.sessions,
+            key=route,
+            session_key_for=self._session_key,
             idle_minutes=self.cfg.messaging.idle_reset_minutes,
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
+            on_busy=lambda sk: self._handle_busy(inbound, sk),
         )
-        # Re-derive: rotation advances the generation, so the pre-rotation
-        # key would address the conversation the rotation just retired.
-        session_key = self._session_key(route)
+        if session_key is None:
+            return  # folded into the running turn
 
         conversation_id = f"feishu:{route[1]}"
         agent = self._resolve_agent()

--- a/test/test_messaging_pre_turn.py
+++ b/test/test_messaging_pre_turn.py
@@ -195,21 +195,21 @@ _SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
 #: mid-turn override parsing, attachment handling, media ingestion), and in
 #: several cases the busy path is no longer a plain ``on_busy(session_key)``.
 #: Listing them here would assert a migration that has not happened.
-_PRE_TURN_CHANNELS = ("webex", "imessage")
+_PRE_TURN_CHANNELS = ("webex", "imessage", "feishu")
 
 #: Rostered channels deliberately NOT on the shared helper. telegram, discord,
 #: teams and slack carry extra pre-turn work between the busy check and
 #: rotation; weixin and wecom run the same kind of steps from their
 #: ``handle_message`` with their own busy checks (wecom additionally clears
-#: attachments there and ingests media before rotating); whatsapp and feishu
-#: hand-roll the sequence in their dispatchers, and although whatsapp's busy
+#: attachments there and ingests media before rotating); whatsapp hand-rolls
+#: the sequence in its dispatcher, and although its busy
 #: handling mirrors webex's closely enough that migration looks mechanical,
 #: it is still a behaviour change -- so folding any of them into the helper
 #: is a separate, reviewed change. Both ratchet directions read this one set:
 #: joining it (a rostered channel must be accounted for) and leaving it (a
 #: migrated channel must be pruned) are each an explicit decision.
 _EXEMPT_CHANNELS = frozenset(
-    {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp", "feishu"}
+    {"telegram", "discord", "teams", "slack", "weixin", "wecom", "whatsapp"}
 )
 
 


### PR DESCRIPTION
## Problem / Motivation

Feishu still hand-rolls the pre-turn busy-check, rotation, and session-key re-derivation sequence even though `messaging.pre_turn.resolve_pre_turn` is the canonical implementation. That keeps the transport outside the structural ratchet after the canonical blocker was removed in #5484.

## Why it matters

The order is correctness-sensitive: rotating before the busy check can miss an in-flight turn, while failing to re-derive after rotation addresses a retired generation. A private copy can silently drift from the shared contract.

## What changed (motivation → approach → change)

Replace Feishu's local sequence with `resolve_pre_turn`, passing the existing steer-only `_handle_busy` behavior as the callback. Remove the Feishu ratchet exemption and add it to the set of channels required to delegate to the shared helper. Commands, queue semantics, and rendered messages are unchanged.

## Tests

- Red-before proof: removing the exemption first produced the two expected ratchet failures (no helper delegation and direct `maybe_rotate` use); the other 14 pre-turn tests passed.
- `pytest -q -n 1 test/test_messaging_pre_turn.py test/test_feishu_transport.py test/test_feishu_renderer.py test/test_feishu_gateway.py test/test_feishu_dispatch.py test/test_feishu_client.py` — 135 passed.
- Focused Black check and Flake8 — passed.

## Manual verification

N/A — the structural ratchet locks the delegation boundary and the Feishu transport suite covers busy, rotation, dispatch, rendering, gateway, and client paths.

## Related Issues

Fixes #5502

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable; behavior and documented ordering are unchanged)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template states that exact CLA wording is pending OSPO.
