### PR TITLE
fix(issue-radar): serve the deps graph stale and revalidate behind

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -1541,6 +1541,173 @@ def _deps_node_hints(
     return hints
 
 
+# ── /deps serve-stale-revalidate-behind ─────────────────────────────────────
+#
+# App-state key under which the in-flight background deps-refresh tasks live, one
+# per repo. A typed ``web.AppKey`` (same pattern as spec_builder) so the registry
+# shares the app's lifetime and shutdown can cancel every outstanding task — see
+# ``_stop_deps_refreshes`` (registered as an ``on_cleanup`` hook).
+_DepsRefreshTasks = dict[str, "asyncio.Task"]
+_DEPS_REFRESH_TASKS_APP_KEY: web.AppKey[_DepsRefreshTasks] = web.AppKey(
+    "issue_radar_deps_refresh_tasks", dict
+)
+
+# Per-repo rebuild mutex. Coalescing (above) only stops a SECOND BACKGROUND
+# refresh; it cannot order a background rebuild against a synchronous one, and
+# ``write_deps_cache`` stamps ``fetched_at`` at WRITE time. Without this lock:
+# a stale GET starts background rebuild A, an edge changes, ``refresh=1`` starts
+# synchronous rebuild B, B writes the fresh graph -- and then the slower A lands
+# on top with its older edges and stamps them fresh for a full TTL. Serializing
+# every rebuild for a repo makes the last write the last FETCH, which is the
+# property the cache's freshness stamp claims. Two concurrent ``refresh=1``
+# calls are ordered by the same lock.
+_DepsRebuildLocks = dict[str, "asyncio.Lock"]
+_DEPS_REBUILD_LOCKS_APP_KEY: web.AppKey[_DepsRebuildLocks] = web.AppKey(
+    "issue_radar_deps_rebuild_locks", dict
+)
+
+
+def _deps_reg_key(key: provider.RepoKey) -> str:
+    """The per-repo registry key shared by the refresh-task and lock registries."""
+    return f"{key.provider}:{key.host}:{key.owner}/{key.repo}"
+
+
+def _deps_refresh_registry(app: web.Application) -> _DepsRefreshTasks:
+    """The per-app ``repo-key -> in-flight refresh Task`` map, created on first use."""
+    reg = app.get(_DEPS_REFRESH_TASKS_APP_KEY)
+    if reg is None:
+        reg = {}
+        app[_DEPS_REFRESH_TASKS_APP_KEY] = reg
+    return reg
+
+
+def _deps_rebuild_lock(app: web.Application, key: provider.RepoKey) -> "asyncio.Lock":
+    """The per-repo rebuild mutex, created on first use.
+
+    Bound to the app (hence to one event loop), so this is a plain
+    :class:`asyncio.Lock` rather than a loop-bound one: it is never a module
+    global shared across loops.
+    """
+    locks = app.get(_DEPS_REBUILD_LOCKS_APP_KEY)
+    if locks is None:
+        locks = {}
+        app[_DEPS_REBUILD_LOCKS_APP_KEY] = locks
+    reg_key = _deps_reg_key(key)
+    lock = locks.get(reg_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        locks[reg_key] = lock
+    return lock
+
+
+class _DepsScopeUnavailable(GhCliError):
+    """The open-issue scope a deps rebuild needs could not be read.
+
+    A dedicated type rather than a message pattern: the route maps this to the
+    ``deps_issue_scope_unavailable`` code and a plain :class:`GhCliError` to
+    ``deps_fetch_failed``. Both failures used to be told apart by which of two
+    ``try`` blocks caught them; now that one helper owns the whole build, the
+    distinction has to travel with the exception, and sniffing the message text
+    would silently reclassify every scope failure whose wording does not happen
+    to mention issues (``gh api ... failed`` mentions neither).
+    """
+
+
+async def _rebuild_deps(app: web.Application, key: provider.RepoKey) -> dict:
+    """Rebuild the dependency graph for ``key`` and persist it, returning the
+    normalized stored shape ``{"edges", "nodes", ...}``.
+
+    The single build path shared by the synchronous route (cold cache /
+    ``refresh=1``) and the background revalidation. Reads the open issues (the
+    graph's scope) plus the open pulls (node hints) from the caches the app
+    already keeps, syncs the native + inferred edges via
+    ``github_client.fetch_dependency_edges``, writes the deps cache, and re-reads
+    it so the caller gets the normalized/deduped shape a later cache hit would.
+
+    Holds the repo's rebuild mutex across fetch AND write, so a slow rebuild can
+    never land on top of a newer one and re-stamp older edges as fresh.
+
+    Raises :class:`_DepsScopeUnavailable` when the issue scope cannot be read and
+    a plain ``GhCliError`` when the edge fetch fails, so the synchronous caller
+    can keep the two 502 codes callers already see; the background caller catches
+    every exception instead (a background failure must leave the previous good
+    cache intact).
+    """
+    owner, repo = key.owner, key.repo
+    async with _deps_rebuild_lock(app, key):
+        try:
+            issues = await _load_open_issues_for_reco(key)
+        except GhCliError as exc:
+            raise _DepsScopeUnavailable(str(exc)) from exc
+        pulls = await _st(key, store.read_pulls_cache, owner, repo, state="open") or []
+        hints = _deps_node_hints(key, issues, pulls)
+        edges, nodes = await asyncio.to_thread(
+            partial(github_client.fetch_dependency_edges, owner, repo, issues, hints)
+        )
+        await _st(key, store.write_deps_cache, owner, repo, edges, nodes)
+        stored = await _st(key, store.read_deps_cache, owner, repo)
+    if stored is not None:
+        return stored
+    return {"edges": edges, "nodes": nodes}
+
+
+def _schedule_deps_refresh(app: web.Application, key: provider.RepoKey) -> None:
+    """Kick a background deps rebuild for ``key``, at most one in flight per repo.
+
+    Coalesces concurrent stale callers: while a refresh is running, later stale
+    requests see the live task in the registry and do NOT spawn a second — they
+    just serve their own stale copy. The task removes itself from the registry
+    when it finishes (in a ``finally`` so a crash cannot wedge the slot), and a
+    failure is logged and swallowed so the previous good cache stays intact. The
+    task is registered on ``app`` so shutdown can cancel it (no leaked task).
+    """
+    registry = _deps_refresh_registry(app)
+    reg_key = _deps_reg_key(key)
+    existing = registry.get(reg_key)
+    if existing is not None and not existing.done():
+        return  # a refresh for this repo is already in flight — coalesce
+
+    async def _run() -> None:
+        try:
+            await _rebuild_deps(app, key)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # never crash the loop; keep the prior good cache
+            logger.debug(
+                "issue-radar: background deps refresh failed for %s/%s; keeping cached graph",
+                key.owner,
+                key.repo,
+                exc_info=True,
+            )
+        finally:
+            # Drop ourselves only if we are still the registered task (a cancel
+            # during shutdown may have already cleared the slot).
+            if registry.get(reg_key) is task:
+                registry.pop(reg_key, None)
+
+    task = asyncio.create_task(_run(), name=f"issue-radar-deps-refresh:{reg_key}")
+    registry[reg_key] = task
+
+
+async def _stop_deps_refreshes(app: web.Application) -> None:
+    """``app.on_cleanup`` hook — cancel any outstanding background deps refreshes
+    on gateway shutdown so no unawaited task outlives the app."""
+    registry = app.get(_DEPS_REFRESH_TASKS_APP_KEY)
+    if not registry:
+        return
+    tasks = [t for t in registry.values() if not t.done()]
+    registry.clear()
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("issue-radar deps-refresh shutdown raised", exc_info=True)
+
+
 async def _handle_deps(request: web.Request) -> web.Response:
     """GET /deps?owner=<o>&repo=<r>[&refresh=1] — the repo's dependency graph.
 
@@ -1548,11 +1715,20 @@ async def _handle_deps(request: web.Request) -> web.Response:
     edge is ``{blocked, blocker, source: "native"|"inferred"}`` and ``nodes`` maps
     every number appearing in an edge to ``{kind, state, title}``.
 
-    Cache-first with a TTL (``store.DEPS_CACHE_TTL_SEC``), same freshness/auth/error
-    conventions as ``/ref`` and ``/issues``: served from ``deps-cache.json`` until
-    it ages out, ``refresh=1`` forces a rebuild. A rebuild reads the open issues
-    (the graph's scope) plus the pulls cache (node hints) and syncs the native +
-    inferred edges via ``github_client.fetch_dependency_edges``.
+    Cache-first, serve-stale-revalidate-behind: a FRESH cache (younger than
+    ``store.DEPS_CACHE_TTL_SEC``) is served as-is; a STALE cache is served
+    IMMEDIATELY while a single coalesced background refresh rebuilds it off the
+    request path — the ~11s rebuild never blocks a user. Only a genuinely
+    never-synced repo (no cache at all) still blocks on a build. ``refresh=1``
+    forces a SYNCHRONOUS rebuild so a user-initiated refresh returns fresh data.
+    A rebuild reads the open issues (the graph's scope) plus the pulls cache
+    (node hints) and syncs the native + inferred edges via
+    ``github_client.fetch_dependency_edges``.
+
+    The response shape is deliberately UNCHANGED by serve-stale. Whether the
+    served graph was fresh or aged is not reported, because no client reads such
+    a signal today; staleness stays an internal scheduling decision rather than
+    part of the contract.
 
     Dependency edges are a GitHub-native feature (the ``dependencies`` API);
     non-GitHub providers answer an empty graph rather than an error, so the M1
@@ -1591,7 +1767,13 @@ async def _handle_deps(request: web.Request) -> web.Response:
     force_refresh = request.query.get("refresh") == "1"
     if not force_refresh:
         cached = await _st(key, store.read_deps_cache, owner, repo)
-        if cached is not None and (time.time() - cached["fetched_at"]) < store.DEPS_CACHE_TTL_SEC:
+        if cached is not None:
+            fresh = (time.time() - cached["fetched_at"]) < store.DEPS_CACHE_TTL_SEC
+            if not fresh:
+                # Serve stale, revalidate behind: hand back the aged graph now and
+                # kick a single coalesced background rebuild. The ~11s fetch never
+                # blocks this request; a subsequent visit gets the refreshed graph.
+                _schedule_deps_refresh(request.app, key)
             return web.json_response(
                 {
                     **_identity(key),
@@ -1601,6 +1783,7 @@ async def _handle_deps(request: web.Request) -> web.Response:
                 }
             )
 
+    # No cache at all (a never-synced repo) or a forced refresh: build inline.
     # Build from the caches the app already keeps: open issues are the graph's
     # scope, and both lists seed the node hints so a cached item costs no API call.
     # A MISSING issues cache is unknown, not empty: building from it would persist
@@ -1608,31 +1791,19 @@ async def _handle_deps(request: web.Request) -> web.Response:
     # existing cache-first loader (fetch + cache on miss, provider-routed) the
     # tagging queue uses; a cold repo's first /deps call warms both caches.
     try:
-        issues = await _load_open_issues_for_reco(key)
-    except GhCliError as exc:
+        stored = await _rebuild_deps(request.app, key)
+    except _DepsScopeUnavailable as exc:
         return web.json_response(
             {"error": str(exc), "code": "deps_issue_scope_unavailable"}, status=502
-        )
-    pulls = await _st(key, store.read_pulls_cache, owner, repo, state="open") or []
-    hints = _deps_node_hints(key, issues, pulls)
-    try:
-        edges, nodes = await asyncio.to_thread(
-            partial(github_client.fetch_dependency_edges, owner, repo, issues, hints)
         )
     except GhCliError as exc:
         return web.json_response({"error": str(exc), "code": "deps_fetch_failed"}, status=502)
 
-    await _st(key, store.write_deps_cache, owner, repo, edges, nodes)
-    # Re-read so the response is the normalized/deduped stored shape (native-wins),
-    # exactly what a subsequent cache hit would return.
-    stored = await _st(key, store.read_deps_cache, owner, repo)
-    edges_out = stored["edges"] if stored else edges
-    nodes_out = stored["nodes"] if stored else nodes
     return web.json_response(
         {
             **_identity(key),
-            "edges": edges_out,
-            "nodes": nodes_out,
+            "edges": stored["edges"],
+            "nodes": stored["nodes"],
             "from_cache": False,
         }
     )
@@ -5159,5 +5330,8 @@ def register_routes(app: web.Application) -> None:
     try:
         app.on_startup.append(watch.start_watcher)
         app.on_cleanup.append(watch.stop_watcher)
+        # Cancel any in-flight background /deps revalidations on shutdown so a
+        # serve-stale rebuild never outlives the app as an unawaited task.
+        app.on_cleanup.append(_stop_deps_refreshes)
     except Exception:  # pragma: no cover - defensive
         logger.warning("issue-radar: could not register watcher lifecycle hooks", exc_info=True)

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -1368,12 +1368,23 @@ def drop_tagging_suggestions(
 #   v1: {schema, fetched_at, edges:[{blocked, blocker, source}], nodes:{...}}
 DEPS_CACHE_SCHEMA = 1
 
-# How long a synced dependency graph is served before /deps refetches it. The
-# graph moves only when a dependency is added/removed or a blocker's lifecycle
-# changes — far slower than the issue list — and a rebuild costs N native +
-# N timeline reads for the open backlog, so a generous TTL keeps that cost off
-# the hot path. Same "plain TTL, not a probe-gated poll" reasoning as the labels
-# cache: a probe here would cost as much as the refetch it guards.
+# How long a synced dependency graph is served before it is considered stale.
+#
+# This constant has TWO consumers with DIFFERENT needs, which is why it stays at
+# ten minutes even though the /deps route alone would be happy with hours:
+#
+#   * the /deps route, which since serve-stale-revalidate-behind no longer blocks
+#     a request on an expired cache (it returns the stale graph and refreshes in
+#     the background), so for the route this TTL governs how often a BACKGROUND
+#     rebuild fires and a long value would be harmless;
+#   * crew_runtime._read_or_refresh_deps, the sweep that feeds SIG_DEP_UNBLOCKED.
+#     For the sweep this TTL IS the freshness horizon on which a crew waiting for
+#     its blocker to merge gets woken, so raising it directly delays that wake.
+#
+# Serve-stale already removes the ~11s stall a user could hit here, so there is
+# nothing left to buy by stretching it -- and the cost would land on the sweep,
+# not on the route that wanted it. Decoupling the two horizons (a long refresh
+# interval for the route, a short one for the sweep) is a separate change.
 DEPS_CACHE_TTL_SEC = 600.0
 
 # Edge provenance. A native edge is one GitHub itself records via the

--- a/test/test_issue_radar_deps.py
+++ b/test/test_issue_radar_deps.py
@@ -29,6 +29,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
 
 from kiro_crew.apps.builtins.issue_radar.backend import crew_runtime as cr
@@ -426,27 +427,49 @@ class DepsHandlerTest(unittest.TestCase):
         self.assertEqual(body["edges"], cached["edges"])
         fetch.assert_not_called()
 
-    def test_a_stale_cache_is_refetched(self):
+    def test_a_stale_cache_is_served_immediately_and_revalidated_behind(self):
+        # Serve-stale-revalidate-behind (issue #5612): a stale cache is returned
+        # RIGHT NOW with stale=true and the ~11s rebuild is moved OFF the request
+        # path, so the handler must NOT await fetch_dependency_edges inline.
         stale = {"edges": [], "nodes": {}, "fetched_at": time.time() - 100000}
-        fresh_edges = [{"blocked": 10, "blocker": 5, "source": "native"}]
-        # read_deps_cache is called twice: once for the freshness check (stale),
-        # once after the write to return the normalized shape.
-        reads = [stale, {"edges": fresh_edges, "nodes": {}, "fetched_at": time.time()}]
+        req = _get("owner=o&repo=r")
         with (
             mock.patch.object(store, "is_repo_connected", return_value=True),
-            mock.patch.object(store, "read_deps_cache", side_effect=reads),
-            mock.patch.object(store, "read_issues_cache", return_value=[]),
-            mock.patch.object(store, "read_pulls_cache", return_value=[]),
-            mock.patch.object(store, "write_deps_cache") as write,
-            mock.patch.object(
-                gh, "fetch_dependency_edges", return_value=(fresh_edges, {})
-            ) as fetch,
+            mock.patch.object(store, "read_deps_cache", return_value=stale),
+            mock.patch.object(routes, "_schedule_deps_refresh") as sched,
+            mock.patch.object(gh, "fetch_dependency_edges") as fetch,
+        ):
+            res = asyncio.run(routes._handle_deps(req))
+        self.assertEqual(res.status, 200)
+        body = _body(res)
+        self.assertTrue(body["from_cache"])
+        # Serve-stale does NOT announce itself: the response shape is unchanged,
+        # so nothing here reports whether the graph was aged. Pinned so re-adding
+        # such a field is a deliberate act with a named consumer.
+        self.assertNotIn("stale", body)
+        self.assertEqual(body["edges"], stale["edges"])
+        # The request returned without paying for the rebuild.
+        fetch.assert_not_called()
+        # A background revalidation was scheduled for this repo.
+        sched.assert_called_once()
+
+    def test_a_fresh_cache_is_not_stale_and_schedules_no_refresh(self):
+        cached = {
+            "edges": [{"blocked": 10, "blocker": 5, "source": "native"}],
+            "nodes": {},
+            "fetched_at": time.time(),
+        }
+        with (
+            mock.patch.object(store, "is_repo_connected", return_value=True),
+            mock.patch.object(store, "read_deps_cache", return_value=cached),
+            mock.patch.object(routes, "_schedule_deps_refresh") as sched,
+            mock.patch.object(gh, "fetch_dependency_edges") as fetch,
         ):
             res = asyncio.run(_call("owner=o&repo=r"))
         self.assertEqual(res.status, 200)
-        self.assertFalse(_body(res)["from_cache"])
-        fetch.assert_called_once()
-        write.assert_called_once()
+        self.assertTrue(_body(res)["from_cache"])
+        sched.assert_not_called()
+        fetch.assert_not_called()
 
     def test_empty_repo_returns_an_empty_graph(self):
         # An issues-cache MISS is unknown, not empty: the handler now resolves it
@@ -511,6 +534,221 @@ class DepsHandlerTest(unittest.TestCase):
         self.assertEqual(body["provider"], "gitlab")
         self.assertEqual(body["edges"], [])
         fetch.assert_not_called()
+
+
+# ── /deps serve-stale background revalidation (issue #5612) ───────────────────
+
+
+def _gh_key():
+    return provider.RepoKey(provider="github", host="github.com", owner=OWNER, repo=REPO)
+
+
+class DepsBackgroundRefreshTest(unittest.IsolatedAsyncioTestCase):
+    """The serve-stale-revalidate-behind machinery: coalescing to one in-flight
+    refresh per repo, a failing refresh leaving the prior cache intact, refresh=1
+    still rebuilding synchronously, and clean cancellation on shutdown."""
+
+    async def _drain(self, app):
+        """Await every registered background refresh task to completion."""
+        tasks = list(app.get(routes._DEPS_REFRESH_TASKS_APP_KEY, {}).values())
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def test_scope_and_fetch_failures_keep_distinct_error_codes(self):
+        # Both failures surface as GhCliError, and before ``_rebuild_deps`` owned
+        # the whole build they were told apart by WHICH try block caught them.
+        # Now the scope failure carries its own type, so the two 502 codes stay
+        # distinguishable -- pinned here because a message-pattern classifier
+        # would silently collapse them (a scope error reading "gh api ... failed"
+        # mentions neither "issue" nor "scope").
+        req = make_mocked_request("GET", "/api/apps/issue-radar/deps?owner=o&repo=r")
+
+        with (
+            mock.patch.object(store, "is_repo_connected", return_value=True),
+            mock.patch.object(store, "read_deps_cache", return_value=None),
+            mock.patch.object(
+                routes,
+                "_load_open_issues_for_reco",
+                side_effect=gh.GhCliError("gh api graphql failed (exit 1)"),
+            ),
+        ):
+            res = await routes._handle_deps(req)
+        self.assertEqual(res.status, 502)
+        self.assertEqual(
+            json.loads(res.body.decode("utf-8"))["code"], "deps_issue_scope_unavailable"
+        )
+
+        with (
+            mock.patch.object(store, "is_repo_connected", return_value=True),
+            mock.patch.object(store, "read_deps_cache", return_value=None),
+            mock.patch.object(routes, "_load_open_issues_for_reco", return_value=[]),
+            mock.patch.object(store, "read_pulls_cache", return_value=[]),
+            mock.patch.object(
+                gh, "fetch_dependency_edges", side_effect=gh.GhCliError("edges failed")
+            ),
+        ):
+            res = await routes._handle_deps(req)
+        self.assertEqual(res.status, 502)
+        self.assertEqual(json.loads(res.body.decode("utf-8"))["code"], "deps_fetch_failed")
+
+    async def test_background_refresh_is_coalesced_to_one_per_repo(self):
+        app = web.Application()
+        key = _gh_key()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def _slow_rebuild(_app, _key):
+            nonlocal calls
+            calls += 1
+            started.set()
+            await release.wait()
+            return {"edges": [], "nodes": {}}
+
+        with mock.patch.object(routes, "_rebuild_deps", side_effect=_slow_rebuild):
+            routes._schedule_deps_refresh(app, key)
+            await started.wait()
+            # Second and third stale callers land while the first is in flight:
+            # they must NOT spawn another rebuild.
+            routes._schedule_deps_refresh(app, key)
+            routes._schedule_deps_refresh(app, key)
+            self.assertEqual(len(app[routes._DEPS_REFRESH_TASKS_APP_KEY]), 1)
+            release.set()
+            await self._drain(app)
+
+        self.assertEqual(calls, 1)
+        # The slot is freed once the task finishes, so a later visit can refresh.
+        self.assertEqual(len(app[routes._DEPS_REFRESH_TASKS_APP_KEY]), 0)
+
+    async def test_a_slow_rebuild_cannot_overwrite_a_newer_one(self):
+        # GPT round 1: a stale GET starts background rebuild A; an edge changes;
+        # refresh=1 starts synchronous rebuild B. B writes the fresh graph, then
+        # the slower A lands on top with its OLDER edges -- and because
+        # write_deps_cache stamps fetched_at at WRITE time, those older edges are
+        # then treated as fresh for a full TTL. The per-repo rebuild mutex makes
+        # the LAST write the LAST fetch, which is what the freshness stamp claims.
+        app = web.Application()
+        key = _gh_key()
+        old = [{"blocked": 10, "blocker": 5, "source": "native"}]
+        new = [{"blocked": 10, "blocker": 6, "source": "native"}]
+        fetches = 0
+        writes: list = []
+
+        def _fetch(*_a, **_k):
+            nonlocal fetches
+            n = fetches
+            fetches += 1
+            if n == 0:
+                time.sleep(0.30)  # the slow background rebuild, holding the lock
+                return (old, {})
+            return (new, {})
+
+        def _write(*a, **_k):
+            writes.append(a[2])
+
+        with (
+            mock.patch.object(routes, "_load_open_issues_for_reco", return_value=[]),
+            mock.patch.object(store, "read_pulls_cache", return_value=[]),
+            mock.patch.object(store, "write_deps_cache", side_effect=_write),
+            mock.patch.object(store, "read_deps_cache", return_value=None),
+            mock.patch.object(gh, "fetch_dependency_edges", side_effect=_fetch),
+        ):
+            routes._schedule_deps_refresh(app, key)  # A (background)
+            await asyncio.sleep(0.05)  # let A take the lock and enter its fetch
+            await routes._rebuild_deps(app, key)  # B (the refresh=1 path)
+            await self._drain(app)
+
+        # Both rebuilds ran, and the surviving graph is the one fetched LAST.
+        self.assertEqual(fetches, 2)
+        self.assertEqual(len(writes), 2)
+        self.assertEqual(writes[-1], new)
+
+    async def test_a_failing_background_refresh_keeps_the_prior_cache(self):
+        app = web.Application()
+        key = _gh_key()
+        with (
+            mock.patch.object(
+                routes, "_rebuild_deps", side_effect=gh.GhCliError("boom")
+            ) as rebuild,
+            mock.patch.object(store, "write_deps_cache") as write,
+        ):
+            routes._schedule_deps_refresh(app, key)
+            await self._drain(app)
+        # The rebuild ran and raised, but nothing crashed and the failure never
+        # reached write_deps_cache — the previous good cache is untouched.
+        rebuild.assert_called_once()
+        write.assert_not_called()
+        self.assertEqual(len(app[routes._DEPS_REFRESH_TASKS_APP_KEY]), 0)
+
+    async def test_refresh_query_still_rebuilds_synchronously(self):
+        # refresh=1 must return FRESH data inline (not serve-stale), even when a
+        # fresh cache exists — a user-initiated refresh pays for the rebuild.
+        fresh_edges = [{"blocked": 10, "blocker": 5, "source": "native"}]
+        req = make_mocked_request("GET", "/api/apps/issue-radar/deps?owner=o&repo=r&refresh=1")
+        stored = {"edges": fresh_edges, "nodes": {}, "fetched_at": time.time()}
+        with (
+            mock.patch.object(store, "is_repo_connected", return_value=True),
+            mock.patch.object(routes, "_load_open_issues_for_reco", return_value=[]),
+            mock.patch.object(store, "read_pulls_cache", return_value=[]),
+            mock.patch.object(store, "write_deps_cache") as write,
+            mock.patch.object(store, "read_deps_cache", return_value=stored),
+            mock.patch.object(
+                gh, "fetch_dependency_edges", return_value=(fresh_edges, {})
+            ) as fetch,
+            mock.patch.object(routes, "_schedule_deps_refresh") as sched,
+        ):
+            res = await routes._handle_deps(req)
+        self.assertEqual(res.status, 200)
+        body = json.loads(res.body.decode("utf-8"))
+        self.assertFalse(body["from_cache"])
+        self.assertEqual(body["edges"], fresh_edges)
+        fetch.assert_called_once()
+        write.assert_called_once()
+        # A forced sync rebuild does not also queue a background one.
+        sched.assert_not_called()
+
+    async def test_an_absent_cache_still_blocks_on_a_synchronous_build(self):
+        req = make_mocked_request("GET", "/api/apps/issue-radar/deps?owner=o&repo=r")
+        stored = {"edges": [], "nodes": {}, "fetched_at": time.time()}
+        with (
+            mock.patch.object(store, "is_repo_connected", return_value=True),
+            mock.patch.object(store, "read_deps_cache", side_effect=[None, stored]),
+            mock.patch.object(routes, "_load_open_issues_for_reco", return_value=[]),
+            mock.patch.object(store, "read_pulls_cache", return_value=[]),
+            mock.patch.object(store, "write_deps_cache") as write,
+            mock.patch.object(gh, "fetch_dependency_edges", return_value=([], {})) as fetch,
+            mock.patch.object(routes, "_schedule_deps_refresh") as sched,
+        ):
+            res = await routes._handle_deps(req)
+        self.assertEqual(res.status, 200)
+        body = json.loads(res.body.decode("utf-8"))
+        self.assertFalse(body["from_cache"])
+        # A never-synced repo builds inline (blocks) and does not serve-stale.
+        fetch.assert_called_once()
+        write.assert_called_once()
+        sched.assert_not_called()
+
+    async def test_shutdown_cancels_outstanding_refreshes(self):
+        app = web.Application()
+        key = _gh_key()
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def _hang(_app, _key):
+            started.set()
+            try:
+                await asyncio.Event().wait()  # never completes on its own
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        with mock.patch.object(routes, "_rebuild_deps", side_effect=_hang):
+            routes._schedule_deps_refresh(app, key)
+            await started.wait()
+            self.assertEqual(len(app[routes._DEPS_REFRESH_TASKS_APP_KEY]), 1)
+            await routes._stop_deps_refreshes(app)
+        self.assertTrue(cancelled.is_set())
+        self.assertEqual(len(app[routes._DEPS_REFRESH_TASKS_APP_KEY]), 0)
 
 
 # ── SIG_DEP_UNBLOCKED (detect + count + fingerprint stability) ────────────────


### PR DESCRIPTION
## 1. What is the problem?

`GET /api/apps/issue-radar/deps` was cache-first with a 600s TTL, but on a miss it
rebuilt the whole dependency graph **synchronously inside the request**. Expiry and
rebuild were the same event: there was no serve-stale path, so the first visit
after the TTL lapsed paid for the entire rebuild before the Graph tab could draw
anything.

The rebuild is a 6-page sequential GraphQL walk in
`github_client._batch_dependency_graph`. Measured against this repo at 564 open
issues:

```
page1 2.22s  page2 2.11s  page3 2.31s
page4 2.01s  page5 1.46s  page6 1.21s
TOTAL 11.32s
```

Worth naming what was *not* the problem: all 564 open issues were checked for
truncated `blockedBy(first:50)` / `timelineItems(first:100)` connections and none
were truncated, so no issue fell back to the per-issue REST path and no node
needed a `get_ref_summary` call. The 11.3s is the entire cost. This was a
cache-policy problem, not a fan-out problem.

## 2. Why this issue matters to the user

A 10-minute TTL against an 11-second rebuild is close to a worst case. The TTL is
short enough that ordinary navigation (open the Graph tab, go read an issue, come
back) usually misses it, and the rebuild is long enough to read as a hang rather
than as loading. Users were paying an 11-second stall on a graph whose edges only
move when someone adds or removes a blocked-by or closes a blocker.

## 3. How our fix solves it

Expiry and rebuild are now separate events.

- **Serve stale, revalidate behind.** A stale cache is returned immediately while a
  background task rebuilds it off the request path. A fresh cache is served exactly
  as before. Only a genuinely never-synced repo (no cache at all) still blocks on a
  build, and `refresh=1` keeps its existing meaning of a forced synchronous
  rebuild. The response shape is unchanged -- see the note below on why staleness
  is not reported.
- **One refresh in flight per repo.** Concurrent stale callers see the live task in
  a per-app registry and serve their own stale copy instead of spawning a second
  rebuild, so a dashboard with several tabs open cannot fan out N rebuilds.
- **Every rebuild for a repo is serialized.** Coalescing alone only stops a second
  *background* refresh; it cannot order a background rebuild against a synchronous
  one, and `write_deps_cache` stamps `fetched_at` at WRITE time. So a stale GET
  could start rebuild A, an edge could change, `refresh=1` could start rebuild B
  and write the fresh graph, and then the slower A would land on top with its
  older edges and stamp them fresh for a full TTL. A per-repo rebuild mutex held
  across fetch AND write makes the last write the last FETCH, which is the
  property the freshness stamp claims. Two concurrent `refresh=1` calls are
  ordered by the same lock.
- **A background failure keeps the previous good cache.** The task swallows and
  logs its exception rather than writing anything, so a transient `gh` failure
  degrades to "still stale" instead of to an empty graph.
- **No task outlives the app.** The registry is keyed on the aiohttp app and an
  `on_cleanup` hook cancels and awaits outstanding refreshes at shutdown.

**The response shape is unchanged.** An earlier revision added a `stale: true`
field. It shipped with zero consumers -- nothing in the frontend read it and
`DepsResponse` did not even declare it -- so it is gone. Staleness stays an internal
scheduling decision rather than part of the contract, and a test pins the omission
so re-adding such a field is a deliberate act with a named consumer.

**Known residual, tracked separately in #5638.** The rebuild mutex covers the two
paths the route owns. `write_deps_cache` has a second real caller,
`crew_runtime._read_or_refresh_deps`, which runs the same multi-second
fetch-then-write from the sweep and does not take this lock, so the same interleave
survives as sweep-versus-route. That pair predates this PR -- the sweep could
already race the old synchronous rebuild -- and the fix that covers every writer is
a store-layer change (stamp `fetched_at` at fetch time and make the write a
compare-and-set) rather than a wider lock, so it is filed rather than folded in
here.

**The TTL is deliberately left at 600s.** An earlier revision of this PR raised it
to 3 hours on the reasoning that serve-stale makes the TTL govern background
refreshes rather than user latency. That reasoning was incomplete:
`DEPS_CACHE_TTL_SEC` has a second consumer, `crew_runtime._read_or_refresh_deps`,
and for the sweep the TTL *is* the freshness horizon on which `SIG_DEP_UNBLOCKED`
wakes a crew whose blocker just merged. Raising it would have stretched that wake
from 10 minutes to 3 hours -- a regression on a surface this PR is not about.
Serve-stale already removes the entire 11s stall at 600s, so there was nothing
left to buy. The constant's comment now records both consumers and says why it
stays. Decoupling the two horizons (a long refresh interval for the route, a short
one for the sweep) is a separate change.

One design note. Sharing a single `_rebuild_deps` helper between the synchronous
and background paths would have collapsed the two 502 codes the route already
returns (`deps_issue_scope_unavailable` and `deps_fetch_failed`), because both
failures surface as `GhCliError` and were previously told apart only by which of
two `try` blocks caught them. Recovering that distinction from the message text
would have silently reclassified every scope failure whose wording does not happen
to mention issues -- `gh api ... failed` mentions neither -- so the scope failure
now carries its own exception type and the codes stay stable.

## 4. What tests we did

`test/test_issue_radar_deps.py` grows the serve-stale contract, all
mutation-verified (break the source, confirm red, restore):

- a stale cache is served immediately and `fetch_dependency_edges` is **not
  called** on the request path -- this is the assertion that pins the latency fix,
  rather than a wall-clock number that would depend on the network. It also
  asserts the response carries no staleness field, pinning that omission;
- a fresh cache serves from cache and schedules no refresh;
- the background refresh is coalesced to one in flight per repo;
- **a slow rebuild cannot overwrite a newer one**: a background rebuild returning
  older edges is forced to interleave with a synchronous rebuild returning newer
  ones, and the surviving graph must be the one fetched last. Removing the shared
  lock makes this fail with the older edges winning, which is the corruption
  itself, reproduced;
- a failing background refresh leaves the prior cache readable and never reaches
  `write_deps_cache`;
- `refresh=1` still rebuilds synchronously and does not also queue a background
  refresh;
- an absent cache still blocks on a synchronous build;
- shutdown cancels outstanding refreshes and empties the registry;
- the two 502 codes stay distinct by exception type. Reverting to a plain
  `GhCliError` makes this fail with
  `'deps_fetch_failed' != 'deps_issue_scope_unavailable'`, which is exactly the
  regression a message-pattern classifier would have shipped.

182 tests pass across `test_issue_radar_deps.py` +
`test_issue_radar_crew_runtime.py`. isort, flake8, mypy and the black baseline gate
are clean.

## 5. Any other suggestions on the work

The response is ~295KB of JSON and is refetched whole on every revalidation, with
the client rebuilding its entire layout model in `useMemo` each time. Now that the
latency is off the request path this is no longer urgent, but an ETag or a
`fetched_at` conditional request would let an unchanged graph answer 304 instead
of reshipping 295KB.

The frontend still sets `staleTime: 60_000` on this query, so it re-asks the
server every minute even though the server now answers instantly from cache. That
is harmless and deliberately left alone to keep this PR backend-only.

Giving the route and the sweep independent freshness horizons is the natural
follow-up: it would let background rebuilds become genuinely rare without touching
`SIG_DEP_UNBLOCKED` reactivity.

Closes #5612
