### PR TITLE
fix(mcp): validate mutation identifiers

### DIFF
--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -213,6 +213,23 @@ def _write_mcp_json(data: dict) -> None:
     _atomic_json_write(_GLOBAL_MCP_JSON, data)
 
 
+def _mcp_identifier(
+    body: dict,
+    field: str,
+    *,
+    label: str,
+    code: str,
+) -> tuple[str, web.Response | None]:
+    """Normalize an MCP identifier or return its field-contract response."""
+    value = body.get(field, "")
+    if not isinstance(value, str):
+        return "", web.json_response(
+            {"error": f"{label} must be a string", "code": code},
+            status=400,
+        )
+    return value.strip(), None
+
+
 # ── MCP Servers ──
 
 
@@ -1047,7 +1064,14 @@ async def api_mcp_toggle(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
-    name = body.get("name", "").strip()
+    name, error = _mcp_identifier(
+        body,
+        "name",
+        label="server name",
+        code="mcp_server_name_type_invalid",
+    )
+    if error is not None:
+        return error
     enabled = body.get("enabled", True)
     if not name:
         return web.json_response({"error": "name is required"}, status=400)
@@ -1111,8 +1135,22 @@ async def api_mcp_toggle_tool(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
-    server = body.get("server", "").strip()
-    tool = body.get("tool", "").strip()
+    server, error = _mcp_identifier(
+        body,
+        "server",
+        label="server name",
+        code="mcp_server_name_type_invalid",
+    )
+    if error is not None:
+        return error
+    tool, error = _mcp_identifier(
+        body,
+        "tool",
+        label="tool name",
+        code="mcp_tool_name_type_invalid",
+    )
+    if error is not None:
+        return error
     enabled = body.get("enabled", True)
     if not server or not tool:
         return web.json_response({"error": "server and tool are required"}, status=400)
@@ -1219,7 +1257,14 @@ async def api_mcp_remove(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
-    name = body.get("name", "").strip()
+    name, error = _mcp_identifier(
+        body,
+        "name",
+        label="server name",
+        code="mcp_server_name_type_invalid",
+    )
+    if error is not None:
+        return error
     if not name:
         return web.json_response({"error": "name is required"}, status=400)
 

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -123,6 +123,39 @@ def _known(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
     monkeypatch.setattr(disc, "list_servers", lambda *a, **k: list(rows))
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler", "body", "code"),
+    [
+        (mcp_mod.api_mcp_toggle, {"name": []}, "mcp_server_name_type_invalid"),
+        (
+            mcp_mod.api_mcp_toggle_tool,
+            {"server": {}, "tool": "ReadFile"},
+            "mcp_server_name_type_invalid",
+        ),
+        (
+            mcp_mod.api_mcp_toggle_tool,
+            {"server": "srv", "tool": 7},
+            "mcp_tool_name_type_invalid",
+        ),
+        (mcp_mod.api_mcp_remove, {"name": True}, "mcp_server_name_type_invalid"),
+    ],
+)
+async def test_mutations_reject_non_string_identifiers_before_writes(
+    sandbox: SimpleNamespace,
+    handler,
+    body: dict[str, Any],
+    code: str,
+) -> None:
+    resp = await handler(_request(body))
+
+    assert resp.status == 400
+    assert _payload(resp)["code"] == code
+    assert not sandbox.global_json.exists()
+    assert sandbox.synced == []
+    assert sandbox.batched == []
+
+
 # ── POST /api/mcp/toggle ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem / Motivation

The MCP toggle, per-tool toggle, and remove handlers call strip directly on server/tool identifier fields. JSON object payloads carrying arrays, objects, numbers, or booleans therefore raise AttributeError and return HTTP 500 before normal validation.

This is separate from #5587's top-level JSON-object sweep: these request bodies are already objects and the missing contract is at the identifier field level. It is also separate from #5014's owner-auth work.

## Why it matters

These endpoints mutate mcp.json, uninstall capabilities, and sync agent configuration. Malformed client input must be rejected deterministically before any lock, write, uninstall, or sync seam is entered.

## What changed (motivation → approach → change)

- Add one MCP identifier normalizer shared by toggle, toggle-tool, and remove.
- Require server/name and tool identifiers to be strings before whitespace normalization.
- Return HTTP 400 with stable mcp_server_name_type_invalid or mcp_tool_name_type_invalid codes.
- Preserve existing missing/blank required-field behavior and all persistence/discovery semantics.
- Add regressions that assert no mcp.json creation and no agent sync on invalid input.

## Tests

- Red before: 4/4 focused cases failed with AttributeError across all three handlers.
- Green after: 137/137 across the complete MCP handler coverage suite and error-code contract.
- Project Black baseline gate passes with 2 changed files and 1,337 known-unformatted files unchanged.
- flake8, isort --check-only, and git diff --check pass.

## Manual verification

N/A — the async handler tests run against the existing filesystem sandbox and directly prove status/code plus absence of writes and syncs.

## Related Issues

Fixes #5621

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and regression tests cover the changed behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public contract documentation exists for these internal dashboard endpoints)
- [x] No secrets, credentials, screenshots, or unrelated files in the diff

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.