### PR TITLE
fix: key cumulative metric streams by process identity beyond PID (#5564)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -371,7 +371,6 @@ src/kiro_crew/messaging/link.py
 src/kiro_crew/metrics/http_metrics.py
 src/kiro_crew/metrics/provider.py
 src/kiro_crew/metrics/recorder.py
-src/kiro_crew/metrics/schema.py
 src/kiro_crew/notifications/bus.py
 src/kiro_crew/notifications/resource_pressure.py
 src/kiro_crew/notifications/settings.py
@@ -379,7 +378,6 @@ src/kiro_crew/perf_sampler.py
 src/kiro_crew/platform/admission.py
 src/kiro_crew/platform/capability_bound.py
 src/kiro_crew/platform/update_layout.py
-src/kiro_crew/platform_compat.py
 src/kiro_crew/pod/cli.py
 src/kiro_crew/pod/config.py
 src/kiro_crew/pod/launchd.py
@@ -439,7 +437,6 @@ test/metrics/test_context_trace.py
 test/metrics/test_cost_breakdown.py
 test/metrics/test_gateway_http_metrics.py
 test/metrics/test_generation_disclosure.py
-test/metrics/test_local_exporter.py
 test/metrics/test_mcp_gateway_metrics.py
 test/metrics/test_provider_bucket_views.py
 test/metrics/test_schema.py
@@ -1040,7 +1037,6 @@ test/test_persistence_probe.py
 test/test_personal_shopper_no_purchase_capability.py
 test/test_pid_lifecycle.py
 test/test_platform_admission.py
-test/test_platform_compat.py
 test/test_platform_compat_coverage.py
 test/test_playwright_e2e.py
 test/test_pod.py

--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -19,7 +19,7 @@ Source: `src/kiro_crew/metrics/` — `schema.py`, `recorder.py`, `provider.py`,
 | `schema.py` | Namespace constants (`NS_CORE = "kirocrew."`, `NS_GENAI = "gen_ai."`, `NS_APP_PREFIX = "app."`) + `validate_name` / `validate_attrs` / `redact` guardrails. Documents the low-cardinality contract. |
 | `recorder.py` | `MetricsRecorder` — facade over the OTEL `Meter`. Every metric passes namespace + privacy guardrails BEFORE reaching an instrument. Instrument-cache creation is lock-guarded (atomic check-then-create). Best-effort: a telemetry failure never propagates to the caller. `meter=None` = no-op recorder. |
 | `provider.py` | Consent gate + process-global recorder (`get_recorder()`) + graceful `shutdown()` / `reset_for_testing()`. `get_recorder()` serves a memoized recorder and re-resolves the `telemetry.enabled` consent value every `_CONSENT_RECHECK_SECS` (30s), rebuilding when it moved — see "Recorder lifecycle & threading" below. Public consent surface: `env_pin()` / `TELEMETRY_ENV_VAR`. When enabled, wires a `PeriodicExportingMetricReader` to the local JSONL exporter. Installs **one `View` per instrument** from `_HISTOGRAM_BUCKETS_MS`, each with its own `ExplicitBucketHistogramAggregation` boundaries (see below) — deliberately NOT a catch-all `instrument_type=Histogram` View. |
-| `local_exporter.py` | `JsonlMetricExporter` — appends one JSON line per export cycle to `<dir>/metrics-YYYY-MM-DD-<pid>.jsonl` (default dir `~/.kiro/crew/metrics`). Per-PID single-writer shards keep append + rotation lock-free, so concurrent exporters do not lose DELTA cycles. A private `.metrics.lock` serializes only retention sweeps; pruning skips canonical shards owned by live PIDs or modified within the safety window. **Bounded retention (rec #14):** shards rotate before an append exceeds `max_total_mb`; closed/expired shards are pruned directly by age and oldest-first size. Pruning is throttled to at most once per 300s and fully best-effort. Dir mode is 0o700, file mode 0o600, and nothing egresses the host. Declares DELTA `preferred_temporality` for Counter/UpDownCounter/Histogram so daily aggregation is an element-wise sum across cycles/PIDs. Observable counters are deliberately NOT mapped and export CUMULATIVE: the delta baseline lives in the provider, which is rebuilt in-process on a telemetry consent change, so DELTA would re-emit the process-lifetime total once per rebuild; the aggregator instead reduces cumulative streams window-relative (time-ordered reset detection + first-in-window baseline), which is rebuild-idempotent. |
+| `local_exporter.py` | `JsonlMetricExporter` — appends one JSON line per export cycle to `<dir>/metrics-YYYY-MM-DD-<pid>.jsonl` (default dir `~/.kiro/crew/metrics`). Per-PID single-writer shards keep append + rotation lock-free, so concurrent exporters do not lose DELTA cycles. A private `.metrics.lock` serializes only retention sweeps; pruning skips canonical shards owned by live PIDs or modified within the safety window. **Bounded retention (rec #14):** shards rotate before an append exceeds `max_total_mb`; closed/expired shards are pruned directly by age and oldest-first size. Pruning is throttled to at most once per 300s and fully best-effort. Dir mode is 0o700, file mode 0o600, and nothing egresses the host. Declares DELTA `preferred_temporality` for Counter/UpDownCounter/Histogram so daily aggregation is an element-wise sum across cycles/PIDs. Observable counters are deliberately NOT mapped and export CUMULATIVE: the delta baseline lives in the provider, which is rebuilt in-process on a telemetry consent change, so DELTA would re-emit the process-lifetime total once per rebuild; the aggregator instead reduces cumulative streams window-relative (deterministic identity boundary + time-ordered legacy reset detection + first-in-window baseline), which is rebuild-idempotent. **Process identity:** each record is stamped once at resource level with `kirocrew.process.start_time` (`schema.RESOURCE_ATTR_PROCESS_START_TIME`) — the writing process's OS start-time token from `platform_compat.own_process_start_time()`, module-cached so provider rebuilds inside one process stamp the SAME value, and reboot-unique (Linux start ticks + boot UUID; macOS microsecond `proc_pidinfo` instant; Windows creation FILETIME). A read that cannot honor one-token-one-process (unreadable boot UUID, no `libproc`, 1s-only sources) emits NO token rather than an aliasable coarse one — a degraded token would merge lifetimes AND mute the reset heuristic that catches merges. The shard-filename PID plus this token identify a process beyond PID reuse, making the aggregator's cumulative reset detection deterministic. The stamp lands on the serialized JSONL line, never on the SDK `Resource` — that `Resource` also feeds the opt-in OTLP reader, and this host-local token must not egress. Fail-soft: when the platform read is unavailable the field is absent and the aggregator's legacy value heuristic applies. Resource level, not a metric attribute, so it never multiplies series cardinality. |
 | `http_metrics.py` | Gateway HTTP observability (rec #1): `record_boot_to_ready()` (boot-to-ready histogram) + `make_route_latency_middleware()` (per-route latency, wired as the outermost middleware on both `start_dashboard`/`start_api_server`). Bounds `route_template` cardinality via `collect_route_templates()` (build-time snapshot) + `route_template()` (`__unknown__` fallback); clamps `method` to a fixed allowlist and `status_class` to `1xx`..`5xx`/`other`. Upgraded WebSocket connections and `text/event-stream` SSE responses are excluded because their handler elapsed time is connection/turn lifetime, not HTTP request latency. Best-effort — a telemetry failure never alters a response. |
 
 ## Recorder lifecycle & threading
@@ -402,15 +402,27 @@ without a handler change. Scalar (non-histogram) metrics in `other` are
 classified by the SDK's own JSON markers — a Sum's `data` block carries
 `aggregation_temporality`/`is_monotonic`, a Gauge's carries neither. DELTA sums
 keep summing across cycles/PIDs; CUMULATIVE sums (observable counters) buffer
-samples per (PID, attrs) stream and reduce them time-ordered after the scan
-(shard iteration order is not chronological): counter-RESET detection — a
-snapshot below the stream's own maximum marks a process boundary (PID reuse,
-restart) and banks the finished segment, while re-emitted snapshots at/above the
-maximum are no-ops — keeps provider rebuilds idempotent AND a reused PID from
-overwriting an earlier process's total, and the stream's first in-window sample
-is subtracted as a baseline so a process older than the window reports only
-in-window activity, never its lifetime total (stream total = banked + live
-segment - baseline; add across streams). Non-finite
+samples per (PID, process-identity, attrs) stream and reduce them time-ordered
+after the scan (shard iteration order is not chronological). The identity half
+of the key is the resource-level `kirocrew.process.start_time` token the
+exporter stamps: a changed token for the same PID is a deterministic process
+boundary, so a reused PID starts a fresh stream even when the new process's
+first snapshot already exceeds the old maximum — the one shape value-based
+detection cannot see — while an unchanged token across provider rebuilds
+stitches the rebuild segments into one stream. Within an identity-keyed stream
+a value below the running maximum is treated as shard garbage (one identity is
+one OS process, whose counters are monotonic), never banked as a reset. Only a
+STRING token counts as an identity: a corrupt shard carrying any other type
+there reads as identity-less rather than minting a stream that mutes the
+heuristic. Identity-less streams (legacy shards, or platforms without a
+start-time read) reduce under the counter-RESET value heuristic — a snapshot
+below the stream's own maximum marks a process boundary and banks the finished
+segment, while re-emitted snapshots at/above the maximum are no-ops — so
+provider rebuilds stay idempotent and pre-change shards keep their exact
+totals. Either way the stream's first in-window sample is subtracted as a
+baseline so a process older than the window reports only in-window activity,
+never its lifetime total (stream total = banked + live segment - baseline; add
+across streams). Non-finite
 scalars (json's Infinity/NaN literals) are rejected per point via one shared
 coercion helper; gauges emit `kind: "gauge"` with `latest` (the newest sample,
 never a sum). Gauge samples are keyed per exporting shard PID so

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -45,6 +45,7 @@ from kiro_crew.dashboard.handlers.usage import context_occupancy, context_trace,
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.hooks import validate_file_path
 from kiro_crew.metrics.provider import TELEMETRY_ENV_VAR, env_pin
+from kiro_crew.metrics.schema import RESOURCE_ATTR_PROCESS_START_TIME
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -469,8 +470,8 @@ def _iter_export_cycles(
 
 def _iter_metric_points(
     shard_paths: list[Path],
-) -> Iterator[tuple[str, dict[str, Any], str, str, dict[str, Any]]]:
-    """Yield ``(name, data point, shard day, shard pid, data block)`` per point.
+) -> Iterator[tuple[str, dict[str, Any], str, str, str, dict[str, Any]]]:
+    """Yield ``(name, data point, shard day, shard pid, identity, data block)``.
 
     Every ``kirocrew.*`` data point is yielded; the name filter is load-bearing
     rather than defensive. One meter carries all three namespaces the recorder
@@ -479,26 +480,37 @@ def _iter_metric_points(
     Dropping the other two here is what keeps them out of :func:`_other_series`,
     whose rows the startup panel renders as core metrics.
 
+    ``identity`` is the writing process's resource-level start-time token
+    (``RESOURCE_ATTR_PROCESS_START_TIME``, stamped by the local exporter), or
+    ``""`` for legacy shards written before the field existed — the scope level
+    is still pure OTLP grouping and stays unread. Tolerate-garbage applies
+    twice: a resource whose shape is not the exporter's dict form, AND a token
+    that is not a string (the exporter only ever writes strings), both read as
+    identity-less rather than raising or minting a spurious identity — a
+    stringified garbage value would silently disable the legacy reset
+    heuristic for that stream.
+
     The metric-level ``data`` block rides along because a Sum's block carries
     ``aggregation_temporality``/``is_monotonic`` while a Gauge's carries neither
     — the scalar branch of :func:`_aggregate` classifies on it.
     """
     for obj, shard_day, shard_pid in _iter_export_cycles(shard_paths):
-        # resource -> scope -> metric is pure OTLP grouping; nothing below reads
-        # the resource or the scope.
-        metrics = (
-            m
-            for rm in obj.get("resource_metrics", []) or []
-            for sm in rm.get("scope_metrics", []) or []
-            for m in sm.get("metrics", []) or []
-        )
-        for metric in metrics:
-            name = metric.get("name") or ""
-            if not name.startswith("kirocrew."):
-                continue
-            data = metric.get("data") or {}
-            for dp in data.get("data_points", []) or []:
-                yield name, dp, shard_day, shard_pid, data
+        for rm in obj.get("resource_metrics", []) or []:
+            resource = rm.get("resource")
+            res_attrs = resource.get("attributes") if isinstance(resource, dict) else None
+            identity = ""
+            if isinstance(res_attrs, dict):
+                raw = res_attrs.get(RESOURCE_ATTR_PROCESS_START_TIME)
+                if isinstance(raw, str):
+                    identity = raw
+            for sm in rm.get("scope_metrics", []) or []:
+                for metric in sm.get("metrics", []) or []:
+                    name = metric.get("name") or ""
+                    if not name.startswith("kirocrew."):
+                        continue
+                    data = metric.get("data") or {}
+                    for dp in data.get("data_points", []) or []:
+                        yield name, dp, shard_day, shard_pid, identity, data
 
 
 def _daily_series(daily: dict[str, dict[str, _Hist]]) -> list[dict[str, Any]]:
@@ -554,7 +566,7 @@ def _other_series(
 
 
 def _cumulative_series(
-    other_cum: dict[str, dict[tuple[str, str], list[tuple[int, float]]]],
+    other_cum: dict[str, dict[tuple[str, str, str], list[tuple[int, float]]]],
 ) -> list[dict[str, Any]]:
     """Window-relative totals for CUMULATIVE sums, name-sorted.
 
@@ -572,30 +584,46 @@ def _cumulative_series(
       process that started in-window loses at most the activity before its
       first export cycle — under-reporting, never over-reporting.
 
-    Within a sorted stream, counter-RESET detection still applies: a value
-    dropping below its own segment max marks a process boundary (PID reuse,
-    restart), banking the finished segment; re-emitted snapshots >= the max are
-    no-ops, so provider rebuilds (telemetry off/on) stay idempotent. Stream
-    total = banked segments + live segment - baseline (never negative: the
-    baseline is a member of the first segment, so that segment's max bounds
-    it); cross-process total = sum over streams.
+    Streams are keyed by (shard PID, process identity, attrs). The identity is
+    the resource-level start-time token the exporter stamps
+    (``RESOURCE_ATTR_PROCESS_START_TIME``), so a PID reused by a new process
+    lands in a NEW stream deterministically — each process contributes its own
+    window-relative delta even when the reuser's first snapshot already exceeds
+    the predecessor's maximum, the one shape the value heuristic below cannot
+    see. An unchanged identity across provider rebuilds (telemetry off/on)
+    stitches the rebuild segments into one stream. Within an identity-keyed
+    stream a value below the running maximum is shard garbage, never a reset:
+    one identity is one OS process, whose observable counters are monotonic,
+    and banking a garbage drop would double-count the recovery.
+
+    The value-below-segment-max RESET heuristic applies ONLY to identity-less
+    streams (legacy shards written before the field existed, or platforms
+    whose start-time read is unavailable): a drop marks a process boundary,
+    banking the finished segment; re-emitted snapshots >= the max are no-ops,
+    so provider rebuilds stay idempotent. Either way, stream total = banked
+    segments + live segment - baseline (never negative: the baseline is a
+    member of the first segment, so that segment's max bounds it);
+    cross-process total = sum over streams.
     """
     out: list[dict[str, Any]] = []
     for name in sorted(other_cum):
         cum_attrs: dict[str, float] = {}
         cum_total = 0.0
-        for (_, csig), samples in other_cum[name].items():
+        for (_, identity, csig), samples in other_cum[name].items():
             ordered = sorted(samples, key=lambda t: t[0])
             baseline = ordered[0][1]
-            banked = 0.0
-            seg: float | None = None
-            for _, val in ordered:
-                if seg is not None and val < seg:
-                    banked += seg
-                    seg = val
-                else:
-                    seg = val if seg is None else max(seg, val)
-            cval = banked + (seg or 0.0) - baseline
+            if identity:
+                cval = max(val for _, val in ordered) - baseline
+            else:
+                banked = 0.0
+                seg: float | None = None
+                for _, val in ordered:
+                    if seg is not None and val < seg:
+                        banked += seg
+                        seg = val
+                    else:
+                        seg = val if seg is None else max(seg, val)
+                cval = banked + (seg or 0.0) - baseline
             if csig:
                 cum_attrs[csig] = cum_attrs.get(csig, 0.0) + cval
             else:
@@ -687,16 +715,19 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
     # concurrently — collapsing them on timestamp alone would show whichever
     # process exported last as "the" process state.
     other_gauge: dict[str, dict[tuple[str, str], tuple[int, float]]] = {}
-    # CUMULATIVE sums (observable counters): per (pid, attrs) stream, buffer
-    # (time_unix_nano, value) samples during the scan. The reduction —
-    # timestamp ordering, counter-RESET detection, window-relative baseline —
-    # happens in _cumulative_series once the scan is done, because shard
-    # iteration order is not chronological and reset detection is only sound
-    # on a time-ordered stream.
-    other_cum: dict[str, dict[tuple[str, str], list[tuple[int, float]]]] = {}
+    # CUMULATIVE sums (observable counters): per (pid, process-identity,
+    # attrs) stream, buffer (time_unix_nano, value) samples during the scan.
+    # The identity is the resource-level start-time token, so a reused PID
+    # starts a NEW stream deterministically ("" for legacy shards, which
+    # reduce under the value heuristic). The reduction — timestamp ordering,
+    # counter-RESET detection, window-relative baseline — happens in
+    # _cumulative_series once the scan is done, because shard iteration order
+    # is not chronological and reset detection is only sound on a time-ordered
+    # stream.
+    other_cum: dict[str, dict[tuple[str, str, str], list[tuple[int, float]]]] = {}
     turn = _Hist()
 
-    for name, dp, shard_day, shard_pid, data in _iter_metric_points(shard_paths):
+    for name, dp, shard_day, shard_pid, identity, data in _iter_metric_points(shard_paths):
         attrs = dp.get("attributes") or {}
         is_hist = "bucket_counts" in dp
         if name == _STARTUP_METRIC and is_hist:
@@ -753,9 +784,9 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
             # accumulate across cycles. CUMULATIVE sums (observable counters:
             # CPU seconds, GC stats) re-emit a process-lifetime snapshot every
             # cycle, so summing them would multiply by cycle count — they are
-            # buffered per (PID, attrs) stream and reduced window-relative
-            # after the scan (_cumulative_series). Gauges keep the newest
-            # sample per attribute set.
+            # buffered per (PID, identity, attrs) stream and reduced
+            # window-relative after the scan (_cumulative_series). Gauges keep
+            # the newest sample per attribute set.
             is_sum = "aggregation_temporality" in data or "is_monotonic" in data
             try:
                 # OTel JSON: DELTA=1, CUMULATIVE=2.
@@ -770,7 +801,9 @@ def _aggregate(shard_paths: list[Path]) -> dict[str, Any]:
                     # it the stream baseline, resurrecting the
                     # lifetime-as-window-total bug on one corrupt record.
                     continue
-                other_cum.setdefault(name, {}).setdefault((shard_pid, key), []).append((ts, val))
+                other_cum.setdefault(name, {}).setdefault((shard_pid, identity, key), []).append(
+                    (ts, val)
+                )
             elif is_sum:
                 rec = other_ctr.setdefault(name, {"total": 0.0, "by_attr": {}})
                 rec["total"] += val

--- a/src/kiro_crew/metrics/local_exporter.py
+++ b/src/kiro_crew/metrics/local_exporter.py
@@ -35,6 +35,7 @@ OSS-CLEAN: depends only on ``opentelemetry`` + the stdlib.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -58,6 +59,7 @@ from opentelemetry.sdk.metrics.export import (
 )
 
 from kiro_crew import platform_compat
+from kiro_crew.metrics.schema import RESOURCE_ATTR_PROCESS_START_TIME
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +77,46 @@ _BYTES_PER_MB = 1024 * 1024
 _SHARD_NAME_RE = re.compile(
     r"metrics-(?P<day>\d{4}-\d{2}-\d{2})-(?P<pid>[1-9]\d*)" r"(?:-(?P<rotation>[1-9]\d*))?\.jsonl"
 )
+
+
+def _stamp_process_identity(line: str) -> str:
+    """Stamp the writing process's start-time identity at resource level.
+
+    One field per exported record: ``RESOURCE_ATTR_PROCESS_START_TIME`` is set
+    on each ``resource_metrics`` entry's resource attributes (in practice one
+    per line — one provider per exporter). The dashboard aggregator keys
+    cumulative-counter streams by (shard PID, this token, attrs), which makes a
+    PID-reuse process boundary deterministic instead of inferable only from a
+    value drop. Resource level deliberately — a per-metric attribute would
+    multiply every instrument's series cardinality (see ``schema.py``).
+
+    Stamped AFTER serialization, into the JSONL line only, never onto the SDK
+    ``Resource``: the provider's one ``Resource`` also feeds the opt-in OTLP
+    reader, so a resource attribute would egress this host-local token to
+    ``telemetry.otlp_endpoint``. The per-cycle re-serialize is the price of
+    keeping the token on-host.
+
+    Fail soft, twice over: when the platform read is unavailable the line is
+    returned untouched, so legacy consumers see exactly the shape they already
+    parse and the aggregator applies its value heuristic; and a line whose
+    payload cannot be parsed and mutated as the exporter's own JSON shape is
+    returned untouched rather than raised on — stamping is auxiliary, and it
+    must never cost the metric payload that was just serialized.
+    """
+    identity = platform_compat.own_process_start_time()
+    if identity is None:
+        return line
+    stamped = False
+    try:
+        payload = json.loads(line)
+        for rm in payload.get("resource_metrics") or []:
+            resource = rm.get("resource")
+            if isinstance(resource, dict):
+                resource.setdefault("attributes", {})[RESOURCE_ATTR_PROCESS_START_TIME] = identity
+                stamped = True
+    except (ValueError, AttributeError, TypeError):
+        return line
+    return json.dumps(payload) if stamped else line
 
 
 class _Shard(NamedTuple):
@@ -227,7 +269,7 @@ class JsonlMetricExporter(MetricExporter):
     ) -> MetricExportResult:
         """Serialize *metrics_data* to a single JSON line and append it."""
         try:
-            line = metrics_data.to_json(indent=None)
+            line = _stamp_process_identity(metrics_data.to_json(indent=None))
             encoded = (line + "\n").encode("utf-8")
             self._dir.mkdir(parents=True, exist_ok=True)
             # ~/.kiro/crew convention: telemetry stays private (dir 0o700, file

--- a/src/kiro_crew/metrics/schema.py
+++ b/src/kiro_crew/metrics/schema.py
@@ -39,6 +39,29 @@ MAX_ATTR_COUNT = 32
 MAX_ATTR_VALUE_LEN = 128
 
 # ---------------------------------------------------------------------------
+# C4 — Resource-level attribute contract
+# ---------------------------------------------------------------------------
+
+# The writing process's OS start-time identity, stamped ONCE per exported JSONL
+# record at resource level by ``local_exporter.JsonlMetricExporter`` (source:
+# ``platform_compat.own_process_start_time``, module-cached per process).
+# Resource level rather than a per-metric attribute deliberately: the value is
+# per-process (exactly one per shard writer), so a metric attribute would
+# multiply every instrument's series cardinality for zero information gain.
+# Together with the shard-filename PID it makes cumulative-counter reset
+# detection deterministic in the dashboard aggregator — a changed token for the
+# same PID IS a process boundary, closing the value-heuristic blind spot where
+# a reusing process out-accumulates its predecessor. The token is opaque,
+# host-local, and reboot-unique (Linux start ticks suffixed with the boot UUID;
+# macOS microsecond start instant; Windows creation FILETIME); nothing parses
+# or compares it across hosts. A read that cannot honor one-token-one-process
+# (unreadable boot UUID, no ``libproc``, 1s-only sources) emits NO token at
+# all — the aggregator mutes its reset heuristic for token-carrying streams,
+# so an aliasable coarse token would be worse than none — and the legacy value
+# heuristic applies instead.
+RESOURCE_ATTR_PROCESS_START_TIME = "kirocrew.process.start_time"
+
+# ---------------------------------------------------------------------------
 # C4 — Privacy helpers
 # ---------------------------------------------------------------------------
 
@@ -74,9 +97,7 @@ def _is_high_entropy(value: str) -> bool:
         and re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", stripped)
     ):
         try:
-            decoded = base64.b64decode(stripped, validate=True).decode(
-                "utf-8", "ignore"
-            )
+            decoded = base64.b64decode(stripped, validate=True).decode("utf-8", "ignore")
         except (binascii.Error, ValueError):
             decoded = ""
         if decoded and decoded != stripped:
@@ -100,9 +121,7 @@ def _is_high_entropy(value: str) -> bool:
         for ch in value:
             freq[ch] = freq.get(ch, 0) + 1
         length = len(value)
-        entropy = -sum(
-            (c / length) * math.log2(c / length) for c in freq.values()
-        )
+        entropy = -sum((c / length) * math.log2(c / length) for c in freq.values())
         # High entropy threshold (4.5 bits/char is suspicious for attribute values)
         if entropy > 4.5:
             return True
@@ -157,33 +176,25 @@ def validate_name(name: str, *, app_id: Optional[str] = None) -> str:
         ValueError: If the name violates namespace rules.
     """
     if not name or not _METRIC_NAME_RE.match(name):
-        raise ValueError(
-            f"Invalid metric name {name!r}: must be lowercase dotted identifiers"
-        )
+        raise ValueError(f"Invalid metric name {name!r}: must be lowercase dotted identifiers")
 
     if app_id is not None:
         # App callers CANNOT spoof core or gen_ai namespaces.
         if name.startswith(NS_CORE):
-            raise ValueError(
-                f"App {app_id!r} cannot emit metrics in the kirocrew.* namespace"
-            )
+            raise ValueError(f"App {app_id!r} cannot emit metrics in the kirocrew.* namespace")
         if name.startswith(NS_GENAI):
-            raise ValueError(
-                f"App {app_id!r} cannot emit metrics in the gen_ai.* namespace"
-            )
+            raise ValueError(f"App {app_id!r} cannot emit metrics in the gen_ai.* namespace")
         # App metrics MUST be prefixed with app.<app_id>.
         expected_prefix = f"app.{app_id}."
         if not name.startswith(expected_prefix):
             raise ValueError(
-                f"App {app_id!r} metrics must start with {expected_prefix!r}, "
-                f"got {name!r}"
+                f"App {app_id!r} metrics must start with {expected_prefix!r}, " f"got {name!r}"
             )
     else:
         # Core callers: must use kirocrew.* or gen_ai.*
         if not (name.startswith(NS_CORE) or name.startswith(NS_GENAI)):
             raise ValueError(
-                f"Core metric name must start with {NS_CORE!r} or "
-                f"{NS_GENAI!r}, got {name!r}"
+                f"Core metric name must start with {NS_CORE!r} or " f"{NS_GENAI!r}, got {name!r}"
             )
 
     return name
@@ -213,9 +224,7 @@ def validate_attrs(
         ValueError: If attribute count exceeds MAX_ATTR_COUNT.
     """
     if len(attrs) > MAX_ATTR_COUNT:
-        raise ValueError(
-            f"Attribute count {len(attrs)} exceeds maximum {MAX_ATTR_COUNT}"
-        )
+        raise ValueError(f"Attribute count {len(attrs)} exceeds maximum {MAX_ATTR_COUNT}")
 
     sanitized: Dict[str, Union[str, int, bool, float]] = {}
     for key, value in attrs.items():

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -226,13 +226,16 @@ def rename_noreplace(
     src_bytes = os.fsencode(src)
     dst_bytes = os.fsencode(dst)
     ctypes.set_errno(0)
-    if fn(
-        src_dir_fd,
-        src_bytes,
-        dst_dir_fd,
-        dst_bytes,
-        _RENAME_NOREPLACE_FLAG,
-    ) == 0:
+    if (
+        fn(
+            src_dir_fd,
+            src_bytes,
+            dst_dir_fd,
+            dst_bytes,
+            _RENAME_NOREPLACE_FLAG,
+        )
+        == 0
+    ):
         return
     error = ctypes.get_errno()
     if error in {errno.EEXIST, errno.ENOTEMPTY}:
@@ -819,6 +822,17 @@ _DARWIN_MAXPATHLEN = 1024
 _DARWIN_VNODE_INFO_PATH_SIZE = _DARWIN_VNODE_INFO_SIZE + _DARWIN_MAXPATHLEN
 _DARWIN_PROC_VNODEPATHINFO_SIZE = 2 * _DARWIN_VNODE_INFO_PATH_SIZE
 
+# ``proc_pidinfo(PROC_PIDTBSDINFO)`` fills a ``proc_bsdinfo`` struct whose
+# start-time pair lives at fixed offsets: 12 leading uint32 fields (48 bytes),
+# ``pbi_comm[16]`` + ``pbi_name[32]`` (96), then 6 more 4-byte fields (120),
+# then ``pbi_start_tvsec`` / ``pbi_start_tvusec`` as two uint64s (120 / 128,
+# struct size 136). Only those two matter here; the total size doubles as the
+# layout check.
+_DARWIN_PROC_PIDTBSDINFO = 3
+_DARWIN_PROC_BSDINFO_SIZE = 136
+_DARWIN_PBI_START_TVSEC_OFFSET = 120
+_DARWIN_PBI_START_TVUSEC_OFFSET = 128
+
 _darwin_libproc: Any = None
 _darwin_libproc_loaded = False
 
@@ -877,6 +891,47 @@ def _darwin_process_cwd(pid: int) -> str | None:
         raw = buf.raw[_DARWIN_VNODE_INFO_SIZE:_DARWIN_VNODE_INFO_PATH_SIZE]
         cwd = raw.split(b"\0", 1)[0].decode("utf-8", errors="replace")
         return cwd or None
+    except Exception:
+        return None
+
+
+def _darwin_process_start_microtime(pid: int) -> str | None:
+    """macOS start time of *pid* via ``libproc``, at microsecond resolution.
+
+    ``proc_pidinfo(PROC_PIDTBSDINFO)`` needs no entitlement for a same-uid
+    process and never spawns a subprocess. The value is the absolute wall-clock
+    start instant (``pbi_start_tvsec`` / ``pbi_start_tvusec``), so it stays
+    unique across reboots and is six decimal orders finer than the 1s ``ps -o
+    lstart=`` probe — fine enough that a recycled PID cannot alias within the
+    same second. The kernel reports how many bytes it filled; anything other
+    than the exact struct size means the layout assumed by the offsets above no
+    longer matches, so the answer is refused rather than sliced out of the
+    wrong place (same rule as the cwd probe).
+    """
+    lib = _darwin_libproc_handle()
+    if lib is None:
+        return None
+    try:
+        buf = ctypes.create_string_buffer(_DARWIN_PROC_BSDINFO_SIZE)
+        filled = lib.proc_pidinfo(
+            pid,
+            _DARWIN_PROC_PIDTBSDINFO,
+            0,
+            buf,
+            _DARWIN_PROC_BSDINFO_SIZE,
+        )
+        if filled != _DARWIN_PROC_BSDINFO_SIZE:
+            return None
+        # Both x86_64 and arm64 macOS are little-endian.
+        sec = int.from_bytes(
+            buf.raw[_DARWIN_PBI_START_TVSEC_OFFSET:_DARWIN_PBI_START_TVUSEC_OFFSET], "little"
+        )
+        usec = int.from_bytes(
+            buf.raw[_DARWIN_PBI_START_TVUSEC_OFFSET:_DARWIN_PROC_BSDINFO_SIZE], "little"
+        )
+        if sec <= 0:
+            return None
+        return f"{sec}.{usec:06d}"
     except Exception:
         return None
 
@@ -1307,8 +1362,8 @@ def reveal_in_file_manager(target: str) -> bool:
         return True
     except OSError:
         logger.warning(
-            "file manager did not start for %s; caller should degrade", target,
-            exc_info=True)
+            "file manager did not start for %s; caller should degrade", target, exc_info=True
+        )
         return False
 
 
@@ -1338,8 +1393,8 @@ def open_with_default_app(target: str) -> bool:
         return True
     except OSError:
         logger.warning(
-            "default application did not start for %s; caller should degrade",
-            target, exc_info=True)
+            "default application did not start for %s; caller should degrade", target, exc_info=True
+        )
         return False
 
 
@@ -1417,9 +1472,7 @@ def process_descendants(pid: int) -> list[int]:
     if type(pid) is not int or pid <= 1:
         return []
     try:
-        parent_map = (
-            _windows_process_parent_map() if IS_WINDOWS else _posix_process_parent_map()
-        )
+        parent_map = _windows_process_parent_map() if IS_WINDOWS else _posix_process_parent_map()
     except Exception:  # noqa: BLE001 - introspection must never break a kill path
         return []
     return _descendants_from_parent_map(pid, parent_map)
@@ -2011,7 +2064,7 @@ def _normalize_local_address(address: str) -> str:
     addr = address.strip().strip("[]").lower()
     if addr.startswith("::ffff:"):
         # v4-mapped form of a v4 address; compare the embedded v4 part.
-        addr = addr[len("::ffff:"):]
+        addr = addr[len("::ffff:") :]
     return addr
 
 
@@ -2103,9 +2156,7 @@ def find_port_listeners(port: int) -> list[PortListener]:
             elif tag == "n" and cur_pid is not None and value.endswith(suffix):
                 # ``n127.0.0.1:8080`` / ``n*:8080`` / ``n[::1]:8080`` — strip
                 # the port suffix and the v6 brackets to the bare host part.
-                entry = PortListener(
-                    cur_pid, value[: -len(suffix)].strip("[]"), cur_family
-                )
+                entry = PortListener(cur_pid, value[: -len(suffix)].strip("[]"), cur_family)
                 if entry not in seen:
                     seen.add(entry)
                     listeners.append(entry)
@@ -2472,6 +2523,78 @@ def process_start_time(pid: int) -> str | None:
         return None
 
 
+#: (pid, token) cache for :func:`own_process_start_time`. Keyed by PID rather
+#: than a bare value so a forked child re-reads its OWN identity instead of
+#: inheriting the parent's — the OTEL SDK re-installs metric exporters in fork
+#: children via ``os.register_at_fork``, so children genuinely export under
+#: this token. Two threads racing the first read is benign: both compute the
+#: same immutable tuple for the same process.
+_OWN_START_TIME: tuple[int, str | None] | None = None
+
+
+def _linux_boot_id() -> str | None:
+    """The kernel's per-boot UUID, or ``None`` when unreadable."""
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text().strip() or None
+    except OSError:
+        return None
+
+
+def _own_identity_token(pid: int) -> str | None:
+    """Reboot-unique start-time token for THIS process, or ``None``.
+
+    The aggregator DISABLES its value-drop reset heuristic for any stream that
+    carries a token, trusting one token = one OS process. A token that cannot
+    honor that contract is therefore worse than no token — an aliased coarse
+    token would merge two lifetimes AND mute the heuristic that catches the
+    merge — so every degraded read returns ``None`` (no identity field, legacy
+    heuristic applies) rather than a best-effort value:
+
+    * **Linux** — ``/proc`` start ticks count from BOOT, so a post-reboot
+      process can repeat an earlier boot's (PID, ticks) pair; metric shards
+      outlive boots. The kernel's per-boot UUID makes the pair reboot-unique;
+      without it, no token.
+    * **macOS** — ``proc_pidinfo`` reports the absolute start instant at
+      microsecond resolution, so a recycled PID cannot alias within the 1s
+      window the ``ps -o lstart=`` probe cannot see past. Without ``libproc``,
+      no token — the 1s probe is exactly such an aliasable coarse source.
+    * **Windows** — the creation ``FILETIME`` (100ns units since 1601) is
+      absolute, already reboot-unique and alias-proof.
+    * **Other POSIX** — only the 1s ``ps`` probe exists: no token.
+    """
+    if sys.platform == "linux":
+        ticks = process_start_time(pid)
+        boot = _linux_boot_id()
+        return f"{ticks}:{boot}" if ticks and boot else None
+    if sys.platform == "darwin":
+        return _darwin_process_start_microtime(pid)
+    if IS_WINDOWS:
+        return process_start_time(pid)
+    return None
+
+
+def own_process_start_time() -> str | None:
+    """This process's own start-time identity, read once and cached.
+
+    A module-scope cache of :func:`_own_identity_token` for the calling
+    process. The cache is the contract, not an optimisation: every reader
+    inside one process must observe the SAME token for the process lifetime,
+    so a metrics provider rebuilt in-process (telemetry off/on) stamps records
+    that stitch into one stream with those written before the rebuild — and a
+    read that degrades mid-process (a ``libproc`` load failing on one call)
+    must not flip the process between stamped and unstamped forms.
+
+    Fail soft: an unreadable or alias-prone platform answer is cached as
+    ``None`` for the process lifetime, so a consumer emits no identity at all
+    rather than an identity that flaps between absent and present.
+    """
+    global _OWN_START_TIME
+    pid = os.getpid()
+    if _OWN_START_TIME is None or _OWN_START_TIME[0] != pid:
+        _OWN_START_TIME = (pid, _own_identity_token(pid))
+    return _OWN_START_TIME[1]
+
+
 def process_thread_count(pid: int) -> int | None:
     """Thread count of *pid*, or ``None`` when it cannot be determined.
 
@@ -2765,9 +2888,7 @@ def _close_process_handle(handle: int) -> None:
         logger.debug("CloseHandle failed for process handle %d", handle, exc_info=True)
 
 
-def kill_process_tree_pinned(
-    pid: int, expected_start_time: str, sig: int = SIGTERM
-) -> bool:
+def kill_process_tree_pinned(pid: int, expected_start_time: str, sig: int = SIGTERM) -> bool:
     """Kill *pid*'s tree only while its verified identity is PINNED OPEN.
 
     :func:`kill_process_tree` addresses the target by PID, and on Windows it

--- a/test/metrics/test_local_exporter.py
+++ b/test/metrics/test_local_exporter.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
@@ -96,13 +97,9 @@ def test_prune_warns_and_defers_once_without_persistent_state(tmp_path, caplog):
 
 def test_prune_protects_live_canonical_writer(tmp_path, monkeypatch):
     exp = JsonlMetricExporter(tmp_path, retention_days=7)
-    day = local_exporter.datetime.now(
-        local_exporter.timezone.utc
-    ).strftime("%Y-%m-%d")
+    day = local_exporter.datetime.now(local_exporter.timezone.utc).strftime("%Y-%m-%d")
     live = _shard(tmp_path, f"metrics-{day}-123.jsonl", 10, age_days=30)
-    rotated = _shard(
-        tmp_path, f"metrics-{day}-123-1.jsonl", 10, age_days=30
-    )
+    rotated = _shard(tmp_path, f"metrics-{day}-123-1.jsonl", 10, age_days=30)
     monkeypatch.setattr(platform_compat, "pid_exists", lambda pid: pid == 123)
 
     exp._prune()
@@ -128,9 +125,7 @@ def test_prune_enforces_total_size_cap_oldest_first(tmp_path):
     assert mid.exists()
 
 
-def test_export_rotates_live_shard_before_it_can_grow_past_cap(
-    tmp_path, monkeypatch
-):
+def test_export_rotates_live_shard_before_it_can_grow_past_cap(tmp_path, monkeypatch):
     # Fresh CI runners can have monotonic uptime below the 300s throttle.
     monkeypatch.setattr(local_exporter.time, "monotonic", lambda: 1.0)
     exp = JsonlMetricExporter(tmp_path, max_total_mb=1)
@@ -202,9 +197,7 @@ def test_export_writes_when_prune_lock_is_contended(tmp_path, monkeypatch):
         nonlocal pruned
         pruned = True
 
-    monkeypatch.setattr(
-        platform_compat, "try_acquire_lock", lambda _fd, *, exclusive: False
-    )
+    monkeypatch.setattr(platform_compat, "try_acquire_lock", lambda _fd, *, exclusive: False)
     monkeypatch.setattr(exp, "_prune", mark_pruned)
 
     assert exp.export(payload).name == "SUCCESS"
@@ -268,3 +261,70 @@ def test_export_then_prune_never_raises(tmp_path):
         assert list(tmp_path.glob("metrics-*.jsonl"))
     finally:
         provider.shutdown()
+
+
+# ── Resource-level process identity (deterministic cumulative resets) ──────
+
+
+def test_export_stamps_process_identity_at_resource_level(tmp_path):
+    """Every record carries the writing process's start-time token, once.
+
+    The token rides at resource level — never as a per-metric attribute — so
+    the dashboard aggregator can key cumulative streams by (PID, identity,
+    attrs) and detect PID reuse deterministically without multiplying any
+    instrument's series cardinality.
+    """
+    own = platform_compat.own_process_start_time()
+    if own is None:
+        pytest.skip("process start time unavailable on this platform")
+    provider = _provider(tmp_path)
+    try:
+        provider.get_meter("test").create_counter("kirocrew.test.count").add(1)
+        provider.force_flush()
+        provider.get_meter("test").create_counter("kirocrew.test.count").add(1)
+        provider.force_flush()
+
+        (shard,) = tmp_path.glob("metrics-*.jsonl")
+        lines = shard.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            parsed = json.loads(line)
+            for rm in parsed["resource_metrics"]:
+                attrs = rm["resource"]["attributes"]
+                # Same module-cached token on every record this process writes,
+                # so provider rebuilds stitch into one stream.
+                assert attrs[local_exporter.RESOURCE_ATTR_PROCESS_START_TIME] == own
+    finally:
+        provider.shutdown()
+
+
+def test_export_omits_identity_when_platform_read_unavailable(tmp_path, monkeypatch):
+    """Fail soft: no token means NO field, never an empty or fake identity.
+
+    An absent field is what routes the aggregator onto its legacy value
+    heuristic; an empty-string stamp would be a third shape nothing handles.
+    """
+    monkeypatch.setattr(platform_compat, "own_process_start_time", lambda: None)
+    provider = _provider(tmp_path)
+    try:
+        provider.get_meter("test").create_counter("kirocrew.test.count").add(1)
+        provider.force_flush()
+
+        (shard,) = tmp_path.glob("metrics-*.jsonl")
+        parsed = json.loads(shard.read_text(encoding="utf-8").strip().splitlines()[0])
+        for rm in parsed["resource_metrics"]:
+            attrs = rm["resource"]["attributes"]
+            assert local_exporter.RESOURCE_ATTR_PROCESS_START_TIME not in attrs
+    finally:
+        provider.shutdown()
+
+
+def test_stamp_returns_the_line_untouched_when_the_shape_resists_mutation():
+    """A resource whose ``attributes`` is not a mapping costs the stamp, not the payload.
+
+    The docstring's promise is load-bearing: a stamping failure inside
+    ``export()``'s try block would otherwise fail the whole cycle and drop the
+    metrics that were just serialized.
+    """
+    hostile = json.dumps({"resource_metrics": [{"resource": {"attributes": "not-a-mapping"}}]})
+    assert local_exporter._stamp_process_identity(hostile) == hostile

--- a/test/metrics/test_process_gauges.py
+++ b/test/metrics/test_process_gauges.py
@@ -177,10 +177,14 @@ def test_observable_counters_survive_provider_rebuild(tmp_path):
     provider, and telemetry consent changes rebuild the provider in-process —
     the first post-rebuild collection would re-emit the process-lifetime total
     as one giant delta. With CUMULATIVE export each cycle re-emits the running
-    snapshot, and the aggregator reduces the (PID, attrs) stream time-ordered
-    and window-relative, so two providers writing to the same shard (an off/on
-    toggle) still aggregate to the in-window activity: never a doubled 250,
-    never the four export cycles summed (500), and never the raw lifetime
+    snapshot, and the aggregator reduces the (PID, process-identity, attrs)
+    stream time-ordered and window-relative — both providers run in THIS
+    process, so the exporter stamps the same module-cached identity on every
+    record and the segments stitch into one stream (on a platform without a
+    start-time read the records carry no identity and the value heuristic
+    stitches them identically). Two providers writing to the same shard (an
+    off/on toggle) still aggregate to the in-window activity: never a doubled
+    250, never the four export cycles summed (500), and never the raw lifetime
     snapshot — the stream's first sample (100) is the baseline, so the growth
     to 150 reports as 50.
     """

--- a/test/metrics/test_telemetry_handler.py
+++ b/test/metrics/test_telemetry_handler.py
@@ -288,6 +288,148 @@ def test_aggregate_cumulative_detects_counter_reset_on_pid_reuse(tmp_path: Path)
     assert rows and rows[0]["total"] == 30.0
 
 
+def _cumulative_metric(points: list[tuple[int, float]]) -> dict:
+    return {
+        "name": "kirocrew.process.cpu.seconds",
+        "data": {
+            "aggregation_temporality": 2,
+            "is_monotonic": True,
+            "data_points": [
+                {"attributes": {}, "value": v, "time_unix_nano": ts} for ts, v in points
+            ],
+        },
+    }
+
+
+def _identity_line(metrics: list, identity: str | None) -> str:
+    """One export-cycle line, optionally stamped like the local exporter.
+
+    The attribute key is spelled literally on purpose: it pins the WIRE format
+    already sitting in shards on disk, so renaming the schema constant cannot
+    silently orphan every stamped shard.
+    """
+    rm: dict = {"scope_metrics": [{"metrics": metrics}]}
+    if identity is not None:
+        rm["resource"] = {"attributes": {"kirocrew.process.start_time": identity}}
+    return json.dumps({"resource_metrics": [rm]})
+
+
+def test_aggregate_cumulative_identity_splits_reused_pid_without_a_value_drop(tmp_path: Path):
+    """A changed identity is a process boundary even when no value drop exists.
+
+    The value heuristic's one blind spot: PID reuse where the new process's
+    FIRST snapshot (150) already exceeds the old process's max (140), so no
+    drop is ever observed and the two lifetimes merge into one stream —
+    reporting 175-100=75, which credits the 140→150 gap between the processes
+    as if it were observed activity. The resource-level identity makes the
+    boundary deterministic: each process is its own stream with its own
+    window-relative baseline, (140-100) + (175-150) = 65.
+    """
+    shard = tmp_path / "metrics-2026-08-21-1234.jsonl"
+    shard.write_text(
+        _identity_line([_cumulative_metric([(100, 100.0), (200, 140.0)])], "111")
+        + "\n"
+        + _identity_line([_cumulative_metric([(300, 150.0), (400, 175.0)])], "222")
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _aggregate([shard])
+    rows = [o for o in result["other"] if o["name"] == "kirocrew.process.cpu.seconds"]
+    assert rows and rows[0]["total"] == 65.0
+
+
+def test_aggregate_cumulative_same_identity_stitches_across_provider_rebuild(tmp_path: Path):
+    """An unchanged identity keeps rebuild segments in ONE stream.
+
+    A telemetry off/on toggle rebuilds the provider in-process; the rebuilt
+    exporter stamps the SAME module-cached token, so its re-emitted snapshots
+    join the existing stream and stay idempotent no-ops — 150-100=50, never a
+    doubled total and never a fresh baseline per rebuild.
+    """
+    shard = tmp_path / "metrics-2026-08-21-1234.jsonl"
+    shard.write_text(
+        _identity_line([_cumulative_metric([(100, 100.0), (200, 140.0)])], "111")
+        + "\n"
+        + _identity_line([_cumulative_metric([(300, 140.0), (400, 150.0)])], "111")
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _aggregate([shard])
+    rows = [o for o in result["other"] if o["name"] == "kirocrew.process.cpu.seconds"]
+    assert rows and rows[0]["total"] == 50.0
+
+
+def test_aggregate_cumulative_identity_stream_treats_a_drop_as_garbage_not_reset(tmp_path: Path):
+    """Within one identity, a value below the running max is never banked.
+
+    One identity is one OS process, whose observable counters are monotonic —
+    so a lower sample is shard garbage. Banking it as a reset would count the
+    pre-drop segment AND the recovery: 140+150-100=190 for a stream whose real
+    in-window growth is 150-100=50.
+    """
+    shard = tmp_path / "metrics-2026-08-21-1234.jsonl"
+    shard.write_text(
+        _identity_line(
+            [_cumulative_metric([(100, 100.0), (200, 140.0), (300, 5.0), (400, 150.0)])],
+            "111",
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _aggregate([shard])
+    rows = [o for o in result["other"] if o["name"] == "kirocrew.process.cpu.seconds"]
+    assert rows and rows[0]["total"] == 50.0
+
+
+def test_aggregate_cumulative_non_string_identity_reads_as_identity_less(tmp_path: Path):
+    """A malformed identity type must not mint a stream or mute the heuristic.
+
+    The exporter only ever writes a string token. A corrupt shard carrying a
+    number/list/object there would, if stringified, create an identity-keyed
+    stream and silently disable reset banking — turning a genuine 100→10→30
+    reset (30 of activity) into max-baseline arithmetic (0). Non-strings read
+    as identity-less, so the value heuristic still banks the reset.
+    """
+    line = {
+        "resource_metrics": [
+            {
+                "resource": {"attributes": {"kirocrew.process.start_time": 12345}},
+                "scope_metrics": [
+                    {"metrics": [_cumulative_metric([(100, 100.0), (200, 10.0), (300, 30.0)])]}
+                ],
+            }
+        ]
+    }
+    shard = tmp_path / "metrics-2026-08-21-1234.jsonl"
+    shard.write_text(json.dumps(line) + "\n", encoding="utf-8")
+    result = _aggregate([shard])
+    rows = [o for o in result["other"] if o["name"] == "kirocrew.process.cpu.seconds"]
+    assert rows and rows[0]["total"] == 30.0
+
+
+def test_aggregate_cumulative_legacy_lines_keep_the_value_heuristic(tmp_path: Path):
+    """Identity-less shards aggregate bit-for-bit as before, alongside stamped ones.
+
+    The legacy stream (no resource field, written before the identity existed)
+    still banks on a value drop — baseline 100, reset to 10, growth to 30 ⇒ 30
+    — while an identity-carrying stream from another process contributes its
+    own window-relative delta (175-150=25). Streams add: 55.
+    """
+    legacy = tmp_path / "metrics-2026-08-21-1234.jsonl"
+    legacy.write_text(
+        _identity_line([_cumulative_metric([(100, 100.0), (200, 10.0), (300, 30.0)])], None) + "\n",
+        encoding="utf-8",
+    )
+    stamped = tmp_path / "metrics-2026-08-21-5678.jsonl"
+    stamped.write_text(
+        _identity_line([_cumulative_metric([(400, 150.0), (500, 175.0)])], "222") + "\n",
+        encoding="utf-8",
+    )
+    result = _aggregate([legacy, stamped])
+    rows = [o for o in result["other"] if o["name"] == "kirocrew.process.cpu.seconds"]
+    assert rows and rows[0]["total"] == 55.0
+
+
 def test_aggregate_cumulative_totals_are_shard_order_independent(tmp_path: Path):
     """Reset detection runs on time-ordered samples, not shard file order.
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -163,9 +163,7 @@ class TestProcessHelpers:
         # still report False via GetExitCodeProcess, or every session recycle
         # logs a false "PID survived kill" and leaks a dead PID into the tracker.
         # On POSIX this reaps normally and is equally False.
-        child = subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(30)"]
-        )
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
         try:
             assert pc.pid_exists(child.pid) is True
             child.kill()
@@ -239,7 +237,9 @@ class TestProcessCwd:
 
     def test_darwin_reads_the_path_at_the_cwd_offset(self, monkeypatch):
         monkeypatch.setattr(
-            pc, "_darwin_libproc_handle", lambda: self._fake_libproc(b"/Users/u/proj"),
+            pc,
+            "_darwin_libproc_handle",
+            lambda: self._fake_libproc(b"/Users/u/proj"),
         )
         assert pc._darwin_process_cwd(4242) == "/Users/u/proj"
 
@@ -256,7 +256,9 @@ class TestProcessCwd:
 
     def test_darwin_refuses_an_error_return(self, monkeypatch):
         monkeypatch.setattr(
-            pc, "_darwin_libproc_handle", lambda: self._fake_libproc(b"/x", filled=-1),
+            pc,
+            "_darwin_libproc_handle",
+            lambda: self._fake_libproc(b"/x", filled=-1),
         )
         assert pc._darwin_process_cwd(4242) is None
 
@@ -358,7 +360,7 @@ class TestStrftime:
         if pc.IS_WINDOWS:
             assert dt.fmt == "%#I:%M %p"
         else:
-            assert dt.fmt == "%-I:%M %p"   # untouched on POSIX
+            assert dt.fmt == "%-I:%M %p"  # untouched on POSIX
 
     def test_real_datetime_formats_without_error(self):
         # End-to-end against a real datetime: must not raise ValueError on
@@ -378,11 +380,11 @@ class TestIsExecutableFile:
         f.write_text("#!/bin/sh\nexit 0\n")
         os.chmod(f, 0o644)  # no x-bit
         if pc.IS_WINDOWS:
-            assert pc.is_executable_file(f) is True   # .sh extension → runnable
+            assert pc.is_executable_file(f) is True  # .sh extension → runnable
         else:
             assert pc.is_executable_file(f) is False  # no x-bit → not runnable
         os.chmod(f, 0o755)  # +x
-        assert pc.is_executable_file(f) is True       # runnable on both now
+        assert pc.is_executable_file(f) is True  # runnable on both now
 
     def test_missing_file_is_not_executable(self, tmp_path):
         assert pc.is_executable_file(tmp_path / "nope.sh") is False
@@ -439,9 +441,7 @@ class TestFindPythonInterpreter:
             return stub if name in ("python", "python3") else real
 
         monkeypatch.setattr("shutil.which", fake_which)
-        monkeypatch.setattr(
-            pc.subprocess, "check_output", lambda *a, **k: "3.12\n"
-        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *a, **k: "3.12\n")
         got = pc.find_python_interpreter()
         assert got == real
         assert pc._is_windows_store_python_stub(got) is False
@@ -650,7 +650,7 @@ class TestChmodShims:
         f.write_text("x")
         fd = os.open(str(f), os.O_RDONLY)
         try:
-            pc.fchmod_safe(fd, 0o600)   # applies on POSIX, no-op on Windows
+            pc.fchmod_safe(fd, 0o600)  # applies on POSIX, no-op on Windows
         finally:
             os.close(fd)
 
@@ -1009,7 +1009,8 @@ class TestProcessIdentityPosix:
         # never race /proc/<pid>/cmdline population on a loaded runner.
         child = subprocess.Popen(
             [
-                sys.executable, "-c",
+                sys.executable,
+                "-c",
                 f"import sys, time; sys.stdout.write('R'); sys.stdout.flush(); "
                 f"time.sleep(30)  # {token}",
             ],
@@ -1086,9 +1087,7 @@ class TestProcessArgvMatchesExact:
             # targets — ssh and the aws v2 binary do not re-exec).
             sleep_bin = shutil.which("sleep") or "/bin/sleep"
             argv = [sleep_bin, "300"]
-            child = subprocess.Popen(
-                argv, start_new_session=True, stderr=subprocess.DEVNULL
-            )
+            child = subprocess.Popen(argv, start_new_session=True, stderr=subprocess.DEVNULL)
         else:
             child, argv = self._spawn("kirocrew-argvexact-probe")
         try:
@@ -1128,9 +1127,7 @@ class TestProcessArgvMatchesExact:
         assert pc.process_argv_matches_exact(os.getpid(), ()) is False
 
     def test_own_process_with_wrong_argv_is_false(self):
-        result = pc.process_argv_matches_exact(
-            os.getpid(), ("zzz-not-this-interpreter", "--nope")
-        )
+        result = pc.process_argv_matches_exact(os.getpid(), ("zzz-not-this-interpreter", "--nope"))
         assert result is False
 
 
@@ -1229,9 +1226,7 @@ class TestProcessStartTime:
         monkeypatch.setattr(pc.sys, "platform", "darwin")
         monkeypatch.setattr(pc, "IS_WINDOWS", False)
         monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/ps")
-        monkeypatch.setattr(
-            pc.subprocess, "check_output", lambda *_a, **_k: b"\xff\xfe not utf-8"
-        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: b"\xff\xfe not utf-8")
         assert pc.process_start_time(4242) is None
 
     def test_empty_ps_output_fails_safe(self, monkeypatch):
@@ -1257,6 +1252,149 @@ class TestProcessStartTime:
 
         monkeypatch.setattr(pc, "_open_process_termination_handle", _refuse)
         assert pc.process_start_time(os.getpid())
+
+
+class TestOwnProcessStartTime:
+    """The module-cached self identity the metrics exporter stamps on shards.
+
+    The cache IS the contract: every reader in one process must observe the
+    same token for the process lifetime, so metric records written before and
+    after an in-process provider rebuild stitch into one stream.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _cold_cache(self, monkeypatch):
+        """Start every test on a cold cache and restore the global after.
+
+        Without this, whichever test runs first fills the module global for
+        the rest of the worker session, making the first-read assertions
+        order-dependent.
+        """
+        monkeypatch.setattr(pc, "_OWN_START_TIME", None)
+
+    def test_matches_the_identity_token_and_is_stable(self):
+        token = pc.own_process_start_time()
+        if token is None:
+            pytest.skip("process start time unavailable on this platform")
+        assert token == pc._own_identity_token(os.getpid())
+        assert pc.own_process_start_time() == token
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux boot-scope contract")
+    def test_linux_token_is_boot_scoped(self):
+        """The durable token carries the boot UUID, not bare start ticks.
+
+        ``/proc`` start ticks count from boot, and metric shards outlive
+        boots: a post-reboot process repeating an earlier boot's (PID, ticks)
+        pair must still read as a different process.
+        """
+        ticks = pc.process_start_time(os.getpid())
+        boot = pc._linux_boot_id()
+        assert ticks
+        token = pc.own_process_start_time()
+        if boot is None:
+            assert token is None
+        else:
+            assert token == f"{ticks}:{boot}"
+
+    def test_same_ticks_across_boots_yield_distinct_tokens(self, monkeypatch):
+        """A repeated (PID, ticks) pair after a reboot is a NEW identity."""
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "process_start_time", lambda _pid: "12345")
+        monkeypatch.setattr(pc, "_linux_boot_id", lambda: "boot-aaaa")
+        first_boot = pc._own_identity_token(os.getpid())
+        monkeypatch.setattr(pc, "_linux_boot_id", lambda: "boot-bbbb")
+        second_boot = pc._own_identity_token(os.getpid())
+        assert first_boot == "12345:boot-aaaa"
+        assert second_boot == "12345:boot-bbbb"
+        assert first_boot != second_boot
+
+    def test_a_degraded_read_yields_no_identity_at_all(self, monkeypatch):
+        """A token that cannot honor one-token-one-process is refused.
+
+        The aggregator MUTES its value-drop reset heuristic for any stream
+        carrying a token, so an aliasable coarse token (bare boot-relative
+        ticks, 1s ``lstart``) would merge two lifetimes AND disable the
+        detector that catches the merge — strictly worse than no token, which
+        routes the stream onto the legacy heuristic.
+        """
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "process_start_time", lambda _pid: "12345")
+        monkeypatch.setattr(pc, "_linux_boot_id", lambda: None)
+        assert pc._own_identity_token(os.getpid()) is None
+
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: None)
+        assert pc._own_identity_token(os.getpid()) is None
+
+        # Platforms with only the 1s ``ps`` probe are outside the closed list.
+        monkeypatch.setattr(pc.sys, "platform", "freebsd14")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc._own_identity_token(os.getpid()) is None
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS libproc contract")
+    def test_darwin_microtime_is_used_when_available(self):
+        """The microsecond ``proc_pidinfo`` instant outranks 1s ``ps`` output.
+
+        A PID recycled within one second aliases under ``lstart``; the
+        microsecond instant cannot.
+        """
+        micro = pc._darwin_process_start_microtime(os.getpid())
+        if micro is None:
+            pytest.skip("libproc unavailable in this environment")
+        assert re.fullmatch(r"[1-9]\d*\.\d{6}", micro)
+        assert pc.own_process_start_time() == micro
+
+    def test_darwin_microtime_parses_the_bsdinfo_layout(self, monkeypatch):
+        """The sec/usec pair is sliced from the pinned struct offsets."""
+
+        class _FakeLib:
+            @staticmethod
+            def proc_pidinfo(_pid, _flavor, _arg, buf, size):
+                raw = bytearray(size)
+                raw[pc._DARWIN_PBI_START_TVSEC_OFFSET : pc._DARWIN_PBI_START_TVSEC_OFFSET + 8] = (
+                    1724500000
+                ).to_bytes(8, "little")
+                raw[pc._DARWIN_PBI_START_TVUSEC_OFFSET : pc._DARWIN_PBI_START_TVUSEC_OFFSET + 8] = (
+                    42
+                ).to_bytes(8, "little")
+                buf.raw = bytes(raw)
+                return size
+
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _FakeLib())
+        assert pc._darwin_process_start_microtime(4242) == "1724500000.000042"
+
+    def test_darwin_microtime_refuses_a_mismatched_struct_size(self, monkeypatch):
+        """A partial fill means the assumed layout is wrong: answer None."""
+
+        class _ShortLib:
+            @staticmethod
+            def proc_pidinfo(_pid, _flavor, _arg, _buf, _size):
+                return 64
+
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _ShortLib())
+        assert pc._darwin_process_start_microtime(4242) is None
+
+    def test_reads_the_platform_once_then_serves_the_cache(self, monkeypatch):
+        first = pc.own_process_start_time()  # populate the cache for THIS pid
+
+        def _boom(_pid):
+            raise AssertionError("cached identity was re-read from the platform")
+
+        monkeypatch.setattr(pc, "_own_identity_token", _boom)
+        assert pc.own_process_start_time() == first
+
+    def test_cache_is_pid_keyed_so_a_forked_child_rereads(self, monkeypatch):
+        """A stale inherited cache entry must be recomputed, not served.
+
+        The OTEL SDK re-installs exporters in fork children, so a child that
+        served the parent's token would share (PID, identity) with any later
+        sibling reusing its PID — the exact merge the identity exists to
+        prevent. Simulate the inherited state directly rather than patching
+        ``os.getpid`` (other threads read it during the patch window).
+        """
+        real = pc.own_process_start_time()
+        monkeypatch.setattr(pc, "_OWN_START_TIME", (os.getpid() + 1, "inherited-stale"))
+        assert pc.own_process_start_time() == real
 
 
 class TestPidLivenessPosix:
@@ -1663,14 +1801,14 @@ class TestTaskkillErrorMapping:
         def _run(*_a, **_kw):
             r = types.SimpleNamespace(returncode=rc, stdout=b"", stderr=stderr)
             return r
+
         return _run
 
     def test_taskkill_rc128_maps_to_process_lookup(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         _fake_windows_bins(monkeypatch)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(128, b"process not found"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(128, b"process not found"))
         with pytest.raises(ProcessLookupError):
             pc.kill_pid(99999, pc.SIGKILL)
         with pytest.raises(ProcessLookupError):
@@ -1680,8 +1818,7 @@ class TestTaskkillErrorMapping:
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         _fake_windows_bins(monkeypatch)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(5, b"access denied"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(5, b"access denied"))
         with pytest.raises(PermissionError):
             pc.kill_pid(99999, pc.SIGKILL)
         with pytest.raises(PermissionError):
@@ -1691,8 +1828,7 @@ class TestTaskkillErrorMapping:
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         _fake_windows_bins(monkeypatch)
-        monkeypatch.setattr(pc.subprocess, "run",
-                            self._fake_run(42, b"weird error"))
+        monkeypatch.setattr(pc.subprocess, "run", self._fake_run(42, b"weird error"))
         with pytest.raises(OSError) as ei:
             pc.kill_pid(99999, pc.SIGKILL)
         # not one of the more specific subclasses
@@ -1713,6 +1849,7 @@ class TestTaskkillErrorMapping:
 
         def _boom(*_a, **_kw):
             raise FileNotFoundError(2, "taskkill.exe not found")
+
         monkeypatch.setattr(pc.subprocess, "run", _boom)
         with pytest.raises(OSError):
             pc.kill_pid(99999, pc.SIGKILL)
@@ -1737,8 +1874,7 @@ class TestRestrictToOwnerArgvOnLinux:
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         # Reset the success-only SID memo so the monkeypatched stub wins
         monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid",
-                            lambda: "*S-1-5-21-1-2-3-1000")
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-1-2-3-1000")
         captured: dict = {}
 
         def fake_run(argv, **_kw):
@@ -1766,11 +1902,12 @@ class TestRestrictToOwnerArgvOnLinux:
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
-        monkeypatch.setattr(pc, "_current_user_sid",
-                            lambda: "*S-1-5-21-9-9-9-9")
-        monkeypatch.setattr(pc.subprocess, "run",
-                            lambda *a, **k: types.SimpleNamespace(
-                                returncode=1, stdout=b"", stderr=b"denied"))
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-9-9-9-9")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"denied"),
+        )
         f = tmp_path / "secret.key"
         f.write_bytes(b"s" * 32)
         with pytest.raises(OSError):
@@ -1855,9 +1992,7 @@ class TestRestrictToOwnerArgvOnLinux:
         f.write_bytes(b"s" * 32)
         pc.restrict_to_owner(f)
         grants = [
-            captured["argv"][i + 1]
-            for i, a in enumerate(captured["argv"][:-1])
-            if a == "/grant:r"
+            captured["argv"][i + 1] for i, a in enumerate(captured["argv"][:-1]) if a == "/grant:r"
         ]
         assert grants, captured["argv"]
         for g in grants:
@@ -1934,10 +2069,11 @@ class TestRestrictToOwnerArgvOnLinux:
             if len(attempts) == 1:
                 return types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
             return types.SimpleNamespace(
-                returncode=0, stdout=b'"ANT\\user","S-1-5-21-1-2-3-500"', stderr=b"")
+                returncode=0, stdout=b'"ANT\\user","S-1-5-21-1-2-3-500"', stderr=b""
+            )
 
         monkeypatch.setattr(pc.subprocess, "run", flaky_run)
-        assert pc._current_user_sid() is None          # first call fails...
+        assert pc._current_user_sid() is None  # first call fails...
         assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...retry succeeds
         assert pc._current_user_sid() == "*S-1-5-21-1-2-3-500"  # ...and is cached
         assert len(attempts) == 2, "success must be memoized (no third spawn)"
@@ -2123,7 +2259,8 @@ class TestRestrictToOwner:
         f.write_bytes(b"s" * 32)
         pc.restrict_to_owner(f)
         out = subprocess.check_output(
-            ["icacls", str(f)], stderr=subprocess.DEVNULL,
+            ["icacls", str(f)],
+            stderr=subprocess.DEVNULL,
         ).decode("utf-8", "replace")
         assert _owner_only_dacl_violations(out) == [], out
 
@@ -2250,9 +2387,7 @@ class TestFindPythonInterpreterReal:
         monkeypatch.setattr(pc.subprocess, "check_output", boom)
         assert pc.find_python_interpreter() is None
 
-    def test_version_gate_ignores_a_sitecustomize_decoy_on_pythonpath(
-        self, tmp_path, monkeypatch
-    ):
+    def test_version_gate_ignores_a_sitecustomize_decoy_on_pythonpath(self, tmp_path, monkeypatch):
         # The selection-side twin of test_origin_probe_ignores_pythonpath: at
         # child startup the ``site`` module imports any ``sitecustomize.py``
         # found on the caller's PYTHONPATH, and that module can monkeypatch
@@ -2349,8 +2484,10 @@ class TestFindListeningPidsErrors:
 
     def _fake_netstat(self, blob: str):
         """Return a fake subprocess.check_output that returns *blob*."""
+
         def _run(*_a, **_kw):
             return blob
+
         return _run
 
     def test_windows_finds_ipv6_listener_via_netstat(self, monkeypatch):
@@ -2392,9 +2529,7 @@ class TestFindListeningPidsErrors:
         # future-proof against a hypothetical Windows build that switches to
         # "TCP6" (the netstat -p flag already accepts "tcpv6"). Guard the
         # defensive path so a future relabel doesn't silently re-break this.
-        blob = (
-            "  TCP6   [::1]:7777             [::]:0                 LISTENING       77\n"
-        )
+        blob = "  TCP6   [::1]:7777             [::]:0                 LISTENING       77\n"
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         _fake_windows_bins(monkeypatch)
@@ -2461,6 +2596,7 @@ class TestFindListeningPidsErrors:
         # canned-blob tests above by exercising the real netstat parse against
         # whatever this Windows build actually prints.
         import socket as _socket
+
         s = _socket.socket(_socket.AF_INET6, _socket.SOCK_STREAM)
         try:
             s.bind(("::1", 0))
@@ -2573,9 +2709,7 @@ class TestKillAsyncVariants:
         monkeypatch.setattr(pc, "kill_pid", fake_kill_pid)
         import asyncio as _asyncio
 
-        result = _asyncio.new_event_loop().run_until_complete(
-            pc.kill_pid_async(4242, pc.SIGKILL)
-        )
+        result = _asyncio.new_event_loop().run_until_complete(pc.kill_pid_async(4242, pc.SIGKILL))
         assert result is True
         assert seen == [(4242, pc.SIGKILL)]
 
@@ -2670,13 +2804,11 @@ class TestKillAsyncVariants:
 
         result = real_loop.run_until_complete(_driver())
         assert result is True
-        assert seen_executors == [sentinel], (
-            f"expected the subprocess_executor sentinel, got {seen_executors!r}"
-        )
+        assert seen_executors == [
+            sentinel
+        ], f"expected the subprocess_executor sentinel, got {seen_executors!r}"
 
-    def test_windows_kill_process_tree_async_offloads_via_subprocess_executor(
-        self, monkeypatch
-    ):
+    def test_windows_kill_process_tree_async_offloads_via_subprocess_executor(self, monkeypatch):
         """Same offload contract as kill_pid_async but for the /T variant."""
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
@@ -2688,9 +2820,7 @@ class TestKillAsyncVariants:
         monkeypatch.setattr(
             pc.subprocess,
             "run",
-            lambda *_a, **_kw: types.SimpleNamespace(
-                returncode=0, stdout=b"", stderr=b""
-            ),
+            lambda *_a, **_kw: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
         )
         monkeypatch.setattr(pc, "subprocess_executor", lambda: sentinel)
 
@@ -2907,9 +3037,7 @@ class TestLocalUserId:
         monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-9-8-7-1002")
         assert pc.local_user_id() != first  # and distinct per user
 
-    def test_windows_without_a_sid_collapses_to_zero(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_windows_without_a_sid_collapses_to_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A partition collapse, not a privilege change: the endpoint is already
         per-user, so two users cannot reach the same pool regardless."""
         monkeypatch.setattr(pc, "IS_POSIX", False)
@@ -2993,13 +3121,9 @@ class TestCurrentUserSidNeverSpawns:
 
     @staticmethod
     def _forbid_spawn(*_a, **_kw):
-        raise AssertionError(
-            "current_user_sid must not spawn -- it runs on the event loop"
-        )
+        raise AssertionError("current_user_sid must not spawn -- it runs on the event loop")
 
-    def test_returns_none_without_spawning_when_the_token_read_fails(
-        self, monkeypatch
-    ):
+    def test_returns_none_without_spawning_when_the_token_read_fails(self, monkeypatch):
         monkeypatch.setattr(pc, "_TOKEN_SID_CACHE", [])
         monkeypatch.setattr(pc, "IS_POSIX", False)
         monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
@@ -3092,7 +3216,9 @@ def test_process_descendants_is_best_effort_on_unreadable_table(monkeypatch):
         lambda: (_ for _ in ()).throw(OSError("boom")),
     )
     monkeypatch.setattr(
-        platform_compat, "_windows_process_parent_map", lambda: (_ for _ in ()).throw(OSError("boom"))
+        platform_compat,
+        "_windows_process_parent_map",
+        lambda: (_ for _ in ()).throw(OSError("boom")),
     )
     assert platform_compat.process_descendants(os.getpid()) == []
 
@@ -3634,9 +3760,7 @@ class TestKillProcessTreePinned:
 
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
-        monkeypatch.setattr(
-            pc, "_windows_process_handle_identity", lambda h: (4321, 777, None)
-        )
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda h: (4321, 777, None))
         monkeypatch.setattr(pc, "_close_process_handle", closed.append)
 
         def _gated_kill(pid, sig):
@@ -3676,9 +3800,7 @@ class TestKillProcessTreePinned:
         closed: list[int] = []
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
-        monkeypatch.setattr(
-            pc, "_windows_process_handle_identity", lambda h: (4321, 777, None)
-        )
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda h: (4321, 777, None))
         monkeypatch.setattr(pc, "_close_process_handle", closed.append)
 
         def _raising_kill(pid, sig):
@@ -3712,9 +3834,7 @@ class TestKillProcessTreePinned:
         assert killed == [(4321, pc.SIGTERM)]
         assert opened == [], "no handle work on POSIX"
 
-    def test_the_pinned_identity_is_the_same_half_process_start_time_returns(
-        self, monkeypatch
-    ):
+    def test_the_pinned_identity_is_the_same_half_process_start_time_returns(self, monkeypatch):
         """Both sides must read the CREATION half, or the comparison is nonsense.
 
         ``process_start_time`` records ``str(identity[1])``; if the pin compared
@@ -3731,9 +3851,7 @@ class TestKillProcessTreePinned:
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_open_process_query_handle", lambda pid: self.HANDLE)
         monkeypatch.setattr(pc, "_close_process_handle", lambda h: None)
-        monkeypatch.setattr(
-            pc, "_windows_process_handle_identity", lambda h: (4321, 777, 888)
-        )
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda h: (4321, 777, 888))
         monkeypatch.setattr(pc, "kill_process_tree", lambda pid, sig: True)
 
         recorded = pc.process_start_time(4321)


### PR DESCRIPTION
Closes #5564

## What

The dashboard telemetry aggregator reduces CUMULATIVE observable counters (`kirocrew.process.cpu.seconds`, `kirocrew.process.gc.*`) into per-`(shard PID, attrs)` streams and infers process boundaries from a value dropping below the stream's own max. That value heuristic has one inherent blind spot (#5564, flagged by GPT review on #4788): a reused PID whose new process's first in-window snapshot already exceeds the old process's max produces no drop, so the two lifetimes merge and the gap between them is credited as observed activity.

This PR carries process identity beyond PID in the shards themselves, exactly along the issue's settled design:

1. **`platform_compat.own_process_start_time()`** — a reboot-unique start-time token, read once per process and cached at module scope (PID-keyed so fork children re-read; the OTEL SDK re-installs exporters in fork children). Composition per platform:
   - **Linux**: `/proc` start ticks **+ kernel boot UUID** — ticks count from boot and shards outlive boots, so bare ticks can repeat across reboots.
   - **macOS**: microsecond `proc_pidinfo(PROC_PIDTBSDINFO)` start instant through the existing `libproc` seam, so a PID recycled within one second cannot alias; the 1s `ps -o lstart=` probe remains the fallback.
   - **Windows**: the absolute creation FILETIME (already reboot-unique).
   - The kill-guard primitive `process_start_time()` is deliberately untouched — its comparisons never cross a boot.
2. **`JsonlMetricExporter`** stamps the token once per record at resource level (`kirocrew.process.start_time`, contract constant in `metrics/schema.py`). The stamp lands on the serialized JSONL line, **never on the SDK `Resource`** — that Resource also feeds the opt-in OTLP reader, and this host-local token must not egress. Fail-soft twice over: no readable identity, or a payload that resists mutation, leaves the line untouched (stamping never costs the metric payload).
3. **`_cumulative_series`** keys streams by `(PID, identity, attrs)`: a changed identity for the same PID is a deterministic boundary with its own window-relative baseline; an unchanged identity stitches provider-rebuild segments into one stream. Only string tokens count as identity (a corrupt non-string reads as identity-less rather than muting the heuristic). The value-drop heuristic survives **only** for identity-less legacy shards, which keep their exact totals; within an identity stream a drop is shard garbage, never a reset.

Scope discipline per the issue: no `_gauge_series` refactor, no gauge-semantics changes, no new metrics, no export/prune reshaping.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| (a) reused PID, second process's first sample exceeds first's max ⇒ TWO streams | `test_aggregate_cumulative_identity_splits_reused_pid_without_a_value_drop` (65, not the merged 75) |
| (b) provider rebuild within one process never double-counts | `test_aggregate_cumulative_same_identity_stitches_across_provider_rebuild` (synthetic) + existing `test_observable_counters_survive_provider_rebuild` now exercising the real stamped pipeline |
| (c) legacy shards aggregate unchanged | `test_aggregate_cumulative_legacy_lines_keep_the_value_heuristic` + all four pre-existing cumulative tests pass untouched |
| identity reader, cross-platform, skip-not-fail | `TestOwnProcessStartTime` (cold-cache autouse fixture; Linux boot-scope contract, cross-boot distinctness, unreadable-boot-id degradation, Darwin microtime layout parse + struct-size refusal + platform-gated live read, read-once cache, fork re-read) |

Plus: exporter stamp round-trip + fail-soft absence + mutation-resistant payload; non-string identity regression.

## Pre-push review (two model-pinned subagents)

- **GPT 5.6 Sol — BLOCKING×3, all resolved**: (1) Linux cross-boot (PID, ticks) collision → boot-UUID suffix adopted; (2) macOS 1s `lstart` same-second alias → microsecond `proc_pidinfo` reader adopted (the review's claimed existing `get_process_start_id` primitive does not exist in the codebase — implemented on the existing `_darwin_libproc_handle` seam instead, which is what the issue's design named); (3) non-string identity stringification → string-only tightening + regression test.
- **Opus 5 — PASS + 8 advisories, 7 adopted**: test class re-parented correctly (the Windows terminate-rights test stays in `TestProcessStartTime`), autouse cold-cache fixture, stamp mutation moved inside the fail-soft try (+`TypeError`), post-serialization-stamp OTLP-egress rationale documented, present-tense comment rewording, `stamped` flag avoiding non-SDK re-serialization, per-branch `cval`, docs reflow.

## Verification

- `isort` / `flake8` / `mypy` (1097 files) / black ratchet (4 touched files graduated + pruned from baseline) / brand / harness / subprocess-encoding / docs-lint: all green.
- Targeted: 720 passed (test/metrics/ + test_platform_compat.py + spawn-audit + security-posture contract suites).
- Full backend `pytest`: 66,696 passed; 81 failures + 2 errors reproduced identically on a pristine `origin/main` worktree on this host (AF_UNIX path length, file-explorer/design-tweak host-env set) — pre-existing, not from this diff.

🤖 Generated by Kiro Crew auto-fix pipeline [operator: bolichen97#bb3ad1ca]
