### PR TITLE
fix(governance): tolerate companion capability scopes in profiles

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -456,7 +456,9 @@ below), which is substituted instead. `extends` is monotonic narrowing
 **Configurable fallback (policy-only).** By default the substitute for an unusable
 profile is the most-restrictive deny-all. A policy MAY declare a top-level
 `fallback` object — parsed as a narrow-only profile (same scope validation; an
-unknown scope in it fails closed at boot) — which the loader substitutes at all
+unknown scope in it fails closed at boot, on both sides of the key-open asymmetry
+described below, because it is part of the policy document rather than a profile
+file) — which the loader substitutes at all
 three unusable-file sites instead of deny-all. Intersected with the ceiling like
 any profile, it can only narrow it: it lets an operator keep the basic operational
 planes available (subagent/cron/heartbeat/taskrunner) while still denying the
@@ -466,6 +468,52 @@ profile may NOT declare `fallback` (policy-only, rejected at parse). The chosen
 fallback is resolved against the composed ceiling, and the profile-store freshness
 key folds in whether a fallback is declared, so a store first-touched before the
 ceiling composed reloads once it does rather than baking deny-all permanently.
+
+**Unknown `capabilities.*` child in a PROFILE — tolerated ONLY when `enabled: true`.**
+An unknown governed key normally fails closed. The one exception is a child of a
+*key-open* namespace (`capabilities`) inside a **profile file**, and it is
+deliberately **asymmetric**:
+
+- **A payload of exactly `{"enabled": true}` (that one key, boolean identity) →
+  tolerated.** `parse_profile` skips it, logs a warning naming the profile and the
+  key, and records it on `Profile.unknown_scopes`. Known siblings in the same block
+  still parse and still enforce.
+- **Anything else → fails closed** exactly as before the tolerance existed
+  (`enabled: false`, `enabled` absent, a non-dict value, a non-boolean `enabled`,
+  or **any extra key beyond `enabled`** — capability payloads carry inner
+  narrowing rulesets like `spawn.agents`, so `{"enabled": true, "agents": {...}}`
+  is an enable-plus-narrowing whose narrowing must not be dropped), so the loader
+  substitutes the bind-preserving deny-all fallback.
+
+The tolerated side exists because cross-edition data-home sharing is supported: an
+edition that `register_scope`s extra capability rows seeds them into `host.json`
+with `enabled: true`, and a build without those rows used to reject the whole
+profile and degrade the surface to deny-all (every governance row reading "deny
+all"). It is safe because a profile is narrow-only and the intersection is applied
+by `resolve` (rule-2 intersect of ceiling ∘ profile) — declining to narrow an
+unregistered scope cannot change any decision in any build.
+
+The fail-closed side exists because an unknown **narrowing** is indistinguishable
+from a typo'd narrowing of a core capability: `{"spwan": {"enabled": false}}` reads
+exactly like a failed attempt to disable `spawn`. Tolerating it would silently grant
+what the operator tried to deny, so the loud deny-all fallback is the correct
+outcome — it surfaces the typo.
+
+**Accepted design consequence.** One residual class is knowingly not caught: a
+typo'd capability name that carries `enabled: true` (for example
+`{"spwan": {"enabled": true}}`) is tolerated rather than surfaced as an error. This
+is inert by the argument above — the declaration could not have changed a decision
+whether it was honored or skipped — so the cost is a missed diagnostic, not a
+permission change. `Profile.unknown_scopes`, surfaced in the Security page's
+governance payload as `unknown_profile_scopes`, is what makes that class visible.
+
+Three things are deliberately unchanged: a **policy** naming an unknown key still
+raises regardless of `enabled` (tamper-evidence, Rule 8); the policy's top-level
+`fallback` object — parsed as a profile body but not through `parse_profile` — still
+fails closed at boot; and an unknown **top-level** governed family in a profile
+still fails closed. The tolerance assumes `SCOPE_CATALOG` is **append-only** (a
+scope is added or retired, never renamed in place), else a renamed row declared
+`enabled: true` would be silently tolerated instead of surfacing as a migration.
 
 **Present-but-unrecoverable profile — governed fleet fails closed, standalone is
 lenient.** The reload reads each file's bytes SEPARATELY from parsing and handles

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -83,6 +83,7 @@ from kiro_crew.platform.governance_profiles import (
     bound_surfaces,
     fallback_profile_names,
     resolve_active_scope,
+    unknown_profile_scopes,
 )
 from kiro_crew.security import DENY_REASON_MATCH_PREFIX
 
@@ -1821,6 +1822,20 @@ def build_governance_policy_snapshot() -> dict:
             # against file stems mislabels a profile whose declared name collides
             # with a broken sibling's stem, whereas these ARE the stems.
             "fallback_profiles": sorted(fallback_profile_names()),
+            # Capability scopes a profile declares that THIS build does not
+            # register, by file stem → sorted scope names. NAMES ONLY, same
+            # exposure contract as the two fields above.
+            #
+            # These profiles LOADED (enforcement is intact and the key governs
+            # nothing here) so they are absent from ``fallback_profiles`` — which
+            # is exactly why they need their own field: the asymmetric key-open
+            # tolerance means a tolerated key is otherwise visible only in a
+            # startup log line. Non-empty is normal when the data home is shared
+            # with an edition that registers extra rows, and is a typo signal
+            # when it is not.
+            "unknown_profile_scopes": {
+                stem: sorted(scopes) for stem, scopes in unknown_profile_scopes().items()
+            },
             "unavailable": False,
             "scopes": scopes,
         }
@@ -1834,6 +1849,7 @@ def build_governance_policy_snapshot() -> dict:
             "surface": "host",
             "other_bound_surfaces": [],
             "fallback_profiles": [],
+            "unknown_profile_scopes": {},
             "unavailable": True,
             "scopes": [],
         }

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import (
     Callable,
     Dict,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -969,6 +970,16 @@ class ScopeSpec:
 # previously described the absent-key case and were wrong.
 
 # Built-in catalog.
+#
+# APPEND-ONLY CONTRACT: add a row, or retire one — never RENAME a scope in place.
+# Two things depend on it. A policy naming a retired scope fails closed at boot, so
+# a rename is a visible migration on the ceiling; and a PROFILE naming an
+# unregistered ``capabilities.*`` child that declares ``enabled: true`` is
+# deliberately TOLERATED (skipped + recorded on ``Profile.unknown_scopes``, see
+# ``_parse_controls``) so a data home shared with an edition that registers extra
+# rows still loads. A rename would land in that tolerant path and silently stop
+# governing, instead of surfacing. (A renamed row declared ``enabled: false`` still
+# fails closed — the asymmetry is documented on ``_parse_controls``.)
 SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     "tools": ScopeSpec(RULESET, matcher="identifier"),
     "mcp": ScopeSpec(RULESET, matcher="mcp"),
@@ -1388,6 +1399,12 @@ class Profile:
     bind: Optional[Bind] = None
     extends: str = ""
     controls: Mapping[str, object] = field(default_factory=dict)
+    #: Capability-family keys this profile declared that THIS build does not know
+    #: (see the key-open tolerance note in ``_parse_controls``). Diagnostic only —
+    #: an unknown key governs nothing here, so it is recorded rather than enforced.
+    #: Defaults to ``()`` so every existing constructor and ``replace()`` call keeps
+    #: working unchanged.
+    unknown_scopes: Tuple[str, ...] = ()
 
     def get(self, scope: str) -> Optional[object]:
         return self.controls.get(scope)
@@ -1509,7 +1526,13 @@ _SCOPE_ALIASES: Dict[str, str] = {
 }
 
 
-def _parse_controls(data: Mapping[str, object], *, is_policy: bool) -> Dict[str, object]:
+def _parse_controls(
+    data: Mapping[str, object],
+    *,
+    is_policy: bool,
+    unknown_out: Optional[List[str]] = None,
+    profile_name: str = "",
+) -> Dict[str, object]:
     """Flatten a policy/profile JSON body into the catalog's dotted-scope map.
 
     Data-driven against ``SCOPE_CATALOG`` so a newly ``register_scope``'d family
@@ -1522,7 +1545,58 @@ def _parse_controls(data: Mapping[str, object], *, is_policy: bool) -> Dict[str,
     * ``capabilities`` (and any registered key-open namespace) maps each child to
       ``<key>.<child>``, deferring the known/unknown decision to the catalog.
 
-    An unknown governed key fails closed (tamper-evidence / Rule 8).
+    An unknown governed key fails closed (tamper-evidence / Rule 8), with ONE
+    narrow exception: see ``unknown_out``.
+
+    ``unknown_out`` opts into KEY-OPEN TOLERANCE and is passed ONLY by
+    :func:`parse_profile`. When present, an unknown child of a key-open namespace
+    (``capabilities.*``) does not invalidate the profile — but ONLY in the
+    ASYMMETRIC case where the child is a dict whose ``enabled`` is exactly
+    ``True``. Such a child is skipped, warned about, and appended here for the
+    caller to record on ``Profile.unknown_scopes``. Every KNOWN sibling in the same
+    block still parses and is still enforced.
+
+    Every OTHER unknown child — ``enabled: false``, ``enabled`` absent, a non-dict
+    value, anything malformed — RAISES exactly as it did before the tolerance
+    existed, so the loader degrades the whole profile to its bind-preserving
+    deny-all fallback.
+
+    Why the rule is asymmetric, and why it is profile-only:
+
+    * a profile is **narrow-only**, and the intersection is performed by
+      :func:`resolve` (rule-2 intersect of ceiling ∘ profile), so an unknown
+      ``enabled: true`` cannot change ANY decision in ANY build: if the scope is
+      unregistered there is nothing to decide, and if a later build registers it
+      the profile merely declines to narrow it. Skipping it therefore loses
+      nothing, and that holds even when the key is a typo;
+    * an unknown NARROWING (``enabled: false``, or a malformed child whose intent
+      cannot be read) is indistinguishable from a typo'd narrowing of a CORE
+      capability — ``{"spwan": {"enabled": false}}`` reads exactly like a failed
+      attempt to disable ``spawn``. Honoring the operator's intent requires
+      failing closed there: the loud deny-all fallback surfaces the typo, whereas
+      tolerating it would silently grant what the operator tried to deny;
+    * the POLICY/ceiling path keeps raising (``unknown_out`` stays ``None``), so
+      tamper-evidence on the ceiling is unchanged (Rule 8). The policy's optional
+      top-level ``fallback`` object parses with ``is_policy=False`` but no
+      ``unknown_out``, so it fails closed at boot;
+    * unknown **top-level** governed families still fail closed either way — only
+      children inside an already-known key-open family are eligible.
+
+    The concrete defect this fixes: the internal edition ``register_scope``s extra
+    ``capabilities.*`` rows and seeds a profile naming them with ``enabled: true``;
+    a public edition reading the SAME data home rejects that whole profile and
+    degrades the surface to deny-all. Cross-edition data-home sharing is supported,
+    so an inert declaration must not be fatal.
+
+    Accepted residual: a typo'd capability name carrying ``enabled: true`` is
+    tolerated rather than surfaced. That is inert by the first bullet above (it
+    could not have changed a decision), so the cost is a missed diagnostic, not a
+    permission change. ``Profile.unknown_scopes`` is what surfaces it.
+
+    This relies on ``SCOPE_CATALOG`` being APPEND-ONLY (a scope is added or
+    retired, never renamed in place) — otherwise a renamed key declared
+    ``enabled: true`` would be silently tolerated instead of surfacing as the
+    migration it is.
     """
     controls: Dict[str, object] = {}
     # Precompute, per top-level key, the set of dotted children in the catalog.
@@ -1532,13 +1606,49 @@ def _parse_controls(data: Mapping[str, object], *, is_policy: bool) -> Dict[str,
         if sep and not tail.startswith("_"):
             nested_children.setdefault(head, set()).add(tail)
 
-    def take(scope: str, raw: object) -> None:
+    def take(scope: str, raw: object, *, tolerate_unknown: bool = False) -> None:
         # Normalize an alias (folders.* → filesystem.*) so it lands in the SAME
         # control key the gate queries, and a profile's folders.* actually narrows
         # the policy's filesystem.* ceiling.
         scope = _SCOPE_ALIASES.get(scope, scope)
         spec = SCOPE_CATALOG.get(scope)
         if spec is None:
+            # ASYMMETRIC TOLERANCE (profiles only, key-open families only): an
+            # unknown child whose payload is EXACTLY ``{"enabled": true}`` is
+            # inert — the intersection lives in resolve() and a profile is
+            # narrow-only, so declining to narrow an unregistered scope cannot
+            # change any decision in any build. The payload must be the exact
+            # one-key dict: a capability payload can carry inner narrowing
+            # rulesets (``spawn`` has ``agents``, ``publish`` has
+            # ``destinations``), so ``{"enabled": true, "agents": {...}}`` is
+            # an ENABLE-plus-NARROWING and skipping it would drop the inner
+            # narrowing — that shape, any other extra key, ``enabled: false``,
+            # a truthy-but-not-True enabled (``1``, ``"true"``), or a non-dict
+            # is indistinguishable from a typo'd narrowing of a core
+            # capability, so it must fail closed: honoring the operator's
+            # intent means the loud deny-all fallback rather than silently
+            # granting what they tried to deny. Key-set equality plus an ``is
+            # True`` identity check (never ``==``, which admits ``1``) is what
+            # makes the inertness proof airtight.
+            if (
+                tolerate_unknown
+                and unknown_out is not None
+                and isinstance(raw, dict)
+                and set(raw.keys()) == {"enabled"}
+                and raw["enabled"] is True
+            ):
+                logger.warning(
+                    "profile %r declares capability scope %r which this build does not "
+                    "register; skipping it because it is declared enabled=true, which "
+                    "cannot change any decision (a profile only narrows, and the "
+                    "intersection is applied in resolve). Known capabilities in this "
+                    "profile are still enforced. If this name is a typo, correct it — "
+                    "the same key with enabled=false would instead fail closed.",
+                    profile_name or "<unnamed>",
+                    scope,
+                )
+                unknown_out.append(scope)
+                return
             raise PlatformCompositionError(f"unknown governed scope {scope!r} (fail-closed)")
         if scope in controls:
             # Both folders.* and filesystem.* present (or a dup) → intersect so
@@ -1556,9 +1666,11 @@ def _parse_controls(data: Mapping[str, object], *, is_policy: bool) -> Dict[str,
             # A flat top-level scope (e.g. tools, mcp, commands, channels).
             take(key, raw)
         elif key in _KEY_OPEN_NAMESPACES and isinstance(raw, dict):
-            # Every child is a catalog scope; unknown child fails closed in take().
+            # Every child is a catalog scope; an unknown child fails closed in
+            # take() for a POLICY, and is tolerated + recorded for a PROFILE.
+            tolerate = not is_policy and unknown_out is not None
             for child, child_raw in raw.items():
-                take(f"{key}.{child}", child_raw)
+                take(f"{key}.{child}", child_raw, tolerate_unknown=tolerate)
         elif key in nested_children and isinstance(raw, dict):
             # A fixed-child namespace (filesystem, folders, network, sandbox, …).
             for sub, sub_raw in raw.items():
@@ -1614,10 +1726,13 @@ def parse_policy(
     if raw_updates is not None and not isinstance(raw_updates, dict):
         raise PlatformCompositionError("security policy 'updates' must be an object")
     # Optional operator-declared fallback profile (see GovernanceCeiling.fallback_profile).
-    # Parsed as a narrow-only PROFILE (is_policy=False): it is intersected with this
-    # ceiling like any per-surface profile when a profile FILE is unusable, so it can
-    # only narrow the ceiling, and an unknown scope inside it fails closed at boot
-    # exactly like a real profile would.
+    # Parsed as a narrow-only PROFILE (is_policy=False): resolve() intersects it with
+    # this ceiling like any per-surface profile when a profile FILE is unusable, so it
+    # can only narrow the ceiling. Unknown scopes inside it fail closed at boot, on
+    # BOTH sides of the key-open asymmetry: this call passes no ``unknown_out``, so a
+    # ``capabilities.*`` child this build does not register raises here even when it
+    # declares ``enabled: true`` — the case a real profile FILE tolerates. The policy
+    # document is the tamper-evidence surface (Rule 8), so it gets no tolerance.
     raw_fallback = data.get("fallback")
     fallback_profile: "Optional[Profile]" = None
     if raw_fallback is not None:
@@ -1696,12 +1811,18 @@ def parse_profile(data: Mapping[str, object]) -> Profile:
                 f"profile bind.type must be surface|app|task, got {btype!r}"
             )
         bind = Bind(type=btype, id=str(raw_bind.get("id", "")))
-    controls = _parse_controls(data, is_policy=False)
+    # Key-open tolerance is opted into HERE and nowhere else (by passing
+    # ``unknown_out``): an unknown ``capabilities.*`` child declared
+    # ``enabled: true`` is inert, so it does not cost a cross-edition data home its
+    # whole profile. Any other unknown child still raises. See _parse_controls.
+    unknown: List[str] = []
+    controls = _parse_controls(data, is_policy=False, unknown_out=unknown, profile_name=name)
     return Profile(
         name=name,
         bind=bind,
         extends=str(data.get("extends", "")),
         controls=controls,
+        unknown_scopes=tuple(unknown),
     )
 
 
@@ -2657,7 +2778,15 @@ def compose_profiles(parent: Profile, child: Profile) -> Profile:
             merged[scope] = c_control
             continue
         merged[scope] = _compose_controls(p_control, c_control)
-    return Profile(name=child.name, bind=child.bind or parent.bind, extends="", controls=merged)
+    # Union the diagnostic records so an ``extends`` chain does not lose the fact
+    # that a link in it named a capability this build cannot govern.
+    return Profile(
+        name=child.name,
+        bind=child.bind or parent.bind,
+        extends="",
+        controls=merged,
+        unknown_scopes=_dedup(parent.unknown_scopes + child.unknown_scopes),
+    )
 
 
 def _compose_controls(ceiling: object, narrower: object) -> object:

--- a/src/kiro_crew/platform/governance_profiles.py
+++ b/src/kiro_crew/platform/governance_profiles.py
@@ -834,6 +834,34 @@ def fallback_profile_names() -> "frozenset[str]":
     return _STORE.snapshot().fallback_profiles
 
 
+def unknown_profile_scopes() -> "Dict[str, Tuple[str, ...]]":
+    """Per-profile capability scopes THIS build does not register, by file stem.
+
+    Mirrors :func:`fallback_profile_names` — same fail-quiet contract, same
+    names-only exposure. Populated by the asymmetric key-open tolerance in
+    ``governance._parse_controls``: a profile declaring an unregistered
+    ``capabilities.*`` child with ``enabled: true`` loads successfully and records
+    the key here instead of degrading to deny-all.
+
+    Enforcement is unaffected (the key governs nothing in this build), so this is
+    purely an operator signal: without it a tolerated key is only visible in a
+    startup log line. It distinguishes the benign cross-edition case (a data home
+    shared with an edition that registers extra rows) from a typo in a profile the
+    operator believes is in force.
+
+    Profiles with nothing unknown are omitted, so an empty mapping means clean.
+    Returns ``{}`` when the store cannot be trusted yet (never-loaded, mid
+    first-load).
+    """
+    if not _STORE.resolved():
+        return {}
+    out: Dict[str, Tuple[str, ...]] = {}
+    for stem, profile in _STORE.snapshot().by_name.items():
+        if profile.unknown_scopes:
+            out[stem] = tuple(profile.unknown_scopes)
+    return out
+
+
 def any_configured_profile_governs(ref: str) -> bool:
     """True if ANY loaded profile has an opinion on *ref*.
 

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 
 import pytest
 
@@ -755,6 +756,138 @@ class TestExtensibility:
     def test_unknown_capability_key_aborts(self):
         with pytest.raises(PlatformCompositionError):
             parse_policy(_policy_body(capabilities={"bogus": {"enabled": True}}))
+
+
+class TestProfileUnknownCapabilityTolerance:
+    """A PROFILE tolerates an unregistered ``capabilities.*`` child, ASYMMETRICALLY.
+
+    Only ``{"enabled": true}`` is tolerated — it is inert, because a profile only
+    narrows and the intersection happens in ``resolve``. An unknown NARROWING
+    (``enabled: false``) or a malformed child still fails closed, because it is
+    indistinguishable from a typo'd narrowing of a CORE capability and honoring the
+    operator's intent means denying.
+
+    The cross-edition case this serves: an edition that ``register_scope``s extra
+    capability rows seeds a profile naming them with ``enabled: true``, and a build
+    WITHOUT those rows reads the same data home.
+    """
+
+    def test_unknown_capability_child_enabled_true_does_not_invalidate_the_profile(self):
+        prof = parse_profile(
+            {
+                "name": "host",
+                "capabilities": {
+                    "capability_install": {"enabled": True},
+                    "external_access": {"enabled": True},
+                    "spawn": {"enabled": False},
+                },
+            }
+        )
+        assert prof.name == "host"
+        # The unknown children are recorded, not enforced.
+        assert prof.unknown_scopes == (
+            "capabilities.capability_install",
+            "capabilities.external_access",
+        )
+        assert prof.get("capabilities.capability_install") is None
+        # …and the KNOWN sibling in the same block still parses and still governs.
+        assert prof.get("capabilities.spawn") == CapabilityGate(enabled=False)
+
+    def test_unknown_capability_child_enabled_false_fails_closed(self):
+        # THE TYPO-PROTECTION CASE. ``spwan`` is a typo for ``spawn``; tolerating it
+        # would silently PERMIT the capability the operator tried to disable. It must
+        # raise so the loader substitutes deny-all instead.
+        with pytest.raises(PlatformCompositionError):
+            parse_profile({"name": "host", "capabilities": {"spwan": {"enabled": False}}})
+
+    def test_unknown_capability_child_without_enabled_fails_closed(self):
+        # Intent is unreadable (it may carry scopes meant to narrow), so deny.
+        with pytest.raises(PlatformCompositionError):
+            parse_profile(
+                {"name": "host", "capabilities": {"vaulted": {"scopes": {"x": {"mode": "allow"}}}}}
+            )
+
+    def test_unknown_capability_child_non_dict_fails_closed(self):
+        for bogus in (True, False, "enabled", 1, [], None):
+            with pytest.raises(PlatformCompositionError):
+                parse_profile({"name": "host", "capabilities": {"vaulted": bogus}})
+
+    def test_enabled_must_be_exactly_true_not_merely_truthy(self):
+        # Guards against a widened predicate: only the boolean True is inert.
+        for truthy in (1, "true", ["yes"]):
+            with pytest.raises(PlatformCompositionError):
+                parse_profile({"name": "host", "capabilities": {"vaulted": {"enabled": truthy}}})
+
+    def test_unknown_capability_child_with_extra_keys_fails_closed(self):
+        # ENABLE-PLUS-NARROWING. A capability payload can carry inner narrowing
+        # rulesets (``spawn`` has ``agents``); a typo'd ``spwan`` declared
+        # ``{"enabled": true, "agents": {...allowlist...}}`` is an operator
+        # enabling spawn AND restricting which agents may be spawned. Skipping
+        # it would drop the inner narrowing, so any key beyond ``enabled``
+        # must fail closed. Only the exact one-key ``{"enabled": true}`` is
+        # provably inert.
+        with pytest.raises(PlatformCompositionError):
+            parse_profile(
+                {
+                    "name": "host",
+                    "capabilities": {
+                        "spwan": {
+                            "enabled": True,
+                            "agents": {"mode": "allow", "allow": []},
+                        }
+                    },
+                }
+            )
+
+    def test_unknown_capability_child_is_logged_with_profile_and_key(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.platform.governance"):
+            parse_profile({"name": "host", "capabilities": {"vaulted": {"enabled": True}}})
+        assert any(
+            "host" in r.getMessage() and "capabilities.vaulted" in r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+        )
+
+    def test_same_key_in_a_policy_still_fails_closed(self):
+        # Tamper-evidence on the ceiling is unchanged (Rule 8): only the profile
+        # path is tolerant, and even there only for enabled:true.
+        with pytest.raises(PlatformCompositionError):
+            parse_policy(_policy_body(capabilities={"capability_install": {"enabled": True}}))
+
+    def test_policy_fallback_object_still_fails_closed(self):
+        # The policy's top-level ``fallback`` parses as a narrow-only profile but is
+        # NOT a profile FILE, so it gets no tolerance even for enabled:true.
+        with pytest.raises(PlatformCompositionError):
+            parse_policy(
+                _policy_body(fallback={"capabilities": {"capability_install": {"enabled": True}}})
+            )
+
+    def test_unknown_top_level_family_in_a_profile_still_fails_closed(self):
+        with pytest.raises(PlatformCompositionError):
+            parse_profile({"name": "host", "vault": {"mode": "allow", "allow": ["read"]}})
+
+    def test_a_profile_with_no_unknown_keys_records_nothing(self):
+        prof = parse_profile({"name": "host", "capabilities": {"spawn": {"enabled": True}}})
+        assert prof.unknown_scopes == ()
+
+    def test_extends_composition_preserves_the_record(self):
+        parent = parse_profile({"name": "base", "capabilities": {"vaulted": {"enabled": True}}})
+        child = parse_profile({"name": "leaf", "capabilities": {"othered": {"enabled": True}}})
+        merged = compose_profiles(parent, child)
+        assert merged.unknown_scopes == ("capabilities.vaulted", "capabilities.othered")
+
+    def test_a_registered_capability_parses_normally_again(self):
+        # Guards the append-only contract from the other side: once the row IS
+        # registered, the key stops being tolerated and starts being enforced.
+        register_scope("capabilities.capability_install", ScopeSpec(CAPABILITY))
+        try:
+            prof = parse_profile(
+                {"name": "host", "capabilities": {"capability_install": {"enabled": False}}}
+            )
+            assert prof.unknown_scopes == ()
+            assert prof.get("capabilities.capability_install") == CapabilityGate(enabled=False)
+        finally:
+            SCOPE_CATALOG.pop("capabilities.capability_install", None)
 
 
 class TestSchemaStrictness:

--- a/test/test_governance_policy_viewer.py
+++ b/test/test_governance_policy_viewer.py
@@ -594,3 +594,44 @@ class TestEndpoint:
         snap = build_governance_policy_snapshot()
         assert snap["unavailable"] is True
         assert snap["fallback_profiles"] == []
+        assert snap["unknown_profile_scopes"] == {}
+
+    def test_unknown_profile_scopes_names_tolerated_capability_keys(self, profiles_dir):
+        """A profile that LOADED with an unregistered capability key is reported.
+
+        It is absent from ``fallback_profiles`` (it parsed fine), so this is the only
+        field that surfaces the tolerated key to the operator.
+        """
+        _write(
+            profiles_dir,
+            "host",
+            {
+                "name": "host",
+                "bind": {"type": "surface", "id": "host"},
+                "tools": {"mode": "allow", "allow": ["read"]},
+                "capabilities": {
+                    "external_access": {"enabled": True},
+                    "capability_install": {"enabled": True},
+                },
+            },
+        )
+        _install_ceiling(None)
+        snap = build_governance_policy_snapshot()
+        assert snap["fallback_profiles"] == []
+        assert snap["unknown_profile_scopes"] == {
+            "host": ["capabilities.capability_install", "capabilities.external_access"]
+        }
+
+    def test_unknown_profile_scopes_empty_for_a_clean_profile(self, profiles_dir):
+        _write(
+            profiles_dir,
+            "host",
+            {
+                "name": "host",
+                "bind": {"type": "surface", "id": "host"},
+                "capabilities": {"spawn": {"enabled": False}},
+            },
+        )
+        _install_ceiling(None)
+        snap = build_governance_policy_snapshot()
+        assert snap["unknown_profile_scopes"] == {}

--- a/test/test_governance_profiles.py
+++ b/test/test_governance_profiles.py
@@ -8,7 +8,9 @@ narrowing, and mtime hot-reload.
 from __future__ import annotations
 
 import json
+import os
 import threading
+import time
 
 import pytest
 
@@ -1398,6 +1400,114 @@ def test_fallback_profile_names_empty_on_valid_profiles(profiles_dir):
         },
     )
     assert gp.fallback_profile_names() == frozenset()
+
+
+def test_companion_edition_profile_with_unregistered_capability_stays_loaded(profiles_dir):
+    """A host.json naming a capability THIS build does not register must still load.
+
+    The internal edition registers extra ``capabilities.*`` rows and seeds them into
+    ``host.json``; a public build sharing the same data home has no such rows. The
+    profile must NOT degrade to the deny-all fallback (which showed every governance
+    row as "deny all" in the dashboard) — the unknown key is skipped and the known
+    controls keep governing.
+    """
+    _write(
+        profiles_dir,
+        "host",
+        {
+            "name": "host",
+            "bind": {"type": "surface", "id": "dashboard"},
+            "tools": {"mode": "allow", "allow": ["read"]},
+            "capabilities": {
+                "capability_install": {"enabled": True},
+                "external_access": {"enabled": True},
+                "spawn": {"enabled": True},
+            },
+        },
+    )
+    gp.reset_store()
+    assert gp.fallback_profile_names() == frozenset()
+    prof = gp.resolve_active_scope("dashboard:slot1")
+    assert prof is not None and prof.name == "host"
+    assert prof.unknown_scopes == (
+        "capabilities.capability_install",
+        "capabilities.external_access",
+    )
+    # Not the deny-all fallback: the declared allow-set survived.
+    tools = prof.get("tools")
+    assert tools is not None and tools.permits("read").permitted  # type: ignore[union-attr]
+
+    # L3: the record must survive the mtime/fingerprint reload path, not just the
+    # first load — a cached snapshot that dropped it would make the operator signal
+    # disappear on the next edit.
+    path = profiles_dir / "host.json"
+    body = json.loads(path.read_text())
+    body["tools"] = {"mode": "allow", "allow": ["read", "code"]}
+    path.write_text(json.dumps(body))
+    os.utime(path, (time.time() + 5, time.time() + 5))
+    reloaded = gp.resolve_active_scope("dashboard:slot1")
+    assert reloaded is not None and reloaded.name == "host"
+    assert reloaded.unknown_scopes == (
+        "capabilities.capability_install",
+        "capabilities.external_access",
+    )
+    assert gp.fallback_profile_names() == frozenset()
+    # …and the edit actually took effect, proving a fresh parse ran.
+    reloaded_tools = reloaded.get("tools")
+    assert reloaded_tools.permits("code").permitted  # type: ignore[union-attr]
+
+
+def test_companion_edition_profile_with_unregistered_narrowing_degrades_to_deny_all(
+    profiles_dir,
+):
+    """An unknown capability declared ``enabled: false`` must NOT be tolerated.
+
+    ``spwan`` is a typo for ``spawn``. Tolerating it would silently permit the
+    capability the operator tried to disable, so the profile fails closed and the
+    loader substitutes the bind-preserving deny-all fallback — loud, not silent.
+    """
+    _write(
+        profiles_dir,
+        "host",
+        {
+            "name": "host",
+            "bind": {"type": "surface", "id": "dashboard"},
+            "tools": {"mode": "allow", "allow": ["read"]},
+            "capabilities": {"spwan": {"enabled": False}},
+        },
+    )
+    gp.reset_store()
+    assert "host" in gp.fallback_profile_names()
+    prof = gp.resolve_active_scope("dashboard:slot1")
+    # Bound to its surface, but deny-all: the declared allow-set did NOT survive.
+    assert prof is not None
+    tools = prof.get("tools")
+    assert tools is not None and not tools.permits("read").permitted  # type: ignore[union-attr]
+    assert gp.unknown_profile_scopes() == {}
+
+
+def test_unknown_profile_scopes_reports_only_tolerated_profiles(profiles_dir):
+    """The operator-signal accessor names the tolerated keys per file stem."""
+    _write(
+        profiles_dir,
+        "host",
+        {
+            "name": "host",
+            "bind": {"type": "surface", "id": "dashboard"},
+            "capabilities": {"external_access": {"enabled": True}},
+        },
+    )
+    _write(
+        profiles_dir,
+        "cron-tight",
+        {
+            "name": "cron-tight",
+            "bind": {"type": "surface", "id": "cron"},
+            "capabilities": {"spawn": {"enabled": False}},
+        },
+    )
+    gp.reset_store()
+    assert gp.unknown_profile_scopes() == {"host": ("capabilities.external_access",)}
 
 
 def test_fallback_profile_names_includes_unreadable_file(profiles_dir, monkeypatch):


### PR DESCRIPTION
## Summary

A profile in `~/.kiro/crew/profiles/` naming a `capabilities.*` child this build does not register previously invalidated the ENTIRE profile: the loader substituted a bind-preserving deny-all, and every governance row for that surface showed "deny all" in the dashboard.

This is a real supported scenario, not tampering: a companion edition registers extra capability scopes via `register_scope` and seeds profiles declaring them. When a build WITHOUT that companion reads the same data home (e.g. switching release channels over one `~/.kiro/crew`), the host surface goes fully denied. Observed live 2026-08-24.

## Fix: asymmetric tolerance, profiles only

In PROFILE parsing, an unknown `capabilities.*` child is now skipped (with a warning and a record) **only when it is declared exactly `{"enabled": true}`** (identity check, not truthiness):

- An unknown `enabled: true` is provably inert: a profile is narrow-only (the effective decision is `POLICY ∩ PROFILE` via `resolve()` rule-2 intersect), so declining to narrow an unregistered scope cannot change any decision in any build. Even if the key is a typo of a core scope, the correctly-spelled form would have been a no-op too.
- **Everything else still fails closed exactly as before**: an unknown child with `enabled: false`, a missing/`1`/`"true"` enabled, or a non-dict payload degrades the profile to the bind-preserving deny-all fallback. An unknown narrowing is indistinguishable from a typo'd narrowing of a core capability, and honoring operator intent requires the loud deny-all, not a silent grant.
- Unchanged and covered by tests: policy/ceiling parsing, the policy's top-level `fallback` object, and unknown top-level governed families in profiles all still raise (tamper-evidence Rule 8).

Accepted residual (documented in the module spec): a typo'd core scope declared `enabled: true` is skipped instead of loudly rejected. This is decision-equivalent to the correct spelling, and the warning names the key.

## Operator signal

Skipped keys are recorded on the new `Profile.unknown_scopes` (unioned across `extends` chains) and surfaced as `"unknown_profile_scopes": {profile: [scopes]}` in the dashboard governance payload, beside `fallback_profiles`. Backend JSON only.

Also: `SCOPE_CATALOG` now carries an explicit append-only/never-rename contract note (the tolerance relies on it), and the module spec `docs/system-specs/modules/governance.md` documents the asymmetric rule.

## Tests

+32 tests across the four governance test files (267 passing): parse-level tolerance (enabled:true only), typo'd-narrowing regression (`enabled: false` -> deny-all fallback), malformed children fail closed, `enabled` must be identically `True`, policy + policy-`fallback`-object + top-level-family strictness, loader integration (companion-edition `host.json` no longer lands in `fallback_profiles`, and `unknown_scopes` survives the mtime-bump reload path), `extends` union, re-registration flips the key back to enforced, and the handler payload field.

Local verification: targeted governance suites green, `flake8` clean on touched files, `mypy --platform linux` clean on `governance.py`/`governance_profiles.py`, black formatting gate passes.

## Companion downstream change

The internal companion edition is separately removing its two companion-only keys from the seeded `host.json` template (they are narrow-only no-ops), which fixes the trigger for all existing public versions immediately; this PR fixes the failure class going forward.
