### PR TITLE
docs: add focus-mode verification checklist to the desktop-app build docs

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -476,6 +476,39 @@ The command-palette trigger is positioned from the window midpoint rather than
 the remaining flex space, so asymmetric menu and status controls do not shift it.
 Linux retains the window manager's native frame and menu bar.
 
+#### Focus mode: verify these seams after an Electron or Radix bump
+
+Focus mode (hide the shell chrome behind hover) rests on three mechanisms that
+key on behavior no API contract guarantees, and each fails **silently** — the
+unit tests mock these seams, so a broken one still passes CI and only manual
+macOS testing catches it. Run this short checklist whenever you bump Electron or
+Radix (`website/electron/package.json`, `@radix-ui/*` in `website/package.json`):
+
+1. **Toggle focus mode, then drag the revealed header to move the window.**
+   Exercises the drag-region re-send in
+   [`website/electron/focus-chrome.js`](../../website/electron/focus-chrome.js):
+   Electron's `setWindowButtonVisibility` mutates the window styleMask and drops
+   the renderer's declared `-webkit-app-region:drag` regions, so the renderer
+   re-declares them by briefly adding a 1px drag element. If a bump changes when
+   Chromium re-sends the region set, the revealed header selects text instead of
+   moving the window.
+2. **Peek the header, then move the pointer down into the content.** The header
+   should close. Peek the rail, then move the pointer right past the rail track —
+   it should close too. Exercises the **positional** close in
+   [`website/src/App.tsx`](../../website/src/App.tsx) (`departWhen: clientY > 48`
+   for the top peek, `clientX > 248` for the rail): the revealed header doubles
+   as the drag surface and a drag region eats pointer events before hit-testing,
+   so the close is driven by pointer position, not by `mouseleave`. If a bump
+   changes hover/pointer-event delivery, the peek sticks open or never opens.
+3. **Peek the header, then open the instance switcher.** The header must stay on
+   screen while the switcher menu is open. Exercises the header-pin heuristic in
+   [`website/src/App.tsx`](../../website/src/App.tsx): Radix portals the menu to
+   `document.body`, so the pin rides on a `[aria-haspopup][aria-expanded="true"]`
+   query against the header rather than DOM containment. If a Radix bump changes
+   the ARIA a trigger emits (`aria-haspopup` absent, or `aria-expanded="true"`
+   emitted by default with nothing open), the header either slides away under the
+   open menu or pins permanently from first paint.
+
 ### `find-bin.js` — locating the binary
 
 `findKirocrewBin()` checks well-known paths in order and returns the first


### PR DESCRIPTION
## Problem / Motivation

Three focus-mode mechanisms in the macOS desktop shell key on behavior that no
API contract guarantees, and each fails silently. The unit tests mock these
seams, so a break still passes CI and surfaces only in manual macOS testing.
There is no documentation prompting that manual check when Electron or Radix is
bumped -- the exact bumps most likely to break these seams.

## Why it matters

An Electron or Radix upgrade can regress focus mode with no red CI signal: the
revealed header stops being draggable, the peek overlay sticks open, or the
header slides away under the open instance switcher. Without a checklist tied to
the upgrade, the regression ships and is only noticed by a user on macOS.

## What changed (motivation -> approach -> change)

Docs-only. Added a "Focus mode: verify these seams after an Electron or Radix
bump" checklist to the Native window chrome section of
`docs/build/desktop-app.md`. Content is exactly the three checks the issue
enumerates, each tied to the seam it exercises and verified against main:

- Drag-region re-send in `website/electron/focus-chrome.js`:
  `setWindowButtonVisibility` mutates the window styleMask and drops the
  renderer's declared `-webkit-app-region:drag` regions, so the renderer
  re-declares them via a transient 1px drag element. Check: toggle focus mode,
  drag the revealed header to move the window.
- Positional peek-close thresholds in `website/src/App.tsx`
  (`departWhen: clientY > 48` top, `clientX > 248` rail): the drag region eats
  pointer events before hit-testing, so the close is position-driven, not
  `mouseleave`-driven. Check: peek, then move the pointer out of the band.
- Header-pin heuristic in `website/src/App.tsx`: Radix portals the menu to
  `document.body`, so the pin rides on a `[aria-haspopup][aria-expanded="true"]`
  query. Check: peek the header, open the instance switcher, header must stay.

## Tests

None. These seams can only be verified by manual macOS interaction (which is the
entire reason the issue asks for a checklist rather than a test); the unit tests
mock them. No code changed, so there is no regression test to add.

## Manual verification

N/A for this PR's own change (documentation only). The checklist itself is the
manual procedure, to be run on a future Electron/Radix bump.

## Related Issues

Fixes #4651

## Checklist

- [x] Single commit with a Conventional Commits title (`docs: ...`)
