### PR TITLE
fix(dashboard): stop wide markdown tables collapsing to one character per line

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -920,8 +920,25 @@ const MD_COMPONENTS: Components = {
     return <CodeBlock code={codeStr} lang={lang} complete={true} />
   },
   pre({ children }) { return <>{children}</> },
-  table({ node, children }) { return <div className="overflow-x-auto my-3"><table {...sp(node)} className="w-full border-collapse text-sm">{children}</table></div> },
-  th({ node, children }) { return <th {...sp(node)} className="text-left text-muted text-[13px] font-medium px-3 py-2 border-b border-border bg-bg-elevated">{children}</th> },
+  // The message bubble sets `overflow-wrap:anywhere; word-break:break-word`
+  // (AssistantMessage.tsx / UserMessage.tsx) so an unbreakable token can never
+  // widen a message past the viewport. Table cells must NOT inherit either one.
+  // `anywhere` participates in MIN-CONTENT sizing, so every cell's min-content
+  // collapsed to a single character — removing the one guarantee that keeps a
+  // table readable (a table is never squeezed below min-content). On a phone a
+  // wide table then compressed until each cell wrapped one CHARACTER per line,
+  // vertically. Verified: resetting `overflow-wrap` alone is NOT enough, because
+  // Chrome still shrinks columns on the inherited `word-break:break-word`, which
+  // splits `$765.72` into `$76 / 5.72`. Both are reset here.
+  //
+  // With word-based column widths restored, `min-w-full` (NOT `w-full`) lets a
+  // table wider than the viewport overflow to its real width and scroll inside
+  // the wrapper, while a narrow table still fills the container. A genuinely
+  // oversized token now widens its column instead of breaking, which the
+  // horizontal scroll already handles.
+  table({ node, children }) { return <div className="overflow-x-auto my-3"><table {...sp(node)} className="min-w-full border-collapse text-sm [overflow-wrap:normal] [word-break:normal]">{children}</table></div> },
+  // Headers carry the column's meaning, so never break them mid-label.
+  th({ node, children }) { return <th {...sp(node)} className="text-left text-muted text-[13px] font-medium px-3 py-2 border-b border-border bg-bg-elevated whitespace-nowrap">{children}</th> },
   td({ node, children }) { return <td {...sp(node)} className="px-3 py-2 border-b border-border text-sm">{children}</td> },
   a: MdAnchor,
   blockquote({ node, children }) { return <blockquote {...sp(node)} className="border-l-[3px] border-accent pl-3 my-2 text-muted italic">{children}</blockquote> },

--- a/website/src/test/MarkdownRenderer.tableWrap.test.tsx
+++ b/website/src/test/MarkdownRenderer.tableWrap.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * A wide markdown table on a phone used to render one CHARACTER per line,
+ * vertically, in every cell — a 10-column scanner table was unreadable.
+ *
+ * The cause was inheritance, not the table's own styling. The message bubble
+ * sets `overflow-wrap: anywhere` and `word-break: break-word` so an unbreakable
+ * token cannot widen a message past the viewport, and table cells inherited
+ * both. `anywhere` participates in MIN-CONTENT sizing, so each cell's
+ * min-content became a single character — which removes the one guarantee that
+ * keeps a table legible, namely that a table is never squeezed below its
+ * min-content width. `w-full` then compressed the table to the container and
+ * every column collapsed to one glyph.
+ *
+ * These assertions are deliberately on the CLASS CONTRACT rather than on
+ * measured geometry: jsdom performs no layout, so the squeeze itself cannot be
+ * observed here. Each one pins a property whose removal reintroduces the bug.
+ */
+describe('markdown table wrapping', () => {
+  const renderTable = () => {
+    const md = [
+      '| Symbol | Price | MACD Hist | Overall |',
+      '| --- | --- | --- | --- |',
+      '| GOOGL | $344.82 | -0.57 | STRONG SELL |',
+    ].join('\n')
+    const { container } = render(<MarkdownRenderer content={md} />)
+    const table = container.querySelector('table')
+    if (!table) throw new Error('no table rendered')
+    return table
+  }
+
+  it('does not inherit the bubble\'s intrinsic-size-collapsing wrap rules', () => {
+    const cls = renderTable().className
+    // `anywhere` is the property that collapsed min-content to one character.
+    expect(cls).toContain('[overflow-wrap:normal]')
+    // Resetting overflow-wrap alone is NOT sufficient: Chrome still shrinks
+    // columns on the inherited `word-break: break-word`, which splits `$765.72`
+    // into `$76 / 5.72`. Verified in a real browser at 390px.
+    expect(cls).toContain('[word-break:normal]')
+  })
+
+  it('treats the container width as a floor, not a ceiling', () => {
+    const cls = renderTable().className
+    // `w-full` caps the table at the container, so the wrapper's
+    // `overflow-x-auto` can never engage; `min-w-full` still fills the
+    // container for a narrow table but lets a wide one overflow and scroll.
+    expect(cls).toContain('min-w-full')
+    expect(cls.split(/\s+/)).not.toContain('w-full')
+  })
+
+  it('keeps the table in a horizontally scrollable wrapper', () => {
+    const wrapper = renderTable().parentElement
+    expect(wrapper?.className).toContain('overflow-x-auto')
+  })
+
+  it('never breaks a column header mid-label', () => {
+    const table = renderTable()
+    const ths = Array.from(table.querySelectorAll('th'))
+    expect(ths.length).toBeGreaterThan(0)
+    for (const th of ths) expect(th.className).toContain('whitespace-nowrap')
+  })
+})


### PR DESCRIPTION
## Problem

A 10-column markdown table in a chat message rendered **every cell as a vertical stack of single characters** on a phone. `Symbol` came out as `S y m b o l` stacked downward, and the table was completely unreadable.

Reproduced at a 390px viewport width, with the real `MarkdownRenderer`:

![before: every cell wraps one character per line, vertically](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-5509/pr-5509/before.png)

## Cause

The cause is inheritance, not the table's own styling.

The message bubble (`AssistantMessage.tsx`, `UserMessage.tsx`) sets:

```tsx
style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
```

so an unbreakable token can never widen a message past the viewport. Table cells inherit both.

`overflow-wrap: anywhere` **participates in min-content sizing** (unlike `break-word`, which per spec does not). So each cell's min-content width collapsed to a single character. That removes the one guarantee keeping a table legible — a table is never squeezed below its min-content width — and `w-full` then compressed the table down to the container, collapsing every column to one glyph.

`w-full` is the second half of it: it caps the table at 100% of the container, so the wrapper's `overflow-x-auto` could never engage. The two rules cancel each other out.

## Fix

- Reset **both** inherited properties on the table (`[overflow-wrap:normal] [word-break:normal]`) so columns size by word again. Resetting `overflow-wrap` alone is **not** sufficient — Chrome still shrinks columns on the inherited `word-break: break-word`, splitting `$765.72` into `$76 / 5.72`. This was verified in a real browser rather than assumed from the spec.
- `w-full` becomes `min-w-full`, making the container width a floor rather than a ceiling: a narrow table still fills the container, a wide one overflows and scrolls in the wrapper that already exists.
- `whitespace-nowrap` on `th` so a column label never breaks mid-word.

Scope is deliberately limited to the markdown renderer, which is the surface that receives arbitrary agent-generated tables of arbitrary width. The fixed-column app UI tables (settings, agents, telemetry) are untouched.

## Verification

Same table, same 390×844 viewport, after the fix — cells intact, one line each:

![after: cells intact on one line, table scrolls horizontally](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-5509/pr-5509/after.png)

Scrolled fully right, the columns pushed off-screen are reachable:

![after, scrolled right: W %R, MACD Hist, ADX, Ichimoku, Overall all readable](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-5509/pr-5509/after-scrolled-right.png)

The squeeze has a clean numeric signature — the first data cell (`SPY`, 3 characters) is many lines **tall** and a few characters **wide**. Measured on the real component, mounted inside a wrapper reproducing the assistant bubble's own wrap rules:

| | first cell `SPY` | table width | wrapper scrollWidth | computed `overflow-wrap` / `word-break` |
|---|---|---|---|---|
| **before** | **157px tall × 36px wide** | 390px (capped at container) | 390 | `anywhere` / `break-word` |
| **after** | **57px tall × 74px wide** | 773px (its real width) | 773 | `normal` / `normal` |

Wrapper `clientWidth` is 366px in both and `overflow-x` is `auto` in both — which is the point: before the fix the wrapper had nothing to scroll, because the table was already capped at the container. `157px` at a 24px line-height is `S / P / Y` stacked vertically.

**Stress case:** a cell holding a long unbreakable token (`https://example.com/a/very/long/unbreakable-token-abcdefghijklmnop`) widens its own column and is reached by the same horizontal scroll, rather than distorting the other columns or overflowing the bubble — the bubble keeps `overflow-hidden`, and only the table's wrapper scrolls.

`tsc -b` is clean, and `eslint` reports 0 errors on both files (the one remaining warning at `MarkdownRenderer.tsx:790` is pre-existing and unrelated to this change).

## Test

`website/src/test/MarkdownRenderer.tableWrap.test.tsx` (4 tests) pins the class contract. jsdom performs no layout, so the squeeze itself cannot be asserted there; each assertion instead pins a property whose removal reintroduces the bug — including the `word-break` reset, which is the one easiest to mistake for redundant and delete.

The capture harness that produced the frames above follows this repo's existing `capture/*.tsx` + `scripts/capture-*.mjs` convention. It is intentionally not committed, to keep the diff to the fix and its regression test.
