### PR TITLE
ci: prune paid-off lockdown allowlist entry (unblocks main CI)

### DIFF
--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -187,7 +187,6 @@ KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
     #
     # #5285's six sites were here until main converted them mid-review; the
     # shrink-only rule below is what forced this list to follow.
-    "src/kiro_crew/snapshot.py::_backup_and_copy": ("#5346", "mc / f"),
     "src/kiro_crew/snapshot.py::_do_merge": ("#5346", "d"),
     "src/kiro_crew/sel.py::_append_lines_locked": ("#5346", "self._path"),
     # Surfaced once _mode_of learned the symbolic spelling: writes a config that


### PR DESCRIPTION
## Problem / Motivation

Pure `main` currently fails its own `Check lockdown-before-publish (secret writers)` step (Backend Lint & Type Check), which reddens every open PR's merge-ref CI regardless of that PR's diff — observed first on PR #5589 (frontend-only). Reproduced on a pristine `main` worktree:

```
Lockdown-before-publish check FAILED: 1 KNOWN_UNCONVERTED entry(ies) no longer violate -- the debt was paid, so delete the entry.
  src/kiro_crew/snapshot.py::_backup_and_copy   (`mc / f`, was tracked by #5346)
```

## Why it matters

Every PR inherits the red on Backend Lint & Type Check via `refs/pull/N/merge`, so CI across the repo is blocked until this lands.

## What changed

Classic cross-merge: the gate ships a **shrink-only** `KNOWN_UNCONVERTED` allowlist (an entry whose site no longer violates must be deleted), and the #5346 fix that converted `snapshot._backup_and_copy` merged concurrently with the gate itself — so the entry went stale the moment both were on main. The fix is exactly what the gate's error prescribes: delete that one entry. No other entry is affected; the list remains shrink-only with 4 tracked sites.

## Tests

The gate is its own test: `python3 scripts/check_lockdown_before_publish.py` fails on main and passes with this change (`Lockdown-before-publish check passed (4 known unconverted site(s) tracked by an open issue).`). No unit test added — the gate's shrink-only rule is the enforcement.

## Manual verification

Ran the script on a pristine main worktree (fails with the entry, passes without it). N/A beyond that — one-line allowlist deletion.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** CI-script allowlist deletion; no rendered UI change.

no linked issue: cross-merge breakage between two already-merged PRs (#5346's fix vs the gate's own landing); the gate's error message fully specifies the fix.
