### PR TITLE
test: cover crash-dump fd surviving loss of its last Python reference

### DIFF
--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -453,6 +453,86 @@ def test_dump_file_fileno_is_stable(dumps_dir: Path) -> None:
         dump_file.close()
 
 
+def test_dump_file_fd_survives_dropping_last_python_reference(dumps_dir: Path) -> None:
+    """The fd outlives every Python reference to the object that owns it (#1571).
+
+    This is the property that separates the raw-fd ``DumpFile`` from a buffered
+    ``open()``: faulthandler's C timer keeps only the integer fd, so if the last
+    Python reference to the file object is dropped and a finalizer closes the fd,
+    the timer later writes to a closed — or worse, a recycled — fd, and the dump
+    file keeps nothing but its header.  A buffered ``TextIOWrapper`` closes on
+    finalization; ``DumpFile`` never closes, so after collection the fd must
+    still be valid, still refer to the same file, and still be writable.
+
+    The two tests above cannot observe this: each keeps the file object bound to
+    a live local for its whole body, so it is never collectable and the
+    finalizer that would close the fd never runs.  ``open_dump_file`` also
+    publishes the object as ``_active_dump_file``, so that reference has to be
+    cleared as well before anything can be collected.
+    """
+    import errno
+    import gc
+
+    # Capture the prior global first, so the value restored in the finally is
+    # not itself a surviving reference to the object under test.
+    prior_active = crash_dump_store._active_dump_file
+    # Sentinel bound BEFORE the try: ``fd`` is assigned partway through the body,
+    # so if open_dump_file raises, the finally must not turn that failure into an
+    # UnboundLocalError.  -1 is never a valid descriptor.
+    fd = -1
+    try:
+        dump_file = open_dump_file(dumps_dir)
+        fd = dump_file.fileno()
+        dump_path = list(dumps_dir.iterdir())[0]
+        original_ino = os.stat(dump_path).st_ino
+
+        # Read the published reference into a bool rather than asserting on the
+        # object: an assert on ``dump_file`` itself can retain it in the frame,
+        # which would keep the object alive and make this test vacuous.
+        was_published = crash_dump_store._active_dump_file is dump_file
+
+        # Drop BOTH references — the module global and the local — then collect.
+        crash_dump_store._active_dump_file = None
+        del dump_file
+        gc.collect()
+
+        assert was_published, "open_dump_file must publish the DumpFile as _active_dump_file"
+
+        # (a) The fd is still valid.  A buffered file object's finalizer would
+        #     have closed it, and os.fstat would raise OSError(EBADF).
+        st = os.fstat(fd)
+
+        # (b) It is still the SAME file.  fd numbers are recycled, so an
+        #     unrelated open() could hand this number back out and make (a) and
+        #     (c) pass against a file that is not the dump.
+        assert st.st_ino == original_ino, (
+            f"fd {fd} no longer refers to the dump file (inode {st.st_ino} != "
+            f"{original_ino}) — it was closed and the number recycled"
+        )
+
+        # (c) It is still writable — this is what faulthandler's C thread does
+        #     when the timer fires, long after the arming frame has gone.
+        marker = b"# written after the last Python reference was dropped\n"
+        assert os.write(fd, marker) == len(marker)
+        assert marker.decode("utf-8") in dump_path.read_text(encoding="utf-8", errors="replace")
+    finally:
+        crash_dump_store._active_dump_file = prior_active
+        # Release the raw fd this test opened.  DumpFile.close() is a deliberate
+        # no-op, so nothing else will: leaving it open leaks a descriptor for the
+        # rest of the session and holds the tmp_path dump file open, which blocks
+        # the fixture's cleanup on Windows.  Every assertion above has already
+        # run by this point, so closing here cannot weaken them.
+        if fd != -1:
+            try:
+                os.close(fd)
+            except OSError as exc:
+                # Tolerate ONLY EBADF: a regression to a buffered open() would
+                # have closed the fd during collection, and raising here would
+                # mask the os.fstat failure that is this test's actual signal.
+                if exc.errno != errno.EBADF:
+                    raise
+
+
 # ── dump_replay_lines ──
 
 


### PR DESCRIPTION
## Problem / Motivation

The crash-dump fd lifetime fix from #1571 (`f507030da`) is correct, but the two tests
shipped with it cannot detect a regression back to the buffered form. Both keep the file
object bound to a **live local** for the entire test body, so it is never collectable and
the finalizer that would close a buffered fd never runs:

- `test_dump_file_fd_survives_repeated_arm_cancel` calls `gc.collect()`, but `dump_file`
  is live across the whole `try/finally` and `open_dump_file` additionally publishes the
  object as `_active_dump_file`, so its refcount never reaches zero. The `gc.collect()` is
  a no-op with respect to the object under test.
- `test_dump_file_fileno_is_stable` asserts only `fd1 == fd2`. A buffered `TextIOWrapper`
  returns the same `fileno()` trivially, and the test never calls `os.fstat`, so it does
  not assert that the fd is *valid* at all — only that the same integer comes back twice.

This is not a theoretical gap. Both tests were **measured** to pass against the pre-fix
`open(path, "w", encoding="utf-8")` form (see *Manual verification*), so a change that
reintroduced buffered `open()` would land green.

## Why it matters

`faulthandler.dump_traceback_later` captures a raw C file descriptor at arm time and writes
to it from its own C thread when the timer fires, seconds or minutes later. If that fd is
closed in the interim, the stall dump contains only its header — and if the number has been
recycled by an unrelated `open()`, the dump writes into someone else's file. That is a
silent failure of the diagnostic exactly when it is needed: the loop-stall report a
maintainer reaches for is empty, and nothing in the test suite would have warned that the
guarantee had been lost.

The fd never being closed is the whole point of `DumpFile` — its `close()` is a documented
no-op and it deliberately has no `__del__`. A guarantee with no discriminating test is one
refactor away from being removed by someone who reads `close(): pass` as dead code.

## What changed (motivation → approach → change)

**Motivation.** The property that actually distinguishes `DumpFile` from a buffered
`open()` is what happens when the last Python reference goes away. No test exercises it.

**Approach.** Reproduce the production hazard directly rather than approximating it: drop
*every* Python reference to the file object, force collection, and only then interrogate
the fd — the same position faulthandler's C thread is in when the timer fires. Two details
this requires, both of which the existing tests miss:

- `open_dump_file` publishes the object as the `_active_dump_file` module global, so
  clearing the local alone leaves a live reference. **Both** must go, or the test is
  vacuous for precisely the reason the existing two are.
- Asserting `os.fstat(fd)` does not raise is not sufficient on its own. fd numbers are
  recycled, so a closed fd whose number was handed back out by an unrelated `open()` would
  satisfy both the validity and the writability check. The inode has to be pinned too.

**Change.** One new test, `test_dump_file_fd_survives_dropping_last_python_reference`,
alongside the two existing fd tests. It records the fd and the dump file's `st_ino`, clears
`_active_dump_file` and `del`s the local, calls `gc.collect()`, and then asserts the fd is:

1. still valid — `os.fstat(fd)` does not raise;
2. still the **same file** — `st.st_ino` matches the recorded inode, so a recycled fd
   number cannot produce a false pass;
3. still writable — `os.write(fd, marker)` succeeds *and* the bytes are read back off disk.

It captures and restores the prior `_active_dump_file` in a `finally`, capturing it
*before* opening so the value restored is not itself a surviving reference to the object
under test.

One deliberate subtlety worth flagging for review: the "did `open_dump_file` publish the
global" check is stored into a **bool** before the references are dropped, rather than
asserted on `dump_file` directly. An `assert` naming the object can retain it in the frame
through pytest's assertion-rewriting temporaries, which would keep it alive and make the
test vacuous — the same failure mode this PR exists to fix.

**Production code is unchanged.** This PR only adds coverage for behaviour that already
ships.

## Tests

`test/test_crash_dump_store.py`: **46 → 47** tests.

Added `test_dump_file_fd_survives_dropping_last_python_reference`, which locks in that the
fd obtained by `open_dump_file` outlives every Python reference to its owning `DumpFile` —
remaining valid, bound to the same inode, and writable after `gc.collect()`.

```
$ pytest test/test_crash_dump_store.py -q
47 passed
```

## Manual verification

The point of this PR is that it discriminates where the shipped tests do not, so that claim
was measured rather than asserted. `open_dump_file` was **temporarily** reverted to its
pre-fix form — `f = open(path, "w", encoding="utf-8")` plus the pre-fix `f.flush()`, taken
verbatim from `f507030da^` — and the three fd tests were re-run:

```
$ pytest test/test_crash_dump_store.py -q -k "dump_file_fd or fileno_is_stable"
>           st = os.fstat(fd)
                 ^^^^^^^^^^^^
E           OSError: [Errno 9] Bad file descriptor

FAILED test/test_crash_dump_store.py::test_dump_file_fd_survives_dropping_last_python_reference - OSError: [Errno 9] Bad file descriptor
1 failed, 2 passed
```

The new test fails with `OSError(9, 'Bad file descriptor')` at the validity check, while
**both** existing fd tests pass — confirming they cannot detect the regression and the new
one can. The production file was then restored and verified byte-identical
(`sha256sum` match, empty `git diff` against the base), and the suite re-run: 47 passed.

The negative control was re-run after a formatting pass on the new test, so the recorded
result reflects the exact text in this diff.

For completeness: under the pre-fix form one other test also fails —
`test_open_dump_file_header_records_pid_domain`, with
`AttributeError: '_io.TextIOWrapper' object has no attribute 'path'`. That is an
API-surface failure, not fd-lifetime detection; it would not catch a regression that kept
the `DumpFile` interface but closed the fd.

`flake8` is clean on the changed file. `black --check` reports the same 8 hunks before and
after this change, i.e. the added lines introduce no new formatting deviation.

## Screenshots / video

N/A — no user-visible UI change. This PR adds a single unit test and touches no production
code.

## Related Issues

Relates to #1571 (the fd lifetime bug) and #1582 (the fix, `f507030da`). This PR adds the
regression coverage those changes lack; it does not alter their behaviour, so it closes
neither.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no behaviour or API change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


