### PR TITLE
fix(sandbox): disable the Gradle daemon inside the namespace launcher

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1730,6 +1730,25 @@ def main():
                 "{strict_host_key_opt}"
             )
 
+        # Gradle would otherwise leave a daemon running after this sandboxed
+        # command exits, holding our mount namespace open with the credential
+        # paths still masked, plus the inherited seccomp filter and emptied
+        # capability bounding set. Nothing here changes what Gradle keys its
+        # daemon context on, so a later build OUTSIDE the sandbox matches and
+        # adopts that daemon, silently running under restrictions and a
+        # credential view it never asked for. Keyed on the EFFECTIVE LAST
+        # -Dorg.gradle.daemon= directive rather than on mere presence, because
+        # duplicate -D resolves last-wins: a trailing =true would otherwise
+        # survive, while appending when ours is already last just duplicates.
+        if [
+            _t
+            for _t in os.environ.get("GRADLE_OPTS", "").split()
+            if _t.startswith("-Dorg.gradle.daemon=")
+        ][-1:] != ["-Dorg.gradle.daemon=false"]:
+            os.environ["GRADLE_OPTS"] = (
+                os.environ.get("GRADLE_OPTS", "") + " -Dorg.gradle.daemon=false"
+            ).strip()
+
         # ── Step 5: Drop capabilities + set NO_NEW_PRIVS ──
         # Inside the user namespace, the child has CAP_SYS_ADMIN (owner of the
         # NS) which lets it umount the credential bind-mounts. Drop ALL

--- a/test/test_sandbox_gradle_daemon.py
+++ b/test/test_sandbox_gradle_daemon.py
@@ -1,0 +1,168 @@
+"""Tests for the namespace launcher's Gradle-daemon guard.
+
+Left to itself, Gradle keeps a daemon running after the sandboxed command that
+started it exits. That daemon holds the sandbox's mount namespace open with the
+credential paths still masked, and keeps the inherited seccomp filter and
+emptied capability bounding set. Nothing in the launcher changes what Gradle
+keys its daemon context on, so a later build run *outside* the sandbox matches
+that context and adopts the daemon. The launcher therefore disables the daemon
+for builds it starts, so none is left behind.
+
+These tests assert on the launcher source that ``_build_launcher_script``
+returns -- the launcher's ``main()`` is a literal segment of that f-string, so
+the guard is extractable from the returned string. This matches the house idiom
+in ``test/test_sandbox_argv.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import types
+
+import pytest
+
+from kiro_crew.sandbox import _build_launcher_script
+
+# ``_build_launcher_script`` calls POSIX-only ``os.getuid``/``os.getgid`` (the
+# namespace launcher is Linux-only), so building it raises AttributeError on
+# Windows. Same skip as test_sandbox_argv.py. See #2041.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="_build_launcher_script uses POSIX-only os.getuid (#2041)",
+)
+
+_FLAG = "-Dorg.gradle.daemon=false"
+_DIRECTIVE = "-Dorg.gradle.daemon="
+_SANDBOX_LEVELS = ("strict", "standard", "cc")
+
+
+def _effective_daemon_directive(opts: str) -> str | None:
+    """Return the LAST ``-Dorg.gradle.daemon=`` directive in *opts*, or None.
+
+    Duplicate ``-D`` resolves last-wins in the JVM, so this -- not substring
+    presence -- is what decides whether the daemon is actually disabled.
+    """
+    found = [tok for tok in opts.split() if tok.startswith(_DIRECTIVE)]
+    return found[-1] if found else None
+
+
+def _guard_node(script: str) -> ast.If:
+    """Return the launcher's Gradle-daemon guard node, or raise if absent.
+
+    Locating the guard by AST rather than by line offset keeps the extraction
+    independent of the template's indentation and of unrelated edits above it.
+    Raising when the guard is gone is deliberate: a refactor that drops the
+    guard turns this module red instead of leaving it silently unreachable.
+    """
+    for node in ast.walk(ast.parse(script)):
+        if isinstance(node, ast.If) and _FLAG in ast.unparse(node.test):
+            return node
+    raise AssertionError(
+        f"no guard testing {_FLAG!r} in the generated launcher: a Gradle daemon "
+        "started inside the sandbox can now outlive it and poison a later "
+        "unsandboxed build"
+    )
+
+
+def _run_guard(script: str, environ: dict[str, str]) -> dict[str, str]:
+    """Execute the extracted guard against *environ* and return the result.
+
+    ``os`` is stubbed with a plain dict so the guard cannot touch the real
+    process environment.
+    """
+    guard = compile(ast.unparse(_guard_node(script)), "<guard>", "exec")
+    env = dict(environ)
+    # exec runs the SHIPPED guard source rather than a re-implementation, which is
+    # what lets this test detect drift; `os` is stubbed, so nothing real is reached.
+    exec(  # noqa: S102  # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+        guard, {"os": types.SimpleNamespace(environ=env)}
+    )
+    return env
+
+
+@_POSIX_ONLY
+class TestGradleDaemonGuardBehaviour:
+    def test_sets_the_flag_when_gradle_opts_is_absent(self):
+        env = _run_guard(_build_launcher_script("strict"), {})
+        # No leading space: GRADLE_OPTS is parsed as JVM args, and a bare
+        # leading separator is noise in every log that echoes it back.
+        assert env["GRADLE_OPTS"] == _FLAG
+
+    def test_sets_the_flag_when_gradle_opts_is_empty(self):
+        env = _run_guard(_build_launcher_script("strict"), {"GRADLE_OPTS": ""})
+        assert env["GRADLE_OPTS"] == _FLAG
+
+    def test_preserves_an_explicit_caller_value(self):
+        # Appending rather than assigning keeps the caller's tuning; clobbering
+        # GRADLE_OPTS would silently drop a heap size the build depends on.
+        env = _run_guard(_build_launcher_script("strict"), {"GRADLE_OPTS": "-Xmx2g"})
+        assert env["GRADLE_OPTS"] == f"-Xmx2g {_FLAG}"
+
+    def test_does_not_add_the_flag_twice(self):
+        already = f"-Xmx2g {_FLAG}"
+        env = _run_guard(_build_launcher_script("strict"), {"GRADLE_OPTS": already})
+        assert env["GRADLE_OPTS"] == already
+        assert env["GRADLE_OPTS"].count(_FLAG) == 1
+
+    def test_the_flag_wins_over_an_inherited_daemon_true(self):
+        # A later -D beats an earlier one in JVM argument order, so appending is
+        # what neutralises an inherited -Dorg.gradle.daemon=true.
+        env = _run_guard(
+            _build_launcher_script("strict"),
+            {"GRADLE_OPTS": "-Dorg.gradle.daemon=true"},
+        )
+        opts = env["GRADLE_OPTS"]
+        assert opts.index("-Dorg.gradle.daemon=true") < opts.index(_FLAG)
+
+    def test_the_flag_wins_when_a_true_directive_comes_last(self):
+        # GRADLE_OPTS carrying BOTH forms with =true LAST. Measured on openjdk 21:
+        # duplicate -D resolves last-wins, so the mere PRESENCE of the false form
+        # does not disable the daemon -- the guard must key on the effective last
+        # directive or the daemon stays enabled and outlives the sandbox.
+        env = _run_guard(
+            _build_launcher_script("strict"),
+            {"GRADLE_OPTS": f"{_FLAG} -Dorg.gradle.daemon=true"},
+        )
+        assert _effective_daemon_directive(env["GRADLE_OPTS"]) == _FLAG
+
+    def test_does_not_append_when_the_false_flag_is_already_effective(self):
+        # Guards the OPPOSITE direction from the test above: an unconditional
+        # append would accrete a duplicate flag on every nested invocation.
+        already = f"{_FLAG} -Xmx2g"
+        env = _run_guard(_build_launcher_script("strict"), {"GRADLE_OPTS": already})
+        assert env["GRADLE_OPTS"] == already
+        assert env["GRADLE_OPTS"].count(_FLAG) == 1
+
+
+@_POSIX_ONLY
+class TestGradleDaemonGuardPlacement:
+    def test_the_guard_is_emitted_at_every_sandbox_level(self):
+        # Every level unshares a mount namespace and masks credential paths, so
+        # a daemon left behind by any of them is adoptable from outside.
+        for level in _SANDBOX_LEVELS:
+            assert _FLAG in _build_launcher_script(level), level
+
+    def test_the_guard_runs_before_the_exec(self):
+        # Set after exec, the flag would never reach the build.
+        script = _build_launcher_script("strict")
+        assert script.index(_FLAG) < script.index("os.execvp(argv[0], argv)")
+
+    def test_the_generated_launcher_still_compiles_at_every_level(self):
+        # The template is an f-string with real placeholders, so an inserted
+        # line containing an unescaped brace would break every level.
+        for level in _SANDBOX_LEVELS:
+            compile(_build_launcher_script(level), "<launcher>", "exec")
+
+
+@_POSIX_ONLY
+class TestGradleDaemonGuardExtractorIsDiscriminating:
+    """Negative control: the extractor must fail when the guard is gone."""
+
+    def test_extractor_raises_when_the_guard_line_is_removed(self):
+        script = _build_launcher_script("strict")
+        node = _guard_node(script)  # fails loudly if the guard is already gone
+        lines = script.splitlines(keepends=True)
+        stripped = "".join(lines[: node.lineno - 1] + lines[node.end_lineno :])
+        with pytest.raises(AssertionError, match="no guard testing"):
+            _guard_node(stripped)


### PR DESCRIPTION
## Problem / Motivation

A Gradle build run inside the Linux namespace sandbox starts a Gradle **daemon** — a long-lived JVM
that deliberately outlives the build that spawned it. That daemon is a child of the sandboxed
process, so when the sandboxed command exits the daemon is still running and still inside the
sandbox:

- it remains in the sandbox's **mount namespace**, where the launcher has bind-mounted empty
  directories over the credential paths (`SENSITIVE_DIRS` / `SENSITIVE_FILES`), so its view of
  `~/.ssh`, `~/.aws` and friends is the masked one — and it holds that namespace open;
- it keeps the **seccomp-BPF filter** installed at Step 6 and the **emptied capability bounding
  set** plus `NO_NEW_PRIVS` from Step 5 — all three are inherited across `fork` and preserved
  across `execve`.

Nothing in the launcher changes any of the inputs Gradle uses to decide whether a running daemon can
serve a new build. So a subsequent build started **outside** the sandbox finds that daemon compatible
and adopts it, and then executes inside the previous sandbox's restrictions and credential view —
silently, with no indication that this happened.

## Why it matters

The user is not told. A developer who runs one agent task in the sandbox and then builds by hand in
their own terminal gets a build executing under restrictions they never asked for, against masked
credential paths. Failures that follow point at the build, not at the sandbox: the daemon is not
mentioned in the error, and `gradle --status` shows a daemon that looks ordinary. The state also
persists until the daemon idles out or is stopped explicitly, so it can outlive the KiroCrew session
entirely.

The blast radius is limited to hosts where a sandboxed command runs Gradle, but on those hosts it is
invisible and confusing, and the guard that avoids it is three lines.

## What changed (motivation → approach → change)

**Symptom:** builds run outside the sandbox can execute under a previous sandbox's restrictions and
masked credential view.

**Root cause:** the sandbox's isolation is scoped to a process tree, but the Gradle daemon is designed
to *survive* its process tree. Any daemon started inside the sandbox therefore becomes a route out of
that scoping, in the direction nobody intended: not an escape from the sandbox, but a leak of the
sandbox into later unsandboxed work.

**Approach considered and rejected — reap the daemon on exit.** The launcher `execvp`s the target and
does not survive to run teardown, so there is no exit hook to hang a `gradle --stop` on; adding one
would mean not exec'ing, which changes the launcher's process model for every sandboxed command.
Stopping *all* daemons would also destroy daemons the user legitimately started outside the sandbox.

**Approach taken — never create one.** Append `-Dorg.gradle.daemon=false` to `GRADLE_OPTS` in the
launcher, beside the existing `GIT_SSH_COMMAND` conditional default, after the sandbox marker exports
and before the Step 5 capability drop. With no daemon there is nothing to outlive the sandbox, and no
teardown to get wrong.

Three properties of the change worth stating explicitly:

- **Appended, not assigned**, so an explicit caller `GRADLE_OPTS` survives. The guard keys on the
  **effective last** `-Dorg.gradle.daemon=` directive rather than on mere presence of the false form:
  duplicate `-D` resolves last-wins, so a trailing `-Dorg.gradle.daemon=true` would survive a
  presence test. Keying on the last directive neutralises that case while still leaving an already
  effective `-Dorg.gradle.daemon=false` untouched, so the ordinary case keeps exactly one flag.
- **It does not force rebuilds.** Gradle's up-to-date checks read on-disk input/output snapshots in
  the project's `.gradle` directory, not daemon memory. The daemon is a warm-JVM optimisation;
  disabling it costs JVM startup on each sandboxed build, which is the normal cost of `--no-daemon`
  and of every CI build that uses it.
- **It is inert for every other toolchain.** `GRADLE_OPTS` is read only by the Gradle launcher
  scripts. Setting it does not affect npm, cargo, Maven or anything else, and the launcher already
  sets a tool-specific variable (`GIT_SSH_COMMAND`) on the same principle.

**Scope:** the Linux namespace launcher only. The macOS `sandbox_exec` path is built by a different
function (`_build_seatbelt_profile`) and is untouched — worth a maintainer's view on whether it wants
the same treatment.

## Tests

New file `test/test_sandbox_gradle_daemon.py`, 11 tests. The launcher's `main()` is a literal segment
of the f-string that `_build_launcher_script` returns, so the guard is located in that returned string
by AST (`ast.If` whose test mentions the flag) and executed against a stubbed `os.environ` dict — the
guard never touches the real process environment. This follows the existing house idiom of asserting
on `_build_launcher_script(...)` output, already used by seven test modules.

Behaviour locked in:

| Test | What it locks in |
|:-----|:-----------------|
| `test_sets_the_flag_when_gradle_opts_is_absent` | sets the flag with no leading separator |
| `test_sets_the_flag_when_gradle_opts_is_empty`  | empty string behaves like absent |
| `test_preserves_an_explicit_caller_value`       | appends rather than clobbering `-Xmx2g` |
| `test_does_not_add_the_flag_twice`              | idempotent when already present |
| `test_the_flag_wins_over_an_inherited_daemon_true` | the flag lands *after* an inherited `daemon=true` |
| `test_the_flag_wins_when_a_true_directive_comes_last` | a trailing `daemon=true` is still overridden — the case a presence test would miss |
| `test_does_not_append_when_the_false_flag_is_already_effective` | no duplicate flag when `daemon=false` is already the effective last directive |
| `test_the_guard_is_emitted_at_every_sandbox_level` | present at `strict`, `standard`, `cc` |
| `test_the_guard_runs_before_the_exec`           | guard precedes `os.execvp`, so it reaches the build |
| `test_the_generated_launcher_still_compiles_at_every_level` | the inserted line did not break the f-string's brace escaping |
| `test_extractor_raises_when_the_guard_line_is_removed` | **negative control** — deleting the guard makes the extractor raise, so a refactor that drops it turns this module red instead of leaving it silently unreachable |

Discrimination was checked in both directions. Against unfixed source, 10 of the 11 fail:

```
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardPlacement::test_the_guard_runs_before_the_exec
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardPlacement::test_the_guard_is_emitted_at_every_sandbox_level
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardExtractorIsDiscriminating::test_extractor_raises_when_the_guard_line_is_removed
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_does_not_append_when_the_false_flag_is_already_effective
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_preserves_an_explicit_caller_value
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_sets_the_flag_when_gradle_opts_is_absent
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_the_flag_wins_over_an_inherited_daemon_true
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_the_flag_wins_when_a_true_directive_comes_last
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_does_not_add_the_flag_twice
FAILED test/test_sandbox_gradle_daemon.py::TestGradleDaemonGuardBehaviour::test_sets_the_flag_when_gradle_opts_is_empty
================== 10 failed, 1 passed, 44 warnings in 3.51s ===================
```

The one that passes on unfixed source is `test_the_generated_launcher_still_compiles_at_every_level`.
It is **non-discriminating by design** — its job is to catch a malformed insertion (an unescaped brace
in the template), not to detect the guard's presence — so an unmodified launcher compiling is the
expected result. It was left as-is rather than contrived into a failure.

With the fix: `11 passed`.

Surrounding suite, `pytest test/ -k sandbox -q`: `731 passed, 3 skipped` on an unmodified tree →
`742 passed, 3 skipped` with this change. That is +11, exactly the new tests; skips unchanged and no
pre-existing test changed state. `flake8` is clean on both changed files.

## Manual verification

N/A — unit coverage sufficient for what the diff changes. The diff's entire effect is one environment
variable in the generated launcher script, and the tests execute that guard directly and assert its
placement relative to the `execvp`.

Two things unit tests here cannot establish, flagged for a maintainer rather than claimed:

- **The end-to-end symptom was not reproduced against `main` in preparing this PR.** The argument
  above is derived from reading the launcher (mount namespace + credential masking, capability drop,
  seccomp filter, `execvp`) together with Gradle's documented daemon-reuse rule. A reviewer wanting a
  live reproduction would run a Gradle build under `wrap_argv`, let the sandboxed command exit, then
  check `gradle --status` and the daemon's `/proc/<pid>/mountinfo` and `/proc/<pid>/status`
  (`Seccomp`, `CapBnd`) from outside.
- **Whether the macOS `sandbox_exec` path deserves the same guard** — see *Scope* above.

## One claim this PR deliberately does **not** make

An earlier characterisation of this problem — including in the notes this PR was written from — said
the daemon *inherits the seccomp filter, on which `File.createNewFile()` on a `.lock` file returns
`ENOSYS`*, and that Gradle reuses daemons keyed on JVM options and the registry directory and **not**
on environment. Both halves are wrong, and the description above is written without them:

1. **The seccomp filter cannot cause that errno.** The launcher's filter returns
   `_SECCOMP_RET_ERRNO | _EPERM` — EPERM (1), not ENOSYS (38) — and denies five namespace syscalls
   only (`mount`, `umount2`, `unshare`, `setns`, `pivot_root`). `open`/`openat` are not denied at all,
   so it cannot make file creation fail.
2. **Gradle's reuse rule does consider `GRADLE_OPTS`.** Gradle's daemon documentation states a daemon
   is reused only when Java home/version and JVM args — explicitly including `GRADLE_OPTS` — match.
   Reuse is therefore not environment-blind.

Point 2 makes the conclusion **stronger** rather than weaker: before this change the launcher sets no
Gradle-relevant environment at all, so the sandboxed and host daemon contexts are *identical* and the
daemon is adoptable across the boundary. Same conclusion, now resting on Gradle's documented rule
instead of contradicting it.

An `IOException: Function not implemented` from a build that adopted a sandbox-born daemon was
observed in a downstream deployment of this sandbox, but its proximate mechanism is not established,
so it is not offered here as evidence. The mount-namespace argument needs no errno and is verifiable
from the source alone.

## Related Issues

None filed. `CONTRIBUTING.md` asks for an issue before a substantial change, and this is behavioural —
happy to open one (a draft is prepared) or to keep the discussion on this PR, whichever you prefer.
Flagged rather than skipped.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality — `pytest test/ -k sandbox -q` goes `731 passed, 3 skipped` → `742 passed, 3 skipped` (+11, the new tests); `flake8` clean on both changed files
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — **maintainer call.**
      `docs/system-specs/modules/security.md` describes the launcher sequence ("scrubs sensitive env
      vars ... and execs the agent") without enumerating the env defaults it sets, and does not mention
      the existing `GIT_SSH_COMMAND` default either, so this change arguably needs no doc edit. Happy
      to add a line if you would rather the env defaults be listed.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

