### PR TITLE
fix(dashboard): stop leaking raw exception text into client error fields

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1373,
+    "missing_code": 1370,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1062,
+  "_compliant": 1078,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -107,7 +107,7 @@
     },
     "dashboard/handlers/mcp.py": {
       "dynamic_status": 1,
-      "missing_code": 36
+      "missing_code": 34
     },
     "dashboard/handlers/mcp_apps.py": {
       "dynamic_status": 1,
@@ -166,7 +166,7 @@
     },
     "dashboard/handlers/themes.py": {
       "dynamic_status": 4,
-      "missing_code": 24
+      "missing_code": 23
     },
     "dashboard/handlers/updates.py": {
       "missing_code": 9

--- a/src/kiro_crew/dashboard/handlers/diagnostics.py
+++ b/src/kiro_crew/dashboard/handlers/diagnostics.py
@@ -66,10 +66,13 @@ async def api_diagnostics_collect(request: web.Request) -> web.Response:
             include_logs=include_logs,
             output_dir=_diagnostics_dir(),
         )
-    except Exception as exc:  # pragma: no cover - defensive
+    except Exception:  # pragma: no cover - defensive
         logger.exception("diagnostics collection failed")
+        # The dashboard renders ``error`` verbatim into a localized UI, so raw
+        # exception text (which can carry paths or internal detail) must not
+        # reach the client. The detail stays in the server log above.
         return web.json_response(
-            {"error": f"collection failed: {exc}", "code": "collection_failed"},
+            {"error": "collection failed", "code": "collection_failed"},
             status=500,
         )
 

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -2418,7 +2418,11 @@ async def api_mcp_gateway_enable(request: web.Request) -> web.Response:
                 source="dashboard",
                 resources=f"enabled={enabled} error={exc}",
             )
-            return web.json_response({"error": f"apply failed: {exc}"}, status=500)
+            # The exception detail is in the SEL log above; the client body
+            # (rendered verbatim into a localized UI) gets a generic message.
+            return web.json_response(
+                {"error": "apply failed", "code": "mcp_apply_failed"}, status=500
+            )
 
     sel().log_api_access(
         caller=request.get("user", "dashboard"),
@@ -3061,8 +3065,11 @@ async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:
         except ConfigReadError:
             return web.json_response({"error": "config.json is corrupt"}, status=500)
         except OSError as exc:
+            # OSError can carry a filesystem path; keep it server-side and send
+            # the client a generic message (rendered verbatim into a localized UI).
+            logger.warning("mcp config lock failed: %s", exc)
             return web.json_response(
-                {"error": f"could not lock config.json: {exc}", "code": "config_lock_failed"},
+                {"error": "could not lock config.json", "code": "config_lock_failed"},
                 status=503,
             )
 
@@ -3093,7 +3100,11 @@ async def api_mcp_gateway_set_stub(request: web.Request) -> web.Response:
                     source="dashboard",
                     resources=f"{audited} stub={stub} error={exc}",
                 )
-                return web.json_response({"error": f"apply failed: {exc}"}, status=500)
+                # Detail is in the SEL log above; the verbatim-rendered client
+                # body gets a generic message.
+                return web.json_response(
+                    {"error": "apply failed", "code": "mcp_apply_failed"}, status=500
+                )
         elif not nothing_written:
             # No callback means no gateway wired this process -- but the allowlist
             # was already persisted above, so the change WAS recorded and takes

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -724,14 +724,16 @@ async def api_memory_embedding_model(request: web.Request) -> web.Response:
 
     try:
         store = await _get_vector_store_async(state)
-    except Exception as exc:  # noqa: BLE001 - surfaced to the caller, not swallowed
+    except Exception:  # noqa: BLE001 - surfaced to the caller, not swallowed
         # Acquire the store BEFORE begin_apply(). If this raised after the
         # progress tracker was armed, is_active() would stay true for the rest of
         # the process lifetime and every later apply would 409 while the card
         # polled an indeterminate bar forever.
         logger.warning("Embedding model apply: vector store unavailable", exc_info=True)
+        # Detail is in the server log above; the client body (rendered verbatim
+        # into a localized UI) gets a generic message.
         return web.json_response(
-            {"ok": False, "error": f"vector memory is unavailable: {exc}",
+            {"ok": False, "error": "vector memory is unavailable",
              "code": "vector_store_unavailable"},
             status=503,
         )

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -633,12 +633,14 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     try:
 
         image = await asyncio.to_thread(render_qr_data_uri, url)
-    except Exception as exc:
+    except Exception:
         logger.debug("tailnet mobile QR encode failed", exc_info=True)
         _audit(request, "tailnet.mobile.qr", "denied", "encode-failed")
+        # Detail is in the server log above; the client body (rendered verbatim
+        # into a localized UI) gets a generic message.
         return web.json_response(
             {
-                "error": f"Could not render the QR code: {exc}",
+                "error": "Could not render the QR code",
                 "code": "encode_failed",
             },
             status=500,

--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 import shutil
@@ -68,6 +69,8 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+logger = logging.getLogger(__name__)
 
 # Theme install/serve traverses the O_NOFOLLOW + fd-real-path chokepoint in
 # hooks (safe_read_file_bytes_nolink), which has no Windows implementation
@@ -682,8 +685,12 @@ async def api_theme_detail(request: web.Request) -> web.Response:
             discovery_executor(), _validate_theme_dir, dir_target
         )
         if err or summary is None:
+            # ``err`` can name the on-disk theme directory; keep it server-side
+            # and send the client a generic message (rendered verbatim in the UI).
+            logger.warning("invalid installed theme: %s", err)
             return web.json_response(
-                {"error": f"invalid installed theme: {err}"}, status=500
+                {"error": "invalid installed theme", "code": "invalid_installed_theme"},
+                status=500,
             )
         manifest, _m_err = await loop.run_in_executor(
             discovery_executor(),

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -1665,7 +1665,10 @@ def _parse_sessions() -> dict:
     try:
         entries = list(sessions_dir.iterdir())
     except OSError as exc:
-        return {"error": f"Cannot read sessions directory: {exc}"}
+        # The OSError carries a filesystem path; keep it server-side and return
+        # a generic message (the ``error`` field is rendered verbatim in the UI).
+        logger.warning("usage: cannot read sessions directory: %s", exc)
+        return {"error": "cannot read sessions directory", "code": "sessions_dir_unreadable"}
 
     for f in entries:
         if f.suffix != ".jsonl":

--- a/src/kiro_crew/dashboard/handlers/worktree.py
+++ b/src/kiro_crew/dashboard/handlers/worktree.py
@@ -633,7 +633,10 @@ def _create_worktree_sync(root: str, branch: str) -> tuple[dict, int]:
         return ({"error": f"Directory already exists: {dest}"}, 409)
     except OSError as exc:
         _cleanup_partial(root, dest, branch, claimed=True, created=False, base_sha=base_sha)
-        return ({"error": f"Cannot create {dest}: {exc.strerror or exc}"}, 500)
+        # The OSError detail and destination path stay server-side; the client
+        # body (rendered verbatim in the UI) gets a generic message + code.
+        logger.warning("worktree create failed: %s", exc)
+        return ({"error": "cannot create worktree directory", "code": "worktree_mkdir_failed"}, 500)
 
     try:
         proc = _run_git(["worktree", "add", dest, branch], root)

--- a/test/test_dashboard_themes_coverage.py
+++ b/test/test_dashboard_themes_coverage.py
@@ -994,7 +994,12 @@ class TestApiThemeDetailGet:
         _write_json(themes_dir / "lcars" / "theme.json", {"name": "LCARS"})
         resp = await th.api_theme_detail(_detail("GET", "lcars"))
         assert resp.status == 500
-        assert _body(resp)["error"].startswith("invalid installed theme:")
+        # The client body carries a generic message + machine code; the raw
+        # validation detail (which can name the on-disk theme dir) stays in the
+        # server log, not the verbatim-rendered `error` field.
+        body = _body(resp)
+        assert body["error"] == "invalid installed theme"
+        assert body["code"] == "invalid_installed_theme"
 
     @pytest.mark.asyncio
     async def test_manifest_read_failure_falls_back_to_an_empty_manifest(

--- a/test/test_dashboard_worktree_coverage.py
+++ b/test/test_dashboard_worktree_coverage.py
@@ -767,21 +767,27 @@ class TestCreateWorktreeSync:
             (sync_env.dest, "feat/x", {"claimed": True, "created": False, "base_sha": "c0ffee"})
         ]
 
-    def test_mkdir_oserror_is_a_500_reporting_strerror(self, sync_env, monkeypatch):
+    def test_mkdir_oserror_is_a_500(self, sync_env, monkeypatch):
         def denied(path, *a, **kw):
             raise PermissionError(13, "Permission denied")
 
         monkeypatch.setattr(wt.os, "mkdir", denied)
         payload, status = wt._create_worktree_sync(sync_env.root, "feat/x")
         assert status == 500
-        assert "Permission denied" in payload["error"]
+        # The OSError strerror + destination path stay server-side; the client
+        # body (rendered verbatim in the UI) gets a generic message + code.
+        assert "Permission denied" not in payload["error"]
+        assert payload["error"] == "cannot create worktree directory"
+        assert payload["code"] == "worktree_mkdir_failed"
         assert sync_env.cleanups[0][2]["created"] is False
 
-    def test_mkdir_oserror_without_strerror_still_reports(self, sync_env, monkeypatch):
+    def test_mkdir_oserror_without_strerror_still_500(self, sync_env, monkeypatch):
         monkeypatch.setattr(wt.os, "mkdir", MagicMock(side_effect=OSError("odd failure")))
         payload, status = wt._create_worktree_sync(sync_env.root, "feat/x")
         assert status == 500
-        assert "odd failure" in payload["error"]
+        assert "odd failure" not in payload["error"]
+        assert payload["error"] == "cannot create worktree directory"
+        assert payload["code"] == "worktree_mkdir_failed"
 
     def test_a_timeout_cleans_up_and_re_raises(self, sync_env):
         sync_env.add_raises = subprocess.TimeoutExpired(["git"], wt._GIT_TIMEOUT)

--- a/test/test_handler_error_no_exception_leak.py
+++ b/test/test_handler_error_no_exception_leak.py
@@ -1,0 +1,128 @@
+"""Regression: dashboard handlers must not interpolate raw exception text into
+the client-visible ``error`` field.
+
+The dashboard renders the ``error`` field of a 4xx/5xx JSON body verbatim into a
+localized UI, so raw driver/exception text (which can carry filesystem paths, SQL
+fragments, or hostnames) must never reach the client, and the prose is
+untranslatable besides. The fix at each site is the subtraction PR #5600 shipped
+in ``knowledge.import_bundle``: a generic fixed ``error`` message plus a
+machine-readable ``code``, with the exception detail going to the server log.
+
+Follow-up from the First Principles review on PR #5600. See issue #5644.
+
+These are source-level guards rather than end-to-end handler drives: the eight
+sites live in six handlers with six different app-setup requirements, and the
+property under test -- "no raw exception object is formatted into the ``error``
+field" -- is a property of the source at each site, so asserting it on the source
+is both precise and stable across refactors of the surrounding harness. Each
+assertion fails on the pre-fix code (which read ``f"...{exc}"``) and passes after.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from kiro_crew.dashboard.handlers import (
+    diagnostics,
+    mcp,
+    memory,
+    tailnet_mobile,
+    themes,
+    usage,
+    worktree,
+)
+
+
+def _error_field_values(func) -> list[ast.expr]:
+    """Return the AST node for every ``"error": <value>`` pair in ``func``.
+
+    Walks the function body for dict literals and collects the value node keyed
+    by the string literal ``"error"`` -- that is the field the dashboard renders
+    verbatim.
+    """
+    tree = ast.parse(inspect.getsource(func).lstrip())
+    values: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for key, val in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "error":
+                    values.append(val)
+    return values
+
+
+def _formats_an_exception(value: ast.expr) -> bool:
+    """True if an ``"error"`` value is an f-string interpolating the exception.
+
+    A plain string constant is safe, and so is an f-string that interpolates a
+    validated request value or a fixed limit constant (``{name!r}``,
+    ``{_MAX_STUB_BATCH}``) -- those carry no internal detail. What must never
+    reach the client is the caught exception itself, conventionally bound as
+    ``exc``, ``e`` or ``err``. This mirrors the reviewer's own grep on PR #5600
+    (``error.*\\{(exc|e|err)\\}``) but is stricter: it also unwraps a ``BoolOp``
+    or conditional so ``{exc.strerror or exc}`` is caught, a spelling that grep
+    (and a naive matcher) misses. Flag a ``FormattedValue`` whose interpolated
+    expression is one of those names, an attribute/call rooted at one
+    (``{exc.strerror}``), or such a name anywhere inside a boolean/conditional.
+    """
+    _EXC_NAMES = {"exc", "e", "err"}
+
+    def _roots_at_exception(expr: ast.expr) -> bool:
+        # Peel attribute/call/subscript wrappers down to the root name.
+        while isinstance(expr, (ast.Attribute, ast.Call, ast.Subscript)):
+            if isinstance(expr, ast.Attribute):
+                expr = expr.value
+            elif isinstance(expr, ast.Call):
+                expr = expr.func
+            else:
+                expr = expr.value
+        if isinstance(expr, ast.Name):
+            return expr.id in _EXC_NAMES
+        # `exc.strerror or exc`, `exc or ""`, `exc if cond else ""` -- any operand
+        # that is exception-rooted makes the whole f-string a leak.
+        if isinstance(expr, ast.BoolOp):
+            return any(_roots_at_exception(v) for v in expr.values)
+        if isinstance(expr, ast.IfExp):
+            return _roots_at_exception(expr.body) or _roots_at_exception(expr.orelse)
+        return False
+
+    if not isinstance(value, ast.JoinedStr):
+        return False
+    for part in value.values:
+        if isinstance(part, ast.FormattedValue) and _roots_at_exception(part.value):
+            return True
+    return False
+
+
+# (handler function, at least one machine code that must appear in its source)
+_FIXED_SITES = [
+    (diagnostics.api_diagnostics_collect, "collection_failed"),
+    (mcp.api_mcp_gateway_enable, "mcp_apply_failed"),
+    (mcp.api_mcp_gateway_set_stub, "config_lock_failed"),
+    (memory.api_memory_embedding_model, "vector_store_unavailable"),
+    (tailnet_mobile.api_tailnet_mobile_qr, "encode_failed"),
+    (themes.api_theme_detail, "invalid_installed_theme"),
+    (usage._parse_sessions, "sessions_dir_unreadable"),
+    (worktree._create_worktree_sync, "worktree_mkdir_failed"),
+]
+
+
+@pytest.mark.parametrize(
+    "func,code",
+    _FIXED_SITES,
+    ids=[f.__name__ for f, _ in _FIXED_SITES],
+)
+def test_error_field_carries_no_interpolated_exception(func, code) -> None:
+    """No ``"error"`` value in a fixed handler interpolates the caught exception."""
+    leaking = [v for v in _error_field_values(func) if _formats_an_exception(v)]
+    assert not leaking, (
+        f"{func.__name__} still interpolates the caught exception into the "
+        f'client-visible "error" field ({len(leaking)} site(s)); use a generic '
+        f'fixed message plus a machine "code" and log the detail server-side'
+    )
+    # The generic body must still carry a machine-readable code so the client can
+    # branch on the failure without parsing prose.
+    has_code = code in inspect.getsource(func)
+    assert has_code, f'{func.__name__} must expose the machine code "{code}" on its error body'

--- a/test/test_handlers_mcp_coverage.py
+++ b/test/test_handlers_mcp_coverage.py
@@ -1244,7 +1244,12 @@ class TestGatewayEnableErrors:
             _request({"enabled": True}, state=state)
         )
         assert resp.status == 500
-        assert "broker died" in _payload(resp)["error"]
+        # The raw exception text stays server-side (in the SEL log below); the
+        # verbatim-rendered client body gets a generic message + machine code.
+        body = _payload(resp)
+        assert "broker died" not in body["error"]
+        assert body["error"] == "apply failed"
+        assert body["code"] == "mcp_apply_failed"
         outcomes = [c.kwargs.get("outcome") for c in sel.log_api_access.call_args_list]
         assert "error" in outcomes
 
@@ -2051,7 +2056,11 @@ class TestGatewaySetStub:
             _request({"name": "ok-mcp", "stub": True}, state=state)
         )
         assert resp.status == 500
-        assert "relink" in _payload(resp)["error"]
+        # Raw exception text stays server-side; client body is generic + coded.
+        body = _payload(resp)
+        assert "relink" not in body["error"]
+        assert body["error"] == "apply failed"
+        assert body["code"] == "mcp_apply_failed"
         # The config write happens BEFORE apply, so it survives the failure.
         saved = json.loads(config_path().read_text(encoding="utf-8"))
         assert saved["mcp_gateway"]["stub_servers"] == ["ok-mcp"]

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -52,7 +52,11 @@ class TestParseSessions:
         ):
             result = _parse_sessions()
             assert "error" in result
-            assert "boom" in result["error"]
+            # The OSError carries a filesystem path; it stays server-side. The
+            # returned `error` is a generic message with a machine-readable code.
+            assert "boom" not in result["error"]
+            assert result["error"] == "cannot read sessions directory"
+            assert result["code"] == "sessions_dir_unreadable"
 
     def test_skips_non_jsonl(self, tmp_path):
         d = tmp_path / "cli"


### PR DESCRIPTION
## What

Nine sibling sites across the dashboard handler tree interpolated the caught
exception into the client-visible `error` field on a 4xx/5xx response
(`{"error": f"...{exc}..."}`). The dashboard renders `error` verbatim into a
localized UI, so each site both leaked internals (driver/exception text can
carry filesystem paths, hostnames, SQL fragments) and shipped untranslatable
prose.

Follow-up from the First Principles review on PR #5600 (which fixed the same
pattern in `knowledge.import_bundle`, and marked these siblings
accepted-and-deferred). Fixes #5644.

## The fix

The same subtraction PR #5600 shipped: a generic fixed message plus a
machine-readable `code` on the client body, with the exception detail going to
the server log (SEL where the surface is already audited).

Sites fixed:

- `diagnostics.api_diagnostics_collect` (500) - detail already in `logger.exception`
- `mcp.api_mcp_gateway_enable` (500) - detail already in the SEL log
- `mcp.api_mcp_gateway_set_stub` apply arm (500) - detail already in the SEL log
- `mcp.api_mcp_gateway_set_stub` config-lock arm (503) - added `logger.warning`
- `memory.api_memory_embedding_model` (503) - detail already in `logger.warning`
- `tailnet_mobile.api_tailnet_mobile_qr` (500) - detail already in `logger.debug`
- `themes.api_theme_detail` (500) - added a module logger + `logger.warning`
- `usage._parse_sessions` (OSError) - added `logger.warning`
- `worktree._create_worktree_sync` (500) - was `{exc.strerror or exc}` plus the
  destination path; generic message + code, added `logger.warning`. Surfaced by
  the First Principles review: the `{exc.strerror or exc}` (BoolOp) spelling
  slips the counting grep, so the regression test's matcher now unwraps
  `BoolOp`/`IfExp` and pins this site too.

The frontend renders `body.error` verbatim as display text and branches on
`body.code`, not on the error string (confirmed across `website/src`), so
replacing the string with a generic message plus a `code` is safe for consumers.

## Deliberately out of scope

- Two 400 validation-feedback sites are left as-is: `security` (invalid-regex)
  and `mcp_custom` (spec validation) echo the user's own submitted input back as
  actionable feedback, not internal state - the same client's-fault-vs-operational
  distinction PR #5600 drew.
- The `{dest}` / `{base}` path echoes elsewhere in `_create_worktree_sync`
  (`Directory already exists: {dest}` at :611/:633, `Cannot resolve a commit to
  branch from ({base})` at :616) are 400/409 responses about the user's OWN
  request input (the path and base they asked to create/branch from), the same
  validation-feedback category as the two sites above - not raw exception text.
  This PR's scope is the exception-interpolation leak; a path-echo policy for
  request-supplied values is a separate, broader question.
- `knowledge.py` is PR #5600's declared scope and is untouched. The wider
  `str(exc)` pattern elsewhere in the tree, and the four exact-shape 500s under
  `apps/`, are outside the dashboard handler tree this PR targets.

## How verified

- `black==26.3.1` (`--target-version py310` `--check`), `flake8==7.1.0`,
  `isort==6.0.0` `--check-only`: clean on all changed files + the new test.
- `mypy==1.14.1` on the changed modules: zero errors in the changed files. (Two
  pre-existing errors in `src/kiro_crew/transcribe.py:437` are inherited from
  main - that file is byte-identical to `origin/main` and errors on its own at
  the base; not caused by this PR.)
- New regression test `test/test_handler_error_no_exception_leak.py` asserts,
  per fixed handler, that no `error` value interpolates the caught exception
  (including through a `BoolOp`/conditional so `{exc.strerror or exc}` is
  caught) and that a machine `code` is present. Verified fail-first: all 9
  parametrized cases FAIL on the pre-fix source and PASS on the fixed source.
- Four existing tests that asserted the raw exception text was present are
  updated to the coded generic-message contract, and `error-code-baseline.json`
  is regenerated via its sanctioned `--update` path.
