### PR TITLE
fix(telemetry): route histogram shard reads through the _finite guard (#5567)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -261,33 +261,106 @@ class _Hist:
         self._groups: dict[tuple[float, ...], dict[str, Any]] = {}
 
     def add(self, dp: dict[str, Any], outcome: str = "") -> None:
-        bc = dp.get("bucket_counts") or []
-        try:
-            key = tuple(float(b) for b in (dp.get("explicit_bounds") or []))
-        except (TypeError, ValueError):
+        # INVARIANT: the WHOLE data point is validated before the FIRST group
+        # mutation, so a rejected point never half-lands and nothing invalid
+        # can enter durable group state. Shards are external input and
+        # Python's json accepts Infinity/NaN literals plus arbitrary-precision
+        # integers, so every read routes through the _finite/_finite_int
+        # chokepoints with the scalar branch's contract: value-poisoned
+        # fields (bounds, count, sum, bucket counts) skip the whole point;
+        # optional stats (min/max) degrade per-stat; a bucket list whose
+        # length disagrees with its bounds degrades to no-buckets (the point
+        # still counts); a garbage timestamp sorts oldest. Validation covers three
+        # classes: VALUE (finite, exact -- ints never roundtrip through
+        # float), STRUCTURE (containers are lists; a bucket list only merges
+        # when it has exactly len(bounds)+1 entries, so group buckets always
+        # match their bounds signature), and ACCUMULATION (the prospective sum must
+        # stay finite -- two individually finite 1e308 sums must not emit an
+        # Infinity literal downstream).
+        bounds_raw = dp.get("explicit_bounds")
+        bc_raw = dp.get("bucket_counts")
+        if bounds_raw is None:
+            bounds_raw = []
+        if bc_raw is None:
+            bc_raw = []
+        if not isinstance(bounds_raw, (list, tuple)) or not isinstance(bc_raw, (list, tuple)):
+            # Any non-list container is garbage and skips the point: a truthy
+            # one (e.g. "explicit_bounds": 5) would raise TypeError at the
+            # for-loop, and a falsy one (false, 0, "") must not silently read
+            # as "absent" and corrupt the group's shape. Only a genuinely
+            # missing/null key defaults to empty.
             return
+        bounds_f: list[float] = []
+        for b in bounds_raw:
+            fb = _finite(b)
+            if fb is None:
+                return
+            if bounds_f and not math.isfinite(fb - bounds_f[-1]):
+                # Derived values must stay finite too: two individually
+                # finite bounds like -1e308 and 1e308 subtract to inf inside
+                # _pct_from_buckets' interpolation (hi - lo) and the API
+                # would emit an Infinity literal. Same class as the
+                # accumulated-sum guard below.
+                return
+            bounds_f.append(fb)
+        key = tuple(bounds_f)
+        n_raw = dp.get("count", 0)
+        n = _finite_int(0 if n_raw is None else n_raw)
+        if n is None:
+            return
+        # Uniform defaulting rule for every field in this method: ONLY a
+        # missing or null key takes the default; any other value must survive
+        # validation on its own ("" or false substituting 0 would let a
+        # malformed point silently skew the mean).
+        sum_raw = dp.get("sum", 0.0)
+        fsum = _finite(0.0 if sum_raw is None else sum_raw)
+        if fsum is None:
+            return
+        bc_f: list[int] = []
+        for v in bc_raw:
+            fv = _finite_int(v)
+            if fv is None:
+                return
+            bc_f.append(fv)
+        # A histogram point's bucket_counts has one more entry than its
+        # bounds (the trailing +Inf bucket). A mismatched length cannot merge
+        # into this bounds generation's shape (it would poison the group's
+        # buckets and crash the percentile interpolation with IndexError),
+        # but it is a merge-compatibility problem, not value poisoning: the
+        # point's independently-validated scalars are still truthful, so the
+        # disagreeing bucket list is DROPPED and the point still counts --
+        # the same degrade path as a count-only point (no bucket_counts at
+        # all), which stays legal. Pinned upstream by
+        # test_telemetry_handlers_cov80.py (count keeps accumulating).
+        if bc_f and len(bc_f) != len(bounds_f) + 1:
+            bc_f = []
         g = self._groups.get(key)
+        # Prospective-accumulation check BEFORE mutation: adding a finite sum
+        # to a finite accumulator can still overflow to inf.
+        acc_sum = (float(g["sum"]) if g is not None else 0.0) + fsum
+        if not math.isfinite(acc_sum):
+            return
         if g is None:
             g = {
                 "count": 0,
                 "sum": 0.0,
                 "min": None,
                 "max": None,
-                "buckets": [0] * len(bc) if bc else [],
+                "buckets": [0] * len(bc_f) if bc_f else [],
                 "bounds": list(key),
                 "outcomes": {},
                 "newest_ns": 0,
             }
             self._groups[key] = g
-        try:
-            ns = int(dp.get("time_unix_nano") or 0)
-        except (TypeError, ValueError):
+        ts_raw = dp.get("time_unix_nano")
+        ns = _finite_int(0 if ts_raw is None else ts_raw)
+        if ns is None:
+            # Ordering-only field: garbage degrades to oldest, never skips.
             ns = 0
         if ns > int(g["newest_ns"]):
             g["newest_ns"] = ns
-        n = int(dp.get("count", 0) or 0)
         g["count"] += n
-        g["sum"] += float(dp.get("sum", 0.0) or 0.0)
+        g["sum"] = acc_sum
         if outcome:
             # Outcome tallies MUST be grouped too. Scoping only the buckets and
             # count would leave the outcome breakdown summing across generations
@@ -295,20 +368,20 @@ class _Hist:
             # an outcome bar totalling more than N, and a fault rate computed
             # over a different population than the latency next to it.
             g["outcomes"][outcome] = g["outcomes"].get(outcome, 0) + n
-        mn, mx = dp.get("min"), dp.get("max")
+        mn, mx = _finite(dp.get("min")), _finite(dp.get("max"))
         if mn is not None:
             g["min"] = mn if g["min"] is None else min(g["min"], mn)
         if mx is not None:
             g["max"] = mx if g["max"] is None else max(g["max"], mx)
-        if bc:
+        if bc_f:
             if not g["buckets"]:
-                g["buckets"] = [0] * len(bc)
-            # Same bounds signature implies same bucket length; the guard only
-            # defends against a malformed shard mixing lengths under one bounds
-            # list, which would otherwise raise IndexError.
-            if len(bc) == len(g["buckets"]):
-                for j, v in enumerate(bc):
-                    g["buckets"][j] += int(v or 0)
+                g["buckets"] = [0] * len(bc_f)
+            # Same bounds signature implies same bucket length (enforced per
+            # point above), so this always holds; kept as cheap defense in
+            # depth against a group built by older state.
+            if len(bc_f) == len(g["buckets"]):
+                for j, v in enumerate(bc_f):
+                    g["buckets"][j] += v
 
     def _dominant(self) -> dict[str, Any] | None:
         """The generation holding the newest sample.
@@ -406,7 +479,8 @@ class _Hist:
 def _finite(raw: Any) -> float | None:
     """Coerce a shard scalar to a finite float, or None.
 
-    THE single entry point for scalar reads in ``_aggregate``. Shards are
+    THE single entry point for untrusted shard reads — the scalar branch in
+    ``_aggregate`` and every field ``_Hist.add`` consumes. Shards are
     external input and Python's ``json`` accepts ``Infinity``/``NaN``
     literals, so a bare ``float(...)`` admits values that poison sums and an
     ``int(float(...))`` timestamp conversion raises ``OverflowError`` — four
@@ -415,11 +489,52 @@ def _finite(raw: Any) -> float | None:
     """
     try:
         v = float(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: json accepts arbitrary-precision integers, and
+        # float(10**400) overflows rather than returning inf.
         return None
     if not math.isfinite(v):
         return None
     return v
+
+
+# OTel histogram count fields are uint64 on the wire; anything beyond this
+# scale is garbage, and the bound keeps accumulated counts far below float
+# range so downstream stats (float division in ``stats()``) cannot overflow.
+_INT_BOUND = 2**63
+
+
+def _finite_int(raw: Any) -> int | None:
+    """Coerce a shard integer field (count, bucket count, ns) EXACTLY, or None.
+
+    Integer inputs never roundtrip through float -- ``int(float(2**53 + 1))``
+    silently rounds to 2**53 and the API would emit corrupted counts.
+    Booleans (JSON ``true``/``false``) are garbage in an integer field, a
+    negative value is invalid for uint64-wire counts, and a fractional value
+    would silently truncate -- all three reject rather than coerce. Values
+    beyond the uint64-scale bound are rejected either way.
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        i = raw
+    elif isinstance(raw, str):
+        # protobuf JSON encodes uint64/int64 as STRINGS; parse them exactly
+        # ("9007199254740993" through float would round to ...992). A
+        # non-integer string falls through to the float path (e.g. "3.0").
+        try:
+            i = int(raw)
+        except ValueError:
+            f = _finite(raw)
+            if f is None or not f.is_integer():
+                return None
+            i = int(f)
+    else:
+        f = _finite(raw)
+        if f is None or not f.is_integer():
+            return None
+        i = int(f)
+    return i if 0 <= i <= _INT_BOUND else None
 
 
 def _day_of(dp: dict[str, Any], fallback: str) -> str:
@@ -765,9 +880,11 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             # sample per attribute set.
             is_sum = "aggregation_temporality" in data or "is_monotonic" in data
             try:
-                # OTel JSON: DELTA=1, CUMULATIVE=2.
+                # OTel JSON: DELTA=1, CUMULATIVE=2. Same chokepoint contract
+                # as _finite: json accepts Infinity literals, and int(inf)
+                # raises OverflowError, not ValueError.
                 cumulative = int(data.get("aggregation_temporality") or 0) == 2
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 cumulative = False
             key = ",".join(f"{k}={attrs[k]}" for k in sorted(attrs)) if attrs else ""
             if is_sum and cumulative:

--- a/test/metrics/test_telemetry_handler.py
+++ b/test/metrics/test_telemetry_handler.py
@@ -6,6 +6,7 @@ logic, so a regression in the shard parser or percentile math fails the test.
 """
 
 import json
+import math
 from pathlib import Path
 
 from kiro_crew.dashboard.handlers.telemetry import _aggregate, _Hist, _pct_from_buckets
@@ -383,12 +384,181 @@ def test_aggregate_rejects_non_finite_scalars(tmp_path: Path):
             ]
         },
     }
-    result = _aggregate([_write_shard(tmp_path, [metric])])
+    # A Sum whose aggregation_temporality is itself poisoned: int(inf) raises
+    # OverflowError, which the coercion's except tuple must absorb (the point
+    # degrades to non-cumulative instead of 500ing the endpoint).
+    poisoned_temporality = {
+        "name": "kirocrew.poisoned.temporality",
+        "data": {
+            "data_points": [{"attributes": {}, "value": 3.0, "time_unix_nano": 7}],
+            "aggregation_temporality": float("inf"),
+            "is_monotonic": True,
+        },
+    }
+    result = _aggregate([_write_shard(tmp_path, [metric, poisoned_temporality])])
     rows = [o for o in result["other"] if o["name"] == "kirocrew.process.threads.os"]
     assert rows and rows[0]["kind"] == "gauge"
     # inf value skipped; inf timestamp coerces the point to ts=0 (sorts
     # oldest), so ts=9 wins.
     assert rows[0]["latest"] == 97.0
+    # The poisoned-temporality Sum degrades to a delta counter (cumulative
+    # False), still counted -- and the payload stays strict JSON.
+    poisoned = [o for o in result["other"] if o["name"] == "kirocrew.poisoned.temporality"]
+    assert poisoned and poisoned[0]["kind"] == "counter"
+    json.dumps(result, allow_nan=False)
+
+
+def test_aggregate_rejects_non_finite_histogram_fields(tmp_path: Path):
+    """Histogram mirror of the scalar guard: one poisoned data point degrades
+    that point, never the endpoint.
+
+    Python's json module parses Infinity/NaN literals, so before the fix a
+    poisoned histogram point flowed straight through ``_Hist.add``'s bare
+    float()/int() coercions: an inf sum/min/bound reached json.dumps and
+    emitted an ``Infinity`` literal (which browser JSON.parse rejects), and
+    an inf count/bucket_count/timestamp raised uncaught OverflowError."""
+    poisoned_sum = _hist_dp({}, ns=2)
+    poisoned_sum["sum"] = float("inf")
+    poisoned_min = _hist_dp({}, ns=3)
+    poisoned_min["min"] = float("nan")
+    poisoned_bound = _hist_dp({}, ns=4)
+    poisoned_bound["explicit_bounds"] = [10, float("inf"), 30, 40, 50]
+    poisoned_count = _hist_dp({}, ns=5)
+    poisoned_count["count"] = float("inf")
+    poisoned_bucket = _hist_dp({}, ns=6)
+    poisoned_bucket["bucket_counts"][1] = float("nan")
+    poisoned_ts = _hist_dp({}, count=3, ns=7)
+    poisoned_ts["time_unix_nano"] = float("inf")
+    # json accepts arbitrary-precision ints: float(10**400) raises
+    # OverflowError, a third path past a naive isfinite check.
+    oversized_count = _hist_dp({}, ns=9)
+    oversized_count["count"] = 10**400
+    # A truthy non-list container raises TypeError at iteration, not inside
+    # the element coercion.
+    scalar_bounds = _hist_dp({}, ns=10)
+    scalar_bounds["explicit_bounds"] = 5
+    scalar_buckets = _hist_dp({}, ns=11)
+    scalar_buckets["bucket_counts"] = True
+    good = _hist_dp({}, count=2, ns=8, each_ms=25.0)
+
+    metric = {
+        "name": "kirocrew.mcp.backend.acquire.duration",
+        "data": {
+            "data_points": [
+                poisoned_sum,
+                poisoned_min,
+                poisoned_bound,
+                poisoned_count,
+                poisoned_bucket,
+                poisoned_ts,
+                oversized_count,
+                scalar_bounds,
+                scalar_buckets,
+                good,
+            ]
+        },
+    }
+    result = _aggregate([_write_shard(tmp_path, [metric])])
+    row = next(o for o in result["other"] if o["name"] == "kirocrew.mcp.backend.acquire.duration")
+
+    # Structurally poisoned points (sum/bound/count/bucket) are skipped whole;
+    # the nan-min point survives with min degraded; the inf-timestamp point
+    # survives sorting oldest. 1 (poisoned_min) + 3 (poisoned_ts) + 2 (good).
+    assert row["count"] == 6
+    assert row["other_generations"] == 0
+    # The emitted payload must serialize to strict JSON — no Infinity/NaN
+    # literal anywhere (this is what the browser's JSON.parse enforces).
+    json.dumps(result, allow_nan=False)
+
+
+def test_hist_add_validates_the_whole_point_before_mutation():
+    """The _Hist.add invariant: nothing invalid ever enters group state.
+
+    Three residual classes past the plain non-finite guard:
+    - EXACTNESS: integer counts must not roundtrip through float
+      (int(float(2**53 + 1)) silently rounds and corrupts emitted counts).
+    - ACCUMULATION: two individually finite 1e308 sums overflow the
+      accumulator to inf, which json.dumps emits as an Infinity literal.
+    - STRUCTURE: a bucket_counts shorter/longer than len(bounds)+1 cannot
+      merge into the group's shape (IndexError in percentile interpolation);
+      the buckets degrade to absent while the point's scalars still count.
+    """
+    big = 2**53 + 1  # not representable as float; float roundtrip rounds it
+    h = _Hist()
+    exact = _hist_dp({}, ns=1)
+    exact["count"] = big
+    exact["bucket_counts"] = [0, big, 0, 0, 0, 0]
+    h.add(exact)
+    assert h.count == big, "integer count must be preserved exactly"
+    assert h.buckets[1] == big
+
+    # Prospective accumulated-sum guard: the second point is skipped whole.
+    h2 = _Hist()
+    a = _hist_dp({}, ns=1)
+    a["sum"] = 1e308
+    b = _hist_dp({}, ns=2)
+    b["sum"] = 1e308
+    h2.add(a)
+    h2.add(b)
+    g = h2._groups[tuple(float(x) for x in _BOUNDS)]
+    assert math.isfinite(g["sum"])
+    assert h2.count == 1, "the overflowing point is skipped whole"
+
+    # Structural guard: a bucket list disagreeing with len(bounds)+1 cannot
+    # merge into the group's shape. The buckets are dropped but the point's
+    # independently-validated scalars still accumulate (pinned upstream by
+    # test_telemetry_handlers_cov80.py -- no IndexError, count keeps counting).
+    h3 = _Hist()
+    short = _hist_dp({}, ns=1)
+    short["explicit_bounds"] = [10]
+    short["bucket_counts"] = [0, 0, 1]  # needs exactly 2 for one bound
+    h3.add(short)
+    assert h3.count == 1, "shape-mismatched buckets degrade; the point still counts"
+    assert h3.buckets == [], "the disagreeing bucket list itself is dropped"
+    # Integer-field strictness: oversized, boolean, negative, and fractional
+    # counts are rejected whole, never clamped, coerced, or truncated.
+    h3b = _Hist()
+    for bad_count in (2**64, True, -1, 2.5):
+        p = _hist_dp({}, ns=1)
+        p["count"] = bad_count
+        h3b.add(p)
+    assert h3b.count == 0
+    # A FALSY non-list container (false/0/"") is garbage, not "absent" —
+    # only a genuinely missing or null key defaults to empty.
+    for bad_container in (False, 0, ""):
+        p = _hist_dp({}, ns=1)
+        p["bucket_counts"] = bad_container
+        h3b.add(p)
+    assert h3b.count == 0
+    none_ok = _hist_dp({}, ns=1)
+    none_ok["explicit_bounds"] = None  # null key = absent, point stays legal
+    none_ok["bucket_counts"] = None
+    h3.add(none_ok)
+    assert h3.count == 1
+
+    # Falsy garbage never substitutes a default: "" as sum must skip the
+    # point, not silently record 0.0 and skew the mean.
+    h4 = _Hist()
+    bad_sum = _hist_dp({}, ns=1)
+    bad_sum["sum"] = ""
+    h4.add(bad_sum)
+    assert h4.count == 0
+    # protobuf JSON encodes uint64 as strings: parse exactly, no float round.
+    quoted = _hist_dp({}, ns=1)
+    quoted["count"] = str(big)
+    quoted["bucket_counts"] = [0, big, 0, 0, 0, 0]
+    h4.add(quoted)
+    assert h4.count == big, "quoted integer count must be preserved exactly"
+
+    # Derived arithmetic must stay finite: individually finite bounds whose
+    # adjacent span overflows (hi - lo = inf) would poison percentile
+    # interpolation with an Infinity literal.
+    h5 = _Hist()
+    wide = _hist_dp({}, ns=1)
+    wide["explicit_bounds"] = [-1e308, 1e308]
+    wide["bucket_counts"] = [0, 1, 0]
+    h5.add(wide)
+    assert h5.count == 0, "non-finite interpolation span is skipped whole"
 
 
 def test_aggregate_gauges_keep_latest_not_sum(tmp_path: Path):


### PR DESCRIPTION
## Problem / Motivation

One poisoned data point in a telemetry shard breaks the entire dashboard metrics read. Python's `json` module accepts `Infinity`/`NaN` literals, so a shard record carrying `inf`/`nan` in a histogram field flows straight through aggregation: `json.dumps` then emits an `Infinity` literal in the `/api/telemetry/*` response, which the browser's `JSON.parse` rejects — the whole metrics panel dies on one bad record.

The scalar branch was hardened against exactly this by the `_finite()` chokepoint, but the histogram branch (`_Hist.add`) still read every shard field through bare `float()`/`int()` coercions: `inf` sum/min/max/bound poisoned the emitted stats, and `inf` count/bucket_counts/time_unix_nano raised uncaught `OverflowError` (a 500 instead of a degraded point).

## Why it matters

Shards are untrusted external input, and the parser's documented contract is tolerate-garbage — "one bad record can never 500 the endpoint." A single malformed or malicious data point taking down every telemetry surface (startup, turn, and all `other` histograms) violates that contract and leaves the operator blind to the very metrics they'd use to debug it.

## What changed (motivation → approach → change)

Symptom: one non-finite histogram field → invalid JSON or a 500 for the whole endpoint. Root cause: `_Hist.add` bypassed the `_finite()` chokepoint the scalar branch already routes through. Change: `_Hist.add` now validates the **complete data point before the first group mutation** — the invariant is that nothing invalid ever enters durable group state, covering three classes:

- **Value**: every field routes through `_finite()` (now also catching `OverflowError` — JSON accepts arbitrary-precision integers, and `float(10**400)` overflows rather than returning `inf`), with the scalar branch's semantics: structural fields (bounds, count, sum, bucket counts) skip the whole point, optional stats (`min`/`max`) degrade per-stat, and a garbage timestamp sorts oldest. Integer fields (count, bucket counts, timestamp) parse through a new `_finite_int()` **exactly** — never roundtripping through float, which would silently corrupt counts above 2^53 — bounded at uint64 scale.
- **Structure**: containers must be lists (a truthy non-list `explicit_bounds` previously raised `TypeError` at the `for` loop — a path the deleted `except (TypeError, ValueError)` used to absorb), and a `bucket_counts` only merges when it has exactly `len(bounds)+1` entries — a disagreeing bucket list is dropped while the point's independently-validated scalars still accumulate (the contract main pins in `test_telemetry_handlers_cov80.py`), so a group's buckets always match its bounds signature and percentile interpolation cannot hit `IndexError`.
- **Accumulation**: the prospective accumulated sum is checked for finiteness before mutation — two individually finite `1e308` sums must not overflow the accumulator into an `Infinity` literal.
- **Scalar sibling**: the Sum branch's `aggregation_temporality` coercion (`int(...)`) now also absorbs `OverflowError` — a shard carrying `"aggregation_temporality": Infinity` previously 500'd through the same class of gap; the point now degrades to a delta counter instead.

## Tests

- `test_aggregate_rejects_non_finite_histogram_fields` (new, mirrors the scalar guard test `test_aggregate_rejects_non_finite_scalars`): feeds ten histogram data points through `_aggregate` — poisoned sum, nan min, inf bound, inf count, nan bucket_count, inf timestamp, `10**400` count, scalar `explicit_bounds`, boolean `bucket_counts`, and one good point — and asserts structurally poisoned points are skipped whole, degradable stats degrade, and the full emitted payload passes `json.dumps(result, allow_nan=False)` (the exact constraint browser `JSON.parse` enforces).
- `test_hist_add_validates_the_whole_point_before_mutation` (new): locks the three residual classes — a `2**53 + 1` count is preserved **exactly** (no float roundtrip), a second `1e308` sum that would overflow the accumulator is skipped whole with the group sum staying finite, a `bucket_counts`/`bounds` length mismatch drops the buckets while the point still counts, and a count beyond uint64 scale is rejected rather than clamped.
- Proven by revert: on pre-fix source the tests fail with `OverflowError`; on fixed source they pass.

## Manual verification

N/A — unit coverage sufficient: the regression test drives the real `_aggregate` over real shard files on disk, exercising the identical code path the HTTP handler calls.

## Related Issues

Closes #5567

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `_finite()` docstring updated to name both call sites
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to the telemetry aggregation handler; no frontend file touched and no rendered pixel changes.


