### PR TITLE
chore(ci): clear every Nightly Build warning that is ours to clear

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -107,6 +107,23 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
+        # The build script provisions python-build-standalone interpreters
+        # through uv; not every runner image ships it, and the script's
+        # curl|sh fallback is POSIX-shaped.
+        #
+        # Exactly ONE setup-uv per job. Its cache key (restore-cache.ts) is
+        # setup-uv-2-<arch>-<platform>-<os>-<python>-<dep-hash> -- every part
+        # job-invariant, so a SECOND invocation in this job derives the same key
+        # and its post step's save makes this step's post fail reserveCache:
+        # "Failed to save: Unable to reserve cache with key setup-uv-2-...,
+        # another job may be creating this cache."
+        #
+        # That message is why the duplicate survived review for so long: it
+        # reads as benign matrix contention. It is not. The key embeds arch and
+        # OS, so the mac and linux-arm64 legs cannot share one, and the run's
+        # two annotations carried two DIFFERENT keys. Same job, different step.
+        # (The x64 leg stayed quiet only because ci.yml's linux-packaging job
+        # already writes that key, so both post steps hit and skip saving.)
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Stamp version
@@ -123,11 +140,6 @@ jobs:
           # equal the feed version for the auto-updater's compare gate.
           node -e "const fs=require('fs');const f='website/electron/package.json';const p=JSON.parse(fs.readFileSync(f));p.version=process.env.STAMP_VERSION;fs.writeFileSync(f,JSON.stringify(p,null,2)+'\n')"
           echo "Building desktop: ${STAMP_VERSION}"
-
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        # The build script provisions python-build-standalone interpreters
-        # through uv; not every runner image ships it, and the script's
-        # curl|sh fallback is POSIX-shaped.
 
       - name: Build desktop app
         # The build script is bash. Invoked directly rather than through the

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -126,7 +126,7 @@ jobs:
         # repo/workflow/commit (CWE-1104) — complements the self-hosted
         # SHA256SUMS (integrity, not authenticity). Runs before the wheel is
         # published to S3/CloudFront.
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ steps.wheel.outputs.path }}
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -272,11 +272,20 @@ jobs:
       # The existing-tag re-run path is handled by the VERIFY step below.
       - name: Attest image provenance (fresh build)
         if: steps.existing.outputs.exists == 'false' && !inputs.promote
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ steps.image.outputs.name }}
           subject-digest: ${{ steps.digest.outputs.value }}
           push-to-registry: true
+          # Pinned to the v2 behaviour this lane was verified with. v3.1.0 added
+          # artifact-metadata storage records and v4 defaults this input to true
+          # whenever push-to-registry is set, so publish-docker is the only site
+          # a bare pin bump would change. The attempt would fail soft (records
+          # need artifact-metadata: write, which this workflow does not grant),
+          # and a soft failure is still a fresh annotation on the one lane
+          # holding a registry-push credential. Adopt records deliberately, not
+          # as a side effect of clearing a Node 20 deprecation warning.
+          create-storage-record: false
 
       # Existing-tag re-run path: require that the already-published digest
       # ALREADY carries provenance attested by THIS repository's workflows.

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -300,7 +300,7 @@ jobs:
       # the job fails and nothing is published.
       - name: Attest artifact provenance
         if: env.HAS_SIGNING_SECRETS && !inputs.promote
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ env.ARTIFACT_PATH }}
 

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -277,7 +277,7 @@ jobs:
       # become the version clients resolve.
       - name: Attest installer provenance
         if: env.HAS_SIGNING_SECRETS && steps.locate.outputs.staged && !inputs.promote
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ env.INSTALLER_PATH }}
 

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Attest build provenance
         # Signed SLSA provenance for the wheel/sdist/AppImage (CWE-1104).
         # Runs right after flatten, before anything leaves the runner.
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           # Attest only artifacts whose bytes are final here. The macOS .zip is
           # re-signed + notarized downstream, so a pre-notarization attestation
@@ -457,7 +457,7 @@ jobs:
       # embeds the ticket into the DMG file (the final released bytes).
       - name: Attest final shipping artifacts
         if: env.HAS_SIGNING_SECRETS
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             work/notarized.zip

--- a/test/test_workflow_cache_setup_uniqueness.py
+++ b/test/test_workflow_cache_setup_uniqueness.py
@@ -1,0 +1,78 @@
+"""A cache-writing ``setup-*`` action may appear at most ONCE per job.
+
+``astral-sh/setup-uv`` and the ``actions/setup-*`` family derive their cache key
+from inputs that are fixed for the whole job -- action version, target triple,
+runner image, interpreter version, lockfile hash. Nothing a later step does can
+change that key, so a SECOND invocation in the same job reserves the identical
+key and races the first step's own post-job cache save. GitHub then reports::
+
+    Failed to save: Unable to reserve cache with key setup-uv-2-...,
+    another job may be creating this cache.
+
+The "another job" wording is what makes this hard to spot: it reads as benign
+cross-job concurrency on a matrix, so a duplicated step survives review and
+then warns on every nightly forever. ``build-desktop.yml`` carried exactly that
+-- two ``setup-uv`` steps in one job, warning on the macOS and Linux-arm64 legs
+of every Nightly Build run.
+
+Static and offline: this reads only the workflow YAML, so it cannot flake.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# Prefixes whose actions maintain a tool cache keyed on job-invariant inputs.
+# Deliberately a prefix match, not a fixed list: a future setup-<tool> lands
+# under the ratchet without anyone remembering to enroll it.
+#
+# This OVER-APPROXIMATES on purpose. Real keys also fold in inputs, so two
+# setup-python steps pinning different versions would not actually collide, yet
+# this still flags them. The repo has no such job today, and the cost of the
+# over-approximation is one conversation whereas the cost of under-matching is a
+# warning on every nightly forever. If a genuine two-interpreter job ever lands,
+# widen this to match on (action, key-feeding inputs) -- do not delete the test.
+_CACHING_ACTION_PREFIXES = ("astral-sh/setup-", "actions/setup-")
+
+
+def _duplicate_cache_setups() -> list[str]:
+    """Return one ``workflow:job action xN`` line per duplicated setup action."""
+    findings: list[str] = []
+    for wf in sorted([*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")]):
+        doc = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            continue
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            actions = [
+                step["uses"].split("@", 1)[0]
+                for step in (job.get("steps") or [])
+                if isinstance(step, dict) and isinstance(step.get("uses"), str)
+            ]
+            for action, count in sorted(Counter(actions).items()):
+                if count > 1 and action.startswith(_CACHING_ACTION_PREFIXES):
+                    findings.append(f"{wf.name}:{job_id} uses {action} x{count}")
+    return findings
+
+
+def test_workflows_exist() -> None:
+    """Guard the guard: an empty glob would make the ratchet vacuously green."""
+    assert list(WORKFLOWS.glob("*.yml")), f"no workflows found under {WORKFLOWS}"
+
+
+def test_no_job_installs_the_same_cache_setup_action_twice() -> None:
+    duplicates = _duplicate_cache_setups()
+    assert not duplicates, (
+        "a cache-writing setup-* action is declared more than once in one job; "
+        "the second invocation reserves the same cache key and races the "
+        "first's post-job save ('Unable to reserve cache with key ...'). Keep "
+        "one invocation per job and fold any rationale into its comment:\n  "
+        + "\n  ".join(duplicates)
+    )


### PR DESCRIPTION
## What

[Nightly Build run 32696300389](https://github.com/kirodotdev/KiroCrew/actions/runs/32696300389) finished **green** but raised 15 warning annotations. This clears 13 of them. Counts are from the check-runs annotations API, not the run page:

| Class | Count | Nature | This PR |
|---|---|---|---|
| `actions/attest-build-provenance@v2` nested actions still on the node20 runtime | 11 | warning only, fires every nightly | fixed |
| `setup-uv` cache reservation failure | 2 | real defect | fixed |
| `react-router` vulnerability exceptions expiring `2026-08-31` | 2 | **gate fails closed from 2026-09-01** | deliberately not touched |

## Node 20 deprecation (11 annotations)

Every release lane pinned `actions/attest-build-provenance` at v2.4.0. Its nested `actions/attest` and `attest-build-provenance/predicate` both declare `using: node20`, so the runner force-runs them on node24 and warns once per publish job. Eleven rather than six because `publish-linux.yml` is a reusable workflow called six times (appimage/deb/rpm × x64/arm64).

Bumped all six call sites to v4.2.2 (`4d101475d8b20a2381f78447822ac1eab6504dd8`).

**Why this is safe on a release-critical provenance path**, verified against upstream rather than assumed:

- Every input in use (`subject-path`, `subject-name`, `subject-digest`, `push-to-registry`) exists in v4.2.2's `action.yml` with unchanged semantics.
- v4 is a composite thin wrapper over `actions/attest`, which declares `using: node24`.
- The predicate is unchanged: v2 ran a `predicate@1.1.5` sub-action feeding `attest@v2.4.0`; v4's inner action, given no predicate inputs, calls `buildSLSAProvenancePredicate()` from the same `@actions/attest` library.
- **Old attestations keep verifying.** The downstream `gh attestation verify --signer-workflow` calls resolve by subject digest plus repo/workflow identity, not by the action version that minted them — a mixed v2/v4 fleet is safe.
- v3.0.0's runner floor (v2.327.1) is met; all six sites run on GitHub-hosted runners.
- The SHA was confirmed to be tag v4.2.2 exactly (`git ls-remote`), and the old `e8998f9…` to be v2.4.0.

### One behaviour difference, pinned off

v3.1.0 added artifact-metadata storage records, and v4 defaults `create-storage-record` to true whenever `push-to-registry` is set — making `publish-docker.yml` the only site a bare bump would change. The attempt would **fail soft** (records need an `artifact-metadata: write` permission this workflow does not grant), but a soft failure is still a fresh annotation on the one release lane holding a registry-push credential, which is precisely what this PR exists to remove. Pinned to `false` to preserve the v2 behaviour the lane was verified with. Adopting storage records is a separate, deliberate change.

## setup-uv cache reservation race (2 annotations)

`build-desktop.yml` installed `astral-sh/setup-uv` **twice in the same job** — the original named step from #132 (`7b590785e`) plus a duplicate added by #421 (`8f17c21b3`). Per setup-uv v9's `restore-cache.ts` the key is `setup-uv-2-<arch>-<platform>-<os>-<python>-<dep-hash>`, every component job-invariant, so the duplicate reserved the identical key and its post step's save made the original's post step fail `reserveCache`.

The warning's own wording is why this survived review for so long:

> Failed to save: Unable to reserve cache with key setup-uv-2-…, **another job may be creating this cache**.

It reads as benign matrix contention. It is not, and the run's own data disproves that reading: the key embeds arch and OS, and the two annotations carried two **different** keys (`aarch64-apple-darwin-macos-15` and `aarch64-unknown-linux-gnu-ubuntu-22.04`), so no two matrix legs can share one. Same job, different step.

The x64 leg's silence supports the diagnosis rather than undermining it: `ci.yml`'s `linux-packaging` job already writes that exact x64 key, so both post steps hit the cache and skip saving, and no race surfaces.

Dropped the duplicate and folded its rationale comment into the survivor. The survivor is the original step in its original position; only the later duplicate was removed. `Stamp version` sits between it and the build, and touches neither PATH nor anything matched by the default `**/uv.lock` cache glob.

## Anti-drift ratchet

`test/test_workflow_cache_setup_uniqueness.py`: no job may declare a cache-writing `setup-*` action more than once. Prefix matched, so a future `setup-<tool>` is covered without anyone enrolling it.

It deliberately **over-approximates** — real keys fold in inputs, so two `setup-python` steps on different versions would not truly collide — and says so in-place, with instructions to widen the match rather than delete the test. The repo is at zero findings after this change. Verified fail-before against `origin/main`'s content, where it flags the duplicate.

## Not addressed here

The remaining 2 annotations are the `react-router` / `react-router-dom` exceptions for GHSA-qwww-vcr4-c8h2 in `.vulnerability-exceptions.json`, which expire **2026-08-31** — the Production Dependency Vulnerability Gate fails closed from 2026-09-01.

Their documented removal condition is the React 19 + React Router 8 migration: `website` is on `react-router 7.18.2` / `react ^18.3.1`, the 7.x line tops out at 7.18.2, and the advisory is fixed only in 8.3.0, which requires React 19. The exceptions are owned by **@pepmach**, and `MAX_EXCEPTION_DAYS = 30` in `scripts/check_npm_audit.py` means the mechanism is designed around a ≤30-day re-affirmation that has not happened since the file was created in #1001 (2026-08-01).

Renewing or retiring them is the owner's call, not a warning-cleanup side effect. **No tracking issue exists for the expiry** — that gap needs filing separately.

## Verification

- `scripts/check_black_formatting.py` (CI-identical): passed.
- `isort`, `flake8`: clean.
- Targeted suites green: `test_workflow_cache_setup_uniqueness`, `test_publish_docker_contract`, `test_workflow_permissions`, `test_node_version_pins`, `test_dependency_vulnerability_gate` — 71 passed.
- Pre-push dual-model review: both models verified the upstream claims independently; one PASS with 4 advisories, one BLOCK on an annotation miscount in the commit message (11/13/2, not 10/12/3) — corrected by amend, and the counts re-derived from the annotations API before pushing. Three advisories adopted (docker comment accuracy, source-grounded setup-uv comment, ratchet over-approximation disclosure).
