### PR TITLE
fix(cli_server): pin UTF-8 on git rev-list and journalctl subprocess calls

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -38,7 +38,6 @@
 1 src/kiro_crew/cli.py
 6 src/kiro_crew/cli_doctor.py
 1 src/kiro_crew/cli_perf.py
-1 src/kiro_crew/cli_server.py
 2 src/kiro_crew/cli_setup.py
 1 src/kiro_crew/cloud/aws.py
 4 src/kiro_crew/cron_script.py

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1106,7 +1106,7 @@ def _update(force: bool = False) -> None:
             ["git", "rev-list", "--count", "--left-right", f"HEAD...origin/{branch}"],
             cwd=proj,
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             timeout=10,
         )
         if result.returncode != 0:
@@ -1785,7 +1785,7 @@ def _logs_cmd(args: argparse.Namespace) -> None:
         probe = subprocess.run(
             ["journalctl", "-u", unit, "-n", "1", "--no-pager"],
             capture_output=True,
-            text=True,
+            **UTF8_TEXT,
             check=False,
         )
         if probe.returncode == 0 and probe.stdout.strip():


### PR DESCRIPTION
## What & why

`src/kiro_crew/cli_server.py` had **two** text-mode `subprocess.run(..., text=True)` calls with no pinned `encoding=`, so they decode child output with `locale.getpreferredencoding()`:

- the `git rev-list --count --left-right HEAD...origin/<branch>` ahead/behind computation, and
- the `journalctl -u <unit> -n 1 --no-pager` availability probe.

On a non-UTF-8 locale (or the Windows console code page) a non-ASCII byte in the child's output — a branch name, a commit subject, a systemd unit name, a log line — can raise `UnicodeDecodeError` or produce mojibake. `git` and `journalctl` both emit UTF-8, so both calls are pinned via the repo's existing `**UTF8_TEXT` splat (already imported in this file and used at 6 other call sites here).

Separately, the file's real count of unpinned text-mode calls (2) exceeded the count recorded in `.github/subprocess-encoding-baseline.txt` (1), so the `check_subprocess_encoding` CI gate failed **closed on any PR that merely touched `cli_server.py`** — a cross-cutting blocker rather than a defect in those PRs. Pinning both calls brings the file to **0** unpinned calls, so its now-stale baseline entry is pruned (the gate's sanctioned "graduated file" path).

## Flow

```
git rev-list / journalctl child (UTF-8 bytes)
        │
        ▼
subprocess.run(..., **UTF8_TEXT)   ← text=True + encoding="utf-8"
        │
        ▼
str output decoded as UTF-8  (was: locale.getpreferredencoding → decode error / mojibake off-UTF-8)
```

## Changed files

- `src/kiro_crew/cli_server.py` — swap the two bare `text=True,` kwargs for `**UTF8_TEXT,` (the `git rev-list` ahead/behind call and the `journalctl` probe).
- `.github/subprocess-encoding-baseline.txt` — remove the now-clean `cli_server.py` entry (0 unpinned calls remain).

## Testing

```
$ python scripts/check_subprocess_encoding.py
subprocess-encoding gate passed: nothing in scope decodes with the locale code page outside the baseline (254 known call(s) in 123 file(s) still listed).

$ python -m flake8 src/kiro_crew/cli_server.py
(clean)

$ python scripts/check_black_formatting.py
black gate passed
```

- Confirmed on pristine `origin/main` that `cli_server.py` has 2 `text=True` calls with only 1 `encoding=` present, and that its baseline entry reads `1` — i.e. the mismatch is a main-side staleness, reproducible on any PR that scopes the file.

## Screenshots / video

N/A — non-UI change (subprocess encoding + CI baseline).

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's Contribution License Agreement.

Part of #5580
