### PR TITLE
fix(taskrunner): clean rejected inline specs

### DIFF
--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -139,6 +139,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
     spec_path = body.get("spec", "")
     if not spec_path:
         return web.json_response({"error": "spec path required"}, status=400)
+    inline_spec_path: Path | None = None
 
     # Validate non-inline paths against traversal, then forward the *validated*
     # resolved path (not the raw input) to the sink below so the guard and the
@@ -162,6 +163,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         fpath = Path(work_dir) / fname
         fpath.parent.mkdir(parents=True, exist_ok=True)
         fpath.write_text(content, encoding="utf-8")
+        inline_spec_path = fpath
         spec_path = str(fpath)
 
     try:
@@ -180,6 +182,15 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
             auto_approve=auto_approve,
         )
     except Exception as exc:
+        if inline_spec_path is not None:
+            try:
+                await asyncio.to_thread(inline_spec_path.unlink, missing_ok=True)
+            except Exception as cleanup_exc:
+                logger.warning(
+                    "Failed to clean rejected inline task spec %s: %s",
+                    inline_spec_path,
+                    cleanup_exc,
+                )
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response({"ok": True, "spec": spec_path, "task_id": task_id})
 

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -294,6 +294,34 @@ class TestStart:
         )
         assert resp.status == 400
         assert _body(resp)["error"] == "cannot start"
+        assert list(runner._work_dir.glob("TASK_*.md")) == []
+
+    @pytest.mark.asyncio
+    async def test_runner_exception_keeps_caller_owned_spec(self, tmp_path: Path) -> None:
+        spec = tmp_path / "TASK.md"
+        spec.write_text("# caller owned", encoding="utf-8")
+        runner = _runner(tmp_path)
+        runner.start_background = AsyncMock(side_effect=RuntimeError("cannot start"))
+
+        resp = await api_taskrunner_start(
+            _request(_state(runner), json_body={"spec": str(spec)})
+        )
+
+        assert resp.status == 400
+        assert spec.read_text(encoding="utf-8") == "# caller owned"
+
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_keeps_original_start_error(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.start_background = AsyncMock(side_effect=RuntimeError("cannot start"))
+
+        with patch.object(Path, "unlink", side_effect=OSError("locked")):
+            resp = await api_taskrunner_start(
+                _request(_state(runner), json_body={"spec": "__inline__:# t"})
+            )
+
+        assert resp.status == 400
+        assert _body(resp)["error"] == "cannot start"
 
 
 # ── cancel / pause / delete / rename ──


### PR DESCRIPTION
## Problem / Motivation

POST /api/taskrunner writes inline task content to work/TASK_<id>.md before start_background accepts the run. When startup raises, the handler returns HTTP 400 but leaves that generated file behind. Repeated rejected starts therefore accumulate orphan specs.

## Why it matters

The files can contain user task content and have no owner after a failed start. Cleanup must be narrow: only the handler-generated inline file, never a caller-owned external spec.

## What changed (motivation → approach → change)

- Track the Path only when api_taskrunner_start creates an inline spec.
- On the existing startup exception path, remove that generated file off the event loop with asyncio.to_thread.
- Treat cleanup as best-effort and preserve the original startup error if unlink itself fails.
- Leave successful inline starts and all external spec paths unchanged.
- Add ownership-boundary and cleanup-failure regressions.

## Tests

- Red before: 1 failure / 1 pass; the failed inline start left TASK_*.md while the caller-owned external spec remained intact.
- Green after: 130/130 across Task Runner handler coverage, auto-approve provenance, and the error-code contract.
- Project Black baseline gate passes with 2 changed files and 1,337 known-unformatted files unchanged.
- flake8, isort --check-only, and git diff --check pass.

## Manual verification

A direct current-main probe forced start_background to raise: before the fix the response was 400 and one TASK_*.md remained. The regression now exercises that same seam in the sandbox.

## Related Issues

Fixes #5626

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and regression tests cover cleanup ownership
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — successful endpoint behavior is unchanged)
- [x] No secrets, credentials, screenshots, or unrelated files in the diff

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.