### PR TITLE
fix(dashboard): warm background split panes on WS reconnect (#2348)

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -11,6 +11,7 @@ import { emitThemeSound } from './themeSound'
 import {
   fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentChunk, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, setFolderSuggestion, sseMcpAppRender, setGoalLoops, sseGoalLoop, sseSideQueue, reconcileWorkflowRuns
 } from '../store/chatSlice'
+import { anchorForSlot, loadLayout, sessionSlots } from './splitLayoutStore'
 import { TAB_ID } from '../api/tabId'
 import { api } from '../api/client'
 import { sanitizeLlmOutput } from '../utils/sanitize'
@@ -692,6 +693,31 @@ export function useWebSocket() {
         // Re-fetch active slot messages to recover from missed chunks
         const active = store.getState().chat.activeSlot
         if (active) dispatch(refreshSlot(active))
+        // refreshSlot self-guards to the ACTIVE slot, but the queue event family
+        // (queue_push/cancel/edit/reorder) is broadcast fire-and-forget with no
+        // replay — a mutation that happened while the socket was down never
+        // reaches this client, so a pane co-rendered in the active slot's split
+        // keeps rendering the queue it held at the drop (#2348). Warm every
+        // OTHER live member of that persisted split: warmSlotCache is the
+        // sanctioned background hydration (self-guards against the active slot,
+        // writes only the per-slot caches and never the active `messages`,
+        // rebuilds queued rows from the server's canonical queue), so the
+        // re-hydration is authoritative and idempotent. Members are validated
+        // against live slots (the ChatPage.splitAnchorForActive pattern) so a
+        // stale layout naming a deleted session costs no 404. With no persisted
+        // split nothing is dispatched. The catch keeps a corrupt persisted
+        // layout from aborting the rest of reconnect setup (resubscribes and
+        // focus re-announce below).
+        if (active) {
+          try {
+            const liveKeys = new Set(store.getState().dashboard.slots.map(s => s.key))
+            for (const member of new Set(sessionSlots(loadLayout(anchorForSlot(active))))) {
+              if (member !== active && liveKeys.has(member)) dispatch(warmSlotCache(member))
+            }
+          } catch (err) {
+            console.warn('reconnect split-pane warm skipped', err)
+          }
+        }
         // Eagerly subscribe to subagent events so chunks arrive even when
         // Activity Panel isn't open — final result still comes via done event.
         dispatch(clearSubagentsForSnapshot())

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -4162,11 +4162,28 @@ const chatSlice = createSlice({
         writeSlotPage(state, key, revived, warmIsPrefix ? hasMore : undefined,
           warmIsPrefix && hasMore ? boundedLen : undefined)
         retainServerTotal(state, key, total, running, warmSeq)
-        // Clear the per-slot run indicator (the _done frame already idles it;
-        // this is belt-and-braces for the fetch-completes-after-_done ordering).
-        const run = (state.slotRun[safeKey(key)] ??= { state: 'idle' })
-        run.state = 'idle'
-        run.lastChunkSeq = undefined
+        // Idle the per-slot run indicator only when the server says the turn is
+        // NOT running. This is a pure non-regression gate for the reconnect
+        // caller (which warms slots MID-TURN): idling is idempotent with the
+        // _done frame — the turn-done caller's belt-and-braces contract for the
+        // fetch-completes-after-_done ordering, unchanged — while the
+        // unconditional write it replaces wiped a RUNNING background pane's
+        // indicator with no server-side recovery until the next chunk frame.
+        // Deliberately NO write in the running direction: the warm is a
+        // point-in-time snapshot racing the ordered live-frame writers
+        // (chunk -> streaming, _done -> idle), and any promotion policy has a
+        // losing ordering (a late fulfillment resurrected a pane a _done had
+        // already idled, wedging its composer locked with no healer inside the
+        // reconnect suppression window). A turn that STARTED while the socket
+        // was down therefore still reads idle until its first post-reconnect
+        // frame — exactly as on main today, where reconnect never touches
+        // background run state at all; closing that pre-existing gap needs an
+        // ordering token on the run entry and is tracked separately.
+        if (!running) {
+          const run = (state.slotRun[safeKey(key)] ??= { state: 'idle' })
+          run.state = 'idle'
+          run.lastChunkSeq = undefined
+        }
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(createSlot.pending, (state) => { state.creatingSlot = true })

--- a/website/src/test/useWebSocketReconnect.splitPanes.test.ts
+++ b/website/src/test/useWebSocketReconnect.splitPanes.test.ts
@@ -1,0 +1,391 @@
+/** WS reconnect must re-hydrate BACKGROUND split panes, not just the active slot.
+ *
+ *  The queue event family (queue_push/cancel/edit/reorder) is broadcast
+ *  fire-and-forget with no per-client buffer, so a mutation that happens while
+ *  the socket is down never reaches this client. The reconnect branch used to
+ *  refresh only the ACTIVE slot (refreshSlot self-guards to it), leaving a
+ *  co-rendered background pane showing the queue state it held at the drop
+ *  (#2348). Warming every other split member through warmSlotCache closes the
+ *  window for the whole event family at once: its hydration rebuilds queued
+ *  rows from the server's canonical queue, so a stale card cannot survive it.
+ *
+ *  Assertions observe `api.chatSlotDetail` rather than thunk internals: a warm
+ *  is the bounded call `(slot, PANE_HYDRATE_LIMIT)`, the active refresh is the
+ *  unbounded call `(slot)` — the same observable the sibling reconnect and
+ *  warm-bound suites key on.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { api } from '../api/client'
+import { store as globalStore } from '../store'
+import chatReducer, { PANE_HYDRATE_LIMIT, setActiveSlot } from '../store/chatSlice'
+import { sseSlots } from '../store/dashboardSlice'
+import { saveLayout } from '../hooks/splitLayoutStore'
+import type { GridNode } from '../hooks/useSessionGrid'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+const sLeaf = (id: string, slot: string): GridNode => ({ type: 'leaf', id, kind: 'session', slot })
+const split = (id: string, children: GridNode[]): GridNode => ({
+  type: 'split',
+  id,
+  dir: 'col',
+  children,
+  sizes: children.map(() => 1 / children.length),
+})
+
+/** Every bounded (warm) fetch the mock saw, by slot key. */
+const warmedSlots = (): string[] =>
+  (api.chatSlotDetail as ReturnType<typeof vi.fn>).mock.calls
+    .filter(c => c[1] === PANE_HYDRATE_LIMIT)
+    .map(c => c[0] as string)
+
+describe('useWebSocket reconnect hydrates background split panes', () => {
+  let testStore: ReturnType<typeof createTestStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    localStorage.clear()
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // The hook DISPATCHES through the Provider store but READS `activeSlot`
+    // and `dashboard.slots` off the singleton store imported from '../store',
+    // so the read paths must be primed there (same harness note as
+    // UseWebSocketCoverage.test.tsx).
+    globalStore.dispatch(setActiveSlot('chat-active'))
+    globalStore.dispatch(sseSlots([{ key: 'chat-active' }, { key: 'chat-bg' }] as never))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    // Unconditional, because the fake-timer installs are restored INLINE at the
+    // end of each test. An assertion that fails before its restore line would
+    // otherwise leave fake timers installed for every LATER test here, burying
+    // the real failure under a cascade of unrelated ones. Idempotent when
+    // timers were never faked.
+    vi.useRealTimers()
+    localStorage.clear()
+    globalStore.dispatch(setActiveSlot(null))
+    globalStore.dispatch(sseSlots([] as never))
+  })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return createElement(Provider, { store: testStore },
+      createElement(QueryClientProvider, { client: qc }, children)
+    )
+  }
+
+  /** First connect, drop, reconnect — returns after the reconnect branch ran.
+   *  The mock is cleared just before the second open so every recorded call
+   *  belongs to the reconnect path alone. */
+  function connectDropReconnect(): void {
+    const ws1 = WS_INSTANCES[0]
+    act(() => { ws1.simulateOpen() })
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) }) // reconnect backoff
+    ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockClear()
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+  }
+
+  it('warms the non-active member of a two-pane split', () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    // The background pane is re-hydrated through the bounded warm path…
+    expect(warmedSlots()).toEqual(['chat-bg'])
+    // …while the active slot keeps its own unbounded refresh.
+    expect(api.chatSlotDetail).toHaveBeenCalledWith('chat-active')
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('dispatches no warm at all for a single-pane session', () => {
+    vi.useFakeTimers()
+    // No persisted split: the common case must not gain a single extra request.
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    expect(warmedSlots()).toEqual([])
+    // The only slot-detail traffic on reconnect is the active slot's refresh.
+    const calls = (api.chatSlotDetail as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls.every(c => c[0] === 'chat-active')).toBe(true)
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('never warms the active slot itself', () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    // Belt (the handler filters it) and braces (warmSlotCache's own
+    // active-slot guard returns before fetching): no bounded call for the
+    // active slot can exist on either layer.
+    expect(warmedSlots()).not.toContain('chat-active')
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('warms a duplicated member once (tree can name a slot twice)', () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [
+      sLeaf('a', 'chat-active'),
+      sLeaf('b', 'chat-bg'),
+      sLeaf('c', 'chat-bg'),
+    ]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    expect(warmedSlots()).toEqual(['chat-bg'])
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('finds the split when the active slot is a member but not the anchor', () => {
+    vi.useFakeTimers()
+    // Layout keyed by its FIRST session leaf ('chat-bg'), so the lookup must go
+    // through anchorForSlot rather than assuming the active slot anchors it.
+    saveLayout(null, split('s', [sLeaf('a', 'chat-bg'), sLeaf('b', 'chat-active')]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    expect(warmedSlots()).toEqual(['chat-bg'])
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('does not warm on the FIRST connect, only on reconnect', () => {
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    const ws1 = WS_INSTANCES[0]
+    act(() => { ws1.simulateOpen() })
+
+    // First connect takes the non-reconnect branch: nothing was missed, so
+    // nothing is warmed and the active slot is not even refreshed.
+    expect(warmedSlots()).toEqual([])
+
+    unmount()
+  })
+
+  it('does not idle a background member that is still running (mid-turn reconnect)', async () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    // The member's turn is still in flight when the socket drops: the warm's
+    // fulfilled reducer must not force its run indicator to idle (there is no
+    // server-side recovery for a background slot until the next chunk frame,
+    // so a quiet phase would stay mislabeled and unlock the pane's composer).
+    testStore = createTestStore({
+      chat: {
+        ...chatReducer(undefined, { type: '@@INIT' }),
+        activeSlot: 'chat-active',
+        slotRun: { 'chat-bg': { state: 'streaming' } },
+      },
+    })
+    // The reconnect fetchSlots reconcile deletes per-slot caches for sessions
+    // absent from the authoritative list — return the live pair so the
+    // preloaded run state survives to meet the warm.
+    ;(api.chatSlots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { key: 'chat-active' }, { key: 'chat-bg' },
+    ])
+    ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [], running: true, has_more: false, total: 0, queue: [],
+    })
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    // A streaming slot warms unbounded by the thunk's own design.
+    expect(api.chatSlotDetail).toHaveBeenCalledWith('chat-bg')
+
+    // Let the warm resolve and its fulfilled reducer run.
+    vi.useRealTimers()
+    await act(async () => { await new Promise(r => setTimeout(r, 20)) })
+    expect(testStore.getState().chat.slotRun['chat-bg']?.state).toBe('streaming')
+
+    unmount()
+  })
+
+  it('still idles the run indicator when the server reports not running', async () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    // Counter-case bounding the gate: a slot whose turn ENDED while the socket
+    // was down (client state stuck streaming, server says settled) must still
+    // be idled by the warm — the belt-and-braces contract of the turn-done
+    // caller survives the gate.
+    testStore = createTestStore({
+      chat: {
+        ...chatReducer(undefined, { type: '@@INIT' }),
+        activeSlot: 'chat-active',
+        slotRun: { 'chat-bg': { state: 'streaming' } },
+      },
+    })
+    ;(api.chatSlots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { key: 'chat-active' }, { key: 'chat-bg' },
+    ])
+    ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [], running: false, has_more: false, total: 0, queue: [],
+    })
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    vi.useRealTimers()
+    await act(async () => { await new Promise(r => setTimeout(r, 20)) })
+    expect(testStore.getState().chat.slotRun['chat-bg']?.state).toBe('idle')
+
+    unmount()
+  })
+
+  it('leaves the run entry absent when the server reports the turn live (no promotion)', async () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    // The warm is a point-in-time snapshot racing the ordered live-frame
+    // writers, so it never writes the RUNNING direction: any promotion policy
+    // has a losing ordering (see the resurrect case below). A turn that
+    // started while the socket was down reads idle until its first
+    // post-reconnect frame — the same behavior as main, where reconnect never
+    // touches background run state; the ordering-token fix is tracked
+    // separately.
+    testStore = createTestStore({
+      chat: { ...chatReducer(undefined, { type: '@@INIT' }), activeSlot: 'chat-active' },
+    })
+    ;(api.chatSlots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { key: 'chat-active' }, { key: 'chat-bg' },
+    ])
+    ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [], running: true, has_more: false, total: 0, queue: [],
+    })
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    vi.useRealTimers()
+    await act(async () => { await new Promise(r => setTimeout(r, 20)) })
+    expect(testStore.getState().chat.slotRun['chat-bg']).toBeUndefined()
+
+    unmount()
+  })
+
+  it('does not resurrect a pane a _done frame already idled (late warm fulfillment)', async () => {
+    vi.useFakeTimers()
+    saveLayout(null, split('s', [sLeaf('a', 'chat-active'), sLeaf('b', 'chat-bg')]))
+    // Ordering pin: snapshot taken while the turn ran (running: true), the
+    // _done frame lands BEFORE the warm's fulfillment reduces (entry exists,
+    // idle). The snapshot must not overwrite the ordered live writer — an
+    // idle-to-streaming promotion here wedged the pane's composer locked with
+    // no healer (the turn is over, so no further chunk frame arrives, and the
+    // reconnect suppression window skips the turn-done warm).
+    testStore = createTestStore({
+      chat: {
+        ...chatReducer(undefined, { type: '@@INIT' }),
+        activeSlot: 'chat-active',
+        // The _done frame's write: entry exists and reads idle.
+        slotRun: { 'chat-bg': { state: 'idle' } },
+      },
+    })
+    ;(api.chatSlots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { key: 'chat-active' }, { key: 'chat-bg' },
+    ])
+    // The snapshot predates the _done: it still claims the turn is running.
+    ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [], running: true, has_more: false, total: 0, queue: [],
+    })
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    vi.useRealTimers()
+    await act(async () => { await new Promise(r => setTimeout(r, 20)) })
+    expect(testStore.getState().chat.slotRun['chat-bg']?.state).toBe('idle')
+
+    unmount()
+  })
+
+  it('skips a layout member whose session no longer exists', () => {
+    vi.useFakeTimers()
+    // Stale persisted layout: 'chat-dead' was deleted while the layout kept
+    // naming it. The live-slots filter (ChatPage.splitAnchorForActive pattern)
+    // must drop it so a reconnect costs no 404 round-trip.
+    saveLayout(null, split('s', [
+      sLeaf('a', 'chat-active'),
+      sLeaf('b', 'chat-bg'),
+      sLeaf('c', 'chat-dead'),
+    ]))
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    expect(warmedSlots()).toEqual(['chat-bg'])
+    const calls = (api.chatSlotDetail as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls.some(c => c[0] === 'chat-dead')).toBe(false)
+
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('completes reconnect setup even when the persisted layout is corrupt', () => {
+    vi.useFakeTimers()
+    // Valid JSON, invalid tree shape: sessionSlots would throw on it. The warm
+    // block must absorb that so the statements after it (subagent resubscribe,
+    // focus re-announce) still run on every reconnect.
+    localStorage.setItem('mc-split-layouts', JSON.stringify({ 'chat-active': {} }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { unmount } = renderHook(() => useWebSocket(), { wrapper })
+    connectDropReconnect()
+
+    expect(warmedSlots()).toEqual([])
+    const ws2 = WS_INSTANCES[1]
+    // The reconnect branch ran to completion past the corrupt-layout read.
+    expect(ws2.send).toHaveBeenCalledWith(JSON.stringify({ type: 'subscribe_subagents' }))
+    expect(ws2.send).toHaveBeenCalledWith(JSON.stringify({ type: 'slot_focused', slot: 'chat-active' }))
+
+    warnSpy.mockRestore()
+    unmount()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary

After a WebSocket drop, the reconnect branch of `ws.onopen` re-hydrated only the **active** slot (`refreshSlot` self-guards to it). The queue event family (`queue_push` / `queue_cancel` / `queue_edit` / `queue_reorder`) is broadcast fire-and-forget with no per-client buffer or replay, so any mutation that happened while the socket was down never reached this client: a session pane co-rendered in a native split but not active kept rendering the queue state it held at the drop, until it became active or its queue drained.

**Fix (client-side, at the reconnect layer, covering the whole queue event family at once):** in the `wasConnectedRef.current` branch, enumerate the active slot's persisted split via the existing `splitLayoutStore` helpers (`anchorForSlot` + `loadLayout` + `sessionSlots`), dedupe members, validate them against live slots (the `ChatPage.splitAnchorForActive` pattern), and dispatch `warmSlotCache` for every live non-active member. `warmSlotCache` is the sanctioned background-hydration path: self-guards against the active slot, writes only per-slot caches, resolves concurrent warms newest-wins via `warmSeq`, and rebuilds queued rows from the server's canonical `queue` — re-hydration is authoritative and idempotent, so an edited/reordered/cancelled/appended card cannot survive it. The block is exception-isolated so a corrupt persisted layout cannot abort the rest of reconnect setup (subagent resubscribe, focus re-announce). With no persisted split, nothing is dispatched.

**Reducer hardening (required by the new caller):** `warmSlotCache.fulfilled` now idles the per-slot run indicator only when the server reports `running: false`. The unconditional idle was safe for the original turn-done caller (the `_done` frame precedes it), but the reconnect caller warms slots **mid-turn**: forcing idle wiped a running background pane's indicator with no server-side recovery until the next chunk frame (`syncSlotRunningFromServer` ignores non-active slots), mislabeling quiet phases and unlocking the pane's composer.

Deliberately **not** server-side queue replay / per-slot event versioning — the issue lists that as an alternative direction; it would supersede rather than complement this change and needs gateway protocol work.

## Tests

10 vitest cases in `website/src/test/useWebSocketReconnect.splitPanes.test.ts`, following the existing `useWebSocketReconnect.test.ts` MockWebSocket harness (singleton-store priming per the `UseWebSocketCoverage.test.tsx` note):

- two-pane split warms the non-active member; single-pane dispatches no warm; the active slot is never warmed; duplicate tree members warm once; a split found via a non-anchor member still warms; first connect never warms
- a still-running member keeps its run state through the warm (pins the reducer gate), and the not-running counter-case still idles (pins the turn-done contract)
- a deleted layout member is skipped (live-slots filter); a corrupt persisted layout no longer aborts reconnect setup

Fail-before verified for both the hook change (3 cases fail without it) and the reducer gate (1 case fails without it).

Verified: `npx tsc -b` clean; full vitest 23535 passed; backend gates clean (zero backend files changed; pytest 65695 passed, 4 failures host-environmental — this host's `/tmp` is owned by uid 65534, which the provider-executable ownership walk rejects by design).

## Pre-push review (dual model-pinned)

Both reviewers ran against the pre-review commit; all findings dispositioned:

- **Adopted (Opus BLOCKING):** the unconditional `run.state = 'idle'` in `warmSlotCache.fulfilled` — gated on server `running` (above), plus the pinning test and its counter-case.
- **Adopted (both advisories):** exception isolation for corrupt layouts (a valid-JSON malformed tree made `sessionSlots` throw synchronously inside `ws.onopen`, skipping subagent resubscribe and focus re-announce on every reconnect); live-slots member filter (stale layouts cost no 404); corrected two inaccurate comment claims (write-set of the fulfilled reducer; "always mounted").
- **Rebutted (GPT BLOCKING — warm snapshot vs. in-flight queue event):** a queue event landing during the warm's fetch window is folded to the fetch-time snapshot. This is the shared hydration path's documented, deliberate semantics (`chatSlice.ts`: "It strips any WS-delivered queued bubbles first (a queue_push may have arrived during the fetch) so the server queue set stays canonical and non-duplicated"), and the identical window exists today at the pre-existing turn-done caller (`useWebSocket.ts` `chat_done` → `warmSlotCache`). Event buffering or a per-slot mutation generation is new replay machinery — the direction the issue explicitly deferred. Within the race window the pane still strictly improves (the snapshot covers the whole outage; the missed post-reconnect event self-heals at the next queue event, turn boundary, or focus).

## Known trade-offs

- **Fan-out bound:** pane count is bounded by split-UI geometry (`MIN_FRAC = 0.12` floor per pane), each warm response by `PANE_HYDRATE_LIMIT`; a member stuck client-side in `streaming` warms unbounded by the thunk's own documented design (bounding a streaming slot would keep just the collapsed tail). Changing that is a `warmSlotCache` design question, out of scope here.
- **Persisted-split members are warmed even when the user is currently in single-chat view** (split mount state is ephemeral React state, not observable from `useWebSocket` without new plumbing). Fail-safe: hydration is idempotent and bounded, and the user re-entering the split sees fresh state.

Closes #2348
