### PR TITLE
fix(security): close six argument-vetting holes and convert four tools to accept-lists

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -20,7 +20,7 @@ import uuid
 from collections.abc import Coroutine, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar
 
 from aiohttp import web
 
@@ -336,7 +336,12 @@ _READ_ONLY_PIPE_RE = re.compile(
     r"^\s*(grep|egrep|fgrep|head|tail|wc|sort|uniq|cut|less|more|cat)\b"
 )
 
-# Reject redirections and command substitutions — conservative.
+# Reject redirections and command substitutions, conservatively.
+#
+# `<` is matched only as `<(` here, NOT bare. Bare `<` and word-initial `#` are
+# TOKEN ELISION rather than command execution, and they are handled per verb in
+# `_side_effect_reason` instead: see `_ELISION_SENSITIVE` for why a global refusal
+# was the wrong place for them.
 _UNSAFE_SHELL_RE = re.compile(r">|`|\$\(|<\(|(?<!&)&(?!&)")
 
 # Discard-only redirect idioms that are read-only despite containing '>'/'&':
@@ -602,17 +607,12 @@ def _is_help_probe(segment: str) -> bool:
 
 # Flags that make the program write a file named on its own command line.
 _WRITE_FLAGS: dict[str, tuple[str, ...]] = {
-    # `-T` does not name the output, it names a DIRECTORY sort writes its
-    # temporaries into — a write to a path the caller chose, one step removed,
-    # exactly like `tree -R` below. Reported by #5038.
-    "sort": ("-o", "--output", "-T", "--temporary-directory"),
     # `-R` writes without being handed a filename: tree re-runs itself in every
     # directory it descends into, adding `-o 00Tree.html` each time, so the file
     # is named by tree rather than by the command line. Same outcome as `-o`, one
     # step removed, which is why looking only for a filename-bearing flag missed
     # it.
     "tree": ("-o", "--output", "-R"),
-    "file": ("-C", "--compile"),
     "uniq": ("-o",),
     "git diff": ("--output",),
     "git show": ("--output",),
@@ -643,8 +643,6 @@ _EXEC_FLAGS: dict[str, tuple[str, ...]] = {
     # `.gitattributes`, i.e. chosen by the checkout rather than by the caller.
     # `--textconv` is the same hand-off through a different config key.
     "git cat-file": ("--filters", "--textconv"),
-    # `sort` compresses its temporary files by running this program.
-    "sort": ("--compress-program",),
     # A pager that runs a filter over its input, reachable as a pipe target.
     # `-k` is the sharper one and it is INDIRECT: it loads a lesskey file, and a
     # lesskey file can set environment variables — including `LESSOPEN`, which less
@@ -657,6 +655,95 @@ _EXEC_FLAGS: dict[str, tuple[str, ...]] = {
     # keyfile, while uppercase `-K` is `--quit-on-intr` and an ordinary read.
     "less": ("--filter", "-k", "--lesskey-file", "--lesskey-src"),
 }
+
+# Flags that name a file which in turn NAMES THE PATHS the program opens. This is
+# an INDIRECTION, not a write, which is why a write-flag table could not hold it:
+# the hook layer applies `is_sensitive_path` to the command text, so it sees the
+# list file and nothing else while the program reads every path inside.
+#
+# Measured on coreutils, with a NUL-separated list containing `/etc/hostname`:
+# `wc --files0-from=list0` and `du --files0-from=list0` both read `/etc/hostname`,
+# a path that never appears in argv.
+#
+# Scoped to the heads that HAVE the flag and are not already covered, and
+# deliberately spelled in full: `--file` is a prefix of `--files0-from`, so a
+# shorter entry would be reached by the abbreviation walk in `_glob_reaches` and
+# cost `grep --file=PATTERNS` and `stat --file` for no gain.
+#
+# `sort` HAS the flag (checked against `--help`) and is deliberately NOT here.
+# It is already refused by `_OPTION_ACCEPT_LISTS`, which admits an option only if
+# it is listed, and `--files0-from` is not in `_SORT_READONLY_LONG`. Listing it
+# twice would change nothing but the reason string, while making a reader think
+# this table is what closes it. The glob defence is unaffected: it derives
+# `--files0-from` from the entries below, not from the key it appears under.
+_INDIRECT_LIST_FLAGS: tuple[str, ...] = ("--files0-from",)
+
+_INDIRECT_LIST_FLAGS_BY_PREFIX: dict[str, tuple[str, ...]] = {
+    prefix: _INDIRECT_LIST_FLAGS for prefix in ("wc", "du")
+}
+
+# Pagers take a `+` argument that is not an option but a string in the pager's OWN
+# command language, and that language contains a shell escape. Measured under a
+# real pty: `git log | less '+!touch FILE'` CREATED the file.
+#
+# Two things about that measurement decide the shape of this rule.
+#
+# It did NOT fire when stdout was a pipe -- less degrades to `cat` with no tty and
+# never runs the startup command. So this is not unconditional code execution; it
+# depends on whether whatever executes the command supplies a tty. The classifier
+# cannot know that (the gate at `hooks.on_tool_call` hands the string to an agent
+# runtime, it does not run it), so it must fail closed on the spelling.
+#
+# `more` did NOT fire on util-linux, which has no `+command`. It is listed anyway
+# because on the BSDs `more` is not a separate program: FreeBSD's
+# `usr.bin/less/Makefile` installs it as a link (`LINKS= ${BINDIR}/less
+# ${BINDIR}/more`), and Apple's `less/main.c` detects the name at startup:
+#
+#     if (strcmp(last_component(progname), "more") == 0)
+#             less_is_more = 1;
+#
+# `less_is_more` changes defaults, not the `+` startup-command path, so `more '+!cmd'`
+# reaches the same shell escape there. This module ships to macOS, and the name a
+# binary is invoked under does not tell the classifier which implementation answers,
+# so both names are listed rather than branching on `sys.platform`.
+#
+# The whole `+` prefix is refused rather than the dangerous letters (`!` shell,
+# `|` pipe-to-shell, `v` editor, `s` save-to-file), because enumerating them is the
+# denylist this PR exists to argue against: the set is the pager's command
+# language, and it grows without asking.
+_PAGER_STARTUP_VERBS: frozenset[str] = frozenset(("less", "more"))
+
+# Words bash DELETES before exec, which `shlex.split` keeps. The token list this
+# module reads is therefore a strict SUPERSET of the real argv, and a phantom word
+# can make a segment look like something it is not. Measured on a scratch repo,
+# with an empty file named `--list` present for the redirect form:
+#
+#     git branch injected # --list     -> CREATED the branch
+#     git tag forged # --list          -> CREATED the tag
+#     git branch injected < --list     -> CREATED the branch
+#     git branch injected <<< --list   -> CREATED the branch
+#
+# In each case `shlex` supplied a `--list` that put the segment in list mode, so
+# the operand walk read `injected` as a pattern instead of a ref to create.
+#
+# WHY THIS IS PER VERB AND NOT A GLOBAL REFUSAL. A phantom word can only ADD to the
+# token list. For a verb decided by its FLAGS, an added word is either inert or gets
+# read as a flag it does not have, so the worst case is an extra prompt: safe. Only a
+# verb decided by POSITION or MODE can be flipped, because there the count and the
+# order of the words carry the decision. Refusing globally cost five ordinary reads
+# that no phantom word could have made unsafe (`wc -l < f`, `grep TODO < f`,
+# `cat < f`, `wc -l <f`, `head -20 < log.txt`), which is a worse trade than the
+# narrower rule.
+#
+# WHY REFUSE RATHER THAN STRIP THE REDIRECT. Stripping the operator and its target
+# looks equivalent and is not: `shlex` has already discarded the quoting, so a token
+# beginning with `<` is indistinguishable from a QUOTED argument that begins with
+# `<`. Stripping would drop a word bash keeps, and for exactly these verbs that
+# opens a hole rather than closing one: `git branch '<new'` reaches `shlex` as
+# `[git, branch, <new]`, and dropping `<new` leaves a bare `git branch` that reads
+# as a listing while bash creates the ref. Refusing fails closed without
+# reimplementing bash's quoting rules, which this module deliberately does not do.
+_ELISION_SENSITIVE_RE = re.compile(r"(?:^|\s)#|<")
 
 # `git branch` and `git tag` each carry a read mode and a write mode under one
 # subcommand, so the prefix match admits the destructive spellings. Some of
@@ -737,7 +824,7 @@ def _consumes_next_word(token: str) -> bool:
     and licensed the bare operand that created the branch.
 
     This is the fourth site on this guard to need the abbreviation axis — after
-    `_matched_flag`, `_system_set_flag` and `_glob_reaches` — which is why it is a
+    `_matched_flag`, `_option_accept_list_violation` and `_glob_reaches` — which is why
     named helper rather than a fourth inline prefix test.
 
     An ATTACHED value (`--format=x`) takes nothing from the next word, so it is
@@ -860,105 +947,373 @@ _EXACT_ONLY_BASH_PREFIXES: frozenset[str] = frozenset(
     )
 )
 
-# Flags that change SYSTEM state rather than writing a file: `hostname` renames
-# the host, `date` sets the clock. Both entries are on the read-only allowlist
-# for their bare listing form, and both carry a setter under the same verb.
+# `sort` is vetted POSITIVELY: every option token must be a recognised read-only
+# flag, and anything unrecognised goes to the human prompt.
 #
-# Kept out of `_WRITE_FLAGS` because they must NOT go through `_matched_flag`'s
-# short-option CLUSTER scan, and `date` is the worked example of why: `-s` sets
-# the clock, while `date -Iseconds` is an ordinary read whose attached VALUE
-# contains an `s`. A cluster scan reads that `s` as `-s` and denies the read.
-# `_system_set_flag` prefix-matches the token instead, which `-Iseconds` (a
-# token starting `-I`) cannot satisfy. Reported by #5038, whose comment names
-# the same trap.
-_SYSTEM_SET_FLAGS: dict[str, tuple[str, ...]] = {
-    # `-b`/`--boot` and `-F`/`--file` set the name with no operand at all.
-    # Case is load-bearing: `-F` sets from a file, `-f` prints the FQDN.
-    "hostname": ("-b", "--boot", "-F", "--file"),
-    "date": ("-s", "--set"),
-}
-
-# Verbs whose bare OPERAND changes system state, with no flag involved:
-# `hostname evil-host` renames the host and `date 08221200` sets the clock.
-# `date`'s one legitimate operand is a `+FORMAT` string, which is why the two
-# need different predicates rather than one shared "no operands" rule.
+# The inversion is here because the denylist demonstrably did not converge on this
+# one tool. Five review rounds produced six distinct spellings of the same escape:
+# `-o FILE`, `--output=FILE`, attached `-oFILE`, bundled `-uo FILE`, abbreviated
+# `--o FILE`, and finally `--compress-program=PROG` -- which is not a write at all
+# but arbitrary CODE EXECUTION. Verified: with the input large enough to spill to
+# temporaries, `sort -S 1k --compress-program=./payload big.txt` ran the payload and
+# exited 0. Enumerated from this box's own `sort --help`, so it is complete for that
+# release rather than for a guess.
 #
-# The flags here take their value from the FOLLOWING word, so that word is not
-# an operand — without them `date -d yesterday` and `date -r FILE`, both reads,
-# would be denied.
-_SYSTEM_OPERAND_VALUE_FLAGS: dict[str, frozenset[str]] = {
-    "hostname": frozenset(),
-    "date": frozenset(("-d", "--date", "-r", "--reference", "-f", "--file")),
-}
+# Deliberately NOT read-only: `-o/--output` (writes), `-T/--temporary-directory`
+# (writes temporaries into a caller-named directory), `--compress-program`
+# (executes), and `--random-source` / `--files0-from` (open a caller-named path).
+# An unlisted flag costs a prompt, so omission is the safe direction.
+# `k`, `t` and `S` are value-taking AND read-only (key, field separator, buffer
+# size); `o` and `T` are value-taking and NOT read-only, which is what makes the
+# value branch below refuse them while `-k2n` and `-S1k` pass.
+_SORT_READONLY_SHORT: frozenset[str] = frozenset("bdfgiMhnRrVcCmsuzktS")
+# Short options that consume the rest of the token (or the next one) as a VALUE.
+# Needed so `-k2n` and `-S1k` read as flag-plus-value instead of a letter cluster
+# where `2` and `1` look like unknown options.
+_SORT_VALUE_SHORT: frozenset[str] = frozenset("ktSTo")
+_SORT_READONLY_LONG: frozenset[str] = frozenset(
+    (
+        "--ignore-leading-blanks",
+        "--dictionary-order",
+        "--ignore-case",
+        "--general-numeric-sort",
+        "--ignore-nonprinting",
+        "--month-sort",
+        "--human-numeric-sort",
+        "--numeric-sort",
+        "--random-sort",
+        "--reverse",
+        "--sort",
+        "--version-sort",
+        "--batch-size",
+        "--check",
+        "--debug",
+        "--key",
+        "--merge",
+        "--stable",
+        "--buffer-size",
+        "--field-separator",
+        "--parallel",
+        "--unique",
+        "--zero-terminated",
+        "--help",
+        "--version",
+    )
+)
 
-# The SHORT setters as LETTERS, and the letters that consume the rest of their
-# token, because a cluster has to be walked rather than prefix-tested. `-s` sets
-# the clock, and it can arrive anywhere in a cluster: GNU resolves
-# `date -us2026-08-23` to `-u` plus `-s 2026-08-23`, which a test anchored at the
-# token's first character never saw.
+
+# `date`'s read-only surface. Enumerated from GNU coreutils `date --help`, then
+# checked for a second axis the other accept-lists did not have to face: whether the
+# same LETTER means different things in different `date` implementations.
 #
-# The value-taking letters are what keeps the walk from reading a VALUE as a flag —
-# the `date -Iseconds` case: `I` takes an optional attached value, so the `s` in
-# `seconds` belongs to that value and the walk stops before it. This is the same
-# distinction, stated per letter, that the note above states per token.
-_SYSTEM_SHORT_SETTERS: dict[str, str] = {"hostname": "bF", "date": "s"}
-_SYSTEM_SHORT_VALUE_TAKING: dict[str, str] = {"hostname": "F", "date": "dfrsI"}
+# `-d` IS on the list, and the reason it is here is worth recording because an earlier
+# revision of this change left it OFF on the belief that BSD/macOS `date -d` sets the
+# kernel's daylight-saving value. That belief came from documentation, not from the
+# implementations, and checking the implementations showed it is false on every
+# platform that ships today. Read from each project's own `getopt(3)` string:
+#
+#   GNU coreutils      `-d STRING`  parses and PRINTS  (verified by execution, 8.22)
+#   FreeBSD  bin/date  "f:I::jnRr:uv:z:"   no `d` at all -> invalid option
+#   Apple    shell_cmds/date  "f:I::jnRr:uv:z:"   no `d` at all -> invalid option
+#   OpenBSD  bin/date  "af:jr:uz:"         no `d` at all -> invalid option
+#   NetBSD   bin/date  "ad:f:jnRr:Uuz:"    `-d` sets rflag and parsedate()s optarg,
+#                                          i.e. the GNU meaning: a reference time to
+#                                          PRINT. `setthetime()` is reached only from
+#                                          a bare operand, never from `-d`.
+#
+# So `-d` either reads or errors, never writes. The historical `-d dst` that set the
+# kernel daylight-saving flag is gone from every current BSD.
+#
+# There was also an internal tell that should have caught this without the source
+# dive: `--date=` was already on the read-only long list, and `-d` is the same option
+# under a shorter spelling on every implementation that has it. Admitting one and
+# refusing the other could not both be right.
+#
+# `-s`/`--set` IS the setter GNU shares, verified accepted and failing only on
+# privilege ("date: cannot set date: Operation not permitted"). `-f`, `-r`, `-I` and
+# `-d` take values, which is what makes `-Iseconds`, `-r FILE` and `-d yesterday` read
+# cleanly while `-s` is refused -- the dilemma that kept `-s` out of the old
+# write-flag table.
+#
+# The other three accept-lists were swept for divergence and need no change: BSD
+# `sort`'s writers are `-o`/`-T` and BSD `file`'s is `-C`, all already excluded, and
+# BSD `hostname` offers only `-f`/`-s` plus a name OPERAND, which `operands="none"`
+# already refuses. BSD `date`'s other setters (`-t` minutes west, `-j`, `-n`, `-v`)
+# are likewise absent from this list, so they fail closed already.
+_DATE_READONLY_SHORT: frozenset[str] = frozenset("dfIrRu")
+_DATE_VALUE_SHORT: frozenset[str] = frozenset("dfIrs")
+_DATE_READONLY_LONG: frozenset[str] = frozenset(
+    (
+        "--date",
+        "--file",
+        "--iso-8601",
+        "--reference",
+        "--rfc-2822",
+        "--rfc-3339",
+        "--universal",
+        "--utc",
+        "--help",
+        "--version",
+    )
+)
+# Long and short forms that consume the NEXT token, so an operand count is not
+# fooled by a flag's value. `-I` is absent on purpose: its TIMESPEC is optional and
+# must be attached (`-Iseconds`), so `-I` never eats the following word.
+_DATE_VALUE_FLAGS: frozenset[str] = frozenset(
+    ("-d", "-f", "-r", "-s", "--date", "--file", "--reference", "--set")
+)
+
+# `hostname`'s surface, from its own `--help`. Tiny and fully enumerable, which is
+# why a positive list is cheap here. `-b/--boot` and `-F/--file` SET the name with
+# no operand (both verified: privilege-only failure, with `-F` re-tested against a
+# file that EXISTS -- against a missing path it fails at open() and looks read-only).
+_HOSTNAME_READONLY_SHORT: frozenset[str] = frozenset("aAdfiIsyVh")
+_HOSTNAME_VALUE_SHORT: frozenset[str] = frozenset("F")
+_HOSTNAME_READONLY_LONG: frozenset[str] = frozenset(
+    (
+        "--alias",
+        "--all-fqdns",
+        "--all-ip-addresses",
+        "--domain",
+        "--fqdn",
+        "--ip-address",
+        "--long",
+        "--nis",
+        "--short",
+        "--yp",
+        "--help",
+        "--version",
+    )
+)
 
 
-def _system_set_flag(verb: str, args: list[str]) -> str:
-    """Return the setter flag *args* supplies for *verb*, or "".
+# `file`'s surface, from its own `--help`. It reached an accept-list rather than a
+# `-C` denylist entry because that is the shape this change keeps converging on: an
+# unlisted option prompts instead of passing, so a flag missing from the help text
+# costs a prompt rather than a write. `git blame --textconv` is the reason that
+# distinction is not academic.
+#
+# `-C/--compile` is the setter: with `-m FILE` it compiles that magic file and writes
+# `FILE.mgc` beside it (verified, 464 bytes). `-z/--uncompress` is ALSO excluded, on
+# the omission-is-cheap principle rather than a measured escape -- libmagic can shell
+# out to an external decompressor for formats it does not handle internally, and the
+# flag is rare enough that a prompt costs nothing. Everything else prints.
+# `f`/`--files-from` is absent, and for a different reason than `-C`: it does not
+# write, it INDIRECTS. `file -f LIST` opens every path named inside LIST, and those
+# paths never appear in the command, so the hook layer's path gates
+# (`is_sensitive_path` / `is_sensitive_bash_command`, applied to the command text) see
+# only LIST and cannot see what is actually read. A guard that inspects argv is blind
+# to one more level of indirection, so the option has to go rather than the guard get
+# cleverer. `sort --files0-from` was already excluded for the same shape; `hostname -F`
+# is already refused as a setter.
+#
+# Kept: `-m/--magic-file`, `-e/--exclude`, `-F/--separator` all take a value, but the
+# value IS the path or string being used, visible in argv, so the guards can act on it.
+# There is no indirection to hide behind.
+#
+# `p`/`--preserve-date` is absent too, and it is the subtlest of the three exclusions.
+# It LOOKS read-only because it RESTORES the access time rather than setting a caller
+# chosen one -- which is how it was originally, and wrongly, admitted here. Restoring
+# still requires a `utimes()` call on the named path, and the `ctime` that call bumps is
+# NOT restorable. So the option erases the evidence that a file was read while leaving a
+# permanent metadata modification behind: the wrong side of read-only in both directions.
+#
+# MEASURED, because `noatime` on this box hides the atime effect entirely and made the
+# obvious test inconclusive. `ctime` advances on any inode metadata write and is visible
+# whatever the mount options are:
+#
+#   file t.txt            -> ctime unchanged   (control)
+#   file -b t.txt         -> ctime unchanged   (control)
+#   file -p t.txt         -> ctime ADVANCED
+#   file --preserve-date  -> ctime ADVANCED
+#
+# The same probe was then run over every other accept-list flag that opens a named file
+# -- `file -m/-k/-L/-s/-r`, `sort`, `sort -u`, `sort -k1`, `date -r`, `date -f`, plus
+# `cat` and `wc -l` as controls -- and all twelve are clean. `-p` is the only one.
+#
+# `-z`/`--uncompress` is also absent, and it belongs to a class this module already
+# names elsewhere rather than to the write-flag class. From `file`'s own
+# `src/compress.c`, the decompressor is SPAWNED:
+#
+#     status = posix_spawnp(&pid, compr[method].argv[0], &fa, NULL, ...)
+#
+# with `compr[]` holding `"gzip"`, `"bzip2"`, `"lzip"`, `"xz"`, `"lrzip"`, `"zstd"` and
+# `method` selected from the examined file's magic bytes. So `-z` runs a program whose
+# NAME is chosen by the content being inspected, which is the same hand-off as
+# `git diff --ext-diff`. Stated because it is a behaviour change: on the write-flag
+# table `file -z` auto-approved, and under this list it prompts.
+_FILE_READONLY_SHORT: frozenset[str] = frozenset("vmbceFiklLhnN0rsd")
+# `f` stays here so `-f LIST` and `-fLIST` are both recognised as flag-plus-value and
+# refused, rather than `LIST` being mistaken for an operand.
+_FILE_VALUE_SHORT: frozenset[str] = frozenset("mefF")
+_FILE_READONLY_LONG: frozenset[str] = frozenset(
+    (
+        "--apple",
+        "--brief",
+        "--checking-printout",
+        "--debug",
+        "--dereference",
+        "--exclude",
+        "--keep-going",
+        "--list",
+        "--magic-file",
+        "--mime",
+        "--mime-encoding",
+        "--mime-type",
+        "--no-buffer",
+        "--no-dereference",
+        "--no-pad",
+        "--print0",
+        "--raw",
+        "--separator",
+        "--special-files",
+        "--help",
+        "--version",
+    )
+)
+# `file` needs no VALUE-FLAG set: `spec.value_flags` is read only by `_operands`,
+# which is behind an early return for `operands == "any"`, and `file`'s operands are
+# the files it identifies. A set here would look load-bearing and never be read.
 
-    Prefix-matches the token, so the attached spelling (`--set=…`, `-s2020`) is
-    caught while an unrelated flag whose attached value merely CONTAINS the
-    letter is not. See the note on `_SYSTEM_SET_FLAGS` for why the cluster scan
-    in :func:`_matched_flag` is the wrong tool here.
 
-    A long option is ALSO matched by any unambiguous abbreviation of it, because
-    GNU's own parser resolves one: `date --se=2026-08-23` reaches `--set` and the
-    clock moves, while a plain prefix test on the flag saw nothing. Avoiding the
-    cluster scan is what this function is for — abbreviation is a separate axis,
-    and `_matched_flag` already accepts it for every other table.
+class _AcceptSpec(NamedTuple):
+    """A tool's read-only surface, stated positively.
 
-    A SHORT setter is found by walking the cluster, because it can sit anywhere in
-    one: GNU resolves `date -us2026-08-23` to `-u` plus `-s 2026-08-23`. The walk
-    stops at the first letter that consumes the rest of the token, which is what
-    keeps `date -Iseconds` a read — the `s` there is part of `I`'s value, not a
-    flag. Avoiding `_matched_flag`'s *undifferentiated* cluster scan is still the
-    point; this one knows which letters take a value.
+    One registry rather than three bespoke checks, because the algorithm turned out
+    identical for every tool that needed it. `sort` had this shape first; `date` and
+    `hostname` arrived at it for the same reason -- a per-tool DENYLIST had already
+    leaked on each of them, and an accept-list is closed by construction instead.
     """
-    for tok in args:
-        head = tok.split("=", 1)[0]
-        if len(tok) > 1 and tok[0] == "-" and tok[1] != "-":
-            setters = _SYSTEM_SHORT_SETTERS.get(verb, "")
-            consumes = _SYSTEM_SHORT_VALUE_TAKING.get(verb, "")
-            for ch in tok[1:]:
-                if ch in setters:
-                    return "-" + ch
-                if ch in consumes:
-                    break
-        for flag in _SYSTEM_SET_FLAGS.get(verb, ()):
-            if len(flag) == 2 and flag[0] == "-" and flag[1] != "-":
-                # Short setters are handled by the cluster walk above; matching
-                # them again by prefix here would re-introduce the `-Iseconds`
-                # false positive this function exists to avoid.
-                continue
-            if tok.startswith(flag):
-                return flag
-            # `--` plus at least one character, and a prefix of this flag. Over-
-            # matching can only add a prompt: an abbreviation that is ambiguous
-            # against the tool's OTHER long options is rejected by the tool itself,
-            # so refusing it here costs a command that was never going to run.
-            if (
-                flag.startswith("--")
-                and head.startswith("--")
-                and len(head) > 2
-                and flag.startswith(head)
-            ):
-                return flag
+
+    reason_fmt: str  # carries `{tok}`
+    readonly_short: frozenset[str]
+    value_short: frozenset[str]
+    readonly_long: frozenset[str]
+    operands: str  # "any" (they are inputs) | "none" | "plus" (only +FORMAT)
+    operand_reason: str
+    value_flags: frozenset[str]  # for operand counting
+
+
+_OPTION_ACCEPT_LISTS: dict[str, _AcceptSpec] = {
+    "sort": _AcceptSpec(
+        reason_fmt="pipe target 'sort {tok}' is not a recognised read-only option",
+        readonly_short=_SORT_READONLY_SHORT,
+        value_short=_SORT_VALUE_SHORT,
+        readonly_long=_SORT_READONLY_LONG,
+        # sort's operands are input FILES, which it reads.
+        operands="any",
+        operand_reason="",
+        value_flags=frozenset(),
+    ),
+    "date": _AcceptSpec(
+        # The reason names the accepted spelling because `date -d` is a form agents
+        # emit constantly, and a refusal that only says no turns every one of them
+        # into a human prompt instead of a self-serve retry.
+        reason_fmt=(
+            "'date {tok}' is not a recognised read-only option; "
+            "'--date=<expr>' is the read-only spelling"
+        ),
+        readonly_short=_DATE_READONLY_SHORT,
+        value_short=_DATE_VALUE_SHORT,
+        readonly_long=_DATE_READONLY_LONG,
+        # `date 08221200` sets the clock (verified: privilege-only failure). A `+`
+        # operand is the output FORMAT and only prints.
+        operands="plus",
+        operand_reason=("'date <operand>' sets the system clock unless it is a +FORMAT string"),
+        value_flags=_DATE_VALUE_FLAGS,
+    ),
+    "file": _AcceptSpec(
+        reason_fmt="'file {tok}' is not a recognised read-only option",
+        readonly_short=_FILE_READONLY_SHORT,
+        value_short=_FILE_VALUE_SHORT,
+        readonly_long=_FILE_READONLY_LONG,
+        # `file`'s operands are the FILES it identifies, which it only reads.
+        operands="any",
+        operand_reason="",
+        value_flags=frozenset(),
+    ),
+    "hostname": _AcceptSpec(
+        reason_fmt="'hostname {tok}' is not a recognised read-only option",
+        readonly_short=_HOSTNAME_READONLY_SHORT,
+        value_short=_HOSTNAME_VALUE_SHORT,
+        readonly_long=_HOSTNAME_READONLY_LONG,
+        operands="none",
+        operand_reason=("'hostname <operand>' sets the hostname; every read form is flag-only"),
+        value_flags=frozenset(("-F", "--file")),
+    ),
+}
+
+#: Keys whose verdict depends on the COUNT or ORDER of words rather than on which
+#: flags are present, so a word bash deletes can flip it. See `_ELISION_SENSITIVE_RE`
+#: for the measurements and for why the refusal is scoped here instead of applied to
+#: every command.
+#:
+#: Derived from the tables that carry those decisions, so a tool added to the accept
+#: list with an operand rule joins this set without a second edit. `git remote` and
+#: `uniq` are named: their decision is positional in the walk itself (first
+#: non-option word is the subcommand; second operand is the output file) rather than
+#: expressed in a table this can read.
+_ELISION_SENSITIVE_KEYS: frozenset[str] = (
+    frozenset(f"git {subcommand}" for subcommand in _GIT_REF_WRITE_FLAGS)
+    | frozenset(("git remote", "uniq"))
+    | frozenset(verb for verb, spec in _OPTION_ACCEPT_LISTS.items() if spec.operands != "any")
+)
+
+
+def _option_accept_list_violation(prefix: str, tokens: list[str]) -> str:
+    """Reason *tokens* leave *prefix*'s positively-vetted read-only surface, else "".
+
+    Deny-by-default per tool: an option has to be RECOGNISED as read-only, so an
+    unlisted one prompts instead of passing. That is what makes this closed by
+    construction where a write-flag denylist was not -- a spelling nobody thought of
+    is refused rather than admitted.
+
+    A long flag must match EXACTLY, which disposes of getopt_long abbreviation for
+    free: `--out` is an abbreviation of `--output` and simply is not in the read-only
+    set. The cost is that an abbreviation of a read-only flag (`--rev` for
+    `--reverse`) also prompts.
+    """
+    spec = _OPTION_ACCEPT_LISTS[prefix]
+    # `--` does not stop this loop either. HARDENING rather than a fix here: measured,
+    # every value-taking read flag of this box's `sort` REJECTS `--` as its value and
+    # aborts (`-k` "invalid number", `-S` "invalid -S argument '--'", `-t`
+    # "multi-character tab"), so `sort -k -- -o OUT` writes nothing today. That is
+    # sort's argument validation saving us, not this classifier, and it is not a
+    # property worth depending on -- the git path above proved the same shape does
+    # write when the tool is more permissive. Cost is a prompt on an input FILE named
+    # like an option (`sort -- -o`).
+    for token in tokens:
+        if not token.startswith("-") or token == "-":
+            continue  # operand, or `-` for stdin
+        if _GLOB_META_RE.search(token):
+            # An option-shaped token whose real spelling the shell has not produced
+            # yet. No legitimate option contains a glob metacharacter, so this costs
+            # nothing, and an operand glob is untouched: it has no leading dash.
+            return spec.reason_fmt.format(tok=token)
+        if token.startswith("--"):
+            if token.partition("=")[0] not in spec.readonly_long:
+                return spec.reason_fmt.format(tok=token)
+            continue
+        for letter in token[1:]:
+            if letter in spec.value_short:
+                # This option takes a value, so the remainder of the token is that
+                # value and carries no further option letters.
+                if letter not in spec.readonly_short:
+                    return spec.reason_fmt.format(tok=f"-{letter}")
+                break
+            if letter not in spec.readonly_short:
+                return spec.reason_fmt.format(tok=f"-{letter}")
+    if spec.operands == "any":
+        return ""
+    operands = _operands(tokens, spec.value_flags)
+    if spec.operands == "none" and operands:
+        return spec.operand_reason
+    if spec.operands == "plus" and any(not o.startswith("+") for o in operands):
+        return spec.operand_reason
     return ""
 
 
-def _operands(args: list[str]) -> list[str]:
+def _operands(args: list[str], value_flags: frozenset[str] = frozenset()) -> list[str]:
     """Operand tokens in *args*, honouring the `--` terminator.
 
     Before the terminator a leading-dash word is an option; after it EVERY word
@@ -967,9 +1322,24 @@ def _operands(args: list[str]) -> list[str]:
     operand and passed a segment that writes `-pwned`.
     """
     if "--" in args:
-        cut = args.index("--")
-        return [tok for tok in args[:cut] if not tok.startswith("-")] + args[cut + 1 :]
-    return [tok for tok in args if not tok.startswith("-")]
+        at = args.index("--")
+        before, after = args[:at], args[at + 1 :]
+    else:
+        before, after = args, []
+    out: list[str] = []
+    previous = ""
+    for tok in before:
+        if tok.startswith("-"):
+            # A short option consumes the NEXT word only when the token is the bare
+            # flag; `-Iseconds` carries its own value, so treating it as `-I` plus a
+            # separate operand would deny an ordinary read.
+            previous = tok if tok in value_flags else ""
+            continue
+        if previous:
+            previous = ""
+            continue
+        out.append(tok)
+    return out + after
 
 
 #: Shell expansions whose RESULT is the argument, while ``shlex`` hands this
@@ -1059,7 +1429,19 @@ _EXTGLOB_RE = re.compile(r"[?*+@!]\(")
 _GLOB_SENSITIVE_WORDS: frozenset[str] = (
     frozenset(
         flag
-        for table in (_WRITE_FLAGS, _EXEC_FLAGS, _GIT_REF_WRITE_FLAGS)
+        for table in (
+            _WRITE_FLAGS,
+            _EXEC_FLAGS,
+            _GIT_REF_WRITE_FLAGS,
+            # Derived, not restated: this is the whole reason `wc --file*` is
+            # refused. A checkout containing a file named `--files0-from=payload`
+            # turns that pattern into the flag, and measured, `wc --file*` then read
+            # a path that appears nowhere in the command. Listing the flag in one
+            # table and having the glob defence read that table is what keeps the
+            # two from drifting -- the same coupling that broke when `sort` moved
+            # off the denylist.
+            _INDIRECT_LIST_FLAGS_BY_PREFIX,
+        )
         for flags in table.values()
         for flag in flags
     )
@@ -1067,6 +1449,17 @@ _GLOB_SENSITIVE_WORDS: frozenset[str] = (
     # A glob that expands to `--` shifts every following word into operand
     # position, which is how the terminator changes what the walk below decides.
     | frozenset(("--",))
+    # The accept-listed tools have no denylist to derive from, but they do not need
+    # one: a letter that TAKES A VALUE and is not READ-ONLY is refused by the
+    # registry by construction, so it is precisely a word a glob must not reach.
+    # For `sort` that yields `-o` and `-T`. Without this, moving a tool to a positive
+    # list dropped it out of this set -- measured, `cat f | sort ?uo victim` was
+    # auto-approved because `-o` had stopped being a sensitive word.
+    | frozenset(
+        f"-{letter}"
+        for spec in _OPTION_ACCEPT_LISTS.values()
+        for letter in spec.value_short - spec.readonly_short
+    )
 )
 
 #: Verbs whose OWN tables carry a short flag, so a glob can expand into a bundled
@@ -1079,6 +1472,8 @@ _SHORT_FLAG_VERBS: frozenset[str] = frozenset(
     for table in (_WRITE_FLAGS, _EXEC_FLAGS)
     for key, flags in table.items()
     if any(len(flag) == 2 and flag[0] == "-" for flag in flags)
+) | frozenset(
+    verb for verb, spec in _OPTION_ACCEPT_LISTS.items() if spec.value_short - spec.readonly_short
 )
 
 
@@ -1221,6 +1616,12 @@ def _side_effect_reason(segment: str) -> str:
     verb = tokens[0].rsplit("/", 1)[-1].lower()
     args = tokens[1:]
 
+    # Checked on the RAW segment, before any table lookup, because the thing being
+    # guarded against is a word that reached `shlex` but will not reach the program.
+    elision_key = f"git {args[0].lower()}" if verb == "git" and args else verb
+    if elision_key in _ELISION_SENSITIVE_KEYS and _ELISION_SENSITIVE_RE.search(segment):
+        return f"a word bash removes could change what '{elision_key}' does"
+
     # Whether an unexpanded word can subvert THIS segment's classification.
     #
     # Every check below is keyed on a table, so a verb with no table has no
@@ -1232,15 +1633,20 @@ def _side_effect_reason(segment: str) -> str:
     # `git` is guarded whatever the subcommand, because the subcommand itself is
     # a decided word: `git $x` reaches bash as `git branch -D release`.
     #
-    # `hostname` and `date` are guarded through `_SYSTEM_OPERAND_VALUE_FLAGS`
-    # rather than a flag table, because their rule is an OPERAND rule: an
-    # unexpanded word IS the decision there, so `hostname $EVIL` renames the host
-    # under a spelling this module read as harmless.
+    # `hostname` and `date` are guarded through `_OPTION_ACCEPT_LISTS` rather than a
+    # write-flag table, because their rule is an OPERAND rule: an unexpanded word IS
+    # the decision there, so `hostname $EVIL` renames the host under a spelling this
+    # module read as harmless.
     guarded = (
         verb in ("git", "uniq")
         or verb in _WRITE_FLAGS
         or verb in _EXEC_FLAGS
-        or verb in _SYSTEM_OPERAND_VALUE_FLAGS
+        or verb in _OPTION_ACCEPT_LISTS
+        # A verb whose arguments this module reads for an INDIRECTION or a pager
+        # startup command has a decision to subvert just as much as one with a
+        # write-flag table, so it belongs in the same guard.
+        or verb in _INDIRECT_LIST_FLAGS_BY_PREFIX
+        or verb in _PAGER_STARTUP_VERBS
     )
 
     # ANSI-C quoting is stripped by `shlex` but honoured by bash, so the token
@@ -1331,7 +1737,7 @@ def _side_effect_reason(segment: str) -> str:
                     # EVERY character of the cluster must be a list letter or a
                     # digit, not merely one of them. `any` read an attached VALUE
                     # as part of the cluster, which is the same trap the note on
-                    # `_SYSTEM_SET_FLAGS` records for `date -Iseconds`: the `l` in
+                    # the accept-list registry records for `date -Iseconds`: the `l` in
                     # `git tag -ulin@kiro.co` selected list mode and the bare
                     # operand it then licensed created a signed tag. A digit is
                     # allowed because `-n` carries an optional count (`-n5`).
@@ -1413,6 +1819,21 @@ def _side_effect_reason(segment: str) -> str:
     if hit:
         return f"'{key} {hit}' runs a program named by the repository"
 
+    hit = _matched_flag(args, _INDIRECT_LIST_FLAGS_BY_PREFIX.get(key, ()))
+    if hit:
+        return f"'{key} {hit}' reads paths named inside a file, which this check cannot see"
+
+    # A `+` argument to a pager is a string in the pager's own command language,
+    # not an option, and that language reaches a shell. A glob is refused here too:
+    # the shell has not produced the real spelling yet, so `less +*` could resolve
+    # against a file named `+!cmd` and nothing downstream would see the `+`.
+    if verb in _PAGER_STARTUP_VERBS:
+        for token in args:
+            if token.startswith("+"):
+                return f"'{verb} {token}' runs a pager startup command, which reaches a shell"
+            if _GLOB_META_RE.search(token) or _EXTGLOB_RE.search(token):
+                return f"a glob in a '{verb}' argument could expand into a startup command"
+
     # `uniq INPUT OUTPUT` writes its second operand. `--` ends the options here
     # too, so a word after it is an operand however it is spelled:
     # `uniq -- input -pwned` writes `-pwned`, while a leading-dash test counted
@@ -1429,52 +1850,15 @@ def _side_effect_reason(segment: str) -> str:
         if len(operands) > 1:
             return "'uniq INPUT OUTPUT' writes its second operand"
 
-    # `hostname` and `date` each carry a SYSTEM-state setter under a verb whose
-    # bare form is a listing, so the prefix match vouched for the setter too.
-    hit = _system_set_flag(verb, args)
-    if hit:
-        changes = "renames the host" if verb == "hostname" else "sets the system clock"
-        return f"'{verb} {hit}' {changes}"
-
-    # Both also change state through a BARE OPERAND, with no flag at all —
-    # `hostname evil-host` and `date 08221200` (which fails only on privilege,
-    # not on parsing). Their legitimate operands differ, so the predicate does
-    # too: every `hostname` read form is flag-only, while `date`'s one operand
-    # is a `+FORMAT` string.
-    if verb in _SYSTEM_OPERAND_VALUE_FLAGS:
-        value_flags = _SYSTEM_OPERAND_VALUE_FLAGS[verb]
-        previous = ""
-        operand_only = False
-        for tok in args:
-            # `--` ends the options here for the same reason it does for a ref:
-            # after it, `hostname -- -evil` names the host `-evil`, and a
-            # leading-dash test read that as one more option and passed it.
-            if tok == "--" and not operand_only:
-                operand_only = True
-                previous = ""
-                continue
-            if not operand_only and tok.startswith("-"):
-                # Whether a flag takes the FOLLOWING word depends on its form,
-                # and long and short disagree. A long option consumes the next
-                # word unless the value is attached with `=`, so
-                # `date --date yesterday` is a read. A short option consumes it
-                # only when the token is the bare flag: `-Iseconds` carries its
-                # own value, so reading it as `-I` + a separate operand would
-                # deny that read.
-                if tok.startswith("--"):
-                    previous = "" if "=" in tok else tok
-                else:
-                    previous = tok if len(tok) == 2 else ""
-                continue
-            if previous in value_flags:
-                previous = ""
-                continue
-            previous = ""
-            if verb == "date":
-                if tok.startswith("+"):
-                    continue
-                return "'date <operand>' sets the system clock unless it is a +FORMAT string"
-            return f"'{verb} <operand>' sets the hostname; every read form is flag-only"
+    # Tools whose read-only option surface is enumerated POSITIVELY. Deny-by-default:
+    # an option has to be recognised as a read before it passes, so a spelling nobody
+    # thought of prompts instead of being admitted. This is what a per-tool write-flag
+    # denylist could not give us on these four -- see the note above the registry for
+    # the six `sort` spellings that arrived one review round at a time.
+    if verb in _OPTION_ACCEPT_LISTS:
+        violation = _option_accept_list_violation(verb, args)
+        if violation:
+            return violation
 
     return ""
 

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -11,6 +11,10 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.chat import _extract_bash_command
 from kiro_crew.dashboard.state import (
+    _GLOB_SENSITIVE_WORDS,
+    _INDIRECT_LIST_FLAGS_BY_PREFIX,
+    _OPTION_ACCEPT_LISTS,
+    _SORT_READONLY_LONG,
     DashboardState,
     _ChatSlot,
     is_read_only_bash,
@@ -708,7 +712,6 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("ls $PWD") is True
         assert is_read_only_bash("head -20 $LOG") is True
         assert is_read_only_bash("grep -rn TODO $DIR") is True
-        assert is_read_only_bash("wc -l ${F}") is True
         assert is_read_only_bash("cat file.{js,ts}") is True
         assert is_read_only_bash("readlink -f $X") is True
         # A table decides the argument: the expansion is still refused.
@@ -717,6 +720,14 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("uniq $ARGS") is False
         assert is_read_only_bash("tree ${FLAG}") is False
         assert is_read_only_bash("file ${FLAG} -m /tmp/magic.src") is False
+        # `wc -l ${F}` MOVED here from the group above, by the rule this test
+        # states rather than as an exception to it: `wc` now has a table
+        # (`_INDIRECT_LIST_FLAGS_BY_PREFIX`), so an expansion CAN reach a word this
+        # module decides on. Measured — with `F=--files0-from=list0` and a
+        # NUL-separated list naming `/etc/hostname`, `wc -l ${F}` printed
+        # `1 /etc/hostname`, a path that appears nowhere in the command.
+        assert is_read_only_bash("wc -l ${F}") is False
+        assert is_read_only_bash("du ${F}") is False
 
     def test_git_tag_annotation_listing_is_not_a_ref_creation(self):
         """`git tag -n` prints annotation lines — a listing with no `branch` twin.
@@ -796,7 +807,12 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("date -u") is True
         assert is_read_only_bash("date -Iseconds") is True
         assert is_read_only_bash("date +%Y-%m-%d") is True
+        # `-d` IS on the accept-list. An earlier revision left it off on the belief
+        # that BSD/macOS `date -d` sets the kernel daylight-saving value; that came
+        # from documentation and the implementations say otherwise. See
+        # `_DATE_READONLY_SHORT` for the per-project `getopt(3)` strings.
         assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date --date=yesterday") is True
         assert is_read_only_bash("date --date=yesterday") is True
         assert is_read_only_bash("date -r /tmp/f") is True
         assert is_read_only_bash("hostname") is True
@@ -876,11 +892,19 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("date --reference /tmp/f") is True
         assert is_read_only_bash("date --file /tmp/dates") is True
         assert is_read_only_bash("date --date=yesterday") is True
+        # `-d` IS on the accept-list. An earlier revision left it off on the belief
+        # that BSD/macOS `date -d` sets the kernel daylight-saving value; that came
+        # from documentation and the implementations say otherwise. See
+        # `_DATE_READONLY_SHORT` for the per-project `getopt(3)` strings.
         assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date --date=yesterday") is True
         assert is_read_only_bash("date -r /tmp/f") is True
         assert is_read_only_bash("date -Iseconds") is True
-        # A value-taking flag does not license a SECOND operand.
+        # A value-taking flag does not license a SECOND operand. `-d` consumes
+        # `yesterday`, which leaves `08221200` as a bare operand, and a bare operand
+        # sets the clock.
         assert is_read_only_bash("date -d yesterday 08221200") is False
+        assert is_read_only_bash("date --date=yesterday 08221200") is False
         assert is_read_only_bash("date --date yesterday 08221200") is False
 
     def test_an_option_looking_glob_is_refused_on_the_metacharacter_alone(self):
@@ -969,7 +993,12 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("date -Iseconds") is True
         assert is_read_only_bash("date -u") is True
         assert is_read_only_bash("date -R") is True
+        # `-d` IS on the accept-list. An earlier revision left it off on the belief
+        # that BSD/macOS `date -d` sets the kernel daylight-saving value; that came
+        # from documentation and the implementations say otherwise. See
+        # `_DATE_READONLY_SHORT` for the per-project `getopt(3)` strings.
         assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date --date=yesterday") is True
         assert is_read_only_bash("date -r /tmp/f") is True
         assert is_read_only_bash("hostname -s") is True
         assert is_read_only_bash("hostname -f") is True
@@ -1136,7 +1165,11 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("hostname --fi=/tmp/name") is False
         assert is_read_only_bash("hostname --file=/tmp/name") is False
         # An abbreviation of a READ option is not a setter.
-        assert is_read_only_bash("date --dat=yesterday") is True
+        # An accept-list cannot honour long-option ABBREVIATIONS: an abbreviation of
+        # a read flag is indistinguishable in kind from one of a write flag, so exact
+        # match is the only rule that stays closed. The full spelling still reads.
+        assert is_read_only_bash("date --dat=yesterday") is False
+        assert is_read_only_bash("date --date=yesterday") is True
         assert is_read_only_bash("date --utc") is True
         assert is_read_only_bash("hostname --fqdn") is True
 
@@ -1255,6 +1288,274 @@ class TestIsReadOnlyBash:
     def test_empty_and_whitespace(self):
         assert is_read_only_bash("") is False
         assert is_read_only_bash("   ") is False
+
+    def test_an_unrecognised_option_prompts_instead_of_passing(self):
+        """The property a write-flag denylist cannot have: closed by construction.
+
+        A denylist admits every spelling nobody thought of. An accept-list refuses
+        them, so the failure mode moves from silent auto-approval to a prompt. These
+        are invented flags, deliberately not real ones -- the point is that the rule
+        does not depend on anyone having enumerated them.
+        """
+        for cmd in (
+            "date --not-a-real-flag",
+            "date -Z",
+            "hostname --invented",
+            "file --no-such-option x",
+            "cat f | sort --hypothetical",
+            "cat f | sort -Q",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+        # The enumerated reads still pass, which is what makes the above a real gate
+        # rather than a blanket refusal.
+        for cmd in (
+            "date",
+            "date -u",
+            "date -Iseconds",
+            "date +%Y",
+            "date -r /tmp/f",
+            "hostname",
+            "hostname -f",
+            "file /etc/hosts",
+            "file -b /etc/hosts",
+            "cat f | sort",
+            "cat f | sort -u",
+            "cat f | sort -k1",
+        ):
+            assert is_read_only_bash(cmd) is True, cmd
+
+    def test_the_accept_list_closes_holes_the_denylist_left(self):
+        """Three shapes that pass a per-tool write-flag table and fail this one.
+
+        `file -f LIST` and `file -p` are not writes in the sense a write-flag table
+        looks for, which is why enumerating writers missed them:
+
+        * `-f/--files-from` is an INDIRECTION. The hook layer applies
+          `is_sensitive_path` to the command TEXT, so it sees `LIST` and nothing else
+          while `file` opens every path named inside it.
+        * `-p/--preserve-date` restores the access time, and restoring requires a
+          `utimes()` call whose `ctime` bump is NOT restorable. Measured on coreutils
+          8.22 with `ctime` as the observable, because `/tmp` mounts `noatime` and
+          atime therefore cannot tell "did nothing" from "put it back".
+        """
+        for cmd in (
+            "file -f LIST",
+            "file --files-from LIST",
+            "file -p /etc/hosts",
+            "file --preserve-date /etc/hosts",
+            "file -pb /etc/hosts",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+
+        # `-z`/`--uncompress` is a third class, and it is stated because it is a
+        # behaviour change: on the write-flag table `file -z` auto-approved. From
+        # `file`'s own `src/compress.c` the decompressor is SPAWNED --
+        # `posix_spawnp(&pid, compr[method].argv[0], ...)` -- with `compr[]` holding
+        # `gzip`/`bzip2`/`lzip`/`xz`/`lrzip`/`zstd` and `method` chosen from the
+        # examined file's magic bytes. So it runs a program named by the content being
+        # inspected, the same hand-off as `git diff --ext-diff`.
+        assert is_read_only_bash("file -z /tmp/a.gz") is False
+        assert is_read_only_bash("file --uncompress /tmp/a.gz") is False
+        # Plain identification is untouched, so this subtracts one flag, not the tool.
+        assert is_read_only_bash("file /tmp/x") is True
+        assert is_read_only_bash("file -b /tmp/x") is True
+
+    def test_date_d_reads_on_every_implementation_that_has_it(self):
+        """`-d` is on the accept-list, and this pins WHY so it is not removed again.
+
+        An earlier revision of this change left `-d` off, on the belief that BSD/macOS
+        `date -d` sets the kernel's daylight-saving value. That belief was
+        documentation-sourced and the implementations contradict it. Read from each
+        project's own `getopt(3)` string:
+
+        * GNU coreutils: `-d STRING` parses and PRINTS (verified by execution, 8.22).
+        * FreeBSD `bin/date`: `"f:I::jnRr:uv:z:"` -- no `d`, so an invalid option.
+        * Apple `shell_cmds/date`: same string, same absence.
+        * OpenBSD `bin/date`: `"af:jr:uz:"` -- no `d`.
+        * NetBSD `bin/date`: `"ad:f:jnRr:Uuz:"` has `-d`, and its branch sets `rflag`
+          and `parsedate()`s the operand, i.e. the GNU meaning. `setthetime()` is
+          reached only from a bare operand, never from `-d`.
+
+        So `-d` either reads or errors, never writes. The historical `-d dst` that set
+        the kernel flag is gone from every current BSD.
+
+        There was also an internal tell that should have caught it without the source
+        dive, and it is asserted here: `--date=` was already admitted, and `-d` is the
+        same option under a shorter spelling wherever it exists.
+        """
+        assert is_read_only_bash("date -d yesterday") is True
+        assert is_read_only_bash("date -d now") is True
+        assert is_read_only_bash("date --date=yesterday") is True
+        # The tell: the long and short spellings of one option must agree.
+        assert is_read_only_bash("date -d yesterday") == is_read_only_bash("date --date=yesterday")
+        # The real setters are unaffected by admitting `-d`.
+        assert is_read_only_bash("date -s 12:00") is False
+        assert is_read_only_bash("date --set=12:00") is False
+        assert is_read_only_bash("date 08221200") is False
+        # `-d` consumes its value, so a following word is still a bare operand.
+        assert is_read_only_bash("date -d yesterday 08221200") is False
+        # And admitting a READ-ONLY value-taking letter must not put it in the
+        # glob-sensitive derivation for `date`, while `-s` stays.
+        spec = _OPTION_ACCEPT_LISTS["date"]
+        assert spec.value_short - spec.readonly_short == frozenset("s")
+        # `-f` stays in the VALUE-flag set so `-f LIST` and `-fLIST` are both read as
+        # flag-plus-value and refused, rather than `LIST` being taken for an operand.
+        assert is_read_only_bash("file -fLIST") is False
+
+    def test_a_glob_still_cannot_reach_an_accept_listed_tools_flags(self):
+        """The derived glob defence has to survive the move to a positive list.
+
+        `_GLOB_SENSITIVE_WORDS` is derived from the write/exec tables, so moving a
+        tool off them dropped it out of the derivation -- measured, `cat f | sort ?uo
+        victim` went from refused to auto-approved. The registry supplies the same
+        words without a denylist: a letter that takes a value and is NOT read-only is
+        one this list refuses by construction, which for `sort` yields `-o` and `-T`.
+        """
+        for cmd in (
+            "cat f | sort ?o victim",
+            "cat f | sort ?uo victim",
+            "cat f | sort ?T /tmp",
+            "cat f | sort --out*",
+            "cat f | sort -u? victim",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+        # A glob in OPERAND position is untouched: it has no leading dash, so it
+        # cannot resolve into an option this list decides on.
+        assert is_read_only_bash("git diff *.py") is True
+        assert is_read_only_bash("ls *.py") is True
+
+    def test_a_word_bash_deletes_cannot_forge_a_read_mode(self):
+        """`shlex` keeps words bash DELETES, so the token list overstates argv.
+
+        The walk that decides `git branch`/`git tag` reads the whole argument list to
+        pick list mode, so a word that never reaches git can still put the segment in
+        list mode -- and then a bare operand is a pattern instead of a ref to create.
+
+        All four forms were measured on a scratch repo. The `<` form needs a file
+        named `--list` to exist, which a checkout can supply; with it present bash
+        exits 0 and the branch appears.
+        """
+        for cmd in (
+            "git branch injected # --list",
+            "git tag forged # --list",
+            "git branch injected < --list",
+            "git branch injected <<< --list",
+            "git branch injected <--list",
+            "uniq in # out",
+            "date < f",
+            "hostname < f",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+
+        # SCOPED TO THE VERBS A PHANTOM WORD CAN FLIP, and this is the load-bearing
+        # half of the rule. A phantom word only ADDS to the token list, so for a verb
+        # decided by its FLAGS the worst case is an extra prompt. Refusing bare `<`
+        # globally instead cost these five, and no phantom word could have made any of
+        # them unsafe.
+        for cmd in (
+            "wc -l < f",
+            "grep TODO < f",
+            "cat < f",
+            "wc -l <f",
+            "head -20 < log.txt",
+        ):
+            assert is_read_only_bash(cmd) is True, cmd
+
+        # Stripping the redirect and its target instead of refusing looks equivalent
+        # and is not, which is why this refuses. `shlex` has already discarded the
+        # quoting, so the line below reaches it as `[git, branch, <new]`; dropping
+        # `<new` would leave a bare `git branch` that reads as a listing while bash
+        # creates the ref.
+        assert is_read_only_bash("git branch '<new'") is False
+
+        # Two costs, stated. The `#` anchor keeps the common spellings free: measured,
+        # `echo a#b` prints `a#b`, so a `#` that does not start a word is not a comment
+        # to bash either.
+        assert is_read_only_bash("echo a#b") is True
+        assert is_read_only_bash("git log --grep='#123'") is True
+        # But the check runs on the RAW segment, before `shlex`, and a quoted `#` after
+        # a space is indistinguishable there from the real comment forms above. That
+        # costs the quoted spelling, for the elision-sensitive verbs only. `git log` is
+        # decided by its flags, so it keeps the read.
+        assert is_read_only_bash("git log --grep 'fix #123'") is True
+        assert is_read_only_bash("git tag -l 'fix #123'") is False
+
+    def test_a_pager_startup_command_cannot_reach_a_shell(self):
+        """A pager's `+` argument is its own command language, which has a shell escape.
+
+        Measured under a real pty: `git log | less '+!touch FILE'` created the file.
+        It did NOT fire when stdout was a pipe -- with no tty less degrades to `cat`
+        and never runs the startup command -- so this is conditional on the executor
+        supplying a tty. The gate hands the string to an agent runtime rather than
+        running it, so it cannot know, and refuses on the spelling.
+
+        `more` is covered because on the BSDs it is not a separate program. FreeBSD's
+        `usr.bin/less/Makefile` installs it as a link to `less`, and Apple's
+        `less/main.c` sets `less_is_more` when `progname` is `more` -- which changes
+        defaults, not the `+` startup-command path. util-linux `more` has no
+        `+command` and did not fire; the name does not tell the classifier which
+        implementation answers.
+
+        The whole `+` prefix is refused rather than the dangerous letters (`!`, `|`,
+        `v`, `s`), because that enumeration is the denylist this change argues
+        against -- it is the pager's command language and it grows without asking.
+        """
+        for cmd in (
+            "git log | less '+!touch /tmp/pwned'",
+            "git log | more '+!touch /tmp/pwned'",
+            "git log | less '+|cat'",
+            "git log | less +v",
+            # The shell has not produced the real spelling yet, so a glob that could
+            # resolve against a file named `+!cmd` is refused too.
+            "git log | less '+*'",
+            "git log | less '*'",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+        # A pager with no startup command is untouched, which is what makes this a
+        # subtraction of one spelling rather than of the pager.
+        assert is_read_only_bash("git log | less") is True
+        assert is_read_only_bash("git log | more") is True
+        assert is_read_only_bash("cat f | less -N") is True
+
+    def test_a_flag_that_names_paths_indirectly_is_refused(self):
+        """`--files0-from` is an indirection, not a write, so no write table held it.
+
+        The hook layer applies `is_sensitive_path` to the command text, so it sees the
+        list file and nothing else while the program opens every path inside.
+        Measured on coreutils with a NUL-separated list naming `/etc/hostname`: `wc
+        --files0-from=list0` and `du --files0-from=list0` both read it, and the path
+        appears nowhere in argv.
+        """
+        for cmd in (
+            "wc --files0-from=/tmp/list0",
+            "wc --files0-from /tmp/list0",
+            "du --files0-from=/tmp/list0",
+            "cat f | sort --files0-from=/tmp/list0",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+        # A glob must not be able to synthesize the flag either. This is DERIVED
+        # from the table rather than restated, so the two cannot drift: measured,
+        # with a file named `--files0-from=list0` present, `wc --file*` read
+        # `/etc/hostname`.
+        assert is_read_only_bash("wc --file*") is False
+        assert is_read_only_bash("du --file*") is False
+        # The flag is spelled in full on purpose. A shorter `--file` entry would be
+        # reached by the abbreviation walk and cost these two ordinary reads.
+        assert is_read_only_bash("grep --file=/tmp/patterns f") is True
+        assert is_read_only_bash("wc -l f") is True
+        assert is_read_only_bash("du -sh .") is True
+
+        # `sort` HAS the flag and is deliberately absent from the table, because the
+        # accept-list already refuses anything it does not list. These pin the two
+        # legs that absence rests on, so re-adding the entry is never necessary and
+        # removing either leg goes red instead of silently opening the class.
+        assert "sort" not in _INDIRECT_LIST_FLAGS_BY_PREFIX
+        assert "--files0-from" not in _SORT_READONLY_LONG
+        assert is_read_only_bash("cat f | sort --files0-from=/tmp/list0") is False
+        # The glob defence derives the word from the `wc`/`du` entries, not from the
+        # key it appears under, so `sort`'s absence does not reach it.
+        assert "--files0-from" in _GLOB_SENSITIVE_WORDS
+        assert is_read_only_bash("cat f | sort --file*") is False
 
 
 # ── unsafe_bash_reason — explains WHY a command is rejected ──


### PR DESCRIPTION
Refs #5037. Supersedes #5038, which was auto-closed when its base branch was deleted on #5342's merge (`merged=false`, `closed_at` two seconds after). Same work, rebased onto current `main`, with the residual classes added back.

**Scope, up front, because the title used to undersell it.** This PR is two halves. One closes six measured auto-approval holes. The other converts `sort`, `date`, `hostname` and `file` from per-tool write-flag denylists to positive accept-lists, which is roughly half the diff and changes the verdict for commands that previously passed. First Principles was right that "six holes" hid the second half, so the title now names both.

## Problem / Motivation

`is_read_only_bash` is the last gate before `hooks.on_tool_call` auto-approves a shell command with no human prompt under `--approval reads`. Six shapes still reach that path on `main` at `e8d6174d7` (which includes #5342). Every one was reproduced by execution on a scratch repo, not read off `--help`:

| shape | measured outcome |
| --- | --- |
| `git branch injected # --list` | branch **created** |
| `git tag forged # --list` | tag **created** |
| `git branch injected <<< --list` | branch **created** |
| `git branch injected < --list` | branch **created** (needs a file named `--list`, which a checkout supplies) |
| `wc --files0-from=list0` / `du --files0-from=list0` | read `/etc/hostname`, a path **absent from argv** |
| `wc --file*` | same, with the flag **synthesized by the glob** |
| `git log \| less '+!touch FILE'` | file **created** (under a pty) |

## Why it matters

A false positive here costs a prompt. A false negative auto-runs an unsafe command with no human gate. The asymmetry is the whole argument: the failure mode has to be a prompt.

Two root causes, and neither is a "write flag", which is why per-tool write-flag tables could not hold them.

**Token elision.** `shlex.split` keeps words that bash **deletes**, so the token list this module reads is a strict *superset* of the real argv. The walk that classifies `git branch` / `git tag` reads the whole argument list to decide list mode, so a word that never reaches git can still put the segment in list mode — and a bare operand is then read as a pattern instead of a ref to create.

**Indirection.** `--files0-from` names a file that names the paths. The hook layer applies `is_sensitive_path` to the command *text*, so it sees the list file and nothing else while the program opens everything inside it.

And one that is neither: a pager's `+` argument is not an option at all but a string in the pager's own command language, and that language contains a shell escape.

## What changed (motivation → approach → change)

**Motivation:** the six shapes above, each measured.

**Approach:** make each fix *derive* from a single table rather than restate a spelling, because the recurring defect in this module is a fact recorded in one table and not propagated to the table derived from it.

**Change, per cause:**

**`_UNSAFE_SHELL_RE` is untouched.** An earlier revision of this PR did widen it to match `<` bare, and that was wrong: it flipped five ordinary reads from pass to prompt (`wc -l < f`, `grep TODO < f`, `cat < f`, `wc -l <f`, `head -20 < log.txt`), which Design Review caught. The rule now lives per verb in `_side_effect_reason`, gated on `_ELISION_SENSITIVE_KEYS`.

The scoping is the argument, not a concession. A phantom word can only **add** to the token list, so for a verb decided by its **flags** an added word is either inert or read as a flag it does not have, and the worst case is an extra prompt. Only a verb decided by **position or mode** can be flipped, because there the count and the order carry the decision. `_ELISION_SENSITIVE_KEYS` is derived from the tables that hold those decisions (`_GIT_REF_WRITE_FLAGS`, plus any accept-list spec whose `operands` is not `"any"`), with `git remote` and `uniq` named because their decision is positional in the walk itself. A side effect of deriving it: `date < f`, `hostname < f` and `uniq in # out` are covered too, which the global rule was only catching by accident.

Stripping the redirect and its target instead of refusing looks equivalent and is not. `shlex` has already discarded the quoting, so `git branch '<new'` arrives as `[git, branch, <new]`; dropping `<new` would leave a bare `git branch` that reads as a listing while bash creates the ref. Refusing fails closed without reimplementing bash's quoting rules, which this module deliberately does not do.

`#` is anchored to the start of a word, which keeps the common spellings free — measured, `echo a#b` prints `a#b` and stays a read. The cost is a quoted `#` after a space on an elision-sensitive verb: `git tag -l 'fix #123'` prompts while `git log --grep 'fix #123'` still reads, and both are asserted.

`--files0-from` gets its own table, `_INDIRECT_LIST_FLAGS_BY_PREFIX`, scoped to `wc` and `du` and spelled in full on purpose: `--file` is a prefix of it, and a shorter entry would be reached by the abbreviation walk in `_glob_reaches` and cost `grep --file=PATTERNS` and `stat --file` for no gain. `_GLOB_SENSITIVE_WORDS` **derives** from that table rather than restating the flag, which is what closes `wc --file*` without a second list to keep in sync.

`sort` also has `--files0-from` and is deliberately **not** in that table, on First Principles' count: the accept-list already refuses anything it does not list, and `--files0-from` is not in `_SORT_READONLY_LONG`, so a second entry would change only the reason string while making a reader think that table is what closes the `sort` case. The glob derivation reads the table's values, not the key they appear under, so `cat f | sort --file*` is still refused. Both legs are pinned by assertions.

Pagers refuse any `+`-led token, and any token carrying a glob metacharacter — the shell has not produced the real spelling yet, so `less +*` could resolve against a file named `+!cmd`. The whole `+` prefix is refused rather than the dangerous letters (`!` shell, `|` pipe-to-shell, `v` editor, `s` save-to-file), because that enumeration *is* the denylist this change argues against: the set is the pager's command language and it grows without asking. Plain `git log | less` and `git log | more` are untouched, so this subtracts one spelling rather than the pager.

**Two things about the pager measurement decide its shape, and both are stated in the code.** It did **not** fire when stdout was a pipe — with no tty, `less` degrades to `cat` and never runs the startup command — so this is not unconditional code execution; it depends on whether whatever executes the command supplies a tty. The gate at `hooks.on_tool_call` hands the string to an agent runtime rather than running it, so it cannot know, and must fail closed on the spelling. And `more` did **not** fire on util-linux, which has no `+command`; it is covered anyway because on the BSDs `more` is not a separate program. FreeBSD's `usr.bin/less/Makefile` installs it as a link (`LINKS= ${BINDIR}/less ${BINDIR}/more`) and Apple's `less/main.c` sets `less_is_more` when `progname` is `more`, which changes defaults and not the `+` startup-command path. The name a binary is invoked under does not tell the classifier which implementation answers.

**Also included: `sort`, `date`, `hostname` and `file` move from per-tool write-flag denylists to positive accept-lists** (`_OPTION_ACCEPT_LISTS` / `_AcceptSpec`). This is the part #5342 explicitly left out of scope. The argument is not symmetry, it is that the denylist demonstrably did not converge: five review rounds on #5038 produced six spellings of one `sort` escape, arriving one round at a time — `-o FILE`, `--output=FILE`, `-oFILE`, `-uo FILE`, `--o FILE`, and `--compress-program=PROG`. The last is the argument on its own, because a write-flag table cannot contain a flag that is not a write. The conversion also closes `file -f` (path indirection), `file -p` (a `utimes()` call whose `ctime` bump is not restorable, so it erases the evidence a file was read while leaving a permanent metadata change) It does **not** close `date -d`: see the retraction below.

## Tests

`test/test_trust_reads.py`: **104 tests in the file, 166 across the two suites that reference the classifier** (`test_trust_reads.py`, `test_dashboard_approval.py`).

Four new tests, each locking in the *mechanism* rather than only the spellings it happens to close:

- `test_a_word_bash_deletes_cannot_forge_a_read_mode` — all four elision forms, plus `echo a#b` and `git log --grep='#123'` asserting the anchor's cost.
- `test_a_pager_startup_command_cannot_reach_a_shell` — `+!`, `+|`, `+v`, and the glob forms, plus plain `less` / `more` / `less -N` still reading.
- `test_a_flag_that_names_paths_indirectly_is_refused` — attached and separated spellings on both heads, the glob synthesis, `sort --files0-from` still refused via the accept-list, and `grep --file=PATTERNS` still reading (which is why the entry is spelled in full).
- `test_an_unrecognised_option_prompts_instead_of_passing` — the accept-list's deny-by-default property, asserted with **invented** flags (`date -Z`, `sort -Q`, `file --no-such-option`) so the rule does not depend on anyone having enumerated the real ones.

**Existing assertions were moved or flipped, not deleted, so the costs stay visible:**

- `wc -l ${F}` **moved** from "no table, expansion cannot change the answer" to "a table decides the argument", by the rule that test already states rather than as an exception to it. `wc` has a table for the first time, so an expansion can reach a decided word — measured, with `F=--files0-from=list0`, `wc -l ${F}` printed `1 /etc/hostname`.
- `date --dat=yesterday` now prompts, because an accept-list cannot honour long-option abbreviations: an abbreviation of a read flag is indistinguishable in kind from an abbreviation of a write flag. `date --date=yesterday` and `date -d yesterday` both still read.

## Manual verification

Cross-check matrix against `909bbbfe7`: **61/61 attack forms refused across 16 classes, 50/50 ordinary reads preserved, 0 read regressions** against clean `main`.

Two candidate regressions were chased down and both were errors in my probe, not in the code — recorded here because they would otherwise look like undisclosed costs:

- `sort -k2n f` and `uniq f` classify as refused, but they classify that way on clean `main` too: neither `sort` nor `uniq` is on the read-only allowlist as a *command head*, only as a pipe stage. `cat f | sort -k2n` and `cat f | uniq` read on both trees.
- `find . -name '*.py'` likewise was never on the allowlist.

`git diff *.py` and `ls *.py` still read, which is the property that broke when the glob defence lost its derivation the first time.

Gates, all re-run **after** the rebase onto `e8d6174d7` rather than before it:

- black baselined gate: `scope origin/main...HEAD (2 changed files)`, passed
- isort, flake8: clean
- mypy: 1088 source files, 9 errors — **all 9 pre-exist on clean `origin/main`**, in `spec_builder/backend/routes.py`, `dashboard/server.py`, `wecom/client.py`. `dashboard/state.py` has 0.

`git secrets --scan` on both changed files is clean; the pre-commit hook's whole-tree scan flags AWS-shaped test fixtures in upstream files that this diff does not touch.

**One more disclosed flip: `file -z` / `--uncompress`.** On the write-flag table it auto-approved; under the accept-list it prompts. It belongs to the exec class rather than the write class, and `file`'s own `src/compress.c` says so: `posix_spawnp(&pid, compr[method].argv[0], ...)`, with `compr[]` holding `gzip`, `bzip2`, `lzip`, `xz`, `lrzip` and `zstd` and `method` chosen from the examined file's magic bytes. It runs a program whose name is picked by the content being inspected — the same hand-off as `git diff --ext-diff`. Plain `file` and `file -b` are untouched.

## What this does NOT convert, counted

First Principles asked for this count to be visible, and it is a fair ask: the argument this PR makes against denylists indicts more verbs than it converts. Grepped from the post-change tree rather than estimated:

| denylist-shaped table | keys |
| --- | --- |
| `_WRITE_FLAGS` | 6: `git diff`, `git log`, `git show`, `less`, `tree`, `uniq` |
| `_EXEC_FLAGS` | 5: `git cat-file`, `git diff`, `git log`, `git show`, `less` |
| `_GIT_REF_WRITE_FLAGS` | 2: `branch`, `tag` |
| `_INDIRECT_LIST_FLAGS_BY_PREFIX` | 2: `du`, `wc` |

**11 distinct keys over 6 programs** (`git`, `tree`, `uniq`, `less`, `wc`, `du`) stay denylisted. Converted here: `sort`, `date`, `hostname`, `file`.

Two things in that table are worth saying out loud rather than leaving a reader to notice.

`less` now carries **three** separate patch mechanisms: `_WRITE_FLAGS["less"]` (`-o`, `-O`, `--log-file`, `--LOG-FILE`), `_EXEC_FLAGS["less"]` (`--filter`, `-k`, `--lesskey-file`, `--lesskey-src`), and the `+`-startup refusal this PR adds. Three patches on one tool is exactly the non-convergence this PR argues about, and `less` is the strongest candidate for the next conversion.

And `_INDIRECT_LIST_FLAGS_BY_PREFIX` is **a new denylist-shaped table that this PR itself adds**. `wc`'s option surface is small enough to accept-list cheaply; `du`'s is roughly forty options and is a real project. I chose the narrow table over either converting both now (a much larger diff in a security-critical function) or leaving the measured `--files0-from` hole open. That is a deliberate trade rather than an oversight, but it does mean this PR both argues against denylists and adds one.

Deferred rather than folded in, on the same grounds that got #5038 split: converting six more programs is a larger change than this one and should get its own review instead of riding inside a fix.

## Retracted claim: `date -d`

An earlier revision of this PR refused `date -d` and told you that BSD/macOS `date -d` sets the kernel's daylight-saving value. **That was wrong, and it was the one claim here I had not executed.** First Principles flagged it as resting on documentation rather than execution, which was the right call. Checking the implementations rather than the man pages, read from each project's own `getopt(3)` string:

| implementation | `-d` | what it does |
| --- | --- | --- |
| GNU coreutils | present | parses and **prints** (executed here, 8.22) |
| FreeBSD `bin/date` | **absent** (`"f:I::jnRr:uv:z:"`) | invalid option |
| Apple `shell_cmds/date` | **absent** (same string) | invalid option |
| OpenBSD `bin/date` | **absent** (`"af:jr:uz:"`) | invalid option |
| NetBSD `bin/date` | present (`"ad:f:jnRr:Uuz:"`) | sets `rflag`, `parsedate()`s the operand: the GNU meaning. `setthetime()` is reached only from a bare operand |

So `-d` either reads or errors, never writes. The historical `-d dst` that set the kernel flag is gone from every current BSD. `-d` is now on the accept-list and `date -d yesterday` reads again.

There was also an internal tell that should have caught this without the source dive, and it is now asserted in the suite: `--date=` was already admitted, and `-d` is the same option under a shorter spelling wherever it exists. Admitting one and refusing the other could not both be right.

`date -s`, `date --set=`, and a bare `date 08221200` operand still prompt. Those are real setters, executed and confirmed failing only on privilege.

## Related Issues

Refs #5037. Supersedes #5038 (auto-closed, not merged). Builds on #5342, which is merged and whose mechanism is underneath this.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the rationale for each rule lives in the code comments beside it, including what was measured and what was not
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER per the repo template: the exact CLA wording is to be supplied by OSPO.
     Not inventing text here. Happy to add the standard wording once it lands in the template. -->