### PR TITLE
fix(tests): decode repository source as UTF-8

### DIFF
--- a/test/test_credential_scrub_sync.py
+++ b/test/test_credential_scrub_sync.py
@@ -54,7 +54,7 @@ class TestScrubListSync:
         loader would happily re-inject (the exact defect behind KIRO_API_KEY
         leaking into /proc/<pid>/environ), or a loader key the entrypoint never
         scrubs, both fail here."""
-        text = _ENTRYPOINT.read_text()
+        text = _ENTRYPOINT.read_text(encoding="utf-8")
         match = re.search(r'^CRED_KEYS="([^"]+)"', text, re.MULTILINE)
         assert match, "CRED_KEYS assignment not found in docker/entrypoint.sh"
         entrypoint_keys = set(match.group(1).split())
@@ -63,7 +63,7 @@ class TestScrubListSync:
     def test_kiro_api_key_is_in_both_lists(self) -> None:
         """The regression this file exists for, pinned by name."""
         assert CRED_KIRO_API_KEY in _CREDENTIAL_KEYS
-        assert CRED_KIRO_API_KEY in _ENTRYPOINT.read_text()
+        assert CRED_KIRO_API_KEY in _ENTRYPOINT.read_text(encoding="utf-8")
 
 
 class TestReadEnvFileCredential:
@@ -242,7 +242,7 @@ class TestJiraTokenScrubGuard:
 
     def test_entrypoint_scrubs_dynamic_jira_tokens(self) -> None:
         """docker/entrypoint.sh feeds JIRA_TOKEN_* into the credential scrub loop."""
-        text = _ENTRYPOINT.read_text()
+        text = _ENTRYPOINT.read_text(encoding="utf-8")
         # The dynamic key capture must exist, restrict to hex suffix, and feed into loop
         assert "JIRA_TOKEN_[0-9A-Fa-f]" in text
         assert "JIRA_DYNAMIC" in text

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -839,8 +839,8 @@ class TestTheWorkerBudgetIsMemoryBounded:
         invoked: a test that inspected only the live plugin manager would pass from
         ``test/`` even after a regression put the hook back in the wrong file.
         """
-        root_conftest = (_REPO_ROOT / "conftest.py").read_text()
-        suite_conftest = (_REPO_ROOT / "test" / "conftest.py").read_text()
+        root_conftest = (_REPO_ROOT / "conftest.py").read_text(encoding="utf-8")
+        suite_conftest = (_REPO_ROOT / "test" / "conftest.py").read_text(encoding="utf-8")
         hook = "def pytest_xdist_auto_num_workers"
 
         assert hook in root_conftest, (


### PR DESCRIPTION
## Problem / Motivation

Two source-inspection test modules decode checked-in UTF-8 files with bare `Path.read_text()`. On Windows systems whose preferred encoding is `cp950`, non-ASCII comments in those source files raise `UnicodeDecodeError` before the assertions run.

## Why it matters

The tests fail solely because of the runner locale, even though the repository content and product behavior are valid. This makes the suite non-portable across supported Windows environments.

## What changed

Specify `encoding="utf-8"` for the five reads of checked-in repository source in:

- `test/test_host_isolation_floor.py`
- `test/test_credential_scrub_sync.py`

The change intentionally does not touch the many temporary ASCII fixtures elsewhere in the suite.

## Tests

Red before, with `PYTHONUTF8` unset and preferred encoding `cp950`:

```text
pytest -q -n 0 test/test_host_isolation_floor.py test/test_credential_scrub_sync.py
4 failed, 77 passed
```

All four failures were `UnicodeDecodeError` from the affected source reads.

Green after fix under the same `cp950` environment:

```text
pytest -q -n 0 test/test_host_isolation_floor.py test/test_credential_scrub_sync.py
81 passed
```

Also passed `flake8`, `isort --check-only`, and `git diff --check` for the changed files.

## Manual verification

Confirmed `locale.getpreferredencoding(False)` returns `cp950` in the red and green runs.

## Screenshots

<!-- no-visual-delta -->

## Related Issues

Fixes #5510

## Checklist

- [x] Focused change with deterministic red-before evidence
- [x] Full affected modules pass in the failing locale
- [x] No product or UI behavior changed

## Contributor License Agreement

I agree to the project's contributor license terms.
