### PR TITLE
fix(cron): harden the post-kill drain against TimeoutExpired and fd leak

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -200,6 +200,36 @@ def _kill_proc_group(proc: subprocess.Popen) -> None:
         pass
 
 
+def _drain_after_kill(proc: subprocess.Popen, job_id: str | None) -> None:
+    """Reap a SIGKILLed child's pipes without leaking fds or hijacking the result.
+
+    ``communicate(timeout=5)`` can ITSELF raise ``TimeoutExpired``: the child
+    outlived the group kill (uninterruptible I/O, or no pgid resolved so only
+    ``proc.kill()`` was tried), or another process inherited the write end of
+    the pipe and holds it open, so EOF never arrives. Waiting longer cannot help
+    once SIGKILL has been sent, and the caller has already decided the outcome —
+    so swallow that one exception rather than letting it displace the caller's
+    ``raise`` / ``return``. Closing the pipes has to happen either way:
+    ``Popen._communicate`` closes them as a side effect of reaching EOF, which
+    is exactly the path not taken here, and nothing else ever closes them.
+    """
+    try:
+        proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Post-kill drain timed out (5s) for cron %s (pid %s); the child "
+            "outlived SIGKILL or another process holds the pipe — closing pipes",
+            job_id, proc.pid,
+        )
+    finally:
+        for pipe in (proc.stdout, proc.stderr):
+            if pipe is not None:
+                try:
+                    pipe.close()
+                except OSError:
+                    pass
+
+
 if TYPE_CHECKING:
     from kiro_crew.cron import CronJob
 
@@ -705,7 +735,7 @@ def run_script_sandboxed(
                 # Popen.communicate does not kill the child on timeout
                 # (unlike subprocess.run) — clean up before re-raising.
                 _kill_proc_group(proc)
-                proc.communicate(timeout=5)
+                _drain_after_kill(proc, job_id)
                 raise
         finally:
             cancelled = _unregister_proc(job_id, proc)
@@ -900,7 +930,7 @@ def run_command_sandboxed(command: str, timeout: int = 300, job_id: str | None =
                 output, stderr_out = proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _kill_proc_group(proc)
-                proc.communicate(timeout=5)
+                _drain_after_kill(proc, job_id)
                 return {"status": "error", "output": f"❌ Command timed out after {timeout}s", "exit_code": -1}
         finally:
             if job_id:

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1525,3 +1525,74 @@ class TestResolveInternalSecret:
         ):
             run_script_sandboxed("/f.py:run", "j1", "", timeout=30)
         assert captured["secret"] == "realsecret"
+
+
+class TestPostKillDrainTimeoutHardening:
+    """The post-kill drain must not leak pipes or mislabel the kill-path result.
+
+    ``Popen.communicate`` does not kill the child on timeout, so both spawners
+    SIGKILL the process group and then reap it with a bounded
+    ``communicate(timeout=5)``. That second drain can ITSELF raise
+    ``TimeoutExpired`` when the pipes never reach EOF — the child outlived the
+    group kill, or another process still holds the write end open. Two
+    invariants have to survive that:
+
+    - the ``PIPE`` fds get closed rather than left open for the life of the
+      gateway. ``Popen._communicate`` closes them as a side effect of reaching
+      EOF, which is exactly the path it does not reach here.
+    - the kill path still reports a *timeout*. In ``run_command_sandboxed`` a
+      ``TimeoutExpired`` raised inside the ``except`` block bypasses that
+      block's own handler list, so the timed-out ``return`` is skipped and the
+      broad ``except Exception`` reports "Command failed" instead.
+    """
+
+    def test_script_drain_timeout_closes_pipes_and_keeps_contract(self):
+        import subprocess as sp
+
+        mock_proc = MagicMock()
+        # A bare MagicMock pid coerces to 1 via __index__, and os.killpg(1, sig)
+        # is kill(-1, sig) — see TestKillBroadcastGuard.
+        mock_proc.pid = 2**22 + 12345  # > PID_MAX default, never a real pid
+        # BOTH the initial read and the post-kill drain time out.
+        mock_proc.communicate.side_effect = sp.TimeoutExpired("cmd", 30)
+        with patch(
+            "kiro_crew.cron_script.resolve_script_path", return_value=("/f.py", "run")
+        ), patch("kiro_crew.cron_script.wrap_argv", return_value=(["true"], None)), patch(
+            "subprocess.Popen", return_value=mock_proc
+        ), patch(
+            # Stub the reap at the shim, NOT via the subprocess.Popen patch above:
+            # same reason as TestRunScriptSandboxedTimeout.
+            "kiro_crew.platform_compat.kill_process_tree",
+            return_value=True,
+        ):
+            result = run_script_sandboxed("/f.py:run", "j1", "", timeout=30)
+        # The drain's own timeout must neither escape nor alter the contract.
+        assert result == {"status": "error", "error": "Script timed out after 30s"}
+        # The fd-leak assertion: both pipes closed even though EOF never came.
+        mock_proc.stdout.close.assert_called_once()
+        mock_proc.stderr.close.assert_called_once()
+
+    def test_command_drain_timeout_closes_pipes_and_keeps_contract(self, monkeypatch):
+        import subprocess as sp
+
+        # See TestRunCommandSandboxed._passthrough_sandbox: bypass the OS-sandbox
+        # wrap and the runtime shell probe so this exercises only the kill path.
+        monkeypatch.setattr(
+            "kiro_crew.cron_script.wrap_argv", lambda argv, **k: (list(argv), None)
+        )
+        monkeypatch.setattr("kiro_crew.cron_script._resolve_command_shell", lambda: "sh")
+        mock_proc = MagicMock()
+        mock_proc.pid = 2**22 + 12345  # > PID_MAX default, never a real pid
+        mock_proc.communicate.side_effect = sp.TimeoutExpired("cmd", 30)
+        with patch("subprocess.Popen", return_value=mock_proc), patch(
+            "kiro_crew.platform_compat.kill_process_tree", return_value=True
+        ):
+            result = run_command_sandboxed("sleep 30", timeout=30)
+        # A timed-out command must report the timeout, not "Command failed".
+        assert result == {
+            "status": "error",
+            "output": "❌ Command timed out after 30s",
+            "exit_code": -1,
+        }
+        mock_proc.stdout.close.assert_called_once()
+        mock_proc.stderr.close.assert_called_once()

--- a/test/test_cron_script_more_coverage.py
+++ b/test/test_cron_script_more_coverage.py
@@ -60,9 +60,13 @@ class _FakeStdout:
 
     def __init__(self, lines) -> None:
         self._lines = list(lines)
+        self.closed = False
 
     def readline(self) -> str:
         return self._lines.pop(0) if self._lines else ""
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class _EndlessStdout:
@@ -92,6 +96,10 @@ class _FakeProc:
     ) -> None:
         self.stdin = _FakeStdin()
         self.stdout: object = _FakeStdout(out_lines)
+        # subprocess.Popen.__init__ assigns all three unconditionally (None when
+        # the stream was not piped), so the stand-in has to define stderr too —
+        # the post-kill drain closes both read pipes.
+        self.stderr: object = _FakeStdout(())
         self.pid = pid
         self.returncode = returncode
         self.terminate_calls = 0


### PR DESCRIPTION
## Problem / Motivation

`Popen.communicate` does not kill the child on timeout (unlike `subprocess.run`), so
both cron sandbox spawners in `src/kiro_crew/cron_script.py` reap a timed-out child by
hand: `_kill_proc_group(proc)` followed by a bare `proc.communicate(timeout=5)`.

That second drain can itself raise `TimeoutExpired` — the child outlived the group kill
(uninterruptible I/O, or no pgid resolved so only `proc.kill()` was tried), or another
process inherited the write end of the pipe and holds it open, so EOF never arrives.
Nothing guards the call, and two things follow:

1. **A timed-out command cron is reported as a failed one.** In
   `run_command_sandboxed`, the `TimeoutExpired` is raised *inside* an `except` block.
   Python does not re-enter that `try`'s handler list, so the intended
   `return {… "❌ Command timed out after {timeout}s" …}` on the next line is never
   reached; the exception propagates to the function's broad `except Exception` and the
   caller gets `{… "❌ Command failed: Command 'cmd' timed out after 30 seconds" …}`
   instead. (`TimeoutExpired` → `SubprocessError` → `Exception`.)

2. **The `PIPE` fds are left open.** `Popen._communicate` closes `proc.stdout` /
   `proc.stderr` as a side effect of reaching EOF on them — which is exactly the path
   it does not reach when the drain times out — and nothing else on the kill path ever
   closes them. `_kill_proc_group` only signals.

Neither defect escapes the spawner (`run_script_sandboxed` has an outer
`except subprocess.TimeoutExpired`, `run_command_sandboxed` the broad handler), so the
symptom is a misleading status string plus retained fds, not a crash.

## Why it matters

The status defect is user-visible and actively misleading: a cron whose command hung is
reported as a command that *failed*, which points whoever reads the job result at the
wrong diagnosis — the command, rather than the timeout and the child that would not
die.

The fd retention is bounded by how often the drain itself times out, not by how often a
cron times out, so this is not a leak on every timeout. But the gateway is long-lived
and the retained handles are never reclaimed, so each occurrence is permanent for the
life of the process, and the condition that produces it (a child surviving SIGKILL, or
a grandchild holding the pipe) is precisely the condition that recurs on a sick host.

## What changed (motivation → approach → change)

Symptom → root cause → change:

- The wrong status string traces to a single structural fact: an exception raised inside
  an `except` block bypasses its own `try`'s handlers. The fix is not to add another
  handler at the call site but to stop the drain from raising at all, since the caller
  has already decided the outcome by the time it runs.
- The retained fds trace to there being no `finally` anywhere on the kill path. Closing
  them at the call sites would duplicate the logic and still leave the raising problem.

So both sites now route through one helper, `_drain_after_kill(proc, job_id)`, added
immediately after `_kill_proc_group`:

- it catches **only** `subprocess.TimeoutExpired` — waiting longer cannot help once
  SIGKILL has been sent — and logs a warning naming the job and pid, so the condition
  stays observable rather than becoming silent;
- it closes `proc.stdout` and `proc.stderr` in a `finally`, each guarded against
  `OSError` so a half-open handle cannot mask the caller's result;
- no bare `except`.

Both callers keep their existing control flow: `run_script_sandboxed` still `raise`s
(still caught by its outer `except subprocess.TimeoutExpired`), and
`run_command_sandboxed` still `return`s its timed-out dict — which now actually runs.
The 5-second drain bound and the public `timeout=` argument are unchanged.

## Tests

`test/test_cron_script.py` — new class `TestPostKillDrainTimeoutHardening` (2 tests,
file goes **102 → 104**). Each patches the child so that *both* `communicate` calls
raise `TimeoutExpired`, i.e. the drain itself times out:

- `test_script_drain_timeout_closes_pipes_and_keeps_contract` — locks in that
  `run_script_sandboxed` does not let the drain's timeout escape, still returns
  `{"status": "error", "error": "Script timed out after 30s"}`, and closes **both**
  pipes.
- `test_command_drain_timeout_closes_pipes_and_keeps_contract` — locks in that
  `run_command_sandboxed` returns the **timed-out** dict rather than the
  `"❌ Command failed: …"` one, and closes both pipes.

Both were confirmed red against the unfixed tree before the fix was written, and green
after (see *Manual verification*).

Honest scope note on the first test: its returned-dict assertion is
**non-discriminating** for the script spawner and is kept as a contract regression guard
only. `run_script_sandboxed`'s outer `except subprocess.TimeoutExpired` produces the
same string whether the drain's fresh `TimeoutExpired` escapes or the original is
re-raised, so only the two `close` assertions discriminate there. The status defect is
specific to the command spawner, and that test's dict assertion *is* discriminating.

`test/test_cron_script_more_coverage.py` — `_FakeProc` needed completing. It is
documented as "a `subprocess.Popen` stand-in" but defined only `stdin` and `stdout`,
while `Popen.__init__` assigns all three unconditionally (`self.stderr = None` before
any piping). The drain closes both read pipes, so the double now defines `stderr`, and
`_FakeStdout` models `close()`. Without this, two existing tests
(`TestRunScriptSandboxed::test_timeout_kills_the_group_and_reaps_before_reporting` and
`TestRunCommandSandboxed::test_timeout_kills_the_group`) fail with
`AttributeError: '_FakeProc' object has no attribute 'stderr'` — the second by way of
the broad handler turning that `AttributeError` into `"❌ Command failed: …"`.

The helper deliberately reads `proc.stderr` directly rather than through
`getattr(proc, "stderr", None)`: a real `Popen` always defines it, so tolerating its
absence would be defensive code serving a test double, and would mask a genuine
missing-attribute bug. Completing the double was verified to be inert on its own — with
the production change reverted and the double kept, both existing tests pass and both
new tests still fail, so it neither hides a regression nor weakens the new coverage.

## Manual verification

Unit coverage is the right instrument here — the defect is a control-flow and
resource-lifetime property of the kill path, reachable deterministically by making the
mocked `communicate` raise, and reproducing it for real needs a child that survives
SIGKILL (D-state I/O). Recorded runs, all on `python3.12.14` / `pytest 9.0.3`:

| Stage | Command | Result |
|---|---|---|
| Baseline, unmodified `upstream/main` | `pytest test/test_cron_script.py -q` | `101 passed, 1 skipped` (102) |
| Negative control (tests added, fix **not** applied) | `pytest test/test_cron_script.py::TestPostKillDrainTimeoutHardening -q` | `FF` — 2 failed |
| After fix | `pytest test/test_cron_script.py -q` | `103 passed, 1 skipped` (104) |
| After fix, sibling suite | `pytest test/test_cron_script_more_coverage.py -q` | `98 passed` |
| After fix, all cron suites | `pytest test/*cron* -q` | `1481 passed, 1 skipped` |
| Lint | `flake8` on the 3 changed files (`max_line_length = 100`) | exit 0, clean |

Negative-control output, verbatim:

```
_ TestPostKillDrainTimeoutHardening.test_script_drain_timeout_closes_pipes_and_keeps_contract _
>       mock_proc.stdout.close.assert_called_once()
E           AssertionError: Expected 'close' to have been called once. Called 0 times.
```

```
_ TestPostKillDrainTimeoutHardening.test_command_drain_timeout_closes_pipes_and_keeps_contract _
>       assert result == {
            "status": "error",
            "output": "❌ Command timed out after 30s",
            "exit_code": -1,
        }
E         Differing items:
E         {'output': "❌ Command failed: Command 'cmd' timed out after 30 seconds"} != {'output': '❌ Command timed out after 30s'}
```

## Screenshots / video

N/A — no user-visible UI change; this is a backend fix in the cron sandbox spawners.

## Related Issues

None filed. This is a small, self-contained, single-file behavioural fix with tests, so
per `CONTRIBUTING.md` an issue-first round trip did not seem warranted — happy to open
one if maintainers would prefer it.

## Checklist

- [x] Single commit with a Conventional Commits title
      (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs cover the
      internal kill path
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: left exactly as the live .github/PULL_REQUEST_TEMPLATE.md has it.
     No CLA text invented — per the template, the wording comes from OSPO. -->
