### PR TITLE
fix(electron): keep boot splash out of reachable navigation history

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -20,6 +20,7 @@ const { createTokenRetryHandler } = require("./token-retry");
 const { createRendererRecovery } = require("./renderer-recovery");
 const { classifyAuthBlock, defaultedPort } = require("./gateway-auth-hint");
 const { exitImmersiveModes } = require("./blocking-prompt");
+const { armSplashHistoryClear } = require("./splash-history");
 const { hideToTray, cancelPendingTrayHide } = require("./hide-to-tray");
 const { attachHtmlFullScreen } = require("./html-fullscreen");
 const { shouldRetryLocalTokenMint, tokenMintRetryDelayMs, TOKEN_MINT_MAX_RETRIES } = require("./token-acquire");
@@ -1425,6 +1426,17 @@ function setupWindowContents(win, backendUrl) {
   });
   view.setBackgroundColor("#00000000");
   win.contentView.addChildView(view);
+
+  // Keep the boot splash / token prompt out of reachable navigation history:
+  // once the dashboard commits, prune the transient shell entries so mouse
+  // button 4 (Chromium's built-in history-back) cannot land the user on a
+  // dead-end loading.html with no way forward. Armed once per window; covers
+  // boot, the gateway reconnect/recovery re-paints, and the renderer-driven
+  // token-prompt handoff. See splash-history.js and #5538.
+  armSplashHistoryClear(view.webContents, {
+    isAlive: () => !win.isDestroyed() && !view.webContents.isDestroyed(),
+    log: glog,
+  });
 
   // Clean up views when window is closed
   win.on("closed", () => {

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -147,6 +147,7 @@
       "bundle-location.js",
       "gateway-auth-hint.js",
       "blocking-prompt.js",
+      "splash-history.js",
       "hide-to-tray.js",
       "html-fullscreen.js",
       "gateway-stop.js",

--- a/website/electron/splash-history.js
+++ b/website/electron/splash-history.js
@@ -1,0 +1,136 @@
+"use strict";
+
+/**
+ * Keep the boot splash (and the token prompt) out of the window's reachable
+ * navigation history — fix for #5538.
+ *
+ * `showLoadingThenConnect` paints `loading.html` into the main window's own
+ * webContents and then replaces it with the dashboard on that SAME
+ * webContents, which makes the splash an ordinary previous entry in Chromium's
+ * navigation history. Chromium binds mouse button 4 (and two-finger swipe on
+ * macOS) to history-back by default, so the gesture pops the dashboard and
+ * lands on a page whose only purpose was to be replaced — with no forward
+ * affordance, quitting is the only way out. The gateway reconnect/recovery
+ * paths re-paint `loading.html` into the live window and `token-prompt.html`
+ * is loaded the same way, so every one of those loads mints another dead-end
+ * history entry, not just the boot one.
+ *
+ * The narrow fix is to remove the unreachable entries, NOT to intercept the
+ * back gesture (`app-command` / `will-navigate` / swallowing button 4): the
+ * dashboard is a single-page app whose own in-app history the user may
+ * legitimately navigate, and blocking back globally is a behavior change
+ * nobody asked for. So: once a NON-transient page (the dashboard) has actually
+ * committed, surgically remove every transient shell entry still in the
+ * history via `navigationHistory.removeEntryAtIndex()` (Electron ≥34; the app
+ * pins Electron ^43 — the pre-36 `clearHistory()` spelling is gone). Removal
+ * is per-entry rather than `navigationHistory.clear()` on purpose: after a
+ * gateway reconnect the history legitimately holds the user's own prior
+ * dashboard routes behind the re-painted splash, and a wholesale clear would
+ * erase those too, breaking in-app Back — the splash entries are the bug, the
+ * dashboard entries are the user's.
+ *
+ * Listening on `did-finish-load` (persistent, armed once per window) rather
+ * than hooking each `loadURL` call site has two properties the call-site
+ * approach lacks:
+ *   - `loadURL`'s promise resolves before the navigation commits, so a
+ *     call-site prune can run against the OLD history state; the event fires
+ *     only after the document actually loaded.
+ *   - the token-prompt → dashboard handoff happens in the RENDERER
+ *     (`window.location.href = …` in token-prompt.html), so there is no
+ *     main-process `loadURL` to hook for it — but `did-finish-load` still
+ *     fires in the main process.
+ * In-app SPA route changes (pushState) do not emit `did-finish-load`, so a
+ * pure-dashboard history is never touched (see transientEntryIndexes).
+ */
+
+// Main-process-loaded shell pages whose only purpose is to be replaced by the
+// dashboard. Anything loaded via `wc.loadFile(...)` arrives as a file:// URL.
+const TRANSIENT_SHELL_PAGES = new Set(["loading.html", "token-prompt.html"]);
+
+/**
+ * True when `url` is one of the transient shell pages this process loads from
+ * disk. Only file: URLs qualify — the dashboard is always http(s), so a
+ * dashboard route that merely CONTAINS "loading.html" in a path or query can
+ * never match.
+ */
+function isTransientShellPage(url) {
+  if (typeof url !== "string" || !url.startsWith("file:")) return false;
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return false;
+  }
+  const base = pathname.slice(pathname.lastIndexOf("/") + 1);
+  return TRANSIENT_SHELL_PAGES.has(base);
+}
+
+/**
+ * Compute which history entries to remove, given a snapshot of the navigation
+ * state. Pure — the I/O lives in armSplashHistoryClear.
+ *
+ * Returns the indexes of transient shell entries, in DESCENDING order —
+ * removal shifts every subsequent index down, so pruning must run
+ * highest-index-first to keep the remaining indexes valid. Empty when:
+ *   - the page the user is looking at is itself a transient shell page
+ *     (the splash must keep working as the current page during boot/recovery;
+ *     the prune runs on the success transition, not on splash load), or
+ *   - no transient entry exists — e.g. the dashboard's own SPA history, which
+ *     is the user's and is deliberately never touched (removing anything else,
+ *     let alone clearing, would break in-app Back after a gateway reconnect).
+ * The active entry is never listed (Chromium refuses to remove it anyway).
+ */
+function transientEntryIndexes({ currentUrl, entries, activeIndex }) {
+  if (isTransientShellPage(currentUrl)) return [];
+  if (!Array.isArray(entries)) return [];
+  const indexes = [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (i !== activeIndex && entry && isTransientShellPage(entry.url)) {
+      indexes.push(i);
+    }
+  }
+  return indexes;
+}
+
+/**
+ * Arm the prune-on-handoff listener on a window's webContents. Call ONCE per
+ * window (from setupWindowContents) — the listener is persistent and covers
+ * every splash/prompt → dashboard handoff for the window's lifetime: boot,
+ * the gateway reconnect/recovery re-paints, and the renderer-driven
+ * token-prompt submit.
+ *
+ * `isAlive` mirrors the surrounding main.js convention: every touch of a
+ * webContents is bracketed by destroyed-checks/try-catch because the window
+ * can be torn down mid-flight, and `did-finish-load` can race that teardown.
+ *
+ * Returns the handler (for tests).
+ */
+function armSplashHistoryClear(wc, { isAlive = () => true, log = () => {} } = {}) {
+  const onDidFinishLoad = () => {
+    try {
+      if (!isAlive()) return;
+      const nav = wc.navigationHistory;
+      if (!nav) return; // ancient/foreign webContents — nothing to guard
+      const indexes = transientEntryIndexes({
+        currentUrl: wc.getURL(),
+        entries: nav.getAllEntries(),
+        activeIndex: nav.getActiveIndex(),
+      });
+      if (indexes.length === 0) return;
+      // Descending order — see transientEntryIndexes.
+      for (const i of indexes) nav.removeEntryAtIndex(i);
+      log(
+        `nav-history: removed ${indexes.length} transient shell entr` +
+          `${indexes.length === 1 ? "y" : "ies"} (loading/token-prompt) ` +
+          "after dashboard handoff (#5538)"
+      );
+    } catch {
+      /* window may be mid-teardown — same tolerance as the loadFile call sites */
+    }
+  };
+  wc.on("did-finish-load", onDidFinishLoad);
+  return onDidFinishLoad;
+}
+
+module.exports = { armSplashHistoryClear, transientEntryIndexes, isTransientShellPage };

--- a/website/electron/test/splash-history.test.js
+++ b/website/electron/test/splash-history.test.js
@@ -1,0 +1,336 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  armSplashHistoryClear,
+  transientEntryIndexes,
+  isTransientShellPage,
+} = require("../splash-history");
+
+// Regression tests for #5538: mouse Back (button 4) navigated the main window
+// back to the boot splash (loading.html), which offers no way forward — the
+// splash was left in Chromium's navigation history because the dashboard is
+// loaded into the SAME webContents that painted it. The fix removes the
+// transient shell entries (loading.html / token-prompt.html) from history once
+// the dashboard commits, so the splash is no longer a reachable history entry.
+// Two things are deliberately NOT done, and these tests pin both:
+//   - the back gesture itself is not intercepted (the dashboard SPA's own
+//     history must keep working), and
+//   - the history is not wholesale-cleared: after a gateway reconnect the
+//     history legitimately holds the user's own prior dashboard routes behind
+//     the re-painted splash, and clearing would erase those too, breaking
+//     in-app Back. Only the transient entries are removed, surgically.
+
+const LOADING = "file:///app/resources/loading.html";
+const LOADING_WITH_ACCENT = "file:///app/resources/loading.html?accent=%23a259ff";
+const TOKEN_PROMPT = "file:///app/resources/token-prompt.html?port=5476&kind=own";
+const DASHBOARD = "http://localhost:5476/?token=abc123";
+const DASH_ROUTE_A = "http://localhost:5476/settings";
+const DASH_ROUTE_B = "http://localhost:5476/sessions/42";
+
+/**
+ * Minimal fake of the slice of Electron's webContents the helper touches:
+ * an EventEmitter-ish `on`, `getURL`, and `navigationHistory` with
+ * getAllEntries/getActiveIndex/removeEntryAtIndex. Navigations are simulated
+ * by pushing entries and firing the captured did-finish-load handler, which is
+ * how the real event sequences (boot, recovery re-paint, token-prompt submit)
+ * are replayed below. `navigateInPage` models an SPA pushState route change:
+ * it mints a history entry but does NOT fire did-finish-load.
+ */
+function makeFakeWebContents() {
+  const handlers = {};
+  let entries = [];
+  let activeIndex = -1;
+  const removedIndexes = [];
+  const wc = {
+    on(event, fn) {
+      handlers[event] = fn;
+    },
+    getURL() {
+      return activeIndex >= 0 ? entries[activeIndex].url : "";
+    },
+    navigationHistory: {
+      getAllEntries: () => entries.map((e) => ({ ...e })),
+      getActiveIndex: () => activeIndex,
+      removeEntryAtIndex(i) {
+        removedIndexes.push(i);
+        if (i === activeIndex) return false; // Chromium refuses the active entry
+        entries.splice(i, 1);
+        if (i < activeIndex) activeIndex -= 1;
+        return true;
+      },
+    },
+  };
+  const commit = (url) => {
+    // A committed navigation truncates any forward entries, then appends.
+    entries.splice(activeIndex + 1);
+    entries.push({ url, title: "" });
+    activeIndex = entries.length - 1;
+  };
+  return {
+    wc,
+    navigate(url) {
+      commit(url);
+      if (handlers["did-finish-load"]) handlers["did-finish-load"]();
+    },
+    navigateInPage(url) {
+      commit(url); // pushState mints an entry but fires no did-finish-load
+    },
+    urls: () => entries.map((e) => e.url),
+    removedIndexes,
+    handlers,
+  };
+}
+
+describe("isTransientShellPage", () => {
+  it("matches the splash and the token prompt as loaded by loadFile (file: URLs, with query)", () => {
+    assert.equal(isTransientShellPage(LOADING), true);
+    assert.equal(isTransientShellPage(LOADING_WITH_ACCENT), true);
+    assert.equal(isTransientShellPage(TOKEN_PROMPT), true);
+  });
+
+  it("never matches the dashboard, even when a dashboard URL mentions loading.html", () => {
+    assert.equal(isTransientShellPage(DASHBOARD), false);
+    // Only file: URLs qualify — an http path/query naming loading.html is the
+    // dashboard's business, not a shell page.
+    assert.equal(isTransientShellPage("http://localhost:5476/loading.html"), false);
+    assert.equal(isTransientShellPage("http://localhost:5476/?page=loading.html"), false);
+  });
+
+  it("tolerates junk without throwing", () => {
+    assert.equal(isTransientShellPage(undefined), false);
+    assert.equal(isTransientShellPage(null), false);
+    assert.equal(isTransientShellPage(""), false);
+    assert.equal(isTransientShellPage("file:"), false);
+  });
+});
+
+describe("transientEntryIndexes", () => {
+  it("lists the splash entry when the dashboard is active with the splash behind it", () => {
+    assert.deepEqual(
+      transientEntryIndexes({
+        currentUrl: DASHBOARD,
+        entries: [{ url: LOADING_WITH_ACCENT }, { url: DASHBOARD }],
+        activeIndex: 1,
+      }),
+      [0]
+    );
+  });
+
+  it("returns indexes in DESCENDING order (removal shifts later indexes down)", () => {
+    assert.deepEqual(
+      transientEntryIndexes({
+        currentUrl: DASHBOARD,
+        entries: [
+          { url: LOADING },
+          { url: TOKEN_PROMPT },
+          { url: DASH_ROUTE_A },
+          { url: LOADING_WITH_ACCENT },
+          { url: DASHBOARD },
+        ],
+        activeIndex: 4,
+      }),
+      [3, 1, 0]
+    );
+  });
+
+  it("lists nothing while the splash itself is the active page", () => {
+    // During boot/recovery the splash is legitimately current — the prune runs
+    // on the success transition, not on splash load.
+    assert.deepEqual(
+      transientEntryIndexes({
+        currentUrl: LOADING,
+        entries: [{ url: LOADING }],
+        activeIndex: 0,
+      }),
+      []
+    );
+  });
+
+  it("lists nothing for a pure-dashboard history (the SPA's own back must keep working)", () => {
+    assert.deepEqual(
+      transientEntryIndexes({
+        currentUrl: DASHBOARD,
+        entries: [{ url: DASH_ROUTE_A }, { url: DASHBOARD }],
+        activeIndex: 1,
+      }),
+      []
+    );
+  });
+
+  it("never lists the active entry, even if it is transient by URL", () => {
+    // Belt-and-braces: Chromium refuses to remove the active entry anyway.
+    assert.deepEqual(
+      transientEntryIndexes({
+        currentUrl: DASHBOARD, // current URL says dashboard…
+        entries: [{ url: LOADING }, { url: DASHBOARD }],
+        activeIndex: 0, // …but the snapshot marks the splash active
+      }),
+      []
+    );
+  });
+
+  it("tolerates a malformed snapshot without throwing", () => {
+    assert.deepEqual(
+      transientEntryIndexes({ currentUrl: DASHBOARD, entries: null, activeIndex: 0 }),
+      []
+    );
+    assert.deepEqual(
+      transientEntryIndexes({ currentUrl: DASHBOARD, entries: [null, undefined], activeIndex: 1 }),
+      []
+    );
+  });
+});
+
+describe("armSplashHistoryClear (simulated handoffs)", () => {
+  it("boot: splash → dashboard removes the splash entry, leaving it unreachable", () => {
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT); // splash paints — no prune (splash is active)
+    assert.equal(fake.removedIndexes.length, 0);
+    fake.navigate(DASHBOARD); // handoff commits
+    assert.deepEqual(fake.urls(), [DASHBOARD]);
+  });
+
+  it("reconnect: prunes ONLY the splash — the user's prior dashboard routes survive", () => {
+    // The regression the wholesale-clear design would have introduced (and the
+    // GPT review blocked on): the user navigates the SPA (real pushState
+    // history entries), the gateway dies, recovery re-paints loading.html into
+    // the LIVE window, then the reconnect handoff loads the dashboard. The
+    // splash entry must go; the user's own routes must NOT — in-app Back keeps
+    // working after a reconnect.
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT); // boot splash
+    fake.navigate(DASHBOARD); // boot handoff → splash pruned
+    fake.navigateInPage(DASH_ROUTE_A); // user navigates the SPA
+    fake.navigateInPage(DASH_ROUTE_B);
+    fake.navigate(LOADING); // gateway died — recovery re-paints the splash
+    fake.navigate(DASHBOARD); // reconnect handoff
+    assert.deepEqual(fake.urls(), [DASHBOARD, DASH_ROUTE_A, DASH_ROUTE_B, DASHBOARD]);
+  });
+
+  it("boot-only fix cannot pass: a second recovery re-paint is pruned too", () => {
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT);
+    fake.navigate(DASHBOARD);
+    fake.navigate(LOADING); // recovery #1
+    fake.navigate(DASHBOARD);
+    fake.navigate(LOADING); // recovery #2
+    fake.navigate(DASHBOARD);
+    assert.equal(fake.urls().some(isTransientShellPage), false);
+  });
+
+  it("token prompt: the renderer-driven prompt → dashboard handoff is covered too", () => {
+    // token-prompt.html navigates itself (window.location.href = dashboard),
+    // so there is no main-process loadURL to hook — the persistent
+    // did-finish-load listener must catch it. Both the splash AND the prompt
+    // entries are pruned.
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT);
+    fake.navigate(TOKEN_PROMPT); // 403 → prompt shown; prompt is active: no prune
+    assert.equal(fake.removedIndexes.length, 0);
+    fake.navigate(DASHBOARD); // user submits the token
+    assert.deepEqual(fake.urls(), [DASHBOARD]);
+  });
+
+  it("in-page SPA route changes never trigger a prune (no did-finish-load)", () => {
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT);
+    fake.navigate(DASHBOARD);
+    const removedSoFar = fake.removedIndexes.length;
+    fake.navigateInPage(DASH_ROUTE_A);
+    fake.navigateInPage(DASH_ROUTE_B);
+    assert.equal(fake.removedIndexes.length, removedSoFar);
+    assert.deepEqual(fake.urls(), [DASHBOARD, DASH_ROUTE_A, DASH_ROUTE_B]);
+  });
+
+  it("dashboard-only reloads (token retry) touch nothing", () => {
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc);
+    fake.navigate(LOADING_WITH_ACCENT);
+    fake.navigate(DASHBOARD);
+    const removedSoFar = fake.removedIndexes.length;
+    fake.navigate("http://localhost:5476/?token=rotated"); // token-retry reload
+    assert.equal(fake.removedIndexes.length, removedSoFar); // pure dashboard — untouched
+  });
+
+  it("is inert when the window is already torn down (isAlive false)", () => {
+    const fake = makeFakeWebContents();
+    armSplashHistoryClear(fake.wc, { isAlive: () => false });
+    fake.navigate(LOADING);
+    fake.navigate(DASHBOARD);
+    assert.equal(fake.removedIndexes.length, 0);
+  });
+
+  it("is inert on a webContents without navigationHistory", () => {
+    const handlers = {};
+    const wc = {
+      on: (ev, fn) => {
+        handlers[ev] = fn;
+      },
+      getURL: () => DASHBOARD,
+      navigationHistory: undefined,
+    };
+    armSplashHistoryClear(wc);
+    assert.doesNotThrow(() => handlers["did-finish-load"]());
+  });
+
+  it("swallows a teardown race (getURL throwing) like the surrounding loadFile sites do", () => {
+    const handlers = {};
+    const wc = {
+      on: (ev, fn) => {
+        handlers[ev] = fn;
+      },
+      getURL: () => {
+        throw new Error("Object has been destroyed");
+      },
+      navigationHistory: {
+        getAllEntries: () => [],
+        getActiveIndex: () => 0,
+        removeEntryAtIndex: () => true,
+      },
+    };
+    armSplashHistoryClear(wc);
+    assert.doesNotThrow(() => handlers["did-finish-load"]());
+  });
+});
+
+// Wiring contract: the behavior tests above prove the helper works; this pins
+// that main.js actually uses it — armed once per window in
+// setupWindowContents, which is what covers the main window AND per-connection
+// windows, and (being a persistent listener) the boot, recovery, and
+// token-prompt handoffs alike. A refactor that drops the arm call would leave
+// every other test green while reintroducing #5538 — the same pattern
+// hide-to-tray.test.js and fullscreen-bounds-settle.test.js use.
+describe("main.js splash-history wiring", () => {
+  const MAIN_JS = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+
+  it("requires the helper", () => {
+    assert.match(MAIN_JS, /require\("\.\/splash-history"\)/);
+  });
+
+  it("arms the prune inside setupWindowContents (once per window, before any handoff)", () => {
+    const start = MAIN_JS.indexOf("function setupWindowContents");
+    assert.notEqual(start, -1, "main.js must define setupWindowContents");
+    // The arm call lives early in the function body — well before the ~2000
+    // chars of view/bounds plumbing that follow view creation.
+    const region = MAIN_JS.slice(start, start + 2000);
+    assert.match(
+      region,
+      /armSplashHistoryClear\(view\.webContents/,
+      "setupWindowContents must arm the splash-history prune on the view's webContents"
+    );
+  });
+
+  it("guards the arm with the window/view liveness check main.js uses everywhere else", () => {
+    const at = MAIN_JS.indexOf("armSplashHistoryClear(view.webContents");
+    assert.notEqual(at, -1);
+    const region = MAIN_JS.slice(at, at + 300);
+    assert.match(region, /isAlive:.*isDestroyed\(\)/s);
+  });
+});


### PR DESCRIPTION
## Problem / Motivation

On the macOS desktop app, pressing mouse button 4 (the OS/Chromium history-back gesture on a 5-button mouse) navigates the app back to the boot splash screen (`loading.html`). The splash has no forward affordance, so the only recovery is quitting and relaunching the app.

## Why it matters

Any user with a multi-button mouse (or a macOS two-finger back swipe) can hit this at any time — one stray gesture bricks the session until a full restart. The dead-end entry is re-minted not just at boot but by every gateway reconnect/recovery repaint and by the token prompt, so the bug stays reachable for the whole app lifetime.

## What changed (motivation → approach → change)

**Symptom:** back gesture lands on the splash with no way out.

**Root cause:** `showLoadingThenConnect` paints `loading.html` into the main window's own `webContents`, then hands off to the dashboard with `loadURL` on that same `webContents` — making the splash an ordinary previous entry in Chromium's navigation history. Nothing anywhere in `website/electron/` clears it (`clearHistory` / `navigationHistory` / `canGoBack` / `goBack`: zero hits before this change). The same dead-end entries are minted by the gateway reconnect paths (which repaint `loading.html` into the live window) and by `token-prompt.html`.

**Change:** remove the unreachable entry instead of blocking the gesture — the dashboard is an SPA whose own in-app history the user may legitimately navigate, so intercepting back globally (`app-command` / `will-navigate` / swallowing button 4) would be a behavior change nobody asked for.

- New `website/electron/splash-history.js`: a small pure-logic helper plus `armSplashHistoryClear(wc)`, a persistent `did-finish-load` listener that **surgically removes** transient shell entries (`loading.html` / `token-prompt.html`, `file:` URLs only) from the window's navigation history via `webContents.navigationHistory.removeEntryAtIndex()` (Electron ≥34 API; the app pins Electron `^43` where the pre-36 `clearHistory()` spelling is gone), in descending index order, **only when** the committed page is not itself a transient shell page. Per-entry removal rather than `navigationHistory.clear()` on purpose: after a gateway reconnect the history legitimately holds the user's own prior dashboard routes behind the re-painted splash, and a wholesale clear would erase those too, breaking in-app Back — the splash entries are the bug, the dashboard entries are the user's. A pure-dashboard history is never touched.
- `main.js`: armed once per window in `setupWindowContents` — the single point through which the main window **and** per-connection windows pass — so one listener covers every splash/prompt → dashboard handoff: boot, both gateway recovery repaints, and the renderer-driven token-prompt submit (`window.location.href` in `token-prompt.html`, which no main-process `loadURL` hook could see). Listening on `did-finish-load` also avoids the `loadURL`-promise pitfall (it resolves before the navigation commits).
- Guarded for teardown the way every other `webContents` touch in this file is: `isAlive` (`win.isDestroyed()` / `webContents.isDestroyed()`) plus try/catch.
- `package.json`: `splash-history.js` added to the electron-builder `build.files` allowlist (the packaging tests enforce this; without it the packaged app would crash on the new `require`).

## Tests

New `website/electron/test/splash-history.test.js` (node:test, same fake-driven style as the neighboring suites):

- `isTransientShellPage`: matches `loading.html` / `token-prompt.html` as `file:` URLs (with query strings); never matches the dashboard, even for `http` URLs that mention `loading.html` in path or query; tolerates junk.
- `transientEntryIndexes`: lists the splash entry behind an active dashboard; returns indexes in descending order (removal shifts later indexes down); lists nothing while the splash is active, for a pure-dashboard history, or for the active entry; tolerates malformed snapshots.
- Simulated handoffs against a fake `webContents` (event capture + navigation-history model with `removeEntryAtIndex` semantics, including the active-entry refusal and index shifting): **boot** splash→dashboard prunes the splash; **reconnect with prior SPA routes** — the user's own pushState entries survive the prune and only the splash entry is removed (this is the regression case for the wholesale-clear design the first review round blocked); **repeat recovery** — a boot-only fix cannot pass; **token prompt** — the renderer-driven prompt→dashboard handoff prunes both splash and prompt entries; in-page SPA route changes and dashboard-only reloads (token retry) never trigger a prune; teardown races (`isAlive` false, `getURL` throwing, missing `navigationHistory`) are inert.
- Wiring contract (same pattern as `hide-to-tray.test.js` / `fullscreen-bounds-settle.test.js`): `main.js` requires the helper, arms it inside `setupWindowContents` on the view's `webContents`, and guards it with the liveness check. Mutation-checked: reverting the `main.js` wiring fails these tests; restoring goes green.

## Manual verification

The physical mouse gesture is not reproducible in CI and does not need to be: the assertion under test is that the splash is no longer a reachable history entry once the dashboard commits — pinned by the simulated-handoff tests above. Full electron shell suite run locally; the new file passes and the remaining failure set is byte-identical to `main`'s baseline on this machine (node 16 environment; CI runs node 24).

## Screenshots / video

N/A — no rendered UI change; the fix only removes an unreachable navigation-history entry.

<!-- no-visual-delta -->
**Why no screenshot:** main-process-only change; no pixel differs — the dashboard renders identically, the splash renders identically, only the back-gesture target set changes.

## Related Issues

Fixes #5538

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe navigation history
- [x] No secrets, credentials, or internal references in the diff
