### PR TITLE
fix(channels): validate agent mutation fields

### DIFF
--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
-from kiro_crew.channel import ChannelManager, run_channel_agent
+from kiro_crew.channel import ApprovalPolicy, ChannelManager, ListenMode, run_channel_agent
 from kiro_crew.config.loader import config_path
 from kiro_crew.sel import sel
 
@@ -246,15 +246,47 @@ async def api_channel_post(request: web.Request) -> web.Response:
 # ── Agent management ──
 
 
+def _agent_field_error(error: str, code: str) -> web.Response:
+    return web.json_response({"error": error, "code": code}, status=400)
+
+
 async def api_channel_add_agent(request: web.Request) -> web.Response:
     ch, body = await _get_channel_body(request)
 
+    role = body.get("role", "Agent")
+    if not isinstance(role, str):
+        return _agent_field_error(
+            "role must be a string", "channel_agent_role_type_invalid"
+        )
+    agent_name = body.get("agent", "")
+    if not isinstance(agent_name, str):
+        return _agent_field_error(
+            "agent must be a string", "channel_agent_name_type_invalid"
+        )
+    task = body.get("task", ch.topic)
+    if not isinstance(task, str):
+        return _agent_field_error(
+            "task must be a string", "channel_agent_task_type_invalid"
+        )
+    is_orchestrator = body.get("is_orchestrator", False)
+    if not isinstance(is_orchestrator, bool):
+        return _agent_field_error(
+            "is_orchestrator must be a boolean",
+            "channel_agent_orchestrator_type_invalid",
+        )
+    try:
+        approval_policy = ApprovalPolicy(body.get("approval", "writes"))
+    except (TypeError, ValueError):
+        return _agent_field_error(
+            "approval must be a valid policy", "channel_agent_approval_invalid"
+        )
+
     agent = ch.add_agent(
-        role=body.get("role", "Agent")[:100],
-        agent_name=body.get("agent", ""),
-        task=body.get("task", ch.topic),
-        is_orchestrator=body.get("is_orchestrator", False),
-        approval_policy=body.get("approval", "writes"),
+        role=role[:100],
+        agent_name=agent_name,
+        task=task,
+        is_orchestrator=is_orchestrator,
+        approval_policy=approval_policy,
     )
     if not agent:
         return web.json_response(
@@ -273,20 +305,24 @@ async def api_channel_update_agent(request: web.Request) -> web.Response:
     if not agent:
         return web.json_response({"error": "agent not found"}, status=404)
 
+    approval_policy = agent.approval_policy
+    listen_mode = agent.listen_mode
     if "approval" in body:
-        from kiro_crew.channel import ApprovalPolicy
-
         try:
-            agent.approval_policy = ApprovalPolicy(body["approval"])
-        except ValueError:
-            pass
+            approval_policy = ApprovalPolicy(body["approval"])
+        except (TypeError, ValueError):
+            return _agent_field_error(
+                "approval must be a valid policy", "channel_agent_approval_invalid"
+            )
     if "listen" in body:
-        from kiro_crew.channel import ListenMode
-
         try:
-            agent.listen_mode = ListenMode(body["listen"])
-        except ValueError:
-            pass
+            listen_mode = ListenMode(body["listen"])
+        except (TypeError, ValueError):
+            return _agent_field_error(
+                "listen must be a valid mode", "channel_agent_listen_invalid"
+            )
+    agent.approval_policy = approval_policy
+    agent.listen_mode = listen_mode
     ch._save()
     return web.json_response({"ok": True, "agent": agent.to_dict()})
 

--- a/test/test_channel_agent_api_validation.py
+++ b/test/test_channel_agent_api_validation.py
@@ -1,0 +1,125 @@
+"""Field-level input contracts for Channels agent mutations."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+import kiro_crew.dashboard.handlers_channel as handlers
+from kiro_crew.channel import ApprovalPolicy, ChannelManager, ListenMode
+
+
+def _request(manager: ChannelManager, body: dict, **match_info: str) -> MagicMock:
+    request = MagicMock()
+    request.app = {
+        "state": SimpleNamespace(channel_manager=manager, sessions=MagicMock(), _yolo=False)
+    }
+    request.match_info = match_info
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+async def _invoke(handler, request) -> web.StreamResponse:
+    try:
+        return await handler(request)
+    except web.HTTPException as exc:
+        return exc
+
+
+def _body(response: web.StreamResponse) -> dict:
+    return json.loads(response.text)
+
+
+@pytest.fixture
+def manager(tmp_path) -> ChannelManager:
+    return ChannelManager(channels_dir=str(tmp_path / "channels"))
+
+
+@pytest.fixture(autouse=True)
+def spawn_spy(monkeypatch) -> MagicMock:
+    spy = MagicMock()
+    monkeypatch.setattr(handlers, "_spawn_agent_task", spy)
+    return spy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        ({"role": 7}, "channel_agent_role_type_invalid"),
+        ({"agent": []}, "channel_agent_name_type_invalid"),
+        ({"task": 3}, "channel_agent_task_type_invalid"),
+        ({"is_orchestrator": "yes"}, "channel_agent_orchestrator_type_invalid"),
+        ({"approval": "unknown"}, "channel_agent_approval_invalid"),
+    ],
+)
+async def test_add_agent_rejects_invalid_fields_before_mutation(manager, spawn_spy, payload, code):
+    channel = manager.create("incident")
+
+    response = await _invoke(
+        handlers.api_channel_add_agent,
+        _request(manager, payload, id=channel.id),
+    )
+
+    assert response.status == 400
+    assert _body(response)["code"] == code
+    assert channel.members == {}
+    spawn_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        ({"approval": "unknown"}, "channel_agent_approval_invalid"),
+        (
+            {"approval": "trusted", "listen": ["all"]},
+            "channel_agent_listen_invalid",
+        ),
+    ],
+)
+async def test_update_agent_rejects_invalid_enums_without_saving(
+    manager, monkeypatch, payload, code
+):
+    channel = manager.create("incident")
+    agent = channel.add_agent(role="Orchestrator", is_orchestrator=True)
+    save_spy = MagicMock()
+    monkeypatch.setattr(channel, "_save", save_spy)
+
+    response = await _invoke(
+        handlers.api_channel_update_agent,
+        _request(manager, payload, id=channel.id, aid=agent.id),
+    )
+
+    assert response.status == 400
+    assert _body(response)["code"] == code
+    assert agent.approval_policy is ApprovalPolicy.WRITES
+    assert agent.listen_mode is ListenMode.ALL
+    save_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_agent_still_applies_valid_enum_values(manager, monkeypatch):
+    channel = manager.create("incident")
+    agent = channel.add_agent(role="Worker")
+    save_spy = MagicMock()
+    monkeypatch.setattr(channel, "_save", save_spy)
+
+    response = await _invoke(
+        handlers.api_channel_update_agent,
+        _request(
+            manager,
+            {"approval": "trusted", "listen": "silent"},
+            id=channel.id,
+            aid=agent.id,
+        ),
+    )
+
+    assert response.status == 200
+    assert agent.approval_policy is ApprovalPolicy.TRUSTED
+    assert agent.listen_mode is ListenMode.SILENT
+    save_spy.assert_called_once_with()


### PR DESCRIPTION
## Problem / Motivation

Channels agent mutation endpoints accept malformed field values inconsistently. Adding an agent can raise an unhandled exception or persist invalid values, while updating an agent silently ignores invalid enum values and still returns success.

## Why it matters

API clients cannot distinguish accepted updates from rejected input, and malformed requests can mutate channel state or spawn an agent before the caller receives an error.

## What changed (motivation → approach → change)

- Validate `role`, `agent`, `task`, and `is_orchestrator` types before `Channel.add_agent` mutates state.
- Parse approval/listen enum values before assignment and return deterministic HTTP 400 responses with stable error codes.
- Stage both update values before assigning either one, so a valid approval paired with an invalid listen mode cannot partially update or save the agent.
- Preserve existing defaults, the 100-character role limit, and valid mutation behavior.

## Tests

- Red before: 7 failures / 1 pass demonstrated the crashes, invalid successful mutations, and silent no-op responses.
- Green after: 8/8 focused agent-mutation contract tests.
- Current rebased head: 52/52 passing across focused tests, Channel model tests, existing Channel handler tests, and the error-code contract.
- `black --check --target-version py310` passes for the new unbaselined test file.
- `flake8`, `isort --check-only`, and `git diff --check` pass for the changed files.

## Manual verification

N/A — the endpoint behavior and mutation/spawn/save side effects are covered directly with async handler tests.

## Related Issues

Fixes #5595

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public interface documentation exists for these internal dashboard endpoints)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.
