### PR TITLE
fix(channels): validate API input before mutation

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1289,
+    "missing_code": 1285,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1335,
+  "_compliant": 1343,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -174,7 +174,7 @@
       "missing_code": 16
     },
     "dashboard/handlers_channel.py": {
-      "missing_code": 20
+      "missing_code": 16
     },
     "dashboard/handlers_instances.py": {
       "missing_code": 18,

--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -77,15 +77,32 @@ def _mgr(request: web.Request) -> ChannelManager:
     return mgr
 
 
+async def _json_object(request: web.Request) -> dict:
+    """Parse a JSON request body and require a top-level object."""
+    try:
+        body = await request.json()
+    except Exception:
+        raise web.HTTPBadRequest(
+            text='{"error":"invalid JSON","code":"invalid_json"}',
+            content_type="application/json",
+        )
+    if not isinstance(body, dict):
+        raise web.HTTPBadRequest(
+            text=(
+                '{"error":"request body must be a JSON object",'
+                '"code":"body_not_object"}'
+            ),
+            content_type="application/json",
+        )
+    return body
+
+
 async def _get_channel_body(request: web.Request):
     """Get channel + parsed JSON body, or raise web.HTTPException."""
     ch = _mgr(request).get(request.match_info["id"])
     if not ch:
         raise web.HTTPNotFound(text='{"error":"not found"}', content_type="application/json")
-    try:
-        body = await request.json()
-    except Exception:
-        raise web.HTTPBadRequest(text='{"error":"invalid JSON"}', content_type="application/json")
+    body = await _json_object(request)
     return ch, body
 
 
@@ -157,25 +174,77 @@ async def api_channel_get(request: web.Request) -> web.Response:
 
 
 async def api_channel_create(request: web.Request) -> web.Response:
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    topic = body.get("topic", "").strip()[:500]
+    body = await _json_object(request)
+    raw_topic = body.get("topic", "")
+    if not isinstance(raw_topic, str):
+        return web.json_response(
+            {"error": "topic must be a string", "code": "channel_topic_type_invalid"},
+            status=400,
+        )
+    topic = raw_topic.strip()[:500]
     if not topic:
-        return web.json_response({"error": "topic required"}, status=400)
+        return web.json_response(
+            {"error": "topic required", "code": "channel_topic_required"}, status=400
+        )
+
+    agents_def = body.get("agents", [])
+    if not isinstance(agents_def, list):
+        return web.json_response(
+            {"error": "agents must be an array", "code": "channel_agents_type_invalid"},
+            status=400,
+        )
+    valid_policies = {policy.value for policy in ApprovalPolicy}
+    for agent_def in agents_def:
+        if not isinstance(agent_def, dict):
+            return web.json_response(
+                {
+                    "error": "each agent must be an object",
+                    "code": "channel_agent_type_invalid",
+                },
+                status=400,
+            )
+        for field in ("role", "agent", "task"):
+            if field in agent_def and not isinstance(agent_def[field], str):
+                return web.json_response(
+                    {
+                        "error": f"agent {field} must be a string",
+                        "code": "channel_agent_field_type_invalid",
+                    },
+                    status=400,
+                )
+        if "is_orchestrator" in agent_def and not isinstance(
+            agent_def["is_orchestrator"], bool
+        ):
+            return web.json_response(
+                {
+                    "error": "agent is_orchestrator must be a boolean",
+                    "code": "channel_agent_orchestrator_type_invalid",
+                },
+                status=400,
+            )
+        approval = agent_def.get("approval", "writes")
+        if not isinstance(approval, str) or approval not in valid_policies:
+            return web.json_response(
+                {
+                    "error": "invalid agent approval policy",
+                    "code": "channel_agent_approval_invalid",
+                },
+                status=400,
+            )
 
     ch = _mgr(request).create(topic)
     if not ch:
         return web.json_response(
-            {"error": "Channel limit reached. Close an existing channel first."},
+            {
+                "error": "Channel limit reached. Close an existing channel first.",
+                "code": "channel_limit_reached",
+            },
             status=429,
         )
 
     state: DashboardState = request.app["state"]
 
     # Spawn agents from preset
-    agents_def = body.get("agents", [])
     has_orchestrator = any(a.get("is_orchestrator") for a in agents_def)
     if not has_orchestrator:
         agents_def = [
@@ -361,10 +430,7 @@ async def api_channel_approve_agent(request: web.Request) -> web.Response:
     agent = ch.members.get(request.match_info["aid"])
     if not agent:
         return web.json_response({"error": "agent not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body = await _json_object(request)
     action = body.get("action", "rejected")  # approved|rejected|trust
     if action not in ("approved", "rejected", "trust"):
         return web.json_response({"error": "invalid action"}, status=400)
@@ -419,8 +485,8 @@ async def api_channel_clear_context(request: web.Request) -> web.Response:
         return web.json_response({"error": "not found"}, status=404)
 
     try:
-        body = await request.json()
-    except Exception:
+        body = await _json_object(request)
+    except web.HTTPBadRequest:
         sel().log_api_access(
             caller="dashboard", operation="channel.clear_context",
             outcome="denied", source="dashboard", resources=ch.id,

--- a/test/test_channel_api_input_validation.py
+++ b/test/test_channel_api_input_validation.py
@@ -1,0 +1,124 @@
+"""Input-contract regressions for the dashboard Channels write API."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.channel import ChannelManager
+from kiro_crew.dashboard.handlers_channel import (
+    api_channel_approve_agent,
+    api_channel_clear_context,
+    api_channel_create,
+    api_channel_post,
+)
+
+
+def _request(manager: ChannelManager, body: object, **match_info: str) -> MagicMock:
+    request = MagicMock()
+    request.app = {
+        "state": SimpleNamespace(channel_manager=manager, sessions=MagicMock(reset=AsyncMock()))
+    }
+    request.match_info = match_info
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+async def _invoke(handler, request) -> web.StreamResponse:
+    """Return HTTP exceptions as responses, matching aiohttp middleware."""
+    try:
+        return await handler(request)
+    except web.HTTPException as exc:
+        return exc
+
+
+@pytest.fixture
+def manager(tmp_path) -> ChannelManager:
+    return ChannelManager(channels_dir=str(tmp_path / "channels"))
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_object_json(manager):
+    response = await _invoke(api_channel_create, _request(manager, ["not", "an", "object"]))
+
+    assert response.status == 400
+    assert json.loads(response.text)["code"] == "body_not_object"
+    assert manager.count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_validates_agent_objects_before_mutating(manager):
+    response = await _invoke(
+        api_channel_create,
+        _request(manager, {"topic": "incident", "agents": ["not-an-agent-object"]}),
+    )
+
+    assert response.status == 400
+    assert json.loads(response.text)["code"] == "channel_agent_type_invalid"
+    assert manager.count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_string_topic_before_mutating(manager):
+    response = await _invoke(
+        api_channel_create,
+        _request(manager, {"topic": ["not", "a", "string"]}),
+    )
+
+    assert response.status == 400
+    assert manager.count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_agent_policy_before_mutating(manager):
+    response = await _invoke(
+        api_channel_create,
+        _request(
+            manager,
+            {
+                "topic": "incident",
+                "agents": [{"role": "Responder", "approval": "invalid-policy"}],
+            },
+        ),
+    )
+
+    assert response.status == 400
+    assert manager.count == 0
+
+
+@pytest.mark.asyncio
+async def test_shared_channel_body_rejects_non_object_json(manager):
+    channel = manager.create("incident")
+    response = await _invoke(
+        api_channel_post,
+        _request(manager, None, id=channel.id),
+    )
+
+    assert response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_approval_rejects_non_object_json(manager):
+    channel = manager.create("incident")
+    agent = channel.add_agent(role="Orchestrator", is_orchestrator=True)
+    response = await _invoke(
+        api_channel_approve_agent,
+        _request(manager, "approved", id=channel.id, aid=agent.id),
+    )
+
+    assert response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_clear_context_rejects_non_object_json(manager):
+    channel = manager.create("incident")
+    response = await _invoke(
+        api_channel_clear_context,
+        _request(manager, 42, id=channel.id),
+    )
+
+    assert response.status == 400


### PR DESCRIPTION
## Problem / Motivation

Channels write endpoints assume every successfully decoded JSON value is an object. Valid JSON such as arrays, strings, numbers, or `null` therefore reaches `.get()` and produces a 500. Channel creation also calls `ChannelManager.create()` before validating the supplied agent definitions, so malformed agents can leave a channel registered and broadcast `channel_created` even though the request fails.

## Why it matters

Malformed client input should be a deterministic 400, not an internal error. More importantly, a rejected create request must not leave observable server state behind or start an agent task.

## What changed (motivation -> approach -> change)

- Added one shared JSON-object parser for Channels mutation handlers.
- Applied the object contract to create, post/add/update through the existing shared helper, approval, and context clearing.
- Added stable machine-readable error codes for the new validation failures and tightened the repository error-code ratchet from 20 to 16 missing codes in this handler.
- Regenerated `error-code-baseline.json` with the repository's official update script (`python test/test_error_code_contract.py --update`), which the file's own `_comment` names. After rebasing onto current `main` the totals are `missing_code` 1285, `_compliant` 1343; the baseline diff is limited to those aggregate values plus the handler ratchet. The generated file was never hand-merged.
- Validated the create topic, agents array, agent object fields, orchestrator flag, and approval policy before calling `ChannelManager.create()`.
- Preserved the existing security-event logging path for rejected clear-context requests.

## Tests

- **Red-before was re-verified on `main` at `9d75b8a95`**, not merely on this PR's original base: six `AttributeError`s still reproduced in `handlers_channel.py` (`'list' object has no attribute 'get'` at the create handler, plus `NoneType`/`str`/`int` at the post, approval and clear-context handlers, and `'list' object has no attribute 'strip'` on the topic), so the defect was live upstream and this PR is not superseded. Rebases after that point changed only the integration base and preserved that validated production contract; the red-before was not re-run on each one.
- Green: `test_channel.py`, `test_handlers_channel_clear_context.py`, `test_handlers_channel_presets.py`, `test_channel_api_input_validation.py`, `test_error_code_contract.py` -- **51 passed**.
- Whole channel surface (every `test_channel*.py`, `test_handlers_channel*.py`, `test_governance_channels_endpoint.py`, plus `test_error_code_contract.py`) -- **772 passed, 7 skipped**. This covers #5618's just-merged non-string message-content contract, which the rebase preserves.
- Gates at the scope CI uses: `flake8`, `isort`, `mypy src/kiro_crew/` (1102 source files, no issues), `scripts/check_black_formatting.py`, and `git diff --check` all clean.

## Manual verification

N/A -- handler-level regressions exercise the invalid payloads and assert that rejected creates leave `ChannelManager.count == 0`.

## Related Issues

Fixes #5586

The separately claimed sibling add/update-agent field contract is tracked in #5595 and implemented by #5598; keeping it separate avoids widening this create/top-level JSON fix after review.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A -- no user-facing contract or configuration changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A -- project CLA wording is not yet available in the repository template.





