### PR TITLE
fix(security): a forged flag in a deleted word could create a git ref

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1479,6 +1479,101 @@ def _side_effect_reason(segment: str) -> str:
     return ""
 
 
+def _elided_shell_construct(cmd: str) -> str:
+    """Reason *cmd* carries a construct bash REMOVES but ``shlex`` keeps.
+
+    Every operand rule in this module reads `shlex.split`'s token list and
+    assumes it is the argv the program receives. Two shell constructs break that
+    assumption by DELETING words rather than rewriting them, and `shlex` has no
+    concept of either — it hands them back as ordinary tokens:
+
+        git branch injected # --list      shlex: [… 'injected', '#', '--list']
+                                          bash:  git branch injected
+        git branch injected <<< --list    shlex: [… 'injected', '<<<', '--list']
+                                          bash:  git branch injected
+
+    In both, the `--list` this module reads never reaches git. It flips
+    `_GIT_REF_LIST_FLAGS` on, the bare `injected` is reclassified from "creates a
+    ref" to "a pattern", and the segment auto-approves — while bash creates the
+    ref. Measured against real git: `git branch injected # --list`,
+    `git tag forged # --list` and `git branch injected <<< --list` each created
+    the ref, so this is a live auto-approval bypass rather than a parse curiosity.
+
+    Refused as a CLASS rather than repaired. Repairing it means deciding what
+    bash would have deleted — i.e. reimplementing shell word removal on top of
+    the quoting rules `shlex` already models differently — and an earlier
+    revision of this fix tried exactly that and reopened the bypass it closed:
+    reproducing the comment made this scanner keep going after the `#`, and a
+    lone `'` inside comment TEXT (`echo x # don't`) then leaked quote state
+    across the newline, so the next line's forged `# --list` was never removed
+    and `git branch evil # --list` auto-approved again. Refusing on the FIRST
+    hit has no "afterwards" to get wrong. A read-only command needs neither
+    construct, and a refused command falls through to the human approval prompt.
+
+    Every way this scanner can disagree with bash therefore costs a prompt
+    rather than an approval. It is deliberately wider than bash in places —
+    `str.isspace()` accepts separators bash does not (U+00A0), and ANSI-C
+    `$'…\''` quoting is not modelled — and in this direction that is a false
+    refusal, never a false approval.
+
+    Quote-aware on purpose, so it costs no ordinary read. Both constructs are
+    shell syntax only when unquoted, and the common false positives are exactly
+    the quoted and non-word-initial spellings:
+
+        grep '#include' file        `#` inside quotes is data
+        git log --grep=#123         `#` mid-word is not a comment to bash
+        grep "<div>" file           `<` inside quotes is data
+
+    A backslash escape is honoured for the same reason (`grep \\# file`).
+
+    Two costs, stated rather than hidden, and asserted in the tests:
+
+    * An ordinary trailing comment is refused (`git status # note`,
+      `ls -la # list files`). Agent-emitted bash carries one often, so this is
+      the larger everyday cost of the two — a real auto-approve-rate loss, taken
+      knowingly because the alternative above is a live bypass.
+    * An unquoted input redirect is refused even where it is genuinely harmless
+      (`wc -l < file`, `grep pattern < file`), since what makes it dangerous is
+      the token-list divergence, not the direction of the data.
+    """
+    quote: str | None = None
+    # Start-of-string counts as a word boundary: bash reads a leading `#` as a
+    # comment, so `# git status` is an empty command rather than a read.
+    at_word_start = True
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if quote is not None:
+            # Inside double quotes a backslash still escapes; inside single
+            # quotes it is literal, exactly as a shell reads it.
+            if ch == "\\" and quote == '"' and i + 1 < n:
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            at_word_start = False
+            continue
+        if ch == "\\" and i + 1 < n:
+            # An escaped character is data, including an escaped `#` or `<`.
+            i += 2
+            at_word_start = False
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            at_word_start = False
+            continue
+        if ch == "#" and at_word_start:
+            return "a comment deletes the rest of the line, which `shlex` keeps"
+        if ch == "<":
+            return "an input redirect removes words that `shlex` keeps"
+        at_word_start = ch.isspace()
+        i += 1
+    return ""
+
+
 def _classify_bash(cmd: str) -> str:
     """Single source of truth for read-only bash classification.
 
@@ -1490,6 +1585,13 @@ def _classify_bash(cmd: str) -> str:
     """
     if not cmd.strip():
         return "empty command"
+    # Runs on the RAW command, before any splitting: a comment elides to the end
+    # of the line regardless of the `&&` / `;` boundaries the regex split below
+    # believes in, so `git status && git branch injected # --list` has to be
+    # caught here rather than per-segment.
+    elided = _elided_shell_construct(cmd)
+    if elided:
+        return f"unsafe shell pattern: {elided}"
     # Strip discard-only redirects (output sinks / stderr-merge) before the
     # unsafe-shell check; they are read-only but contain '>' / '&'.
     scrubbed = _DEVNULL_REDIR_RE.sub(" ", cmd)

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -673,6 +673,107 @@ class TestIsReadOnlyBash:
         # One operand after the terminator is the input, and reads.
         assert is_read_only_bash("cat f | uniq -- input") is True
 
+    def test_a_construct_bash_deletes_cannot_forge_a_flag(self):
+        """`shlex` keeps the words bash REMOVES, so a fake flag reached the tables.
+
+        Every operand rule here reads `shlex.split`'s token list as if it were the
+        program's argv. A comment and a herestring break that by deleting words
+        rather than rewriting them, and `shlex` models neither:
+
+            git branch injected # --list    shlex keeps '#', '--list'
+                                            bash runs `git branch injected`
+
+        The `--list` this module reads never reaches git. It turns list mode on,
+        the bare `injected` is reclassified from "creates a ref" to "a pattern",
+        and the segment auto-approves — while bash creates the ref. Measured
+        against real git: `git branch injected # --list`, `git tag forged # --list`
+        and `git branch injected <<< --list` each created the ref.
+
+        Refused as a class rather than repaired, since repairing it means deciding
+        what bash would have deleted — reimplementing word removal on top of
+        quoting rules `shlex` already models differently.
+        """
+        assert is_read_only_bash("git branch injected # --list") is False
+        assert is_read_only_bash("git tag forged # --list") is False
+        assert is_read_only_bash("git branch injected <<< --list") is False
+        assert is_read_only_bash("git branch injected < --list") is False
+        # A comment elides to end of LINE, past the `&&` the segment split
+        # believes in, so the whole raw command has to be scanned.
+        assert is_read_only_bash("git status && git branch injected # --list") is False
+        assert is_read_only_bash("# git status") is False
+
+    def test_refusing_on_the_first_hit_leaves_no_state_to_get_wrong(self):
+        """Why the construct is REFUSED and not reproduced.
+
+        An earlier revision of this fix reproduced the comment instead — stripped
+        it and classified the remainder — so that an ordinary trailing comment
+        would keep auto-approving. That reopened the very bypass this exists to
+        close: stripping means the scan CONTINUES past the `#`, and bash treats a
+        comment body as literal text while the scanner does not. A lone `'` in
+        comment text then leaked quote state across the newline, the next line's
+        forged `# --list` was never removed, and the ref-creating command
+        auto-approved again.
+
+        Refusing on the FIRST hit has no "afterwards" to get wrong, which is what
+        makes these inputs safe rather than a promise to handle them.
+        """
+        # The regression that killed the reproduce-the-comment approach.
+        assert is_read_only_bash("echo x # don't\ngit branch evil # --list") is False
+        # A second line is never reached, so it can never be smuggled past.
+        assert is_read_only_bash("echo hi # note\ngit branch x") is False
+        # Wider than bash is the SAFE direction: bash does not end a word on
+        # U+00A0 and does not read this `#` as a comment, so refusing it is a
+        # false refusal — never a false approval.
+        assert is_read_only_bash("git branch injected\u00a0# --list") is False
+        # ANSI-C `$'…'` quoting is likewise unmodelled, and likewise only ever
+        # costs a prompt.
+        assert is_read_only_bash("$'x\\' # y' ; git branch injected") is False
+
+    def test_an_elided_construct_is_detected_quote_aware(self):
+        """Both constructs are shell syntax only when unquoted, so quoting is honoured.
+
+        Scanning for a bare `#` or `<` would have cost the ordinary reads that
+        carry one as DATA, which is most of the ones that carry one at all.
+        """
+        # `#` inside quotes, and `#` mid-word, are not comments to bash.
+        assert is_read_only_bash("grep '#include' file") is True
+        assert is_read_only_bash("git log --grep '#123'") is True
+        assert is_read_only_bash("git log --grep=#123") is True
+        assert is_read_only_bash("echo a#b") is True
+        assert is_read_only_bash("grep \\# file") is True
+        # The plain reads are untouched.
+        assert is_read_only_bash("git status") is True
+        assert is_read_only_bash("git branch --list 'feat/*'") is True
+        assert is_read_only_bash("cat f | sort -u") is True
+
+    def test_the_two_costs_of_refusing_the_class_are_asserted_not_assumed(self):
+        """The price of the fail-safe direction, pinned so it cannot drift silently.
+
+        Neither of these is a bypass and neither is blocked — both fall through to
+        the human approval prompt. They are asserted so the auto-approve-rate loss
+        is visible in the suite rather than discovered in use, and so that anyone
+        who later narrows the refusal has a test telling them what they are
+        buying back.
+        """
+        # Cost 1, the larger one: an ordinary trailing comment is refused. Bash
+        # would simply delete it, so these ARE reads — but the classifier cannot
+        # tell this `#` from the forged-flag `#` above without reproducing the
+        # deletion, which is what reopened the bypass. Agent-emitted bash carries
+        # a trailing comment often, so this is a real everyday loss.
+        assert is_read_only_bash("git status # note") is False
+        assert is_read_only_bash("ls -la # list files") is False
+        assert is_read_only_bash("grep -rn foo src # find it") is False
+        assert "comment" in unsafe_bash_reason("git status # note")
+        # Cost 2: an unquoted input redirect is refused even where it is
+        # harmless, because the danger is the token-list divergence rather than
+        # the direction of the data.
+        assert is_read_only_bash("wc -l < file") is False
+        assert is_read_only_bash("grep pattern < file") is False
+        assert "redirect" in unsafe_bash_reason("wc -l < file")
+        # Quoting is the escape hatch for both: a user who means the `#` as data
+        # keeps their auto-approval.
+        assert is_read_only_bash("grep '#note' file") is True
+
     def test_a_positional_or_special_parameter_hides_the_real_argument(self):
         """`$@` and `$1` are expansions whose NAME is not an identifier.
 


### PR DESCRIPTION
## Problem / Motivation

`_classify_bash` — the single source of truth for read-only bash classification, gating both `--approval reads` / trust-reads auto-approval and the `hooks.on_tool_call` path — reads `shlex.split`'s token list and treats it as the argv the program will receive. Two shell constructs break that assumption by **deleting** words rather than rewriting them, and `shlex` models neither, handing both back as ordinary tokens:

```
git branch injected # --list      shlex: [… 'injected', '#', '--list']
                                  bash:  git branch injected

git branch injected <<< --list    shlex: [… 'injected', '<<<', '--list']
                                  bash:  git branch injected
```

The `--list` this module reads never reaches git. It satisfies `_GIT_REF_LIST_FLAGS`, list mode turns on, and the bare `injected` is reclassified from "creates a ref" to "a pattern" — so the segment auto-approves while bash creates the ref.

Measured against real git in a throwaway repo, not inferred:

| command | result |
| --- | --- |
| `git branch injected1 # --list` | branch `injected1` **CREATED** |
| `git tag forged1 # --list` | tag `forged1` **CREATED** |
| `git branch injected3 <<< --list` | branch `injected3` **CREATED** |
| `git branch injected2 < --list` | auto-approved; no ref (bash fails on the missing file) |

Reported by @SebastianYuSun while reviewing #5342, which introduced the list-mode operand rule this exploits. #5342 has since merged, so all three land on `main`.

## Why it matters

This is a security gate failing open. A user running with `--approval reads` (or trust-reads) has asked for read-only commands to skip the prompt; these three spellings look read-only to the classifier and mutate the repository instead — bypassing both the dashboard approval prompt and the `hooks.on_tool_call` gate, silently. Ref creation is the demonstrated payload, but the defect is generic: any operand rule in this module that keys off a flag can be handed a flag that bash will delete.

## What changed (motivation → approach → change)

**Root cause** is not the list-mode rule from #5342 — that rule is correct given its input. It is that the input is wrong: `shlex.split` does not model word *deletion*, so the token list the classifier reasons over is not the argv bash produces.

**Approach: refuse the class, and return on the FIRST hit.** `_elided_shell_construct(cmd)` in `src/kiro_crew/dashboard/state.py`, called at the top of `_classify_bash` before the existing `_DEVNULL_REDIR_RE` / `_UNSAFE_SHELL_RE` handling. A refused command is not blocked — it falls through to the human approval prompt.

That design was arrived at the hard way, and the history is the argument for it. An earlier revision of this PR **reproduced** the comment instead — stripped it and classified the remainder — specifically so an ordinary trailing comment would keep auto-approving. It reopened the very bypass it closed. Reproducing means the scan continues past the `#`, and bash treats a comment *body* as literal text while a quote-tracking scanner does not; a lone `'` in comment text leaked quote state across the newline, so the next line's forged `# --list` was never removed:

```
echo x # don't
git branch evil # --list          -> auto-approved, bash creates the ref
```

Refusing on the first hit has no "afterwards" to get wrong. Repairing this class means deciding what bash *would have* deleted — reimplementing shell word removal on top of the quoting rules `shlex` already models differently — and a genuinely read-only command needs neither construct.

The corollary is worth stating plainly: **every way this scanner can disagree with bash costs a prompt, never an approval.** It is deliberately wider than bash in places — `str.isspace()` accepts separators bash does not (U+00A0), and ANSI-C `$'…\''` quoting is not modelled — and in this direction each is a false refusal. Both spellings are asserted in the tests.

It runs on the **raw** command before any splitting, because a comment elides to end of *line* regardless of the `&&` / `;` boundaries the regex split believes in: `git status && git branch injected # --list` has to be caught before the split, not per segment.

It is **quote-aware**, so it costs no ordinary read. Both constructs are shell syntax only when unquoted, and the likely false positives are exactly the quoted and non-word-initial spellings — all asserted as still reading:

```
grep '#include' file        # inside quotes is data
git log --grep '#123'       same, as a flag value
git log --grep=#123         mid-word # is not a comment to bash
echo a#b                    same
grep \# file                an escaped # is data
```

### Two costs, asserted rather than hidden

Refusing a class means paying for its benign members. Both are asserted in a test whose only job is to pin them, so the loss is visible in the suite rather than discovered in use:

1. **An ordinary trailing comment is refused** — `git status # note`, `ls -la # list files`, `grep -rn foo src # find it`. Bash would simply delete it, so these *are* reads. The classifier cannot tell this `#` from the forged-flag `#` without reproducing the deletion, which is what reopened the bypass above. Agent-emitted bash carries a trailing comment often, so **this is the larger of the two costs and a real auto-approve-rate loss**, taken knowingly. Quoting is the escape hatch: `grep '#note' file` still auto-approves.
2. **An unquoted input redirect is refused** even where it is harmless — `wc -l < file`, `grep pattern < file` — because what makes it dangerous is the token-list divergence, not the direction of the data. `<` and `<<<` are one test for that reason.

### Deliberately not in scope

@SebastianYuSun's review names four more classes open on `main` (`wc` / `du --files0-from`, `git diff --filters`, `wc --file*` glob synthesis); I confirmed the first three auto-approve. They are a different mechanism — indirection through a file of names, not word deletion — so they want their own change.

Folding the five quote-blind alternations of `_UNSAFE_SHELL_RE` into this scanner (which would also remove the pre-existing `grep "<div>"` over-block) is the natural next subtraction, but it *loosens* what auto-approves — the opposite risk direction from this PR, which only ever moves commands toward the prompt. It wants its own review rather than a ride along a security fix. The broader argument for replacing these denylist tables with positive per-verb allowlists is tracked in #5370.

## Tests

Four methods in `test/test_trust_reads.py`. Three are **mutation-verified** (they fail with the fix reverted, pass with it); the fourth asserts only preserved reads, so it passes on `main` by construction and exists as a no-regression guard.

- `test_a_construct_bash_deletes_cannot_forge_a_flag` — each measured bypass now classifies as unsafe, plus the post-`&&` form that motivates scanning pre-split, plus `# git status` (nothing left to run).
- `test_refusing_on_the_first_hit_leaves_no_state_to_get_wrong` — the reason the design is refuse-and-stop. Pins the multi-line regression that killed the reproduce-the-comment approach (`echo x # don't\ngit branch evil # --list`), and the two spellings where this scanner is wider than bash (U+00A0 separator, ANSI-C `$'…\''`) — asserted as refused, since wider-than-bash is the safe direction here.
- `test_an_elided_construct_is_detected_quote_aware` — the quoted / mid-word / escaped spellings still read, and the plain reads are untouched.
- `test_the_two_costs_of_refusing_the_class_are_asserted_not_assumed` — both costs above, including the reason strings, plus the quoting escape hatch. This is the test that makes the auto-approve-rate loss visible and tells anyone who later narrows the refusal what they are buying back.

Counts: 100 in `test_trust_reads.py`; 282 across the three files covering both classifier call sites (`test_trust_reads.py`, `test_dashboard_approval.py`, `test_hooks.py`); 5655 in the wider `-k "trust or approval or hooks or security or chat_runner or state"` sweep, with two pre-existing sandbox failures in files this diff does not touch (`test_dev_fleet_app.py::test_trusted_bin_pins_the_resolved_target_not_the_symlink`, `test_host_isolation_floor.py::…[kiro_crew.agent-_DEFAULT_KIRO_HOOKS_DIR]`, both confirmed failing on clean `main`).

`black`, `flake8`, `isort` clean; `mypy` reports `Success: no issues found in 1 source file`.

## Manual verification

1. **Real git, not inference.** In a throwaway repo, ran each command through real bash and listed refs with `git branch --list` / `git tag --list` — the three rows marked CREATED above are observed refs. `git branch injected2 < --list` left no ref only because bash fails on the missing file; it was still auto-approving, so it is fixed too.
2. **Every case probed on both sides.** Ran `_classify_bash` on `main` and on this branch for all 24 cases across the four tests. All bypasses moved from auto-approve to prompting, every preserved-read case stayed auto-approving, and both declared costs prompt with the expected reason.
3. **Both blocking review findings reproduced, then re-probed.** `echo x # don't\ngit branch evil # --list` auto-approved on the reproduce-the-comment revision (confirmed) and prompts here. The U+00A0 and ANSI-C spellings prompt here; I could not get either to auto-approve on the previous revision either, but both are asserted because the direction of the divergence is the thing that matters.
4. **Boundary spellings checked for a hole in the word-start rule.** `git branch injected;# --list`, ` ;# `, `;#--list`, `|# ` all prompt (the segment split catches the ref-creating half). `git branch injected)# --list` auto-approves but is a **bash syntax error** — verified against real bash: `syntax error near unexpected token ')'`, no ref created — so it is not exploitable.

One pre-existing over-block noticed while verifying and **not** introduced here: `grep "<div>" file` is already refused on `main`, because `_UNSAFE_SHELL_RE` matches `>` without quote awareness. Out of scope, and noted above as the natural follow-up.

## Related Issues

no linked issue: reported in review of #5342 rather than filed as an issue; the broader allowlist redesign is tracked in #5370.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior is internal to the classifier; the rationale and both costs live in the function docstring
- [x] No secrets, credentials, or internal references in the diff
