### PR TITLE
fix(channels): reject non-string message content

### DIFF
--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -209,7 +209,16 @@ async def api_channel_close(request: web.Request) -> web.Response:
 
 async def api_channel_post(request: web.Request) -> web.Response:
     ch, body = await _get_channel_body(request)
-    content = body.get("content", "").strip()[:10000]
+    raw_content = body.get("content", "")
+    if not isinstance(raw_content, str):
+        return web.json_response(
+            {
+                "error": "content must be a string",
+                "code": "channel_message_content_type_invalid",
+            },
+            status=400,
+        )
+    content = raw_content.strip()[:10000]
     if not content:
         return web.json_response({"error": "content required"}, status=400)
     # Validate mentions

--- a/test/test_channel_message_api_validation.py
+++ b/test/test_channel_message_api_validation.py
@@ -1,0 +1,63 @@
+"""Field-level input contract for Channels message posts."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.channel import ChannelManager
+from kiro_crew.dashboard.handlers_channel import api_channel_post
+
+
+def _request(manager: ChannelManager, body: dict, channel_id: str) -> MagicMock:
+    request = MagicMock()
+    request.app = {"state": SimpleNamespace(channel_manager=manager)}
+    request.match_info = {"id": channel_id}
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+async def _invoke(request) -> web.StreamResponse:
+    try:
+        return await api_channel_post(request)
+    except web.HTTPException as exc:
+        return exc
+
+
+def _body(response: web.StreamResponse) -> dict:
+    return json.loads(response.text)
+
+
+@pytest.fixture
+def manager(tmp_path) -> ChannelManager:
+    return ChannelManager(channels_dir=str(tmp_path / "channels"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", [None, [], {}, 7, True])
+async def test_post_rejects_non_string_content_before_mutation(manager, monkeypatch, content):
+    channel = manager.create("incident")
+    post_spy = AsyncMock()
+    monkeypatch.setattr(channel, "post", post_spy)
+
+    response = await _invoke(_request(manager, {"content": content}, channel.id))
+
+    assert response.status == 400
+    assert _body(response)["code"] == "channel_message_content_type_invalid"
+    assert channel.messages == []
+    post_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_keeps_string_trim_and_length_limit(manager):
+    channel = manager.create("incident")
+
+    response = await _invoke(_request(manager, {"content": f"  {'a' * 10001}  "}, channel.id))
+
+    assert response.status == 200
+    assert _body(response)["message"]["content"] == "a" * 10000
+    assert channel.messages[-1].content == "a" * 10000


### PR DESCRIPTION
## Problem / Motivation

POST /api/channels/{id}/messages calls strip on content without first checking its type. Valid JSON object payloads carrying null, arrays, objects, numbers, or booleans therefore raise AttributeError and surface as HTTP 500.

This is separate from #5586/#5588 (top-level JSON-object validation) and #5595/#5598 (agent mutation fields): this request body is already an object, and the invalid field is message content.

## Why it matters

Malformed client input can turn a deterministic validation error into an internal server error. The handler contract should reject it before Channel.post or any message mutation.

## What changed (motivation → approach → change)

- Read content into a raw value and require a string before normalization.
- Return HTTP 400 with the stable channel_message_content_type_invalid code for other JSON value types.
- Preserve the existing whitespace trim and 10,000-character limit for valid strings.
- Add handler-level regressions that spy on Channel.post and assert no message mutation.

## Tests

- Red before: 5 failures / 1 pass; every non-string case raised AttributeError while valid string normalization passed.
- Green after on the rebased head: 50/50 across the new contract tests, Channel model tests, existing Channel handler tests, and the error-code ratchet.
- Project Black baseline gate passes with 2 changed files and 1,337 known-unformatted files unchanged.
- flake8, isort --check-only, per-file Black for the new test, and git diff --check pass.

## Manual verification

N/A — request status, response code, no-post/no-mutation behavior, and valid normalization are exercised directly at the async handler seam.

## Related Issues

Fixes #5614

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and regression tests cover the changed behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public documentation exists for this internal dashboard endpoint)
- [x] No secrets, credentials, screenshots, or unrelated files in the diff

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.