### PR TITLE
fix: report a search path only where a PATH search happened

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -3450,6 +3450,15 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         _key = spec_path_key(_env)
         _declared = _env.get(_key, "") if _key else ""
         _search = mcp_search_path(_declared if isinstance(_declared, str) else "")
+        # A command carrying a directory component is not PATH-searched:
+        # ``shutil.which`` returns before it reads ``path=`` when
+        # ``os.path.dirname(cmd)`` is truthy, checking exactly the one location
+        # the command names. Reporting ``_search`` for it would send the reader
+        # to audit directories that were never consulted, which is the opposite
+        # of the not-installed/installed-elsewhere distinction this path draws --
+        # so return "" as the searched path even though the lookup still runs.
+        if os.path.dirname(cmd):
+            return shutil.which(cmd, path=_search), ""
         # The search path is returned, not recomputed by the caller: a candidate
         # that declares its own ``env.PATH`` is searched against a DIFFERENT path
         # than one that does not, so a caller reporting ``mcp_search_path("")``
@@ -3605,13 +3614,26 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # against a different path, so recomputing one here would name
             # directories that were never consulted. The candidate list stays at
             # DEBUG: that is about which spec won, not about why none resolved.
-            logger.warning(
-                "Dropping MCP server %r: command not found: %s — %s; %s",
-                name,
-                spec.get("command", ""),
-                describe_search_path(dedup_path(os.pathsep.join(searched))),
-                MCP_PATH_HINT,
-            )
+            if searched:
+                logger.warning(
+                    "Dropping MCP server %r: command not found: %s — %s; %s",
+                    name,
+                    spec.get("command", ""),
+                    describe_search_path(dedup_path(os.pathsep.join(searched))),
+                    MCP_PATH_HINT,
+                )
+            else:
+                # No candidate was PATH-searched (e.g. every command carries a
+                # directory component, which shutil.which looks up directly).
+                # ``describe_search_path("")`` would render "searched no
+                # directories (empty PATH)" and blame a PATH that was never
+                # consulted, so omit the clause instead.
+                logger.warning(
+                    "Dropping MCP server %r: command not found: %s; %s",
+                    name,
+                    spec.get("command", ""),
+                    MCP_PATH_HINT,
+                )
             logger.debug("MCP %r resolution failed; tried %s", name, "; ".join(tried))
     config["mcpServers"] = valid_servers
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -1617,11 +1617,18 @@ async def probe_server(
 
         # Resolve command to absolute path using the merged env PATH
         effective_path = env.get("PATH") or ""
+        # A command carrying a directory component is not PATH-searched:
+        # ``shutil.which`` looks it up directly and ignores ``path=``. Reporting
+        # ``effective_path`` for it would name directories that were never
+        # consulted, inverting the not-installed/installed-elsewhere distinction
+        # the search-path report exists to draw -- so the report gets "" while
+        # the lookup below still uses the real PATH.
+        reported_path = "" if os.path.dirname(server.command) else effective_path
         resolved = shutil.which(server.command, path=effective_path)
         if not resolved:
             server.status = "error"
-            server.error = _unresolved_error(server.command, effective_path)
-            _warn_unresolvable_once(server.name, server.command, effective_path)
+            server.error = _unresolved_error(server.command, reported_path)
+            _warn_unresolvable_once(server.name, server.command, reported_path)
             return server
 
         # The command resolved, so forget any prior "not found" report — keyed on
@@ -1889,10 +1896,15 @@ async def probe_server(
         )
     except FileNotFoundError:
         server.status = "error"
-        server.error = _unresolved_error(server.command, effective_path)
-        # ``effective_path`` was bound before the try, so it is always safe to
-        # read here even if the failure preceded PATH resolution.
-        _warn_unresolvable_once(server.name, server.command, effective_path)
+        # Report the search path only for a bare command: a directory-qualified
+        # one is looked up directly by shutil.which, not PATH-searched, so naming
+        # ``effective_path`` would cite directories never consulted. Recomputed
+        # here (not read from ``reported_path``) because this handler can fire
+        # before the try-body binds it, just as ``effective_path`` is bound
+        # before the try for exactly that reason.
+        _reported = "" if os.path.dirname(server.command) else effective_path
+        server.error = _unresolved_error(server.command, _reported)
+        _warn_unresolvable_once(server.name, server.command, _reported)
     except SandboxUnavailableError as exc:
         # The PROBE could not run — this says nothing about the server, and the
         # two must not be reported alike. Ahead of the generic clause, which would

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -1873,6 +1873,35 @@ class TestProbeRemote:
         mock_remote.assert_not_awaited()
         assert result.status == "error"
 
+    @pytest.mark.asyncio
+    async def test_directory_qualified_command_reports_no_search_path(self) -> None:
+        """A directory-qualified command is looked up directly, not PATH-searched.
+
+        Regression for #5053: ``shutil.which`` returns before it reads ``path=``
+        when the command carries a directory component, so it checks exactly the
+        one location named. Reporting the declared search path for it told the
+        reader it "searched N directories" that were never consulted -- the exact
+        not-installed vs installed-elsewhere confusion #4954 exists to prevent,
+        stated backwards. The error for such a command must be the bare
+        ``command not found: <cmd>`` with no directory list.
+        """
+        abs_missing = os.path.join(os.sep, "opt", "vendor", "bin", "ghost-mcp")
+        server = McpServerInfo(name="dirq", command=abs_missing)
+        result = await probe_server(server)
+        assert result.status == "error"
+        assert f"command not found: {abs_missing}" in result.error
+        assert "directories" not in result.error  # nothing was searched
+        assert "empty PATH" not in result.error
+
+    @pytest.mark.asyncio
+    async def test_bare_command_still_reports_the_search_path(self) -> None:
+        """The bare-command path is unchanged: it IS PATH-searched, so say so."""
+        server = McpServerInfo(name="bare", command="ghost-mcp-xyz")
+        result = await probe_server(server)
+        assert result.status == "error"
+        assert "command not found: ghost-mcp-xyz" in result.error
+        assert "directories" in result.error  # PATH was searched, report it
+
 
 class TestProbeServerConsentGate:
     """``probe_server`` itself refuses a consent-disabled server.


### PR DESCRIPTION
Fixes #5053

## What this changes

When an MCP server's `command` carries a directory component -- an absolute path like `/opt/vendor/bin/foo`, or a relative `./tool` -- and it does not resolve, both report surfaces told the reader it was searched for across the whole declared `PATH`. It was not: `shutil.which` returns before it reads `path=` when `os.path.dirname(cmd)` is truthy, checking exactly the one location the command names.

This is precisely backwards for the distinction #4954 exists to draw ("say where it looked, so a user can tell not-installed from installed-outside-the-search-path"). For a directory-qualified command the truth is the third case -- the path given does not exist -- and the report converted it into "not found in any of the N directories searched", sending the reader to audit a `PATH` that was never consulted.

The defect was raised on #4954 itself by the Opus review and deferred; this is that follow-up.

## Approach

Report a search path only where a search actually happened:

- `agent._resolve_command` returns `""` as the searched path for a command with a directory component. The lookup still runs against the real PATH (`shutil.which` ignores `path=` there anyway), only the *reported* path becomes empty.
- The config-rebuild drop-warning omits the search-path clause entirely when no candidate was PATH-searched, rather than rendering `describe_search_path("")` -> "searched no directories (empty PATH)", which would blame a PATH that was fine and simply never consulted.
- `mcp_discovery.probe_server` passes `""` to `_unresolved_error` / `_warn_unresolvable_once` for a directory-qualified command, at both unresolved exits (the resolve check and the `FileNotFoundError` handler). Both helpers already degrade to the plain `command not found: <cmd>` on an empty search path, so no helper change was needed.

No behaviour change for a bare command: it is PATH-searched, so it still reports the directories.

## Verification

Ran the repo gates from the worktree:

- `python3 scripts/check_black_formatting.py` -- passed (agent.py is black-clean; mcp_discovery.py and test_mcp_discovery.py are in the black baseline, so edits there were kept surgical and not whole-file reformatted).
- `python3 scripts/check_subprocess_encoding.py` -- passed.
- `isort --check-only src/kiro_crew test conftest.py xdist_budget.py` -- passed.
- `flake8` on the three changed files -- clean.
- `mypy --platform linux src/kiro_crew` -- the only 4 errors are pre-existing in `transcribe.py` and `apps/builtins/ops_mission_control/backend/providers/cloudwatch.py` (boto3 stub overloads), both untouched by this branch and present on `main`; none in the changed files.
- `python -m pytest test/test_mcp_discovery.py test/test_unresolved_command_message.py test/test_agent.py` -- passed.

New regression tests in `test/test_mcp_discovery.py`:

- `test_directory_qualified_command_reports_no_search_path` -- **fails before** this change (the error names "searched 14 directories" for a command that was never PATH-searched) and passes after.
- `test_bare_command_still_reports_the_search_path` -- passes before and after, pinning that the bare-command path is unchanged.

No inherited CI reds attributable to this diff.
