### PR TITLE
fix: harden agent-only refresh in _update with devnull stdin (#5616)

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1231,17 +1231,47 @@ def _update(force: bool = False) -> None:
     print("\n✅ Kiro Crew updated!")
     print(f"\n{DATA_WARNING}\n")
 
-    # Re-install agent config so new denied commands take effect.
-    # Run as subprocess since the current process has old code loaded.
+    _refresh_agent_config(proj)
+
+
+def _refresh_agent_config(proj: str) -> None:
+    """Re-install agent config so new denied commands take effect.
+
+    Runs as a subprocess since the current process has old code loaded. The
+    refresh is best-effort: the update itself has already succeeded, so any
+    failure here downgrades to a warning telling the operator to re-run setup.
+
+    Two hardening properties this call site must keep:
+
+    * ``stdin`` is ``DEVNULL``. With ``capture_output=True`` the child's
+      output is piped into a buffer nobody displays until the call returns,
+      so any prompt it asks is invisible — and with an inherited terminal it
+      would block silently until the timeout. EOF on stdin makes a prompt
+      return immediately instead of hanging (``_input_or_skip`` takes its
+      ``_SetupAborted`` path, which setup treats as a clean skip; a bare
+      ``input()`` gets ``EOFError``), structurally, without relying on every
+      prompt in setup to guard itself with an isatty check.
+    * ``TimeoutExpired`` is caught. It is raised, not returned, so without a
+      handler a slow refresh would traceback out of ``kirocrew update`` right
+      after the success banner printed.
+    """
     print("  🔒 Refreshing agent config…")
-    r = subprocess.run(
-        [sys.executable, "-m", "kiro_crew", "setup", "--agent-only"],
-        cwd=proj,
-        capture_output=True,
-        timeout=30,
-        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
-        **UTF8_TEXT,
-    )
+    try:
+        r = subprocess.run(
+            [sys.executable, "-m", "kiro_crew", "setup", "--agent-only"],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=30,
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "agent-only config refresh timed out after %ss; skipping (best-effort)", exc.timeout
+        )
+        print("  ⚠️  Agent config refresh timed out — run: kirocrew setup --agent-only")
+        return
     if r.returncode == 0:
         print("  ✅ Agent config refreshed (deniedCommands + hooks updated)")
     else:

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -776,8 +776,9 @@ def _setup_sandbox_consent() -> None:
         # Kiro Crew rather than disabling it. Neither warrants this opt-in.
         return
     # A prompt nobody can see is a hang, not consent: `kirocrew update` runs
-    # setup with its output captured while stdin is still inherited, so an
-    # invisible question would block until that path's timeout aborts the update.
+    # setup with its output captured and stdin on DEVNULL, so a question asked
+    # there is invisible and reads EOF. This guard keeps the decision at a real
+    # terminal rather than letting a non-interactive run answer it.
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         print("  ⚠️  No sandbox backend on this host, so agent subprocesses are")
         print("     refused. Run `kirocrew setup` from a terminal to decide, or set")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -808,6 +808,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_server.py::_logs_cmd",
         "cli_server.py::_spawn_detached_gateway",
         "cli_server.py::_update",
+        # The agent-only config refresh extracted from _update: a fixed argv
+        # (`<this interpreter> -m kiro_crew setup --agent-only`) built from
+        # sys.executable plus literals, cwd from the detected install layout —
+        # no shell, no PATH lookup, nothing agent-influenced. stdin=DEVNULL
+        # and TimeoutExpired handling are pinned by
+        # test_update_agent_refresh.py.
+        "cli_server.py::_refresh_agent_config",
         # (_divergence_verdict removed — its counting now delegates to the
         # git_divergence module, allowlisted below, and spawns nothing itself.)
         "cli_server.py::_update_wheel",

--- a/test/test_update_agent_refresh.py
+++ b/test/test_update_agent_refresh.py
@@ -1,0 +1,110 @@
+"""The ``kirocrew update`` agent-only refresh must be hardened at its call site.
+
+The refresh runs ``setup --agent-only`` as a child with ``capture_output=True``,
+so two properties are load-bearing (issue #5616):
+
+* ``stdin`` is redirected to ``DEVNULL`` — a captured-output child must never
+  inherit the parent terminal, or any prompt it asks is invisible and blocks
+  silently until the timeout.
+* ``subprocess.TimeoutExpired`` is swallowed — the refresh is best-effort and
+  runs after the update already succeeded, so a timeout must downgrade to a
+  warning, never traceback out of ``kirocrew update``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+
+from kiro_crew import cli_server
+
+
+class _RunRecorder:
+    """Record the kwargs ``_refresh_agent_config`` passes to ``subprocess.run``."""
+
+    def __init__(self, returncode: int = 0) -> None:
+        self.calls: list[dict] = []
+        self._returncode = returncode
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": argv, **kwargs})
+        completed = subprocess.CompletedProcess(argv, self._returncode, stdout="", stderr="")
+        return completed
+
+
+class TestRefreshAgentConfigStdin:
+    def test_child_stdin_is_devnull(self, monkeypatch, tmp_path) -> None:
+        """The child must read EOF, not the parent terminal.
+
+        Asserted on the recorded kwargs rather than by running a real child:
+        the property under test is the call-site contract itself.
+        """
+        recorder = _RunRecorder()
+        monkeypatch.setattr(cli_server.subprocess, "run", recorder)
+
+        cli_server._refresh_agent_config(str(tmp_path))
+
+        assert len(recorder.calls) == 1
+        call = recorder.calls[0]
+        assert call.get("stdin") is subprocess.DEVNULL
+        # The refresh keeps its pre-existing shape alongside the hardening.
+        assert call.get("capture_output") is True
+        assert call.get("timeout") == 30
+        assert call["argv"][-2:] == ["setup", "--agent-only"]
+
+
+class TestRefreshAgentConfigOutcome:
+    def test_success_path_reports_refreshed(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(cli_server.subprocess, "run", _RunRecorder(returncode=0))
+
+        cli_server._refresh_agent_config(str(tmp_path))
+
+        assert "Agent config refreshed" in capsys.readouterr().out
+
+    def test_nonzero_exit_downgrades_to_warning(self, monkeypatch, tmp_path, capsys) -> None:
+        monkeypatch.setattr(cli_server.subprocess, "run", _RunRecorder(returncode=1))
+
+        cli_server._refresh_agent_config(str(tmp_path))
+
+        assert "Agent config refresh failed" in capsys.readouterr().out
+
+
+class TestRefreshAgentConfigTimeout:
+    def test_timeout_is_swallowed_and_warned(self, monkeypatch, tmp_path, capsys, caplog) -> None:
+        """A timed-out refresh must not raise — the update already succeeded."""
+
+        def _timeout(argv, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout", 30))
+
+        monkeypatch.setattr(cli_server.subprocess, "run", _timeout)
+
+        # The assertion is the absence of an exception; the messages pin the
+        # downgrade path so a silent swallow cannot pass either.
+        cli_server._refresh_agent_config(str(tmp_path))
+
+        out = capsys.readouterr().out
+        assert "Agent config refresh timed out" in out
+        assert "kirocrew setup --agent-only" in out
+        assert any("timed out" in rec.message for rec in caplog.records)
+
+
+class TestUpdateWiring:
+    def test_update_git_path_calls_the_refresh_helper(self) -> None:
+        """``_update()`` must keep routing its refresh through the hardened helper.
+
+        Source-level pin (the pattern test_update_git_guard.py already uses):
+        driving the whole ``_update()`` flow needs a git checkout, a release
+        feed, and an installer, all irrelevant to this contract.
+        """
+        src = inspect.getsource(cli_server._update)
+        assert "_refresh_agent_config(proj)" in src
+
+    def test_the_hardened_helper_is_the_only_agent_only_spawn(self) -> None:
+        """No second, unhardened copy of the refresh anywhere in the module.
+
+        Counted over the whole module rather than asserted absent from
+        ``_update()`` alone, so a future prose mention of the flag in some
+        other branch cannot be misread as a duplicated spawn.
+        """
+        module_src = inspect.getsource(cli_server)
+        assert module_src.count('"setup", "--agent-only"') == 1


### PR DESCRIPTION
## Problem / Motivation

The `setup --agent-only` refresh at the tail of `_update()` in `src/kiro_crew/cli_server.py` runs a child with `capture_output=True` while `stdin` stays inherited, and nothing catches `subprocess.TimeoutExpired` from its `timeout=30`. Two latent gaps at that one call site: any prompt reachable in the child is invisible (output is piped into a buffer nobody displays) yet still reads the parent terminal, so it blocks silently until the timeout. And the timeout itself surfaces as an unhandled traceback rather than the warning at the next line that was written for exactly this case.

Neither gap reproduces on `main` today; the issue is explicit that these are hardening items. The only prompt reachable on the agent-only path already guards itself with an isatty check, so the invariant currently rests on every future prompt author remembering that guard.

## Why it matters

The refresh runs after the "Kiro Crew updated!" success banner, so a timeout means the operator sees success and then a stack trace: the worst-placed failure in `_update()`. And the per-prompt guard has a structural hole: `_input_or_skip` aborts on EOF, which covers piped or closed stdin, but an inherited live terminal never produces EOF, so a future bare `input()` above the agent-only return would hang the update for the full 30 seconds. One call-site change retires the whole class instead of relying on each prompt to guard itself.

## What changed (motivation -> approach -> change)

Symptom to root cause: a captured-output child must never inherit stdin (an invisible prompt is a hang, not a question), and a best-effort refresh must never traceback out of a successful update (`TimeoutExpired` is raised, not returned, and `_update()` has no handler).

The refresh moved into a small helper `_refresh_agent_config(proj)`: same behavior, plus the two hardening properties, and a seam the tests can drive directly without a git checkout, release feed, and installer:

- `stdin=subprocess.DEVNULL`: any child prompt reads EOF and returns immediately instead of hanging (`_input_or_skip` takes its `_SetupAborted` path, a bare `input()` gets `EOFError`), structurally, for every prompt present or future.
- `try/except subprocess.TimeoutExpired`: logs a warning and downgrades to the same "run `kirocrew setup --agent-only`" guidance the non-zero-exit branch already prints, so a slow refresh skips instead of crashing.

Kept minimal per the issue's scope: the other six `subprocess.run` calls in `_update()` and the bare-`input()` sweep in setup are explicitly out of scope. The now-stale comment on `_setup_sandbox_consent`'s isatty guard (which described `kirocrew update` as inheriting stdin) is reworded in the same commit, and the helper's spawn is allowlisted in the spawn audit (fixed argv from `sys.executable` plus literals, nothing agent-influenced).

## Tests

`test/test_update_agent_refresh.py`, all mutation-verified:

- `test_child_stdin_is_devnull`: the call-site contract, `stdin=DEVNULL` plus the pre-existing shape (`capture_output`, `timeout=30`, the `setup --agent-only` argv). Fails when the `stdin=DEVNULL` line is removed.
- `test_timeout_is_swallowed_and_warned`: a `TimeoutExpired` from the child does not propagate; the downgrade path prints the guidance and logs a warning. Fails when the `except` handler is neutered to re-raise.
- `test_success_path_reports_refreshed` / `test_nonzero_exit_downgrades_to_warning`: the pre-existing return-code handling is preserved.
- `test_update_git_path_calls_the_refresh_helper` / `test_the_hardened_helper_is_the_only_agent_only_spawn`: `_update()` routes through the hardened helper and the module contains exactly one `setup --agent-only` spawn (no unhardened second copy).

Local gates green: black baseline, subprocess-encoding, isort, flake8, mypy (touched files clean), brand check, full pytest (the only new red was the spawn-audit key for the extracted helper, fixed in this commit; remaining reds reproduce identically on `origin/main` in this environment, host-capacity and tool-availability asserts, not this change).

## Manual verification

N/A - unit coverage sufficient: the change is a call-site contract on one `subprocess.run` (kwargs plus exception handling), asserted directly at that seam; running a real `setup --agent-only` would mutate the operator's live agent config.

Closes #5616
