### PR TITLE
fix(dashboard): relay the crew-tab stable-order preference into embedded panes

### DIFF
--- a/website/src/components/EmbeddedDragRegionReporter.test.tsx
+++ b/website/src/components/EmbeddedDragRegionReporter.test.tsx
@@ -15,6 +15,7 @@ function model(over: Partial<HostModel> = {}): HostModel {
     macInset: false,
     electron: true,
     pinnedCrews: [],
+    stableOrder: false,
     ...over,
   }
 }

--- a/website/src/components/EmbeddedHostBridge.tsx
+++ b/website/src/components/EmbeddedHostBridge.tsx
@@ -65,6 +65,12 @@ function parseHostModel(data: unknown): HostModel | null {
     pinnedCrews: Array.isArray(d.pinnedCrews)
       ? d.pinnedCrews.filter((id): id is string => typeof id === 'string')
       : [],
+    // Tri-state, mirroring `focusMode` above: a non-boolean (typically absent)
+    // means the host predates this relay, so it has no `mc-set-stable-order`
+    // handler either. `null` records "no opinion" so the bar can order by the
+    // pre-relay default AND withhold a toggle that host could never honor;
+    // coercing to `false` would make the two cases indistinguishable.
+    stableOrder: typeof d.stableOrder === 'boolean' ? d.stableOrder : null,
   }
 }
 

--- a/website/src/components/InstanceTabBar.tsx
+++ b/website/src/components/InstanceTabBar.tsx
@@ -554,8 +554,9 @@ function SwitcherMenu({
             behind a separator so it never reads as one more crew to switch to.
             `onSelect`'s preventDefault keeps the menu open — the user sees the
             checkmark flip and can keep adjusting pins in the same session, the
-            same discipline the per-crew pin toggle uses. Hidden in an embedded
-            pane, where the preference has no host-model relay yet. */}
+            same discipline the per-crew pin toggle uses. In an embedded pane the
+            toggle relays up to the parent (mc-set-stable-order), so it is shown
+            there too. */}
         {showStableOrderToggle ? (
           <>
             <DropdownMenuSeparator />
@@ -886,24 +887,36 @@ function Switcher({
   onTogglePin?: (id: string) => void
   /** Override for the stable-order preference. Defaults to this realm's own
    *  localStorage-backed store; callers that own the preference elsewhere pass
-   *  it explicitly. */
-  stableOrder?: boolean
+   *  it explicitly. An embedded pane passes the value the host relayed, or
+   *  `null` when the host sent no opinion at all (an older parent predating the
+   *  relay, which has no `mc-set-stable-order` handler). `null` orders by the
+   *  pre-relay default and suppresses the toggle -- see `showStableOrderToggle`
+   *  below -- rather than exposing a control that could never take effect. */
+  stableOrder?: boolean | null
   /** Paired toggler for `stableOrder`. */
   onToggleStableOrder?: () => void
   /** True inside a remote pane's embedded switcher. The stable-order preference
-   *  has no host-model relay yet, so a pane toggling it would write only its own
-   *  cross-origin localStorage and drift from the parent header and sibling panes.
-   *  Until that relay exists, an embedded switcher forces the default ordering and
-   *  hides the toggle, rather than exposing a control that silently half-works. */
+   *  is parent-owned and relayed through `mc-host-model` (`stableOrder`), and an
+   *  embedded toggle posts `mc-set-stable-order` back up, so the pane applies and
+   *  offers the same preference as the local bar. The flag only feeds the older-
+   *  host safety net in the resolution above; it no longer hides the toggle. */
   embedded?: boolean
 }) {
   const [storePinned, storeTogglePin] = useCrewPins()
   const pinned = pinnedProp ?? storePinned
   const togglePin = onTogglePinProp ?? storeTogglePin
   const [storeStableOrder, storeToggleStableOrder] = useCrewSwitcherStableOrder()
-  // Embedded panes ignore their own origin's store (it is not the authoritative
-  // preference and would apply inconsistently); everywhere else it is the default.
-  const stableOrder = embedded ? false : (stableOrderProp ?? storeStableOrder)
+  // The stable-order preference is parent-owned. An embedded pane receives it as
+  // a prop relayed through `mc-host-model` (and toggles it back up via
+  // `mc-set-stable-order`), so it no longer reads its own cross-origin store; a
+  // top-level bar falls back to this realm's localStorage-backed store.
+  //
+  // `null` from an embedded pane means the host predates the relay, so it has no
+  // handler for the toggle's message. Offering the control there would let the
+  // user click a checkbox that can never change state, so the pane both orders
+  // by the pre-relay default and hides the toggle in that one case.
+  const relayUnsupported = embedded && (stableOrderProp ?? null) === null
+  const stableOrder = (stableOrderProp ?? (embedded ? false : storeStableOrder)) === true
   const toggleStableOrder = onToggleStableOrderProp ?? storeToggleStableOrder
   const [clippedPinned, setClippedPinned] = useState<Set<string>>(() => new Set())
   const active = entries.find(e => (e.id ?? null) === activeId) ?? entries[0]
@@ -954,7 +967,7 @@ function Switcher({
         clippedPinned={clippedPinned}
         stableOrder={stableOrder}
         onToggleStableOrder={toggleStableOrder}
-        showStableOrderToggle={!embedded}
+        showStableOrderToggle={!relayUnsupported}
       />
     </div>
   )
@@ -979,6 +992,16 @@ function EmbeddedInstanceTabBar({ variant }: { variant: 'strip' | 'inline' }) {
     // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
     window.parent?.postMessage({ type: 'mc-set-crew-pin', v: 1, id }, '*')
   }, [])
+  // The stable-order preference also lives on the parent (one shared value across
+  // every pane). This pane cannot write the parent's store from its own iframe
+  // realm, so it relays the flipped value up and lets the parent re-broadcast the
+  // model back down. `null` = this host predates the relay, which the Switcher
+  // reads as "order by the default and do not offer the toggle at all".
+  const hostStableOrder = host?.stableOrder ?? null
+  const onToggleStableOrder = useCallback(() => {
+    // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+    window.parent?.postMessage({ type: 'mc-set-stable-order', v: 1, on: !hostStableOrder }, '*')
+  }, [hostStableOrder])
   const entries = useMemo<SwitcherEntry[]>(() => {
     if (!host) return []
     return [
@@ -1015,6 +1038,8 @@ function EmbeddedInstanceTabBar({ variant }: { variant: 'strip' | 'inline' }) {
         onSelect={onSelect}
         pinned={pinnedFromHost}
         onTogglePin={onTogglePin}
+        stableOrder={hostStableOrder}
+        onToggleStableOrder={onToggleStableOrder}
         embedded
       />
     </div>

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -36,7 +36,7 @@ import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { api } from '../api/client'
 import { useAppDispatch, useAppSelector } from '../store'
 import { removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
-import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin } from './InstanceTabBar'
+import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { LINUX_CAPTION_CONTROLS_WIDTH, TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
@@ -87,6 +87,11 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // Stable array identity per pin change, so the model memo below does not
   // re-broadcast on every render.
   const pinnedCrews = useMemo(() => [...pinnedCrewSet], [pinnedCrewSet])
+  // The crew-switcher "keep tab order fixed" preference, relayed into every
+  // embedded pane so a remote pane's bar orders its chips the same way the local
+  // bar does. Reactive like the pins: a change re-broadcasts the model, and an
+  // embedded toggle routes back here via `mc-set-stable-order`.
+  const [stableOrder] = useCrewSwitcherStableOrder()
   // Focus mode is a property of the WINDOW, not of one pane: a remote crew shown
   // inside a focused window must hide its chrome too. Relayed down the host model
   // below, and it also gates the host drag strips (see their render site).
@@ -239,6 +244,15 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // panes) via the module store, keeping the set one shared value.
         const id = (data as { id?: unknown }).id
         if (typeof id === 'string' && id) toggleCrewPin(id)
+      } else if (data.type === 'mc-set-stable-order') {
+        // The "keep tab order fixed" toggle was flipped inside an embedded pane.
+        // Like the pin, it has no access to the parent's preference store from
+        // its own iframe realm, so it relays the desired value here; applying it
+        // broadcasts to every bar (local header + all panes) via the module
+        // store, keeping the preference one shared value. Idempotent, so the
+        // model re-broadcast's return trip to the sending pane is a no-op.
+        const on = (data as { on?: unknown }).on
+        if (typeof on === 'boolean') setStableOrder(on)
       } else if (data.type === 'mc-set-focus-mode') {
         // Focus mode was toggled inside an embedded pane. It belongs to the WINDOW,
         // not to one pane, so applying it here is what makes the state one shared
@@ -454,9 +468,10 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // Array, not the Set itself: structured clone rejects a Set across this
         // boundary in some engines and the receiver validates element-wise anyway.
         pinnedCrews,
+        stableOrder,
       }
     },
-    [instancesQuery.data, warm, unread, activeId, macInset, focusMode, pinnedCrews],
+    [instancesQuery.data, warm, unread, activeId, macInset, focusMode, pinnedCrews, stableOrder],
   )
 
   // Post the model into one embedded pane, addressed to its exact loopback
@@ -483,7 +498,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   // to a loopback frame.
   useEffect(() => {
     for (const id of Object.keys(warm)) postModelTo(id)
-  }, [warm, activeId, unread, macInset, instancesQuery.data, postModelTo, pinnedCrews])
+  }, [warm, activeId, unread, macInset, instancesQuery.data, postModelTo, pinnedCrews, stableOrder])
 
   // Keep warm iframes mounted across Local<->remote switches (hide-not-unmount).
   // Also render when the active tab is a remote instance with no warm iframe

--- a/website/src/store/instancesSlice.ts
+++ b/website/src/store/instancesSlice.ts
@@ -72,6 +72,18 @@ export interface HostModel {
    *  `mc-set-crew-pin` back up so the set stays one shared value across every
    *  pane. A plain array because postMessage cannot carry a Set. */
   pinnedCrews: string[]
+  /** The parent's "keep tab order fixed" preference, relayed so the embedded bar
+   *  applies the same ordering as the local bar instead of always reshuffling on
+   *  switch (its own cross-origin-iframe localStorage the parent can never
+   *  reach). An embedded toggle posts `mc-set-stable-order` back up so the value
+   *  stays one shared preference across every pane.
+   *
+   *  Tri-state on purpose, exactly like `focusMode` above: `null` means the host
+   *  SENT NO OPINION — an older parent whose model predates this field, and which
+   *  therefore also has no `mc-set-stable-order` handler. Coercing that absence
+   *  to `false` would leave the pane offering a toggle the host can never honor,
+   *  so `null` orders by the pre-relay default AND hides the control instead. */
+  stableOrder: boolean | null
 }
 
 interface InstancesState {

--- a/website/src/test/EmbeddedSwitcher.test.tsx
+++ b/website/src/test/EmbeddedSwitcher.test.tsx
@@ -22,6 +22,7 @@ const model = (over: Partial<HostModel> = {}): HostModel => ({
   macInset: false,
   electron: true,
   pinnedCrews: [],
+  stableOrder: false,
   ...over,
 })
 
@@ -93,18 +94,86 @@ describe('EmbeddedInstanceTabBar (option B)', () => {
     expect(screen.queryByTestId('crew-chip-row')).toBeNull()
   })
 
-  it('does not offer the stable-order toggle, which has no host-model relay yet', async () => {
-    // The stable-order preference is not relayed through the host model, so a
-    // pane toggling it would write only its own cross-origin localStorage and
-    // drift from the parent header and sibling panes. Until that relay exists the
-    // embedded switcher hides the control rather than half-working.
+  it('offers the stable-order toggle and reflects the relayed value', async () => {
+    // The preference is relayed through the host model (`stableOrder`), so the
+    // embedded switcher shows the same control the local bar does, pre-checked to
+    // the parent's value rather than reading its own cross-origin localStorage.
     const store = createTestStore({
-      instances: { warm: {}, activeId: null, mru: [], unread: {}, host: model({ activeId: null }) },
+      instances: {
+        warm: {}, activeId: null, mru: [], unread: {},
+        host: model({ activeId: null, stableOrder: true }),
+      },
     })
     renderWithProviders(<InstanceTabBar variant="inline" />, { store })
     await userEvent.click(screen.getByRole('button', { name: /Switch crew/i }))
+    const toggle = await screen.findByTestId('crew-stable-order-toggle')
+    expect(toggle).toBeTruthy()
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('withholds the stable-order toggle from a host that predates the relay', async () => {
+    // Version skew, host side: an older parent omits `stableOrder` from its model
+    // AND has no `mc-set-stable-order` handler. Offering the toggle there would
+    // let the user click a checkbox that can never change state, so absence
+    // (parsed to `null`) both orders by the pre-relay default and hides it.
+    const store = createTestStore({
+      instances: {
+        warm: {}, activeId: null, mru: [], unread: {},
+        host: model({ activeId: null, stableOrder: null }),
+      },
+    })
+    const { container } = renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+    await userEvent.click(screen.getByRole('button', { name: /Switch crew/i }))
     await screen.findByRole('menuitemradio', { name: /Cloud One/ })
     expect(screen.queryByTestId('crew-stable-order-toggle')).toBeNull()
+    // Ordering falls back to the pre-relay default: the active crew still leads.
+    expect(container.querySelector('.tb-crew-active-chip')).not.toBeNull()
+  })
+
+  it('relays a stable-order toggle up to the parent instead of writing its own store', async () => {
+    const post = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore({
+      instances: {
+        warm: {}, activeId: null, mru: [], unread: {},
+        // Relayed value is off, so flipping it must post `on: true` up. Like the
+        // pin, the pane cannot persist the parent-owned preference locally.
+        host: model({ activeId: null, stableOrder: false }),
+      },
+    })
+    renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+
+    await userEvent.click(screen.getByRole('button', { name: /Switch crew/i }))
+    await userEvent.click(await screen.findByTestId('crew-stable-order-toggle'))
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mc-set-stable-order', on: true }),
+      '*',
+    )
+  })
+
+  it('does NOT pull the active pinned crew to a leading chip when stable-order is relayed on', () => {
+    // The exact runtime scenario the relay must fix: a CONNECTED remote crew is
+    // the active pane, it is pinned, and the parent relays stableOrder=true. The
+    // active crew must be highlighted in place inside the chip row, never hoisted
+    // to a leading `tb-crew-active-chip` — that hoist is the reorder-on-switch.
+    const store = createTestStore({
+      instances: {
+        warm: {}, activeId: null, mru: [], unread: {},
+        host: model({ activeId: 'cd-1', pinnedCrews: ['cd-1'], stableOrder: true }),
+      },
+    })
+    const { container } = renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+    expect(container.querySelector('.tb-crew-active-chip')).toBeNull()
+  })
+
+  it('DOES lead with the active crew when stable-order is relayed off (proves the mechanism)', () => {
+    const store = createTestStore({
+      instances: {
+        warm: {}, activeId: null, mru: [], unread: {},
+        host: model({ activeId: 'cd-1', pinnedCrews: ['cd-1'], stableOrder: false }),
+      },
+    })
+    const { container } = renderWithProviders(<InstanceTabBar variant="inline" />, { store })
+    expect(container.querySelector('.tb-crew-active-chip')).not.toBeNull()
   })
 
   it('relays a pin toggle up to the parent instead of writing its own store', async () => {
@@ -140,12 +209,13 @@ describe('EmbeddedHostBridge (option B relay)', () => {
       window.dispatchEvent(
         new MessageEvent('message', {
           source: window.parent,
-          data: { type: 'mc-host-model', ...model({ macInset: true, self: { state: 'connected' } }) },
+          data: { type: 'mc-host-model', ...model({ macInset: true, self: { state: 'connected' }, stableOrder: true }) },
         }),
       )
     })
     await waitFor(() => expect(store.getState().instances.host?.tabs).toHaveLength(1))
     expect(store.getState().instances.host?.macInset).toBe(true)
+    expect(store.getState().instances.host?.stableOrder).toBe(true)
     expect(document.documentElement.classList.contains('embedded-mac-inset')).toBe(true)
   })
 
@@ -197,5 +267,33 @@ describe('EmbeddedHostBridge (option B relay)', () => {
     } finally {
       __resetFocusMode()
     }
+  })
+
+  it('records a missing stableOrder as null rather than false', async () => {
+    // The pane must be able to tell "host says off" from "host never sent it":
+    // only the latter means the host has no mc-set-stable-order handler, and the
+    // bar keys the toggle's visibility off exactly that distinction.
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const store = createTestStore()
+    renderWithProviders(<EmbeddedHostBridge />, { store })
+
+    const { stableOrder: _omitted, ...withoutStableOrder } = model()
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: window.parent,
+        data: { type: 'mc-host-model', ...withoutStableOrder },
+      }))
+    })
+    await waitFor(() => expect(store.getState().instances.host?.tabs).toHaveLength(1))
+    expect(store.getState().instances.host?.stableOrder).toBeNull()
+
+    // An explicit false IS an opinion and is preserved as false.
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: window.parent,
+        data: { type: 'mc-host-model', ...model({ stableOrder: false }) },
+      }))
+    })
+    await waitFor(() => expect(store.getState().instances.host?.stableOrder).toBe(false))
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The crew-tab **"Keep tab order fixed"** preference (shipped in #5343) only worked in the top-level dashboard header. As soon as a remote crew was connected and active, clicking its tab still reshuffled the row — the exact behaviour the toggle exists to prevent.

Root cause: a connected remote crew renders its **own** switcher inside a cross-origin iframe served by that crew's gateway. #5343 deliberately shipped an `embedded` guard that forced the default active-first ordering and hid the toggle in those panes, because the preference had no way to cross the frame boundary — a pane reading its own origin's `localStorage` would silently drift from the parent header. That guard was correct, but it left the preference simply not applying wherever a remote crew was on screen.

## Why it matters

Users who pin several crews and switch between them constantly are the ones who turn this preference on, and a connected remote crew is precisely where they spend their time. The toggle reads as broken: it is checked, the crews are pinned, and the row still jumps on every switch. The `expanded` and `pinnedCrews` preferences already cross this boundary through the `mc-host-model` relay, so the inconsistency is also visible between sibling controls in the same dropdown.

## What changed (motivation → approach → change)

**Symptom:** toggle on, crews pinned, clicking a connected remote crew still reorders the row.

**Root cause:** the embedded bar is a separate document with its own `localStorage`, so it never saw the parent's preference. #5343's `embedded` guard therefore pinned it to the default ordering.

**Change:** carry the preference across the boundary on the relay that already exists for exactly this class of parent-owned preference, mirroring `pinnedCrews` (#3665) end to end:

- `HostModel` gains `stableOrder`; `InstancesViewport` includes it in the broadcast model and accepts `mc-set-stable-order` back from a pane (validated `boolean`, applied through the shared module store so every bar — header and all panes — flips together).
- `EmbeddedHostBridge` parses the field; `EmbeddedInstanceTabBar` applies it and offers the toggle, replacing the `embedded`-forces-default guard.

**One deliberate subtlety — the field is tri-state (`boolean | null`), not a plain boolean.** The two halves of this relay live on *different machines* that upgrade independently: the sender is the local dashboard, the receiver is the remote crew's gateway. So an upgraded pane will meet an older parent that omits the field *and* has no `mc-set-stable-order` handler. Coercing that absence to `false` would leave the pane rendering a toggle whose every click is dropped — a permanently dead control. `null` records "the host sent no opinion", which lets the pane order by the pre-relay default **and** withhold the toggle in that one case, while an explicit `false` from a supporting host is still honoured as off. This follows the tri-state `focusMode` field already in the same parser, which exists for the same version-skew reason.

## Tests

`website/src/test/EmbeddedSwitcher.test.tsx` (+4 cases, all in the embedded-pane suite):

- **Relayed value is applied and offered** — a host relaying `stableOrder: true` shows the toggle pre-checked, proving the pane no longer reads its own store.
- **Toggle relays up, never persists locally** — flipping it posts `mc-set-stable-order` with the inverted value instead of writing the iframe origin's `localStorage`.
- **Older host is not offered a dead control** — a model omitting the field hides the toggle *and* keeps the pre-relay active-leads ordering (asserted after opening the menu, so absence cannot pass from an unrendered menu).
- **Parser keeps absence distinguishable from off** — a missing field records `null` while an explicit `false` stays `false`; this is what makes the previous case decidable.

The pre-existing `EmbeddedSwitcher` case that locked in "no toggle in embedded panes" is **replaced**, since that guard is what this PR removes; its intent is preserved by the older-host case above. Fixtures in `EmbeddedDragRegionReporter.test.tsx` carry the new field.

Full frontend suite green: 1517 files / 23673 tests, 0 failed. `tsc -b`, eslint (647/664 warnings), `i18n:check`, jscpd and the production build all pass.

## Manual verification

The originating report was verified from the running app rather than from tests, which is how the true root cause was found. The local parent bar was instrumented and logged 96/96 renders with an identical chip order and the active-crew hoist never firing — proving the local half was already correct and isolating the fault to the embedded pane. `curl` against the four live tunnel ports then confirmed those gateways served a bundle with `mc-set-stable-order` absent, i.e. the receiving half genuinely did not exist yet.

End-to-end behaviour of this diff cannot be fully exercised on one machine, because it needs a parent and a remote gateway **both** running this code — that is the deployment step this PR unblocks, not something it can self-verify. The version-skew path (older parent + upgraded pane) is covered by unit tests instead, since it is a pure function of the relayed model.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no rendered delta on any surface a screenshot can reach. In the default configuration (preference off) the row is pixel-identical; with it on, the change is only visible inside a *connected remote crew's* pane, which requires a second machine running this same build — and #5343 already carries the SHA-pinned screenshots of the ordering behaviour itself. The one new visual state is the toggle's presence in an embedded dropdown, which the added tests assert directly.

## Related Issues

no linked issue: follow-up to #5343, which shipped the top-level half and explicitly deferred the embedded-pane relay.

## Checklist

- [x] Single commit, Conventional Commits title
- [x] Tests added/updated for the new behaviour
- [x] No new i18n keys (reuses `components.instanceTabBar.keep_tab_order_fixed` from #5343)
- [x] `tsc -b`, eslint, i18n parity, jscpd and production build green locally
