### PR TITLE
fix(gate): admit the selector's targets before they become pytest argv

### DIFF
--- a/scripts/local-gate.py
+++ b/scripts/local-gate.py
@@ -57,6 +57,16 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SELECTOR = _REPO_ROOT / "scripts" / "ci-surface-tests.py"
 
+# The selector's stdout becomes argv for pytest and vitest, so it is validated
+# with the SAME helper `run_scoped_tests.py` uses rather than a second copy of
+# the rule -- two spellings of one admission check drift, and this one would
+# drift silently because nothing here would fail when it did.
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+from run_scoped_tests import (  # noqa: E402  (path set immediately above)
+    SelectionUntrustworthy,
+    validated_targets,
+)
+
 # Bucket rules -- MUST mirror ci.yml's `changes` job filters. test_local_gate.py
 # pins this against the workflow file so drift fails a test instead of shipping.
 _FRONTEND_PREFIXES = ("website/",)
@@ -215,13 +225,22 @@ def build_plan(args: argparse.Namespace) -> Plan:
             _backend_full(plan)
             _frontend_full(plan)
             return plan
+        try:
+            must_run = validated_targets(must_run, _REPO_ROOT)
+        except SelectionUntrustworthy as exc:
+            plan = Plan(f"selector target refused -- full gate (fail-open): {exc}")
+            _backend_full(plan)
+            _frontend_full(plan)
+            return plan
         plan = Plan(f"frontend-only diff -- full frontend + {len(must_run)} backend guard file(s)")
         _frontend_full(plan)
         if must_run:
             plan.add(
                 "backend (cross-surface guards)",
+                # `--` ends option parsing, matching `run_scoped_tests.backend_argv`.
+                # Belt and braces: `validated_targets` already refuses a leading `-`.
                 [sys.executable, "-m", "pytest", "-q", "-n", "auto", "--dist", "loadgroup",
-                 *must_run],
+                 "--", *must_run],
                 _REPO_ROOT,
             )
         return plan
@@ -238,11 +257,22 @@ def build_plan(args: argparse.Namespace) -> Plan:
     # CI's frontend-test scope step does.
     vitest_targets = [p for p in must_run if not p.startswith("website/electron/")]
     vitest_rel = [p.removeprefix("website/") for p in vitest_targets]
+    try:
+        vitest_rel = validated_targets(vitest_rel, _REPO_ROOT / "website")
+    except SelectionUntrustworthy as exc:
+        plan = Plan(f"selector target refused -- full gate (fail-open): {exc}")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
     plan = Plan(f"backend-only diff -- full backend + {len(vitest_rel)} frontend guard spec(s)")
     _backend_full(plan)
     if vitest_rel:
         plan.add(
             "frontend (cross-surface guards)",
+            # Deliberately NO `--` here: `vitest run -- <paths>` stops treating the
+            # positionals as filters and runs the whole suite, which would report a
+            # narrow scope while running everything. `run_scoped_tests.frontend_argv`
+            # carries the measurement; `validated_targets` is the real protection.
             ["npx", "vitest", "run", *vitest_rel],
             _REPO_ROOT / "website",
         )

--- a/test/test_local_gate.py
+++ b/test/test_local_gate.py
@@ -244,9 +244,12 @@ def test_backend_only_diff_narrows_frontend(gate, monkeypatch) -> None:
     monkeypatch.setattr(gate, "changed_files", lambda base: ["src/kiro_crew/gateway.py"])
     monkeypatch.setattr(
         gate, "selector_must_run",
+        # REAL paths on purpose: the gate refuses a target the tree does not
+        # carry, so a placeholder would exercise the fail-open branch instead
+        # of the narrowed shape this test is about.
         lambda surface: [
-            "website/src/utils/sanitize.test.ts",
-            "website/electron/permissions.test.js",  # electron job's guard: filtered
+            "website/src/test/AcpAdapter.defaults.test.ts",
+            "website/electron/test/app-menu.test.js",  # electron job's guard: filtered
         ],
     )
     plan = gate.build_plan(_args())
@@ -254,9 +257,98 @@ def test_backend_only_diff_narrows_frontend(gate, monkeypatch) -> None:
     assert labels == ["backend (full)", "frontend (cross-surface guards)"]
     _label, cmd, cwd = plan.commands[1]
     # electron guard filtered out; path re-rooted for cwd=website
-    assert cmd[-1] == "src/utils/sanitize.test.ts"
+    assert cmd[-1] == "src/test/AcpAdapter.defaults.test.ts"
     assert not any("electron" in part for part in cmd)
     assert cwd.name == "website"
+
+
+# ---------------------------------------------------------------------------
+# build_plan(): the selector's stdout is argv, so it is admitted, not trusted
+# ---------------------------------------------------------------------------
+
+HOSTILE_TARGETS = [
+    "--config=evil.ini",       # reaches pytest as an OPTION, not a path
+    "-p=no:randomly",
+    "../outside.py",           # escapes the tree
+    "test/does_not_exist.py",  # named but absent: the selection is stale
+]
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_TARGETS)
+def test_hostile_backend_target_falls_open(gate, monkeypatch, hostile: str) -> None:
+    """A target that could act as an option or escape the tree runs everything.
+
+    The selector's stdout is spliced straight into a pytest argv, so a file
+    named ``--config=evil.ini`` would be read as a FLAG rather than a path.
+    There is no shell (argv is always a list), so the exposure is argument
+    injection -- and a test runner's own flags are quite enough to do damage.
+
+    Falling open is this file's existing contract for anything doubtful, and
+    it is also what ``SelectionUntrustworthy`` documents: the caller runs
+    everything.
+    """
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(gate, "selector_must_run", lambda surface: [hostile])
+    plan = gate.build_plan(_args())
+    assert _is_full(plan)
+    assert "fail-open" in plan.reason
+    assert not any(hostile in part for _l, cmd, _c in plan.commands for part in cmd)
+
+
+@pytest.mark.parametrize("hostile", ["--reporter=evil", "../outside.test.ts"])
+def test_hostile_frontend_target_falls_open(gate, monkeypatch, hostile: str) -> None:
+    """Same admission on the vitest hand-off.
+
+    Checked separately because the frontend path re-roots each target to
+    ``cwd=website`` first, so it validates against a different root and a
+    single shared assertion would not prove both.
+    """
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["src/kiro_crew/gateway.py"])
+    monkeypatch.setattr(gate, "selector_must_run", lambda surface: ["website/" + hostile])
+    plan = gate.build_plan(_args())
+    assert _is_full(plan)
+    assert "fail-open" in plan.reason
+
+
+def test_one_hostile_target_condemns_the_whole_selection(gate, monkeypatch) -> None:
+    """A good target beside a bad one must not be run as a narrowed plan.
+
+    Dropping the bad entry and keeping the rest would be the tempting
+    behaviour and the wrong one: a selection containing something the gate
+    cannot explain is not a selection it can justify narrowing on.
+    """
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(
+        gate, "selector_must_run",
+        lambda surface: ["test/test_local_gate.py", "--config=evil.ini"],
+    )
+    assert _is_full(gate.build_plan(_args()))
+
+
+def test_backend_targets_are_preceded_by_a_double_dash(gate, monkeypatch) -> None:
+    """pytest gets ``--``; vitest deliberately does not.
+
+    ``run_scoped_tests.frontend_argv`` carries the measurement for the
+    asymmetry: ``vitest run -- <paths>`` stops treating the positionals as
+    filters and runs the whole suite, so the report would claim a narrow
+    scope while everything ran.
+    """
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["website/src/App.tsx"])
+    monkeypatch.setattr(
+        gate, "selector_must_run", lambda surface: ["test/test_local_gate.py"],
+    )
+    _label, cmd, _cwd = gate.build_plan(_args()).commands[1]
+    assert cmd[-2] == "--" and cmd[-1] == "test/test_local_gate.py"
+
+
+def test_vitest_targets_are_not_preceded_by_a_double_dash(gate, monkeypatch) -> None:
+    monkeypatch.setattr(gate, "changed_files", lambda base: ["src/kiro_crew/gateway.py"])
+    monkeypatch.setattr(
+        gate, "selector_must_run",
+        lambda surface: ["website/src/test/AcpAdapter.defaults.test.ts"],
+    )
+    _label, cmd, _cwd = gate.build_plan(_args()).commands[1]
+    assert "--" not in cmd
 
 
 def test_backend_only_diff_with_no_guards_runs_backend_alone(gate, monkeypatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

`scripts/local-gate.py` runs `ci-surface-tests.py` and splices its stdout straight into a test-runner argv:

```python
[sys.executable, "-m", "pytest", "-q", "-n", "auto", "--dist", "loadgroup", *must_run]
["npx", "vitest", "run", *vitest_rel]
```

Nothing between the subprocess read and the argv checks what those lines are:

| selector line | what the runner sees |
|---|---|
| `--config=evil.ini` | a pytest **option**, not a path |
| `-p=no:randomly` | a plugin directive |
| `../outside.py` | a target outside the tree |
| `test/does_not_exist.py` | a stale selection, silently narrowing to nothing |

There is no shell involved — argv is always a list, never `shell=True` — so the exposure is **argument** injection rather than command injection. A test runner's own flags are quite enough: `-p`, `--config`, `--rootdir` all change what runs and what it runs against.

Counted in #5262's First Principles review, against the PR that closed the identical hole on the other selector:

> **Unfixed siblings of the hardening:** `local-gate.py:201` and `local-gate.py:223` splice the same selector stdout into pytest/vitest argv unvalidated — 2 sites carrying the exact exposure `validated_targets()` closes.

## Why it matters

The gate's whole promise is *"a heuristic miss costs local time, never a skipped test"* — its own docstring. Argv that the gate did not intend breaks that promise in the one direction it says it never will: `-p no:cacheprovider`, a redirected `--rootdir`, or a target that quietly resolves to nothing all end with the gate reporting a narrow, green run that did not test what it claimed.

It is also the last unguarded copy. `run_scoped_tests.py` already admits its selector's output; this file is the one that still trusts it.

## What changed (motivation → approach → change)

**Symptom** — selector stdout becomes runner flags.

**Root cause** — an admission check exists for one selector consumer and not the other.

**Change** — import the existing helper rather than restate the rule:

```python
sys.path.insert(0, str(_REPO_ROOT / "scripts"))
from run_scoped_tests import SelectionUntrustworthy, validated_targets
```

and validate at both sites, each against its own root (`_REPO_ROOT` for pytest, `_REPO_ROOT / "website"` for vitest, which re-roots its targets first).

**The disposition needed no new decision.** `SelectionUntrustworthy`'s own docstring says *"the caller runs everything"*, and falling open is already this file's contract for every doubtful input, so a refused target joins an unreadable diff and a failed selector on the existing fail-open branch.

**One bad entry condemns the whole selection.** Dropping it and keeping the rest is the tempting behaviour and the wrong one: a selection containing something the gate cannot explain is not one it can justify narrowing on.

**`--` for pytest, deliberately not for vitest.** `run_scoped_tests.frontend_argv` carries the measurement — `vitest run -- <paths>` stops treating the positionals as filters and runs the whole suite (1,474 spec files, 22,939 tests) while the gate still reports a narrow scope. Both spellings are now the same in both files.

No new constant, no new mechanism, no change to which tests a legitimate selection runs.

## Tests

| Test | Behavior locked in |
|---|---|
| `test_hostile_backend_target_falls_open` (×4: `--config=evil.ini`, `-p=no:randomly`, `../outside.py`, a nonexistent path) | the full gate runs, the reason says fail-open, and the hostile string appears in no argv |
| `test_hostile_frontend_target_falls_open` (×2) | same admission on the vitest hand-off — checked separately because it validates against a different root after re-rooting |
| `test_one_hostile_target_condemns_the_whole_selection` | a good target beside a bad one does **not** produce a narrowed plan |
| `test_backend_targets_are_preceded_by_a_double_dash` | pytest argv ends `-- <target>` |
| `test_vitest_targets_are_not_preceded_by_a_double_dash` | vitest argv carries no `--` |

**Red-before**, production file alone reverted to `origin/main`, tests kept:

```
8 failed, 27 passed
  test_hostile_backend_target_falls_open[--config=evil.ini]      assert False
  test_hostile_backend_target_falls_open[-p=no:randomly]         assert False
  test_hostile_backend_target_falls_open[../outside.py]          assert False
  test_hostile_backend_target_falls_open[test/does_not_exist.py] assert False
  test_hostile_frontend_target_falls_open[--reporter=evil]       assert False
  test_hostile_frontend_target_falls_open[../outside.test.ts]    assert False
  test_one_hostile_target_condemns_the_whole_selection           assert False
  test_backend_targets_are_preceded_by_a_double_dash             'loadgroup' == '--'
```

After: **35 passed**.

**Two existing fixtures had to become real paths, and this is worth a reviewer's eye.** `validated_targets` refuses a target the tree does not carry, so `website/src/utils/sanitize.test.ts` and `website/electron/permissions.test.js` — both invented — began exercising the new fail-open branch instead of the narrowed shape their tests are about. They are now `website/src/test/AcpAdapter.defaults.test.ts` and `website/electron/test/app-menu.test.js`, which exist. No assertion was weakened, and the electron-filtering and re-rooting checks still assert exactly what they did.

Gates: `flake8` · `isort --check-only` · `scripts/check_black_formatting.py` · `scripts/check_subprocess_encoding.py` — all clean.

## Manual verification

Ran the gate itself on this branch: `python scripts/local-gate.py --dry-run` prints `meta or both surfaces touched -- full gate`, which is correct for a `scripts/**` diff, and the import of the sibling helper resolves at runtime rather than only under pytest's path.

## Related Issues

The sibling counted in #5262's First Principles review, which closed the same exposure in `scripts/run_scoped_tests.py`. No issue was filed for it.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: the contract is stated where the check happens; the gate's docstring already documents fail-open as the universal disposition.
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
