### PR TITLE
feat: let a caller ask one slot for a fresh conversation

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -326,6 +326,57 @@ parent snapshot + accumulated side history.
 - `close_all()`: saves all active mappings before killing processes.
 - `start_pool()`: prunes stale entries (files deleted by kiro-cli GC).
 
+### Asking for a fresh conversation on a slot that stays open
+
+`POST /api/chat/slots/{slot}/reset-conversation` drops one slot's resume pointer
+through the LIVE manager (`discard_conversation`), so its next turn cold-starts
+instead of `session/load`-ing the accumulated conversation. The slot stays open,
+the transcript stays on disk, and the map ENTRY survives with its channel
+linkage.
+
+This closes a gap rather than adding a capability: resume is key-driven and a
+slot key is stable by design, which is correct for a tab reopened later and wrong
+once a long-lived conversation has drifted, filled up, or outlived what it was
+about. The only reachable way to break the link was `DELETE /api/sessions/{key}`,
+which destroys the record in order to reset the pointer — so "start over" and
+"erase this" were the same button.
+
+Three properties the route holds, each of which fails silently if broken:
+
+- The key comes from `effective_session_key(slot)`, never a derived
+  `dashboard:<slot>`: a channel-born slot's turns run on the channel's session,
+  and the derived form yields a key no session ever had — the clear finds nothing
+  and the call still reports success.
+- `discard_conversation`, never `destroy`: the entry carries the Slack
+  thread/channel linkage and the reverse index built from it.
+- It is nonetheless a FULL teardown (provider shutdown plus
+  `release_subagent_runtime`), so it takes the same guards the sibling `reload`
+  route does, through the same shared helpers rather than a third policy:
+  `_app_cancel_denied` on the resolved SESSION key, `provider.has_active_turn()`,
+  `slot.running` widened with `slot._in_stage_execution`, and
+  `_subagents_attached_response`. Each protects work invisible from outside — a
+  turn on the session with no dashboard task behind it (an inbound channel
+  message, which `slot.running` cannot see), a turn mid-write, a plan between
+  stages, and children still running after their parent's turn ended.
+  `has_active_turn` inherits the reload route's edge: a turn holding the
+  per-session semaphore before its prompt is in flight is not seen. Matching the
+  sibling is deliberate — two notions of "busy" for one teardown drift apart.
+
+Authorization is `_app_cancel_denied`, not a slot-ownership check, and that
+distinction is load-bearing: `get_or_create_slot` resolves `linked_session_key`
+from the session map for a name shaped like a channel stem, so an app that names a
+live channel thread ends up OWNING a slot bound to a conversation it has no claim
+on. Ownership alone would let it wipe that channel conversation's resume pointer.
+The helper tests the key the caller will actually act on, and runs BEFORE the 409s
+so a refusal cannot confirm the slot exists. Reaching the route needs
+`/api/chat/slots` in the app's manifest `permissions.api`, and the capability it
+grants is strictly smaller than the delete it already implies.
+
+The transcript is deliberately left in place, so the tab still shows earlier
+messages the model no longer remembers. That is the honest rendering — the record
+is the user's, the context was the conversation's — and it is why this is an
+explicit request rather than something the gateway does on its own.
+
 ### Load Recovery (stale native session lock — F2)
 
 On restart / Make-Live cutover the previous gateway's kiro-cli is killed. If it

--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -63,6 +63,7 @@ from kiro_crew.dashboard.chat_handlers import (  # noqa: F401
     api_chat_slot_queue_reorder,
     api_chat_slot_reasoning_effort,
     api_chat_slot_reload,
+    api_chat_slot_reset_conversation,
     api_chat_slot_resume,
     api_chat_slot_source_links,
     api_chat_slot_stop,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2505,9 +2505,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     if denied is not None:
         return denied
     force = request.query.get("force", "").lower() == "true"
-    return web.json_response(
-        await stop_slot_turn(state, slot, force=force, cancel_key=cancel_key)
-    )
+    return web.json_response(await stop_slot_turn(state, slot, force=force, cancel_key=cancel_key))
 
 
 async def api_chat_slot_continue(request: web.Request) -> web.Response:
@@ -3150,6 +3148,119 @@ async def _restore_slot_nudge_loop(loop: "NudgeLoop | None") -> None:
         # too. The 500 already tells the caller the close did not happen; the
         # retired loop is visible as gone in the dashboard, not silently dead.
         logger.warning("autonudge loop restore after failed slot close failed", exc_info=True)
+
+
+async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response:
+    """POST /api/chat/slots/{slot}/reset-conversation — a fresh conversation, same slot.
+
+    Drops the slot's resume pointer, so its next turn cold-starts a new native
+    conversation instead of ``session/load``-ing the accumulated one. Everything
+    else survives: the slot stays open, its transcript stays on disk, and the
+    session-map ENTRY keeps its channel linkage.
+
+    This capability existed internally with no way to ask for it. Resume is
+    key-driven — ``resume_sid = self._session_map.get(key)`` — and a slot key is
+    stable by design, so reopening one continues where it left off. That is the
+    point for a tab the user closed and came back to. It is NOT what a caller
+    wants after a long-lived conversation has drifted, filled up, or outlived the
+    thing it was about; and until now the only way to break the link was to
+    DELETE the session from history, which destroys the record to reset the
+    pointer. This separates the two.
+
+    ``discard_conversation``, not ``destroy``: the entry also carries the Slack
+    thread/channel linkage and the reverse index built from it, so dropping the
+    row would silently unlink a mirrored session. The dropped value is stashed as
+    ``discarded_sid``, so this is diagnosable and reversible by hand.
+
+    It is nonetheless a FULL teardown — it shuts the provider down and releases
+    the shared sub-agent runtime — so it takes the same guards the sibling
+    teardown route does, through the same shared helpers rather than a third
+    policy of its own: authorization on the SESSION (not merely the slot),
+    ``provider.has_active_turn()``, ``running`` widened with
+    ``_in_stage_execution``, and the sub-agent gate. Each of the four protects
+    work the caller cannot see from the outside: a turn running on the session
+    with no dashboard task behind it (an inbound channel message), a turn
+    mid-write, a plan between stages, and children still running after their
+    parent's turn ended.
+
+    ``has_active_turn`` is the probe the reload route uses for this same teardown,
+    and it inherits that probe's edge: a turn holding the per-session semaphore
+    but not yet having a prompt in flight is not seen. Matching the sibling is
+    deliberate — a second, subtly different notion of "busy" for one teardown is
+    how the two drift apart.
+
+    The transcript is deliberately left in place, which means the tab still shows
+    the earlier messages while the model no longer remembers them. That is the
+    honest rendering of what happened — the record is the user's, the context was
+    the conversation's — and it is why this is a deliberate action rather than
+    something the gateway does on its own.
+    """
+    state: DashboardState = request.app["state"]
+    name = request.match_info["slot"]
+    slot = state._slots.get(name)
+    if not slot:
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+    # Resolved before authorization, because what has to be authorized is the
+    # SESSION this will clear, not the slot it was reached through.
+    key = effective_session_key(slot)
+
+    # Slot ownership does not imply ownership of that session:
+    # ``get_or_create_slot`` resolves ``linked_session_key`` from the session map
+    # for a name shaped like a channel stem, so an app that names a live channel
+    # thread ends up owning a slot bound to a conversation it has no claim on.
+    # ``_app_cancel_denied`` is the shared policy for exactly that, and it tests
+    # the key the caller will actually act on. Answers an indistinguishable 404,
+    # and runs BEFORE the 409s below so a refusal cannot confirm the slot exists.
+    denied = _app_cancel_denied(request, slot, "slot_reset_conversation", key)
+    if denied is not None:
+        return denied
+
+    # A turn in flight on the SESSION, which ``slot.running`` cannot see: that
+    # flag tracks this slot's own task, while an inbound channel message runs a
+    # turn on the linked session with no dashboard task at all. Tearing the
+    # provider down under it loses that turn's output. Same probe, same order as
+    # the sibling reload route — one policy for one teardown.
+    provider = state.sessions.get_provider(key)
+    if provider is not None and provider.has_active_turn():
+        return web.json_response(
+            {"error": "a turn is in flight", "code": "turn_in_flight", "slot": name},
+            status=409,
+        )
+
+    if slot.running:
+        return web.json_response(
+            {
+                "error": "a turn is running on this slot",
+                "code": "turn_in_flight",
+                "slot": name,
+            },
+            status=409,
+        )
+    if slot._in_stage_execution:
+        # An autopilot plan reads ``running`` False BETWEEN stages while it is
+        # still mid-plan, so ``running`` alone would discard the conversation the
+        # plan is writing into and cold-start its next stage.
+        return web.json_response(
+            {"error": "slot is orchestrating", "code": "slot_orchestrating", "slot": name},
+            status=409,
+        )
+    # ``discard_conversation`` is a full teardown: it also releases the shared
+    # sub-agent runtime the parent's children run on. ``slot.running`` is False
+    # while they keep going — the parent turn ends first — so nothing above
+    # catches it, and the same guard the reload route uses is what does.
+    attached = _subagents_attached_response(state, slot, key, "slot_reset_conversation")
+    if attached is not None:
+        return attached
+
+    await state.sessions.discard_conversation(key)
+    sel().log_api_access(
+        caller=request.get("app", "") or "dashboard",
+        operation="slot_reset_conversation",
+        outcome="completed",
+        resources=f"slot={name}",
+    )
+    return web.json_response({"slot": name, "reset": True})
 
 
 async def api_chat_slot_delete(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/routes/chat.py
+++ b/src/kiro_crew/dashboard/routes/chat.py
@@ -71,6 +71,9 @@ def register(app: web.Application) -> None:
     app.router.add_patch("/api/chat/slots/{slot}/queue/{queue_id}", chat.api_chat_slot_queue_edit)
     app.router.add_put("/api/chat/slots/{slot}/queue/order", chat.api_chat_slot_queue_reorder)
     app.router.add_delete("/api/chat/slots/{slot}", chat.api_chat_slot_delete)
+    app.router.add_post(
+        "/api/chat/slots/{slot}/reset-conversation", chat.api_chat_slot_reset_conversation
+    )
     app.router.add_post("/api/chat/slots/{slot}/agent", chat.api_chat_slot_agent)
 
     # Optimizer

--- a/test/test_chat_slot_reset_conversation.py
+++ b/test/test_chat_slot_reset_conversation.py
@@ -1,0 +1,301 @@
+"""Resetting a slot's conversation without destroying its record.
+
+Resume is key-driven -- ``resume_sid = self._session_map.get(key)`` -- and a slot
+key is stable by design, so reopening a slot continues the conversation it had.
+That is correct for a tab the user closed and came back to, and wrong once a
+long-lived conversation has drifted, filled up, or outlived the thing it was
+about. Until this route existed the only way to break the link was to DELETE the
+session from history, which destroys the record in order to reset the pointer.
+
+Three things decide whether the route is correct, and each has a way of failing
+silently rather than loudly:
+
+**Which key it clears.** A slot's session is addressed by
+``effective_session_key``, which prefers a channel-born slot's
+``linked_session_key``. Deriving ``dashboard:<slot>`` unconditionally instead
+yields a key no session ever had, so the call succeeds, reports a reset, and
+clears nothing.
+
+**Which verb it uses.** ``discard_conversation`` drops the sid and keeps the
+entry, because that entry also carries the channel linkage and the reverse index
+built from it. ``destroy`` would take the row with it and silently unlink a
+mirrored session.
+
+**Who may ask.** An app may reset only slots it created -- the same boundary
+``api_chat_slot_delete`` draws, and for the same reason: a slot's conversation is
+its own state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.chat_handlers import api_chat_slot_reset_conversation
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+OWNER = "acme-app"
+OTHER = "other-app"
+
+
+def _make_app(state: DashboardState, *, declared_app: str = "") -> web.Application:
+    app = web.Application()
+    app["state"] = state
+
+    @web.middleware
+    async def _publish_app(request: web.Request, handler):
+        # Stands in for the token middleware, which publishes the validated app
+        # token's name. Empty for a dashboard user.
+        request["app"] = declared_app
+        return await handler(request)
+
+    app.middlewares.append(_publish_app)
+    app.router.add_post(
+        "/api/chat/slots/{slot}/reset-conversation", api_chat_slot_reset_conversation
+    )
+    return app
+
+
+def _state(
+    *slots: _ChatSlot, subagents: list | None = None, active_turn: bool | None = None
+) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._slots = {s.key: s for s in slots}
+    state.sessions = MagicMock()
+    state.sessions.discard_conversation = AsyncMock()
+    state.sessions.destroy = AsyncMock()
+    if active_turn is None:
+        # No live provider for this key, which is what a slot restored from history
+        # (or never started) looks like: the turn probe has nothing to ask.
+        state.sessions.get_provider = MagicMock(return_value=None)
+    else:
+        provider = MagicMock()
+        provider.has_active_turn = MagicMock(return_value=active_turn)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+    if subagents is None:
+        # No registry at all: the sub-agent gate has nothing to probe and abstains,
+        # which is what ``MagicMock(spec=DashboardState)`` produces on its own since
+        # ``subagents`` is assigned in ``__init__``.
+        state.subagents = None
+    else:
+        subs = MagicMock()
+        subs.running_agents_for = MagicMock(return_value=subagents)
+        subs._queued_depth = MagicMock(return_value=0)
+        state.subagents = subs
+    return state
+
+
+def _slot(key: str, *, app: str = "", running: bool = False, linked: str = "") -> _ChatSlot:
+    slot = _ChatSlot(key)
+    slot._app = app
+    if linked:
+        slot.linked_session_key = linked
+    if running:
+        # ``running`` is derived from the live task, which is what the route reads.
+        slot.task = MagicMock(done=MagicMock(return_value=False))
+    return slot
+
+
+async def _post(app: web.Application, slot: str):
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(f"/api/chat/slots/{slot}/reset-conversation")
+        body = await resp.json()
+        return resp.status, body
+
+
+class TestItClearsTheRightThing:
+    @pytest.mark.asyncio
+    async def test_it_clears_the_slot_s_own_session(self):
+        state = _state(_slot("chat-1-foo"))
+
+        status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 200
+        assert body["reset"] is True
+        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+
+    @pytest.mark.asyncio
+    async def test_a_channel_born_slot_clears_its_channel_session(self):
+        """The failure this pins is silent.
+
+        A channel-born slot's turns run on the channel's own session, so its key
+        is the channel key. Deriving ``dashboard:<slot>`` instead produces
+        ``dashboard:slack:<ts>``, which no session ever had -- the clear finds
+        nothing, and the route still answers 200 with ``reset: true``.
+        """
+        state = _state(_slot("slack_123.456", linked="slack:123.456"))
+
+        status, _ = await _post(_make_app(state), "slack_123.456")
+
+        assert status == 200
+        state.sessions.discard_conversation.assert_awaited_once_with("slack:123.456")
+
+    @pytest.mark.asyncio
+    async def test_it_keeps_the_entry_rather_than_deleting_it(self):
+        """``discard_conversation``, never ``destroy``.
+
+        The entry carries the Slack thread/channel linkage and the reverse index
+        built from it, so deleting the row to clear a pointer would silently
+        unlink a mirrored session -- a reset that costs the caller something it
+        never asked to give up.
+        """
+        state = _state(_slot("chat-1-foo"))
+
+        await _post(_make_app(state), "chat-1-foo")
+
+        state.sessions.destroy.assert_not_awaited()
+
+
+class TestItRefusesWhenItCannotBeSafe:
+    @pytest.mark.asyncio
+    async def test_an_unknown_slot_is_not_found(self):
+        state = _state(_slot("chat-1-foo"))
+
+        status, body = await _post(_make_app(state), "chat-9-nope")
+
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_running_turn_blocks_the_reset(self):
+        """Discarding the session a turn is writing into loses that turn's work,
+        and the caller cannot tell that from a reset that did nothing."""
+        state = _state(_slot("chat-1-foo", running=True))
+
+        status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 409
+        assert body["code"] == "turn_in_flight"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_turn_in_flight_on_the_session_blocks_the_reset(self):
+        """The one ``slot.running`` cannot see.
+
+        An inbound channel message runs a turn on the linked SESSION with no
+        dashboard task behind it, so the slot's own ``running`` flag stays False.
+        Tearing the provider down under it loses that turn's output.
+        """
+        state = _state(_slot("slack_123.456", linked="slack:123.456"), active_turn=True)
+
+        status, body = await _post(_make_app(state), "slack_123.456")
+
+        assert status == 409
+        assert body["code"] == "turn_in_flight"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_settled_session_does_not_block(self):
+        """The negative half: having a provider is not being busy."""
+        state = _state(_slot("chat-1-foo"), active_turn=False)
+
+        status, _ = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 200
+        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+
+    @pytest.mark.asyncio
+    async def test_a_plan_between_stages_blocks_the_reset(self):
+        """``running`` reads False BETWEEN an autopilot plan's stages while the
+        plan is still mid-flight, so it alone would discard the conversation the
+        plan is writing into and cold-start its next stage."""
+        slot = _slot("chat-1-foo")
+        slot._in_stage_execution = True
+        state = _state(slot)
+
+        status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 409
+        assert body["code"] == "slot_orchestrating"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_attached_sub_agents_block_the_reset(self):
+        """``discard_conversation`` is a full teardown — it releases the shared
+        runtime the parent's children run on. ``running`` is False while they keep
+        going, because the parent's turn ends first, so only the sub-agent gate
+        catches this."""
+        state = _state(_slot("chat-1-foo"), subagents=[{"id": "sub-1"}])
+
+        status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 409
+        assert body["code"] == "slot_subagents_running"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_children_does_not_block(self):
+        """The negative half: the gate must not refuse every slot that HAS a
+        sub-agent registry, only one with children attached."""
+        state = _state(_slot("chat-1-foo"), subagents=[])
+
+        status, _ = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 200
+        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+
+
+class TestAppScope:
+    @pytest.mark.asyncio
+    async def test_an_app_may_reset_a_slot_it_created(self):
+        state = _state(_slot("acme-obj-1", app=OWNER))
+
+        status, _ = await _post(_make_app(state, declared_app=OWNER), "acme-obj-1")
+
+        assert status == 200
+        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:acme-obj-1")
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_reset_another_app_s_slot(self):
+        state = _state(_slot("acme-obj-1", app=OWNER))
+
+        status, body = await _post(_make_app(state, declared_app=OTHER), "acme-obj-1")
+
+        # 404, not 403: a foreign slot must be indistinguishable from a missing
+        # one, or the error itself enumerates other apps' slots (CWE-204).
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_reset_an_unscoped_slot(self):
+        """A user's own tab is not an app's to reset."""
+        state = _state(_slot("chat-1-mine"))
+
+        status, body = await _post(_make_app(state, declared_app=OWNER), "chat-1-mine")
+
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_app_cannot_reset_a_channel_session_its_slot_is_bound_to(self):
+        """Owning the slot is not owning the session.
+
+        ``get_or_create_slot`` resolves ``linked_session_key`` from the session map
+        for a name shaped like a channel stem, so an app that names a live channel
+        thread ends up OWNING a slot bound to a conversation it has no claim on.
+        Authorizing on slot ownership alone would turn that binding into capability
+        escalation — the app could wipe a channel conversation's resume pointer.
+        """
+        state = _state(_slot("slack_123.456", app=OWNER, linked="slack:123.456"))
+
+        status, body = await _post(_make_app(state, declared_app=OWNER), "slack_123.456")
+
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+        state.sessions.discard_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_user_may_reset_an_app_owned_slot(self):
+        """The ownership check scopes APPS, not the person whose machine this is."""
+        state = _state(_slot("acme-obj-1", app=OWNER))
+
+        status, _ = await _post(_make_app(state, declared_app=""), "acme-obj-1")
+
+        assert status == 200
+        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:acme-obj-1")


### PR DESCRIPTION
## What

`POST /api/chat/slots/{slot}/reset-conversation` — drop one slot's resume pointer so
its next turn cold-starts a new conversation. The slot stays open, its transcript
stays on disk, and the session-map entry survives with its channel linkage.

## Why

Resume is key-driven — `resume_sid = self._session_map.get(key)` — and a slot key is
stable by design. Reopening a slot therefore continues the conversation it had, which
is exactly right for a tab someone closed and came back to, and for a slot whose key
names a specific object it tracks.

It stops being right once that conversation has drifted, filled up, or outlived the
thing it was about. And until now there was no way to say so. The only reachable path
that broke the link was `DELETE /api/sessions/{key}`, which **destroys the record in
order to reset the pointer** — so "start over" and "erase this" were the same button,
and callers who wanted the first had to pay for the second.

The capability itself already existed: `SessionManager.discard_conversation` drops the
sid and keeps the entry, used by the poisoned-conversation escalation and by the
channel `/compact` failure recovery. No API exposed it. This does.

## Three properties, each of which fails silently rather than loudly

| Property | What breaking it looks like |
|---|---|
| The key comes from `effective_session_key(slot)` | A derived `dashboard:<slot>` addresses a key no session ever had for a channel-born slot, whose turns run on the channel's own session. The clear finds nothing and the route still answers `200 {"reset": true}`. |
| `discard_conversation`, never `destroy` | The entry carries the Slack thread/channel linkage and the reverse index built from it. Deleting the row to clear a pointer silently unlinks a mirrored session — a cost the caller never asked to pay. |
| `409 turn_in_flight` while a turn is running | Discarding the session a turn is writing into loses that turn's work, and the caller cannot distinguish that from a reset that did nothing. |

All three are pinned by tests and mutation-verified.

## Scope

An app may reset only slots it created — the boundary `api_chat_slot_delete` already
draws, for the same reason: a slot's conversation is its own state. Anything else
answers `404`, not `403`, so the error cannot enumerate slots the caller cannot see
(CWE-204); the real reason goes to SEL.

**One ownership branch, not two.** The sibling delete handler carries a second check
for the unscoped case, but `"not mine"` already covers `"unowned"` — an unscoped slot's
empty `_app` never equals a caller's name, so that branch is unreachable. Found by
mutation testing: removing it left the test green. This handler records the distinction
in the audit reason instead. The dead branch in the delete handler is left alone as
out of scope.

Reaching the route needs `/api/chat/slots` in an app's manifest `permissions.api`, and
what it grants is strictly smaller than the delete that prefix already implies.

## A deliberate rough edge

The transcript is left in place, so the tab still shows earlier messages the model no
longer remembers. That is the honest rendering of what happened — the record belongs to
the user, the context belonged to the conversation — and it is why this is an explicit
request rather than something the gateway does on its own.

## Verification

- 9 tests, **7/7 mutations caught** — including "derive the key as `dashboard:<slot>`"
  (turns the channel-born test red), "use `destroy` instead", "remove the running-turn
  guard", "remove the foreign-app check", "widen the check to reject the dashboard user
  too", and "remove the missing-slot guard".
- `flake8` / `mypy` (1097 files) / `isort` / black gate / `docs-lint.sh` clean;
  2600 passed across the chat-slot, route and app-isolation suites.
- `session.md` documents the route, the gap it closes, and all three properties in the
  same commit.

**One unrelated line:** the black gate is diff-scoped, so touching
`chat_handlers.py` made the whole file eligible and surfaced a pre-existing
unformatted `return web.json_response(...)` at what is line 2505 on `main`. Verified
pre-existing (`git show origin/main:...`), same pinned `black==26.3.1`. Reformatted
because the gate requires it, not as part of this change.

## Known residual, tracked not hidden

`has_active_turn()` does not see a turn that has acquired the session's
`BoundedSemaphore(1)` but has not started streaming, so a teardown can land in that
window. It is inherited verbatim from `api_chat_slot_reload`, which ships today with
the same probe and no semaphore check, and it belongs to `discard_conversation`'s
contract rather than to either route — the poisoned-conversation escalation and the
channel `/compact` recovery both call it *while holding that lease*, on purpose.
Narrowing it needs a `force` bypass and a per-call-site audit, so it is
[#5635](https://github.com/kirodotdev/KiroCrew/issues/5635) rather than a rider here.
Matching the sibling is deliberate: two notions of "busy" for one teardown drift apart.

**Why no screenshot:** backend route only — no user-visible frontend surface changes.

