### PR TITLE
fix(ci): repair the three main-branch breakages failing every open PR

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1235,7 +1235,11 @@ _ACTIVE_RUNS: dict[str, tuple[asyncio.Task, Any]] = {}
 # operations that constitute the critical section (read flag + register, or
 # set flag + snapshot) — it is never held across slow kill/await calls, so
 # there is no risk of asyncio lock contention or done-callback deadlocks.
-_SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()
+# LoopBoundLock (not a bare asyncio.Lock) because a module-global primitive
+# binds to the import-time loop and raises RuntimeError from any other loop
+# (Python 3.10+, see #4800) — this module is imported once but serves
+# whichever loop the gateway runs.
+_SHUTDOWN_ADMISSION_LOCK = LoopBoundLock()
 _SHUTDOWN_IN_PROGRESS = False
 
 

--- a/src/kiro_crew/skill_trust.py
+++ b/src/kiro_crew/skill_trust.py
@@ -180,7 +180,7 @@ def _parse_store(text: str) -> frozenset[str]:
     """
     try:
         data = json.loads(text)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         logger.error("%s: not valid JSON (%s); ignoring every grant", _STORE_FILENAME, exc)
         return frozenset()
     if not isinstance(data, dict):
@@ -353,7 +353,7 @@ def _read_entries_unlocked() -> list[dict[str, Any]]:
         raise TrustStoreUnreadable(f"{_STORE_FILENAME} is unreadable: {exc}") from exc
     try:
         data = json.loads(text)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except ValueError as exc:
         raise TrustStoreUnreadable(f"{_STORE_FILENAME} is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise TrustStoreUnreadable(f"{_STORE_FILENAME} is not a JSON object")

--- a/website/src/hooks/useDialogFocusTrap.ts
+++ b/website/src/hooks/useDialogFocusTrap.ts
@@ -82,7 +82,7 @@ export function useDialogFocusTrap(
         // purpose: `claimKey` stops propagation on the keys it declines, and
         // a hoisted claim would swallow Escapes belonging to callers that own
         // dismissal on bubble-phase listeners (`handleEscape = false`).
-        if (!imeLatchRef.current!.claimKey(e)) return
+        if (!imeLatch.claimKey(e)) return
         onEscape()
         return
       }


### PR DESCRIPTION
## Problem / Motivation

Every open PR is currently failing CI in bulk — Frontend Lint, Build Desktop ×3, Build Wheel, E2E, Linux Packaging, and the Loop-Bound Locks Gate all go red within 1–2 minutes. The cause is not in any of those PRs: **main itself carries three independent breakages**, and CI builds the merge ref (PR branch + current main), so main's defects fail everyone.

1. **Undeclared identifier on main** — `website/src/hooks/useDialogFocusTrap.ts:85` calls `imeLatchRef.current!.claimKey(e)`, but this file never declares `imeLatchRef`; its latch is `imeLatch` (line 71), and line 110 already calls it correctly. Three concurrent IME-guard PRs (#5421 / #5473 / #5482) merged textually but not semantically — the Escape branch kept a sibling hook's spelling (`useListKeyboardNav.ts` declares `imeLatchRef`) while this hook declares the direct object. `tsc` fails on every merge ref.
2. **Bare module-global asyncio primitive** — `src/kiro_crew/apps/builtins/dev_fleet/server.py:1238` declares `_SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()` at module scope, which the new Loop-Bound Locks Gate rejects: a module-global primitive binds to the import-time (or first-use) event loop and raises `RuntimeError` when acquired from another loop (Python 3.10+, see #4800).

3. **Redundant except member reintroduced past a ratchet** — `src/kiro_crew/skill_trust.py:183` and `:356` pair `json.JSONDecodeError` with a bare `ValueError` in except tuples. The redundancy ratchet (`test_jsondecodeerror_redundancy_ratchet.py`, added by #5320 after the #5287 cleanup) rejects the pattern because `JSONDecodeError` subclasses `ValueError`. #4736 merged concurrently with the ratchet and reintroduced it — the same textual-merge/semantic-conflict class as defect 1. Deterministic, not flaky: the test is a source scan and fails identically on unmodified `origin/main`.

**These interlock.** PRs #5515 and #5520 fix the tsc error alone — both are failing the Loop-Bound Locks Gate on their own merge refs, and any PR fixing one defect alone still fails the gates the others trip. No single-defect PR can reach green, which is why this PR carries all three one-line fixes.

## Why it matters

Main is unmergeable-into for the whole repository: every open PR reds out on defects it does not carry, CI minutes burn on doomed runs, and contributors mis-attribute the failures to their own diffs. Both existing fix attempts are structurally unable to land.

## What changed (motivation → approach → change)

- `website/src/hooks/useDialogFocusTrap.ts`: `imeLatchRef.current!.claimKey(e)` → `imeLatch.claimKey(e)`. The enclosing effect already lists `imeLatch` in its dependency array (line 116), so no deps change is needed. This preserves the IME-guard semantics all three merged PRs intended.
- `src/kiro_crew/apps/builtins/dev_fleet/server.py`: `_SHUTDOWN_ADMISSION_LOCK = asyncio.Lock()` → `LoopBoundLock()`, with a comment mapping to the gate's rule. `LoopBoundLock` is already imported in this module (line 61) and interface-compatible (`async with`, `.locked()`) — it is the exact remediation the gate's message names, and the pattern used by the module-global locks in `publish_sync.py` and `tips.py`.

- `src/kiro_crew/skill_trust.py`: `except (json.JSONDecodeError, ValueError)` → `except ValueError` at both sites — behavior identical (the subclass is still caught), and it is the exact form the #5287/#5320 cleanup established.

## Tests

No new tests — both defects are already covered by gates that were red and are now green:

- `python3 scripts/check_loop_bound_locks.py --test` and the scan both exit 0 (`no bare module-global asyncio primitives`).
- `npx tsc --noEmit` reports zero errors.
- The redundancy ratchet passes, and the skill_trust suites pass with the narrowed except clauses (**21 + 129 store tests**).
- The four dev_fleet suites that exercise `_SHUTDOWN_ADMISSION_LOCK` (`test_devfleet_active_runs_shutdown.py`, `test_dev_fleet_server_coverage.py`, `test_dev_fleet_app.py`, `test_dev_fleet_server_more_coverage.py`) pass with the `LoopBoundLock` in place: **660 passed, 1 skipped**. They monkeypatch the lock with `asyncio.Lock()` inside a running loop, which stays valid.
- `isort` / `flake8` clean on the changed Python file; the 4 `mypy` errors are byte-identical on unmodified `origin/main` (platform xattr stubs in `hooks.py` / `liveness.py`), not introduced here.

## Manual verification

N/A — both defects are mechanically decided by the compiler and the gate script; the green gate runs above are the verification.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** one-identifier rename inside a keyboard handler and a lock-class swap — no rendered output changes.

## Related Issues

no linked issue: emergency main-branch repair; supersedes single-defect attempts #5515 and #5520, which cannot reach green while the other defect stands.

