### PR TITLE
test: release the raw dump fd at the remaining open_dump_file sites

### DIFF
--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -6,8 +6,10 @@ Follows the same injectable-dependency pattern as test_loop_watchdog.py.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -31,6 +33,55 @@ def dumps_dir(tmp_path: Path) -> Path:
     d = tmp_path / "crash-dumps"
     d.mkdir()
     return d
+
+
+@contextlib.contextmanager
+def opened_dump_file(dumps_dir: Path) -> Iterator[crash_dump_store.DumpFile]:
+    """Yield an open dump file and release its raw fd when the block exits.
+
+    ``open_dump_file`` hands out a raw descriptor from :func:`os.open`, and
+    ``DumpFile.close()`` is a deliberate no-op ("the fd lives until process
+    exit") with no finalizer anywhere in the module.  So a test that calls
+    ``open_dump_file`` releases nothing even with ``finally: f.close()``: it
+    leaks a descriptor for the rest of the session and holds the ``tmp_path``
+    dump file open, which blocks the fixture's cleanup on Windows.  Tests that
+    need the file only for their own body acquire it through here.
+
+    This is a test-local concern.  Production must keep never closing the fd —
+    faulthandler's C timer may fire at any moment — which is what
+    ``test_dump_file_fd_survives_dropping_last_python_reference`` pins.
+    """
+    import errno
+
+    # Capture the prior global BEFORE opening, so the value restored below is
+    # not itself the object this block is about to close.
+    prior_active = crash_dump_store._active_dump_file
+    # Sentinel bound BEFORE the try: ``fd`` is assigned partway through, so if
+    # open_dump_file raises, the finally must not convert that real failure into
+    # an UnboundLocalError.  -1 is never a valid descriptor.
+    fd = -1
+    try:
+        dump_file = open_dump_file(dumps_dir)
+        fd = dump_file.fileno()
+        yield dump_file
+    finally:
+        # open_dump_file publishes the object as ``_active_dump_file``; restore
+        # the prior value so the descriptor closed below is not left reachable
+        # from a module global for the rest of the session.
+        crash_dump_store._active_dump_file = prior_active
+        if fd != -1:
+            # Still exercise the documented file-like no-op that production
+            # offers for exactly this ``finally`` shape, then release the fd it
+            # deliberately does not.
+            dump_file.close()
+            try:
+                os.close(fd)
+            except OSError as exc:
+                # Tolerate ONLY EBADF: a regression that closed the fd early
+                # would raise here, and re-raising would mask the assertion in
+                # the caller that is the real signal.
+                if exc.errno != errno.EBADF:
+                    raise
 
 
 def _create_header_only_dump(
@@ -111,8 +162,7 @@ def test_rotate_empty_dir(dumps_dir: Path) -> None:
 
 
 def test_open_dump_file_creates_file(dumps_dir: Path) -> None:
-    f = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as f:
         assert f is not None
         assert not f.closed
         # File should exist on disk
@@ -124,21 +174,16 @@ def test_open_dump_file_creates_file(dumps_dir: Path) -> None:
         content = files[0].read_text(encoding="utf-8")
         assert "KiroCrew loop-stall crash dump" in content
         assert "PID:" in content
-    finally:
-        f.close()
 
 
 def test_open_dump_file_returns_writable_fd(dumps_dir: Path) -> None:
-    f = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as f:
         # faulthandler needs to write to this fd
         f.write("Thread 0x1234 (most recent call first):\n")
         f.flush()
         files = list(dumps_dir.iterdir())
         content = files[0].read_text(encoding="utf-8")
         assert "Thread 0x1234" in content
-    finally:
-        f.close()
 
 
 # ── Newest dump detection ──
@@ -323,8 +368,7 @@ def test_watchdog_dump_file_param_custom_callback(dumps_dir: Path) -> None:
     dump_targets: list[object] = []
 
     # Open a dump file
-    dump_file = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as dump_file:
         # Create watchdog with dump_file — custom dump callback to verify it's wired
         wd = LoopStallWatchdog(
             stall_after=30.0,
@@ -338,8 +382,6 @@ def test_watchdog_dump_file_param_custom_callback(dumps_dir: Path) -> None:
         clock.advance(31.0)
         assert wd.check() is True
         assert dump_targets == ["called"]
-    finally:
-        dump_file.close()
 
 
 def test_watchdog_dump_file_default_dump(dumps_dir: Path) -> None:
@@ -363,8 +405,7 @@ def test_watchdog_dump_file_default_dump(dumps_dir: Path) -> None:
 
     clock = _Clock()
 
-    dump_file = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as dump_file:
         wd = LoopStallWatchdog(
             stall_after=30.0,
             exit_after=None,
@@ -390,8 +431,6 @@ def test_watchdog_dump_file_default_dump(dumps_dir: Path) -> None:
         assert "thread" in content.lower(), (
             f"Expected thread stacks in dump file, got: {content!r}"
         )
-    finally:
-        dump_file.close()
 
 
 # ── fd stability (regression for #1571) ──
@@ -412,8 +451,7 @@ def test_dump_file_fd_survives_repeated_arm_cancel(dumps_dir: Path) -> None:
     import faulthandler
     import gc
 
-    dump_file = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as dump_file:
         # Simulate 20 cancel/re-arm cycles (beat() every 5s for ~100s of runtime).
         # Each cycle exercises the same code path that runs in production.
         for _ in range(20):
@@ -436,21 +474,16 @@ def test_dump_file_fd_survives_repeated_arm_cancel(dumps_dir: Path) -> None:
         assert "thread" in content.lower(), (
             f"Expected thread stacks after 20 arm/cancel cycles, got: {content!r}"
         )
-    finally:
-        dump_file.close()
 
 
 def test_dump_file_fileno_is_stable(dumps_dir: Path) -> None:
     """The fd number returned by fileno() never changes across the DumpFile lifetime."""
-    dump_file = open_dump_file(dumps_dir)
-    try:
+    with opened_dump_file(dumps_dir) as dump_file:
         fd1 = dump_file.fileno()
         dump_file.write("some data\n")
         dump_file.flush()
         fd2 = dump_file.fileno()
         assert fd1 == fd2, "fileno() must return the same fd across calls"
-    finally:
-        dump_file.close()
 
 
 def test_dump_file_fd_survives_dropping_last_python_reference(dumps_dir: Path) -> None:
@@ -711,15 +744,15 @@ def test_open_dump_file_header_records_pid_domain(dumps_dir: Path) -> None:
     # later sweep on a different host/namespace treats it as unattributable,
     # and (where procfs exists) with the start ID so a recycled PID cannot
     # masquerade as the owner.
-    f = open_dump_file(dumps_dir)
-    content = f.path.read_text(encoding="utf-8")
-    start_id = crash_dump_store._pid_start_id(os.getpid())
-    start_tok = f" start={start_id}" if start_id is not None else ""
-    assert f"# PID: {os.getpid()} @ {crash_dump_store._pid_domain()}{start_tok}\n" in content
-    # And a same-process sweep must classify it as alive-owned, not sweep it.
-    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
-    assert removed == 0
-    assert f.path.exists()
+    with opened_dump_file(dumps_dir) as f:
+        content = f.path.read_text(encoding="utf-8")
+        start_id = crash_dump_store._pid_start_id(os.getpid())
+        start_tok = f" start={start_id}" if start_id is not None else ""
+        assert f"# PID: {os.getpid()} @ {crash_dump_store._pid_domain()}{start_tok}\n" in content
+        # And a same-process sweep must classify it as alive-owned, not sweep it.
+        removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+        assert removed == 0
+        assert f.path.exists()
 
 
 def test_sweep_keeps_header_only_dump_without_pid_line(dumps_dir: Path) -> None:


### PR DESCRIPTION
## Problem / Motivation

`open_dump_file()` hands out a raw descriptor from `os.open()`, and `DumpFile.close()` is a
deliberate no-op — *"Intentional no-op. The fd lives until process exit."* — with no `__del__`,
`weakref`, `finalize` or `atexit` anywhere in the module. So a test that calls `open_dump_file`
releases nothing, **even when it already does `finally: f.close()`**.

Seven tests in `test/test_crash_dump_store.py` leak a descriptor for the rest of the session and
hold their `tmp_path` dump file open, which blocks the fixture's cleanup on Windows:

`test_open_dump_file_creates_file`, `test_open_dump_file_returns_writable_fd`,
`test_watchdog_dump_file_param_custom_callback`, `test_watchdog_dump_file_default_dump`,
`test_dump_file_fd_survives_repeated_arm_cancel`, `test_dump_file_fileno_is_stable`,
`test_open_dump_file_header_records_pid_domain`.

The eighth call site was fixed under this same rule in #5576; these are its remaining siblings.

## Why it matters

The leak is directly observable and it accumulates. Recording the descriptor each test opens, on
unmodified `main`, the numbers climb across the run — `4, 5, 6, 7, 8, 9, 10` — one descriptor
retained per test, none returned.

It is also **invisible to the suite**. Under a mutation that reintroduces the leak, all 47 tests
still report `47 passed`. The file's own assertions cannot see this property in either direction, so
nothing in CI would flag a regression here or a return of it.

## What changed (motivation → approach → change)

**Motivation.** Seven sites need the same release, and the subtle part is not the `os.close` — it is
the two ways a naive guard makes things worse. `fd` is bound partway through each body, so an
unguarded `os.close(fd)` in `finally` turns a real failure into an `UnboundLocalError` that masks it.
And a regression to a buffered `open()` closes the fd during collection, so an over-broad `except`
would swallow the `os.fstat` failure that is the fd-lifetime test's actual signal.

**Approach.** A single test-local `@contextmanager opened_dump_file(dumps_dir)` rather than seven
inline guards, for three reasons:

- The EBADF-only filter is the part that is easy to get subtly wrong. Seven copies is seven chances
  to widen it and mask a genuine failure; one helper is one place to get right, and any site added
  later inherits it.
- Six of the seven sites *already* had `try/finally: f.close()`, so `with` **replaces** existing
  scaffolding instead of adding new — the diff is a net simplification and no assertion body moves.
- The seventh had no `try/finally` at all, where an inline guard would mean adding a whole block
  while `with` needs only the re-indent.

**Change.** The helper acquires the file, yields it, and on exit restores `_active_dump_file`, still
calls the documented `DumpFile.close()` no-op, then releases the descriptor with `os.close(fd)`
behind an assignment guard, tolerating **only** `errno.EBADF`. Seven sites converted to `with`.

Two deliberate details:

- It restores `_active_dump_file`. `open_dump_file` publishes the object to that module global, so
  closing the descriptor without restoring would leave a module-level `DumpFile` holding a dead fd —
  a hazard this change would otherwise introduce rather than a pre-existing one.
- It keeps calling `DumpFile.close()`. That no-op exists precisely so `finally: f.close()` in tests
  does not raise `AttributeError`; if every test stopped calling it, the contract would lose its only
  exercise.

**`test_dump_file_fd_survives_dropping_last_python_reference` is deliberately NOT converted** and is
byte-identical to `main`. It is the discriminating regression pin for the production guarantee — that
the fd survives losing its last Python reference — and it must keep asserting that directly rather
than through a helper. Production behaviour is unchanged: **zero production lines in this diff.**

## Tests

`test/test_crash_dump_store.py`: **47 → 47**. No test added or removed; all 47 pass, and the eight
fd-related tests pass individually.

**Stated limitation:** this adds no committed test that would catch the leak returning. The property
is a resource fact rather than an assertion about behaviour, and the check used to verify it (below)
runs a test body through a harness and then inspects the descriptor, which does not fit the file's
existing shape. A committed guard would be a reasonable follow-up; it is not in this diff, so the
protection here is the helper being the single acquisition path, not a test.

## Manual verification

The tests' own assertions pass under both the leak and the fix, so they cannot verify this. A
resource check was used instead: spy the test module's `open_dump_file` binding to record each
descriptor, run the body, then assert `os.fstat(fd)` raises `OSError(EBADF)`.

- **Against unmodified `main` — RED, as required.** `SITES: 0/7 released`, all seven `verdict=OPEN`,
  descriptors climbing `4..10`. The harness's own control — the already-fixed eighth test — reported
  `CLOSED` in the same run, which is what licenses those seven OPEN verdicts as a fact about the
  tests rather than about the harness.
- **With the change — GREEN.** `SITES: 7/7 released`, control still `CLOSED`. Corroborating detail:
  the recorded descriptor is now `4` for every one of the seven, i.e. returned to the OS and reused,
  where unmodified `main` climbed.
- **Negative control 1.** Replacing the helper's `os.close(fd)` with `pass` returns the check to
  `0/7 released` and the climbing descriptors. Under that same mutation `pytest` still reported
  `47 passed`, which is the direct measurement behind the "invisible to the suite" claim above.
- **Negative control 2.** All pre-existing assertions in the seven tests still pass; count unchanged.
- **Negative control 3 — the regression pin is not blunted.** With production temporarily reverted to
  the pre-fix buffered `open()` form, `test_dump_file_fd_survives_dropping_last_python_reference`
  still fails at its intended line:

  ```
  >           st = os.fstat(fd)
  E           OSError: [Errno 9] Bad file descriptor
  ```

  So neither the helper's EBADF tolerance nor anything else masked it. The whole file under that
  reverted production form is `2 failed / 45 passed`; the second failure is
  `test_open_dump_file_header_records_pid_domain` raising
  `AttributeError: '_io.TextIOWrapper' object has no attribute 'path'`, an API-surface consequence of
  the deliberately-broken form rather than an fd-lifetime signal. Production was restored afterwards
  and confirmed byte-identical by checksum, with an empty diff against `main` for `src/`.

`flake8` is clean. `black --check` reports the same **8** proposed hunks before and after this change,
all landing on lines this PR does not author, so it adds no new formatter disagreement; those
pre-existing hunks are left alone as out of scope.

## Screenshots / video

N/A — no user-visible UI change. This PR touches one test file and no production code.

## Related Issues

Relates to #1571 (the crash-dump fd lifetime bug) and #1582 (its fix). Continues #5576, which fixed
the first of these eight call sites and added the regression pin this PR deliberately leaves
untouched. Closes none of them.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no behaviour or API change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
