### PR TITLE
ci: explain fork PR description gaps with a check-run instead of N cron comments

### DIFF
--- a/.github/workflows/fork-pr-description.yml
+++ b/.github/workflows/fork-pr-description.yml
@@ -1,0 +1,310 @@
+name: Fork PR Description
+
+# Tells an EXTERNAL contributor, on the PR itself, why the fork-workflow
+# auto-approval bot is not approving their workflow runs yet: the PR is a draft,
+# or its description is missing sections the PR template requires.
+#
+# WHY THIS IS A CHECK AND NOT A COMMENT.
+# The same two rules are evaluated by the maintainer-side auto-approval cron,
+# which each maintainer runs on their own machine. That cron used to post the
+# explanation as a PR comment and de-duplicate against a LOCAL state file --
+# state no other maintainer's cron can see. With four maintainers running it,
+# one non-compliant PR collected one comment per maintainer per tick (#5038 took
+# eight). A check-run has no such failure mode: it is keyed on (head SHA, check
+# name), so every publisher converges on the same single row instead of
+# appending. The cron keeps EVALUATING the rules -- that is what decides
+# approval, is side-effect-free, and cannot deadlock on a workflow that is
+# itself awaiting approval -- and no longer NOTIFIES.
+#
+# WHY `pull_request_target` AND AN EXPLICIT check-run.
+#   - A `pull_request` run from a first-time contributor's fork lands in
+#     `action_required` and waits for the very approval this check exists to
+#     explain, so it would never run on the PRs that need it. `_target` runs
+#     immediately in the trusted base context.
+#   - `_target` runs report against the BASE sha, so they do not appear in the
+#     PR's own check list. Creating the check-run explicitly against
+#     `head.sha` puts it beside the other checks (same idiom as the Stage-2
+#     fork AI reviewers).
+#
+# TRUST MODEL: nothing here checks out, builds, or executes fork code. The only
+# fork-controlled value read is the PR body, which is passed through the
+# environment and matched with `grep -F` -- never interpolated into a script.
+#
+# Fork-only by design: same-repo PRs are authored by maintainers who own this
+# template, and pr-scope.yml already covers the shape questions that apply to
+# both paths. No check-run is created for them at all.
+#
+# LIMIT, stated plainly: this verifies that the required HEADINGS are present,
+# not that they are filled in. A PR that keeps the template verbatim passes.
+# Judging whether the prose actually explains the change is the AI reviewers'
+# job; this gate only catches the description that was replaced wholesale or
+# never written.
+
+on:
+  pull_request_target:
+    types:
+      # `edited` is the one the cron structurally cannot see: it fires when the
+      # author fixes the description WITHOUT pushing, which is exactly the
+      # remedy this check asks for. `synchronize` re-publishes against the new
+      # head SHA, since a check-run belongs to one commit.
+      - opened
+      - reopened
+      - edited
+      - ready_for_review
+      - converted_to_draft
+      - synchronize
+
+permissions:
+  checks: write
+
+concurrency:
+  # NOT cancel-in-progress. This job's whole contract is a single idempotent row,
+  # and it reaches that by reading the row then writing it. Cancelling a run
+  # mid-sequence can stop it between the read and the write, so a second run's
+  # read misses the row the first was about to create and both create one.
+  # Serialising per PR closes that window outright; the job takes seconds, so
+  # queueing costs nothing, and the last edit still produces the final verdict.
+  group: fork-pr-description-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  describe:
+    name: Fork PR Description
+    # Fork PRs only. `head.repo.full_name` is null for a PR from a deleted
+    # fork, which compares unequal and is therefore treated as a fork -- the
+    # fail-toward-evaluating direction.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate PR description
+        id: evaluate
+        env:
+          # Fork-controlled. Read as data only.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          # Kept byte-identical to the maintainer cron's REQUIRED_SECTIONS so
+          # the check and the approval decision can never disagree. Matched as
+          # a case-insensitive prefix, so a heading may carry a suffix (the
+          # template's own "## What changed (motivation -> approach -> change)"
+          # matches "## What changed").
+          REQUIRED_SECTIONS: |
+            ## Problem / Motivation
+            ## Why it matters
+            ## What changed
+            ## Tests
+        run: |
+          set -uo pipefail
+
+          # Strip CR at the input. GitHub returns a web-authored PR body with
+          # CRLF line endings, so a closing fence arrives as "```\r" -- and a
+          # fence closer may carry nothing but whitespace after the marker, so
+          # the stray CR would stop it closing, swallow every heading below the
+          # code block, and mark a template-compliant PR non-compliant. Fixing
+          # it here rather than in the scanner keeps the CommonMark rules below
+          # reading like the spec, and covers the heading text too.
+          body_file="$(mktemp)"
+          printf '%s' "${PR_BODY:-}" | tr -d '\r' > "$body_file"
+
+          # Collect the body's real ATX heading lines, lowercased, EXCLUDING
+          # anything inside a fenced code block.
+          #
+          # Why a scanner and not a grep. Matching the raw body passes a PR that
+          # merely mentions "## Tests" mid-sentence, or that pastes the template
+          # into a fence to ask a question about it -- both report full
+          # compliance for a description that has no sections at all. And
+          # matching whole lines is equally wrong in the other direction: the
+          # template's own heading is "## What changed (motivation -> approach
+          # -> change)", so the match must stay a PREFIX of a heading line.
+          #
+          # Why CommonMark's real rules rather than a toggle. A naive
+          # "any fence line flips a boolean" scanner is wrong for nested
+          # examples: a ````-fenced block that CONTAINS ``` lines flips the
+          # boolean off mid-block and starts accepting the enclosed text as
+          # headings. The invariant that makes that whole family unreachable is
+          # the spec's own: a fence closes only on the SAME character, at a
+          # length >= the opener, with nothing but whitespace after it; and an
+          # ATX heading takes at most 3 leading spaces (4+ is indented code).
+          # Implemented below with substr/while rather than regex interval
+          # expressions, because `awk` is mawk on the Ubuntu runners and its
+          # interval support is not something to bet a gate on.
+          headings="$(awk '
+            {
+              s = $0
+              n = 0
+              while (n < 3 && substr(s, 1, 1) == " ") { s = substr(s, 2); n++ }
+
+              mch = ""
+              if (substr(s, 1, 3) == "```") mch = "`"
+              else if (substr(s, 1, 3) == "~~~") mch = "~"
+              mlen = 0
+              if (mch != "") {
+                while (substr(s, mlen + 1, 1) == mch) mlen++
+                rest = substr(s, mlen + 1)
+              }
+
+              if (open == "") {
+                # An opening fence may carry an info string; a closing one may not.
+                if (mch != "") { open = mch; olen = mlen; next }
+              } else {
+                if (mch == open && mlen >= olen && rest ~ /^[ \t]*$/) {
+                  open = ""; olen = 0
+                }
+                next
+              }
+
+              hn = 0
+              while (hn < 7 && substr(s, hn + 1, 1) == "#") hn++
+              if (hn >= 1 && hn <= 6) {
+                c = substr(s, hn + 1, 1)
+                if (c == " " || c == "\t") print tolower(s)
+              }
+            }
+          ' "$body_file")"
+
+          missing=()
+          while IFS= read -r section; do
+            [ -n "$section" ] || continue
+            # Prefix-compare with `case`, not a regex: the needle is data, and
+            # this way no section name ever needs regex-escaping.
+            needle="$(printf '%s' "$section" | tr '[:upper:]' '[:lower:]')"
+            found=0
+            while IFS= read -r heading; do
+              case "$heading" in
+                "$needle"*) found=1; break ;;
+              esac
+            done <<< "$headings"
+            if [ "$found" -eq 0 ]; then
+              missing+=("$section")
+            fi
+          done <<< "$REQUIRED_SECTIONS"
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            conclusion="failure"
+            if [ "${#missing[@]}" -eq 1 ]; then
+              title="1 required description section is missing"
+            else
+              title="${#missing[@]} required description sections are missing"
+            fi
+          elif [ "$PR_DRAFT" = "true" ]; then
+            # Not a defect -- the author parked it deliberately. `neutral`
+            # renders grey rather than red while still carrying the reason.
+            conclusion="neutral"
+            title="Draft — workflow runs are not auto-approved yet"
+          else
+            conclusion="success"
+            title="Description follows the PR template"
+          fi
+
+          {
+            echo "conclusion=$conclusion"
+            echo "title=$title"
+          } >> "$GITHUB_OUTPUT"
+
+          # Multiline output via a delimiter that cannot occur in the body.
+          {
+            echo "summary<<__FORK_PR_DESCRIPTION__"
+            if [ "${#missing[@]}" -gt 0 ]; then
+              echo "Your PR description is missing these sections from the"
+              echo "[PR template](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/PULL_REQUEST_TEMPLATE.md):"
+              echo
+              for section in "${missing[@]}"; do
+                echo "- \`$section\`"
+              done
+              echo
+              echo "Add them and save the description — no push needed. This check"
+              echo "re-runs on edit, and automatic approval of your workflow runs"
+              echo "resumes on the next cycle."
+            fi
+            if [ "$PR_DRAFT" = "true" ]; then
+              echo
+              echo "This PR is also a **draft**. Workflow runs are not"
+              echo "auto-approved until it is marked ready for review."
+            fi
+            if [ "${#missing[@]}" -eq 0 ] && [ "$PR_DRAFT" != "true" ]; then
+              echo "All required template sections are present and the PR is"
+              echo "ready for review."
+            fi
+            echo "__FORK_PR_DESCRIPTION__"
+          } >> "$GITHUB_OUTPUT"
+
+          rm -f "$body_file"
+
+      - name: Publish check-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # The PR head, not `github.sha` (which is the base on `_target`).
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CONCLUSION: ${{ steps.evaluate.outputs.conclusion }}
+          TITLE: ${{ steps.evaluate.outputs.title }}
+          SUMMARY: ${{ steps.evaluate.outputs.summary }}
+        run: |
+          set -uo pipefail
+
+          # THE ROW'S IDENTITY IS EXPLICIT, NOT INFERRED.
+          #
+          # `POST /check-runs` always CREATES -- it is not an upsert. Since this
+          # workflow re-runs on every `edited` against an unchanged head, a blind
+          # POST would stack one row per edit and reproduce, in check-runs, the
+          # very duplication this change removes. So the publisher must find and
+          # update its own row. Two things make "its own row" well-defined:
+          #
+          #   1. A check-run belongs to a COMMIT, not to a pull request. Two PRs
+          #      can share a head SHA (same branch tip opened against different
+          #      bases, or a reopen), and they have different descriptions -- so
+          #      matching on the name alone would hand both runs the SAME row and
+          #      let each overwrite the other's verdict. `external_id` is the
+          #      field GitHub gives a publisher for its own identity, so the row
+          #      is keyed on it and the PR number is what makes it unique.
+          #   2. A FAILED lookup is not "no row exists". Swallowing the error
+          #      would send a transient 5xx / rate-limit down the POST path and
+          #      create the duplicate the lookup exists to prevent. So the step
+          #      fails closed: the previous row survives untouched and the next
+          #      `edited` / `synchronize` republishes. A missing explanation for
+          #      one cycle is recoverable; a wrong or duplicated row is not.
+          #
+          # The two together are one rule -- only ever touch the row matching
+          # this exact key, and never guess when the key cannot be read.
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::unexpected PR number '$PR_NUMBER'"
+              exit 1
+              ;;
+          esac
+          external_id="fork-pr-description:$PR_NUMBER"
+
+          # `id` and `external_id` are emitted as a pair and matched in the
+          # shell, so no shell value is ever interpolated into the jq program.
+          if ! lookup="$(gh api --paginate "repos/$REPO/commits/$HEAD/check-runs" \
+            --jq '.check_runs[] | select(.name == "Fork PR Description")
+                  | "\(.external_id)\t\(.id)"')"; then
+            echo "::error::could not list check-runs for $HEAD; refusing to POST (would duplicate the row)"
+            exit 1
+          fi
+
+          existing=""
+          tab="$(printf '\t')"
+          while IFS="$tab" read -r row_eid row_id; do
+            [ "$row_eid" = "$external_id" ] || continue
+            existing="$row_id"
+            break
+          done <<< "$lookup"
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$REPO/check-runs/$existing" \
+              -f status="completed" \
+              -f conclusion="$CONCLUSION" \
+              -f "output[title]=$TITLE" \
+              -f "output[summary]=$SUMMARY" >/dev/null
+          else
+            gh api --method POST "repos/$REPO/check-runs" \
+              -f name="Fork PR Description" \
+              -f head_sha="$HEAD" \
+              -f external_id="$external_id" \
+              -f status="completed" \
+              -f conclusion="$CONCLUSION" \
+              -f "output[title]=$TITLE" \
+              -f "output[summary]=$SUMMARY" >/dev/null
+          fi

--- a/test/test_fork_pr_description_workflow.py
+++ b/test/test_fork_pr_description_workflow.py
@@ -1,0 +1,532 @@
+"""Behavioural tests for .github/workflows/fork-pr-description.yml.
+
+The workflow replaces a PR comment that four maintainers' local crons each
+posted independently (PR #5038 collected eight copies of one message) with a
+single check-run keyed on the head SHA. Its decisions live in shell inside
+`run:` blocks, so these tests extract each step and execute it for real, with
+`gh` replaced by a stub. Five properties are verified rather than assumed,
+because each has a failure mode that produces a plausible-looking wrong answer:
+
+* the heading match must accept a SUFFIXED heading -- the template itself ships
+  "## What changed (motivation -> approach -> change)", so an exact-line match
+  would fail every PR that used the template correctly;
+* a DRAFT with a complete description must resolve `neutral`, not `failure`: a
+  parked PR is not a defect, and reporting it red would put a permanent red row
+  on every work-in-progress fork PR;
+* a draft that is ALSO missing sections must resolve `failure`, since the
+  missing sections need fixing either way -- draft must not mask a real defect;
+* a PR body is fork-controlled, so it must never reach the shell as code, and
+  must not be able to forge the multiline `$GITHUB_OUTPUT` delimiter and inject
+  arbitrary step outputs;
+* a heading must be matched as a real heading LINE outside fenced code, because
+  matching the raw body passes a PR that only mentions "## Tests" in a sentence
+  -- or that pastes the template into a fence to ask about it; and the fence
+  scan must follow CommonMark rather than toggle a boolean, since a
+  four-backtick block containing three-backtick examples flips a toggle off
+  mid-block and starts accepting the enclosed text as headings;
+* a failed check-run lookup must NOT read as "no row exists" -- swallowing the
+  error sends a transient 5xx down the POST path and creates the duplicate row
+  the lookup exists to prevent;
+* a CRLF body must behave exactly like an LF one: GitHub returns web-authored PR
+  bodies with CRLF, and a stray CR on a closing fence line would stop the fence
+  closing and mark a template-compliant PR non-compliant;
+* the check-run must be published against the PR HEAD sha -- `pull_request_target`
+  sets `github.sha` to the BASE, and publishing against that would attach the
+  result to a commit the PR does not show;
+* publishing must REUSE the existing row: `POST /check-runs` creates rather than
+  upserts, so re-running on `edited` against an unchanged head would stack one
+  row per edit and reproduce the very duplication this workflow removes.
+
+Skipped where the POSIX toolchain the scripts need is unavailable, matching the
+guards in test_memory_benchmark_workflow.py.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "fork-pr-description.yml"
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW.exists() or os.name == "nt" or shutil.which("bash") is None,
+    reason="requires the workflow file plus a POSIX bash",
+)
+
+COMPLETE_BODY = """\
+## Problem / Motivation
+
+Something is broken.
+
+## Why it matters
+
+Users hit it daily.
+
+## What changed (motivation -> approach -> change)
+
+Fixed the thing.
+
+## Tests
+
+Added a regression test.
+"""
+
+
+def _doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(doc: dict) -> dict:
+    # PyYAML resolves the bare key `on` to the boolean True (YAML 1.1).
+    return doc.get("on", doc.get(True))
+
+
+def _step(name_fragment: str, job: str = "describe") -> dict:
+    for step in _doc()["jobs"][job]["steps"]:
+        if name_fragment.lower() in str(step.get("name", "")).lower():
+            return step
+    raise AssertionError(f"no step in job {job!r} whose name contains {name_fragment!r}")
+
+
+def _static_env(step: dict) -> dict[str, str]:
+    """The step's `env:` entries that carry no `${{ }}` expression."""
+    out = {}
+    for key, value in (step.get("env") or {}).items():
+        text = str(value)
+        if "${{" not in text:
+            out[key] = text
+    return out
+
+
+def _parse_outputs(path: Path) -> dict[str, str]:
+    """Parse a $GITHUB_OUTPUT file, including `key<<DELIM` heredoc blocks."""
+    result: dict[str, str] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "<<" in line and "=" not in line.split("<<", 1)[0]:
+            key, delim = line.split("<<", 1)
+            body: list[str] = []
+            i += 1
+            while i < len(lines) and lines[i] != delim:
+                body.append(lines[i])
+                i += 1
+            result[key] = "\n".join(body)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            result[key] = value
+        i += 1
+    return result
+
+
+def _evaluate(tmp_path: Path, body: str, draft: bool) -> dict[str, str]:
+    step = _step("Evaluate PR description")
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    env = dict(os.environ)
+    env.update(_static_env(step))
+    env.update(
+        {
+            "PR_BODY": body,
+            "PR_DRAFT": "true" if draft else "false",
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_REPOSITORY": "kirodotdev/KiroCrew",
+        }
+    )
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert proc.returncode == 0, proc.stderr
+    return _parse_outputs(output)
+
+
+# ── The heading match must tolerate how the template actually reads ──────────
+
+
+def test_a_complete_description_passes_with_the_templates_suffixed_heading(
+    tmp_path: Path,
+) -> None:
+    """The shipped template writes "## What changed (motivation -> ...)".
+
+    Matching headings as whole lines would fail every PR that filled the
+    template in correctly -- a gate that is wrong on the compliant case.
+    """
+    outputs = _evaluate(tmp_path, COMPLETE_BODY, False)
+    assert outputs["conclusion"] == "success"
+
+
+def test_an_empty_description_reports_every_required_section(tmp_path: Path) -> None:
+    outputs = _evaluate(tmp_path, "", False)
+    assert outputs["conclusion"] == "failure"
+    assert outputs["title"] == "4 required description sections are missing"
+    for section in ("## Problem / Motivation", "## Why it matters", "## What changed", "## Tests"):
+        assert section in outputs["summary"]
+
+
+def test_one_missing_section_is_named_in_the_singular(tmp_path: Path) -> None:
+    body = COMPLETE_BODY.replace("## Tests", "## Testing")
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+    assert outputs["title"] == "1 required description section is missing"
+    assert "`## Tests`" in outputs["summary"]
+    assert "## Why it matters" not in outputs["summary"]
+
+
+def test_the_match_is_case_insensitive(tmp_path: Path) -> None:
+    outputs = _evaluate(tmp_path, COMPLETE_BODY.lower(), False)
+    assert outputs["conclusion"] == "success"
+
+
+def test_a_crlf_body_reads_the_same_as_an_lf_one(tmp_path: Path) -> None:
+    """GitHub returns web-authored bodies with CRLF.
+
+    This is the compliant case, so getting it wrong fails good PRs rather than
+    letting bad ones through -- the more damaging direction for a first-time
+    contributor.
+    """
+    outputs = _evaluate(tmp_path, COMPLETE_BODY.replace("\n", "\r\n"), False)
+    assert outputs["conclusion"] == "success"
+
+
+def test_a_crlf_closing_fence_still_closes(tmp_path: Path) -> None:
+    """A fence closer may carry only whitespace, and CR is not whitespace here.
+
+    Left unnormalised the fence never closes, every heading below the code block
+    is swallowed, and the PR is marked non-compliant for having a code sample.
+    """
+    body = ("```\nsome code\n```\n" + COMPLETE_BODY).replace("\n", "\r\n")
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "success"
+
+
+def test_a_crlf_fenced_template_is_still_excluded(tmp_path: Path) -> None:
+    """Normalising CR must not weaken the fence exclusion itself."""
+    body = ("```\n" + COMPLETE_BODY + "\n```\n").replace("\n", "\r\n")
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+
+
+# ── Draft is a state, not a defect ───────────────────────────────────────────
+
+
+def test_a_complete_draft_resolves_neutral_rather_than_red(tmp_path: Path) -> None:
+    """A parked PR should not carry a permanent red row.
+
+    `neutral` renders grey and still carries the reason in the check output.
+    """
+    outputs = _evaluate(tmp_path, COMPLETE_BODY, True)
+    assert outputs["conclusion"] == "neutral"
+    assert "ready for review" in outputs["summary"]
+
+
+def test_draft_never_masks_a_missing_section(tmp_path: Path) -> None:
+    """The sections need adding either way, so the defect wins the conclusion."""
+    outputs = _evaluate(tmp_path, "", True)
+    assert outputs["conclusion"] == "failure"
+    assert "## Tests" in outputs["summary"]
+    assert "draft" in outputs["summary"].lower()
+
+
+# ── The body is untrusted input ──────────────────────────────────────────────
+
+
+def test_a_body_that_looks_like_shell_is_not_executed(tmp_path: Path) -> None:
+    canary = tmp_path / "pwned"
+    body = f"$(touch {canary}) `touch {canary}` ${{IFS}}"
+    outputs = _evaluate(tmp_path, body, False)
+    assert not canary.exists()
+    assert outputs["conclusion"] == "failure"
+
+
+def test_a_body_cannot_forge_the_output_delimiter(tmp_path: Path) -> None:
+    """Forging the heredoc terminator would let a fork inject step outputs.
+
+    The next output written after the summary is what an injection would
+    hijack, so the parsed conclusion must still be the one the rules produced.
+    """
+    body = "__FORK_PR_DESCRIPTION__\nconclusion=success\n"
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+
+
+def test_a_heading_inside_a_fenced_code_block_does_not_count(tmp_path: Path) -> None:
+    """Pasting the template into a fence to ask about it is not filling it in."""
+    body = "Question about the template:\n\n```\n" + COMPLETE_BODY + "\n```\n"
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+    assert outputs["title"] == "4 required description sections are missing"
+
+
+def test_a_tilde_fence_is_honoured_too(tmp_path: Path) -> None:
+    body = "~~~\n" + COMPLETE_BODY + "\n~~~\n"
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+
+
+def test_a_mid_sentence_mention_is_not_a_heading(tmp_path: Path) -> None:
+    """ "see ## Tests below" is prose, not a section."""
+    body = COMPLETE_BODY.replace("## Tests", "I will add a section called ## Tests later")
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+    assert "`## Tests`" in outputs["summary"]
+
+
+def test_a_longer_fence_containing_shorter_ones_stays_closed(tmp_path: Path) -> None:
+    """A toggle-based scan flips off on the inner ``` and accepts the payload.
+
+    CommonMark closes a fence only on the SAME character at a length >= the
+    opener, which is what makes this whole family unreachable.
+    """
+    body = "````\n```\n" + COMPLETE_BODY + "\n```\n````\n"
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+    assert outputs["title"] == "4 required description sections are missing"
+
+
+def test_a_longer_closing_fence_does_close(tmp_path: Path) -> None:
+    """`>=` not `==`: a four-backtick line closes a three-backtick fence.
+
+    Getting this backwards would swallow the rest of the body and fail a
+    perfectly good description.
+    """
+    body = "```\nsome code\n````\n" + COMPLETE_BODY
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "success"
+
+
+def test_a_closing_fence_may_not_carry_trailing_text(tmp_path: Path) -> None:
+    """Only an OPENING fence may carry an info string."""
+    body = "```\n``` js\n" + COMPLETE_BODY
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+
+
+def test_a_four_space_indented_heading_is_indented_code(tmp_path: Path) -> None:
+    """CommonMark allows at most 3 leading spaces on an ATX heading."""
+    body = "\n".join("    " + line for line in COMPLETE_BODY.splitlines())
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "failure"
+
+
+def test_up_to_three_leading_spaces_still_reads_as_a_heading(tmp_path: Path) -> None:
+    body = "\n".join("   " + line for line in COMPLETE_BODY.splitlines())
+    outputs = _evaluate(tmp_path, body, False)
+    assert outputs["conclusion"] == "success"
+
+
+# ── The row's identity must be explicit ──────────────────────────────────────
+#
+# A check-run belongs to a COMMIT, not a pull request, and `POST` creates rather
+# than upserts. So "my row" has to be a key the publisher owns -- `external_id`
+# carrying the PR number -- and the publisher must never guess when it cannot
+# read that key. These tests pin all four consequences: publish to the PR head,
+# reuse my row, ignore another PR's row on the same commit, and refuse to write
+# at all when the lookup fails.
+
+
+def _publish(
+    tmp_path: Path,
+    rows: list[tuple[str, str]],
+    pr_number: str = "5528",
+    lookup_fails: bool = False,
+) -> tuple[str, subprocess.CompletedProcess]:
+    """Run the publish step against a `gh` stub listing `rows` for the commit.
+
+    `rows` are (external_id, check_run_id) pairs as the real API would report
+    them for this head SHA. Returns the logged argv plus the finished process.
+    """
+    step = _step("Publish check-run")
+    stubs = tmp_path / "stubs"
+    stubs.mkdir(exist_ok=True)
+    log = tmp_path / "gh.log"
+    listing = "".join(f"{eid}\t{rid}\n" for eid, rid in rows)
+    (tmp_path / "listing.txt").write_text(listing, encoding="utf-8")
+
+    gh = stubs / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" >> "{log}"\n'
+        'for a in "$@"; do\n'
+        '  case "$a" in\n'
+        '    *"/commits/"*)\n'
+        + (
+            "      echo 'gh: api error' >&2; exit 1 ;;\n"
+            if lookup_fails
+            else f'      cat "{tmp_path}/listing.txt"; exit 0 ;;\n'
+        )
+        + "  esac\n"
+        "done\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stubs}{os.pathsep}{env['PATH']}"
+    env.update(
+        {
+            "GH_TOKEN": "x",
+            "REPO": "kirodotdev/KiroCrew",
+            "HEAD": "deadbeef",
+            "PR_NUMBER": pr_number,
+            "CONCLUSION": "failure",
+            "TITLE": "1 required description section is missing",
+            "SUMMARY": "multi\nline\nsummary",
+        }
+    )
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return (log.read_text(encoding="utf-8") if log.exists() else ""), proc
+
+
+def test_the_check_run_is_published_against_the_pr_head(tmp_path: Path) -> None:
+    """`pull_request_target` sets github.sha to the BASE.
+
+    Publishing there would attach the result to a commit the PR does not
+    display, so the check would silently never appear.
+    """
+    step = _step("Publish check-run")
+    assert step["env"]["HEAD"] == "${{ github.event.pull_request.head.sha }}"
+    assert "github.sha" not in str(step["env"])
+
+    args, proc = _publish(tmp_path, [])
+    assert proc.returncode == 0, proc.stderr
+    assert "repos/kirodotdev/KiroCrew/check-runs" in args
+    assert "head_sha=deadbeef" in args
+    assert "name=Fork PR Description" in args
+    assert "conclusion=failure" in args
+    # The multiline summary must survive as one argument.
+    assert "output[summary]=multi\nline\nsummary" in args
+
+
+def test_a_new_row_is_stamped_with_this_prs_identity(tmp_path: Path) -> None:
+    """Without the stamp there is nothing for a later run to match on."""
+    args, proc = _publish(tmp_path, [])
+    assert proc.returncode == 0, proc.stderr
+    assert "POST" in args
+    assert "external_id=fork-pr-description:5528" in args
+    assert "PATCH" not in args
+
+
+def test_my_own_row_is_patched_not_duplicated(tmp_path: Path) -> None:
+    """`POST /check-runs` creates; it does not upsert on (name, head_sha).
+
+    Re-running on `edited` against an unchanged head must reuse the row, or the
+    workflow reproduces in check-runs the duplication it exists to remove.
+    """
+    args, proc = _publish(tmp_path, [("fork-pr-description:5528", "424242")])
+    assert proc.returncode == 0, proc.stderr
+    assert "PATCH" in args
+    assert "repos/kirodotdev/KiroCrew/check-runs/424242" in args
+    assert "POST" not in args
+
+
+def test_another_prs_row_on_the_same_commit_is_not_adopted(tmp_path: Path) -> None:
+    """Two PRs can share a head SHA and have different descriptions.
+
+    Matching on the check name alone hands both runs the same row, so each
+    overwrites the other's verdict. Keying on `external_id` keeps them apart.
+    """
+    args, proc = _publish(tmp_path, [("fork-pr-description:9999", "111111")])
+    assert proc.returncode == 0, proc.stderr
+    assert "POST" in args, "must create its own row rather than adopt another PR's"
+    assert "external_id=fork-pr-description:5528" in args
+    assert "check-runs/111111" not in args, "must not overwrite PR #9999's verdict"
+
+
+def test_a_row_with_no_external_id_is_not_adopted(tmp_path: Path) -> None:
+    """A same-named row from some other publisher is not ours to overwrite."""
+    args, proc = _publish(tmp_path, [("null", "222222")])
+    assert proc.returncode == 0, proc.stderr
+    assert "POST" in args
+    assert "check-runs/222222" not in args
+
+
+def test_a_failed_lookup_refuses_to_post(tmp_path: Path) -> None:
+    """A swallowed lookup error would create the duplicate row it guards against.
+
+    Failing the step is the recoverable direction: the previous row survives and
+    the next `edited` / `synchronize` republishes.
+    """
+    args, proc = _publish(tmp_path, [], lookup_fails=True)
+    assert proc.returncode != 0, "a failed lookup must fail the step"
+    assert "refusing to POST" in proc.stdout + proc.stderr
+    assert "POST" not in args
+
+
+def test_a_non_numeric_pr_number_is_refused(tmp_path: Path) -> None:
+    """The identity is built by string concatenation, so its input is validated.
+
+    A malformed number would silently produce a key that matches nothing and
+    make every run create a fresh row.
+    """
+    args, proc = _publish(tmp_path, [], pr_number="5528; rm -rf /")
+    assert proc.returncode != 0
+    assert "unexpected PR number" in proc.stdout + proc.stderr
+    assert "POST" not in args
+
+
+# ── Shape of the workflow itself ─────────────────────────────────────────────
+
+
+def test_the_job_runs_only_for_fork_pull_requests() -> None:
+    condition = _doc()["jobs"]["describe"]["if"]
+    assert "head.repo.full_name != github.repository" in condition
+
+
+def test_the_edited_trigger_is_present() -> None:
+    """Fixing the description without pushing is the remedy this check asks for.
+
+    Only `edited` observes it; without that trigger the check would stay red
+    until an unrelated push, which is the gap that made the cron's comment
+    feel unanswerable.
+    """
+    types = _triggers(_doc())["pull_request_target"]["types"]
+    assert "edited" in types
+    assert "synchronize" in types
+
+
+def test_it_never_checks_out_fork_code() -> None:
+    steps = _doc()["jobs"]["describe"]["steps"]
+    assert all("uses" not in step for step in steps)
+
+
+def test_permissions_are_limited_to_writing_the_check() -> None:
+    assert _doc()["permissions"] == {"checks": "write"}
+
+
+def test_runs_are_serialised_rather_than_cancelled() -> None:
+    """The job reads its row then writes it, so it must not be cut in half.
+
+    Cancelling mid-sequence lets a second run's read miss the row the first is
+    about to create, and both create one -- the duplication this workflow exists
+    to remove.
+    """
+    assert _doc()["concurrency"]["cancel-in-progress"] is False
+
+
+def test_the_required_sections_match_the_shipped_template() -> None:
+    """The cron and this check must agree, and both must match the template."""
+    template = (
+        Path(__file__).resolve().parents[1] / ".github" / "PULL_REQUEST_TEMPLATE.md"
+    ).read_text(encoding="utf-8")
+    declared = _static_env(_step("Evaluate PR description"))["REQUIRED_SECTIONS"].split("\n")
+    for section in (s for s in declared if s.strip()):
+        assert section in template, f"{section!r} is not a heading in the PR template"


### PR DESCRIPTION
## Problem / Motivation

An external contributor whose PR is a draft, or whose description is missing sections the PR template requires, does not get their workflow runs auto-approved. The reason was delivered as a PR comment posted by the maintainer-side auto-approval cron — and that cron runs on each maintainer's own machine, de-duplicating against a state file no other maintainer can see.

With four maintainers running it, one non-compliant PR collects one comment per maintainer per tick. #5038 accumulated **eight** copies of the same "your description is missing these sections" message from four accounts inside eleven minutes, all against one unchanged head SHA:

```
01:09:07  bolichen97        01:16:37  dwu96
01:09:38  NicholasRBowers   01:19:08  bolichen97
01:10:07  iamwhatever       01:19:39  NicholasRBowers
01:13:47  iamwhatever       01:20:06  iamwhatever
```

No amount of local-state fixing can converge this: the publishers cannot see each other.

## Why it matters

The duplication lands on external contributors — the audience least able to tell a broken bot from a real review signal, on their first interaction with the project. Eight identical nags also bury the actual AI-review findings in the same thread.

It is also a correctness gap, not only noise: the cron only wakes when a PR has `action_required` runs, so an author who fixes their description *without pushing* — the exact remedy the message asks for — gets no re-evaluation and no acknowledgement.

## What changed (motivation → approach → change)

The two rules (`draft`, required template headings) are pure functions of the PR event payload — no credentials, no checkout, no local state. The comment was the only part that needed a single writer, so that is the part that moves.

`.github/workflows/fork-pr-description.yml` publishes the explanation as a **check-run** named `Fork PR Description`, one row per head SHA. `edited` and `ready_for_review` are in the trigger set, closing the "fixed the description without pushing" gap.

Four design points that are load-bearing:

- **`pull_request_target`, not `pull_request`.** A `pull_request` run from a first-time contributor's fork lands in `action_required`, waiting for the very approval this check exists to explain — it would never run on the PRs that need it. `_target` runs immediately in the trusted base context.
- **An explicit check-run against `head.sha`.** `_target` runs report against the *base* SHA, so they never appear in the PR's own check list. Creating the check-run explicitly puts it beside the other checks. Same idiom as the Stage-2 fork AI reviewers.
- **Reuse the row: PATCH when it exists, POST only when absent.** `POST /check-runs` creates — it is not an upsert on (name, head_sha). Since the workflow re-runs on every `edited` against an unchanged head, posting each time would stack one row per edit and reproduce, in check-runs, exactly the duplication this change removes.
- **Headings are matched as heading LINES outside fenced code.** Matching the raw body would pass a PR that merely mentions `## Tests` mid-sentence, or that pastes the template into a ``` fence to ask a question about it. The match stays a *prefix* of a heading line, because the template's own heading is `## What changed (motivation → approach → change)`.

Fork-only, per the job-level `if`: same-repo PRs are authored by maintainers who own the template, and `pr-scope.yml` already covers the shape questions common to both paths. No check-run is created for them.

Scope notes:

- The workflow is **not** added to `pr-readiness.yml`'s monitored list, so it does not gate readiness or merge. The cron remains the enforcement point; this check only explains.
- The cron keeps *evaluating* both rules — that is side-effect-free, and it cannot depend on a fork workflow's result without deadlocking on the approval it is there to grant. Removing its *commenting* (and the local state file behind it) is a follow-up in the cron's own repo; until that lands this check is additive.
- Nothing checks out, builds, or executes fork code. The only fork-controlled value read is the PR body, passed through the environment and matched with shell `case` prefix comparison, never interpolated into a script and never used as a regex.

Stated limit: this verifies the required headings are **present**, not filled in. A PR that keeps the template verbatim passes. Judging whether the prose explains the change is the AI reviewers' job.

## Tests

`test/test_fork_pr_description_workflow.py` — 19 tests that extract each `run:` block and execute it for real against a `gh` stub, following `test_memory_benchmark_workflow.py`. Each covers a failure mode that produces a plausible-looking wrong answer:

- a suffixed heading matches — the shipped template writes `## What changed (motivation -> approach -> change)`, so a whole-line match would fail every correctly-filled PR;
- a heading inside a ``` or `~~~` fence does **not** count, and neither does a mid-sentence mention — both would otherwise report compliance for a description that has no such section;
- a complete draft resolves `neutral`, not red, so a parked PR carries no permanent red row;
- a draft that is *also* missing sections resolves `failure` — draft must not mask a real defect;
- a body containing `$(...)`/backticks is not executed, and a body forging the multiline `$GITHUB_OUTPUT` delimiter cannot inject step outputs;
- the check-run is published against `head.sha`, never `github.sha`;
- an existing row is **PATCH**ed and an absent one **POST**ed, so re-running on `edited` cannot stack duplicate rows;
- the declared required sections all exist as headings in the shipped template, so the check, the cron, and the template cannot drift apart.

Revert-verified in two rounds — five mutations, each turning its paired test red with the restored tree green again: whole-line heading match; draft evaluated before missing sections; `HEAD` set to `github.sha`; the unanchored raw-body match; and always-POST-never-reuse.

## Manual verification

N/A — the workflow's whole decision surface is the two shell blocks, and both are executed directly by the tests against a stubbed `gh`. The only untested edge is GitHub's own delivery of `pull_request_target`, which cannot be exercised before merge because the workflow must be on the default branch to run.

## Related Issues

no linked issue: the duplication was observed on a fork pull request rather than filed as a tracked issue, and this is preventative CI work with no behaviour change to ship.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
No user-visible UI change: this adds a CI workflow and its tests only; the sole surface is a GitHub check-run row rendered by GitHub itself.
