### PR TITLE
refactor(cron): own removal audits at service seam

### DIFF
--- a/src/kiro_crew/apps/cron_sdk.py
+++ b/src/kiro_crew/apps/cron_sdk.py
@@ -365,7 +365,11 @@ class CronSDK:
         """
         self._assert_owned(job_id, "cron_remove_job")
         result = _run_sync_mutator(
-            self._cron.remove_job, job_id, _api="remove_job"
+            self._cron.remove_job,
+            job_id,
+            _api="remove_job",
+            actor=self._owner_prefix,
+            source="cron_sdk",
         )
         self._audit_remove(job_id)
         return result
@@ -374,7 +378,9 @@ class CronSDK:
         """Event-loop-native :meth:`remove_job` (routes through
         ``CronService.remove_job_async``)."""
         self._assert_owned(job_id, "cron_remove_job")
-        result = await self._cron.remove_job_async(job_id)
+        result = await self._cron.remove_job_async(
+            job_id, actor=self._owner_prefix, source="cron_sdk"
+        )
         self._audit_remove(job_id)
         return result
 

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1097,24 +1097,7 @@ def _cron(args: argparse.Namespace) -> None:
             print(f"Job not found: {args.job_id}")
 
     elif action == "remove":
-        removed = svc.remove_job(args.job_id)
-        # SEL audit: single delete records the affected job and outcome, same
-        # shape as cron.add/cron.update above. Exception-contained: the first
-        # sel() of a process constructs the log and can raise, and the job is
-        # already removed — a completed delete must not exit as a crash
-        # because the audit trail is unavailable.
-        try:
-            sel().log_api_access(
-                caller="cli",
-                operation="cron.remove",
-                outcome="allowed" if removed else "not_found",
-                source="cli",
-                resources=(
-                    f"job_id={args.job_id}" if removed else f"job_id={args.job_id} reason=not_found"
-                ),
-            )
-        except Exception as e:
-            print(f"Warning: audit log write failed: {e}", file=sys.stderr)
+        removed = svc.remove_job(args.job_id, actor="cli", source="cli")
         if removed:
             print(f"Removed job: {args.job_id}")
         else:

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1994,26 +1994,87 @@ class CronService:
                 return job
         return None
 
-    def remove_job(self, job_id: str) -> bool:
+    def remove_job(
+        self,
+        job_id: str,
+        *,
+        actor: str,
+        source: str,
+        one_shot_path: str | None = None,
+    ) -> bool:
         """Remove a job by ID.
+
+        ``actor`` and ``source`` are required so every caller-requested
+        removal is attributable at this mutation seam. Automated one-shot
+        callers additionally provide ``one_shot_path`` to retain their
+        distinct audit outcome and path discriminator.
 
         Raises :class:`CronStoreBusy` on lock contention; see
         :meth:`remove_job_async` for the event-loop-safe variant.
         """
         ok = self._remove_job_locked(job_id)
+        self._audit_requested_removal(
+            job_id,
+            removed=ok,
+            actor=actor,
+            source=source,
+            one_shot_path=one_shot_path,
+        )
         if ok:
             self._arm_timer()
         return ok
 
-    async def remove_job_async(self, job_id: str) -> bool:
+    async def remove_job_async(
+        self,
+        job_id: str,
+        *,
+        actor: str,
+        source: str,
+        one_shot_path: str | None = None,
+    ) -> bool:
         """Event-loop-safe :meth:`remove_job`: the lock+save runs off the loop.
 
         Raises :class:`CronStoreBusy` (retryable) on sustained contention.
         """
         ok = await asyncio.to_thread(self._remove_job_locked, job_id)
+        self._audit_requested_removal(
+            job_id,
+            removed=ok,
+            actor=actor,
+            source=source,
+            one_shot_path=one_shot_path,
+        )
         if ok:
             self._arm_timer()
         return ok
+
+    def _audit_requested_removal(
+        self,
+        job_id: str,
+        *,
+        removed: bool,
+        actor: str,
+        source: str,
+        one_shot_path: str | None = None,
+    ) -> None:
+        """Audit one removal after persistence and outside the store lock."""
+        if one_shot_path is not None:
+            if removed:
+                self.audit_one_shot_removal(job_id, one_shot_path)
+            return
+        resources = f"job_id={job_id}"
+        if not removed:
+            resources += " reason=not_found"
+        try:
+            sel.sel().log_api_access(
+                caller=actor,
+                operation="cron.remove",
+                outcome="allowed" if removed else "not_found",
+                source=source,
+                resources=resources,
+            )
+        except Exception:
+            logger.warning("SEL audit for cron removal failed (job %s)", job_id, exc_info=True)
 
     def defer_removal(self, job_id: str) -> None:
         """Queue a one-shot job for removal on the next timer tick.
@@ -2164,8 +2225,13 @@ class CronService:
                 logger.info("Removed %d cron job(s) in batch", len(targets))
         return removed, missing
 
-    async def remove_jobs(self, job_ids: list[str]) -> tuple[list[str], list[str]]:
+    async def remove_jobs(
+        self, job_ids: list[str], *, actor: str, source: str
+    ) -> tuple[list[str], list[str]]:
         """Remove many jobs under ONE lock/reload/save, off the event loop.
+
+        ``actor`` and ``source`` are required so the completed batch is
+        audited here after persistence, outside the store lock.
 
         Returns ``(removed_ids, missing_ids)`` preserving input order. Looping
         :meth:`remove_job` per id would pay the file-lock + reload +
@@ -2175,12 +2241,39 @@ class CronService:
         runs in a worker thread; only ``_arm_timer`` (asyncio.create_task)
         runs back on the loop, and only when something was actually removed.
         """
-        removed, missing = await asyncio.to_thread(self._remove_jobs_locked, list(job_ids))
+        requested = list(job_ids)
+        removed, missing = await asyncio.to_thread(self._remove_jobs_locked, requested)
+        self._audit_requested_batch_removal(
+            requested, removed, missing, actor=actor, source=source
+        )
         if removed:
             self._arm_timer()
         return removed, missing
 
-    def remove_jobs_sync(self, job_ids: list[str]) -> tuple[list[str], list[str]]:
+    def _audit_requested_batch_removal(
+        self,
+        requested: list[str],
+        removed: list[str],
+        missing: list[str],
+        *,
+        actor: str,
+        source: str,
+    ) -> None:
+        """Audit one caller-requested batch after persistence and off-lock."""
+        try:
+            sel.sel().log_api_access(
+                caller=actor,
+                operation="cron.batch_delete",
+                outcome="ok" if removed else "failed",
+                source=source,
+                resources=f"requested={requested} deleted={removed} failed={missing}",
+            )
+        except Exception:
+            logger.warning("SEL audit for cron batch removal failed", exc_info=True)
+
+    def remove_jobs_sync(
+        self, job_ids: list[str], *, actor: str, source: str
+    ) -> tuple[list[str], list[str]]:
         """Synchronous sibling of :meth:`remove_jobs` — ONE atomic locked batch.
 
         Removes every id in ``job_ids`` under a SINGLE :meth:`_remove_jobs_locked`
@@ -2193,7 +2286,11 @@ class CronService:
         facade (the ``_file_lock`` loop-safety guard rejects it on a running
         loop). On the loop use :meth:`remove_jobs`.
         """
-        removed, missing = self._remove_jobs_locked(list(job_ids))
+        requested = list(job_ids)
+        removed, missing = self._remove_jobs_locked(requested)
+        self._audit_requested_batch_removal(
+            requested, removed, missing, actor=actor, source=source
+        )
         if removed:
             self._arm_timer()
         return removed, missing

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -303,28 +303,11 @@ async def api_cron_delete(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
     try:
-        ok = await state.crons.remove_job_async(job_id)
+        ok = await state.crons.remove_job_async(
+            job_id, actor="dashboard", source="api_cron_delete"
+        )
     except CronStoreBusy:
         return web.json_response(_CRON_BUSY_BODY, status=_CRON_BUSY_STATUS)
-    # SEL audit: a destructive single delete must record who/what/when + the
-    # affected job and outcome, mirroring cron.batch_delete below. Written
-    # immediately after the store mutation settles — before history cleanup —
-    # so a history-store failure cannot lose the record of a completed delete.
-    # Best-effort (batched append that swallows write failures), and the call
-    # itself is exception-contained: the first sel() of a process CONSTRUCTS
-    # the log (trust-dir creation, HMAC key validation) and can raise, and by
-    # this point the job is already deleted — a completed delete must never be
-    # reported as a failure because the audit trail is unavailable.
-    try:
-        _sel().log_api_access(
-            caller="dashboard",
-            operation="cron.remove",
-            outcome="ok" if ok else "not_found",
-            source="api_cron_delete",
-            resources=f"job_id={job_id}",
-        )
-    except Exception:
-        logger.warning("SEL audit for cron delete failed (job %s)", job_id, exc_info=True)
     if ok:
         await state.crons.get_history().delete_job_history(job_id)
         state.push_refresh("crons")
@@ -374,7 +357,9 @@ async def api_cron_batch_delete(request: web.Request) -> web.Response:
         # back on the loop (asyncio.create_task needs it): moving it off-loop
         # would raise AFTER the on-disk delete and leave the scheduler timer
         # cancelled.
-        deleted, failed = await state.crons.remove_jobs(unique_ids)
+        deleted, failed = await state.crons.remove_jobs(
+            unique_ids, actor="dashboard", source="api_cron_batch_delete"
+        )
     except Exception:
         # The batch itself raised (unexpected) — report everything as failed.
         logger.warning("Batch delete failed", exc_info=True)
@@ -392,16 +377,6 @@ async def api_cron_batch_delete(request: web.Request) -> web.Response:
                 "History cleanup failed for cron %s (job already removed)",
                 job_id, exc_info=True,
             )
-    # SEL audit: a destructive batch action must record who/what/when + the
-    # affected resources and outcome. Cron IDs are non-sensitive (no
-    # creds/PII), so logging them is compliant.
-    _sel().log_api_access(
-        caller="dashboard",
-        operation="cron.batch_delete",
-        outcome="ok" if deleted else "failed",
-        source="api_cron_batch_delete",
-        resources=f"requested={unique_ids} deleted={deleted} failed={failed}",
-    )
     if deleted:
         state.push_refresh("crons")
     # ok reflects whether anything was actually deleted — consistent with the

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1959,24 +1959,9 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         if own_err:
             return own_err
         try:
-            removed = svc.remove_job(jid)
+            removed = svc.remove_job(jid, actor="mcp", source="mcp")
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
-        # SEL audit: single delete records the affected job and outcome, same
-        # shape as cron.create/cron.update above. Best-effort and exception-
-        # contained: the first sel() of a process CONSTRUCTS the log and can
-        # raise, and the job is already removed — a completed delete must not
-        # surface as a tool error because the audit trail is unavailable.
-        try:
-            sel().log_api_access(
-                caller="mcp",
-                operation="cron.remove",
-                outcome="allowed" if removed else "not_found",
-                source="mcp",
-                resources=f"job_id={jid}",
-            )
-        except Exception:
-            logger.warning("SEL audit for cron_remove failed (job %s)", jid, exc_info=True)
         if removed:
             return f"Removed job: {jid}"
         return f"Job not found: {jid}"
@@ -2011,11 +1996,12 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 resources=f"count={len(jobs)}",
             )
         try:
-            for j in jobs:
-                svc.remove_job(j.id)
+            removed, _missing = svc.remove_jobs_sync(
+                [j.id for j in jobs], actor=session_key or "mcp", source="mcp"
+            )
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
-        return f"Removed {len(jobs)} job(s)."
+        return f"Removed {len(removed)} job(s)."
 
     if name == "cron_pause":
         jid = args["job_id"]

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -1996,12 +1996,15 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 resources=f"count={len(jobs)}",
             )
         try:
-            removed, _missing = svc.remove_jobs_sync(
+            # Distinct from the ``removed: bool`` that ``cron_remove``'s
+            # single-job path binds above: this is the batch's removed-id LIST,
+            # and reusing the name would rebind one variable to two types.
+            removed_ids, _missing = svc.remove_jobs_sync(
                 [j.id for j in jobs], actor=session_key or "mcp", source="mcp"
             )
         except CronStoreBusy:
             return "Error: cron store busy, please retry"
-        return f"Removed {len(removed)} job(s)."
+        return f"Removed {len(removed_ids)} job(s)."
 
     if name == "cron_pause":
         jid = args["job_id"]

--- a/src/kiro_crew/messaging/commands.py
+++ b/src/kiro_crew/messaging/commands.py
@@ -485,9 +485,8 @@ async def cron_remove_all_reply(
     Public for the same reason as :func:`spawn_task_reply`: a channel that
     parsed ``remove all`` itself should not have to rebuild the sentence.
 
-    *source* is the channel name and *caller* the person who typed it, both for the
-    SEL audit below. They default empty so a caller that has neither still gets the
-    record with the surface unnamed, which is worth more than no record.
+    *source* is the channel name and *caller* the person who typed it. Both are
+    forwarded to the service so the persisted mutation and its audit cannot drift.
     """
     jobs = cron_service.list_jobs(include_disabled=True)
     if not jobs:
@@ -498,30 +497,13 @@ async def cron_remove_all_reply(
     # One batch lock/reload/save, offloaded by the service itself, so a chat
     # gateway's loop is never parked on the store lock.
     try:
-        removed_ids, missing_ids = await cron_service.remove_jobs([job.id for job in jobs])
+        await cron_service.remove_jobs(
+            [job.id for job in jobs],
+            actor=caller or source or "system",
+            source=source or "messaging",
+        )
     except CronStoreBusy:
         return _CRON_BUSY
-    # SEL audit: every plural delete path leaves the same ``cron.batch_delete``
-    # record the dashboard's does (MCP's ``cron_remove_all`` logs its own
-    # authz-scoped tool event instead). Once the jobs are gone from crons.json the
-    # trail is the only way to tell a deliberate remove-all from data loss, and this
-    # is the SHARED path now, so every channel gets it rather than only the one
-    # whose copy carried the audit. Best-effort and exception-contained: the first
-    # ``sel()`` of a process CONSTRUCTS the log and can raise, and the jobs are
-    # already removed -- audit unavailability must not fail the command.
-    try:
-        sel().log_api_access(
-            caller=caller or source or "system",
-            operation="cron.batch_delete",
-            outcome="ok" if removed_ids else "failed",
-            source=source or "messaging",
-            resources=(
-                f"requested={[job.id for job in jobs]} "
-                f"deleted={removed_ids} failed={missing_ids}"
-            ),
-        )
-    except Exception:
-        logger.warning("SEL audit for cron remove-all failed", exc_info=True)
     return f"✅ Removed {len(lines)} cron job(s):\n" + "\n".join(lines)
 
 
@@ -534,9 +516,8 @@ async def cron_command_reply(
     ``*_async`` variants; a contended store answers "busy, retry" rather than
     parking the caller's loop on the lock.
 
-    *source* and *caller* name the channel and the person for the remove-all SEL
-    audit; both are keyword-only with empty defaults so every existing positional
-    call site is unchanged.
+    *source* and *caller* name the channel and person for removal attribution;
+    both are keyword-only with empty defaults so existing positional calls work.
     """
     parts = text.strip().lower().split()
     if len(parts) < 2 or parts[0] != "cron":
@@ -551,27 +532,15 @@ async def cron_command_reply(
         if job_id == "all":
             return await cron_remove_all_reply(cron_service, source=source, caller=caller)
         try:
-            removed = await cron_service.remove_job_async(job_id)
+            removed = await cron_service.remove_job_async(
+                job_id,
+                actor=caller or source or "system",
+                source=source or "messaging",
+            )
         except CronStoreBusy:
             # A contended store means the delete never happened, so there is no
             # mutation to audit -- matching the dashboard's single-delete busy path.
             return _CRON_BUSY
-        # SEL audit on the single delete, on the same reasoning as the batch one
-        # below it: once the job is gone from crons.json the trail is the only way to
-        # tell a deliberate removal from data loss. Emitted for a MISSING id too,
-        # because "someone asked to delete a job that was not there" is exactly the
-        # shape worth being able to see. Exception-contained: the first ``sel()`` of a
-        # process constructs the log and can raise, and the job is already removed.
-        try:
-            sel().log_api_access(
-                caller=caller or source or "system",
-                operation="cron.remove",
-                outcome="allowed" if removed else "not_found",
-                source=source or "messaging",
-                resources=f"job_id={job_id}",
-            )
-        except Exception:
-            logger.warning("SEL audit for cron remove failed", exc_info=True)
         return f"✅ Removed cron job `{job_id}`" if removed else f"❌ Job `{job_id}` not found"
     if action in ("pause", "resume"):
         enabled = action == "resume"

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3089,7 +3089,12 @@ class GatewayOrchestrator:
                 logger.warning("Cron '%s' delivery failed: %s", job.name, notify_exc)
             if remove and delivered and self.cron_svc:
                 try:
-                    removed = await self.cron_svc.remove_job_async(job.id)
+                    await self.cron_svc.remove_job_async(
+                        job.id,
+                        actor="cron",
+                        source="cron",
+                        one_shot_path="cron_gateway",
+                    )
                 except CronStoreBusy:
                     # No caller to retry this fire-and-forget removal, so hand
                     # it to the service's deferred-removal queue: the job is
@@ -3104,17 +3109,6 @@ class GatewayOrchestrator:
                         "Cron '%s': store busy, queued one-shot removal for " "the next timer tick",
                         job.name,
                     )
-                else:
-                    if removed:
-                        # SEL audit: automated one-shot (Done) removal after
-                        # delivery (issue #5408). One owner for the record
-                        # shape: the service's helper emits the same
-                        # cron.remove event as the deferred-drain and
-                        # run-merge paths, best-effort and exception-contained
-                        # (audit unavailability never fails the delivery
-                        # callback). removed=False means another path already
-                        # deleted the job — that path owns the audit record.
-                        self.cron_svc.audit_one_shot_removal(job.id, "cron_gateway")
 
         async def _alert_cron_failure(job: CronJob, detail: str, *, denied: bool = False) -> None:
             """Tell the user WHY a script/command cron run failed or was denied.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1172,14 +1172,10 @@ class TestCronCli:
             mock_svc.remove_job.return_value = True
             args = argparse.Namespace(cron_action="remove", job_id="abc123")
             _cron(args)
-            mock_svc.remove_job.assert_called_once_with("abc123")
-            mock_sel.return_value.log_api_access.assert_called_once_with(
-                caller="cli",
-                operation="cron.remove",
-                outcome="allowed",
-                source="cli",
-                resources="job_id=abc123",
+            mock_svc.remove_job.assert_called_once_with(
+                "abc123", actor="cli", source="cli"
             )
+            mock_sel.return_value.log_api_access.assert_not_called()
 
     def test_cron_remove_not_found_audits_not_found(self):
         with (
@@ -1190,13 +1186,10 @@ class TestCronCli:
             mock_svc.remove_job.return_value = False
             args = argparse.Namespace(cron_action="remove", job_id="ghost")
             _cron(args)
-            mock_sel.return_value.log_api_access.assert_called_once_with(
-                caller="cli",
-                operation="cron.remove",
-                outcome="not_found",
-                source="cli",
-                resources="job_id=ghost reason=not_found",
+            mock_svc.remove_job.assert_called_once_with(
+                "ghost", actor="cli", source="cli"
             )
+            mock_sel.return_value.log_api_access.assert_not_called()
 
     def test_cron_remove_succeeds_when_audit_raises(self, capsys):
         # The first sel() of a process constructs the log and can raise; the
@@ -1208,12 +1201,12 @@ class TestCronCli:
         ):
             mock_svc = mock_svc_cls.return_value
             mock_svc.remove_job.return_value = True
-            mock_sel.side_effect = RuntimeError("SEL trust root unavailable")
             args = argparse.Namespace(cron_action="remove", job_id="abc123")
             _cron(args)
             out = capsys.readouterr()
             assert "Removed job: abc123" in out.out
-            assert "audit log write failed" in out.err
+            assert out.err == ""
+            mock_sel.assert_not_called()
 
 
 class TestPortEnvValidatedAtEntry:

--- a/test/test_cron.py
+++ b/test/test_cron.py
@@ -166,8 +166,8 @@ class TestCronService:
         svc = CronService(base_dir=tmp_path)
         svc._load()
         job = svc.add_job(name="rm", message="bye", every_secs=300)
-        assert svc.remove_job(job.id)
-        assert not svc.remove_job("nonexistent")
+        assert svc.remove_job(job.id, actor="test", source="test")
+        assert not svc.remove_job("nonexistent", actor="test", source="test")
 
     def test_list_jobs(self, tmp_path: Path) -> None:
         svc = CronService(base_dir=tmp_path)

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -231,7 +231,9 @@ class TestScriptExecution:
         result, _ = await _run_script_callback(gw, job, {"status": "done", "message": "CR merged"})
         assert "CR merged" in (result or "")
         assert job.last_result == "CR merged"
-        gw.cron_svc.remove_job_async.assert_called_once_with("sj1")
+        gw.cron_svc.remove_job_async.assert_called_once_with(
+            "sj1", actor="cron", source="cron", one_shot_path="cron_gateway"
+        )
 
     @pytest.mark.asyncio
     async def test_done_busy_store_defers_removal_not_dropped(self):
@@ -270,7 +272,9 @@ class TestScriptExecution:
             assert captured_cb is not None
             await captured_cb(job)
 
-        gw.cron_svc.remove_job_async.assert_called_once_with("sj1")
+        gw.cron_svc.remove_job_async.assert_called_once_with(
+            "sj1", actor="cron", source="cron", one_shot_path="cron_gateway"
+        )
         # The removal was queued for deferred drain, not dropped.
         gw.cron_svc.defer_removal.assert_called_once_with("sj1")
 

--- a/test/test_cron_locking_regression.py
+++ b/test/test_cron_locking_regression.py
@@ -310,7 +310,9 @@ class TestReadPathsLocked:
                     svc.get_job(jid)
                 await asyncio.sleep(0)
 
-        remove_task = asyncio.create_task(svc.remove_jobs(ids[::2]))
+        remove_task = asyncio.create_task(
+            svc.remove_jobs(ids[::2], actor="test", source="test")
+        )
         read_tasks = [asyncio.create_task(reader()) for _ in range(4)]
         await asyncio.gather(remove_task, *read_tasks)
 
@@ -804,7 +806,7 @@ class TestMutatorContract:
             with pytest.raises(CronStoreBusy):
                 svc.update_job(existing.id, name="renamed")
             with pytest.raises(CronStoreBusy):
-                svc.remove_job(existing.id)
+                svc.remove_job(existing.id, actor="test", source="test")
             with pytest.raises(CronStoreBusy):
                 svc.enable_job(existing.id, enabled=False)
             with pytest.raises(CronStoreBusy):
@@ -846,7 +848,7 @@ class TestMutatorContract:
                 with pytest.raises(CronStoreBusy):
                     await svc.update_job_async(job.id, name="renamed")
                 with pytest.raises(CronStoreBusy):
-                    await svc.remove_job_async(job.id)
+                    await svc.remove_job_async(job.id, actor="test", source="test")
                 with pytest.raises(CronStoreBusy):
                     await svc.enable_job_async(job.id, enabled=False)
                 # Sampled while the lock is still held, BEFORE the ticker is
@@ -879,7 +881,7 @@ class TestMutatorContract:
             assert await svc.enable_job_async(job.id, enabled=False) is True
             assert await svc.ack_job_async(job.id, "note") is True
             assert await svc.unack_job_async(job.id) is True
-            assert await svc.remove_job_async(job.id) is True
+            assert await svc.remove_job_async(job.id, actor="test", source="test") is True
             assert svc.get_job(job.id) is None
 
         asyncio.run(scenario())

--- a/test/test_cron_removal_audit_seam.py
+++ b/test/test_cron_removal_audit_seam.py
@@ -1,0 +1,106 @@
+"""Regression coverage for CronService-owned removal auditing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import kiro_crew.cron as cron_mod
+from kiro_crew.cron import CronService, CronStoreBusy
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def log_api_access(self, **event) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def recorder(monkeypatch) -> _Recorder:
+    value = _Recorder()
+    monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=lambda: value))
+    return value
+
+
+def test_single_remove_audits_at_service_seam(tmp_path, recorder):
+    service = CronService(base_dir=tmp_path)
+    job = service.add_job("cleanup", "run", every_secs=3600)
+
+    assert service.remove_job(job.id, actor="cli", source="cli") is True
+
+    assert recorder.events == [
+        {
+            "caller": "cli",
+            "operation": "cron.remove",
+            "outcome": "allowed",
+            "source": "cli",
+            "resources": f"job_id={job.id}",
+        }
+    ]
+
+
+def test_missing_single_remove_is_audited(tmp_path, recorder):
+    service = CronService(base_dir=tmp_path)
+
+    assert service.remove_job("ghost", actor="mcp", source="mcp") is False
+
+    assert recorder.events[0]["outcome"] == "not_found"
+    assert recorder.events[0]["resources"] == "job_id=ghost reason=not_found"
+
+
+@pytest.mark.asyncio
+async def test_batch_remove_audits_requested_deleted_and_missing(tmp_path, recorder):
+    service = CronService(base_dir=tmp_path)
+    first = service.add_job("first", "run", every_secs=3600)
+    second = service.add_job("second", "run", every_secs=3600)
+
+    result = await service.remove_jobs([first.id, "ghost", second.id], actor="U123", source="slack")
+
+    assert result == ([first.id, second.id], ["ghost"])
+    event = recorder.events[0]
+    assert event["caller"] == "U123"
+    assert event["operation"] == "cron.batch_delete"
+    assert event["outcome"] == "ok"
+    assert first.id in event["resources"]
+    assert second.id in event["resources"]
+    assert "ghost" in event["resources"]
+
+
+def test_sync_batch_remove_uses_the_same_audit_seam(tmp_path, recorder):
+    service = CronService(base_dir=tmp_path)
+    job = service.add_job("cleanup", "run", every_secs=3600)
+
+    result = service.remove_jobs_sync([job.id, "ghost"], actor="mcp-session", source="mcp")
+
+    assert result == ([job.id], ["ghost"])
+    assert recorder.events[0]["caller"] == "mcp-session"
+    assert recorder.events[0]["operation"] == "cron.batch_delete"
+
+
+def test_store_failure_emits_no_audit(tmp_path, recorder, monkeypatch):
+    service = CronService(base_dir=tmp_path)
+
+    def busy(_job_id):
+        raise CronStoreBusy("busy")
+
+    monkeypatch.setattr(service, "_remove_job_locked", busy)
+    with pytest.raises(CronStoreBusy):
+        service.remove_job("job", actor="dashboard", source="api_cron_delete")
+
+    assert recorder.events == []
+
+
+def test_audit_failure_does_not_undo_saved_removal(tmp_path, monkeypatch):
+    service = CronService(base_dir=tmp_path)
+    job = service.add_job("cleanup", "run", every_secs=3600)
+
+    def unavailable():
+        raise RuntimeError("audit unavailable")
+
+    monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=unavailable))
+
+    assert service.remove_job(job.id, actor="cli", source="cli") is True
+    assert service.get_job(job.id) is None

--- a/test/test_cron_sdk.py
+++ b/test/test_cron_sdk.py
@@ -81,17 +81,19 @@ class MockCronService:
             return list(self._jobs)
         return [j for j in self._jobs if j.enabled]
 
-    def remove_job(self, job_id: str) -> bool:
+    def remove_job(self, job_id: str, *, actor: str, source: str) -> bool:
         for i, j in enumerate(self._jobs):
             if j.id == job_id:
                 self._jobs.pop(i)
                 return True
         return False
 
-    async def remove_job_async(self, job_id: str) -> bool:
-        return self.remove_job(job_id)
+    async def remove_job_async(self, job_id: str, *, actor: str, source: str) -> bool:
+        return self.remove_job(job_id, actor=actor, source=source)
 
-    def remove_jobs_sync(self, job_ids: list[str]) -> tuple[list[str], list[str]]:
+    def remove_jobs_sync(
+        self, job_ids: list[str], *, actor: str, source: str
+    ) -> tuple[list[str], list[str]]:
         removed: list[str] = []
         missing: list[str] = []
         present = {j.id for j in self._jobs}
@@ -102,8 +104,10 @@ class MockCronService:
             self._jobs = [j for j in self._jobs if j.id not in targets]
         return removed, missing
 
-    async def remove_jobs(self, job_ids: list[str]) -> tuple[list[str], list[str]]:
-        return self.remove_jobs_sync(list(job_ids))
+    async def remove_jobs(
+        self, job_ids: list[str], *, actor: str, source: str
+    ) -> tuple[list[str], list[str]]:
+        return self.remove_jobs_sync(list(job_ids), actor=actor, source=source)
 
     def remove_jobs_by_owner_sync(self, owner_prefix: str) -> list[str]:
         removed = [

--- a/test/test_dashboard_cron_batch_delete_handler.py
+++ b/test/test_dashboard_cron_batch_delete_handler.py
@@ -1,7 +1,8 @@
 """Tests for api_cron_batch_delete HTTP handler (DELETE /api/crons).
 
 Mirrors the single-delete contract (remove_job + delete_job_history) but over a
-list of ids, with per-id failure isolation and a single refresh push.
+list of ids, with per-id failure isolation and a single refresh push. Audit
+attribution is delegated to the CronService batch mutation seam.
 """
 
 from __future__ import annotations
@@ -28,7 +29,9 @@ def _make_state(existing_ids):
     state = MagicMock()
     state.crons = MagicMock()
 
-    async def remove_jobs(job_ids):
+    async def remove_jobs(job_ids, *, actor, source):
+        assert actor == "dashboard"
+        assert source == "api_cron_batch_delete"
         # Mirror CronService.remove_jobs: one async batch call returning
         # (removed_ids, missing_ids) in input order.
         removed, missing = [], []
@@ -49,8 +52,7 @@ def _make_state(existing_ids):
 class TestApiCronBatchDelete:
     @pytest.fixture(autouse=True)
     def stub_sel(self):
-        # Stub the SEL recorder so tests don't write real audit events; expose
-        # it so the audit-event test can assert on it.
+        # The handler must not retain a duplicate call-site audit.
         with patch("kiro_crew.dashboard.handlers.cron._sel") as sel_fn:
             recorder = MagicMock()
             sel_fn.return_value = recorder
@@ -66,7 +68,9 @@ class TestApiCronBatchDelete:
             assert data["ok"] is True
             assert sorted(data["deleted"]) == ["a", "b", "c"]
             assert data["failed"] == []
-        state.crons.remove_jobs.assert_called_once_with(["a", "b", "c"])
+        state.crons.remove_jobs.assert_called_once_with(
+            ["a", "b", "c"], actor="dashboard", source="api_cron_batch_delete"
+        )
         assert state.crons.get_history().delete_job_history.await_count == 3
         # One refresh for the whole batch, not one per id.
         state.push_refresh.assert_called_once_with("crons")
@@ -105,7 +109,9 @@ class TestApiCronBatchDelete:
             data = await resp.json()
             assert sorted(data["deleted"]) == ["a", "b"]
         # remove_jobs invoked ONCE with the deduplicated id list
-        state.crons.remove_jobs.assert_called_once_with(["a", "b"])
+        state.crons.remove_jobs.assert_called_once_with(
+            ["a", "b"], actor="dashboard", source="api_cron_batch_delete"
+        )
 
     @pytest.mark.asyncio
     async def test_empty_ids_is_400(self):
@@ -172,17 +178,17 @@ class TestApiCronBatchDelete:
         state.push_refresh.assert_called_once_with("crons")
 
     @pytest.mark.asyncio
-    async def test_emits_sel_audit_event(self, stub_sel):
+    async def test_delegates_audit_to_service(self, stub_sel):
         state = _make_state(["a", "b"])
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.delete("/api/crons", json={"ids": ["a", "b", "ghost"]})
             assert resp.status == 200
-        stub_sel.log_api_access.assert_called_once()
-        kw = stub_sel.log_api_access.call_args.kwargs
-        assert kw["operation"] == "cron.batch_delete"
-        assert kw["source"] == "api_cron_batch_delete"
-        # requested ids + outcome captured for auditability
-        assert "a" in kw["resources"] and "ghost" in kw["resources"]
+        state.crons.remove_jobs.assert_awaited_once_with(
+            ["a", "b", "ghost"],
+            actor="dashboard",
+            source="api_cron_batch_delete",
+        )
+        stub_sel.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_real_cronservice_delete_succeeds_and_scheduler_survives(self, tmp_path):

--- a/test/test_dashboard_cron_delete_handler.py
+++ b/test/test_dashboard_cron_delete_handler.py
@@ -1,10 +1,8 @@
 """Tests for api_cron_delete HTTP handler (DELETE /api/crons/{id}).
 
-The single-delete path must emit the same class of SEL audit event as the
-batch handler (``cron.batch_delete``): after a job disappears from
-``crons.json`` the audit trail is the only way to tell a deliberate delete
-from accidental data loss, so a single delete without an audit record is a
-gap, not a smaller batch.
+The handler must pass its attribution to ``CronService.remove_job_async`` and
+must not emit a second call-site audit. The service seam owns the record after
+the store mutation settles.
 """
 
 from __future__ import annotations
@@ -32,7 +30,9 @@ def _make_state(existing_ids):
     state = MagicMock()
     state.crons = MagicMock()
 
-    async def remove_job_async(job_id):
+    async def remove_job_async(job_id, *, actor, source):
+        assert actor == "dashboard"
+        assert source == "api_cron_delete"
         if job_id in known:
             known.discard(job_id)
             return True
@@ -47,8 +47,7 @@ def _make_state(existing_ids):
 class TestApiCronDeleteAudit:
     @pytest.fixture(autouse=True)
     def stub_sel(self):
-        # Stub the SEL recorder so tests don't write real audit events; expose
-        # it so the audit-event tests can assert on it.
+        # The handler must not retain a duplicate call-site audit.
         with patch("kiro_crew.dashboard.handlers.cron._sel") as sel_fn:
             recorder = MagicMock()
             sel_fn.return_value = recorder
@@ -62,12 +61,10 @@ class TestApiCronDeleteAudit:
             assert resp.status == 200
             data = await resp.json()
             assert data["ok"] is True
-        stub_sel.log_api_access.assert_called_once()
-        kw = stub_sel.log_api_access.call_args.kwargs
-        assert kw["operation"] == "cron.remove"
-        assert kw["source"] == "api_cron_delete"
-        assert kw["outcome"] == "ok"
-        assert "job-1" in kw["resources"]
+        state.crons.remove_job_async.assert_awaited_once_with(
+            "job-1", actor="dashboard", source="api_cron_delete"
+        )
+        stub_sel.log_api_access.assert_not_called()
         # Delete behavior itself is unchanged: history purged + refresh pushed.
         state.crons.get_history().delete_job_history.assert_awaited_once_with("job-1")
         state.push_refresh.assert_called_once_with("crons")
@@ -80,11 +77,10 @@ class TestApiCronDeleteAudit:
             assert resp.status == 200
             data = await resp.json()
             assert data["ok"] is False
-        stub_sel.log_api_access.assert_called_once()
-        kw = stub_sel.log_api_access.call_args.kwargs
-        assert kw["operation"] == "cron.remove"
-        assert kw["outcome"] == "not_found"
-        assert "ghost" in kw["resources"]
+        state.crons.remove_job_async.assert_awaited_once_with(
+            "ghost", actor="dashboard", source="api_cron_delete"
+        )
+        stub_sel.log_api_access.assert_not_called()
         state.push_refresh.assert_not_called()
 
     @pytest.mark.asyncio
@@ -112,10 +108,10 @@ class TestApiCronDeleteAudit:
             # The handler does not swallow the history failure; the audit must
             # already have been written regardless of how the response ends.
             assert resp.status == 500
-        stub_sel.log_api_access.assert_called_once()
-        kw = stub_sel.log_api_access.call_args.kwargs
-        assert kw["operation"] == "cron.remove"
-        assert kw["outcome"] == "ok"
+        state.crons.remove_job_async.assert_awaited_once_with(
+            "job-1", actor="dashboard", source="api_cron_delete"
+        )
+        stub_sel.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_audit_failure_never_fails_a_completed_delete(self, stub_sel):
@@ -123,7 +119,6 @@ class TestApiCronDeleteAudit:
         # HMAC key validation) and can raise. The job is already gone by then:
         # the delete must still report success, purge history, and refresh.
         state = _make_state(["job-1"])
-        stub_sel.log_api_access.side_effect = RuntimeError("SEL trust root unavailable")
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.delete("/api/crons/job-1")
             assert resp.status == 200
@@ -131,3 +126,4 @@ class TestApiCronDeleteAudit:
             assert data["ok"] is True
         state.crons.get_history().delete_job_history.assert_awaited_once_with("job-1")
         state.push_refresh.assert_called_once_with("crons")
+        stub_sel.log_api_access.assert_not_called()

--- a/test/test_mcp_cron.py
+++ b/test/test_mcp_cron.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from types import SimpleNamespace
 
 import pytest
 
@@ -339,9 +340,11 @@ class TestCronRemoveAudit:
             def log_tool_invocation(self, **kw):
                 events.append(kw)
 
+        import kiro_crew.cron as cron_mod
         import kiro_crew.mcp_cron as mcp_cron_mod
 
         monkeypatch.setattr(mcp_cron_mod, "sel", lambda: _FakeSel())
+        monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=lambda: _FakeSel()))
         return events
 
     def test_cron_remove_emits_sel_audit(self, monkeypatch, tmp_path, sel_events):
@@ -400,12 +403,14 @@ class TestCronRemoveAudit:
         assert len(jobs) == 1
         jid = jobs[0].id
 
+        import kiro_crew.cron as cron_mod
         import kiro_crew.mcp_cron as mcp_cron_mod
 
         def _raising_sel():
             raise RuntimeError("SEL trust root unavailable")
 
         monkeypatch.setattr(mcp_cron_mod, "sel", _raising_sel)
+        monkeypatch.setattr(cron_mod, "sel", SimpleNamespace(sel=_raising_sel))
         result = _call_tool_inner("cron_remove", {"job_id": jid})
         assert result == f"Removed job: {jid}"
         assert not [j for j in CronService(base_dir=tmp_path).list_jobs() if j.id == jid]

--- a/test/test_mcp_cron_caller_identity.py
+++ b/test/test_mcp_cron_caller_identity.py
@@ -373,7 +373,7 @@ def test_the_list_scoping_decision_lands_on_the_audit_trail() -> None:
         svc2 = CronService(base_dir=mcp_cron.config_dir())
         for job in svc2.list_jobs(include_disabled=True):
             if job.session_key != "dashboard:alice":
-                svc2.remove_job(job.id)
+                svc2.remove_job(job.id, actor="test", source="test")
         _call_tool_inner("cron_list", {})
         assert [e for e in events if e.get("tool_name") == "cron_list"] == [], events
     finally:

--- a/test/test_messaging_commands.py
+++ b/test/test_messaging_commands.py
@@ -640,12 +640,11 @@ class TestCron:
     async def test_remove_all_reports_each_job_and_batches_one_write(self) -> None:
         svc = MagicMock()
         svc.list_jobs.return_value = [_job("j1"), _job("j2")]
-        # `remove_jobs` answers `(removed_ids, missing_ids)`; the reply unpacks it
-        # for the SEL batch audit, so a bare mock is not a stand-in for the service.
+        # The command forwards the whole batch to the service's mutation/audit seam.
         svc.remove_jobs = AsyncMock(return_value=(["j1", "j2"], []))
         out = await cron_command_reply("cron remove all", svc) or ""
         assert "Removed 2 cron job(s)" in out and "`j1`" in out and "`j2`" in out
-        assert svc.remove_jobs.await_args.args[0] == ["j1", "j2"]
+        svc.remove_jobs.assert_awaited_once_with(["j1", "j2"], actor="system", source="messaging")
 
     @pytest.mark.asyncio
     async def test_remove_all_redacts_each_job_name(self) -> None:
@@ -655,12 +654,12 @@ class TestCron:
         assert _AWS_KEY not in (await cron_remove_all_reply(svc) or "")
 
     @pytest.mark.asyncio
-    async def test_every_channel_gets_the_delete_audits_not_only_slack(self) -> None:
-        """The audits moved WITH the command, which is the point of the hoist.
+    async def test_every_channel_forwards_delete_attribution_not_only_slack(self) -> None:
+        """Every shared command caller reaches the service-owned audit seam.
 
-        They arrived on Slack's own copy of `cron remove`; hoisting the command
-        without them would have been a silent revert for Slack and would have left
-        every other channel deleting cron jobs with no trail at all.
+        Actor and source arrived on Slack's old copy of `cron remove`; hoisting the
+        command must retain them for every channel without a duplicate command-level
+        audit.
         """
         svc = MagicMock()
         svc.list_jobs.return_value = [_job("j1")]
@@ -669,15 +668,11 @@ class TestCron:
 
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             await cron_command_reply("cron remove all", svc, source="telegram", caller="7")
-            batch = mock_sel.return_value.log_api_access.call_args.kwargs
             await cron_command_reply("cron remove j1", svc, source="telegram", caller="7")
-            single = mock_sel.return_value.log_api_access.call_args.kwargs
 
-        assert batch["operation"] == "cron.batch_delete"
-        assert single["operation"] == "cron.remove"
-        for event in (batch, single):
-            assert event["source"] == "telegram", "the surface must be the channel, not slack"
-            assert event["caller"] == "7", "and the caller the person who typed it"
+        svc.remove_jobs.assert_awaited_once_with(["j1"], actor="7", source="telegram")
+        svc.remove_job_async.assert_awaited_once_with("j1", actor="7", source="telegram")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_a_caller_that_names_nobody_still_leaves_a_record(self) -> None:
@@ -691,7 +686,8 @@ class TestCron:
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             await cron_command_reply("cron remove all", svc, source="webex")
 
-        assert mock_sel.return_value.log_api_access.call_args.kwargs["caller"] == "webex"
+        svc.remove_jobs.assert_awaited_once_with(["j1"], actor="webex", source="webex")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_remove_all_on_an_empty_roster_touches_nothing(self) -> None:

--- a/test/test_slack_cron_remove_audit.py
+++ b/test/test_slack_cron_remove_audit.py
@@ -1,9 +1,6 @@
-"""SEL audit for the remaining cron-removal paths (issue #5408).
+"""SEL audit coverage for cron-removal paths (issues #5408 and #5438).
 
-PR #5405 (in review) adds the ``cron.remove`` audit to the dashboard, MCP, and
-CLI single-delete paths; on base, the plural ``cron.batch_delete`` is the only
-audited removal. These tests lock in the same shapes for the paths neither
-covers:
+These tests lock in the caller attribution and one-shot record shapes for:
 
 * Slack keyword ``cron remove <id>`` (``slack/handler.py``)
 * Slack ``cron remove all`` (the plural path, mirroring ``cron.batch_delete``)
@@ -11,10 +8,10 @@ covers:
   Done removal, the deferred drain, and the ``delete_after_run`` consume in
   ``_merge_job_result``
 
-Each path asserts both halves of the contract: the event is emitted on
-success, and the removal still succeeds when the audit raises (the first
-``sel()`` of a process constructs the log and can raise). The composite
-gateway-then-merge test locks the exactly-one-record invariant across paths.
+Caller-requested paths assert that actor/source attribution reaches the
+CronService seam without a duplicate call-site emit. Automated paths retain
+their one-shot outcome/path contract. The composite gateway-then-merge test
+locks the exactly-one-record invariant across paths.
 """
 
 from __future__ import annotations
@@ -54,13 +51,8 @@ class TestSlackSingleRemoveAudit:
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             out = await h._handle_cron_command("cron remove j1", svc, "C", "t", user_id="U123")
         assert out is not None and "Removed cron job" in out
-        mock_sel.return_value.log_api_access.assert_called_once_with(
-            caller="U123",
-            operation="cron.remove",
-            outcome="allowed",
-            source="slack",
-            resources="job_id=j1",
-        )
+        svc.remove_job_async.assert_awaited_once_with("j1", actor="U123", source="slack")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_remove_missing_audits_not_found(self):
@@ -69,10 +61,8 @@ class TestSlackSingleRemoveAudit:
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             out = await h._handle_cron_command("cron remove ghost", svc, "C", "t", user_id="U123")
         assert out is not None and "not found" in out
-        kw = mock_sel.return_value.log_api_access.call_args.kwargs
-        assert kw["operation"] == "cron.remove"
-        assert kw["outcome"] == "not_found"
-        assert "ghost" in kw["resources"]
+        svc.remove_job_async.assert_awaited_once_with("ghost", actor="U123", source="slack")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_caller_falls_back_to_surface_when_no_user(self):
@@ -80,7 +70,8 @@ class TestSlackSingleRemoveAudit:
         svc.remove_job_async = AsyncMock(return_value=True)
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             await h._handle_cron_command("cron remove j1", svc, "C", "t")
-        assert mock_sel.return_value.log_api_access.call_args.kwargs["caller"] == "slack"
+        svc.remove_job_async.assert_awaited_once_with("j1", actor="slack", source="slack")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_busy_store_audits_nothing(self):
@@ -122,13 +113,8 @@ class TestSlackRemoveAllAudit:
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             out = await mc.cron_remove_all_reply(svc, source="slack", caller="U123")
         assert "Removed 2 cron job(s)" in out
-        mock_sel.return_value.log_api_access.assert_called_once()
-        kw = mock_sel.return_value.log_api_access.call_args.kwargs
-        assert kw["caller"] == "U123"
-        assert kw["operation"] == "cron.batch_delete"
-        assert kw["outcome"] == "ok"
-        assert kw["source"] == "slack"
-        assert "j1" in kw["resources"] and "j2" in kw["resources"]
+        svc.remove_jobs.assert_awaited_once_with(["j1", "j2"], actor="U123", source="slack")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_remove_all_nothing_deleted_audits_failed(self):
@@ -139,7 +125,8 @@ class TestSlackRemoveAllAudit:
         svc.remove_jobs = AsyncMock(return_value=([], ["j1"]))
         with patch("kiro_crew.messaging.commands.sel") as mock_sel:
             await mc.cron_remove_all_reply(svc, source="slack", caller="U123")
-        assert mock_sel.return_value.log_api_access.call_args.kwargs["outcome"] == "failed"
+        svc.remove_jobs.assert_awaited_once_with(["j1"], actor="U123", source="slack")
+        mock_sel.return_value.log_api_access.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_busy_store_audits_nothing(self):
@@ -240,7 +227,7 @@ class TestDeferredDrainAudit:
         svc = CronService(base_dir=tmp_path)
         job = svc.add_job("one-shot", "ping", at_ts=time.time() + 3600, delete_after_run=True)
         svc.defer_removal(job.id)
-        svc.remove_job(job.id)
+        svc.remove_job(job.id, actor="test", source="test")
         sel_recorder.events.clear()
         svc._tick_scan_locked()
         assert not _remove_events(sel_recorder)
@@ -284,7 +271,7 @@ class TestMergeJobResultOneShotAudit:
         # consume here; the gateway path owns that audit record.
         svc = CronService(base_dir=tmp_path)
         job = svc.add_job("reminder", "ping", at_ts=time.time() - 5, delete_after_run=True)
-        svc.remove_job(job.id)
+        svc.remove_job(job.id, actor="test", source="test")
         sel_recorder.events.clear()
         job.last_run_ts = time.time()
         job.last_status = "ok"
@@ -402,8 +389,13 @@ class TestGatewayDoneRemovalAudit:
         job = _make_script_job()
         result, _ = await _run_done_callback(gw, job)
         assert "all done" in (result or "")
-        gw.cron_svc.remove_job_async.assert_called_once_with("sj1")
-        gw.cron_svc.audit_one_shot_removal.assert_called_once_with("sj1", "cron_gateway")
+        gw.cron_svc.remove_job_async.assert_called_once_with(
+            "sj1",
+            actor="cron",
+            source="cron",
+            one_shot_path="cron_gateway",
+        )
+        gw.cron_svc.audit_one_shot_removal.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_busy_store_defers_without_gateway_audit(self):

--- a/test/test_slack_gateway_cron_exec_coverage.py
+++ b/test/test_slack_gateway_cron_exec_coverage.py
@@ -1172,7 +1172,12 @@ class TestDeliverScriptResult:
         result = {"status": "done", "message": "all clear"}
         async with _cron_cb(orch, svc=svc, sel_obj=_blind_sel(), script_result=result) as cb:
             assert await cb(job) == "all clear"
-        svc.remove_job_async.assert_awaited_once_with(job.id)
+        svc.remove_job_async.assert_awaited_once_with(
+            job.id,
+            actor="cron",
+            source="cron",
+            one_shot_path="cron_gateway",
+        )
 
     @pytest.mark.asyncio
     async def test_done_defers_removal_when_store_is_busy(self):

--- a/test/test_validation_user_actions.py
+++ b/test/test_validation_user_actions.py
@@ -496,9 +496,12 @@ class TestMcpCronUserActions:
             job.id = "x"
             job.session_key = ""
             svc.list_jobs.return_value = [job]
-            svc.remove_job.return_value = True
+            svc.remove_jobs_sync.return_value = (["x"], [])
             result = self._simulate_tool_call("cron_remove_all", {})
         assert "Removed 1" in result
+        svc.remove_jobs_sync.assert_called_once_with(
+            ["x"], actor="mcp", source="mcp"
+        )
 
 
 # ── JSON-RPC Envelope: simulate kiro-cli protocol ──


### PR DESCRIPTION
## Problem / Motivation

Cron deletion auditing is currently owned by dashboard, CLI, MCP, and messaging call sites. A new removal surface can call `CronService.remove_job*` or `remove_jobs*` successfully without supplying caller attribution or producing a destructive-action audit. Several call sites also emit only after returning from the service, which makes correct persistence/audit ordering a convention rather than a seam invariant.

## Why it matters

Once a job disappears from `crons.json`, the audit trail is the only durable distinction between an intentional removal and data loss. Requiring attribution at the mutation API makes an omitted audit an immediate interface error instead of a later review discovery.

## What changed (motivation → approach → change)

- Made `actor` and `source` required keyword arguments on `CronService.remove_job`, `remove_job_async`, `remove_jobs`, and `remove_jobs_sync`.
- Added exception-contained single and batch audit helpers that run after the locked save returns; store failures therefore emit nothing, while audit failures never undo or misreport a completed removal.
- Preserved automated one-shot `one_shot_completed` records and their `path=` discriminator through `one_shot_path` at the same service seam.
- Threaded attribution through dashboard, CLI, MCP, shared messaging commands, the cron gateway, and CronSDK callers; MCP remove-all now uses one atomic sync batch instead of a partial-success per-job loop.
- Removed duplicate call-site emits and updated their tests to assert exact service attribution with no second record.
- Rebasing onto current main retained the newly hoisted shared `messaging.commands` architecture and moved attribution forwarding there instead of restoring Slack-local command logic.

## Tests

- Red-before: 5/5 initial seam regressions failed because the service rejected `actor`/`source` and emitted no caller-requested removal audit.
- Current rebased head: 132/132 passing across service seam, shared messaging cron commands, Slack audits/gateway delivery, dashboard single/batch deletion, MCP and user-action contracts, CronSDK, and session-scope tests.
- Baselined Black gate checked all 10 changed Python files not already in the repository baseline; all clean.
- `python -m flake8` on all 21 changed Python files.
- `python -m isort --check-only` on all 21 changed Python files.
- `git diff --check`.
- `python -m mypy src/kiro_crew/` — **no issues in 1101 source files**. This is the fix evidence for the second commit: the rebase surfaced a type error this branch introduced, where `mcp_cron.py`'s batch path unpacked `remove_jobs_sync`'s `(removed_ids, missing_ids)` into `removed`, a name the single-job path above had already bound to `bool`. Renaming the batch binding to `removed_ids` is the whole fix — no behaviour, call, or message changed.
- `python -m pytest test/test_mcp_cron.py test/test_mcp_cron_caller_identity.py test/test_cron.py test/test_cron_removal_audit_seam.py test/test_dashboard_cron_batch_delete_handler.py` — 140 passed.

## Manual verification

N/A — service-level tests exercise success, not-found, partial batch, lock failure, and audit-unavailable ordering; surface tests verify exact attribution forwarding.

## Related Issues

Fixes #5438

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (inline service contract and regression documentation)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — project CLA wording is not yet available in the repository template.

