### PR TITLE
fix: redact cron stderr/stdout before truncating, report stderr tail

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -722,7 +722,10 @@ def run_script_sandboxed(
         except (json.JSONDecodeError, IndexError):
             return {
                 "status": "error",
-                "error": f"Bad output: {redact(stdout[:200])}",
+                # Redact the complete stdout BEFORE truncating: slicing first
+                # could cut a credential at the boundary, leaving its unredacted
+                # head in the diagnostic.
+                "error": f"Bad output: {redact(stdout)[:200]}",
             }
     except subprocess.TimeoutExpired:
         return {"status": "error", "error": f"Script timed out after {timeout}s"}
@@ -912,7 +915,13 @@ def run_command_sandboxed(command: str, timeout: int = 300, job_id: str | None =
         if proc.returncode != 0:
             output = f"⚠️ Exit code {proc.returncode}\n\n{output}"
             if stderr_out:
-                output += f"\n\nstderr:\n{stderr_out[:1000]}"
+                # A command that dies hard leaves its diagnosis last: report the
+                # stderr tail, not the head, so a chatty startup warning can't
+                # displace the terminal error. Redact the complete stderr BEFORE
+                # truncating: slicing first could cut off a credential's
+                # detectable prefix (e.g. the scheme of a token-bearing URL),
+                # letting the raw secret tail through redaction.
+                output += f"\n\nstderr:\n{redact(stderr_out.rstrip())[-1000:]}"
         return {
             "status": "ok" if proc.returncode == 0 else "error",
             "output": output,

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -167,6 +167,57 @@ class TestRunCommandSandboxed:
         assert "truncated" in result["output"]
         assert len(result["output"]) <= 70000
 
+    def test_nonzero_exit_reports_stderr_tail_not_head(self):
+        """A leading startup warning must not displace the terminal error."""
+        leading_warning = "startup warning: " + ("x" * 1000)
+        terminal_error = "sh: fatal: actual cause"
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", leading_warning + "\n" + terminal_error)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = run_command_sandboxed("boom")
+        assert result["status"] == "error"
+        assert "actual cause" in result["output"]
+        assert "startup warning" not in result["output"]
+
+    def test_nonzero_exit_redacts_stderr_before_truncating(self):
+        """A credential straddling the 1000-char boundary must not leak its tail.
+
+        Redaction must run on the WHOLE stderr before the tail slice: slicing
+        first can cut off a secret's detectable prefix, so the pattern no
+        longer matches and the raw tail reaches the cron result.
+        """
+        # Built at runtime so no credential-shaped literal lands in the repo.
+        fake_key = "AKIA" + "B" * 16  # matches the AWS access-key-id pattern
+        # Sized so the 1000-char tail window starts 2 chars into the credential:
+        # a slice-then-redact order keeps "IA" + all 16 B's but drops the
+        # "AK" prefix, so the pattern no longer matches and the tail leaks.
+        padding = "p" * 100
+        trailing = "e" * 982
+        stderr_text = padding + fake_key + trailing
+        assert len(stderr_text) - 1000 == len(padding) + 2
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", stderr_text)
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = run_command_sandboxed("boom")
+        assert result["status"] == "error"
+        assert "B" * 16 not in result["output"]
+        assert fake_key not in result["output"]
+        # Positive proof the payload flowed through redaction (not a vacuous
+        # pass on an empty result): the marker's tail survives the tail slice.
+        assert "credential]" in result["output"]
+        assert "e" * 50 in result["output"]
+
+    def test_nonzero_exit_short_stderr_stays_whole(self):
+        """A stderr already shorter than the 1000-char bound is kept whole."""
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ("", "short failure\n")
+        with patch("subprocess.Popen", return_value=mock_proc):
+            result = run_command_sandboxed("boom")
+        assert result["output"].endswith("stderr:\nshort failure")
+
 
 class TestCronSandboxUnavailableIsStructuredNotRaised:
     """A host with no OS sandbox backend (every Windows host) makes wrap_argv
@@ -1154,6 +1205,38 @@ class TestRunScriptSandboxedErrorPaths:
             result = run_script_sandboxed("/f.py:run", "j1", "")
         assert result["status"] == "error"
         assert "Bad output" in result.get("error", "")
+
+    def test_bad_json_output_redacts_before_truncating(self, tmp_path):
+        """A credential straddling the 200-char boundary must not leak its head.
+
+        Redaction must run on the WHOLE stdout before the head slice: slicing
+        first can cut a secret mid-pattern, so redaction no longer matches and
+        the raw head reaches the diagnostic.
+        """
+        # Built at runtime so no credential-shaped literal lands in the repo.
+        fake_key = "AKIA" + "B" * 16  # matches the AWS access-key-id pattern
+        # Sized so the 200-char head window ends 10 chars into the credential:
+        # a slice-then-redact order keeps "AKIA" + 6 B's — too short for the
+        # pattern to match, so the raw head leaks into the diagnostic.
+        padding = "p" * 190
+        stdout_text = padding + fake_key + "e" * 50
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (stdout_text, "")
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "")
+        assert result["status"] == "error"
+        assert "AKIA" not in result["error"]
+        assert fake_key not in result["error"]
+        # Positive proof the payload flowed through redaction (not a vacuous
+        # pass on an empty diagnostic): the 200-char head window ends 10 chars
+        # into the replacement marker, so its head survives the slice.
+        assert "[REDACTED:" in result["error"]
+        assert padding in result["error"]
 
 
 class TestMcpCronHandlerPaths:


### PR DESCRIPTION
## Problem / Motivation

Two sibling sites in `src/kiro_crew/cron_script.py` retain the truncation patterns that the fix to `run_script_sandboxed`'s failure branch (#4402) removed, and were deliberately left out of that PR's scope:

1. **`run_command_sandboxed` failure branch** appended `stderr_out[:1000]` -- the HEAD of stderr, unredacted. A command cron that emits a chatty startup warning before crashing reports the warning instead of the terminal error, and a credential anywhere in that head reaches the cron result raw.
2. **`run_script_sandboxed`'s bad-output diagnostic** built `redact(stdout[:200])` -- truncating BEFORE redacting. A credential straddling the 200-char boundary loses the tail the redaction pattern needs, so its unredacted head leaks into the diagnostic.

## Why it matters

Cron failure output flows to alert surfaces (Slack, dashboard notifications, logs). The head slice makes the report useless exactly when it is needed (the terminal error is displaced by startup noise), and both slice-before-redact orderings defeat credential redaction at the truncation boundary -- `redact()`'s patterns (e.g. AKIA-prefixed access-key ids) cannot match a string the slice already cut in half.

## What changed (motivation → approach → change)

Symptom, root cause, then the change, mirroring the ordering #4402 established:

- **`run_command_sandboxed` failure branch:** `stderr_out[:1000]` becomes `redact(stderr_out.rstrip())[-1000:]`. Redact the complete stderr first (so no boundary can strand a secret), then take the TAIL -- a process that dies hard leaves its diagnosis last, so the tail carries the traceback, not the startup warning.
- **`run_script_sandboxed` bad-output diagnostic:** `redact(stdout[:200])` becomes `redact(stdout)[:200]`. Same 200-char window, but redaction now sees the whole stream before the slice.

Deliberately NOT touched: the nonzero-exit/empty-stdout branch a few lines above the diagnostic (`stderr[:500]`) -- that hunk is exactly the diff of the still-open #4402 and is fixed there; changing it here would collide with that PR. This PR covers only the two sites #5547 names.

## Tests

Four new tests, each mutation-verified red against the pre-fix code:

- `TestRunCommandSandboxed::test_nonzero_exit_reports_stderr_tail_not_head` -- a >1000-char leading warning must not displace the terminal error.
- `TestRunCommandSandboxed::test_nonzero_exit_redacts_stderr_before_truncating` -- an AWS-key-shaped credential laid so the 1000-char tail window starts 2 chars into it: slice-then-redact leaks the 16-char tail, redact-then-slice does not. Positive assertions pin that the redaction marker and surrounding context survive (no vacuous pass).
- `TestRunCommandSandboxed::test_nonzero_exit_short_stderr_stays_whole` -- a short stderr is reported whole (pins the `rstrip` behavior).
- `TestRunScriptSandboxedErrorPaths::test_bad_json_output_redacts_before_truncating` -- a credential laid so the 200-char head window ends 10 chars into it: slice-then-redact leaks the raw head, redact-then-slice shows the marker's head instead.

Local gates: black gate, subprocess-encoding gate, isort, flake8, `mypy src/kiro_crew` (1088 files clean), `test/test_cron_script.py` 105 passed / 1 skipped. Full suite run; the only failures are this host's pre-existing real-home-layout floor failures, reproduced identically on a pristine `main` worktree (zero cron-related).

## Manual verification

N/A -- unit coverage sufficient: both changes are pure string-ordering fixes on already-tested branches, and the tests pin the exact byte layouts of the leak.

Closes #5547
