### PR TITLE
fix: don't treat a cron record-load AttributeError as bad data

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -784,10 +784,21 @@ def _record_is_enabled(j: dict[str, Any]) -> bool:
 def _job_from_record(j: dict[str, Any]) -> CronJob:
     """Build one :class:`CronJob` from its serialized record.
 
-    Raises ``KeyError``/``TypeError``/``AttributeError`` when the record is
-    malformed (missing required keys, or not shaped like a job object at all).
-    The caller (:meth:`CronService._load`) isolates that failure to THIS entry
-    — one bad record must never discard the rest of the store (#4664).
+    Raises ``KeyError``/``TypeError`` when the record is malformed (missing
+    required keys, or not shaped like a job object at all). The caller
+    (:meth:`CronService._load`) isolates that failure to THIS entry — one bad
+    record must never discard the rest of the store (#4664).
+
+    It does NOT raise ``AttributeError`` for any record ``json.loads`` can
+    produce: every ``.get()`` below is dominated by a ``[...]`` subscript on the
+    same object, and only a ``dict`` survives a string subscript. An
+    ``AttributeError`` from this function therefore signals a defect in this
+    code, not bad data, so :meth:`CronService._load` deliberately lets it
+    propagate rather than catching it: catching it there would reclassify a
+    valid job as malformed, and because ``_save`` rewrites ``jobs[]`` from
+    ``self._jobs`` the next write would erase that job from disk permanently —
+    turning a code defect into silent, unrecoverable data loss. Letting it
+    propagate trades a loud failure at load for that silent loss.
     """
     return CronJob(
         id=j["id"],
@@ -3523,11 +3534,17 @@ class CronService:
             # well-formed job survives. The whole-store reset below is reserved
             # for a genuinely unparseable file (json.JSONDecodeError), where
             # there is nothing to salvage.
+            #
+            # The caught tuple is deliberately NARROWER than the exceptions
+            # _job_from_record can raise: KeyError and TypeError are its two
+            # bad-data signals, and AttributeError is not reachable from JSON.
+            # See _job_from_record's docstring for why, and for what catching it
+            # would cost.
             jobs: list[CronJob] = []
             for j in records:
                 try:
                     jobs.append(_job_from_record(j))
-                except (KeyError, TypeError, AttributeError) as entry_exc:
+                except (KeyError, TypeError) as entry_exc:
                     entry_id = (
                         j.get("id", "<missing id>") if isinstance(j, dict) else "<not an object>"
                     )

--- a/test/test_cron_load_malformed_entry.py
+++ b/test/test_cron_load_malformed_entry.py
@@ -15,11 +15,15 @@ whole-store reset for a genuinely unparseable file (``json.JSONDecodeError``).
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from pathlib import Path
 
-from kiro_crew.cron import CronService
+import pytest
+
+from kiro_crew import cron as cron_mod
+from kiro_crew.cron import CronService, _job_from_record
 
 
 def _write_store(path: Path, jobs: list) -> None:
@@ -143,3 +147,130 @@ def test_top_level_non_object_resets_store_and_counts_zero(tmp_path, caplog) -> 
         assert mgr._jobs == [], payload
         assert any("Failed to load cron store" in r.message for r in caplog.records)
         assert mgr.count_enabled_from_disk() == 0, payload
+
+
+# --- Narrowing the per-record catch: a code defect is not "bad data" -------
+#
+# ``CronService._load`` used to catch ``AttributeError`` around
+# ``_job_from_record``, which cannot raise it from any JSON-representable
+# record (proved by
+# ``test_json_shaped_malformations_raise_only_key_or_type_error`` below). The
+# rationale, and what catching it costs, lives once in ``_job_from_record``'s
+# docstring; these tests pin the behaviour. The read-only
+# ``count_enabled_from_disk`` probe keeps the wider tuple -- narrowing that
+# site is deliberately out of scope here.
+
+
+def _boom_on_a_valid_record(_j: dict) -> bool:
+    """Stand in for a code defect in the record->job path.
+
+    ``_record_is_enabled`` is called by ``_job_from_record`` for every record,
+    so patching it raises on records that are perfectly well-formed -- exactly
+    the shape of a refactor or a new validator going wrong.
+    """
+    raise AttributeError("simulated code defect in the record->job path")
+
+
+def test_code_defect_does_not_empty_a_live_registry(tmp_path, monkeypatch) -> None:
+    """A code defect must not silently truncate a loaded registry.
+
+    DISCRIMINATING: with the blanket catch, both well-formed records are
+    reclassified as malformed and ``self._jobs`` becomes empty.
+    """
+    mgr = CronService(base_dir=tmp_path)
+    _write_store(mgr._path, [_good("a"), _good("b")])
+    mgr._load()
+    assert [j.id for j in mgr._jobs] == ["a", "b"], "precondition: both jobs load cleanly"
+
+    monkeypatch.setattr(cron_mod, "_record_is_enabled", _boom_on_a_valid_record)
+
+    # A reload -- _sync() runs one whenever the file changes on disk.
+    with contextlib.suppress(AttributeError):
+        mgr._load()
+
+    assert [j.id for j in mgr._jobs] == ["a", "b"]
+
+
+def test_code_defect_does_not_make_the_loss_permanent(tmp_path, monkeypatch) -> None:
+    """The next write must not persist a registry a code defect emptied.
+
+    DISCRIMINATING, and the harm this change exists to prevent: ``_save``
+    serialises ``self._jobs`` only, so once a defect has emptied the registry
+    the first subsequent write erases both jobs from disk for good.
+    """
+    mgr = CronService(base_dir=tmp_path)
+    _write_store(mgr._path, [_good("a"), _good("b")])
+    mgr._load()
+
+    monkeypatch.setattr(cron_mod, "_record_is_enabled", _boom_on_a_valid_record)
+    with contextlib.suppress(AttributeError):
+        mgr._load()
+
+    mgr._save()  # any later mutation persists whatever the registry now holds
+
+    reread = json.loads(mgr._path.read_text(encoding="utf-8"))
+    assert [j["id"] for j in reread["jobs"]] == ["a", "b"]
+
+
+def test_json_shaped_malformations_raise_only_key_or_type_error() -> None:
+    """CHARACTERISATION (passes before and after): ``AttributeError`` is not a
+    bad-data signal for this builder, so dropping it from the caught tuple
+    costs no malformed-record coverage.
+
+    Every ``.get()`` in the extraction path is dominated by a ``[...]``
+    subscript on the same object (``j["id"]`` before any ``j.get(...)``;
+    ``j["schedule"]["kind"]`` before any ``j["schedule"].get(...)``). From
+    JSON only a ``dict`` survives a string subscript, and a ``dict`` always
+    has ``.get`` -- so no ``json.loads`` output can reach the ``.get`` calls
+    without a ``dict`` in hand.
+    """
+    malformed: list[object] = [
+        # record itself is not an object
+        "garbage",
+        ["id", "name"],
+        3,
+        1.5,
+        True,
+        None,
+        # record is an object but incomplete
+        {},
+        {"id": "x"},
+        {"id": "x", "name": "n", "message": "m"},  # no "schedule"
+        {"id": "x", "message": "m", "schedule": {"kind": "every"}},  # no "name"
+        # schedule container is the wrong shape
+        {"id": "x", "name": "n", "message": "m", "schedule": "every"},
+        {"id": "x", "name": "n", "message": "m", "schedule": []},
+        {"id": "x", "name": "n", "message": "m", "schedule": 7},
+        {"id": "x", "name": "n", "message": "m", "schedule": None},
+        {"id": "x", "name": "n", "message": "m", "schedule": {}},  # no "kind"
+    ]
+    for record in malformed:
+        with pytest.raises((KeyError, TypeError)) as caught:
+            _job_from_record(record)  # type: ignore[arg-type]
+        assert not isinstance(caught.value, AttributeError), record
+
+    # Positive control: the same call on a well-formed record does NOT raise,
+    # so the loop above is exercising the real extraction path.
+    assert _job_from_record(_good("ok")).id == "ok"
+
+
+def test_genuine_bad_data_still_skips_and_still_drops_on_the_next_write(tmp_path) -> None:
+    """CHARACTERISATION (passes before and after): the documented contract for
+    a genuinely malformed record is unchanged.
+
+    ``docs/system-specs/modules/learn-cron-dashboard.md`` states that a
+    skipped record is dropped from disk by the first write that follows, and
+    the load warning is the operator's recovery window. Narrowing the caught
+    tuple must not alter that -- only which exceptions count as bad data.
+    """
+    mgr = CronService(base_dir=tmp_path)
+    bad = {"id": "bad", "message": "m", "schedule": {"kind": "every"}}  # no "name"
+    _write_store(mgr._path, [_good("a"), bad])
+
+    mgr._load()
+    assert [j.id for j in mgr._jobs] == ["a"]
+
+    mgr._save()
+
+    reread = json.loads(mgr._path.read_text(encoding="utf-8"))
+    assert [j["id"] for j in reread["jobs"]] == ["a"]


### PR DESCRIPTION
## Problem / Motivation

`CronService._load` builds each `crons.json` record in its own `try` block and skips
the ones that raise, so one malformed record cannot discard the registry (#4664, via
#4674). The caught tuple is `(KeyError, TypeError, AttributeError)`.

`AttributeError` does not belong in it. `_job_from_record` cannot raise
`AttributeError` for any record `json.loads` can produce: every `.get()` in the
extraction path is dominated by a `[...]` subscript on the same object
(`j["id"]` before any `j.get(...)`; `j["schedule"]["kind"]` before any
`j["schedule"].get(...)`), and only a `dict` survives a string subscript — a `dict`
always has `.get`. So an `AttributeError` there is not a statement about the record,
it is a defect in the record→job code: a refactor, or a validator added later.

Catching it reclassifies a valid, correctly-scheduled job as malformed. And because
`_save` rewrites `jobs[]` from `self._jobs`, the next write erases that job from disk
— the behaviour the load warning and the module spec both describe for a *malformed*
record, applied to a job that was fine. A code bug becomes silent, unrecoverable
data loss.

## Why it matters

`_load` is not only a boot path — `_sync()` re-runs it on every external change to
`crons.json`. A defect reached this way empties the live registry at runtime, and the
first subsequent mutation (any `add`/`update`/`enable`/run-result merge) persists the
emptiness. Recovery depends on someone reading a `WARNING` before that write. The
observable failure is "my cron jobs disappeared", with no error and an exit status of
success everywhere.

## What changed (motivation → approach → change)

**Motivation** — a code defect must not be laundered into permanent data loss by a
handler meant for bad data.

**Approach** — narrow the caught tuple rather than add machinery. `KeyError` and
`TypeError` are the two signals the extraction path actually produces from bad data;
`AttributeError` is unreachable from JSON, so removing it costs no malformed-record
coverage and changes no behaviour for any real store. What it changes is the
behaviour for a *defect*: loud failure at load instead of a silently truncated
registry.

**Change** — in `_load`, `except (KeyError, TypeError, AttributeError)` →
`except (KeyError, TypeError)`, with a comment stating why the tuple is narrower than
what the builder can raise. `_job_from_record`'s docstring is corrected: it claimed to
raise `AttributeError` for a malformed record, which it cannot do from JSON.

Deliberately **out of scope**, to keep this minimal:

- `count_enabled_from_disk` (`cron.py:2528` on the base) guards `_job_from_record` with the same
  tuple. That site is a read-only probe — it discards the return value and drops
  nothing from disk — so the harm above does not apply. Its comment does contain the
  same inaccuracy (it says a non-dict entry "would otherwise crash
  `_record_is_enabled` with an `AttributeError`"; in fact `j["id"]` raises `TypeError`
  first), but narrowing it there trades a different risk — an uncaught exception in
  the WS status pusher — and belongs in its own change.
- No documentation change is required. No file under `docs/` pins the caught tuple,
  and `docs/system-specs/modules/learn-cron-dashboard.md:67` describes the contract
  for a **malformed** record (skip, warn, dropped by the next write). That contract is
  unchanged here — only which exceptions count as malformed.

## Tests

`test/test_cron_load_malformed_entry.py`, **8 → 12**. All 12 pass.

Two **discriminating** (they fail against the blanket catch):

- `test_code_defect_does_not_empty_a_live_registry` — a simulated code defect
  (`_record_is_enabled` patched to raise `AttributeError` on well-formed records) must
  not truncate an already-loaded registry.
- `test_code_defect_does_not_make_the_loss_permanent` — after that defect, `_save()`
  must not persist the loss. This is the harm the change exists to prevent.

Two **characterisation**, labelled as such in their docstrings because they pass both
before and after — they are the safety argument, not the control:

- `test_json_shaped_malformations_raise_only_key_or_type_error` — 15 JSON-representable
  malformations (non-object record; missing `id`/`name`/`message`/`schedule`;
  `schedule` as `str`/`list`/`int`/`None`/`{}`) all raise `KeyError` or `TypeError`,
  never `AttributeError`, with a positive control asserting a well-formed record does
  **not** raise. This is what makes the narrowing safe.
- `test_genuine_bad_data_still_skips_and_still_drops_on_the_next_write` — pins the
  unchanged contract: a genuinely malformed record is still skipped and still dropped
  by the following write.

Regression sweep: all 66 `test/test_*cron*.py` files — **1504 passed, 1 skipped**.

## Manual verification

- Negative control, against unmodified `upstream/main` source with the two
  discriminating tests applied: `2 failed, 10 passed`, both failures
  `AssertionError: assert [] == ['a', 'b']`, with the captured log showing both
  well-formed jobs warned as malformed:

  ```
  WARNING kiro_crew.cron:cron.py:3534 Skipping malformed cron job entry (id='a'):
  AttributeError('simulated code defect in the record->job path'); the entry will be
  dropped from the store on the next write
  ```

- After the fix: `12 passed`.
- `flake8` 7.1.0 and `isort` 6.0.0 (both the versions pinned in `pyproject.toml`):
  clean on both changed files. `black` 26.3.1 (also the pinned version): clean on the
  test file. `black` reports 31 objections in `cron.py`; these are **pre-existing** —
  the same check against pristine `upstream/main:src/kiro_crew/cron.py` reports the
  same 31 lines, and the set difference is empty, so this change adds none.

## Screenshots / video

N/A — no user-visible UI change.

## Related Issues

No issue is filed for this. Context: issue `#4664` reported that one malformed record
dropped the whole store; PR `#4674` (merged, commit `c31787e0d`) fixed that with the
per-entry isolation and introduced this caught tuple. This PR narrows the tuple only.

`#4674` also signposted a `crons.json.corrupt` quarantine as future work
("deliberately left out to keep this fix minimal"). That is a larger, separable change
which would renegotiate the contract documented at
`docs/system-specs/modules/learn-cron-dashboard.md:67`, and is **not** proposed here.
Happy to open an issue for it if that is the preferred route.

Precedent for the shape of this change: `#5287` — *"drop the redundant
`json.JSONDecodeError` from 86 except tuples that already catch `ValueError`"* — merged
as `#5320` (`36a0d569e`).

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (8 → 12; 1504
      passed across the cron suite)
- [x] Self-review completed; code follows project style guidelines (flake8 / isort /
      black at the pinned versions)
- [x] Documentation updated (if applicable) — `_job_from_record`'s docstring corrected;
      no `docs/` change needed, verified no doc pins the tuple
- [x] No secrets, credentials, or internal references in the diff

## Rebase / verification note

Branched at `05ea678b9f` and rebased forward with no conflicts at any step; the current
base is `e60a67c30`. Every number above was re-measured on that tree, not inherited. Two
files moved across that range and both were checked: `cron.py` gained SEL auditing of automated one-shot removals
(#5408 / #5405) and touches none of `_load`'s catch, `_job_from_record`, or `_save`; and
`docs/system-specs/modules/learn-cron-dashboard.md` changed only its Cron REST API,
AutoNudge, and Kiro-CLI-login sections — the "Load resilience (per-entry isolation)" bullet
this change reasons about is byte-identical and still at line 67.

