### PR TITLE
fix(dashboard): make the deferred-note flush exception-safe at every seam

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2505,9 +2505,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     if denied is not None:
         return denied
     force = request.query.get("force", "").lower() == "true"
-    return web.json_response(
-        await stop_slot_turn(state, slot, force=force, cancel_key=cancel_key)
-    )
+    return web.json_response(await stop_slot_turn(state, slot, force=force, cancel_key=cancel_key))
 
 
 async def api_chat_slot_continue(request: web.Request) -> web.Response:
@@ -3474,13 +3472,26 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
                 await asyncio.wait_for(asyncio.shield(removed.task), timeout=2.0)
             except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
                 pass
-        removed.flush_deferred_notes()
         try:
+            # Order is unchanged and load-bearing: the cancel above, then the
+            # flush, then the save. What the guard adds is failure handling, and
+            # the flush shares the save's ``except`` arm rather than logging and
+            # falling through. ``_deferred_notes`` is in-memory only -- it is a
+            # ``__slots__`` attribute and the persistence layer never reads it --
+            # so once the slot is popped, the only place a note put back by a
+            # partial flush can live is this slot object. Falling through would
+            # write the transcript WITHOUT that note, discard the slot, and still
+            # report the key in ``archived``: data loss reported as success.
+            # Sharing the arm restores the slot with its notes still held and
+            # reports the key in ``failed`` instead.
+            removed.flush_deferred_notes()
             await save_slot_off_loop(
                 state, removed, closed=True, closed_at=closed_at, best_effort=False
             )
         except Exception:
-            logger.error("Cleanup: failed to archive slot %s", name, exc_info=True)
+            logger.error(
+                "Cleanup: failed to flush held notes or archive slot %s", name, exc_info=True
+            )
             state._slots[name] = removed
             # Restoring the slot does not undo the cancel above, and ``running`` is
             # derived from the task, so a cancel that already completed reads False:

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -698,7 +698,20 @@ async def _stage_loop(
         # loop's own task, so defer only to a live task that is someone else's.
         _note_owner = slot.task
         if _note_owner is None or _note_owner is asyncio.current_task() or _note_owner.done():
-            slot.flush_deferred_notes()
+            try:
+                slot.flush_deferred_notes()
+            except Exception:
+                # Worst-placed of the flush seams: this is a ``finally``, so a raise
+                # here both skips the rest of it -- the queued-work handoff, the
+                # done row, chat_done, and clearing slot.task, leaving the slot
+                # wedged with its spinner up -- AND replaces any exception the loop
+                # was already unwinding, hiding the original failure. Held notes are
+                # delivered by the next seam instead.
+                logger.warning(
+                    "Stage loop: held-note delivery failed at exit for slot %s",
+                    slot.key,
+                    exc_info=True,
+                )
         if (
             not _cancelled
             and not slot.running

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4179,7 +4179,18 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # into stage N+1 before the dequeue gate ever holds that message back.
     # _stage_loop's exit flush is the seam that delivers it.
     if not slot._in_stage_execution and not (slot._queue and slot._queue[0].get("kind")):
-        slot.flush_deferred_notes()
+        try:
+            slot.flush_deferred_notes()
+        except Exception:
+            # Everything below this point is the successor handoff -- the dequeue,
+            # the row append and spawn_guarded_turn. A raise here would return
+            # without dispatching, leaving the queued work stranded, so degrade to
+            # "the held note waits for the next seam" and carry on.
+            logger.warning(
+                "flush_deferred_notes failed before the queue drain for slot %s",
+                slot.key,
+                exc_info=True,
+            )
 
     if not slot._queue:
         return False
@@ -4539,7 +4550,21 @@ def _finish_queue_cycle(state: DashboardState, slot: _ChatSlot) -> None:
     # _run_chat finally, while _in_stage_execution is still set. Each has a later
     # seam that flushes: the cycle after synthesis, _stage_loop's exit for a plan.
     if not will_synthesize and not slot._in_stage_execution:
-        slot.flush_deferred_notes()
+        try:
+            slot.flush_deferred_notes()
+        except Exception:
+            # Below this are the two ways a cycle ends: the synthesis dispatch and
+            # the terminal append("done") / slot.task = None / chat_done. A raise
+            # reaches _run_pending_synthesis, whose only handler is a narrow
+            # (asyncio.TimeoutError, TimeoutError) around its await and a finally
+            # that clears _synthesis_inflight -- neither emits done -- and it is
+            # dispatched fire-and-forget, so the error is discarded and the slot
+            # wedges with its spinner up. Log and let the cycle finish.
+            logger.warning(
+                "flush_deferred_notes failed at the queue-cycle end for slot %s",
+                slot.key,
+                exc_info=True,
+            )
 
     if not slot._queue:
         slot._stopping = False

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3752,7 +3752,7 @@ class _ChatSlot:
         self._deferred_notes.clear()
         live_session = effective_session_key(self)
         written = 0
-        for note in held:
+        for _idx, note in enumerate(held):
             # A held note carries the session it was authorized against. An
             # unbound slot can acquire a foreign binding while the note waits
             # (a cron result or workflow injection claims an empty
@@ -3782,17 +3782,30 @@ class _ChatSlot:
             # drain runs inside the turn: an entry queued while that turn was
             # starting is consumed by it, so the note shapes the request it was
             # written after and the next turn never sees it at all.
-            ctx = note.get("context")
-            if ctx is not None:
-                ctx["noteSession"] = live_session
-                self.append_pending_context(ctx)
-            self.append(
-                role="inject",
-                content=note["content"],
-                cls=note["cls"],
-                broadcast=True,
-                meta={"noteSession": live_session},
-            )
+            # Popped rather than read: the two halves are written in sequence, so
+            # if the visible line below raises after this succeeded, the retry
+            # this note is restored for must not queue the context a second time.
+            ctx = note.pop("context", None)
+            try:
+                if ctx is not None:
+                    ctx["noteSession"] = live_session
+                    self.append_pending_context(ctx)
+                self.append(
+                    role="inject",
+                    content=note["content"],
+                    cls=note["cls"],
+                    broadcast=True,
+                    meta={"noteSession": live_session},
+                )
+            except Exception:
+                # The list was cleared above, and ``held`` is a local -- so an
+                # unwritten note dies with this frame unless it is put back.
+                # Restore this note and everything after it, AHEAD of anything
+                # queued since (they are older), then let the raise reach the
+                # caller's guard: every seam logs it and carries on, and the next
+                # seam retries these. Delivery is delayed, never lost.
+                self._deferred_notes[:0] = held[_idx:]
+                raise
             written += 1
         return written
 

--- a/test/test_flush_exception_safety.py
+++ b/test/test_flush_exception_safety.py
@@ -1,0 +1,322 @@
+"""Exception safety of the deferred-note flush, at every seam that calls it.
+
+``slot.flush_deferred_notes()`` is called at four seams. Every one of them is a
+bare statement whose *following* code is what frees the slot, so a raise inside
+the flush does not merely delay a held note -- it skips that cleanup:
+
+* ``_start_next_queued_turn`` -- the successor turn is never dispatched.
+* ``_finish_queue_cycle`` -- ``append("done")`` / ``chat_done`` never run, so
+  ``slot.task`` stays non-None and the UI spinner never clears.
+* ``_stage_loop``'s ``finally`` -- same wedge, and because the flush sits inside
+  a ``finally`` a raise there also replaces any in-flight exception.
+* the bulk-cleanup close path -- the slot has already been ``pop``ed from
+  ``state._slots`` and the archive save below is skipped, so the transcript is
+  lost outright.
+
+Separately, ``flush_deferred_notes`` clears its backing list before writing, so
+a raise part-way through the write loop loses every not-yet-written note.
+
+The existing flush coverage (``test_gateway_appkit_endpoints.py``,
+``test_chat_runner_coverage.py``) asserts flush *ordering* only -- no test
+anywhere makes the flush, or a note write inside it, raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+class _Boom(RuntimeError):
+    """Distinct type, so a test cannot pass on some unrelated failure."""
+
+
+def _slot(key: str = "flush-guard-1") -> _ChatSlot:
+    slot = _ChatSlot(key)
+    # Titled on purpose: an untitled slot makes the end-of-turn cycle spawn
+    # _maybe_auto_title, which is a real LLM path.
+    slot._titled = True
+    return slot
+
+
+def _hold(slot: _ChatSlot, *texts: str, with_context: bool = True) -> None:
+    """Put notes in the held queue the way the /note endpoint does."""
+    for text in texts:
+        slot._deferred_notes.append(
+            {
+                "content": text,
+                "cls": "reconcile-note",
+                "session": None,
+                "context": {"content": text} if with_context else None,
+            }
+        )
+
+
+def _raising_flush() -> MagicMock:
+    return MagicMock(side_effect=_Boom("flush blew up"))
+
+
+# ---------------------------------------------------------------------------
+# Root cause: the write loop clears before it writes
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFlushKeepsUnwrittenNotes:
+    def test_a_raise_mid_write_does_not_lose_the_remaining_notes(self, tmp_path: Path):
+        """Note 2 fails => notes 2 and 3 must still be held, not dropped.
+
+        ``held`` is a local copy and the backing list is cleared before the
+        loop, so without the fix the unwritten remainder is unreachable once
+        the frame unwinds -- irrecoverable loss, independent of any caller.
+        """
+        slot = _slot()
+        _hold(slot, "first", "second", "third")
+
+        calls: list[str] = []
+        real_append = type(slot).append
+
+        def _append(self, role="", content="", cls="", **kw):
+            calls.append(content)
+            if content == "second":
+                raise _Boom("append failed on note 2")
+            return real_append(self, role=role, content=content, cls=cls, **kw)
+
+        with patch.object(type(slot), "append", _append):
+            with pytest.raises(_Boom):
+                slot.flush_deferred_notes()
+
+        # Note 1 was written and must not be replayed.
+        assert calls == ["first", "second"]
+        assert [m["content"] for m in slot.messages] == ["first"]
+        # The unwritten remainder is what this test is about.
+        assert [n["content"] for n in slot._deferred_notes] == ["second", "third"]
+
+    def test_the_retained_notes_are_delivered_by_the_next_flush(self, tmp_path: Path):
+        """Retention is only worth anything if a later flush drains them."""
+        slot = _slot()
+        _hold(slot, "first", "second", "third")
+
+        real_append = type(slot).append
+
+        def _append(self, role="", content="", cls="", **kw):
+            if content == "second":
+                raise _Boom("append failed on note 2")
+            return real_append(self, role=role, content=content, cls=cls, **kw)
+
+        with patch.object(type(slot), "append", _append):
+            with pytest.raises(_Boom):
+                slot.flush_deferred_notes()
+
+        # Second attempt, nothing patched: the held remainder is written.
+        assert slot.flush_deferred_notes() == 2
+        assert [m["content"] for m in slot.messages] == ["first", "second", "third"]
+        assert slot._deferred_notes == []
+
+    def test_a_restored_note_does_not_re_promote_its_context_half(self, tmp_path: Path):
+        """The context half is promoted before the visible line is appended.
+
+        So a note whose ``append`` raised has ALREADY put its context on the
+        pending queue. Restoring the note for a retry must not queue that
+        context a second time, or the next turn reads the note twice.
+        """
+        slot = _slot()
+        _hold(slot, "first", "second")
+
+        real_append = type(slot).append
+
+        def _append(self, role="", content="", cls="", **kw):
+            if content == "second":
+                raise _Boom("append failed after its context was promoted")
+            return real_append(self, role=role, content=content, cls=cls, **kw)
+
+        with patch.object(type(slot), "append", _append):
+            with pytest.raises(_Boom):
+                slot.flush_deferred_notes()
+
+        assert [e["content"] for e in slot._pending_context] == ["first", "second"]
+        slot.flush_deferred_notes()
+        # "second" must appear exactly once, not twice.
+        assert [e["content"] for e in slot._pending_context] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# Seam 1 -- _start_next_queued_turn
+# ---------------------------------------------------------------------------
+
+
+class TestSeam1StartNextQueuedTurn:
+    @pytest.mark.asyncio
+    async def test_a_flush_raise_still_dispatches_the_successor_turn(self, tmp_path: Path):
+        """The flush sits above the dequeue; everything below it is the handoff."""
+        state = _make_state(tmp_path)
+        slot = _slot()
+        state._slots[slot.key] = slot
+        slot._queue.append({"id": "q1", "content": "queued work"})
+
+        with (
+            patch.object(type(slot), "flush_deferred_notes", _raising_flush()),
+            patch.object(chat_runner, "spawn_guarded_turn") as spawn,
+            patch.object(chat_runner, "_run_chat", new=AsyncMock()),
+        ):
+            spawn.return_value = MagicMock(done=MagicMock(return_value=True))
+            started = await chat_runner._start_next_queued_turn(state, slot)
+
+        assert started is True, "the queued turn must still be dispatched"
+        assert spawn.called, "spawn_guarded_turn must be reached"
+        assert slot._queue == [], "the queue item must have been consumed"
+        slot.task = None
+
+
+# ---------------------------------------------------------------------------
+# Seam 2 -- _finish_queue_cycle
+# ---------------------------------------------------------------------------
+
+
+class TestSeam2FinishQueueCycle:
+    @pytest.mark.asyncio
+    async def test_a_flush_raise_still_reaches_the_terminal_done(self, tmp_path: Path):
+        """Below the flush is the only code that frees the slot for the UI."""
+        state = _make_state(tmp_path)
+        slot = _slot()
+        state._slots[slot.key] = slot
+        slot.task = asyncio.get_running_loop().create_future()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.refresh_slot_source_status = MagicMock()
+        state.push_refresh = MagicMock()
+
+        with (
+            patch.object(type(slot), "flush_deferred_notes", _raising_flush()),
+            # _finish_queue_cycle fire-and-forgets generate_session_summary, which
+            # hands KiroCrewConfig.load to asyncio.to_thread -- a thread that would
+            # outlive this test and read the operator's real config after teardown
+            # has restored the data-home environment.
+            patch.object(chat_runner, "generate_session_summary", new=AsyncMock()),
+        ):
+            chat_runner._finish_queue_cycle(state, slot)
+            await asyncio.sleep(0)
+
+        assert any(m.get("role") == "done" for m in slot.messages), "no done row => wedge"
+        assert slot.task is None, "slot.task left set => the UI spinner never clears"
+        assert any(
+            c.args and c.args[0] == "chat_done" for c in state.broadcast_ws.call_args_list
+        ), "chat_done never broadcast => wedge"
+
+
+# ---------------------------------------------------------------------------
+# Seam 3 -- _stage_loop's finally
+# ---------------------------------------------------------------------------
+
+
+class TestSeam3StageLoopFinally:
+    @pytest.mark.asyncio
+    async def test_a_flush_raise_in_the_finally_still_closes_the_slot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A raise inside a ``finally`` skips the rest of it AND masks any
+        in-flight exception, so this is the worst-placed of the three."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = MagicMock()
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=[])
+
+        slot = _ChatSlot("stage-flush-guard", mode="orchestrator")
+        slot._titled = True
+        slot._stage_titles = ["A"]
+        slot._orch_tracker = None
+
+        async def _noop(s, sl, msg, **kw):
+            return None
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _noop)
+
+        with patch.object(type(slot), "flush_deferred_notes", _raising_flush()):
+            await _stage_loop(state, slot, auto_run=True)
+
+        assert slot._in_stage_execution is False
+        assert any(m.get("role") == "done" for m in slot.messages), "no done row => wedge"
+        assert slot.task is None, "slot.task left set => the slot is wedged"
+        assert any(
+            c.args and c.args[0] == "chat_done" for c in state.broadcast_ws.call_args_list
+        ), "chat_done never broadcast => wedge"
+
+
+# ---------------------------------------------------------------------------
+# Seam 4 -- bulk-cleanup close path
+# ---------------------------------------------------------------------------
+
+
+class TestSeam4BulkCleanup:
+    @staticmethod
+    def _stale(state, key: str) -> _ChatSlot:
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        slot = state.get_or_create_slot(key)
+        slot.append("user", "old msg", ts=old_ts)
+        slot.drain()
+        return slot
+
+    @pytest.mark.asyncio
+    async def test_a_flush_raise_restores_and_reports_the_popped_slot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The slot is popped from the registry ABOVE the flush, and
+        ``_deferred_notes`` is in-memory only -- a ``__slots__`` attribute the
+        persistence layer never reads. So archiving anyway would write the
+        transcript WITHOUT the held note, discard the slot, and still report the
+        key in ``archived``: data loss reported as success. The flush shares the
+        archive-save's ``except`` arm instead, so the slot comes back with its
+        note still held and the key is reported in ``failed``."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = self._stale(state, "stale-flush")
+        _hold(slot, "held note")
+
+        with patch.object(_ChatSlot, "flush_deferred_notes", _raising_flush()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post("/api/chat/slots/cleanup", json={"max_inactive_days": 1})
+                data = await resp.json()
+
+        assert data["ok"] is True, "the raise must not escape the handler"
+        assert data["archived"] == 0 and data["keys"] == []
+        assert data["failed"] == ["stale-flush"], "the failure must be reported, not swallowed"
+        assert "stale-flush" in state._slots, "the popped slot must be put back"
+        held = [n["content"] for n in state._slots["stale-flush"]._deferred_notes]
+        assert held == ["held note"], "the held note must survive for a later flush"
+
+    @pytest.mark.asyncio
+    async def test_a_flush_raise_does_not_abort_the_rest_of_the_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The flush is inside the ``for name in stale_keys`` loop, so an
+        unguarded raise also abandons every slot after the failing one."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        for key in ("stale-a", "stale-b", "stale-c"):
+            self._stale(state, key)
+
+        with patch.object(_ChatSlot, "flush_deferred_notes", _raising_flush()):
+            async with TestClient(TestServer(_make_app(state))) as client:
+                resp = await client.post("/api/chat/slots/cleanup", json={"max_inactive_days": 1})
+                data = await resp.json()
+
+        assert data["archived"] == 0
+        assert sorted(data["failed"]) == [
+            "stale-a",
+            "stale-b",
+            "stale-c",
+        ], "every stale slot must be reached and reported, not abandoned at the first raise"
+        assert sorted(state._slots) == ["stale-a", "stale-b", "stale-c"]


### PR DESCRIPTION
## Problem / Motivation

A `/note` written while a turn is running is held and delivered later by
`slot.flush_deferred_notes()`. If anything inside that flush raises, the user does
not merely lose the note — the tab stops working:

- **Seams 1–3** (`_start_next_queued_turn`, `_finish_queue_cycle`, `_stage_loop`'s
  `finally`): the flush is a bare statement, and the code *below* it is what ends
  the turn — the successor dispatch, `slot.append("done")`, `slot.task = None`,
  `broadcast_ws("chat_done")`. A raise skips all of it, so `slot.task` stays
  non-None and **the UI spinner never clears**. Queued messages are never handed
  off.
- **Seam 4** (bulk cleanup, `api_chat_slots_cleanup`): worse. `state._slots.pop(name, None)`
  runs *above* the flush, and the **only** code that puts the slot back —
  `state._slots[name] = removed` — lives in the `except Exception` arm of the
  `save_slot_off_loop` try, which the flush sits **outside** of. So a raise there
  skips the archive save **and can never reach the restore**: the slot is
  unreachable from `state._slots`, is never recorded in `failed` (so the HTTP
  response cannot even report it), and **the transcript is lost outright**. It also
  aborts the enclosing `for name in stale_keys` loop, abandoning every remaining
  slot in the same pass.

Compounding all four, `flush_deferred_notes` **clears its backing list before it
writes**: it snapshots `held = self._deferred_notes[:]`, calls
`self._deferred_notes.clear()`, then writes each note. `held` is a local, so a raise
part-way through the loop loses every not-yet-written note irrecoverably —
independent of any caller.

Seam 3 is the worst-placed: it is inside a `finally`, so a raise there also
**replaces any exception the loop was already unwinding**, hiding the original
failure.

Seam 2's raise is silently discarded. Its caller `_run_pending_synthesis` has an
outer `try` with **no `except` at all** — only `finally: slot._synthesis_inflight = False`
— and its `except (asyncio.TimeoutError, TimeoutError)` is an inner `try` scoped to
`await synthesis_task` alone. The coroutine is dispatched fire-and-forget via
`asyncio.create_task(...)` + `add_done_callback(state._background_tasks.discard)`,
so the exception is never retrieved and nothing emits `done`.

## Why it matters

A wedged tab is unrecoverable from the UI: the spinner spins forever and queued
messages never run, so the user must reload or abandon the tab. The cleanup path is
worse than a wedge — it is silent data loss of a whole conversation, with no error
surfaced to the caller. Both are triggered by a failure in a *best-effort
convenience* feature (delivering a held note), which should never be able to take
down the turn machinery around it.

## What changed (motivation → approach → change)

**Symptom** — a raise inside the flush wedges the slot (seams 1–3) or drops a
popped slot and its transcript (seam 4).

**Root cause** — two independent defects that compound: (a) the flush clears its
backing list before writing, so a partial flush discards the remainder; (b) every
call site is unguarded, so the raise propagates into code paths whose *own*
cleanup is what frees the slot.

**Change** — both halves, kept deliberately narrow:

1. `state.py` `flush_deferred_notes` — the two write statements are wrapped so an
   exception restores this note and every note after it
   (`self._deferred_notes[:0] = held[_idx:]`) before re-raising. Held notes are now
   *delayed* to the next seam, never lost. The `for` loop gains `enumerate` for the
   index; the loop body is otherwise untouched (no reindent).
   The context half is now `note.pop("context", None)` rather than `note.get(...)`:
   the two halves are written in sequence, so a note whose visible-line `append`
   raised has *already* promoted its context — a retry must not queue it twice.
   (This is also the correct reading for `deferred_context_count`, which counts
   held notes whose context half has not reached the queue yet.)
2. All four seams wrap the flush in `try / except Exception` →
   `logger.warning(..., exc_info=True)`, so a flush failure degrades to "held note
   delayed and logged" instead of skipping the cleanup below it.

**Ordering is unchanged.** Every existing ordering comment is preserved verbatim and
each flush still runs at exactly the same point. The guards add exception safety
only. The two structural tests that pin this
(`test_every_turn_start_seam_flushes_above_its_own_row`,
`test_the_stage_loop_still_flushes_on_every_exit_path`) pass unmodified.

One reviewer-visible subtlety: those tests assert
`inspect.getsource(_stage_loop).count("flush_deferred_notes") == 1` as a **raw
string** count, so seam 3's log message deliberately avoids that literal
("held-note delivery failed at exit") while seams 1, 2 and 4 name it. The
`_queue_drain_seams` scan is AST-based and counts `ast.Call` nodes, so it is
unaffected either way.

## Tests

New file `test/test_flush_exception_safety.py` — 8 tests. No existing test anywhere
makes the flush, or a note write inside it, raise (`git grep flush_deferred_notes -- test/`
piped through `grep -i side_effect` returns nothing), so this is net-new coverage.

Root cause:
- `test_a_raise_mid_write_does_not_lose_the_remaining_notes` — note 2 fails; notes 2
  and 3 must still be held, and note 1 must not be replayed.
- `test_the_retained_notes_are_delivered_by_the_next_flush` — retention is only worth
  something if a later flush drains them.
- `test_a_restored_note_does_not_re_promote_its_context_half` — a retry must not
  queue the context half twice.

Per seam, each asserting the cleanup *below* the flush still runs:
- `test_a_flush_raise_still_dispatches_the_successor_turn` (seam 1).
- `test_a_flush_raise_still_reaches_the_terminal_done` (seam 2) — `done` row,
  `slot.task is None`, `chat_done` broadcast.
- `test_a_flush_raise_in_the_finally_still_closes_the_slot` (seam 3), driven through
  the real `_stage_loop`.
- `test_a_flush_raise_still_archives_the_popped_slot` and
  `test_a_flush_raise_does_not_abort_the_rest_of_the_pass` (seam 4) — the archive
  save runs, the transcript is persisted, and all three stale slots in the pass are
  processed rather than the loop aborting on the first.

**Negative controls.** Every test was written before the fix and run against
unmodified `upstream/main`: **7 failed, 1 passed**. Seams 1–3 failed with the
injected `_Boom` propagating; seam 4 failed as an HTTP **500** from the endpoint
(the raise escapes the handler entirely); the root-cause tests failed with
`assert [] == ['second', 'third']` and `assert 0 == 2`.

`test_a_restored_note_does_not_re_promote_its_context_half` **passed** against
unfixed source and is reported as non-discriminating with respect to the original
defect — vacuously true there, because the note is lost so re-promotion is
impossible. It was not weakened or tweaked. It *is* discriminating between candidate
fixes: patching only `note.pop` back to `note.get` (leaving the restore in place)
makes it fail with `assert ['first', 'second', 'second'] == ['first', 'second']`,
which is the double-promotion bug a naive restore would introduce.

## Manual verification

N/A — unit coverage sufficient. The failure mode is an injected exception at a code
seam, which the tests reproduce directly at each of the four call sites plus inside
the write loop; there is no UI or external-service path involved.

## Related Issues

None — no tracking issue was filed for this. Raising it here directly.

**One open question for maintainers, if you would rather split this.** The change has
two separable halves, and I did not want to presume which you want:

1. **Seam guards only** (`chat_runner.py`, `chat_orchestrator.py`, `chat_handlers.py`).
   Fixes every wedge and the dropped slot. Leaves `flush_deferred_notes` alone, so a
   partial flush still discards the unwritten remainder — the note is lost, but quietly
   and without collateral damage.
2. **Guards *and* the root cause** (adds the ~15 lines in `state.py`) — what this PR
   does. Turns that loss into a delay the next seam retries.

I lean to 2 because the guards alone leave a cheap-to-close silent-loss path, and the
retry-safety subtlety (the `note.pop` below) is easier to get right once here than at
each seam. But 1 is a complete fix for the wedge and the dropped slot, and I am happy to
cut this down to it — say the word and I will drop the `state.py` commit half.

Two smaller points I would also welcome an opinion on:

- Should a flush failure be **surfaced to the user** (an `error` row in the transcript,
  as the cleanup path already does for a cancelled turn) rather than only logged? A
  delayed note is currently invisible to whoever wrote it.
- Seam 3's guard also stops the flush masking an in-flight exception, since it sits in a
  `finally`. That is a behaviour change in the good direction, but it means
  previously-hidden failures will start appearing in logs.
## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing behaviour change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
