### PR TITLE
fix: isolate the interpreter version-gate probe with -I (#5530)

### DIFF
--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3751,11 +3751,17 @@ def find_python_interpreter(reject: Optional[Callable[[str], bool]] = None) -> s
         if _is_windows_store_python_stub(p):
             continue
         try:
+            # -I isolates the probe from the caller's environment: without it,
+            # ``site`` imports any ``sitecustomize.py`` found on the caller's
+            # PYTHONPATH at child startup, and that module can monkeypatch
+            # ``sys.version_info`` to steer WHICH interpreter this loop selects.
+            # Because -I implies -E (PYTHON* env vars ignored), the UTF-8 pin
+            # must ride the argv as ``-X utf8``, matching
+            # ``dep_sync._probe_interpreter``.
             out = subprocess.check_output(
-                [p, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+                [p, "-I", "-X", "utf8", "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
                 timeout=5,
                 stderr=subprocess.DEVNULL,
-                env={**os.environ, "PYTHONIOENCODING": "utf-8"},
                 **UTF8_TEXT,
             ).strip()
             major, _, minor = out.partition(".")

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2250,6 +2250,31 @@ class TestFindPythonInterpreterReal:
         monkeypatch.setattr(pc.subprocess, "check_output", boom)
         assert pc.find_python_interpreter() is None
 
+    def test_version_gate_ignores_a_sitecustomize_decoy_on_pythonpath(
+        self, tmp_path, monkeypatch
+    ):
+        # The selection-side twin of test_origin_probe_ignores_pythonpath: at
+        # child startup the ``site`` module imports any ``sitecustomize.py``
+        # found on the caller's PYTHONPATH, and that module can monkeypatch
+        # ``sys.version_info`` — here forcing this real >= 3.10 interpreter to
+        # report 3.4, which would make the version gate reject it and steer
+        # selection. The gate runs the probe isolated (-I), so the decoy is
+        # never imported and the candidate is judged by its REAL version.
+        # This spawns a real child; the probe is a read-only version query
+        # that creates nothing, so no cwd pin is needed.
+        decoy = tmp_path / "decoy-pythonpath"
+        decoy.mkdir()
+        (decoy / "sitecustomize.py").write_text(
+            "import sys\nsys.version_info = (3, 4, 0, 'final', 0)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PYTHONPATH", str(decoy))
+        # Every candidate name resolves to this suite's own interpreter — a
+        # real, runnable >= 3.10 CPython on every platform CI runs.
+        monkeypatch.setattr("shutil.which", lambda name: sys.executable)
+
+        assert pc.find_python_interpreter() == sys.executable
+
 
 class TestFindListeningPidsErrors:
     def test_returns_empty_when_lsof_missing(self, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

`platform_compat.find_python_interpreter` version-gates each candidate interpreter with an unisolated child probe: `subprocess.check_output([p, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"], ...)` with no `-I`. At child startup the `site` module imports any `sitecustomize.py` found on the caller's `PYTHONPATH`, and that module can monkeypatch `sys.version_info` — so a hostile or accidental `PYTHONPATH` entry can make an old interpreter present as >= 3.10 (or a good one as too old), steering WHICH interpreter the resolver selects.

After #5501, every downstream ANSWER probe of the selected interpreter already runs isolated (`-I -X utf8` via `dep_sync._probe_interpreter`), so the answers are no longer forgeable — but the SELECTION step was still open. This closes the remaining selection half of the same defect class.

## Why it matters

`find_python_interpreter` is the single source of truth for "where is a usable system python" — its answer becomes the STT/whisper install target and the interpreter other probes are aimed at. A steered selection can route those flows to an unusable (or deliberately chosen) interpreter. Severity is low — it needs a `PYTHONPATH` entry in the gateway's environment, and the downstream answers are already trustworthy — but it is a real hardening gap, and the empirical reproduction is one two-line `sitecustomize.py` away.

## What changed (motivation → approach → change)

Symptom: interpreter selection steerable via `PYTHONPATH` → root cause: the version-gate child runs `site` initialization against the caller's environment → change: run the probe in isolated mode, mirroring the isolation the answer probes already use.

- `src/kiro_crew/platform_compat.py`: the version-gate invocation gains `-I`. Because `-I` implies `-E` (all `PYTHON*` env vars ignored), the existing `PYTHONIOENCODING` env pin becomes dead code; the UTF-8 pin moves to argv as `-X utf8`, exactly matching `dep_sync._probe_interpreter`. Everything else is intact: the `_is_windows_store_python_stub` rejection, the `brazil-path` / `build/private` skips, the 5s timeout, the `>= 3.10` comparison, and the surrounding candidate loop.
- Empirically verified before coding: without `-I`, a decoy `sitecustomize.py` on `PYTHONPATH` makes a 3.12 interpreter report `3.4`; with `-I -X utf8` it reports its real version.

The pre-push Opus review identified two sibling probes of the same class in files this PR does not touch (`_unusable` in `dashboard/handlers/core.py`, `_python3_bin_dir` in `transcribe.py`); filed as the remainder ledger in #5537 rather than widening this diff.

## Tests

- `test_version_gate_ignores_a_sitecustomize_decoy_on_pythonpath` (new, in `TestFindPythonInterpreterReal`): places a `sitecustomize.py` decoy on `PYTHONPATH` that forces the suite's own real >= 3.10 interpreter to report 3.4, and asserts `find_python_interpreter`'s selection is unaffected. **Mutation-verified**: removing `-I` from the gate probe makes the test fail (the decoy then steers the child to report 3.4, the gate rejects every candidate, and selection returns `None`).
- All existing `find_python_interpreter` tests pass unchanged (the mocked-`check_output` tests are argv-shape-independent).

## Manual verification

N/A — unit coverage sufficient: the decoy test spawns the real child and exercises the exact steering mechanism from the issue; lint/mypy/pytest all green locally (the only full-suite failures reproduce identically on a clean `origin/main` checkout of this host).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only subprocess hardening; no frontend file touched and no rendered surface changes.

## Related Issues

Fixes #5530

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior-preserving hardening with in-code rationale
- [x] No secrets, credentials, or internal references in the diff
