### PR TITLE
test: restore dynamic Jira credentials between tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ test collected from any testpath, because what they protect is the
 developer's machine rather than the correctness of one suite. Everything that is
 merely suite-specific isolation stays in ``test/conftest.py``.
 
-The floor has five parts, and each one exists because the "remember to isolate
+The floor has six parts, and each one exists because the "remember to isolate
 this" contract failed at least once:
 
 * **Services.** ``$XDG_CONFIG_HOME`` is redirected and the stdlib spawn funnels
@@ -25,6 +25,10 @@ this" contract failed at least once:
   under ``src/kiro_crew/apps/builtins/*/tests/`` -- which see this conftest and no
   other -- write the operator's live ``~/.kiro/crew`` the moment they touch
   ``config_dir()``.
+* **Credential environment.** Recognised fixed credentials and validated
+  ``JIRA_TOKEN_<HEX>`` keys are restored after every test, so a fabricated
+  ``.env`` cannot silently override the next test's credentials in the same
+  worker.
 * **The agent-spec home.** ``kiro_agents_dir()`` is a LAZY resolver, so neither of
   the two above reaches it, and a test that reaches the spec write path rewrites
   the machine-wide ``<kiro home>/agents/kirocrew.json`` -- the file that decides
@@ -384,20 +388,27 @@ def _no_credential_env_residue():
     token from one file's temp ``.env`` silently satisfied the other's assertion,
     and only when both landed in the same worker.
 
-    Bounded to the recognised credential keys, so this is two dict passes over
-    ~20 names per test and cannot mask an unrelated environment change.
+    Bounded to the recognised fixed keys and the validated ``JIRA_TOKEN_<HEX>``
+    shape. Two linear environment scans per test also catch a dynamic key that
+    did not exist at setup, without masking an unrelated environment change.
     """
-    from kiro_crew.config.loader import _CREDENTIAL_KEYS
+    from kiro_crew.config.loader import _CREDENTIAL_KEYS, _JIRA_TOKEN_RE
 
-    before = {key: os.environ.get(key) for key in _CREDENTIAL_KEYS}
+    fixed = frozenset(_CREDENTIAL_KEYS)
+
+    def _is_credential(key: str) -> bool:
+        return key in fixed or _JIRA_TOKEN_RE.match(key) is not None
+
+    before = {key: value for key, value in os.environ.items() if _is_credential(key)}
     try:
         yield
     finally:
-        for key, value in before.items():
-            if value is None:
+        current = {key for key in os.environ if _is_credential(key)}
+        for key in current | before.keys():
+            if key not in before:
                 os.environ.pop(key, None)
             else:
-                os.environ[key] = value
+                os.environ[key] = before[key]
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -761,6 +761,30 @@ class TestTheWorkingDirectoryIsRestored:
         )
 
 
+_DYNAMIC_CREDENTIAL_ORDER: dict[str, bool] = {}
+
+
+@pytest.mark.xdist_group(name="dynamic_credential_env_floor")
+class TestDynamicCredentialEnvironmentIsRestored:
+    """A dynamic per-host Jira token must not leak to the next test.
+
+    ``load_credentials`` propagates ``JIRA_TOKEN_<HEX>`` keys even though they
+    are not members of the fixed ``_CREDENTIAL_KEYS`` tuple. Keep these tests
+    adjacent on one worker so the second observes the first test's teardown.
+    """
+
+    def test_a_test_can_inject_a_dynamic_jira_token(self) -> None:
+        os.environ["JIRA_TOKEN_AABBCC"] = "token-from-previous-test"
+        _DYNAMIC_CREDENTIAL_ORDER["injected"] = True
+
+    def test_the_next_test_does_not_inherit_the_dynamic_token(self) -> None:
+        assert _DYNAMIC_CREDENTIAL_ORDER.get("injected"), (
+            "the injecting test did not run on this worker, so this assertion "
+            "would prove nothing"
+        )
+        assert "JIRA_TOKEN_AABBCC" not in os.environ
+
+
 # ── the logging record factory ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem / Motivation

The root autouse credential-isolation fixture restores only the fixed `_CREDENTIAL_KEYS` tuple. The loader also recognizes validated `JIRA_TOKEN_<HEX>` variables, so a test-created dynamic Jira token survives teardown and contaminates the next test on the same worker.

## Why it matters

Cross-test credential residue makes results order-dependent and can let a fabricated test `.env` satisfy later assertions. Isolation needs to cover exactly the credential shapes the loader accepts, including keys that did not exist at fixture setup.

## What changed (motivation → approach → change)

Align the fixture with the loader by using its anchored `_JIRA_TOKEN_RE` alongside the fixed key set. Snapshot recognized variables at setup, scan them again at teardown, restore pre-existing values, and remove newly introduced values. Add two adjacent tests in one xdist group so the second deterministically verifies teardown from the first.

## Tests

- Red-before proof: the second same-worker regression test failed because `JIRA_TOKEN_AABBCC` remained in `os.environ`.
- `PYTHONUTF8=1 pytest -q -n 1 test/test_host_isolation_floor.py test/test_credential_scrub_sync.py` — 83 passed.
- Focused Flake8 and import-order checks — passed.

## Manual verification

N/A — the regression deliberately leaves a dynamic token behind and verifies the autouse teardown boundary in the immediately following worker test.

## Related Issues

Fixes #5503

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (the root isolation-floor documentation now includes credential environment restoration)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template states that exact CLA wording is pending OSPO.