### PR TITLE
fix(i18n): drop the default Simplified Chinese Han alias

### DIFF
--- a/website/docs/i18n-catalog.md
+++ b/website/docs/i18n-catalog.md
@@ -314,24 +314,30 @@ Kana, Hangul, Devanagari and Bengali, collects them into `--script-fallbacks` an
 consulted for Latin or general punctuation, so they cannot change Latin metrics
 or leading, and they are a no-op when the named face is not installed.
 
-The `:root` tokens use the Simplified Chinese `KC Han Fallback` and
-`KC Han Mono Fallback` aliases. Under `html:lang(ja)`, both shared tokens switch
+The `:root` tokens carry only the non-Han script aliases (Devanagari, Bengali).
+Regional Han faces are scoped with `html:lang(zh-CN)`, `html:lang(ja)`, and
+`html:lang(ko)` so untagged CJK in an English UI reaches the browser/OS
+locale-aware cascade instead of being forced through Simplified Chinese glyph
+forms. A bare `:lang(zh)` is not used: it also matches Traditional tags
+(`zh-TW`, `zh-HK`, `zh-Hant`). Under `html:lang(zh-CN)` the tokens switch to
+`KC Han Fallback` and `KC Han Mono Fallback`; under `html:lang(ja)` they switch
 to `KC Japanese Fallback` and `KC Japanese Mono Fallback`, whose ranges include
 Kana as well as shared ideographs; under `html:lang(ko)` they switch to
 `KC Korean Fallback` and `KC Korean Mono Fallback`, whose ranges add the Hangul
 syllable and Jamo blocks. Keep every other locale's aliases out of these tokens:
 if the named face is unavailable, the browser must reach its language-aware
-fallback for that script instead of being forced through a Simplified Chinese
-alias — which for Korean cannot draw Hangul at all. Every user font choice and
-theme declaration consumes the shared tokens, so changing the document language
-updates proportional and monospace fallbacks without a component-specific font
-stack.
+fallback for that script instead of being forced through a foreign Han alias —
+which for Korean cannot draw Hangul at all. The rules set only the fallback
+tokens: `--font-body` / `--mono` already resolve `var(--script-fallbacks)` on
+`<html>` (`:root` and `useZoom`), so document language updates both stacks
+without redeclaring them. Content `lang=` inside an English document is not
+wired; there is no in-repo producer of those attributes yet.
 
 **Do not reorder those stacks or drop the token when adding a family.** Moving a
 Latin family in front silently returns zh-CN, ja, ko, hi and bn to whatever the
 platform picks for a missing glyph. A test pins the `:root` tokens, every
-declaration site (including the theme blocks, which redeclare both), the Japanese
-and Korean locale overrides, and the ordering.
+declaration site (including the theme blocks, which redeclare both), the
+`html:lang(zh-CN/ja/ko)` overrides, and the ordering.
 
 ## Translating the corpus
 

--- a/website/src/i18n/LanguageProvider.test.tsx
+++ b/website/src/i18n/LanguageProvider.test.tsx
@@ -138,8 +138,8 @@ describe('LanguageProvider', () => {
   })
 
   // A regional tag must land on the bare code, or the locale-specific font
-  // override keyed on it — `html:lang(ja)`, `html:lang(ko)` — never matches and the
-  // script silently renders through the Simplified Chinese alias.
+  // override keyed on it — `html:lang(ja)`, `html:lang(ko)` — never matches and
+  // Kana / Hangul fall through to the untagged OS cascade instead of their aliases.
   it.each([['ja-JP', 'ja'], ['ko-KR', 'ko']])(
     'normalizes the %s browser tag for the locale-specific font override',
     async (tag, expected) => {

--- a/website/src/i18n/scriptFonts.test.ts
+++ b/website/src/i18n/scriptFonts.test.ts
@@ -56,12 +56,13 @@ const SC_ALIASES = [
 /**
  * Locale-specific aliases, keyed by the `html:lang()` rule that activates them.
  *
- * `KC Han Fallback` draws Simplified glyph forms and no Hangul at all, so leaving
- * it in front for `lang=ja` or `lang=ko` puts an alias that cannot serve the locale
- * ahead of one that can — which is why each entry REPLACES the default pair rather
- * than prepending to it.
+ * These are NOT the untagged default. A leading Simplified Chinese face would
+ * draw Japanese and Korean content (and untagged CJK in an English UI) with
+ * the wrong regional glyph forms. Each entry REPLACES every other Han pair
+ * rather than prepending to it.
  */
 const REGIONAL = [
+  { lang: 'zh-CN', body: 'KC Han Fallback', mono: 'KC Han Mono Fallback' },
   { lang: 'ja', body: 'KC Japanese Fallback', mono: 'KC Japanese Mono Fallback' },
   { lang: 'ko', body: 'KC Korean Fallback', mono: 'KC Korean Mono Fallback' },
 ] as const
@@ -74,6 +75,7 @@ const REGIONAL_ALIASES = REGIONAL.flatMap(r => [r.body, r.mono])
  * or merged token fails here rather than rendering from the OS cascade.
  */
 const SCRIPT_PROBES: Record<string, ReadonlyArray<readonly [string, number]>> = {
+  'zh-CN': [['CJK Unified Ideographs', 0x4e00], ['CJK punctuation', 0x3001]],
   ja: [['hiragana', 0x3042], ['katakana', 0x30a2]],
   ko: [['Hangul syllables', 0xac00], ['Hangul compatibility jamo', 0x3131]],
 }
@@ -150,6 +152,11 @@ function covers(family: string, codePoint: number): boolean {
 
 function ruleBody(pattern: RegExp): string {
   return INDEX_CSS.match(pattern)?.[1] ?? ''
+}
+
+/** An `html:lang(tag)` rule. Document-level only — no descendant content scope. */
+function htmlLangRuleBody(lang: string): string {
+  return ruleBody(new RegExp(`html:lang\\(${lang}\\)\\s*\\{([^}]*)\\}`))
 }
 
 /** A token is unusable unless it is present and carries the shared script aliases. */
@@ -282,7 +289,7 @@ describe('script fallback faces', () => {
     expect(root).toMatch(/--script-fallbacks-mono:/)
   })
 
-  it('keeps the Simplified Chinese aliases as the default token', () => {
+  it('keeps regional Han aliases out of the untagged default token', () => {
     const rootBlock = ruleBody(/:root\s*\{([^}]*)\}/)
     expect(rootBlock, 'no :root block found in index.css').not.toBe('')
 
@@ -290,7 +297,9 @@ describe('script fallback faces', () => {
     const rootMono = scriptToken(rootBlock, true)
     expectCommon('root body', root)
     expectCommon('root mono', rootMono)
-    expectAliasPair('root', root, rootMono, ...SC_ALIASES)
+    // Untagged CJK (English UI, Japanese chat, mixed messages) must reach the
+    // browser/OS locale-aware cascade. A leading regional Han alias would force
+    // every shared ideograph through one region's glyph forms.
     for (const family of REGIONAL_ALIASES) {
       expect(root, `${family} leaked into the default body token`).not.toContain(family)
       expect(rootMono, `${family} leaked into the default mono token`).not.toContain(family)
@@ -298,7 +307,7 @@ describe('script fallback faces', () => {
   })
 
   it.each(REGIONAL)('swaps to isolated aliases for html:lang($lang)', ({ lang, body, mono }) => {
-    const block = ruleBody(new RegExp(`html:lang\\(${lang}\\)\\s*\\{([^}]*)\\}`))
+    const block = htmlLangRuleBody(lang)
     expect(block, `no html:lang(${lang}) block found in index.css`).not.toBe('')
 
     const bodyToken = scriptToken(block)
@@ -315,6 +324,16 @@ describe('script fallback faces', () => {
       expect(bodyToken, `${family} leaked into the ${lang} body token`).not.toContain(family)
       expect(monoToken, `${family} leaked into the ${lang} mono token`).not.toContain(family)
     }
+  })
+
+  it('scopes Simplified aliases to html:lang(zh-CN), not a bare :lang(zh)', () => {
+    // `:lang(zh)` also matches zh-TW / zh-HK / zh-Hant and would force
+    // Traditional content through Simplified faces — the same class of bug
+    // this change removes for Japanese. The dashboard's Chinese UI is zh-CN.
+    const bareZh = INDEX_CSS.match(/(?<![\w-]):lang\(zh\)(?=\s*[,{])/)
+    expect(bareZh, 'bare :lang(zh) matches Traditional Chinese tags').toBeNull()
+    expect(INDEX_CSS).toMatch(/html:lang\(zh-CN\)/)
+    expect(INDEX_CSS).not.toMatch(/:lang\(zh-Hans\)/)
   })
 })
 

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -57,9 +57,9 @@
                  U+FE30-FE4F, U+FF00-FFEF;
 }
 /* Japanese and Simplified Chinese share Han code points but not always glyph
-   forms. A separate alias lets html:lang(ja) select Japanese faces without
-   changing the SC default used by zh-CN. Kana joins the Han ranges so Japanese
-   punctuation and syllabaries come from the same face. */
+   forms. A separate alias lets :lang(ja) select Japanese faces without
+   changing the SC aliases used by :lang(zh-CN). Kana joins the Han ranges so
+   Japanese punctuation and syllabaries come from the same face. */
 @font-face {
   font-family: 'KC Japanese Fallback';
   font-style: normal; font-weight: 400;
@@ -89,7 +89,7 @@
 }
 /* Korean needs its own alias for a different reason than Japanese does: Hangul
    (U+AC00-D7AF and the Jamo blocks) is absent from the SC and JP faces' coverage
-   in practice, so leaving zh-CN's alias in front for html:lang(ko) puts an alias
+   in practice, so leaving a Simplified alias in front for :lang(ko) puts an alias
    that cannot draw Hangul ahead of one that can, and the browser resolves each
    syllable from the OS cascade instead. The Han ranges are claimed too — Korean
    copy is Hangul-only, but a quoted 한자 in user content should draw the Korean
@@ -120,9 +120,9 @@
                  U+AC00-D7AF, U+D7B0-D7FF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF;
 }
 /* Monospace Han, for code and CLI surfaces. Rarely installed on a stock machine;
-   when absent 'KC Han Fallback' follows it in --script-fallbacks-mono, so Han in a
-   code block draws from a proportional face — the same pairing the browser's own
-   fallback produces today, and better than a missing glyph. */
+   when absent 'KC Han Fallback' follows it in the :lang(zh-CN) mono token, so Han in
+   a code block draws from a proportional face — the same pairing the browser's
+   own fallback produces today, and better than a missing glyph. */
 @font-face {
   font-family: 'KC Han Mono Fallback';
   font-style: normal; font-weight: 400;
@@ -263,11 +263,14 @@
   /* Single source of truth for the script fallbacks. Every declaration of
      --font-body / --mono — here, in the theme blocks below, and the ones built in
      hooks/useTheme.tsx and hooks/useZoom.ts — references these by name instead of
-     repeating the list. Locale-specific overrides below swap regional Han faces
-     without changing any consumer stack. They lead each stack; unicode-range is
-     what makes leading safe. */
-  --script-fallbacks:'KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
-  --script-fallbacks-mono:'KC Han Mono Fallback','KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+     repeating the list. Regional Han aliases are NOT in the untagged default:
+     a leading Simplified Chinese face would force Japanese (and other untagged
+     CJK) through the wrong glyph forms. html:lang(zh-CN/ja/ko) below swap
+     isolated regional faces for that UI language. A bare :lang(zh) is avoided
+     — it also matches zh-TW/zh-HK. They lead each stack; unicode-range is what
+     makes leading safe. */
+  --script-fallbacks:'KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks-mono:'KC Devanagari Fallback','KC Bengali Fallback';
   /* An installed theme pack fills --theme-font-sans / --theme-font-mono with its
      own faces (see hooks/themeCss.ts). Reading them here means code surfaces
      follow a pack's monospace face without the user having to switch the whole UI
@@ -277,6 +280,13 @@
   --font-body:var(--theme-font-sans, var(--script-fallbacks),'Space Grotesk',-apple-system,BlinkMacSystemFont,sans-serif);
   --mono:var(--theme-font-mono, var(--script-fallbacks-mono),'JetBrains Mono',ui-monospace,SFMono-Regular,monospace);
   --radius-sm:6px;--radius-md:8px;--radius-lg:12px;--radius-xl:16px;
+}
+html:lang(zh-CN) {
+  /* Isolated Simplified aliases for Chinese UI. Not :lang(zh): that also
+     matches zh-TW / zh-HK / zh-Hant. Document-level only — :root/--font-body
+     and useZoom already resolve var(--script-fallbacks) on <html>. */
+  --script-fallbacks:'KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks-mono:'KC Han Mono Fallback','KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
 }
 html:lang(ja) {
   /* Never retain the SC aliases here. If no named Japanese face is installed,


### PR DESCRIPTION
## Problem / Motivation

When the dashboard UI language is English (including **Auto** resolving to English), Japanese chat content inherits the root script-fallback token. That token started with `KC Han Fallback`, whose local sources are Simplified Chinese faces (PingFang SC, Microsoft YaHei, Noto Sans CJK SC). Shared Han characters and CJK punctuation therefore rendered with Simplified glyph forms even when the content was Japanese.

#1675 already swaps Japanese aliases when `<html lang="ja">`. It does not cover Japanese (or other CJK) **content** inside an English UI.

## Why it matters

Anyone whose UI is English and who reads Japanese, Korean, or mixed CJK in chat sees the wrong regional glyph forms (punctuation placement and character shapes). Reported on stable 0.3.0 as a macOS desktop bug.

## What changed (motivation → approach → change)

Root cause: `--script-fallbacks` on `:root` always led with a regional Han face. There is no correct single-region default for untagged CJK, and inferring language from message text is out of scope.

Approach: leave Han aliases off the untagged token so the browser/OS locale-aware cascade can choose, and activate isolated regional faces only for the document UI language.

- `:root` keeps Devanagari and Bengali only.
- `html:lang(zh-CN)`, `html:lang(ja)`, and `html:lang(ko)` install that locale's Han pair. These set only the fallback tokens; `--font-body` / `--mono` already resolve `var(--script-fallbacks)` on `<html>`.
- A bare `:lang(zh)` is not used — it also matches Traditional tags (`zh-TW`, `zh-HK`, `zh-Hant`).
- Content `lang=` inside an English document is not wired. Nothing in-repo emits those attributes yet.

Chinese UI (`html lang="zh-CN"`) still gets the Simplified aliases. Japanese and Korean UI keep their existing isolated aliases.

## Tests

- `scriptFonts.test.ts`: the untagged `:root` token must not contain any regional Han alias; each `html:lang(zh-CN|ja|ko)` block must carry only that locale's pair; a bare `:lang(zh)` / `:lang(zh-Hans)` selector is forbidden.
- `LanguageProvider.test.tsx`: `ja-JP` / `ko-KR` still normalize to the bare codes those `html:lang()` rules key on.

`npx vitest run src/i18n/scriptFonts.test.ts src/i18n/LanguageProvider.test.tsx` — 65 passed.

## Manual verification

N/A for the CSS contract — the script-font gate is the source of truth and does not need a running dashboard. Visual glyph confirmation still wants a desktop session with Display language Auto/English and Japanese chat containing shared Han + punctuation. I did not have that session in this environment.

<!-- no-visual-delta -->
**Why no screenshot:** English chrome is unchanged. The only rendered delta is CJK glyph selection from the OS font cascade, which a screenshot of the English UI cannot show and which `scriptFonts.test.ts` already pins as the CSS contract.

## Related Issues

Fixes #5627

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`website/docs/i18n-catalog.md`)
- [x] No secrets, credentials, or internal references in the diff