### PR TITLE
fix(security): redact before truncation at five slice-before-redact sites

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1297,7 +1297,14 @@ def _sel_hook_rejected(event: str, command: str, reason: str) -> None:
                 source="cli",
                 operation="kiro_hooks_rejected",
                 outcome="rejected",
-                resources=redact(f"event={event} command={command[:200]}"),
+                # redact-then-truncate on the interpolated value, through the
+                # same context-aware shim as the outer call: slicing ``command``
+                # raw could cut a credential at the boundary, and slicing after
+                # baseline-only redaction would still cut a companion-only token
+                # before the companion regexes see it. Context redaction runs
+                # over the FULL command first, so no redactor ever sees a
+                # boundary-cut fragment.
+                resources=redact(f"event={event} command={redact(command)[:200]}"),
                 error=reason,
             )
         )

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
@@ -46,6 +46,7 @@ from kiro_crew.platform_compat import RENAME_NOREPLACE_AVAILABLE, rename_norepla
 try:
     from kiro_crew.security import (
         is_sensitive_path,
+        redact_and_truncate,
         redact_credentials,
         redact_exfiltration_urls,
     )
@@ -256,6 +257,21 @@ def _redact(text: str) -> str:
     text, _ = redact_exfiltration_urls(text)
     text, _ = redact_credentials(text)
     return text
+
+
+def _redact_and_truncate(text: str, max_chars: int) -> str:
+    """Scrub like ``_redact``, then truncate — never ``_redact(x[:n])``.
+
+    Truncating first can cut a credential at the boundary, leaving a fragment
+    the redaction regexes no longer match, so the raw remainder would leak.
+    Fails CLOSED exactly like ``_redact``: with no security module there is no
+    way to scrub, so withhold the text rather than serving a bounded raw slice.
+    """
+    if not isinstance(text, str) or not text:
+        return text or ""
+    if not _HAS_SECURITY:
+        return _UNSCRUBBABLE
+    return redact_and_truncate(text, max_chars)
 
 
 def _audit(operation: str, resources: str = "", outcome: str = "success") -> None:
@@ -2230,7 +2246,7 @@ async def _ensure_worker_slot(
     # admission predicate creation and discovery enforce (_usable_name, which is
     # the grammar plus redaction-stability -- see _load_index).
     if not _usable_name(name):
-        _audit("spec_slot_name_denied", _redact(name[:64]), outcome="denied")
+        _audit("spec_slot_name_denied", _redact_and_truncate(name, 64), outcome="denied")
         logger.warning("refusing a spec slot for a name that fails the grammar")
         return None
     # Resolved ONCE, before any await below. Recomputing it afterwards let a
@@ -3124,7 +3140,7 @@ async def _serialize_messages(state: Any, slot_key: str) -> list[dict]:
             # Mirror the main chat: surface tool activity as a compact line
             # (first line, bounded) so the embedded chat shows the agent working.
             first = (content or "").strip().splitlines()[0] if content else ""
-            out.append({"role": "tool", "content": _redact(first[:200]), "ts": ts})
+            out.append({"role": "tool", "content": _redact_and_truncate(first, 200), "ts": ts})
             continue
         out.append({"role": role, "content": _redact(content or ""), "ts": ts})
     return out

--- a/src/kiro_crew/dashboard/handlers_project.py
+++ b/src/kiro_crew/dashboard/handlers_project.py
@@ -2,7 +2,11 @@
 
 from aiohttp import web
 
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import (
+    redact_and_truncate,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
 
 _VISIBLE_SOURCES = {"text", "spec", "file", "chat", "dashboard", "mcp"}
 
@@ -21,12 +25,22 @@ def _redact(text: str) -> str:
     return text
 
 
+def _redact_and_truncate(text: str, max_chars: int) -> str:
+    """Redact over the FULL text, then truncate (never ``_redact(x[:n])``).
+
+    Truncating first can cut a credential in half at the boundary, leaving a
+    fragment the redaction regexes no longer match. Delegates to the canonical
+    helper so redaction always precedes the slice.
+    """
+    return redact_and_truncate(text, max_chars)
+
+
 def _run_to_project(run) -> dict:
     desc = getattr(run, "description", None) or run.spec_content or run.original_input or ""
     return {
         "id": run.task_id,
         "name": _redact(run.name or run.task_id),
-        "description": _redact(desc[:4000]),
+        "description": _redact_and_truncate(desc, 4000),
         "status": run.status,
         "created_at": run.started_at or 0,
         "updated_at": getattr(run, "updated_at", run.started_at) or 0,

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -79,7 +79,11 @@ from kiro_crew.providers.base import (
     LLMEvent,
 )
 from kiro_crew.resource_status import cached_admission_check
-from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.security import (
+    redact_and_truncate,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionManager
 from kiro_crew.session_surface import has_dashboard_surface
@@ -291,6 +295,16 @@ def _redact(text: str) -> str:
     text, _ = redact_exfiltration_urls(text)
     text, _ = redact_credentials(text)
     return text
+
+
+def _redact_and_truncate(text: str, max_chars: int) -> str:
+    """Redact over the FULL text, then truncate (never ``_redact(x[:n])``).
+
+    Truncating first can cut a credential in half at the boundary, leaving a
+    fragment the redaction regexes no longer match — the raw remainder would
+    then leak into the surface this feeds. Delegates to the canonical helper.
+    """
+    return redact_and_truncate(text, max_chars)
 
 
 # Bounds for a rendered exception chain. The rendering reaches a WS frame, a
@@ -3018,7 +3032,7 @@ class SubagentManager:
         return [
             {
                 "id": a.id,
-                "task": _redact(a.task[:80]),
+                "task": _redact_and_truncate(a.task, 80),
                 "agent": _redact(a.agent),
                 "parent": a.parent_session_key,
                 "rss_mb": round(a.last_rss_gb * 1024, 1),

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -5264,3 +5264,46 @@ class TestResetOutputEscapesUntrustedPaths:
         # Both paths are repr'd, so a control byte in either could not execute.
         assert "'" in str(exc.value), "paths are quoted (repr), not raw"
         assert "a.json" in str(exc.value) and "b.json" in str(exc.value)
+
+
+class TestSelHookRejectedRedaction:
+    """#5582: ``_sel_hook_rejected`` must redact ``command`` before its 200-char cut.
+
+    The old spelling sliced ``command[:200]`` inside the f-string and redacted
+    the assembled message afterwards, so a credential cut at the boundary lost
+    its tail, stopped matching the credential regex, and the raw prefix escaped
+    into the SEL audit row.
+    """
+
+    def _capture_sel(self, monkeypatch) -> list:
+        import kiro_crew.agent as agent_mod
+
+        events: list = []
+
+        class _Log:
+            def log(self, event) -> None:
+                events.append(event)
+
+        monkeypatch.setattr(agent_mod, "sel", lambda: _Log())
+        return events
+
+    def test_credential_straddling_the_cut_is_not_leaked(self, monkeypatch) -> None:
+        from kiro_crew.agent import _sel_hook_rejected
+
+        events = self._capture_sel(monkeypatch)
+        # fabricated AKIA-shaped literal, inlined (a ``secret``-named binding
+        # trips CodeQL's name-based sensitive-source heuristic); the 200-char
+        # cut lands 8 chars into the 20-char key
+        command = "x" * 192 + "AKIAIOSFODNN7EXAMPLE" + " --flag"
+        _sel_hook_rejected("preToolUse", command, "denied")
+        assert len(events) == 1
+        assert "AKIA" not in events[0].resources
+
+    def test_plain_command_truncation_unchanged(self, monkeypatch) -> None:
+        """Ordinary path is result-preserving: no secret ⇒ the same 200-char slice."""
+        from kiro_crew.agent import _sel_hook_rejected
+
+        events = self._capture_sel(monkeypatch)
+        _sel_hook_rejected("preToolUse", "c" * 250, "denied")
+        assert len(events) == 1
+        assert events[0].resources == f"event=preToolUse command={'c' * 200}"

--- a/test/test_project_alias.py
+++ b/test/test_project_alias.py
@@ -91,6 +91,29 @@ class TestRedactAndConvert:
         result = _run_to_project(run)
         assert result["description"] == ""
 
+    def test_run_to_project_description_redacts_before_truncating(self):
+        """#5582: a credential straddling the 4000-char cut must not leak.
+
+        The old spelling ``_redact(desc[:4000])`` sliced first, so a key cut at
+        the boundary lost its tail, stopped matching the credential regex, and
+        the raw prefix escaped into the dashboard payload.
+        The fabricated AKIA-shaped literal is inlined rather than bound to a
+        ``secret``-named variable, which would trip CodeQL's name-based
+        sensitive-source heuristic on this real call path.
+        """
+        run = _make_run()
+        # cut lands 8 chars into the fabricated 20-char key
+        run.description = "x" * 3992 + "AKIAIOSFODNN7EXAMPLE" + " trailing"
+        result = _run_to_project(run)
+        assert "AKIA" not in result["description"]
+        assert len(result["description"]) <= 4000
+
+    def test_run_to_project_plain_description_truncation_unchanged(self):
+        """Ordinary path is result-preserving: no secret ⇒ the same 4000-char slice."""
+        run = _make_run()
+        run.description = "d" * 4100
+        assert _run_to_project(run)["description"] == "d" * 4000
+
     def test_run_to_project_description_falls_back_to_spec_content(self):
         run = _make_run()
         run.spec_content = "Do the thing"

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -1894,6 +1894,32 @@ class TestEnsureWorkerSlot:
         assert "spec_slot_name_denied" in ops
 
     @pytest.mark.asyncio
+    async def test_denied_name_audit_redacts_before_truncating(self, tmp_path, _quiet_sel):
+        """#5582: a credential straddling the 64-char audit cut must not leak.
+
+        The old spelling ``_redact(name[:64])`` sliced first, so a key cut at
+        the boundary lost its tail, stopped matching the credential regex, and
+        the raw prefix escaped into the SEL audit row.
+
+        The fabricated AKIA-shaped literal is deliberately inlined rather than
+        bound to a ``secret``-named variable: CodeQL's name-based sensitive-
+        source heuristic would otherwise taint this real call path and flag
+        every downstream ``logger.warning(..., name, ...)`` in production code
+        as clear-text secret logging (10 false alerts on unchanged lines).
+        """
+        # fails the grammar; the 64-char cut lands 8 chars into the 20-char key
+        name = "x" * 56 + "AKIAIOSFODNN7EXAMPLE" + " tail"
+        state = _State()
+        assert await r._ensure_worker_slot(state, name, _entry(tmp_path)) is None
+        denied = [
+            c.kwargs["resources"]
+            for c in _quiet_sel.log_api_access.call_args_list
+            if c.kwargs["operation"] == "spec_slot_name_denied"
+        ]
+        assert denied, "the denial must still be audited"
+        assert all("AKIA" not in res for res in denied)
+
+    @pytest.mark.asyncio
     async def test_a_cold_slot_is_created_scoped_and_titled(self, tmp_path):
         state = _State()
         with _no_rehydrate():
@@ -2270,6 +2296,35 @@ class TestSerializeMessages:
         state = _State(**{"spec-builder-demo": slot})
         out = await r._serialize_messages(state, "spec-builder-demo")
         assert out == [{"role": "tool", "content": "fs_write tasks.md", "ts": "1"}]
+
+    @pytest.mark.asyncio
+    async def test_a_tool_line_credential_straddling_the_cut_is_not_leaked(self):
+        """#5582: a credential straddling the 200-char cut must not leak.
+
+        The old spelling ``_redact(first[:200])`` sliced first, so a key cut at
+        the boundary lost its tail, stopped matching the credential regex, and
+        the raw prefix escaped into the embedded-chat payload.
+        The fabricated AKIA-shaped literal is inlined rather than bound to a
+        ``secret``-named variable, which would trip CodeQL's name-based
+        sensitive-source heuristic on this real call path.
+        """
+        # cut lands 8 chars into the fabricated 20-char key
+        first = "x" * 192 + "AKIAIOSFODNN7EXAMPLE" + " trailing"
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [{"role": "tool", "content": first + "\nmore", "ts": "1"}]
+        state = _State(**{"spec-builder-demo": slot})
+        out = await r._serialize_messages(state, "spec-builder-demo")
+        assert "AKIA" not in out[0]["content"]
+        assert len(out[0]["content"]) <= 200
+
+    @pytest.mark.asyncio
+    async def test_a_plain_tool_line_truncation_unchanged(self):
+        """Ordinary path is result-preserving: no secret ⇒ the same 200-char slice."""
+        slot = _Slot("spec-builder-demo")
+        slot.messages = [{"role": "tool", "content": "t" * 250 + "\nmore", "ts": "1"}]
+        state = _State(**{"spec-builder-demo": slot})
+        out = await r._serialize_messages(state, "spec-builder-demo")
+        assert out[0]["content"] == "t" * 200
 
     @pytest.mark.asyncio
     async def test_an_empty_tool_turn_does_not_raise_on_the_first_line(self):

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -1134,6 +1134,31 @@ class TestReadSurfaces:
         mgr._agents["queued"] = _info("queued", queued=True)
         assert mgr.task_memory_rows() == []
 
+    def test_task_memory_rows_redact_before_truncate(self) -> None:
+        """#5582: a credential straddling the 80-char cut must not leak a fragment.
+
+        The old spelling ``_redact(a.task[:80])`` sliced first, so a key cut at
+        the boundary lost its tail and no longer matched the credential regex —
+        the raw prefix escaped into the session-memory surface.
+        The fabricated AKIA-shaped literal is inlined rather than bound to a
+        ``secret``-named variable, which would trip CodeQL's name-based
+        sensitive-source heuristic on this real call path.
+        """
+        # cut lands 8 chars into the fabricated 20-char key
+        task = "x" * 72 + "AKIAIOSFODNN7EXAMPLE" + " trailing"
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", task=task, parent_session_key="dash:1")
+        row = {r["id"]: r for r in mgr.task_memory_rows()}["a"]
+        assert "AKIA" not in row["task"]
+        assert len(row["task"]) <= 80
+
+    def test_task_memory_rows_plain_task_truncation_unchanged(self) -> None:
+        """Ordinary path is result-preserving: no secret ⇒ the same 80-char slice."""
+        mgr = _manager()
+        mgr._agents["a"] = _info("a", task="t" * 100, parent_session_key="dash:1")
+        row = {r["id"]: r for r in mgr.task_memory_rows()}["a"]
+        assert row["task"] == "t" * 80
+
     def test_get_running_all_and_count(self) -> None:
         mgr = _manager()
         live = _info("live")


### PR DESCRIPTION
## Summary

Five call sites composed redaction and truncation in the wrong order — `_redact(x[:n])`, slice first, redact second — so a credential or exfiltration URL straddling the truncation boundary was cut before the redaction regexes ever saw it. The prefix-anchored, fixed-width credential patterns (e.g. `(?:AKIA|ASIA)[A-Z0-9]{16}`) cannot match a fragment missing its prefix or tail, so the surviving raw fragment escaped into SEL audit rows, logs, and dashboard payloads.

All five sites now redact the FULL text before slicing, keeping each module's existing redaction entry-point convention:

- `src/kiro_crew/subagent.py` — `task_memory_rows`'s 80-char task preview; a thin `_redact_and_truncate` sibling (delegating to `security.redact_and_truncate`) added next to the module's `_redact` wrapper.
- `src/kiro_crew/dashboard/handlers_project.py` — `_run_to_project`'s 4000-char description; same sibling-wrapper pattern.
- `src/kiro_crew/agent.py` — `_sel_hook_rejected`'s SEL resource string. The slice sat mid-f-string (`command[:200]` inside a string redacted whole). This site uses the module's **context-aware** shim on the interpolated value — `redact(command)[:200]` — rather than the baseline helper: in a composed host, `redact_and_truncate` would still slice a companion-only token before the companion regexes see it (caught by the server GPT review on an earlier revision).
- `src/kiro_crew/apps/builtins/spec_builder/backend/routes.py` — the `spec_slot_name_denied` audit (64) and the transcript tool-line preview (200); the module's `_redact_and_truncate` keeps `_redact`'s fail-closed guard (`_UNSCRUBBABLE` when the security module is unavailable).

No `max_chars` value changes (80/4000/200/64/200 preserved). Secret-free inputs produce byte-identical output — this is purely an ordering fix.

`dashboard/handlers/files.py` (`redact(raw[:7])`) is deliberately untouched: its input is regex-verified hex and cannot carry a credential.

## Verification

- One regression test per site, each feeding a fabricated AKIA-shaped literal positioned to **straddle** that site's exact truncation boundary, asserting no raw fragment survives; plus a result-preservation test per site (no secret ⇒ the same slice as before). Fixture literals are inlined rather than bound to `secret`-named variables — the binding tripped CodeQL's name-based sensitive-source heuristic into flagging 10 unchanged production log lines (dispositioned in comments).
- Every boundary assertion **mutation-checked**: each site's one-line fix was reverted in turn, its test confirmed to FAIL against the unfixed spelling, then re-applied (all five mutations killed, re-verified after the site-3 respelling).
- Full backend suite: 65,588 passed, 94 failed + 2 errors — a base-worktree run (`git worktree add … origin/main`) of the same files produced the **byte-identical failure set** (comm -23/-13 both empty), so all failures are pre-existing environmental, zero regressions.
- black / isort / flake8 / mypy, brand, harness, changelog, focus-cue, docs-lint, per-file coverage, vendor manifest, scrub-lint: all green. tsc and jscpd green. The vite build / vitest / eslint lanes and 8 electron cases could not run locally (host node is 16; node 22/24 will not install on this old-glibc box — failures are `t.after is not a function` / `styleText` API gaps, and the diff touches no `website/` file); CI's node-24 lanes cover them.
- Local review lanes both PASS on the final head `882aece`: gpt-5.6-sol mirror of the codex gate (no findings) and an Opus-lane two-stage review (all discovery candidates falsified in validation; no findings).

## Deliberately deferred — why this is `Refs` and not `Fixes`

Refs #5582. Two items in the issue's scope are **not** fixed here, per the dependency gate:

- `cron_script.py` `_stderr_tail` overlap read, and
- consolidating the `cron_script.py` stdout call onto the helper.

Open [PR #5574](https://github.com/kirodotdev/KiroCrew/pull/5574)'s diff is exactly `cron_script.py` + `test/test_cron_script.py`; touching those files here guarantees a conflict and duplicated review. They belong to a follow-up after #5574 merges, so #5582 stays open until that follow-up lands. The `run_command_sandboxed` `stderr[:500]` site is #4402's diff, and the head-anchored bounding class is tracked as #5555 — both out of scope here.
