### PR TITLE
refactor(metrics): share one open-fd probe across gauge and gatewayd diagnostic (#5568)

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -267,7 +267,7 @@ presence without the endpoint string),
 
 | `kirocrew.process.threads.python` | gauge | — | `metrics/process_gauges.py::register_process_gauges`, callbacks run only at reader collection (no polling threads). `threading.active_count()`. |
 | `kirocrew.process.threads.os` | gauge | — | Same module; `platform_compat.process_thread_count(os.getpid())` — OS-level count that catches native pools (ggml, grpc) invisible to `threading`. Linux-only; None elsewhere (gap, not zero). |
-| `kirocrew.process.open_fds` | gauge | — | Same module; `/proc/self/fd` or `/dev/fd` entry count minus the enumeration fd. |
+| `kirocrew.process.open_fds` | gauge | — | Same module; delegates to `platform_compat.count_open_fds` (shared with gatewayd's zombie-diagnostic `fd_count`): `/proc/self/fd` or `/dev/fd` entry count minus the enumeration fd; Windows reports the kernel handle count (platform-dependent semantics). |
 | `kirocrew.process.memory.rss_bytes` / `.peak_rss_bytes` | gauge (By) | — | Same module; delegate to `platform_compat.proc_rss_bytes` (current) / `proc_peak_rss_bytes` (high-water mark), both cross-platform. A 0 return maps to None: gap, never a fake zero sample. |
 | `kirocrew.process.cpu.seconds` | counter (s) | — | Same module; `platform_compat.proc_cpu_seconds` cumulative user+system CPU, exported CUMULATIVE (rebuild-idempotent; see exporter row). |
 | `kirocrew.process.gc.collections` / `.collected` / `.uncollectable` | counter | `generation` (`0`/`1`/`2`) | Same module; `gc.get_stats()` per generation. Rules GC in/out of a leak diagnosis (rising uncollectable = reference cycles; flat collected with rising RSS = native leak). |

--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -187,7 +187,6 @@ KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
     #
     # #5285's six sites were here until main converted them mid-review; the
     # shrink-only rule below is what forced this list to follow.
-    "src/kiro_crew/snapshot.py::_backup_and_copy": ("#5346", "mc / f"),
     "src/kiro_crew/snapshot.py::_do_merge": ("#5346", "d"),
     "src/kiro_crew/sel.py::_append_lines_locked": ("#5346", "self._path"),
     # Surfaced once _mode_of learned the symbolic spelling: writes a config that

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -82,6 +82,7 @@ from kiro_crew.mcp_gateway.stub import fallback_counts as stub_fallback_counts
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.platform_compat import IS_WINDOWS
+from kiro_crew.platform_compat import count_open_fds as _shared_count_open_fds
 from kiro_crew.platform_compat import get_process_start_id as _get_process_start_id
 from kiro_crew.platform_compat import proc_rss_bytes as _proc_rss_bytes
 from kiro_crew.sandbox import _PYTHON_ENV_PREFIXES, warm_backend
@@ -3204,41 +3205,19 @@ def _count_open_fds() -> int:
     the count per snapshot lets us confirm or eliminate that path without
     deploying a separate tracer.
 
-    Platform implementations:
-    - Linux: ``/proc/self/fd``
-    - macOS/BSD: ``/dev/fd``
-    - Windows: ``GetProcessHandleCount`` via ctypes (handle count, not
-      fd count — the field documents this as platform-dependent)
+    Delegates to :func:`platform_compat.count_open_fds` — the one shared
+    per-platform probe (Linux ``/proc/self/fd``, macOS/BSD ``/dev/fd``,
+    Windows ``GetProcessHandleCount``), also behind the
+    ``kirocrew.process.open_fds`` gauge — so this diagnostic cannot drift
+    from the figure the metrics report. The shared probe subtracts the
+    enumeration fd on POSIX, so the value here is exactly one lower than the
+    raw count the pre-consolidation duplicate reported; immaterial for a
+    zombie-diagnostic snapshot field.
 
     Returns ``-1`` when the platform cannot provide the value.
     """
-    # Linux — preferred, most precise.
-    try:
-        return len(os.listdir("/proc/self/fd"))
-    except OSError:
-        pass
-
-    # macOS / BSD — /dev/fd is a per-process virtual directory.
-    try:
-        return len(os.listdir("/dev/fd"))
-    except OSError:
-        pass
-
-    # Windows — count kernel handles for the current process.
-    if sys.platform == "win32":
-        try:
-            import ctypes
-            from ctypes import wintypes
-
-            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
-            handle_count = wintypes.DWORD()
-            current_process = kernel32.GetCurrentProcess()
-            if kernel32.GetProcessHandleCount(current_process, ctypes.byref(handle_count)):
-                return handle_count.value
-        except (OSError, AttributeError, ValueError):
-            pass
-
-    return -1
+    count = _shared_count_open_fds()
+    return -1 if count is None else count
 
 
 def _read_rss_kb() -> int:

--- a/src/kiro_crew/metrics/process_gauges.py
+++ b/src/kiro_crew/metrics/process_gauges.py
@@ -71,10 +71,6 @@ if TYPE_CHECKING:  # annotation-only; never imported at runtime
 
 logger = logging.getLogger(__name__)
 
-# Linux exposes one entry per open fd; the read is two syscalls.
-# /dev/fd exists on macOS/BSD too, so the fd gauge is not Linux-only.
-_FD_DIRS = ("/proc/self/fd", "/dev/fd")
-
 GAUGE_THREADS_PYTHON = "kirocrew.process.threads.python"
 GAUGE_THREADS_OS = "kirocrew.process.threads.os"
 GAUGE_OPEN_FDS = "kirocrew.process.open_fds"
@@ -120,17 +116,15 @@ def read_os_threads() -> int | None:
 
 
 def read_open_fds() -> int | None:
-    """Count of open file descriptors, or None when no fd directory exists.
+    """Count of open file descriptors, or None when the platform has no probe.
 
-    Enumerating the directory opens one fd itself (the directory handle), so
-    the count is decremented by one to reflect steady state.
+    Thin delegate to :func:`platform_compat.count_open_fds`, the one shared
+    per-platform probe (also behind gatewayd's zombie-diagnostic ``fd_count``
+    field). POSIX counts fd-directory entries minus the enumeration fd itself;
+    Windows reports the kernel handle count — platform-dependent semantics,
+    but coverage this gauge previously lacked.
     """
-    for fd_dir in _FD_DIRS:
-        try:
-            return max(0, len(os.listdir(fd_dir)) - 1)
-        except OSError:
-            continue
-    return None
+    return platform_compat.count_open_fds()
 
 
 def _gc_stats() -> list[dict[str, int]]:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3979,6 +3979,56 @@ def proc_peak_rss_bytes() -> int:
     return 0 if counters is None else int(counters.PeakWorkingSetSize)
 
 
+# Per-process fd directories, in preference order: /proc/self/fd (Linux),
+# /dev/fd (macOS/BSD; also present on Linux as a symlink to the former).
+_FD_DIRS = ("/proc/self/fd", "/dev/fd")
+
+
+def count_open_fds() -> int | None:
+    """Return this process's open file descriptor count, or None if unavailable.
+
+    The one shared probe behind both the ``kirocrew.process.open_fds`` gauge
+    (``metrics/process_gauges.py``) and gatewayd's zombie-diagnostic
+    ``fd_count`` snapshot field, so the two figures cannot drift apart.
+
+    - POSIX: entry count of ``/proc/self/fd`` (Linux) or ``/dev/fd``
+      (macOS/BSD), minus one because enumerating the directory opens one fd
+      itself (the directory handle) — callers want the steady state.
+    - Windows: ``GetProcessHandleCount`` — kernel HANDLEs, not fds, so the
+      semantics are platform-dependent (callers document this). Returned raw:
+      the query opens no extra handle, so no correction applies.
+
+    Returns None when no probe works; each caller maps its own sentinel.
+    """
+    for fd_dir in _FD_DIRS:
+        try:
+            return max(0, len(os.listdir(fd_dir)) - 1)
+        except OSError:
+            continue
+    if not IS_WINDOWS:
+        return None
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        # argtypes/restype are load-bearing on 64-bit: without them ctypes
+        # defaults GetCurrentProcess's return to a 32-bit int and TRUNCATES the
+        # pseudo-handle (see _windows_memory_counters).
+        kernel32.GetCurrentProcess.argtypes = []
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        kernel32.GetProcessHandleCount.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        kernel32.GetProcessHandleCount.restype = wintypes.BOOL
+        handle_count = wintypes.DWORD()
+        if kernel32.GetProcessHandleCount(
+            kernel32.GetCurrentProcess(), ctypes.byref(handle_count)
+        ):
+            return int(handle_count.value)
+        return None
+    except Exception:
+        return None
+
+
 def proc_rss_bytes_for_pid(pid: int) -> int | None:
     """Resident set size (bytes) of an ARBITRARY *pid*, or None if unavailable.
 

--- a/test/metrics/test_process_gauges.py
+++ b/test/metrics/test_process_gauges.py
@@ -63,18 +63,17 @@ def test_os_thread_count_matches_proc_when_available():
     assert count >= threading.active_count()
 
 
-def test_open_fds_positive_and_excludes_probe_fd():
-    count = pg.read_open_fds()
-    if count is None:
-        pytest.skip("no fd directory on this platform")
-    # stdin/stdout/stderr at minimum; the enumeration fd itself is excluded.
-    assert count >= 3
+def test_open_fds_delegates_to_the_shared_probe():
+    # The probe's behavior (fd-dir correction, Windows handle count) is pinned
+    # in test_platform_compat_coverage.py; here only the delegation matters.
+    with patch.object(pg.platform_compat, "count_open_fds", return_value=17):
+        assert pg.read_open_fds() == 17
 
 
 def test_readers_return_none_not_raise_when_proc_missing():
     with patch.object(pg.platform_compat, "process_thread_count", return_value=None):
         assert pg.read_os_threads() is None
-    with patch.object(pg.os, "listdir", side_effect=OSError("no proc")):
+    with patch.object(pg.platform_compat, "count_open_fds", return_value=None):
         assert pg.read_open_fds() is None
 
 

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -2145,6 +2145,77 @@ class TestProcPeakRss:
         assert pc.proc_peak_rss_bytes() == 0
 
 
+class TestCountOpenFds:
+    """``count_open_fds`` is the ONE shared open-fd probe.
+
+    Both the ``kirocrew.process.open_fds`` gauge and gatewayd's
+    zombie-diagnostic ``fd_count`` delegate here, so these tests pin the probe
+    once: the POSIX steady-state correction, the None contract, and the
+    Windows handle-count route the gauge previously lacked.
+    """
+
+    def test_posix_count_is_positive_and_excludes_the_probe_fd(self):
+        count = pc.count_open_fds()
+        if count is None:
+            pytest.skip("no fd probe on this platform")
+        # stdin/stdout/stderr at minimum; the enumeration fd itself excluded.
+        assert count >= 3
+
+    def test_posix_correction_never_goes_negative(self, monkeypatch, tmp_path):
+        empty = tmp_path / "fd"
+        empty.mkdir()
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(empty),))
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.count_open_fds() == 0
+
+    def test_second_fd_dir_is_the_fallback(self, monkeypatch, tmp_path):
+        fallback = tmp_path / "fd"
+        fallback.mkdir()
+        for name in ("0", "1", "2", "3"):
+            (fallback / name).write_text("")
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(tmp_path / "missing"), str(fallback)))
+        # Four entries, minus the enumeration fd the listing itself opens.
+        assert pc.count_open_fds() == 3
+
+    def test_none_when_no_probe_works_on_posix(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(tmp_path / "missing"),))
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.count_open_fds() is None
+
+    def test_windows_reads_the_kernel_handle_count_raw(self, monkeypatch, tmp_path):
+        def _get_handle_count(_process: Any, out: Any) -> int:
+            out._obj.value = 42
+            return 1
+
+        _fake_windows(
+            monkeypatch,
+            kernel32=types.SimpleNamespace(
+                GetCurrentProcess=_const(1),
+                GetProcessHandleCount=_Fn(_get_handle_count),
+            ),
+        )
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(tmp_path / "missing"),))
+        # Raw: the handle query opens no extra handle, so no -1 correction.
+        assert pc.count_open_fds() == 42
+
+    def test_windows_api_failure_is_none(self, monkeypatch, tmp_path):
+        _fake_windows(
+            monkeypatch,
+            kernel32=types.SimpleNamespace(
+                GetCurrentProcess=_const(1),
+                GetProcessHandleCount=_const(0),
+            ),
+        )
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(tmp_path / "missing"),))
+        assert pc.count_open_fds() is None
+
+    def test_windows_loader_failure_is_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        monkeypatch.setattr(pc, "_FD_DIRS", (str(tmp_path / "missing"),))
+        assert pc.count_open_fds() is None
+
+
 class TestProcRssForPid:
     @_LINUX_ONLY
     def test_linux_reads_statm_for_this_process(self):

--- a/tests/test_gatewayd_diag.py
+++ b/tests/test_gatewayd_diag.py
@@ -28,12 +28,15 @@ class TestCountOpenFds:
             # On truly unsupported platforms, -1 is acceptable.
             assert result == -1 or result > 0
 
-    def test_returns_minus_one_when_all_sources_fail(self) -> None:
-        """If /proc/self/fd, /dev/fd, and Win32 all fail, return -1."""
-        with patch("os.listdir", side_effect=OSError("mocked")):
-            with patch.object(sys, "platform", "linux"):
-                result = _count_open_fds()
-        assert result == -1
+    def test_returns_minus_one_when_the_shared_probe_has_no_value(self) -> None:
+        """A None from the shared probe maps to the diagnostic's -1 sentinel."""
+        with patch("kiro_crew.mcp_gateway.gatewayd._shared_count_open_fds", return_value=None):
+            assert _count_open_fds() == -1
+
+    def test_passes_the_shared_probe_count_through_unchanged(self) -> None:
+        """Delegation is thin: the shared reader's count is returned as-is."""
+        with patch("kiro_crew.mcp_gateway.gatewayd._shared_count_open_fds", return_value=7):
+            assert _count_open_fds() == 7
 
     def test_proc_self_fd_preferred_on_linux(self) -> None:
         """On Linux, /proc/self/fd is used and returns a sane count."""


### PR DESCRIPTION
## Problem / Motivation

Two independent open-file-descriptor probes exist. #4788 added
`read_open_fds` in `src/kiro_crew/metrics/process_gauges.py` (POSIX-only
`/proc/self/fd` → `/dev/fd`, with a `max(0, n-1)` correction for the directory
handle the listing itself opens). The pre-existing `_count_open_fds` in
`src/kiro_crew/mcp_gateway/gatewayd.py` duplicates the same two POSIX probes
(raw count, no correction) plus a Windows `GetProcessHandleCount` ctypes path.
The duplicates had already drifted: the gauge had no Windows coverage, and the
gateway probe lacked the self-handle correction.

## Why it matters

Two copies of the same platform probe drift independently — a fix or platform
addition lands in one and not the other, and the `kirocrew.process.open_fds`
gauge and gatewayd's zombie-diagnostic `fd_count` report figures that cannot be
reconciled during an FD-leak investigation, which is exactly when they are read
side by side.

## What changed (motivation → approach → change)

Duplicated per-platform probes → consolidate into `platform_compat`, the module
that already owns the analogous shared readers (`proc_rss_bytes` /
`proc_peak_rss_bytes`), and make both call sites thin delegates:

- New `platform_compat.count_open_fds() -> int | None`: `/proc/self/fd` then
  `/dev/fd` returning `max(0, len-1)` (enumeration opens the directory handle
  itself), then Windows `GetProcessHandleCount` returning the raw handle count
  (the query opens no extra handle), else `None`. The Windows path declares
  `argtypes`/`restype` — load-bearing on 64-bit (see `_windows_memory_counters`),
  which the old gatewayd copy omitted.
- `process_gauges.read_open_fds` delegates to it, thereby gaining Windows
  coverage (the drift the issue names). Windows reports kernel HANDLEs, not
  fds — platform-dependent semantics, documented at the probe, the delegate,
  and `docs/system-specs/modules/metrics.md`.
- `gatewayd._count_open_fds` delegates with `return -1 if n is None else n`;
  sentinel mapping (None vs -1) stays at each call site. Its POSIX value
  shifts down by exactly one (steady-state correction the shared probe
  applies), immaterial for a zombie-diagnostic snapshot field.

Riding along (base ratchet, not this PR's feature): rebasing onto current main
tripped the lockdown-before-publish ratchet — `src/kiro_crew/snapshot.py::_backup_and_copy`
in `KNOWN_UNCONVERTED` no longer violates (debt paid on main), so the stale
entry is deleted per the check's own instruction
(`scripts/check_lockdown_before_publish.py`).

## Tests

- `test/test_platform_compat_coverage.py::TestCountOpenFds` (new) pins the
  shared probe once: live POSIX count excludes the enumeration fd; the
  `max(0, n-1)` floor; second fd-dir fallback; `None` when no probe works; the
  Windows handle-count route (raw, no correction); Windows API-failure and
  loader-failure both → `None`.
- `test/metrics/test_process_gauges.py`: probe tests replaced by thin
  delegation tests (value passthrough, `None` passthrough).
- `tests/test_gatewayd_diag.py`: delegation tests (`None` → `-1` sentinel, raw
  count passthrough); live-platform tests kept.

## Manual verification

N/A — unit coverage sufficient: both call sites are pure delegation and the
probe's platform branches are pinned by the new tests.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only metrics/diagnostic consolidation; no
rendered UI change.

## Related Issues

Fixes #5568

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

