### PR TITLE
ci: drop paid lockdown ledger entry for snapshot._backup_and_copy

### DIFF
--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -187,7 +187,6 @@ KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
     #
     # #5285's six sites were here until main converted them mid-review; the
     # shrink-only rule below is what forced this list to follow.
-    "src/kiro_crew/snapshot.py::_backup_and_copy": ("#5346", "mc / f"),
     "src/kiro_crew/snapshot.py::_do_merge": ("#5346", "d"),
     "src/kiro_crew/sel.py::_append_lines_locked": ("#5346", "self._path"),
     # Surfaced once _mode_of learned the symbolic spelling: writes a config that


### PR DESCRIPTION
## Problem / Motivation

Main is red: the lockdown-before-publish check fails with "1 KNOWN_UNCONVERTED entry(ies) no longer violate -- the debt was paid, so delete the entry" for `src/kiro_crew/snapshot.py::_backup_and_copy`. This reds `Backend Lint & Type Check (3.10)` and `Backend Tests (shard 2)` on all platforms, on main and on every open PR.

## Why it matters

Every open PR inherits these reds, so nothing can reach all-checks-green until the ledger entry is removed. Observed blocking #5600 (and reproduced on a clean `origin/main` checkout at `89f893a2d`).

## What changed (motivation -> approach -> change)

A merge to main converted `_backup_and_copy` to the compliant write pattern, paying the debt tracked by #5346, but did not delete the corresponding `KNOWN_UNCONVERTED` ledger entry in `scripts/check_lockdown_before_publish.py`. The ratchet is deliberately two-sided (a paid-but-still-listed entry is itself a failure), which is exactly the signal firing now.

Change: delete the one stale ledger entry. The remaining #5346 sites (`_do_merge`, `sel.py::_append_lines_locked`, ...) still violate and stay listed.

## Tests

- `python scripts/check_lockdown_before_publish.py` now passes (4 known unconverted sites tracked).
- `test/test_lockdown_before_publish.py` full suite: 76 passed (previously `test_every_known_unconverted_entry_still_violates` and `test_src_has_no_unclassified_violation` failed).
- isort/flake8 clean on the touched file; black gate passes.

## Manual verification

N/A -- unit coverage sufficient: the change is one ledger line and the gate's own suite pins both sides of the ratchet.

Closes #5605
