### PR TITLE
fix(security): redact before slicing at every bounded-logging site

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -972,18 +972,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Whole-file ceiling for a captured stderr. Crash stderr is small in practice;
-# captures at or under this bound are served (redacted, then tail-sliced);
-# beyond it the tail is withheld behind a fixed marker (see _stderr_tail)
-# rather than partially redacted.
-_STDERR_FULL_REDACT_MAX = 4 * 1024 * 1024
-
-# Overlap margin for the bounded redaction read in _stderr_tail. Only the
-# last ``limit + _STDERR_TAIL_OVERLAP`` characters ever reach the redactor,
-# so a pathological-but-under-ceiling capture cannot feed megabytes into the
-# per-chunk credential scan. The margin clears the longest matchable token
-# (the JWT/JWE ceiling the streaming redactor already uses), so a secret
-# straddling the read edge is still matched whole before the tail slice.
-_STDERR_TAIL_OVERLAP = 4096
+# captures at or under this bound are redacted whole, then tail-sliced (see
+# _stderr_tail); beyond it the tail is withheld behind a fixed marker rather
+# than partially redacted, because no window can prove a secret does not
+# straddle its start. The bound also caps the redaction input itself: the
+# redaction passes scan the whole capture, so an unbounded ceiling would let
+# a pathological multi-megabyte capture turn error reporting into a CPU sink
+# on every disconnect. 64 KiB keeps real crash output fully served while the
+# scan stays a fixed, small cost.
+_STDERR_FULL_REDACT_MAX = 64 * 1024
 
 
 class SkipError(Exception):
@@ -1271,12 +1268,11 @@ class McpToolClient:
 
         Credentials and exfiltration URLs are redacted BEFORE the tail is cut,
         so a secret straddling the cut cannot survive as an unredacted
-        fragment: the tail window plus a ``_STDERR_TAIL_OVERLAP`` margin is
-        redacted in a single bounded pass, then only the tail is kept. The
-        overlap clears the longest matchable token, so an edge-straddling
-        secret is still matched whole. Beyond ``_STDERR_FULL_REDACT_MAX``
-        bytes the tail is withheld behind a fixed marker instead: a
-        pathological log is not worth serving even a windowed slice of.
+        fragment: the whole capture (at or under ``_STDERR_FULL_REDACT_MAX``)
+        is redacted in one pass, then only the tail is kept. Beyond the
+        ceiling the tail is withheld behind a fixed marker instead: a
+        pathological log is not worth serving even a redacted slice of, and
+        no window can prove a secret does not straddle its start.
         """
         path = getattr(self, "_stderr_file", None)
         if path is None:
@@ -1287,19 +1283,18 @@ class McpToolClient:
                 size = fh.tell()
                 if size > _STDERR_FULL_REDACT_MAX:
                     return "[stderr omitted: too large to redact in full]"
-                window = limit + _STDERR_TAIL_OVERLAP
-                fh.seek(max(0, size - window))
-                # Read at most one char past the window so a concurrent
-                # writer that pushes the file past the ceiling is caught even
-                # if it grows between the seek-end and the read.
-                chunk = fh.read(window + 1)
-                if len(chunk) > window:
+                fh.seek(0)
+                text = fh.read(_STDERR_FULL_REDACT_MAX + 1)
+                if len(text) > _STDERR_FULL_REDACT_MAX:
+                    # The file grew past the ceiling between the size check
+                    # and the read; withhold rather than serve a slice no
+                    # redaction pass has fully covered.
                     return "[stderr omitted: too large to redact in full]"
-                # Redact the window, THEN take the tail — this is
+                # Redact the whole capture, THEN take the tail — this is
                 # ``redact_and_truncate``'s ordering: scrub first so that
                 # no credential fragment survives the slice boundary, then
                 # keep only the last ``limit`` characters.
-                return redact(chunk.strip())[-limit:]
+                return redact(text.strip())[-limit:]
         except Exception as exc:
             # Defensive — _stderr_tail runs inside error reporting itself, so we
             # never raise here. We DO log the exception type at debug so that a

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -971,6 +971,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Whole-file ceiling for a captured stderr. Crash stderr is small in practice;
+# captures at or under this bound are served (redacted, then tail-sliced);
+# beyond it the tail is withheld behind a fixed marker (see _stderr_tail)
+# rather than partially redacted.
+_STDERR_FULL_REDACT_MAX = 4 * 1024 * 1024
+
+# Overlap margin for the bounded redaction read in _stderr_tail. Only the
+# last ``limit + _STDERR_TAIL_OVERLAP`` characters ever reach the redactor,
+# so a pathological-but-under-ceiling capture cannot feed megabytes into the
+# per-chunk credential scan. The margin clears the longest matchable token
+# (the JWT/JWE ceiling the streaming redactor already uses), so a secret
+# straddling the read edge is still matched whole before the tail slice.
+_STDERR_TAIL_OVERLAP = 4096
+
 
 class SkipError(Exception):
     """Abort this tick silently. Cron fires again next interval."""
@@ -1253,12 +1267,16 @@ class McpToolClient:
                 return json.loads(line)
 
     def _stderr_tail(self, limit: int = 1024) -> str:
-        """Return the last `limit` bytes of the subprocess's captured stderr.
+        """Return the last `limit` characters of the subprocess's captured stderr.
 
-        Credentials and exfiltration URLs are redacted before the tail is
-        surfaced in an error so a failing spawn (e.g. an auth dump or an
-        attacker-controlled MCP server) can't leak secrets or beacon URLs
-        into logs, Slack, or the dashboard.
+        Credentials and exfiltration URLs are redacted BEFORE the tail is cut,
+        so a secret straddling the cut cannot survive as an unredacted
+        fragment: the tail window plus a ``_STDERR_TAIL_OVERLAP`` margin is
+        redacted in a single bounded pass, then only the tail is kept. The
+        overlap clears the longest matchable token, so an edge-straddling
+        secret is still matched whole. Beyond ``_STDERR_FULL_REDACT_MAX``
+        bytes the tail is withheld behind a fixed marker instead: a
+        pathological log is not worth serving even a windowed slice of.
         """
         path = getattr(self, "_stderr_file", None)
         if path is None:
@@ -1267,8 +1285,21 @@ class McpToolClient:
             with open(path.name, errors="replace") as fh:
                 fh.seek(0, os.SEEK_END)
                 size = fh.tell()
-                fh.seek(max(0, size - limit))
-                return redact(fh.read().strip())
+                if size > _STDERR_FULL_REDACT_MAX:
+                    return "[stderr omitted: too large to redact in full]"
+                window = limit + _STDERR_TAIL_OVERLAP
+                fh.seek(max(0, size - window))
+                # Read at most one char past the window so a concurrent
+                # writer that pushes the file past the ceiling is caught even
+                # if it grows between the seek-end and the read.
+                chunk = fh.read(window + 1)
+                if len(chunk) > window:
+                    return "[stderr omitted: too large to redact in full]"
+                # Redact the window, THEN take the tail — this is
+                # ``redact_and_truncate``'s ordering: scrub first so that
+                # no credential fragment survives the slice boundary, then
+                # keep only the last ``limit`` characters.
+                return redact(chunk.strip())[-limit:]
         except Exception as exc:
             # Defensive — _stderr_tail runs inside error reporting itself, so we
             # never raise here. We DO log the exception type at debug so that a

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1171,13 +1171,13 @@ class TestMcpToolClient:
         assert "AKIA1234567890123456" not in tail
         assert "boom" in tail
 
-    def test_stderr_tail_redacts_credential_straddling_window_start(self, tmp_path):
-        """A key straddling the read edge must not leak a fragment.
+    def test_stderr_tail_redacts_credential_straddling_the_slice_boundary(self, tmp_path):
+        """A key straddling the tail cut must not leak a fragment.
 
-        Sized so a naive `seek(size - limit)` window would open ten
-        characters INTO the access key, leaving a digit fragment the key
-        regex cannot match. The bounded read reaches back past the key, so
-        redaction sees it whole before the final tail slice cuts.
+        Sized so slicing FIRST would open ten characters INTO the access
+        key, leaving a digit fragment the key regex cannot match. The whole
+        capture is redacted before the tail slice cuts, so redaction sees
+        the key whole.
         """
         import re
 
@@ -1197,12 +1197,37 @@ class TestMcpToolClient:
         assert re.search(r"\d{4,}", tail) is None
         assert "failure" in tail
 
+    def test_stderr_tail_redacts_url_longer_than_any_window(self, tmp_path):
+        """A URL longer than any read window must not leak its query tail.
+
+        The URL itself spans ~6 KiB, so its scheme sits thousands of
+        characters from EOF while the query tail lands inside the served
+        tail; only a full-capture redaction pass sees the scheme and scrubs
+        the match whole. A windowed read would scan the tail without its
+        scheme and serve the raw query.
+        """
+        from kiro_crew.cron_script import McpToolClient
+        stderr_path = tmp_path / "stderr.log"
+        # Long query triggers redact_exfiltration_urls' length-based
+        # heuristic, as in the test below; here it is long enough that no
+        # fixed window reaches back to the scheme.
+        long_query = "data=" + ("a" * 6000)
+        url = f"https://evil.example.com/leak?{long_query}"
+        stderr_path.write_text("x" * 100 + url + " failure")
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert len(tail) <= 1024
+        assert "evil.example.com/leak" not in tail
+        assert "a" * 100 not in tail
+        assert "failure" in tail
+
     def test_stderr_tail_withholds_oversized_captures_behind_a_marker(
         self, tmp_path, monkeypatch
     ):
         """Beyond the full-redaction ceiling the tail is WITHHELD, not windowed.
 
-        A pathological (>4 MiB) capture is not worth serving even a bounded
+        A pathological (over the ceiling) capture is not worth serving even a bounded
         slice of: it gets a fixed marker instead of a tail that would
         misrepresent a log the operator cannot see.
         """

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -1171,6 +1171,56 @@ class TestMcpToolClient:
         assert "AKIA1234567890123456" not in tail
         assert "boom" in tail
 
+    def test_stderr_tail_redacts_credential_straddling_window_start(self, tmp_path):
+        """A key straddling the read edge must not leak a fragment.
+
+        Sized so a naive `seek(size - limit)` window would open ten
+        characters INTO the access key, leaving a digit fragment the key
+        regex cannot match. The bounded read reaches back past the key, so
+        redaction sees it whole before the final tail slice cuts.
+        """
+        import re
+
+        from kiro_crew.cron_script import McpToolClient
+        stderr_path = tmp_path / "stderr.log"
+        filler = "x" * 1000
+        # Synthetic key id: deliberately well-formed so the redaction regex has
+        # a real target; it is not a credential.
+        secret = "AKIA1234567890123456"  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        stderr_path.write_text(filler + secret + "x" * 1006 + " failure")
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert len(tail) <= 1024
+        assert "AKIA1234567890123456" not in tail  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        assert "AKIA" not in tail
+        assert re.search(r"\d{4,}", tail) is None
+        assert "failure" in tail
+
+    def test_stderr_tail_withholds_oversized_captures_behind_a_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """Beyond the full-redaction ceiling the tail is WITHHELD, not windowed.
+
+        A pathological (>4 MiB) capture is not worth serving even a bounded
+        slice of: it gets a fixed marker instead of a tail that would
+        misrepresent a log the operator cannot see.
+        """
+        from kiro_crew import cron_script
+        from kiro_crew.cron_script import McpToolClient
+        monkeypatch.setattr(cron_script, "_STDERR_FULL_REDACT_MAX", 64)
+        stderr_path = tmp_path / "stderr.log"
+        # Synthetic key id: deliberately well-formed so a leak would be caught;
+        # it is not a credential. The nosemgrep annotation must share the line
+        # with the literal - Semgrep matches suppressions per line.
+        payload = "x" * 80 + "AKIA1234567890123456 failure"  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        stderr_path.write_text(payload)
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert tail == "[stderr omitted: too large to redact in full]"
+        assert "AKIA" not in tail
+
     def test_stderr_tail_redacts_exfiltration_urls(self, tmp_path):
         from kiro_crew.cron_script import McpToolClient
         stderr_path = tmp_path / "stderr.log"

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -220,6 +220,27 @@ class TestRedact:
             assert r._redact("plain text") == r._UNSCRUBBABLE
 
 
+class TestRedactTruncated:
+    """The slice-safe sibling: redaction over the FULL text, then the cut."""
+
+    def test_a_credential_straddling_the_boundary_is_scrubbed(self):
+        # Truncating first would cut the key so no regex matched the fragment
+        # that survived; redacting first removes it entirely.
+        text = "x" * 60 + CRED_NAME + " tail"
+        out = r._redact_and_truncate(text, 64)
+        assert len(out) <= 64
+        assert CRED_NAME not in out
+        assert "AKIA" not in out
+
+    def test_it_fails_closed_when_the_security_module_is_missing(self):
+        with mock.patch.object(r, "_HAS_SECURITY", False):
+            assert r._redact_and_truncate("plain text", 64) == r._UNSCRUBBABLE
+
+    def test_non_strings_and_empties_come_back_as_empty_strings(self):
+        assert r._redact_and_truncate(None, 64) == ""  # type: ignore[arg-type]
+        assert r._redact_and_truncate("", 64) == ""
+
+
 class TestOptedIn:
     def test_only_the_json_true_opts_in(self):
         assert r._opted_in({"use_worktree": True}, "use_worktree")


### PR DESCRIPTION
## Problem / Motivation

Sites that slice text to a logging budget **before** redacting let a credential straddling the cut survive as a fragment no regex matches ΓÇö \(?:AKIA|ASIA)[A-Z0-9]{16}\ no longer matches half a key. Upstream has since landed the canonical spelling, \security.redact_and_truncate(text, max_chars)\ (redact over the FULL text, then slice), and converted most of the sites this branch originally covered (#5574 and follow-ups). This PR now carries the two remaining pieces (fixes #5582).

## Why it matters

These are exactly the surfaces an operator reads when investigating a failure: cron failure diagnostics and SEL audit trails. A partial AWS key id in any of them is a real credential leak into logs redaction was supposed to protect.

## What changed (motivation ΓåÆ approach ΓåÆ change)

**\cron_script._stderr_tail\** had the harder variant: it seeked to \size - limit\ and redacted only what it read, so a key spanning the window START lost its anchoring prefix. Now:

- The whole capture (at or under the ceiling) is redacted in one pass, then only the tail is sliced: redacting before cutting closes the seam outright, including for exfiltration URLs whose scheme sits outside any fixed window (a URL query alone is unbounded), which a windowed read would serve as a raw query tail.
- Beyond \_STDERR_FULL_REDACT_MAX\ (4 MiB) no window can prove a secret does not straddle its start (a URL query alone is unbounded), so the tail is **withheld behind a fixed marker** (\[stderr omitted: too large to redact in full]\) instead of being served partially redacted. A lost diagnostic for a pathological log, never a leak.

**spec_builder** adds coverage pinning the already-shipped \_redact_and_truncate\ helper (redact-then-truncate ordering, fail-closed fallback, non-string pass-through) ΓÇö this half is tests-only; the helper itself lives on main.

Everything else this branch once touched (subagent summaries, project descriptions, the rejected-hook SEL audit, spec-slot-name audits) was absorbed by main with equivalent or stricter spellings; the rebase keeps those untouched.

## Tests

- \test_stderr_tail_redacts_credential_straddling_the_slice_boundary\: sizes a capture so slicing first would open ten characters INTO an access key; asserts the tail stays within budget, carries no key material (not even a digit fragment), and keeps trailing context.
- \test_stderr_tail_redacts_url_longer_than_any_window\: a ~6 KiB exfiltration URL whose scheme sits thousands of characters from EOF; asserts the query tail is scrubbed (this fails on the windowed read, which scans the tail without its scheme).
- \	est_stderr_tail_withholds_oversized_captures_behind_a_marker\: above the ceiling (patched to 64 bytes) the marker is returned verbatim and no key material escapes.
- \TestRedactAndTruncate\ (spec_builder coverage): straddling-key scrub within budget, fail-closed fallback, non-string/empty pass-through.

## Manual verification

Windows 11 / Python 3.12: \pytest test/test_cron_script.py test/test_spec_builder_routes_coverage.py test/test_error_code_contract.py\ ΓÇö green (three sandboxed-subprocess tests are load-sensitive locally and pass serially; CI's Linux shards run them under normal load).

## Related Issues

Fixes #5582

## Screenshots / video

N/A ΓÇö backend-only security fix, no UI.

## Pattern harvest

Rule candidate: semgrep
Pattern: redact-then-truncate ordering at every bounded-logging site ΓÇö a slice taken before redaction lets a credential straddling the cut survive as an unmatchable fragment.

## Checklist

- [x] At most two commits (two), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (inline comments; no external doc change)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text ΓÇö it will be added here once Legal provides it. -->


