### PR TITLE
fix(dialog): repair the undefined imeLatchRef breaking tsc on main

### DIFF
--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -82,7 +82,7 @@ export function useDialogFocusTrap(
         // purpose: `claimKey` stops propagation on the keys it declines, and
         // a hoisted claim would swallow Escapes belonging to callers that own
         // dismissal on bubble-phase listeners (`handleEscape = false`).
-        if (!imeLatchRef.current!.claimKey(e)) return
+        if (!imeLatch.claimKey(e)) return
         onEscape()
         return
       }


### PR DESCRIPTION
## Summary

main's `tsc -b` is currently broken (TS2552 in `website/src/hooks/useDialogFocusTrap.ts:85`): the Escape branch references `imeLatchRef.current`, a ref that does not exist in this hook. The stale name arrived when #5473 propagated the ref-based IME-latch pattern from the six hand-rolled Tab traps into this hook, which holds its latch as the plain `imeLatch` value from `useDocumentImeLatch` (used correctly in the Tab branch 25 lines below).

Impact beyond the type error: at runtime every Escape keypress inside a focus-trapped dialog throws a `ReferenceError` instead of dismissing the dialog. This is very likely the `Frontend Tests (3)` red on main's own ci.yml runs since ~05:2x.

## Fix

One token: `imeLatchRef.current!.claimKey(e)` → `imeLatch.claimKey(e)`, matching the hook's own Tab branch.

## Verified

- `tsc -b` clean on this branch (fails on main)
- `CommandBarOverlay.test.tsx` (a `useDialogFocusTrap` consumer incl. Escape handling) 22/22

no linked issue: one-line repair of a build-breaking regression that landed on main within the hour; filing an issue would outlive the fix.
