### PR TITLE
feat: per-turn usage API for one session

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -247,11 +247,9 @@ src/kiro_crew/dashboard/handlers/source_providers.py
 src/kiro_crew/dashboard/handlers/sso_login.py
 src/kiro_crew/dashboard/handlers/steering.py
 src/kiro_crew/dashboard/handlers/taskrunner.py
-src/kiro_crew/dashboard/handlers/telemetry.py
 src/kiro_crew/dashboard/handlers/terminal.py
 src/kiro_crew/dashboard/handlers/themes.py
 src/kiro_crew/dashboard/handlers/tunnel.py
-src/kiro_crew/dashboard/handlers/usage.py
 src/kiro_crew/dashboard/handlers/webapp_preview.py
 src/kiro_crew/dashboard/handlers/weixin_qr.py
 src/kiro_crew/dashboard/handlers_channel.py

--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -624,6 +624,45 @@ serves it as `GET /api/telemetry/context-trace?slot=<session key>` (`400` when
 `slot` is missing or blank), independent of the `telemetry.enabled` switch since
 these rows are always written.
 
+**Per-turn usage rows for one session.** `usage.slot_turn_usage(slot, days)` is
+the per-turn drill-down under `slot_spend`'s aggregate: one row per turn with
+`ts`, `model`, and the numeric fields named by `usage.TURN_USAGE_FIELDS`
+(tokens in/out, cache create/read, `credits`, `cost`, `duration_ms`, and the
+context meter pair). A non-numeric or non-finite field is dropped from its row,
+never the row itself. `handlers/telemetry.py::api_usage_turns` serves it as
+`GET /api/usage/turns?slot=<session key>[&days=N]` (`400` on a missing slot;
+`days` clamps to `[1, SPEND_WINDOW_DAYS]` rather than refusing, because shards
+beyond the window are retired anyway). This is the endpoint an **app** is
+granted through its manifest's `permissions.api` to account for what its own
+agent slots cost — apps otherwise have no path to credits, and the shard files'
+location and row shape stay this module's private contract. **App isolation is
+ROW-level** (App Kit §5.2, deny-by-default): each row is stamped with the
+owning app at write time (`_build_token_record`'s `app` field, threaded from
+the turn's slot), and an app caller receives only rows stamped with its own
+app — however the slot is named, and whether or not it is still live. A
+live-slot ownership check was deliberately rejected: it leaks on slot-name
+reuse (a recreated slot vouches for the previous owner's retained rows) and
+denies an app its own completed sessions, which are exactly what an audit
+reads. A foreign slot key answers `200` with no rows — indistinguishable from
+a slot that never ran — and rows predating the stamp are invisible to app
+callers. A **disabled app is refused outright** (`is_app_enabled`,
+deny-by-default, the same gate the opt-in builtin routes wrap every handler
+in): disable revokes read access, not only future writes. Every app-caller
+decision is SEL-logged — including a malformed request's refusal — and SEL
+plus the enablement probe run off-loop. The window is enforced **per row**,
+not only per shard file (the oldest shard in a window covers a whole day);
+a row whose timestamp cannot be parsed is excluded — accounting excludes
+what it cannot date. Dashboard users (empty request app) read any slot.
+**Stamping boundary:** rows are stamped at the two write sites that can run
+app-owned work — the dashboard chat runner (the slot's `_app`) and the
+subagent completion path (`info.app`, an app-dispatched subagent's spend).
+The task-runner, workflow, Slack and background-one-liner writers do not
+stamp because those surfaces are not app-owned — an empty stamp there is the
+correct value, not a gap. Webhook-session rows are currently unstamped and
+therefore invisible to app callers; if webhook sessions gain app ownership,
+that write site must stamp too. Same independence from the
+`telemetry.enabled` switch as the context trace.
+
 **Where it renders.** The breakdown is a **per-session side-panel tab**
 (`ViewKind` `context`, opened from the panel's `+` menu directly under Logs), not
 a section of the global Telemetry page. It is a **developer surface**: the `+`

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -7637,6 +7637,10 @@ async def _run_chat(
                         agent=read_effective_agent(client) or slot.agent or "",
                         context_used=_ctx_used,
                         context_window=_ctx_window,
+                        # Ownership is recorded at write time (see
+                        # _build_token_record): the row must outlive the slot
+                        # without becoming readable by whoever recreates its name.
+                        app=getattr(slot, "_app", "") or "",
                         ctx_blocks=slot_ctx_blocks,
                         phase=slot_ctx_phase,
                         # Same wall clock the turn-duration histogram below is

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -421,6 +421,7 @@ from kiro_crew.dashboard.handlers.telemetry import (  # noqa: E402, F401
     api_collection_status,
     api_context_trace,
     api_telemetry_startup,
+    api_usage_turns,
 )
 from kiro_crew.dashboard.handlers.terminal import (  # noqa: E402, F401
     api_terminal_complete,

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -23,6 +23,7 @@ Percentiles are interpolated from the histogram buckets (the DELTA-temporality
 exporter + the explicit-bucket View in ``provider.py`` make this meaningful and
 day-additive). mean/min/max are exact from the data point.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -36,10 +37,17 @@ from typing import Any, Iterator, NamedTuple
 from aiohttp import web
 
 from kiro_crew import __version__, beacon
+from kiro_crew import sel as _sel_mod
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.dashboard.chat_utils import slot_transcript_key
-from kiro_crew.dashboard.handlers.usage import context_occupancy, context_trace, cost_breakdown
+from kiro_crew.dashboard.handlers.usage import (
+    SPEND_WINDOW_DAYS,
+    context_occupancy,
+    context_trace,
+    cost_breakdown,
+    slot_turn_usage,
+)
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.hooks import validate_file_path
 from kiro_crew.metrics.provider import TELEMETRY_ENV_VAR, env_pin
@@ -91,9 +99,7 @@ _OTHER_SPLIT_ATTRS = frozenset({"warm"})
 # cross-module test enforces that, so a dead entry (e.g. a "cancelled" label
 # nothing ever emitted — user cancels map to "error") cannot linger and
 # mislead readers about what fault_rate counts.
-_TERMINAL_FAULT_OUTCOMES = frozenset(
-    {"error", "timeout", "unknown", "stall_exhausted"}
-)
+_TERMINAL_FAULT_OUTCOMES = frozenset({"error", "timeout", "unknown", "stall_exhausted"})
 
 # (shard-fingerprint, TTL) cache — shards are append-only, so a change to any
 # shard's (mtime, size) invalidates the cache exactly when needed (same pattern
@@ -185,9 +191,7 @@ def _shards_in_window(directory: Path, days: int) -> list[Path]:
     return out
 
 
-def _pct_from_buckets(
-    bucket_counts: list[int], bounds: list[float], q: float
-) -> float:
+def _pct_from_buckets(bucket_counts: list[int], bounds: list[float], q: float) -> float:
     """Interpolate the q-quantile (0..1) from explicit histogram buckets.
 
     ``bucket_counts`` has one more element than ``bounds`` (the trailing +Inf
@@ -374,9 +378,14 @@ class _Hist:
         g = self._dominant()
         if g is None:
             return {
-                "count": 0, "mean_ms": 0.0, "p50_ms": 0.0,
-                "p90_ms": 0.0, "min_ms": 0.0, "max_ms": 0.0,
-                "other_generations": 0, "total_count": 0,
+                "count": 0,
+                "mean_ms": 0.0,
+                "p50_ms": 0.0,
+                "p90_ms": 0.0,
+                "min_ms": 0.0,
+                "max_ms": 0.0,
+                "other_generations": 0,
+                "total_count": 0,
             }
         cnt = int(g["count"])
         return {
@@ -555,9 +564,7 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             # Which conversation source paid this startup. Older shards predate
             # the attribute, so they aggregate under "unknown" rather than being
             # dropped.
-            by_channel.setdefault(
-                str(attrs.get("channel", "unknown")), _Hist()
-            ).add(dp)
+            by_channel.setdefault(str(attrs.get("channel", "unknown")), _Hist()).add(dp)
             # Outcomes go through _Hist so they are scoped to the same bounds
             # generation as the count and percentiles reported.
             overall.add(dp, outcome=oc)
@@ -607,15 +614,11 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             # Internal phase split (kiro backend): spawn_init, session_new,
             # set_model. Deliberately outside the startup totals above — these
             # are components of one startup, not startups.
-            "phases": [
-                {"name": n, **phases[n].stats()} for n in sorted(phases)
-            ],
+            "phases": [{"name": n, **phases[n].stats()} for n in sorted(phases)],
             # Startup cost grouped by conversation source, so a slow surface can
             # be identified directly instead of being inferred by correlating
             # export windows against the gateway log.
-            "by_channel": [
-                {"name": n, **by_channel[n].stats()} for n in sorted(by_channel)
-            ],
+            "by_channel": [{"name": n, **by_channel[n].stats()} for n in sorted(by_channel)],
         },
         "turn": turn_block,
         "other": other,
@@ -632,9 +635,7 @@ def _parse_startup_metrics() -> dict[str, Any]:
         return {"startup": None, "turn": None, "other": [], "shard_count": 0}
 
     try:
-        key = tuple(
-            sorted((str(p), p.stat().st_mtime, p.stat().st_size) for p in shards)
-        )
+        key = tuple(sorted((str(p), p.stat().st_mtime, p.stat().st_size) for p in shards))
     except OSError:
         key = None
     now = time.time()
@@ -735,11 +736,83 @@ async def api_context_trace(request: web.Request) -> web.Response:
     """
     slot = (request.query.get("slot") or "").strip()
     if not slot:
-        return web.json_response(
-            {"error": "slot is required", "code": "slot_required"}, status=400
-        )
+        return web.json_response({"error": "slot is required", "code": "slot_required"}, status=400)
     trace = await asyncio.to_thread(context_trace, slot, _WINDOW_DAYS)
     return web.json_response(trace)
+
+
+async def api_usage_turns(request: web.Request) -> web.Response:
+    """GET /api/usage/turns?slot=<session key>[&days=N] — per-turn usage rows.
+
+    The per-turn drill-down under the Spend tab's aggregate, and the surface an
+    APP is granted (via its manifest's ``permissions.api``) to account for what
+    its own agent slots cost — tokens, credits, duration and the context meter,
+    one row per turn. Same independence as the context trace: usage rows are
+    always written, so this works with OTEL collection off.
+
+    App isolation is ROW-level (App Kit §5.2, deny-by-default): an app caller
+    receives only rows stamped with its own app at write time, however the slot
+    is named and whether or not it is still live. A foreign slot key therefore
+    answers 200 with no rows — indistinguishable from a slot that never ran —
+    and rows that predate the stamp are invisible to app callers. A live-slot
+    ownership check was deliberately rejected: it leaks on slot-name reuse and
+    denies an app its own completed sessions, which are exactly what an audit
+    reads. A DISABLED app is refused outright (``is_app_enabled``,
+    deny-by-default, same gate the opt-in builtin routes wrap every handler
+    in): disable must revoke read access, not only future writes.
+
+    Every app-caller decision is SEL-logged — including a malformed request's
+    refusal, so a probing app leaves a trail — and all SEL calls plus the
+    enablement check run off-loop (first use initialises SEL's key material on
+    disk). ``days`` clamps to the spend window's ceiling rather than refusing:
+    shards beyond it have been retired anyway.
+    """
+    request_app = str(request.get("app", "") or "")
+    slot = (request.query.get("slot") or "").strip()
+
+    def _audit(outcome: str, error: str = "", resources: str = "") -> None:
+        _sel_mod.sel().log_api_access(
+            caller=request_app,
+            operation="usage_turns",
+            outcome=outcome,
+            source="app_isolation",
+            resources=resources or f"slot={slot or '(missing)'}",
+            error=error,
+        )
+
+    if request_app and not await asyncio.to_thread(_app_is_enabled, request_app):
+        await asyncio.to_thread(_audit, "denied", "app is disabled")
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+    if not slot:
+        if request_app:
+            await asyncio.to_thread(_audit, "denied", "slot missing")
+        return web.json_response({"error": "slot is required", "code": "slot_required"}, status=400)
+    try:
+        days = int(request.query.get("days") or SPEND_WINDOW_DAYS)
+    except ValueError:
+        days = SPEND_WINDOW_DAYS
+    days = max(1, min(days, SPEND_WINDOW_DAYS))
+    turns = await asyncio.to_thread(
+        slot_turn_usage, slot, days, app=request_app if request_app else None
+    )
+    if request_app:
+        await asyncio.to_thread(_audit, "allowed", "", f"slot={slot} rows={len(turns)}")
+    return web.json_response({"slot": slot, "days": days, "turns": turns})
+
+
+def _app_is_enabled(app_name: str) -> bool:
+    """Deny-by-default enablement probe, import deferred to the worker thread.
+
+    Late import for the same reason the builtin routes defer theirs: the apps
+    manager pulls in the registry, and a module-scope import here would create
+    a handlers→apps import edge the dashboard package deliberately avoids.
+    """
+    try:
+        from kiro_crew.apps.manager import is_app_enabled
+
+        return bool(is_app_enabled(app_name))
+    except Exception:  # noqa: BLE001 — an unanswerable check is a denial
+        return False
 
 
 def _persisted_titles(conversation_log: Any, slot_keys: list[str]) -> dict[str, str]:
@@ -834,9 +907,7 @@ async def _with_conversation_titles(request: web.Request, cost: dict[str, Any]) 
 
     conversation_log = getattr(state, "conversation_log", None)
     if unresolved and conversation_log is not None:
-        titles.update(
-            await asyncio.to_thread(_persisted_titles, conversation_log, unresolved)
-        )
+        titles.update(await asyncio.to_thread(_persisted_titles, conversation_log, unresolved))
 
     rows = []
     for row in conversations:

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -10,7 +10,7 @@ import math
 import re
 import time
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -206,9 +206,7 @@ def slot_spend(days: int = SPEND_WINDOW_DAYS) -> dict[str, dict[str, float]]:
                     # cutoff must still be excluded individually.
                     ts_raw = str(obj.get("ts") or "")
                     try:
-                        ts_str = (
-                            ts_raw[:-1] + "+00:00" if ts_raw.endswith("Z") else ts_raw
-                        )
+                        ts_str = ts_raw[:-1] + "+00:00" if ts_raw.endswith("Z") else ts_raw
                         ts_epoch = datetime.fromisoformat(ts_str).timestamp()
                     except (ValueError, TypeError, AttributeError):
                         continue
@@ -505,6 +503,112 @@ def context_occupancy(days: int = 14) -> dict[str, Any]:
     )
 
 
+#: Numeric per-turn fields copied from a shard row into a usage-turns row, in
+#: the order the API returns them. One owner: the reader below and its tests
+#: both consume this tuple, so a field added to the recorder shows up in the
+#: API by being added HERE, not by editing two lists that can drift.
+TURN_USAGE_FIELDS: tuple[str, ...] = (
+    "input",
+    "output",
+    "cache_create",
+    "cache_read",
+    "credits",
+    "cost",
+    "duration_ms",
+    "context_used",
+    "context_window",
+)
+
+
+def _parse_row_ts(raw: str) -> float | None:
+    """A shard row's ``ts`` as an epoch, or ``None`` when unparseable.
+
+    The SAME spelling as this module's other shard-ts readers (``Z`` rewritten
+    to ``+00:00`` for py3.10's ``fromisoformat``; a naive stamp interpreted in
+    local time via ``.timestamp()``): two readers of the same rows must not
+    disagree about which rows a window contains.
+    """
+    try:
+        ts_str = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        return datetime.fromisoformat(ts_str).timestamp()
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def slot_turn_usage(
+    slot: str, days: int = SPEND_WINDOW_DAYS, *, app: str | None = None
+) -> list[dict[str, Any]]:
+    """Per-turn usage rows for ONE session, oldest first.
+
+    The per-turn drill-down under :func:`slot_spend`'s aggregate: each row is
+    one turn's shard record — model, token counts, credits, duration, and the
+    context meter — for the slot named. Built for the app-facing usage API: an
+    app that runs agent sessions (via app-owned slots) can account for what its
+    own turns cost without reaching into the shard files, whose location and
+    row shape are this module's private contract.
+
+    Same walk and the same reasons as :func:`context_trace`: per-session
+    per-turn detail stays OUT of the OTEL pipeline because slot keys are
+    unbounded-cardinality labels. Malformed lines and foreign slots are
+    skipped, not errors — a shard is an append-only log written by a live
+    gateway, and a torn tail line is expected during a write.
+
+    ``app`` is the ownership filter for app callers: only rows STAMPED with
+    that app at write time are returned. Ownership recorded on the row is what
+    survives the slot — a live-slot check both leaks on slot-name reuse (a
+    recreated slot vouches for the previous owner's rows) and denies an app
+    its own completed sessions. Rows written before the stamp existed carry no
+    ``app`` and are invisible to app callers: deny-by-default for ownership
+    that was never recorded. ``None`` (the dashboard) reads everything.
+
+    The window is enforced per ROW, not only per shard file: the oldest shard
+    in the window covers a whole day, so without a row-level cutoff a request
+    for N days returns rows up to a day older than asked — wrong in the one
+    place this API exists for, accounting.
+    """
+    turns: list[dict[str, Any]] = []
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).timestamp()
+    for shard_path in _shards_in_window(days):
+        try:
+            with shard_path.open() as fh:
+                for line in fh:
+                    try:
+                        obj = json.loads(line)
+                    except ValueError:
+                        continue
+                    if not isinstance(obj, dict) or obj.get("_type") != "tokens":
+                        continue
+                    if str(obj.get("slot") or "") != slot:
+                        continue
+                    if app is not None and str(obj.get("app") or "") != app:
+                        continue
+                    ts = _parse_row_ts(str(obj.get("ts") or ""))
+                    if ts is None or ts < cutoff:
+                        # An unparseable timestamp cannot prove it is inside the
+                        # window; accounting excludes what it cannot date.
+                        continue
+                    row: dict[str, Any] = {
+                        "ts": str(obj.get("ts") or ""),
+                        "model": str(obj.get("model") or ""),
+                    }
+                    for field in TURN_USAGE_FIELDS:
+                        value = obj.get(field)
+                        # ints are accepted directly: math.isfinite would convert
+                        # to float first and an oversized int raises OverflowError
+                        # (a corrupt row must never 500 the endpoint). bool is an
+                        # int subclass and is not a count.
+                        if isinstance(value, bool):
+                            continue
+                        if isinstance(value, int) or (
+                            isinstance(value, float) and math.isfinite(value)
+                        ):
+                            row[field] = value
+                    turns.append(row)
+        except (OSError, UnicodeDecodeError):
+            continue
+    return turns
+
+
 def context_trace(slot: str, days: int = 14) -> dict[str, Any]:
     """Per-turn injection breakdown for one session, newest shard last.
 
@@ -546,9 +650,7 @@ def context_trace(slot: str, days: int = 14) -> dict[str, Any]:
                     raw = obj.get("ctx_blocks")
                     if not isinstance(raw, dict) or not raw:
                         continue
-                    blocks = {
-                        str(k): _coerce_int(v) for k, v in raw.items() if _coerce_int(v) > 0
-                    }
+                    blocks = {str(k): _coerce_int(v) for k, v in raw.items() if _coerce_int(v) > 0}
                     if not blocks:
                         continue
                     for label, size in blocks.items():
@@ -704,9 +806,11 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
                     if credits > float(priciest["credits"]):
                         priciest = {"credits": credits, "slot": slot, "ts": ts_raw}
 
-                    for bucket, name in ((by_model, model),
-                                         (by_channel, telemetry_channel_of(slot or None)),
-                                         (by_category, session_category(slot))):
+                    for bucket, name in (
+                        (by_model, model),
+                        (by_channel, telemetry_channel_of(slot or None)),
+                        (by_category, session_category(slot)),
+                    ):
                         e = bucket.setdefault(name, {"name": name, "credits": 0.0, "turns": 0})
                         e["credits"] = float(e["credits"]) + credits
                         e["turns"] = int(e["turns"]) + 1
@@ -718,8 +822,15 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
                     if slot:
                         c = convos.setdefault(
                             slot,
-                            {"slot": slot, "credits": 0.0, "turns": 0, "peak_pct": 0.0,
-                             "first_ts": ts_epoch, "last_ts": ts_epoch, "_occ": []},
+                            {
+                                "slot": slot,
+                                "credits": 0.0,
+                                "turns": 0,
+                                "peak_pct": 0.0,
+                                "first_ts": ts_epoch,
+                                "last_ts": ts_epoch,
+                                "_occ": [],
+                            },
                         )
                         c["credits"] = float(c["credits"]) + credits
                         c["turns"] = int(c["turns"]) + 1
@@ -745,8 +856,9 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
 
     total = float(cur_tot["credits"])
 
-    def _rank(bucket: dict[str, dict[str, Any]], deltas: dict[str, float] | None
-              ) -> list[dict[str, Any]]:
+    def _rank(
+        bucket: dict[str, dict[str, Any]], deltas: dict[str, float] | None
+    ) -> list[dict[str, Any]]:
         out = []
         for e in sorted(bucket.values(), key=lambda x: -float(x["credits"])):
             row = {
@@ -845,9 +957,7 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
             "prior_turns": int(prev_tot["turns"]),
             "prior_per_turn": _per_turn(prev_tot),
             "delta_pct": (
-                round((total - prev_credits) / prev_credits * 100, 0)
-                if prev_credits > 0
-                else None
+                round((total - prev_credits) / prev_credits * 100, 0) if prev_credits > 0 else None
             ),
             "priciest": {
                 "credits": round(float(priciest["credits"]), 1),
@@ -970,11 +1080,7 @@ def read_effective_model(source: object) -> str:
         for attr in ("_resolved_model_id", "_model"):
             for node in chain:
                 candidate = getattr(node, attr, "")
-                if (
-                    isinstance(candidate, str)
-                    and candidate
-                    and candidate.strip().lower() != "auto"
-                ):
+                if isinstance(candidate, str) and candidate and candidate.strip().lower() != "auto":
                     return candidate
     except Exception:
         pass
@@ -1066,8 +1172,17 @@ def _build_token_record(
     elapsed_ms: int = 0,
     ctx_blocks: dict[str, int] | None = None,
     phase: str = "",
+    app: str = "",
 ) -> dict[str, Any]:
     """Build the JSONL token-usage record dict (no I/O).
+
+    ``app`` stamps the OWNING app on the row when the turn ran on an app-owned
+    slot. Ownership recorded at write time is what survives the slot: a live
+    ``_app`` check at read time both leaks on slot-name reuse (a recreated slot
+    would vouch for the previous owner's rows) and denies an app its own
+    completed sessions. Empty for dashboard/user slots, and absent from rows
+    written before the field existed — an app caller sees neither, which is
+    the deny-by-default answer for ownership that was never recorded.
 
     ``surface`` tags the dispatch origin (``dashboard``, ``cron``, ``subagent``,
     …) and ``agent`` the agent id resolved for the turn. ``context_used`` /
@@ -1108,6 +1223,7 @@ def _build_token_record(
         "_type": "tokens",
         "ts": now.isoformat(),
         "slot": slot_key,
+        "app": app,
         "provider": provider or "",
         "model": model or "",
         "input": getattr(u, "input_tokens", 0),
@@ -1153,8 +1269,7 @@ def _finite_only(record: dict[str, Any]) -> dict[str, Any]:
     is exactly what a bad one looks like, so the check cannot be a type check.
     """
     return {
-        k: (0.0 if isinstance(v, float) and not math.isfinite(v) else v)
-        for k, v in record.items()
+        k: (0.0 if isinstance(v, float) and not math.isfinite(v) else v) for k, v in record.items()
     }
 
 
@@ -1187,8 +1302,7 @@ def _write_token_record(record: dict[str, Any], now: datetime) -> None:
         if not non_finite:
             raise
         logger.warning(
-            "token usage: replaced non-finite value(s) with 0.0 before persisting; "
-            "fields=%s",
+            "usage row: replaced non-finite value(s) with 0.0 before persisting; " "fields=%s",
             ",".join(non_finite),
         )
         line = json.dumps(_finite_only(record), allow_nan=False)
@@ -1209,6 +1323,7 @@ def persist_token_record(
     elapsed_ms: int = 0,
     ctx_blocks: dict[str, int] | None = None,
     phase: str = "",
+    app: str = "",
     model_source: object = None,
 ) -> None:
     """Append a token usage record to today's shard under
@@ -1249,6 +1364,7 @@ def persist_token_record(
                 elapsed_ms=elapsed_ms,
                 ctx_blocks=ctx_blocks,
                 phase=phase,
+                app=app,
             ),
             now,
         )
@@ -1269,6 +1385,7 @@ async def persist_token_record_async(
     elapsed_ms: int = 0,
     ctx_blocks: dict[str, int] | None = None,
     phase: str = "",
+    app: str = "",
     model_source: object = None,
 ) -> None:
     """Async variant: builds the record on-loop, offloads the file write.
@@ -1297,6 +1414,7 @@ async def persist_token_record_async(
             elapsed_ms=elapsed_ms,
             ctx_blocks=ctx_blocks,
             phase=phase,
+            app=app,
         )
         await asyncio.to_thread(_write_token_record, record, now)
     except Exception:

--- a/src/kiro_crew/dashboard/routes/system.py
+++ b/src/kiro_crew/dashboard/routes/system.py
@@ -59,6 +59,7 @@ def register(app: web.Application) -> None:
     app.router.add_get("/api/usage", handlers.api_usage)
     app.router.add_get("/api/telemetry/startup", handlers.api_telemetry_startup)
     app.router.add_get("/api/telemetry/context-trace", handlers.api_context_trace)
+    app.router.add_get("/api/usage/turns", handlers.api_usage_turns)
     app.router.add_get("/api/telemetry/beacon", handlers.api_beacon_status)
     app.router.add_get("/api/telemetry/collection", handlers.api_collection_status)
     app.router.add_get("/api/tailnet/status", handlers.api_tailnet_status)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -6065,6 +6065,10 @@ class SubagentManager:
                 _complete_event,
                 provider="claude_code" if is_cc else "acp",
                 surface="subagent",
+                # Ownership stamp (see _build_token_record): an app-dispatched
+                # subagent's spend must be readable by that app's audit — the
+                # illustrator lane of an app is exactly this path.
+                app=info.app or "",
                 # Explicit/inherited `agent` FIRST here — unlike every other
                 # surface. Under session sharing this subagent reuses the
                 # PARENT's runtime, so read_effective_agent() would report the

--- a/test/metrics/test_usage_turns.py
+++ b/test/metrics/test_usage_turns.py
@@ -1,0 +1,318 @@
+"""Per-slot per-turn usage rows: the app-facing read side.
+
+``usage.slot_turn_usage(slot, days)`` returns one row per turn of one session —
+tokens, credits, duration, context meter — from the same shards ``slot_spend``
+aggregates; ``telemetry.api_usage_turns`` is the thin HTTP wrapper an app is
+granted through its manifest's ``permissions.api``. Mirrors
+test_context_trace's temp-shard fixture and drives the REAL reader over
+synthetic rows.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers import usage as usage_mod
+from kiro_crew.dashboard.handlers.telemetry import api_usage_turns
+from kiro_crew.dashboard.handlers.usage import TURN_USAGE_FIELDS, slot_turn_usage
+
+
+@pytest.fixture(autouse=True)
+def _isolated_shards(tmp_path, monkeypatch):
+    monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", tmp_path)
+    return tmp_path
+
+
+def _row(slot, *, ts=None, **extra):
+    row = {
+        "_type": "tokens",
+        "ts": ts or datetime.now(timezone.utc).isoformat(),
+        "slot": slot,
+        "model": "some-model",
+        "input": 1000,
+        "output": 200,
+        "cache_create": 0,
+        "cache_read": 5000,
+        "credits": 1.25,
+        "cost": 0.0,
+        "duration_ms": 42000,
+        "context_used": 74000,
+        "context_window": 200000,
+    }
+    row.update(extra)
+    return row
+
+
+def _write(shard_dir, rows, day=None):
+    day = day or datetime.now().astimezone().strftime("%Y-%m-%d")
+    path = shard_dir / f"{day}.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+    return path
+
+
+class TestSlotTurnUsage:
+    def test_returns_only_the_named_slots_rows(self, _isolated_shards):
+        _write(
+            _isolated_shards,
+            [
+                _row("endless-run-abc"),
+                _row("chat-1-123"),
+                _row("endless-run-abc", credits=2.5),
+            ],
+        )
+        turns = slot_turn_usage("endless-run-abc")
+        assert len(turns) == 2
+        assert [t["credits"] for t in turns] == [1.25, 2.5]
+        assert all(t["model"] == "some-model" for t in turns)
+
+    def test_every_declared_field_rides_along(self, _isolated_shards):
+        _write(_isolated_shards, [_row("s1")])
+        (turn,) = slot_turn_usage("s1")
+        for field in TURN_USAGE_FIELDS:
+            assert field in turn, f"declared field {field} missing from the row"
+
+    def test_an_oversized_integer_field_does_not_crash_the_reader(self, _isolated_shards):
+        # math.isfinite(huge_int) raises OverflowError on the float conversion;
+        # a corrupt row must degrade, never 500 the endpoint. bool is an int
+        # subclass and is not a count.
+        _write(_isolated_shards, [_row("s1", input=10**400, credits=True)])
+        (turn,) = slot_turn_usage("s1")
+        assert turn["input"] == 10**400, "a large integer is a value, not corruption"
+        assert "credits" not in turn
+
+    def test_non_numeric_and_non_finite_values_are_dropped(self, _isolated_shards):
+        _write(
+            _isolated_shards,
+            [_row("s1", credits="oops", duration_ms=float("inf"))],
+        )
+        (turn,) = slot_turn_usage("s1")
+        assert "credits" not in turn
+        assert "duration_ms" not in turn
+        assert turn["input"] == 1000, "the bad fields are dropped, not the row"
+
+    def test_torn_tail_lines_and_foreign_types_are_skipped(self, _isolated_shards):
+        path = _write(_isolated_shards, [_row("s1"), {"_type": "other", "slot": "s1"}])
+        with path.open("a") as fh:
+            fh.write('{"_type": "tokens", "slot": "s1", "trunc')
+        assert len(slot_turn_usage("s1")) == 1
+
+    def test_an_unknown_slot_is_an_empty_list(self, _isolated_shards):
+        _write(_isolated_shards, [_row("s1")])
+        assert slot_turn_usage("nobody") == []
+
+    def test_rows_outside_the_window_are_not_read(self, _isolated_shards):
+        old_day = (datetime.now().astimezone() - timedelta(days=30)).strftime("%Y-%m-%d")
+        _write(_isolated_shards, [_row("s1")], day=old_day)
+        _write(_isolated_shards, [_row("s1", credits=9.0)])
+        turns = slot_turn_usage("s1", days=2)
+        assert [t["credits"] for t in turns] == [9.0]
+
+
+class TestApiUsageTurns:
+    @staticmethod
+    def _app() -> web.Application:
+        app = web.Application()
+        app.router.add_get("/api/usage/turns", api_usage_turns)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_slot_is_required(self):
+        async with TestClient(TestServer(self._app())) as client:
+            resp = await client.get("/api/usage/turns")
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "slot_required"
+
+    @pytest.mark.asyncio
+    async def test_returns_the_slots_turns(self, _isolated_shards):
+        _write(_isolated_shards, [_row("endless-run-abc")])
+        async with TestClient(TestServer(self._app())) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "endless-run-abc"})
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["slot"] == "endless-run-abc"
+            assert len(body["turns"]) == 1
+            assert body["turns"][0]["credits"] == 1.25
+
+    @pytest.mark.asyncio
+    async def test_days_is_clamped_not_refused(self, _isolated_shards):
+        _write(_isolated_shards, [_row("s1")])
+        async with TestClient(TestServer(self._app())) as client:
+            for bad in ("9999", "0", "-3", "banana"):
+                resp = await client.get("/api/usage/turns", params={"slot": "s1", "days": bad})
+                assert resp.status == 200, f"days={bad} must clamp, not fail"
+                body = await resp.json()
+                assert 1 <= body["days"] <= usage_mod.SPEND_WINDOW_DAYS
+
+
+class TestAppIsolation:
+    """App Kit §5.2 on the usage read: ownership lives on the ROW.
+
+    An app caller receives only rows stamped with its own app at write time —
+    however the slot is named, and whether or not it is still live. A live-slot
+    check was deliberately rejected: it leaks on slot-name reuse (a recreated
+    slot would vouch for the previous owner's retained rows) and denies an app
+    its own completed sessions, which are exactly what an audit reads. Rows
+    that predate the stamp are invisible to app callers: deny-by-default for
+    ownership that was never recorded.
+    """
+
+    @staticmethod
+    def _app(request_app: str = "") -> web.Application:
+        app = web.Application()
+
+        @web.middleware
+        async def stamp(request, handler):
+            request["app"] = request_app
+            return await handler(request)
+
+        app.middlewares.append(stamp)
+        app.router.add_get("/api/usage/turns", api_usage_turns)
+        return app
+
+    @pytest.fixture(autouse=True)
+    def _quiet_sel(self, monkeypatch):
+        import kiro_crew.sel as sel_mod
+        from kiro_crew.dashboard.handlers import telemetry as tele_mod
+
+        calls: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+        # Enablement is a separate axis, gated ON here so ownership semantics
+        # are what these tests exercise; the disabled-app test flips it off.
+        monkeypatch.setattr(tele_mod, "_app_is_enabled", lambda name: True)
+        self.sel_calls = calls
+
+    @pytest.mark.asyncio
+    async def test_an_app_reads_only_rows_stamped_with_its_own_app(self, _isolated_shards):
+        _write(
+            _isolated_shards,
+            [
+                _row("shared-name", app="acme-app", credits=1.0),
+                _row("shared-name", app="other-app", credits=2.0),
+                _row("shared-name", credits=3.0),  # pre-stamp row: no owner recorded
+            ],
+        )
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "shared-name"})
+            assert resp.status == 200
+            turns = (await resp.json())["turns"]
+            assert [t["credits"] for t in turns] == [1.0], (
+                "an app sees its own stamped rows only — never another owner's, "
+                "never pre-stamp rows"
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_dead_sessions_own_rows_remain_readable(self, _isolated_shards):
+        # No live slot exists at all; ownership recorded on the row is enough.
+        _write(_isolated_shards, [_row("finished-run", app="acme-app")])
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "finished-run"})
+            assert resp.status == 200
+            assert len((await resp.json())["turns"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_slot_is_indistinguishable_from_an_empty_one(self, _isolated_shards):
+        _write(_isolated_shards, [_row("theirs", app="other-app")])
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            for probe in ("theirs", "never-existed"):
+                resp = await client.get("/api/usage/turns", params={"slot": probe})
+                assert resp.status == 200
+                assert (await resp.json())["turns"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_user_reads_everything(self, _isolated_shards):
+        _write(
+            _isolated_shards,
+            [_row("any-slot", app="acme-app"), _row("any-slot")],
+        )
+        async with TestClient(TestServer(self._app(""))) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "any-slot"})
+            assert resp.status == 200
+            assert len((await resp.json())["turns"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_app_is_refused_outright(self, _isolated_shards, monkeypatch):
+        from kiro_crew.dashboard.handlers import telemetry as tele_mod
+
+        monkeypatch.setattr(tele_mod, "_app_is_enabled", lambda name: False)
+        _write(_isolated_shards, [_row("mine", app="acme-app")])
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "mine"})
+            assert resp.status == 404, "disable must revoke read access, not only writes"
+        assert any(c.get("error") == "app is disabled" for c in self.sel_calls)
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_app_request_is_still_audited(self, _isolated_shards):
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            resp = await client.get("/api/usage/turns")  # no slot
+            assert resp.status == 400
+        assert any(
+            c.get("outcome") == "denied" and c.get("error") == "slot missing"
+            for c in self.sel_calls
+        ), "a probing app must leave a trail even when the request is malformed"
+
+    @pytest.mark.asyncio
+    async def test_grants_are_audited_off_the_denial_path_too(self, _isolated_shards):
+        _write(_isolated_shards, [_row("mine", app="acme-app")])
+        async with TestClient(TestServer(self._app("acme-app"))) as client:
+            resp = await client.get("/api/usage/turns", params={"slot": "mine"})
+            assert resp.status == 200
+        assert any(c.get("outcome") == "allowed" for c in self.sel_calls)
+
+
+class TestRowLevelWindow:
+    def test_a_boundary_shard_rows_older_than_the_cutoff_are_excluded(self, _isolated_shards):
+        # The oldest shard FILE in a 2-day window covers a whole day; a row in
+        # it can still be older than now-2d. The cutoff is per row.
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=2, hours=3)).isoformat()
+        fresh_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        day = (datetime.now().astimezone() - timedelta(days=1)).strftime("%Y-%m-%d")
+        _write(_isolated_shards, [_row("s1", ts=old_ts, credits=1.0)], day=day)
+        _write(_isolated_shards, [_row("s1", ts=fresh_ts, credits=2.0)])
+        turns = slot_turn_usage("s1", days=2)
+        assert [t["credits"] for t in turns] == [2.0]
+
+    def test_a_shard_with_invalid_bytes_is_skipped_not_a_500(self, _isolated_shards):
+        # Same contract as slot_spend's reader: a corrupt shard (invalid UTF-8)
+        # is skipped; the endpoint must never 500 over one bad file.
+        from datetime import datetime as _dt
+
+        day = _dt.now().astimezone().strftime("%Y-%m-%d")
+        bad = _isolated_shards / f"{day}.jsonl"
+        bad.write_bytes(b"\xff\xfe broken \xff\n")
+        assert slot_turn_usage("s1", days=2) == []
+
+    def test_an_unparseable_timestamp_is_excluded(self, _isolated_shards):
+        _write(_isolated_shards, [_row("s1", ts="not-a-date", credits=1.0)])
+        assert slot_turn_usage("s1", days=2) == [], "accounting excludes what it cannot date"
+
+
+class TestWriteSiteStamping:
+    """The write sites that can run app-owned work must stamp the row.
+
+    Source-level pin on the two load-bearing sites (chat runner slot._app,
+    subagent info.app): behavioural coverage lives in each surface's own
+    suite, but a refactor that silently drops the kwarg would undercount an
+    app's audit forever (old rows are unrecoverable by design), so the stamp's
+    PRESENCE is pinned here where the API contract lives.
+    """
+
+    _ROOT = Path(__file__).resolve().parents[2]
+
+    def test_chat_runner_stamps_the_slots_app(self):
+        src = (self._ROOT / "src/kiro_crew/dashboard/chat_runner.py").read_text(encoding="utf-8")
+        assert 'app=getattr(slot, "_app", "") or ""' in src
+
+    def test_subagent_completion_stamps_the_dispatching_app(self):
+        src = (self._ROOT / "src/kiro_crew/subagent.py").read_text(encoding="utf-8")
+        assert 'app=info.app or ""' in src


### PR DESCRIPTION
## What

`GET /api/usage/turns?slot=<session key>[&days=N]` — one row per turn of one session: `ts`, `model`, tokens in/out, cache create/read, **`credits`**, `cost`, `duration_ms`, and the context meter pair, read from the same usage shards `slot_spend()` aggregates.

**This PR also changes the write side and ships an isolation regime** (stated up front because it is most of the diff):

- **Every usage row now records the owning app at write time** (`_build_token_record`'s `app` field), threaded from the two write sites that can run app-owned work: the dashboard chat runner (the slot's `_app`) and the subagent completion path (`info.app`). Other writers (task runner, workflows, Slack, background one-liners) are not app-owned surfaces — an empty stamp there is the correct value. The stamp ships now even though the read endpoint has no in-tree consumer yet, because pre-stamp rows are unrecoverable by design: every day without the stamp is app-attributable history lost.
- **App isolation is row-level, deny-by-default** (App Kit §5.2): an app caller receives only rows stamped with its own app, however the slot is named and whether or not it is still live. A foreign slot answers 200 with no rows — indistinguishable from a slot that never ran. A live-slot ownership check was deliberately rejected (leaks on slot-name reuse; denies an app its own completed sessions).
- **A disabled app is refused outright** (`is_app_enabled`, the same deny-by-default gate the opt-in builtin routes use): disable revokes reads, not only future writes.
- **Every app-caller decision is SEL-audited**, malformed requests included, with SEL and the enablement probe running off-loop.
- The window is enforced **per row** (the oldest shard file covers a whole day); unparseable timestamps are excluded — accounting excludes what it cannot date. `days` clamps to `[1, SPEND_WINDOW_DAYS]`.

## Why

An app that runs agent sessions has no path to credits: the shard files' location and row shape are the usage module's private contract. The endpoint is granted per-app through the existing `permissions.api` mechanism; no SDK changes needed (`useAppApi()` covers granted paths). **Consumer status, stated plainly:** no in-tree consumer grants this path yet; the first intended consumer is an installed app's per-turn performance/audit page (in review on that app's repo). The write-side stamp does not wait for it, for the unrecoverability reason above.

## Verification

- 21 endpoint tests: reader semantics, row-level isolation (4), disabled-app gate, audit-before-400, per-row window boundary, corrupt-shard tolerance, and 2 source pins on the stamp kwargs
- 8/8 seeded guard mutations caught across rounds (row filter, pre-stamp leak, filter pass-through, disabled gate, window cutoff, decode guard, plus the earlier live-check pair retired with that design)
- black gate, isort, flake8, mypy (1088 files), docs-lint clean; spec updated in the same commit (`metrics.md`)

**Why no screenshot:** backend-only API endpoint; no user-visible frontend surface changed.

---
**Diff-volume note** (per First Principles): of the changed lines in the two touched handlers, roughly 200 are black-formatting (both files were graduated from the black-baseline in this commit, declared in the commit message); the functional change is ~40 lines plus tests and spec.