### PR TITLE
fix(knowledge): 400 not 500 on non-object or invalid JSON request bodies

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1378,
+    "missing_code": 1373,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 966,
+  "_compliant": 1062,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -103,7 +103,7 @@
       "missing_code": 1
     },
     "dashboard/handlers/knowledge.py": {
-      "missing_code": 66
+      "missing_code": 61
     },
     "dashboard/handlers/mcp.py": {
       "dynamic_status": 1,

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -12,6 +12,7 @@ import tempfile
 import zipfile
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
 
 from aiohttp import web
 
@@ -151,6 +152,52 @@ def _store(request: web.Request):
 
 def _pipeline(request: web.Request):
     return request.app.get("knowledge_pipeline")
+
+
+async def _json_object_body(
+    request: web.Request, *, allow_absent: bool = False
+) -> tuple[dict[str, Any] | None, web.Response | None]:
+    """Parse the request body as a JSON **object**, or produce the 400 to return.
+
+    ``await request.json()`` happily returns a list, string, or number for a
+    body that is valid JSON but not an object, and every caller in this module
+    then calls ``.get()`` on the result -- which raises and turns a client
+    mistake into a 500. One owner for the parse-and-shape guard keeps the
+    module's ``request.json()`` call sites on a single contract instead of
+    bespoke per-handler guards.
+
+    Returns ``(body, None)`` on success, or ``(None, error_response)`` when
+    the caller should return early. *allow_absent* treats a request without a
+    readable body as an empty object, for endpoints whose fields all have
+    defaults.
+
+    Deliberately separate from ``_shared.read_bounded_json``, which shares the
+    ``invalid_json``/``body_not_object`` codes: switching these nine sites onto
+    it would mean choosing a byte cap per endpoint (its ``max_bytes`` must be
+    a number, and knowledge bundles have no principled ceiling today), would
+    change the ``"invalid JSON"`` message text existing tests and callers pin,
+    and it has no *allow_absent*. Consolidating the two helpers is deferred
+    scope, not a disagreement about the contract.
+    """
+    if allow_absent and not request.can_read_body:
+        return {}, None
+    try:
+        parsed = await request.json()
+    except (LookupError, RecursionError, ValueError):
+        # json.JSONDecodeError and UnicodeDecodeError are ValueError
+        # subclasses; LookupError is an unknown charset= codec in the
+        # client's Content-Type header; RecursionError is a deeply nested
+        # JSON document blowing the parser's stack. All are client mistakes.
+        # Transport failures (disconnect mid-body, read timeout) deliberately
+        # propagate: they are not a client JSON mistake and keep their 500
+        # status class.
+        return None, web.json_response(
+            {"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    if not isinstance(parsed, dict):
+        return None, web.json_response(
+            {"error": "body must be a JSON object", "code": "body_not_object"},
+            status=400)
+    return parsed, None
 
 
 def _create_embedder(app):
@@ -490,10 +537,10 @@ async def update_item(request: web.Request) -> web.Response:
     item_id = request.match_info["id"]
     if not store.get_item(item_id):
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     allowed = {"tags", "item_type", "status", "title", "summary", "namespace"}
     fields = {k: v for k, v in body.items() if k in allowed}
     if not fields:
@@ -823,10 +870,10 @@ async def pick_folder(request: web.Request) -> web.Response:
 async def add_source(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources -- add a remote source."""
     store = _store(request)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     name = body.get("name", "")
     source_type = body.get("source_type", "")
     uri = body.get("uri", "")
@@ -1172,10 +1219,10 @@ async def rename_source(request: web.Request) -> web.Response:
     source_id = request.match_info["id"]
     if not store.db.execute("SELECT 1 FROM sources WHERE id = ?", (source_id,)).fetchone():
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     name = body.get("name")
     if not isinstance(name, str):
         return web.json_response({"error": "name must be a string"}, status=400)
@@ -1300,7 +1347,10 @@ async def retry_file(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources/{id}/files/retry -- reset file to pending."""
     store = _store(request)
     source_id = request.match_info["id"]
-    body = await request.json()
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     file_path = body.get("file_path", "")
     if not file_path:
         return web.json_response({"error": "file_path required"}, status=400)
@@ -1319,7 +1369,10 @@ async def skip_file(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources/{id}/files/skip -- mark file as skipped."""
     store = _store(request)
     source_id = request.match_info["id"]
-    body = await request.json()
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     file_path = body.get("file_path", "")
     if not file_path:
         return web.json_response({"error": "file_path required"}, status=400)
@@ -1344,10 +1397,10 @@ async def ingest_text(request: web.Request) -> web.Response:
     pipeline = _pipeline(request)
     if not pipeline:
         return web.json_response({"error": "pipeline not configured"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     text = body.get("text", "")
     if not text:
         return web.json_response({"error": "no text provided"}, status=400)
@@ -1592,10 +1645,10 @@ async def export_all(request: web.Request) -> web.Response:
 
 async def import_bundle(request: web.Request) -> web.Response:
     """POST /api/knowledge/import -- accept .knowledge JSON bundle."""
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     shape_error = _validate_knowledge_bundle(body)
     if shape_error is not None:
         _sel_log("import", outcome="rejected", reason=shape_error)
@@ -1708,7 +1761,10 @@ async def batch_embed_items(request: web.Request) -> web.Response:
     if not await embedder.is_available_async():
         return web.json_response({"error": "Embedding model not available"}, status=503)
 
-    body = await request.json() if request.can_read_body else {}
+    body, body_err = await _json_object_body(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     rebuild = body.get("rebuild", False)
     force = body.get("force", False)
 
@@ -1879,11 +1935,10 @@ async def add_agent_document_route(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "pipeline not configured",
              "code": "pipeline_unavailable"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await _json_object_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_object_body returns (dict, None) on success
     result = await add_agent_document(
         pipeline,
         title=str(body.get("title") or ""),

--- a/test/test_knowledge_handlers_coverage.py
+++ b/test/test_knowledge_handlers_coverage.py
@@ -709,14 +709,15 @@ class TestImportBundle:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("payload", [[1, 2, 3], "just a string", 42])
     async def test_non_object_json_is_400_not_500(self, store, payload):
-        # request.json() happily parses a bare array/string/number/null; the
-        # handler's own redaction loop then calls body.get(...) on it, an
-        # AttributeError past every try/except in the function.
+        # request.json() happily parses a bare array/string/number/null. The
+        # shared _json_object_body guard answers the non-object case for all
+        # nine request.json() sites in this module, so it fires before the
+        # bundle-shape validator and owns this code.
         async with _client(_make_app(store)) as client:
             resp = await client.post("/api/knowledge/import", json=payload)
             assert resp.status == 400
             body = await resp.json()
-        assert body["code"] == "malformed_knowledge_bundle"
+        assert body["code"] == "body_not_object"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("bundle", [
@@ -1706,3 +1707,222 @@ class TestSetupKnowledgeRoutes:
         watcher.stop.assert_awaited_once()
         await asyncio.gather(forever, return_exceptions=True)
         assert forever.cancelled()
+
+
+# ------------------------------------------------- JSON object body guard
+
+
+def _guard_app(store, **kwargs):
+    """``_make_app`` plus the mutation routes the body-shape guard tests hit."""
+    app = _make_app(store, **kwargs)
+    r = app.router
+    r.add_post("/api/knowledge/sources", kh.add_source)
+    r.add_patch("/api/knowledge/sources/{id}", kh.rename_source)
+    r.add_post("/api/knowledge/sources/{id}/files/retry", kh.retry_file)
+    r.add_post("/api/knowledge/sources/{id}/files/skip", kh.skip_file)
+    return app
+
+
+# Valid JSON that is not an object: calling ``.get`` on either raised
+# AttributeError and surfaced as a 500 before the shared guard.
+_NON_OBJECT_BODIES = ([1, 2], 7)
+
+
+class TestJsonObjectBodyGuard:
+    """Every ``request.json()`` site answers 400, not 500, on a body that is
+    valid JSON but not an object -- and the two previously-unguarded sites
+    (files/retry, files/skip) now answer 400 on invalid JSON too."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_update_item_non_object_body_is_400(self, store, payload):
+        item_id = store.add_item("a", "body", "note")
+        async with _client(_guard_app(store)) as client:
+            resp = await client.patch(f"/api/knowledge/items/{item_id}", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_add_source_non_object_body_is_400(self, store, payload):
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post("/api/knowledge/sources", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_rename_source_non_object_body_is_400(self, store, payload):
+        sid = store.add_source("s", "web", "https://example.com")
+        async with _client(_guard_app(store)) as client:
+            resp = await client.patch(f"/api/knowledge/sources/{sid}", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("endpoint", ["retry", "skip"])
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_file_state_non_object_body_is_400(self, store, endpoint, payload):
+        sid = store.add_source("s", "local_folder", "/tmp/x")
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{sid}/files/{endpoint}", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("endpoint", ["retry", "skip"])
+    async def test_file_state_invalid_json_is_400_not_500(self, store, endpoint):
+        # These two sites previously had no try/except at all: a malformed
+        # body escaped as a raw JSONDecodeError and surfaced as a 500.
+        sid = store.add_source("s", "local_folder", "/tmp/x")
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{sid}/files/{endpoint}",
+                data="not json", headers={"Content-Type": "application/json"})
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_ingest_text_non_object_body_is_400(self, store, payload):
+        sid = store.add_source("s", "web", "https://example.com")
+        async with _client(_guard_app(store, pipeline=MagicMock())) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{sid}/ingest-text", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_import_bundle_non_object_body_is_400(self, store, payload):
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post("/api/knowledge/import", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_agent_document_non_object_body_is_400(
+            self, store, monkeypatch, payload):
+        monkeypatch.setattr(f"{MODULE}.KiroCrewConfig.load", staticmethod(_cfg))
+        async with _client(_guard_app(store, pipeline=MagicMock())) as client:
+            resp = await client.post("/api/knowledge/agent-document", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", _NON_OBJECT_BODIES)
+    async def test_batch_embed_non_object_body_is_400(self, store, payload):
+        async with _client(_guard_app(store, embedder=_FakeEmbedder())) as client:
+            resp = await client.post("/api/knowledge/embedding/generate", json=payload)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_batch_embed_invalid_json_is_400(self, store):
+        async with _client(_guard_app(store, embedder=_FakeEmbedder())) as client:
+            resp = await client.post(
+                "/api/knowledge/embedding/generate",
+                data="{oops", headers={"Content-Type": "application/json"})
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_batch_embed_absent_body_still_means_defaults(self, store):
+        # No body at all keeps the fill-NULL default path (not a 400): the
+        # guard's allow_absent branch preserves the pre-guard contract.
+        async with _client(_guard_app(store, embedder=_FakeEmbedder())) as client:
+            resp = await client.post("/api/knowledge/embedding/generate")
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_yields_code_at_every_site(self, store, monkeypatch):
+        # At the previously-guarded sites the parse-failure path's entire
+        # change is the machine-readable ``code`` field -- pin it everywhere.
+        monkeypatch.setattr(f"{MODULE}.KiroCrewConfig.load", staticmethod(_cfg))
+        item_id = store.add_item("a", "body", "note")
+        sid = store.add_source("s", "web", "https://example.com")
+        app = _guard_app(store, pipeline=MagicMock(), embedder=_FakeEmbedder())
+        endpoints = [
+            ("patch", f"/api/knowledge/items/{item_id}"),
+            ("post", "/api/knowledge/sources"),
+            ("patch", f"/api/knowledge/sources/{sid}"),
+            ("post", f"/api/knowledge/sources/{sid}/files/retry"),
+            ("post", f"/api/knowledge/sources/{sid}/files/skip"),
+            ("post", f"/api/knowledge/sources/{sid}/ingest-text"),
+            ("post", "/api/knowledge/import"),
+            ("post", "/api/knowledge/embedding/generate"),
+            ("post", "/api/knowledge/agent-document"),
+        ]
+        async with _client(app) as client:
+            for method, path in endpoints:
+                resp = await getattr(client, method)(
+                    path, data="{oops", headers={"Content-Type": "application/json"})
+                assert resp.status == 400, (path, resp.status)
+                assert (await resp.json())["code"] == "invalid_json", path
+
+    @pytest.mark.asyncio
+    async def test_absent_body_is_400_at_non_allow_absent_site(self, store):
+        # Only the embedding-generate site opts into allow_absent; everywhere
+        # else an empty body is a client mistake, not silent defaults.
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post("/api/knowledge/sources")
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_unknown_charset_is_400_not_500(self, store):
+        # charset= names a codec Python does not have: request.json() raises
+        # LookupError (not a ValueError), which must also read as a client
+        # mistake, not a 500.
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post(
+                "/api/knowledge/sources", data=b'{"name": "x"}',
+                headers={"Content-Type": "application/json; charset=not-a-codec"})
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_recursion_error_is_400_not_500(self):
+        # A deeply nested document blows the JSON parser's recursion budget:
+        # request.json() raises RecursionError (not a ValueError), which must
+        # also read as a client mistake. The raise threshold varies by Python
+        # version and platform (~1k on 3.10, ~10k on 3.12, lower on
+        # small-stack Windows), so a real payload either misses the threshold
+        # or gambles with the worker's C stack -- pin the contract at the
+        # helper boundary like the transport-error test below.
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=RecursionError())
+        body, err = await kh._json_object_body(request)
+        assert body is None
+        assert err is not None
+        assert err.status == 400
+        assert json.loads(err.text)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_transport_errors_propagate_not_400(self):
+        # A disconnect mid-body is not a client JSON mistake: the narrowed
+        # ValueError catch must let transport failures keep their 500 class.
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ConnectionResetError())
+        with pytest.raises(ConnectionResetError):
+            await kh._json_object_body(request)
+
+    @pytest.mark.asyncio
+    async def test_file_state_object_body_still_works(self, store):
+        # The guard must not break the success path it fronts.
+        sid = store.add_source("s", "local_folder", "/tmp/x")
+        store.db.execute(
+            "INSERT INTO folder_file_state (source_id, file_path, last_seen, status) "
+            "VALUES (?, ?, '2026-01-01', 'failed')", (sid, "/tmp/x/a.md"))
+        store.db.commit()
+        async with _client(_guard_app(store)) as client:
+            resp = await client.post(
+                f"/api/knowledge/sources/{sid}/files/retry",
+                json={"file_path": "/tmp/x/a.md"})
+            assert resp.status == 200
+            row = store.db.execute(
+                "SELECT status FROM folder_file_state WHERE source_id = ?",
+                (sid,)).fetchone()
+            assert row["status"] == "pending"


### PR DESCRIPTION
## Problem / Motivation

`knowledge.py` has 9 `await request.json()` sites that call `.get()` on the parsed body. A body that is valid JSON but not an object -- a list or an int -- raised `AttributeError` and surfaced as a 500, and the `files/retry` / `files/skip` sites had no `try/except` at all, so invalid JSON also escaped as a raw 500 there. Follow-up from the First Principles review of #3748, which hardened only `import_bundle` (and is unmerged, so on main all 9 sites were exposed).

## Why it matters

A malformed request is a client mistake and should get a clean, machine-readable 400. A 500 pages the operator, pollutes logs with tracebacks, and gives API callers no way to distinguish "my request was wrong" from "the server is broken". With 9 bespoke guards (or none), the error contract drifts per handler.

## What changed

- One module-local helper `_json_object_body(request, *, allow_absent=False)` now owns the parse-and-shape guard for all 9 sites: 400 `{"error": "invalid JSON", "code": "invalid_json"}` on a parse failure, 400 `{"error": "body must be a JSON object", "code": "body_not_object"}` on a non-dict -- matching the codes `_shared.read_bounded_json` already uses.
- The catch covers `ValueError` (`json.JSONDecodeError` / `UnicodeDecodeError`), `LookupError` (an unknown `charset=` codec in the client Content-Type header), and `RecursionError` (deeply nested JSON blowing the parser stack), while transport failures (disconnect mid-body, read timeout) propagate and keep their 500 status class.
- The embedding-generate site opts into `allow_absent=True`, preserving its absent-body-means-defaults contract.
- Deliberately NOT reusing `_shared.read_bounded_json`: it shares the error codes but requires choosing a byte cap per endpoint (knowledge bundles have no principled ceiling today), changes the "invalid JSON" message text existing tests and callers pin, and lacks `allow_absent`. Consolidating the two helpers is deferred scope; the helper docstring records the rationale.
- `error-code-baseline.json` re-snapshotted: attaching `code` fields improved the module's `missing_code` count 66->61 and the ratchet test requires the baseline to track improvements.

## Tests

27 new tests in `test/test_knowledge_handlers_coverage.py::TestJsonObjectBodyGuard`; the non-object and previously-unguarded invalid-JSON cases were mutation-verified red-on-base (21/23 fail on main with `assert 500 == 400`), and the transport-propagation pin was mutation-verified against a widened `except Exception`:

- non-object valid JSON (list / int) -> 400 `body_not_object` at every one of the 9 sites
- invalid JSON -> 400 `invalid_json` pinned (with `code`) at every one of the 9 sites, including `files/retry` and `files/skip` which previously 500'd
- absent body at a non-`allow_absent` site -> 400 `invalid_json`; absent body at embedding-generate -> still the defaults path (200)
- transport errors (`ConnectionResetError`) propagate out of the helper rather than becoming a 400
- success path preserved: `files/retry` with a proper object body still flips the row to `pending`

Local gates green: black / subprocess-encoding / brand scans, isort, flake8, mypy (0 issues in 1088 files), full pytest (65,708 passed; 10 host-environment failures proven identical on clean main). Pre-push review: GPT and Opus lanes both NO BLOCKING; Opus quality findings addressed (narrowed catch + invalid-JSON coverage + commit body) or dispositioned in the helper docstring.

Closes #5560

Kiro Crew [operator: chenmingwei23]
