### PR TITLE
fix(dashboard): repair the dialog focus trap's Escape IME claim after the #5473/#5482 merge race

### DIFF
--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -82,7 +82,7 @@ export function useDialogFocusTrap(
         // purpose: `claimKey` stops propagation on the keys it declines, and
         // a hoisted claim would swallow Escapes belonging to callers that own
         // dismissal on bubble-phase listeners (`handleEscape = false`).
-        if (!imeLatchRef.current!.claimKey(e)) return
+        if (!imeLatch.claimKey(e)) return
         onEscape()
         return
       }


### PR DESCRIPTION
## Problem / Motivation

`main` is red on `tsc -b` (`website/src/hooks/useDialogFocusTrap.ts(85,14): error TS2552: Cannot find name 'imeLatchRef'`), and the break is not type-only: `imeLatchRef` does not exist at runtime either, so every `Escape` pressed in a dialog using the trap with `handleEscape` throws a `ReferenceError` before the trap can decide anything.

Root cause is a semantic merge race between two IME-guard PRs that touched the same hook with no textual conflict: #5473's refactor moved the latch to a plain `imeLatch` binding (from `useDocumentImeLatch`), while the Escape branch merged from #5482 still reads the older `imeLatchRef.current` shape.

## Why it matters

- Every frontend-touching PR inherits the tsc red, and the fork AI-review lanes gate on CI green — reviews skip repo-wide until this lands.
- At runtime, Escape-to-dismiss is broken in every dialog wired through this trap.

## What changed (motivation → approach → change)

The Tab branch in the same handler already claims through `imeLatch.claimKey(e)` (line 110), so the fix is to point the Escape branch at the same instance: `imeLatchRef.current!.claimKey(e)` → `imeLatch.claimKey(e)`. One token, no behavioral delta beyond restoring the intended behavior — the claim semantics documented in the surrounding comment are unchanged.

## Tests

- `npx tsc -b` — clean (was failing at the tip of `main`).
- `src/hooks/useDialogFocusTrap.imeGuard.test.tsx` + `src/hooks/useImeGuard.documentLatch.test.tsx` — all 25 pass, covering the Escape claim path this line sits on.

## Manual verification

N/A — the type checker plus the existing IME-guard unit suite cover the single-line change.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** one-token identifier fix inside an event handler; no rendered output changes.

## Related Issues

no linked issue: the break is a semantic collision between already-merged PRs (#5473, #5482), not a tracked defect.

## Checklist

- [x] Tests pass locally
- [x] Lint/type checks pass
- [x] PR body follows the template
