### PR TITLE
fix(dashboard): ratchet boundary-Tab traps onto the shared IME latch

### DIFF
--- a/website/src/components/ProjectPicker.tsx
+++ b/website/src/components/ProjectPicker.tsx
@@ -256,7 +256,18 @@ export default function ProjectPicker({ open, onOpenChange, anchorRef, anchorRec
                 else if (e.key === 'ArrowLeft' && e.currentTarget.selectionStart === 0 && e.currentTarget.selectionEnd === 0 && browseParent && browseParent !== browsePath) {
                   e.preventDefault(); browse(browseParent)                            // caret at start -> go to parent
                 }
-                else if (e.key === 'Escape' || e.key === 'Tab') { e.preventDefault(); onOpenChange(false); btnRef?.current?.focus() }
+                else if (e.key === 'Escape' || e.key === 'Tab') {
+                  // This input is a composable free-text path field. An Escape
+                  // or Tab the IME owns is cancelling or cycling the candidate
+                  // list, not leaving the picker — acting on it would close the
+                  // popover and yank focus mid-composition. `claimKey` claims
+                  // through this input's own tracked latch (the
+                  // `bindComposition` spread above feeds it) and owns the
+                  // whole decline: native consumption per the latch contract,
+                  // and the synthetic propagation stop React ancestors read.
+                  if (!ime.claimKey(e)) return
+                  e.preventDefault(); onOpenChange(false); btnRef?.current?.focus()
+                }
               }}
               className="flex-1 bg-bg-elevated border border-border rounded px-2 py-1.5 text-[13px] font-mono text-text placeholder:text-muted focus:outline-none focus-visible:border-accent"
             />

--- a/website/src/hooks/useImeGuard.ts
+++ b/website/src/hooks/useImeGuard.ts
@@ -220,6 +220,28 @@ export function useImeGuard() {
   }
 
   /**
+   * Synthetic-event twin of `ImeLatch.claimKey`, for choose-class keys that
+   * are NOT Enter (a boundary Tab that would cycle focus, an Escape that
+   * would dismiss): it claims through this instance's latch, so the decline
+   * owns both halves exactly as the native contract specifies — always
+   * `stopPropagation`, `preventDefault` only in the post-composition window
+   * where the browser would otherwise act. The latch consumes the NATIVE
+   * event; the SYNTHETIC propagation flag is stopped here too, because React
+   * walks its own flag when dispatching to component ancestors and the
+   * native call does not set it — leaving that to the caller would re-open
+   * the split-the-halves drift this file's ratchet exists to prevent. Enter
+   * branches keep using `claimEnter`, whose ACCEPTED path also consumes the
+   * key (a submitted Enter must never insert a newline); `claimKey` leaves an
+   * accepted key's default to the caller, which is what a Tab site needs —
+   * it consumes only the wrap it owns.
+   */
+  const claimKey = (e: KeyboardEvent) => {
+    if (latch.claimKey(e.nativeEvent)) return true
+    e.stopPropagation()
+    return false
+  }
+
+  /**
    * Spread onto any input or textarea that needs IME-safe composition tracking.
    *
    * The blur reset is not optional and not the caller's to remember. A composition
@@ -270,5 +292,5 @@ export function useImeGuard() {
     },
   })
 
-  return { onCompositionStart, onCompositionEnd, isComposing, claimEnter, reset, bindComposition, bindEnter }
+  return { onCompositionStart, onCompositionEnd, isComposing, claimEnter, claimKey, reset, bindComposition, bindEnter }
 }

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -11,6 +11,7 @@ import InfoTip from '../components/InfoTip'
 import Modal from '../components/Modal'
 import Clickable from '../components/Clickable'
 import { useNavigate } from 'react-router-dom'
+import { useDocumentImeLatch } from '../hooks/useImeGuard'
 import { useAppDispatch } from '../store'
 import { addNotification } from '../store/notificationsSlice'
 import { setPendingInput } from '../store/chatSlice'
@@ -392,6 +393,10 @@ function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: Con
   const popRef = useRef<HTMLDivElement>(null)
   const cancelRef = useRef<HTMLButtonElement>(null)
   const confirmRef = useRef<HTMLButtonElement>(null)
+  // Shared IME latch for the boundary-Tab trap below (see the comment on the
+  // Tab branches): the trap listens at document capture, so it receives
+  // NATIVE KeyboardEvents that the synthetic-only guard cannot consume.
+  const imeLatch = useDocumentImeLatch(open)
 
   const close = useCallback(() => {
     setOpen(false)
@@ -409,11 +414,25 @@ function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: Con
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // An Escape the IME owns is cancelling a candidate, not the popover —
+        // and `close()` also yanks focus back to the trigger, the same harm
+        // as the Tab wrap below. Same claim, same reason.
+        if (!imeLatch.claimKey(e)) return
         close()
       } else if (e.key === 'Tab' && e.shiftKey && document.activeElement === cancelRef.current) {
+        // A boundary Tab the IME owns must not cycle focus — the user is
+        // choosing a candidate, not leaving the field. `claimKey` owns the
+        // whole decline (native-event contract in useImeGuard.ts) and must
+        // run before the preventDefault() and focus move. Both ring
+        // boundaries are buttons today, so no composition can start on them —
+        // the guard pins that this stays safe if the popover ever grows a
+        // text field. Mid-popover Tabs fall through: they are the browser's
+        // to move, so they are also not the trap's to claim.
+        if (!imeLatch.claimKey(e)) return
         e.preventDefault()
         confirmRef.current?.focus()
       } else if (e.key === 'Tab' && !e.shiftKey && document.activeElement === confirmRef.current) {
+        if (!imeLatch.claimKey(e)) return
         e.preventDefault()
         cancelRef.current?.focus()
       }
@@ -433,7 +452,7 @@ function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: Con
       window.removeEventListener('scroll', onScrollOrResize, true)
       window.removeEventListener('resize', onScrollOrResize)
     }
-  }, [close, open])
+  }, [close, open, imeLatch])
 
   const toggle = () => {
     if (!open && triggerRef.current) setRect(triggerRef.current.getBoundingClientRect())

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -1083,6 +1083,59 @@ describe('DevFleetPage', () => {
     expect(trigger).toHaveFocus()
   })
 
+  it('declines a boundary Tab that belongs to an IME composition', async () => {
+    // On WebKit the keydown that commits a candidate arrives AFTER
+    // compositionend with `isComposing` already false — unguarded, the trap
+    // would yank focus and abort the composition. Both ring boundaries are
+    // buttons today, so no composition can start on them; this pins that the
+    // trap stays safe if the popover ever grows a text field.
+    const { pop } = await openPullBuildConfirm()
+    const cancel = within(pop).getByText('Cancel')
+    const start = within(pop).getByText('Start')
+    expect(cancel).toHaveFocus()
+
+    fireEvent.compositionStart(cancel)
+    fireEvent.compositionEnd(cancel)
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+    // Declined: focus stays where it was instead of wrapping to Start.
+    expect(cancel).toHaveFocus()
+    expect(start).not.toHaveFocus()
+  })
+
+  it('declines the forward-boundary Tab too — each branch carries its own claim', async () => {
+    // The scan requires the claim BETWEEN a branch and its focus move, but a
+    // behavioural pin per boundary is what proves the claim actually runs:
+    // one guarded branch must not stand in for its sibling.
+    const { pop } = await openPullBuildConfirm()
+    const start = within(pop).getByText('Start')
+    start.focus()
+    expect(start).toHaveFocus()
+
+    fireEvent.compositionStart(start)
+    fireEvent.compositionEnd(start)
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    // Declined: no wrap back to Cancel.
+    expect(start).toHaveFocus()
+  })
+
+  it('declines an Escape that belongs to an IME composition (popover stays open)', async () => {
+    // Escape on the same document-capture listener closes the popover AND
+    // yanks focus back to the trigger — the same harm as the Tab wrap, so
+    // the same claim guards it.
+    const { pop } = await openPullBuildConfirm()
+    const cancel = within(pop).getByText('Cancel')
+
+    fireEvent.compositionStart(cancel)
+    fireEvent.compositionEnd(cancel)
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    // Declined: the popover is still there and focus did not move.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(cancel).toHaveFocus()
+  })
+
   it('confirm popover opens downward when there is room below', async () => {
     mockFleet(FLEET_MENU)
     renderPage()

--- a/website/src/test/ImeEnterClaimRatchet.test.ts
+++ b/website/src/test/ImeEnterClaimRatchet.test.ts
@@ -217,6 +217,60 @@ function scanUnguardedEnterBlurCommits(lines: string[]): number[] {
   return hits
 }
 
+/**
+ * A Tab branch that moves focus but consults NO composition signal at all.
+ *
+ * The absent-guard twin of the Enter→blur rule above, for the OTHER
+ * choose-class key: IMEs use Tab to cycle the candidate list, and on WebKit
+ * the keydown that commits a candidate arrives after `compositionend` with
+ * `isComposing` already false — so a hand-rolled dialog focus trap that wraps
+ * the boundary Tab yanks focus and aborts the composition. Every rule above
+ * is keyed on a composition signal the offender must already have NAMED, so
+ * a trap that consults none of them matches none of them, and the shape
+ * spreads by copy exactly like the Enter ones did: six dialogs carried it
+ * before the shared latch existed, and a seventh grew in a page nobody wrote
+ * an IME test for.
+ *
+ * `.focus(` within the branch's forward window is the scoping anchor, and it
+ * is a deliberate one: in this tree a Tab branch that calls `.focus()` (with
+ * or without options — `preventScroll` is this tree's own convention) exists
+ * only to re-aim the key somewhere the user did not send it (a trap's wrap,
+ * a picker's close-and-return). The guard is `claimKey(` BETWEEN the branch
+ * and the first focus move after it — the claim has to run before the move
+ * it declines, so a claim past the move (or a sibling branch's claim beyond
+ * it) does not clear this one. A Tab branch that acts through STATE
+ * (accepting a suggestion, indenting a list item) has no focus call to
+ * anchor on and is out of this rule's scope by design: fail open rather
+ * than mis-flag, consistent with the rest of this file. A `.focus(` further
+ * than the window is likewise not this structure.
+ */
+const TAB_BRANCH = /key === 'Tab'|key !== 'Tab'/
+const FOCUS_MOVE = /\.focus\(/
+const TAB_CLAIM = /\bclaimKey\(/
+const TRAP_WINDOW = 25
+
+function scanUnguardedTabFocusTraps(lines: string[]): number[] {
+  const code = lines.map(l => {
+    const t = l.trim()
+    return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') ? '' : l
+  })
+  const hits: number[] = []
+  code.forEach((line, i) => {
+    if (!TAB_BRANCH.test(line)) return
+    // The focus move has to be on this branch's window, not merely later in
+    // the file — a Tab branch with no focus call is a different structure.
+    const focusAt = code
+      .slice(i, i + TRAP_WINDOW + 1)
+      .findIndex(l => FOCUS_MOVE.test(l))
+    if (focusAt === -1) return
+    // The claim guards THIS branch only when it runs between the key check
+    // and the move: one guarded branch must not clear an unguarded sibling.
+    const span = code.slice(i, i + focusAt + 1)
+    if (!span.some(l => TAB_CLAIM.test(l))) hits.push(i + 1)
+  })
+  return hits
+}
+
 describe('IME Enter claim ratchet', () => {
   it('routes every Enter-submit branch through the guard', () => {
     const offenders: string[] = []
@@ -283,6 +337,28 @@ describe('IME Enter claim ratchet', () => {
     // An entry here commits a text field on an Enter it never checked. Add the
     // early return (`if (ime.isComposing(e)) return`) before the blur, and the
     // `bindComposition` spread that tracks the latch it reads.
+    expect(offenders).toEqual([])
+  })
+
+  it('never moves focus on a Tab the branch did not claim', () => {
+    // The boundary-Tab twin of the rule above: `DevFleetPage` carried exactly
+    // this — a hand-rolled focus trap on a document-capture listener, copied
+    // from the same pre-latch shape six dialogs shared — and no rule in this
+    // file could see it, because every one of them requires the site to have
+    // named a composition signal it consulted no part of. Both of that trap's
+    // ring boundaries are buttons today, so the defect was unreachable; this
+    // rule is what pins that a layout change (or the next copy of the shape)
+    // cannot make it reachable silently.
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (rel === 'hooks/useImeGuard.ts') continue
+      const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
+      for (const n of scanUnguardedTabFocusTraps(lines)) offenders.push(`${rel}:${n}`)
+    }
+    // An entry here re-aims a Tab it never checked. Route the branch through
+    // the shared latch: `useDocumentImeLatch(...).claimKey(e)` for native
+    // document/window listeners, `useImeGuard().claimKey(e)` for synthetic
+    // handlers — the claim runs BEFORE the preventDefault() and focus move.
     expect(offenders).toEqual([])
   })
 
@@ -544,5 +620,124 @@ describe('ratchet rule fixtures', () => {
         // ime.isComposing is handled upstream, honestly
         if (e.key === 'Enter') e.currentTarget.blur()
       }}`))).toHaveLength(1)
+  })
+
+  it('flags a boundary-Tab trap that does not claim the key', () => {
+    // The pre-latch shape all six converted dialogs shared, and the one
+    // DevFleetPage carried after them: two boundary branches, each
+    // preventDefault() + a focus wrap, no claim anywhere. Both branches flag —
+    // each is independently a place the defect re-enters.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Tab' && e.shiftKey && document.activeElement === cancelRef.current) {
+          e.preventDefault()
+          confirmRef.current?.focus()
+        } else if (e.key === 'Tab' && !e.shiftKey && document.activeElement === confirmRef.current) {
+          e.preventDefault()
+          cancelRef.current?.focus()
+        }
+      }`))).toHaveLength(2)
+    // The sanctioned shape: claimKey before the preventDefault and focus move.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Tab' && e.shiftKey && document.activeElement === cancelRef.current) {
+          if (!imeLatch.claimKey(e)) return
+          e.preventDefault()
+          confirmRef.current?.focus()
+        } else if (e.key === 'Tab' && !e.shiftKey && document.activeElement === confirmRef.current) {
+          if (!imeLatch.claimKey(e)) return
+          e.preventDefault()
+          cancelRef.current?.focus()
+        }
+      }`))).toHaveLength(0)
+    // The enumerating trap (the converted dialogs' shape): the wrap decision
+    // sits several code lines below the key check, still inside the window.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Tab') return
+        const focusable = getFocusable(dialogRef.current)
+        if (focusable.length === 0) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        const wrapsBackward = event.shiftKey && document.activeElement === first
+        const wrapsForward = !event.shiftKey && document.activeElement === last
+        if (!wrapsBackward && !wrapsForward) return
+        event.preventDefault()
+        ;(wrapsBackward ? last : first).focus()
+      }`))).toHaveLength(1)
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Tab') return
+        const focusable = getFocusable(dialogRef.current)
+        if (focusable.length === 0) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        const wrapsBackward = event.shiftKey && document.activeElement === first
+        const wrapsForward = !event.shiftKey && document.activeElement === last
+        if (!wrapsBackward && !wrapsForward) return
+        if (!imeLatch.claimKey(event)) return
+        event.preventDefault()
+        ;(wrapsBackward ? last : first).focus()
+      }`))).toHaveLength(0)
+    // ONE guarded branch must not clear an unguarded sibling: the claim has
+    // to sit between each branch and the move it guards, so the sibling's
+    // claim (which sits past this branch's own focus call) does not count.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Tab' && e.shiftKey && document.activeElement === cancelRef.current) {
+          if (!imeLatch.claimKey(e)) return
+          e.preventDefault()
+          confirmRef.current?.focus()
+        } else if (e.key === 'Tab' && !e.shiftKey && document.activeElement === confirmRef.current) {
+          e.preventDefault()
+          cancelRef.current?.focus()
+        }
+      }`))).toHaveLength(1)
+    // A focus call carrying options is this tree's own convention
+    // (preventScroll keeps the page behind a dialog from twitching) and
+    // anchors the rule the same as a bare one.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab') return
+        e.preventDefault()
+        items[0].focus({ preventScroll: true })
+      }`))).toHaveLength(1)
+    // The one-line close-and-return spelling (a picker's Tab-to-dismiss): the
+    // focus call sits ON the branch line, and the same-line window catches it.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Escape' || e.key === 'Tab') { e.preventDefault(); onOpenChange(false); btnRef?.current?.focus() }
+      }}`))).toHaveLength(1)
+    // Its guarded form claims through the synthetic delegate.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Escape' || e.key === 'Tab') {
+          if (!ime.claimKey(e)) return
+          e.preventDefault(); onOpenChange(false); btnRef?.current?.focus()
+        }
+      }}`))).toHaveLength(0)
+    // Scoped to a FOCUS MOVE: a Tab branch that acts through state (accepting
+    // a suggestion, indenting a list item) has no focus call to anchor on and
+    // is out of scope by design — fail open rather than mis-flag.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab' && open && suggestions.length > 0) { e.preventDefault(); setDraft(suggestions[0].path) }
+      }}`))).toHaveLength(0)
+    // A focus call beyond the window is a different structure, not this trap.
+    const farFocus = [
+      "if (e.key !== 'Tab') return",
+      ...Array.from({ length: 30 }, () => 'noop()'),
+      'inputRef.current?.focus()',
+    ]
+    expect(scanUnguardedTabFocusTraps(farFocus)).toHaveLength(0)
+    // A claim mentioned only in a comment does not launder the site.
+    expect(scanUnguardedTabFocusTraps(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        // claimKey( is deliberately skipped here, honestly
+        if (e.key === 'Tab' && e.shiftKey && document.activeElement === cancelRef.current) {
+          e.preventDefault()
+          confirmRef.current?.focus()
+        }
+      }`))).toHaveLength(1)
   })
 })

--- a/website/src/test/ImeEnterGuardSites.test.tsx
+++ b/website/src/test/ImeEnterGuardSites.test.tsx
@@ -212,6 +212,39 @@ describe('ProjectPicker path input — rule 2: gate the Enter path only', () => 
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
     expect(vi.mocked(api.browseDirs)).toHaveBeenCalledWith('/home/u/alpha')
   })
+
+  // The Escape || Tab branch closes the picker and returns focus to the
+  // trigger — the composition-abort harm on a composable free-text path
+  // field: an IME candidate-cycling Tab (or candidate-cancelling Escape)
+  // must not be adopted as "leave the picker".
+  async function openBrowseWithSpy() {
+    const onOpenChange = vi.fn()
+    renderWithProviders(
+      <ProjectPicker open={true} onOpenChange={onOpenChange} anchorRect={rect(100, 50)} onSelect={vi.fn()} />,
+    )
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    return { input: screen.getByPlaceholderText('/path/to/project') as HTMLInputElement, onOpenChange }
+  }
+
+  it('does NOT close the picker on the committing Tab in the post-composition window', async () => {
+    const { input, onOpenChange } = await openBrowseWithSpy()
+    armLatch(input)
+    fireEvent.keyDown(input, { key: 'Tab' })
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('does NOT close the picker on an Escape that cancels a candidate', async () => {
+    const { input, onOpenChange } = await openBrowseWithSpy()
+    armLatch(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('closes the picker on a plain Tab (positive control)', async () => {
+    const { input, onOpenChange } = await openBrowseWithSpy()
+    fireEvent.keyDown(input, { key: 'Tab' })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
 })
 
 describe('BroadcastBar input — rule 1 single-line Enter-only site: bindEnter', () => {

--- a/website/src/test/useImeGuard.test.ts
+++ b/website/src/test/useImeGuard.test.ts
@@ -280,4 +280,80 @@ describe('useImeGuard', () => {
       }
     })
   })
+
+  describe('claimKey (synthetic delegate onto the instance latch)', () => {
+    // The delegate hands e.nativeEvent to ImeLatch.claimKey, so consumption
+    // happens on the NATIVE half: stopPropagation always on a decline,
+    // preventDefault only when both native signals are clear (the tracked
+    // latch window). The delegate itself stops the SYNTHETIC propagation on
+    // a decline — React walks its own flag for component ancestors, which
+    // the native call does not set. An ACCEPTED key is left untouched —
+    // unlike claimEnter, the caller consumes it as part of acting (a trap's
+    // own preventDefault).
+    const tabKey = (opts: { isComposing?: boolean; keyCode?: number } = {}) => {
+      const preventDefault = vi.fn()
+      const stopPropagation = vi.fn()
+      const syntheticStopPropagation = vi.fn()
+      const e = {
+        stopPropagation: syntheticStopPropagation,
+        nativeEvent: {
+          isComposing: opts.isComposing ?? false,
+          keyCode: opts.keyCode ?? 9,
+          preventDefault,
+          stopPropagation,
+        },
+      } as unknown as React.KeyboardEvent
+      return { e, preventDefault, stopPropagation, syntheticStopPropagation }
+    }
+
+    it('reports true and leaves the key untouched when no composition is in flight', () => {
+      const { result } = renderHook(() => useImeGuard())
+      const { e, preventDefault, stopPropagation, syntheticStopPropagation } = tabKey()
+      expect(result.current.claimKey(e)).toBe(true)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+      expect(syntheticStopPropagation).not.toHaveBeenCalled()
+    })
+
+    it('declines and consumes inside the tracked-latch window (native signals clear)', () => {
+      // The WebKit hazard: the committing keydown arrives after compositionend
+      // with isComposing already false, so only the latch can see it — and the
+      // browser WOULD act on it, so the decline must own both halves.
+      vi.useFakeTimers()
+      try {
+        const { result } = renderHook(() => useImeGuard())
+        act(() => {
+          result.current.onCompositionStart()
+          result.current.onCompositionEnd()
+        })
+        const { e, preventDefault, stopPropagation, syntheticStopPropagation } = tabKey()
+        expect(result.current.claimKey(e)).toBe(false)
+        expect(preventDefault).toHaveBeenCalledTimes(1)
+        expect(stopPropagation).toHaveBeenCalledTimes(1)
+        expect(syntheticStopPropagation).toHaveBeenCalledTimes(1)
+
+        act(() => { vi.advanceTimersByTime(50) })
+        const after = tabKey()
+        expect(result.current.claimKey(after.e)).toBe(true)
+        expect(after.preventDefault).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('declines a mid-composition key without cancelling its default action', () => {
+      // A native signal set means the browser is consuming the key for the
+      // IME itself (candidate navigation, or the commit) — cancelling that
+      // would eat the user's composition. Propagation still stops on BOTH
+      // halves: the key is not the caller's, and not any ancestor's either.
+      const { result } = renderHook(() => useImeGuard())
+      for (const opts of [{ isComposing: true }, { keyCode: 229 }]) {
+        const { e, preventDefault, stopPropagation, syntheticStopPropagation } = tabKey(opts)
+        expect(result.current.claimKey(e)).toBe(false)
+        expect(preventDefault).not.toHaveBeenCalled()
+        expect(stopPropagation).toHaveBeenCalledTimes(1)
+        expect(syntheticStopPropagation).toHaveBeenCalledTimes(1)
+      }
+    })
+  })
 })


### PR DESCRIPTION
# fix(dashboard): ratchet boundary-Tab traps onto the shared IME latch

## Problem / Motivation

Every rule in the `ImeEnterClaimRatchet` source scan is keyed on a composition signal the offender must already have NAMED (`key === 'Enter'`, `isComposing(...)`, `addEventListener('compositionstart'`, `nativeEvent.isComposing`). A boundary-Tab focus trap that consults NO composition signal -- exactly the pre-fix shape of all six dialog traps converted in #5427 -- matches none of them, so the composition-abort defect class can re-enter the tree with zero red signal. Two instances proved the gap: `DevFleetPage`'s confirm popover carried a hand-rolled boundary-Tab trap on a document-capture listener with no latch (unreachable today -- both ring boundaries are buttons -- but nothing pinned that), and `ProjectPicker`'s `Escape || Tab` close-and-refocus branch carried the reachable form on a composable free-text path field.

## Why it matters

For a CJK-input user, IMEs use Tab to cycle the candidate list and Escape to cancel it, and on WebKit the keydown that commits a candidate arrives AFTER `compositionend` with `isComposing` already false. In `ProjectPicker` that means a candidate-cycling Tab (or candidate-cancelling Escape) closes the picker and yanks focus back to the trigger mid-composition -- the user loses the path they were composing. And without a ratchet rule, the next hand-rolled dialog trap anyone copies reintroduces the same defect silently, which is precisely how the six #5427 sites accumulated.

## What changed (motivation → approach → change)

- **New ratchet rule** (`scanUnguardedTabFocusTraps`): keyed on a `key === 'Tab'` / `key !== 'Tab'` branch with a `.focus(` call in its forward window, requiring `claimKey(` BETWEEN the branch and the first focus move after it. Per-branch scoping is deliberate: one guarded branch must not clear an unguarded sibling (the claim past this branch's own focus call does not count). The anchor accepts `.focus({ preventScroll: true })` -- this tree's own focus-call convention. Tab branches that act through state setters (file-explorer `PathBar`, md-notebook indentation, mochi slash-command accept) have no focus anchor and are out of scope by design: fail open rather than mis-flag, consistent with the file's other rules. Fixtures pin the predicate in both directions, including the partial-guard masking case, the options-carrying focus call, comment laundering, and the beyond-window fail-open.
- **`useImeGuard` gains a `claimKey` synthetic delegate** onto its instance latch (`ImeLatch.claimKey` already existed for native listeners). The delegate owns BOTH halves of a decline: native consumption per the latch contract, plus the synthetic `stopPropagation` React ancestors read -- leaving either half to the caller is the split-the-guard drift this ratchet file exists to prevent.
- **`DevFleetPage` conversion**: the ConfirmBtn popover's document-capture trap routes both Tab boundaries AND the Escape branch through `useDocumentImeLatch(open)` -- Escape on the same listener closes the popover and yanks focus to the trigger, the same harm class, and this commit's own ProjectPicker change guards Escape alongside Tab, so leaving DevFleetPage's Escape bare would have made it the one converted site guarding one choose-key and not the other.
- **`ProjectPicker` conversion**: the `Escape || Tab` branch claims through `ime.claimKey(e)` -- the input's `bindComposition` spread already feeds that instance latch, so no second document-level listener set is needed.

## Tests

- 5 ratchet fixture groups for the new predicate (pre-#5427 two-branch shape, enumerating-trap shape, one-line close-and-return shape, guarded forms of each, partial-guard masking, `preventScroll` spelling, state-setter out-of-scope, beyond-window fail-open, comment laundering).
- 3 `claimKey` delegate unit tests (accept untouched; latch-window decline consumes native + synthetic halves; mid-composition decline preserves the IME's default action).
- 3 `DevFleetPage` decline tests (backward boundary, forward boundary -- each branch carries its own claim -- and Escape keeps the popover open).
- 3 `ProjectPicker` site tests (committing Tab does not close the picker, candidate-cancelling Escape does not close it, plain Tab still closes -- positive control).
- Every guard is mutation-verified: removing any single claim, the delegate's synthetic stop, or neutering the scan window reds a specific test. Notably, removing ONLY the forward-Tab claim now reds both the scan and a behavior test (it previously would have been masked by the sibling's claim -- caught by both pre-push reviewers, fixed with the per-branch span).
- Full local gates: `npx tsc -b` clean, `npx vitest run` -- the 4 touched files 163/163 after rebasing onto main with #5522 (the 15 pre-rebase suite failures were all main-owned, verified byte-identical at the base commit), eslint 648 warnings within the 664 ceiling with 0 errors, jscpd clean, brand + i18n gates clean.

## Manual verification

Covered by the behavioral decline tests above (keyboard-only change; the decline path is not reachable by mouse).

## Screenshots / video

No visual delta -- test/ratchet + keyboard-guard change only. `no-screenshots` label applies.

## Related Issues

Closes #5475

Out of scope, tracked separately: the three state-setter Tab sites named in the issue's scope-widening comment (file-explorer `PathBar` accept-suggestion, md-notebook list indentation, mochi slash-command accept) act with no `.focus()` anchor, so the trap-shape rule structurally cannot see them; they need either one-off conversions through `claimKey` or a differently-anchored rule. Also considered and declined: adding `useDocumentImeLatch(` to the `SHARED_LATCH` alternation -- that hook owns its own subscription, so no legitimate consumer hand-writes a `compositionstart` listener beside it, and the current fail-closed direction is safe.

## Checklist

- [x] Tests added/updated
- [x] Docs updated where behavior is documented (no spec documents this surface; `side.md`'s composer-guard description remains accurate)
- [x] Follows AGENTS.md / website/AGENTS.md conventions

## Contribution License Agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
