### PR TITLE
fix: route residual bare aws probes through resolve_aws_bin (#5392)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/deps.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/deps.py
@@ -25,6 +25,23 @@ import shutil
 import subprocess
 import sys
 
+# The deploy engine owns the repo-wide ``aws``-CLI resolution chokepoint, and
+# narrate.py's polly spawn resolves through it -- so this doctor must probe the
+# same binary, or its verdict disagrees with what the pipeline actually runs
+# under a GUI-launched gateway's minimal PATH. The doctor also has to stay
+# runnable WITHOUT kiro_crew on sys.path (diagnosing that environment is part
+# of its job), so the resolver is an optional dependency: when it is not
+# importable the probe degrades to the bare-name PATH lookup so the remaining
+# checks still run. (In that environment narrate.py cannot import either, so
+# spawn-parity is moot there; the fallback keeps the doctor itself alive.)
+try:
+    from kiro_crew.deploy.engine import resolve_aws_bin
+except ImportError:  # kiro_crew not importable for this interpreter
+
+    def resolve_aws_bin() -> str:
+        """Bare-name fallback matching the plain PATH-probe behaviour."""
+        return "aws"
+
 
 def _home() -> pathlib.Path:
     """Resolved on call, never bound at import.
@@ -145,7 +162,9 @@ def check_speech() -> Result:
     )
     if piper_ready:
         return Result("speech", True, "auto picks piper -- local, nothing leaves the machine")
-    if shutil.which("aws"):
+    # Probe the same binary narrate.py's resolved polly spawn executes, so the
+    # doctor's verdict agrees with the pipeline under a minimal PATH.
+    if shutil.which(resolve_aws_bin()):
         detail = "auto picks polly -- runs in YOUR AWS account (costs a little)"
         if piper_bin:
             detail += "; piper is installed but has no model, so auto skips it. Set "

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references/narrate.py
@@ -56,6 +56,7 @@ from _pathcheck import (  # noqa: E402
     safe_output_path,
 )
 
+from kiro_crew.deploy.engine import resolve_aws_bin  # noqa: E402
 from kiro_crew.security import (  # noqa: E402
     redact_credentials,
     redact_exfiltration_urls,
@@ -256,7 +257,10 @@ def resolve_provider(requested: str, piper_binary: str, piper_model: str) -> str
         return requested
     if _piper_ready(piper_binary, piper_model):
         return "piper"
-    if shutil.which("aws"):
+    # Probe the same binary the polly spawn in synthesize() executes (the
+    # shared deploy-engine resolver), so auto's answer holds under a
+    # GUI-launched gateway's minimal PATH.
+    if shutil.which(resolve_aws_bin()):
         return "polly"
     raise SystemExit(
         "no speech provider available. This pipeline speaks through piper or polly\n"
@@ -300,7 +304,9 @@ def synthesize(
     if provider == "polly":
         out = dest_raw.with_suffix(".mp3")
         argv = [
-            "aws",
+            # Resolved absolutely (shared deploy-engine resolver) so a
+            # GUI-launched gateway's minimal PATH still finds the CLI.
+            resolve_aws_bin(),
             "polly",
             "synthesize-speech",
             "--output-format",

--- a/src/kiro_crew/cli_cloud.py
+++ b/src/kiro_crew/cli_cloud.py
@@ -21,6 +21,7 @@ from kiro_crew.cloud import login as login_mod
 from kiro_crew.cloud import sizes, ssm, ui, wizard
 from kiro_crew.cloud.aws import AWSError, CloudActionDenied
 from kiro_crew.cloud.config import DEFAULT_REGION, CloudConfig
+from kiro_crew.deploy.engine import resolve_aws_bin
 from kiro_crew.validation import ValidationError
 
 
@@ -363,8 +364,11 @@ def _cloud_doctor(args: argparse.Namespace) -> int:
 
     profile, region = _resolve(args)
     ui.note(f"{ui.BOLD}KiroCrew cloud — diagnostics{ui.RESET}")
-    # Client prerequisites.
-    if shutil.which("aws"):
+    # Client prerequisites. Probe the exact binary resolved spawn sites execute
+    # (the shared deploy-engine resolver), so the doctor's verdict agrees with
+    # what `kirocrew cloud` commands actually run under a GUI-launched
+    # gateway's minimal PATH.
+    if shutil.which(resolve_aws_bin()):
         ui.ok("aws CLI found")
     else:
         ui.fail("aws CLI not found — install it (https://aws.amazon.com/cli/)")

--- a/test/test_cloud_cli.py
+++ b/test/test_cloud_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 
 import pytest
 
@@ -423,3 +424,32 @@ class TestCloudLogin:
 
     def test_tunnel_is_alias_of_connect(self):
         assert cli_cloud._DISPATCH["tunnel"] is cli_cloud._DISPATCH["connect"]
+
+
+class TestDoctor:
+    def test_doctor_probes_resolved_aws_binary(self, monkeypatch, capsys):
+        """The doctor probes the binary resolved spawns execute, never the
+        bare name — a bare-name probe disagrees with resolved spawn sites
+        under a GUI-launched gateway's minimal PATH."""
+        resolved = "/opt/aws-cli/aws"
+        probed: list[str] = []
+
+        def fake_which(name, *args, **kwargs):
+            probed.append(name)
+            return name if name == resolved else None
+
+        monkeypatch.setattr(cli_cloud, "resolve_aws_bin", lambda: resolved)
+        monkeypatch.setattr(shutil, "which", fake_which)
+        monkeypatch.setattr(cli_cloud, "_resolve", lambda _args: ("dev", "us-west-2"))
+        monkeypatch.setattr(cli_cloud.ssm, "session_manager_plugin_installed", lambda: True)
+        monkeypatch.setattr(
+            cli_cloud.iam,
+            "reachability_check",
+            lambda profile, region: {"reachable": False, "note": ""},
+        )
+
+        assert cli_cloud.handle_cloud(_args(cloud_action="doctor")) == 0
+        out = capsys.readouterr().out
+        assert "aws CLI found" in out
+        assert resolved in probed
+        assert "aws" not in probed  # the bare-name probe is the defect

--- a/test/test_video_skill_aws_resolution.py
+++ b/test/test_video_skill_aws_resolution.py
@@ -1,0 +1,132 @@
+"""The residual ``aws`` probe/spawn sites route through the shared resolver.
+
+The deploy engine's ``resolve_aws_bin()`` is the repo's single ``aws``-CLI
+resolution chokepoint. A probe that asks ``shutil.which("aws")`` with the bare
+name disagrees with the resolved spawn sites under a GUI-launched gateway's
+minimal PATH: the probe answers "not installed" while the resolved spawn
+succeeds, or the reverse. These tests pin each converted site in the
+feature-demo-recording reference scripts to the resolver; the cloud doctor's
+converted probe is pinned beside its siblings in ``test_cloud_cli.py``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_REFS = (
+    _REPO_ROOT / "src/kiro_crew/apps/builtins/dev_fleet/skills/feature-demo-recording/references"
+)
+
+_RESOLVED = "/opt/aws-cli/aws"
+
+
+def _recording_which(probed: list[str]):
+    """A ``shutil.which`` stand-in that recognises only the resolved path."""
+
+    def fake_which(name: str, *args: object, **kwargs: object) -> str | None:
+        probed.append(name)
+        return name if name == _RESOLVED else None
+
+    return fake_which
+
+
+@pytest.fixture
+def narrate_mod():
+    """Load narrate.py, undoing its module-level ``sys.path`` insert and the
+    ``_pathcheck`` registration so neither leaks into later tests."""
+    path_before = list(sys.path)
+    had_pathcheck = "_pathcheck" in sys.modules
+    try:
+        yield load_skill_script("kc_video_narrate_aws_probe", _REFS / "narrate.py")
+    finally:
+        sys.path[:] = path_before
+        if not had_pathcheck:
+            sys.modules.pop("_pathcheck", None)
+
+
+class TestDepsSpeechProbe:
+    def test_check_speech_probes_resolved_binary(self, monkeypatch):
+        deps = load_skill_script("kc_video_deps_aws_probe", _REFS / "deps.py")
+        monkeypatch.delenv("KC_VIDEO_PIPER_MODEL", raising=False)
+        monkeypatch.setattr(deps, "resolve_aws_bin", lambda: _RESOLVED)
+        probed: list[str] = []
+        monkeypatch.setattr(shutil, "which", _recording_which(probed))
+
+        result = deps.check_speech()
+
+        assert result["ok"]
+        assert "polly" in result["detail"]
+        assert _RESOLVED in probed
+        assert "aws" not in probed  # the bare-name probe is the defect
+
+    def test_resolver_degrades_to_bare_name_without_kiro_crew(self, monkeypatch):
+        # A None entry makes ``from kiro_crew.deploy.engine import ...`` raise
+        # ImportError, which is the standalone-interpreter environment the
+        # doctor must keep diagnosing instead of crashing on import.
+        monkeypatch.setitem(sys.modules, "kiro_crew.deploy.engine", None)
+        deps = load_skill_script("kc_video_deps_aws_fallback", _REFS / "deps.py")
+        assert deps.resolve_aws_bin() == "aws"
+
+        # And the degraded probe is a WORKING bare-name PATH lookup: the
+        # doctor's speech check stays green when plain "aws" is on PATH.
+        monkeypatch.delenv("KC_VIDEO_PIPER_MODEL", raising=False)
+        probed: list[str] = []
+
+        def bare_which(name: str, *args: object, **kwargs: object) -> str | None:
+            probed.append(name)
+            return "/usr/bin/aws" if name == "aws" else None
+
+        monkeypatch.setattr(shutil, "which", bare_which)
+        result = deps.check_speech()
+        assert result["ok"]
+        assert "polly" in result["detail"]
+        assert "aws" in probed
+
+
+class TestNarrateAwsResolution:
+    def test_resolve_provider_probes_resolved_binary(self, monkeypatch, narrate_mod):
+        monkeypatch.setattr(narrate_mod, "resolve_aws_bin", lambda: _RESOLVED)
+        probed: list[str] = []
+        monkeypatch.setattr(shutil, "which", _recording_which(probed))
+
+        assert narrate_mod.resolve_provider("auto", "", "") == "polly"
+        assert _RESOLVED in probed
+        assert "aws" not in probed
+
+    def test_synthesize_polly_argv_head_is_resolved(self, monkeypatch, tmp_path, narrate_mod):
+        monkeypatch.setattr(narrate_mod, "resolve_aws_bin", lambda: _RESOLVED)
+        # safe_output_path confines outputs to the CWD, so stand inside tmp_path.
+        monkeypatch.chdir(tmp_path)
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = list(argv)
+            # The CLI writes the staged output itself; emulate the success shape
+            # so _staged_output publishes and synthesize returns normally.
+            pathlib.Path(argv[-1]).write_bytes(b"mp3")
+            return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        out = narrate_mod.synthesize(
+            "polly",
+            "hello world",
+            tmp_path / "line00",
+            voice="Matthew",
+            piper_binary="",
+            piper_model="",
+            aws_profile="",
+            aws_region="",
+        )
+
+        assert out.suffix == ".mp3"
+        assert captured["argv"][0] == _RESOLVED
+        assert captured["argv"][1:3] == ["polly", "synthesize-speech"]


### PR DESCRIPTION
## Summary

PR #5360 fixed the GUI-launch minimal-PATH root cause by routing aws binary
resolution through `deploy/engine.py::resolve_aws_bin()`, but four residual
surfaces still probed or spawned with the bare name `aws`. Under a
launchd-minimal PATH those probes disagree with what resolved spawn sites
actually execute (probe says "not installed" while the resolved spawn works,
or the reverse).

Refs #5392 — resolves items 2–3. Deliberately NOT `Closes`: the issue's item 1
(the `session-manager-plugin` probe in `cloud/ssm.py`) is a recorded design
decision about child-env injection and stays open on the issue for a human
decision.

## Changes

Mechanical conversion mirroring the established in-repo pattern
(`aws_consent._aws_cli_resolvable()`, artifact-deploy
`attach_backend.py`/`detach_backend.py`):

- `dev_fleet` feature-demo-recording `references/deps.py` `check_speech()`:
  probes `shutil.which(resolve_aws_bin())`. The resolver import is an optional
  dependency (`try/except ImportError` with a bare-name fallback) so the
  standalone doctor stays runnable without `kiro_crew` on `sys.path` — in that
  environment the probe degrades to the bare-name lookup so the remaining
  checks still run.
- `references/narrate.py` `resolve_provider()`: probes the resolved binary so
  `auto`'s answer matches the polly spawn below it.
- `references/narrate.py` `synthesize()`: the polly argv head is
  `resolve_aws_bin()` instead of the bare name. (`narrate.py` already
  hard-imports from `kiro_crew`, so the import adds no new coupling.)
- `cli_cloud.py` `_cloud_doctor()`: probes the resolved binary so the doctor's
  report agrees with what resolved `kirocrew cloud` spawns actually run.

## Testing

- New `test/test_video_skill_aws_resolution.py` pins each converted
  reference-script site to the resolver, pins the `deps.py` bare-name
  ImportError fallback, and exercises `check_speech()` under the fallback to
  prove the degraded probe is a working PATH lookup.
- New `TestDoctor` in `test/test_cloud_cli.py` pins the doctor's probe to the
  resolved binary (asserts the bare name is never probed).
- Local gates green: isort / flake8 (pinned 7.1.0) / mypy (1088 files, no
  issues) / full pytest — 65694 passed; the only 14 failures reproduce
  identically on unmodified `main` in the same environment (host-env
  core-count/home-dir assertions, unrelated files).

## Pre-push review

Two model-pinned read-only lanes: GPT (gpt-5.6-sol) PASS, no findings; Opus
(claude-opus-5) PASS, 0 blocking. Adopted 2 Opus advisories (comment parity
claim in `deps.py`, fallback test now exercises `check_speech()`); declined 2
(dead `return out` line pre-existing on `main`, informational function-local
`import shutil` placement on an unchanged line).
