### PR TITLE
fix: isolate doctor and STT interpreter probes from caller env

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -18,7 +18,7 @@ import urllib.request
 from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
-from kiro_crew import agent_state, diagnostics, platform_compat, sandbox
+from kiro_crew import agent_state, dep_sync, diagnostics, platform_compat, sandbox
 from kiro_crew._bootstrap import _source_checkout_root
 from kiro_crew.acp import kas_assets, kas_auth
 from kiro_crew.acp.client import KIRO_CLI_BIN
@@ -2027,6 +2027,26 @@ def _doctor_whatsapp(cfg: KiroCrewConfig, issues: list[str]) -> None:
     print(f"  dm policy:   {wa.dm_policy}")
 
 
+def _venv_deps_ok(venv_py: Path) -> bool:
+    """True when *venv_py* ITSELF can import the gateway's core dependencies.
+
+    Routed through :func:`dep_sync._probe_interpreter` (``-I -X utf8`` plus a
+    neutral ``cwd``) because the question is about the venv, not the process
+    asking: an unisolated ``python -c`` puts the doctor's CWD at
+    ``sys.path[0]`` and inherits ``PYTHONPATH``, so a decoy package on either
+    route makes the check answer for the caller -- reporting the modules
+    available in a venv that cannot actually serve them, a false-healthy from
+    the diagnostic whose job is to catch exactly that install.
+    """
+    try:
+        proc = dep_sync._probe_interpreter(
+            venv_py, "import websockets, slack_sdk, aiohttp", timeout=5
+        )
+    except Exception:
+        return False
+    return proc.returncode == 0
+
+
 def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False) -> None:
     """Verify KiroCrew setup — check dependencies, config, credentials, connectivity.
 
@@ -2362,14 +2382,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
             print(f"  python:      ❌ venv python broken: {exc}")
             issues.append("venv python")
         else:
-            try:
-                subprocess.run(
-                    [str(venv_py), "-c", "import websockets, slack_sdk, aiohttp"],
-                    capture_output=True,
-                    timeout=5,
-                ).check_returncode()
+            if _venv_deps_ok(venv_py):
                 print("  deps:        ✅ websockets, slack_sdk, aiohttp available")
-            except Exception:
+            else:
                 print("  deps:        ❌ missing modules (websockets/slack_sdk/aiohttp)")
                 issues.append("python deps")
     else:

--- a/src/kiro_crew/dep_sync.py
+++ b/src/kiro_crew/dep_sync.py
@@ -370,7 +370,9 @@ def requires_python(repo: Path) -> str | None:
     return cfg.get("options", "python_requires").strip() or None
 
 
-def _probe_interpreter(target_py: Path, code: str) -> subprocess.CompletedProcess[str]:
+def _probe_interpreter(
+    target_py: Path, code: str, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
     """Run *code* under *target_py*, isolated from the caller's CWD and env.
 
     Every probe here asks a question about the VENV -- where it resolves this
@@ -390,17 +392,31 @@ def _probe_interpreter(target_py: Path, code: str) -> subprocess.CompletedProces
     decode below) where a ``PYTHONIOENCODING`` entry would be ignored,
     keeping a non-ASCII checkout path from mangling -- or crashing -- the
     answer on a non-UTF-8 locale. ``cwd`` is pinned to the interpreter's own
-    directory as well: it keeps the child's working directory valid even when
-    the caller's has been deleted, and a venv's script directory holds
-    executables, never an importable package.
+    directory as well: under ``-I`` the working directory is never on
+    ``sys.path``, whatever it contains, so the pin exists to keep the child's
+    working directory valid even when the caller's has been deleted. The
+    interpreter path is absolutized first (without resolving symlinks, which
+    would erase a venv's identity), because a relative path -- which
+    ``shutil.which`` can return for a relative ``PATH`` entry -- would
+    otherwise be re-resolved against the changed cwd and spawn nothing.
+
+    ``code`` MUST be a fixed literal owned by the caller: this helper is the
+    spawn-audit allowlist's designated isolated-probe entry point, and its
+    "fixed argv" justification stops holding the moment caller-derived text
+    reaches the child. ``timeout`` is forwarded to :func:`subprocess.run`
+    for callers on an interactive path (the doctor, the STT toolchain scan)
+    that must not hang on a wedged interpreter; ``None`` keeps the sync
+    path's unbounded wait.
     """
+    target = Path(os.path.abspath(target_py))
     return subprocess.run(
-        [str(target_py), "-I", "-X", "utf8", "-c", code],
+        [str(target), "-I", "-X", "utf8", "-c", code],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
-        cwd=Path(target_py).parent,
+        cwd=target.parent,
+        timeout=timeout,
     )
 
 

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -11,15 +11,13 @@ import logging
 import os
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import aws_consent, platform_compat
+from kiro_crew import aws_consent, dep_sync, platform_compat
 from kiro_crew.sandbox import _PYTHON_ENV_PREFIXES
-from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 # Transcribe-path deps are an OPTIONAL 'aws' extra (amazon-transcribe + boto3).
 # The module MUST stay importable when they're absent (default install, partial
@@ -123,15 +121,16 @@ def _python3_bin_dir() -> str:
         py = platform_compat.find_python_interpreter()
         if not py:
             return ""
-        out = subprocess.check_output(
-            [py, "-c", "import sysconfig; print(sysconfig.get_path('scripts'))"],
-            timeout=5,
-            # The child re-encodes its stdout with the console code page when piped
-            # on Windows unless pinned; the decode side alone cannot fix that.
-            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
-            **UTF8_TEXT,
-        ).strip()
-        return out
+        # Through dep_sync._probe_interpreter (-I -X utf8, neutral cwd): the
+        # probe imports sysconfig by name, so a decoy module on the caller's
+        # PYTHONPATH or CWD would otherwise shadow the stdlib and answer with
+        # whatever path it likes — steering the Whisper script search there.
+        proc = dep_sync._probe_interpreter(
+            Path(py), "import sysconfig; print(sysconfig.get_path('scripts'))", timeout=5
+        )
+        if proc.returncode != 0:
+            return ""
+        return proc.stdout.strip()
     except Exception:
         return ""
 
@@ -308,9 +307,10 @@ def _find_parakeet_mlx() -> str | None:
     # installed via `pipx` (see `_build_stt_install_script`), which always
     # puts its shim on PATH or in one of `_PARAKEET_MLX_SEARCH_PATHS` below —
     # so the probe would never find anything here, while still paying its
-    # cost: it shells out to a system Python synchronously (`subprocess.
-    # check_output`, 5s timeout) on the event loop this function runs on
-    # (dashboard GET/PUT /api/config/stt), which can stall the gateway.
+    # cost: it shells out to a system Python synchronously
+    # (`dep_sync._probe_interpreter`, 5s timeout) on the event loop this
+    # function runs on (dashboard GET/PUT /api/config/stt), which can stall
+    # the gateway.
     for p in _PARAKEET_MLX_SEARCH_PATHS:
         if os.path.isfile(p) and os.access(p, os.X_OK):
             return p

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -1740,3 +1742,104 @@ class TestWhatsAppSection:
 
         source = inspect.getsource(cli_doctor._doctor)
         assert "_doctor_whatsapp(cfg, issues)" in source
+
+
+class TestVenvDepsProbe:
+    """The deps probe answers for the VENV, never the doctor's own process.
+
+    ``python -c`` puts the child's CWD at ``sys.path[0]`` and inherits
+    ``PYTHONPATH``, so an unisolated probe imports whatever decoy package
+    sits on either route -- making the doctor's verdict describe the
+    caller's environment instead of the venv under test (the false-healthy
+    the isolated ``dep_sync._probe_interpreter`` closes). The decoys here
+    raise on import: a probe that can still see them fails against an
+    interpreter that genuinely serves the real modules, so each test proves
+    the route is closed in a way that does not depend on which direction the
+    decoy lies in. The probe children run a fixed read-only import with the
+    cwd the code under test pins (the interpreter's own bin dir) -- nothing
+    is written, so the tmp-cwd rule for file-creating children does not
+    apply, and pointing them at ``tmp_path`` would test nothing.
+    """
+
+    _DEP_NAMES = ("websockets", "slack_sdk", "aiohttp")
+
+    def _plant_raising_decoys(self, root: Path) -> Path:
+        decoy = root / "decoy-path"
+        for name in self._DEP_NAMES:
+            pkg = decoy / name
+            pkg.mkdir(parents=True)
+            (pkg / "__init__.py").write_text(
+                "raise ImportError('decoy package imported')", encoding="utf-8"
+            )
+        return decoy
+
+    def test_decoy_on_pythonpath_is_invisible_to_the_probe(self, tmp_path, monkeypatch) -> None:
+        """PYTHONPATH entries rank ahead of site-packages, so an unisolated
+        probe imports the raising decoys and misreports this healthy
+        interpreter as missing its deps."""
+        decoy = self._plant_raising_decoys(tmp_path)
+        monkeypatch.setenv("PYTHONPATH", str(decoy))
+
+        assert cli_doctor._venv_deps_ok(Path(sys.executable)) is True
+
+    def test_decoy_in_the_callers_cwd_is_invisible_to_the_probe(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The second route: the caller's CWD lands at ``sys.path[0]`` for an
+        unisolated ``python -c``, ranking the decoys above site-packages."""
+        decoy = self._plant_raising_decoys(tmp_path)
+        monkeypatch.chdir(decoy)
+
+        assert cli_doctor._venv_deps_ok(Path(sys.executable)) is True
+
+    def test_missing_modules_still_report_missing(self, monkeypatch) -> None:
+        """Isolation must not soften the verdict: a probe exiting nonzero is
+        exactly the missing-deps answer the doctor section exists to show."""
+        monkeypatch.setattr(
+            cli_doctor.dep_sync,
+            "_probe_interpreter",
+            lambda *a, **k: subprocess.CompletedProcess(args=[], returncode=1),
+        )
+
+        assert cli_doctor._venv_deps_ok(Path(sys.executable)) is False
+
+    def test_a_wedged_interpreter_reports_missing(self, monkeypatch) -> None:
+        """A hung venv python must surface as a deps failure, not hang the
+        operator's doctor run or escape as a traceback."""
+
+        def _hang(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="python", timeout=5)
+
+        monkeypatch.setattr(cli_doctor.dep_sync, "_probe_interpreter", _hang)
+
+        assert cli_doctor._venv_deps_ok(Path(sys.executable)) is False
+
+    def test_an_unspawnable_interpreter_reports_missing(self, tmp_path) -> None:
+        assert cli_doctor._venv_deps_ok(tmp_path / "no-such-venv" / "python") is False
+
+    def test_the_probe_asks_the_venv_for_all_three_core_deps(self, monkeypatch) -> None:
+        """Pins the probe's question itself: the decoy tests above pass any
+        probe that ignores PYTHONPATH, including one that stopped importing a
+        module the gateway needs."""
+        seen: dict = {}
+
+        def record(target_py, code, timeout=None):
+            seen.update(target=target_py, code=code, timeout=timeout)
+            return subprocess.CompletedProcess(args=[], returncode=0)
+
+        monkeypatch.setattr(cli_doctor.dep_sync, "_probe_interpreter", record)
+
+        assert cli_doctor._venv_deps_ok(Path("/v/bin/python")) is True
+        assert seen["code"] == "import websockets, slack_sdk, aiohttp"
+        assert seen["target"] == Path("/v/bin/python")
+        assert seen["timeout"] == 5
+
+    def test_the_probe_is_wired_into_the_doctor_run(self) -> None:
+        """Guards the call site: every other test drives the helper directly,
+        so a deleted call would leave them green while the doctor silently
+        skipped the check. ``_doctor()`` spawns subprocesses and calls
+        ``sys.exit``, so its source is read rather than run."""
+        import inspect
+
+        source = inspect.getsource(cli_doctor._doctor)
+        assert "_venv_deps_ok(venv_py)" in source

--- a/test/test_dep_sync.py
+++ b/test/test_dep_sync.py
@@ -1010,6 +1010,48 @@ def test_every_interpreter_probe_runs_isolated_with_a_neutral_cwd(tmp_path):
         assert kwargs.get("cwd") == target.parent, "probe needs a neutral cwd"
 
 
+def test_probe_forwards_a_timeout_to_the_child(tmp_path):
+    """Interactive callers (the doctor's deps check, the STT toolchain scan)
+    bound the probe so a wedged interpreter cannot hang them; the sync path's
+    default ``None`` keeps its unbounded wait."""
+    target = tmp_path / "venv" / "bin" / "python"
+    target.parent.mkdir(parents=True)
+    seen: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(kwargs)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch.object(dep_sync.subprocess, "run", side_effect=fake_run):
+        dep_sync._probe_interpreter(target, "print(1)", timeout=7)
+        dep_sync._probe_interpreter(target, "print(1)")
+
+    assert seen[0].get("timeout") == 7
+    assert seen[1].get("timeout") is None
+
+
+def test_probe_absolutizes_a_relative_interpreter_path(tmp_path, monkeypatch):
+    """A relative target -- ``shutil.which`` returns one for a relative PATH
+    entry -- must not be re-resolved against the probe's own cwd pin: spawning
+    ``tools/python3`` from ``cwd=tools`` would look for ``tools/tools/python3``
+    and report a healthy interpreter as unprobeable."""
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "python3").touch()
+    monkeypatch.chdir(tmp_path)
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["argv0"] = cmd[0]
+        seen["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch.object(dep_sync.subprocess, "run", side_effect=fake_run):
+        dep_sync._probe_interpreter(Path("tools/python3"), "print(1)")
+
+    assert seen["argv0"] == str(tmp_path / "tools" / "python3")
+    assert seen["cwd"] == tmp_path / "tools"
+
+
 def test_sync_captures_pip_output_instead_of_writing_it_to_stderr(tmp_path, capsys):
     """pip's output must reach ``emit``, never the inherited stderr.
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -699,6 +699,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # fixed-argv helper, _probe_interpreter, which is where their single
         # spawn now lives: `<target python> -I -X utf8 -c <fixed probe>` with a
         # neutral cwd, so the answer describes the venv instead of the caller.
+        # The doctor's venv deps check (cli_doctor._venv_deps_ok) and the STT
+        # scripts-dir probe (transcribe._python3_bin_dir) route through the
+        # same helper for the same reason: their argv is equally fixed, and an
+        # unisolated `python -c` would let a decoy on the caller's
+        # PYTHONPATH/CWD answer for the interpreter under test.
         "dep_sync.py::_probe_interpreter",
         "dep_sync.py::sync",
         "dep_sync.py::sync_or_reinstall",
@@ -1136,7 +1141,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apple_speech/__init__.py::inventory",
         "apple_speech/__init__.py::start",
         "apple_speech/__init__.py::transcribe",
-        "transcribe.py::_python3_bin_dir",
+        # (`transcribe.py::_python3_bin_dir` is absent: its scripts-dir probe
+        # routes through `dep_sync.py::_probe_interpreter`, so an entry here
+        # would be stale.)
         "transcribe.py::_run_whisper_cli",
         "transcribe.py::_transcribe_aws",
         # JSON-Schema ``pattern`` validation for MCP app→gateway tool-call args

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
+import sys
+import sysconfig
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew import dep_sync
 from kiro_crew import platform_compat as _pc
+from kiro_crew import transcribe
 from kiro_crew.config.loader import SttConfig
 from kiro_crew.sandbox import _PYTHON_ENV_PREFIXES
 from kiro_crew.transcribe import (
@@ -1426,3 +1431,63 @@ class TestProfileCredentialResolver:
         with patch.dict("sys.modules", {"amazon_transcribe": MagicMock(), "amazon_transcribe.auth": mock_creds_module}):
             with pytest.raises(RuntimeError, match="No AWS credentials found"):
                 await resolver.get_credentials()
+
+# ---------------------------------------------------------------------------
+# _python3_bin_dir isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPython3BinDirIsolation:
+    """The scripts-dir probe asks the stdlib, never the caller's environment.
+
+    The probe imports ``sysconfig`` by name in a child ``python -c``, which
+    unisolated resolves imports from the caller's CWD (``sys.path[0]``) and
+    ``PYTHONPATH`` ahead of the stdlib -- so a decoy ``sysconfig.py`` on
+    either route could answer with any path it likes and steer the Whisper
+    script search there. Routed through ``dep_sync._probe_interpreter``
+    (``-I``), both routes are closed.
+    """
+
+    def _plant_decoy_sysconfig(self, root: Path) -> Path:
+        decoy = root / "decoy-path"
+        decoy.mkdir()
+        (decoy / "sysconfig.py").write_text(
+            "def get_path(name):\n    return '/decoy-scripts'\n", encoding="utf-8"
+        )
+        return decoy
+
+    def test_decoy_sysconfig_on_pythonpath_is_ignored(self, tmp_path, monkeypatch) -> None:
+        decoy = self._plant_decoy_sysconfig(tmp_path)
+        monkeypatch.setenv("PYTHONPATH", str(decoy))
+        monkeypatch.setattr(_pc, "find_python_interpreter", lambda: sys.executable)
+
+        out = transcribe._python3_bin_dir()
+
+        # Same interpreter as this process, so the stdlib's own answer is the
+        # expected value; the decoy's constant must never be it.
+        assert out == sysconfig.get_path("scripts")
+        assert out != "/decoy-scripts"
+
+    def test_decoy_sysconfig_in_the_callers_cwd_is_ignored(self, tmp_path, monkeypatch) -> None:
+        decoy = self._plant_decoy_sysconfig(tmp_path)
+        monkeypatch.chdir(decoy)
+        monkeypatch.setattr(_pc, "find_python_interpreter", lambda: sys.executable)
+
+        out = transcribe._python3_bin_dir()
+
+        assert out == sysconfig.get_path("scripts")
+        assert out != "/decoy-scripts"
+
+    def test_a_failing_probe_answers_empty(self, monkeypatch) -> None:
+        """A broken system python degrades to "" (search continues elsewhere),
+        never a traceback out of the toolchain scan."""
+        monkeypatch.setattr(_pc, "find_python_interpreter", lambda: sys.executable)
+        monkeypatch.setattr(
+            dep_sync,
+            "_probe_interpreter",
+            lambda *a, **k: subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=""
+            ),
+        )
+
+        assert transcribe._python3_bin_dir() == ""


### PR DESCRIPTION
## Problem / Motivation

`kirocrew doctor`'s venv dependency check ran the venv python as a bare `python -c "import websockets, slack_sdk, aiohttp"` with the doctor's own CWD at `sys.path[0]` and an inherited `PYTHONPATH`. A decoy package on either route makes the probe import the decoy instead of asking the venv, so the doctor prints `deps: available` for a venv that cannot actually serve the gateway -- a false-healthy verdict from the diagnostic whose whole job is to catch exactly that install. `transcribe._python3_bin_dir` carried the weaker stdlib-shadow variant of the same defect: its child imports `sysconfig` by name, so a decoy `sysconfig` module on the caller's PYTHONPATH/CWD can answer with any path and steer the Whisper script search there.

## Why it matters

An operator debugging a broken install trusts the doctor's verdict; a false-healthy `deps` line sends them hunting everywhere except the actual problem. The reproduction is mundane, not exotic: any caller running from a checkout's `src/` (the Dev Fleet backend does) or with a stale `PYTHONPATH` hits it. PR #5494 already fixed the identical unisolated-probe pattern in `dep_sync`; this PR fixes the doctor and STT scripts-dir sites, and the remaining siblings surfaced in review are tracked as #5530 (interpreter selection gate) and #5535 (STT install-target probes).

## What changed

Symptom: the probes answer for the caller, not the interpreter under test. Root cause: `python -c` puts the child's CWD at `sys.path[0]` and inherits `PYTHONPATH`, so both routes rank caller-controlled directories ahead of the venv's site-packages / the stdlib. Fix: both sites now route through the isolation `dep_sync._probe_interpreter` already provides (`-I -X utf8`, neutral cwd) instead of growing a second copy of it:

- `dep_sync._probe_interpreter` gains a forwarded `timeout` (default `None` keeps the sync path's unbounded wait) and now absolutizes the target before pinning `cwd`, since a relative interpreter path -- which `shutil.which` returns for a relative `PATH` entry -- would otherwise be re-resolved against the changed cwd and spawn nothing. Its docstring states the literal-only contract for `code` (the spawn-audit "fixed argv" story depends on it) and rests the cwd rationale on `-I` keeping the working directory off `sys.path`.
- The doctor's inline probe becomes `cli_doctor._venv_deps_ok`, a testable helper with the same verdict mapping (nonzero exit, timeout, or unspawnable interpreter all report missing; the `--version` "venv python broken" failure mode stays distinct).
- `transcribe._python3_bin_dir` routes its sysconfig probe through the same helper. The removed `PYTHONIOENCODING` env pin is not lost: `-I` implies `-E`, which would ignore it, and `-X utf8` rides the argv to pin the child's encode side instead.
- `test/test_spawn_audit.py`: the now-spawnless `transcribe.py::_python3_bin_dir` allowlist entry is removed (the staleness gate makes this mandatory) and the `dep_sync.py::_probe_interpreter` justification names the two new callers.

## Tests

- `test_cli_doctor.py::TestVenvDepsProbe`: raising decoy packages planted on PYTHONPATH and in the caller's CWD must be invisible to the probe (each red if `-I` / the cwd pin is removed -- mutation-verified); nonzero exit, `TimeoutExpired`, and an unspawnable interpreter all map to missing; the probe's import list and 5s timeout are pinned; a source-level check keeps `_venv_deps_ok` wired into `_doctor`.
- `test_transcribe.py::TestPython3BinDirIsolation`: decoy `sysconfig` on PYTHONPATH / in CWD is ignored (the answer equals the real stdlib's), and a failing probe degrades to `""`.
- `test_dep_sync.py`: `timeout` is forwarded verbatim and absent by default; a relative interpreter path is absolutized before the cwd pin (red without the fix).
- Full backend gates green locally: black gate, subprocess-encoding gate, isort, flake8, mypy, pytest (the 86 failures + 2 errors on this host are byte-identical on unmodified `main` -- environmental, list-diffed to confirm).

## Manual verification

Reproduced the defect empirically before fixing: with a decoy on PYTHONPATH, the unisolated probe imports the decoy for any target interpreter; under `-I -X utf8` with the pinned cwd the genuine venv/stdlib answers. Also verified `-I` does not shift the sysconfig scheme (`get_path('scripts')` byte-identical plain vs isolated), so legitimate STT installs keep resolving.

Closes #5501

