### PR TITLE
fix(cli): pin utf-8 on the last two text-mode subprocess calls

### DIFF
--- a/test/test_subprocess_encoding_gate.py
+++ b/test/test_subprocess_encoding_gate.py
@@ -242,6 +242,17 @@ class TestBaselineRatchet:
         )
         assert survivors == {"src/a.py": 2}
 
+    def test_cli_server_stays_clean(self) -> None:
+        """cli_server.py once held an unpinned text-mode call the baseline
+        under-counted, so any PR touching the file failed the gate even when
+        the PR added nothing (#5580). Both calls are pinned now and the
+        baseline entry is pruned; this pins the file at zero so it can never
+        silently re-enter the list."""
+        rel = "src/kiro_crew/cli_server.py"
+        violations = gate._violations_in_source((ROOT / rel).read_text(encoding="utf-8"))
+        assert violations == []
+        assert rel not in gate._read_baseline(BASELINE)
+
     def test_write_read_roundtrip(self, tmp_path: Path) -> None:
         path = tmp_path / "baseline.txt"
         entries = {"src/b.py": 2, "src/a.py": 7}


### PR DESCRIPTION
﻿## Problem / Motivation

`src/kiro_crew/cli_server.py` carried **two** text-mode `subprocess.run(..., text=True)` calls with no pinned `encoding=`, while `.github/subprocess-encoding-baseline.txt` recorded the file at **1**. The `check_subprocess_encoding` gate therefore failed closed for any PR that brought the file into its changed-file scope — even ones adding no subprocess call of their own — because main's real count already exceeded its recorded baseline (fixes #5580).

## Why it matters

The baseline is a ratchet that may only shrink; when the committed number is BELOW reality, the gate is a cross-cutting blocker on unrelated PRs instead of a guard. And both calls decode child output with `locale.getpreferredencoding()` — on a non-UTF-8 locale or the Windows console code page, a branch name, commit subject, or unit line from the child can arrive mojibake'd or raise `UnicodeDecodeError`.

## What changed (motivation → approach → change)

Both calls take the repo-canonical `**UTF8_TEXT` splat (`subprocess_utf8.py`), which every neighbouring call in this file already uses:

- the `git rev-list --count --left-right HEAD...origin/<branch>` ahead/behind computation;
- the `journalctl -u <unit> -n 1 --no-pager` availability probe.

`git` and `journalctl` both emit UTF-8, so pinning is strictly correct. With the file at zero unpinned calls, its baseline entry is pruned via the gate's sanctioned `--update-baseline` (which can only lower counts and delete lines), and a regression test pins the file at zero so it cannot silently re-enter the list.

## Tests

`test_cli_server_stays_clean` in `test/test_subprocess_encoding_gate.py`: scans the REAL committed `cli_server.py` through the gate's own AST rules and asserts zero violations plus absence from the baseline. All 31 pre-existing gate tests pass unchanged.

## Manual verification

```
python scripts/check_subprocess_encoding.py
  → subprocess-encoding gate passed (scope: origin/main...HEAD)
pytest test/test_subprocess_encoding_gate.py → 32 passed
flake8 clean on both touched files.
```

## Related Issues

Fixes #5580 · Related: #3219, #3669, #5249

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: gate semantics unchanged; baseline is data
- [x] No secrets, credentials, or internal references in the diff
