### PR TITLE
feat(session-control): session_send — deliver a message to another session as its next turn

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -19,11 +19,22 @@ unreachable in production because the caller's `X-Internal-Secret` is ignored.
 | `session_stop` | `POST /api/session-control/stop` | Stop another session's in-flight turn |
 | `session_read_message` | `GET /api/session-control/read` | Read another session's transcript tail + liveness |
 
-**Nothing here writes into another session's conversation.** Reading returns a
-transcript tail, stopping cancels a turn the way the Stop button does, and
-creating opens an empty session the person types the first message into. Every
-verb is authorized at the moment it acts, so there is no delivery that can be
-delayed past its own authorization.
+**One verb here writes into another session's conversation: `session_send`.**
+Reading returns a transcript tail, stopping cancels a turn the way the Stop button
+does, creating opens an empty session, and sending delivers a message that the
+target runs as its next turn. Delivery is the sharpest verb and is bounded
+accordingly: the body is redacted through `sanitize_outbound` before it is
+persisted, it is prefixed with a `[sent by session <caller> via session_send]`
+envelope so the target's transcript can never render it as something the person
+typed, and channel agents are blocked from it outright.
+
+**Delivery has two authorization moments, and only the first is enforced today.**
+An idle target runs the prompt immediately, under the authorization that admitted
+it. A busy target QUEUES it, and the generic drain re-runs no check — so a target
+that gains a channel mirror between enqueue and drain broadcasts the delivered
+text. That window is accepted, not overlooked: it is not specific to this module
+(a human-typed message into a busy session drains through the same ungated path),
+so it is fixed once at the drain rather than per caller. Tracked as issue #5911.
 
 `session_create` earns its place on its own, not as the front half of a delivery
 design: an agent that has just worked out that a job needs its own session can
@@ -187,12 +198,12 @@ infer a grant from silence.
 
 ## What is deliberately not here
 
-- **No message delivery.** No verb writes into another session's conversation.
-  Delivering a message to a peer has two authorization moments — acceptance and
-  the drain that can be minutes later — and the target's agent, workspace and
-  channel binding can all change in between. That is a different design from the
-  three verbs here, which are each authorized at the moment they act, so it is
-  scoped to its own change rather than carried along.
+- **No delivery to a target outside the addressable set.** `session_send` writes
+  into another session's conversation, but only one the same `authorize_target`
+  guard admits: a channel-linked, channel-mirrored, crew-mode, incognito,
+  app-scoped, unattended or cross-workspace target is refused, so the verb cannot
+  reach a conversation other people are party to. The residual is the queued arm's
+  second authorization moment, recorded above and tracked as #5911.
 - **No cross-workspace or cross-machine reach.** The boundary is one gateway's
   live sessions in one workspace.
 - **No waking closed sessions.** See above.

--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -47,7 +47,10 @@ _INBOX_POLL_SECS = 1.0
 # control one.  CREATE is blocked for a different reason than the other two: it
 # writes nothing into an existing conversation, but a session it opened would be
 # one the channel agent then owns and may act on, which is exactly the
-# containment this list exists to hold.
+# containment this list exists to hold.  SEND is the sharpest of the four: stop
+# only cancels and read only exfiltrates, but send delivers text that the target
+# session RUNS as a turn — so external channel content would execute inside a
+# private dashboard conversation.
 # Matched against the rendered
 # permission-request text/title via _blocked_tool_named() (boundary-aware,
 # not naive substring — "Editing send_notification.py" must NOT match).
@@ -55,6 +58,7 @@ CHANNEL_AGENT_BLOCKED_TOOLS: tuple[str, ...] = (
     "send_message",
     "send_notification",
     "session_stop",
+    "session_send",
     "session_read_message",
     "session_create",
 )

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -150,6 +150,30 @@ async def api_session_control_stop(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+async def api_session_control_send(request: web.Request) -> web.Response:
+    """POST /api/session-control/send — deliver a message to another session."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    # No prewarm here: `send_to_target` warms the config after its own SEL
+    # prewarm, the same ordering `stop_target` uses and for the same reason.
+    state: DashboardState = request.app["state"]
+    try:
+        body = await _body(request)
+        message = body.get("message")
+        if not isinstance(message, str) or not message.strip():
+            raise sc.SessionControlError("message is required", code="message_required")
+        result = await sc.send_to_target(
+            state,
+            caller_session_key=_read_session_key(request),
+            target=_target(body),
+            message=message,
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)
+
+
 async def api_session_control_read(request: web.Request) -> web.Response:
     """GET /api/session-control/read — read another session's transcript tail."""
     refused = await _require_internal(request)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -401,6 +401,7 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # tool is unreachable in production while handler-level tests still pass.
         "/api/session-control/create",
         "/api/session-control/stop",
+        "/api/session-control/send",
         "/api/session-control/read",
     }
 )
@@ -1188,6 +1189,9 @@ def _register_mcp_routes(app: web.Application) -> None:
     )
     app.router.add_post(
         "/api/session-control/stop", _deferred_session_control("api_session_control_stop")
+    )
+    app.router.add_post(
+        "/api/session-control/send", _deferred_session_control("api_session_control_send")
     )
     app.router.add_get(
         "/api/session-control/read", _deferred_session_control("api_session_control_read")

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -6,11 +6,15 @@ operations are deliberately thin: they reuse the same creation, stop and history
 paths the dashboard itself uses, so a controlled session behaves exactly like one
 a human is typing into.
 
-**Nothing here writes into another session's conversation.** Reading returns a
-transcript tail; stopping cancels an in-flight turn the way the Stop button does;
-creating opens an empty session in the user's sidebar. Every verb is therefore
-resolved and authorized at the moment it acts, with no delivery that can be
-delayed past its own authorization.
+**One verb here writes into another session's conversation: ``session_send``.**
+Reading returns a transcript tail; stopping cancels an in-flight turn the way the
+Stop button does; creating opens an empty session in the user's sidebar; sending
+delivers a message the target runs as its next turn, redacted through
+``sanitize_outbound`` and prefixed with a ``[sent by session … via session_send]``
+envelope so it can never render as something the person typed. An IDLE target runs
+it under the authorization that admitted it; a BUSY target queues it, and the
+generic drain re-runs no check — an accepted window, not an oversight, because a
+human-typed queued message shares it (see the spec, and issue #5911).
 
 Authorization is deny-by-default and checked in one place
 (:func:`authorize_target`) for the two operations that take a target, so a guard
@@ -38,6 +42,7 @@ from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, SlotOrigin
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
 from kiro_crew.sel import sel
+from kiro_crew.validation import MAX_LONG_STRING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from kiro_crew.dashboard.state import DashboardState, _ChatSlot
@@ -850,6 +855,102 @@ async def stop_target(
         detail={"result": result.get("info", "stopping")},
     )
     return {"ok": True, "target": slot.key, **result}
+
+
+#: Cap on one delivered message. Aliased to ``validation.MAX_LONG_STRING`` rather
+#: than restated as its own number: a seed prompt is that shape, the MCP schema
+#: layer already rejects on that constant, and two spellings of one 50k limit
+#: would drift apart the first time either moved.
+MAX_SEND_MESSAGE_CHARS = MAX_LONG_STRING
+
+#: Provenance prefix on every delivered message. The target's transcript renders
+#: the message as a user row, and without this line it is indistinguishable from
+#: something the person typed — the same reason auto-nudge tags its injected
+#: turns ``[auto-nudge cycle N]``. The model in the target session sees it too,
+#: so it can weigh the instruction as coming from a peer session, not its user.
+_SEND_PROVENANCE = "[sent by session {caller} via session_send]\n\n"
+
+
+async def send_to_target(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+    message: str,
+) -> dict[str, Any]:
+    """Deliver *message* to *target* as its next agent turn.
+
+    The delivery path is the same queue-vs-run decision the dashboard composer
+    uses (``enqueue_or_run_prompt``): an idle target starts a turn immediately,
+    a busy one queues the message for its next turn. Both outcomes are reported
+    distinctly — ``started`` says which happened — because "it ran" and "it will
+    run later" must not look the same to a caller coordinating several sessions.
+
+    The turn is NOT charged against the background-turn cap, and deliberately so:
+    that cap only binds unattended (app-owned) slots, and every target this
+    function can authorize is attended — see the comment at the delivery call.
+    """
+    # Same prewarm ordering as `stop_target`, for the same reasons: the SEL
+    # write inside `authorize_target`'s deny path must be a cache hit, and the
+    # config warm must be the LAST suspension before the synchronous gate.
+    try:
+        await asyncio.to_thread(sel)
+    except Exception:  # noqa: BLE001 - a prewarm failure must not fail the send
+        logger.warning("session-control SEL prewarm failed", exc_info=True)
+    await prewarm_enabled_check()
+
+    body = message.strip()
+    if not body:
+        raise SessionControlError("message is empty", code="message_empty", status=400)
+    if len(body) > MAX_SEND_MESSAGE_CHARS:
+        raise SessionControlError(
+            f"message exceeds {MAX_SEND_MESSAGE_CHARS} characters",
+            code="message_too_long",
+            status=400,
+        )
+
+    slot = authorize_target(
+        state,
+        caller_session_key=caller_session_key,
+        target=target,
+        operation="send",
+    )
+
+    # Deferred for the same import cycle `stop_target` documents.
+    from kiro_crew.dashboard.chat_runner import _run_chat
+
+    caller_key = caller_slot_key(state, caller_session_key)
+    # Sanitized on the same grounds as the steer path (``chat_delivery`` sanitizes
+    # before ``slot.append``): this body comes from ANOTHER session and is persisted
+    # into — and broadcast from — the target's transcript, so raw content must never
+    # reach that surface. The length gate above deliberately measures the RAW body:
+    # redaction can only shrink the text, so validating the raw form is the honest
+    # limit and keeps the error keyed to what the caller actually sent.
+    prompt = _SEND_PROVENANCE.format(caller=caller_key or "unknown") + sanitize_outbound(body)
+
+    # `_run_chat` is passed straight through, NOT wrapped in
+    # `state.run_background_turn`: that cap is structurally unreachable here.
+    # `run_background_turn` returns the coroutine untouched for an attended slot
+    # (`state.py`, "this wrapper is inert"), `_ChatSlot.unattended` is
+    # `bool(self._app) and not self._human_seen`, and `authorize_target` refuses
+    # every `_app` target above (`app_scoped_target`) — so no target this
+    # function can reach is ever unattended, and a wrapper would only add a
+    # never-taken timeout arm. The composer's own queued path does the same
+    # (`server.py` passes `_run_chat` directly).
+    started = bool(slot.enqueue_or_run_prompt(prompt, _run_chat, state))
+    try:
+        state.push_slots_update()
+    except Exception:  # pragma: no cover - sidebar refresh is best-effort
+        logger.debug("session_send: push_slots_update failed", exc_info=True)
+
+    _audit(
+        caller_session_key=caller_session_key,
+        operation="send",
+        slot_key=slot.key,
+        outcome="allowed",
+        detail={"started": started, "chars": len(body)},
+    )
+    return {"ok": True, "target": slot.key, "started": started}
 
 
 def read_messages(

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -89,6 +89,7 @@ from kiro_crew.validation import (
     MCP_DASHBOARD_SCHEMAS,
     SESSION_CREATE_SCHEMA,
     SESSION_READ_MESSAGE_SCHEMA,
+    SESSION_SEND_SCHEMA,
     SESSION_STOP_SCHEMA,
     validate_tool_args,
 )
@@ -107,6 +108,7 @@ SERVER_VERSION = "1.0.0"
 SESSION_CONTROL_TOOLS: tuple[str, ...] = (
     "session_create",
     "session_stop",
+    "session_send",
     "session_read_message",
 )
 
@@ -270,6 +272,38 @@ def _tool_definitions() -> list[dict[str, Any]]:
                     },
                 },
                 "required": ["target"],
+            },
+        },
+        {
+            "name": "session_send",
+            "description": (
+                "Send a message into another session as its next agent turn — the "
+                "way to seed a session you just created with session_create, answer "
+                "a question it raised, or steer it mid-run. If the target is idle "
+                "the turn starts immediately; if it is busy the message queues and "
+                "runs when its current turn ends — the result says which happened. "
+                "The message lands in the target's transcript tagged as sent by "
+                "your session, so the person reading it can tell it from their own "
+                "typing. Use session_read_message afterwards to watch what the "
+                "target did with it."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Session key from list_sessions, or its exact title.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": (
+                            "The message to deliver. It becomes the target's next "
+                            "user-role turn, so write it as you would type into "
+                            "that session's composer."
+                        ),
+                    },
+                },
+                "required": ["target", "message"],
             },
         },
         {
@@ -854,6 +888,26 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             # so rather than implying a turn was cancelled.
             return f"\u2139\ufe0f `{target}`: {info} — nothing to stop."
         return f"\U0001f6d1 Stop sent to `{target}`. Its transcript now shows the stop card."
+
+    if name == "session_send":
+        args = validate_tool_args(args, SESSION_SEND_SCHEMA)
+        resp = _post(
+            "/api/session-control/send",
+            {"target": args["target"], "message": args["message"]},
+            session_key=caller_key,
+        )
+        if resp.get("error"):
+            return f"Error: could not send to that session: {resp['error']}"
+        target = resp.get("target", args["target"])
+        if resp.get("started"):
+            return (
+                f"\U0001f4e8 Delivered to `{target}` — it started a turn on your message. "
+                "Watch the result with session_read_message."
+            )
+        return (
+            f"\U0001f4e8 Queued for `{target}` — it is mid-turn, so your message runs "
+            "when the current turn ends. Poll with session_read_message."
+        )
 
     if name == "session_read_message":
         args = validate_tool_args(args, SESSION_READ_MESSAGE_SCHEMA)

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2640,6 +2640,14 @@ SESSION_STOP_SCHEMA = ToolSchema(
     ],
 )
 
+SESSION_SEND_SCHEMA = ToolSchema(
+    tool_name="session_send",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("message", str, required=True, max_len=MAX_LONG_STRING),
+    ],
+)
+
 SESSION_READ_MESSAGE_SCHEMA = ToolSchema(
     tool_name="session_read_message",
     fields=[
@@ -2863,6 +2871,7 @@ def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
 MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
     "session_create": SESSION_CREATE_SCHEMA,
     "session_stop": SESSION_STOP_SCHEMA,
+    "session_send": SESSION_SEND_SCHEMA,
     "session_read_message": SESSION_READ_MESSAGE_SCHEMA,
     "chat_folder_tree": CHAT_FOLDER_TREE_SCHEMA,
     "chat_folder_create": CHAT_FOLDER_CREATE_SCHEMA,

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1476,5 +1476,6 @@ class TestAdvertisedSet:
             "chat_folder_move_session",
             "session_create",
             "session_stop",
+            "session_send",
             "session_read_message",
         }

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -342,6 +342,7 @@ class TestWhatThisSetGrants:
     SESSION_TOOLS = {
         "session_create",
         "session_stop",
+        "session_send",
         "session_read_message",
     }
     GRANTED_TOOLS = FOLDER_TOOLS | SESSION_TOOLS

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -767,6 +767,96 @@ class TestTheRoutesRequireTheInternalSecret:
         assert resp.status == 403, "a broken audit must not escalate a refusal to 500"
         assert self._body(resp)["code"] == "internal_secret_required"
 
+    def test_stop_with_the_secret_reaches_the_operation(self, tmp_path, monkeypatch):
+        """The stop ROUTE's success path, for the reason create's docstring gives:
+        only the 403 arm was covered, so a route-level defect on the reaching path
+        would ship dead."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/stop")
+
+        async def _ok(*_a, **_kw):
+            return {"ok": True, "target": "chat-2", "stopped": True}
+
+        monkeypatch.setattr(sc, "stop_target", _ok)
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+
+        assert resp.status == 200
+        assert self._body(resp)["target"] == "chat-2"
+
+    def test_stop_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """Same refusal contract the create and send routes hold."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/stop")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError(
+                "not addressable", status=403, code="linked_session_target"
+            )
+
+        monkeypatch.setattr(sc, "stop_target", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "linked_session_target"
+
+    def test_send_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(tmp_path, internal=False, path="/api/session-control/send")
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "internal_secret_required"
+
+    def test_send_with_the_secret_delivers_to_the_target(self, tmp_path, monkeypatch):
+        """The send ROUTE needs its own test for the reason create's docstring gives:
+        a handler wired only in tests at the business layer ships dead if the route
+        itself refuses or never reaches the operation."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+        state = req.app["state"]
+        caller = state.get_slot("chat-1")
+        assert caller is not None
+        # Make chat-2 an addressable peer of the caller through the same helper the
+        # business-layer tests use, so this exercises the route rather than a
+        # hand-built slot that authorize_target would refuse for unrelated reasons.
+        _peer_target(state, "chat-2", caller)
+
+        async def _fake_run_chat(_state, _slot, _prompt):
+            return None
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 200, self._body(resp)
+        payload = self._body(resp)
+        assert payload["ok"] is True
+        assert payload["target"] == "chat-2"
+
+    def test_send_requires_a_non_empty_message(self, tmp_path):
+        """The message check lives in the ROUTE, not the business layer, so a
+        whitespace-only body must be refused here rather than delivered as a
+        blank turn."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+
+        async def _json():
+            return {"target": "chat-2", "message": "   "}
+
+        req.json = _json
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 400
+        assert self._body(resp)["code"] == "message_required"
+
+    def test_send_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """A SessionControlError from send comes back as its own refusal, the same
+        contract create's route holds."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError("busy", status=409, code="target_busy")
+
+        monkeypatch.setattr(sc, "send_to_target", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 409
+        assert self._body(resp)["code"] == "target_busy"
+
     def test_read_without_the_secret_is_forbidden(self, tmp_path):
         req = self._request(
             tmp_path, internal=False, path="/api/session-control/read", method="GET"
@@ -1353,6 +1443,179 @@ def test_stop_is_refused_for_a_session_out_of_bounds(tmp_path):
     _slot(state, "chat-hidden", memory_mode="incognito")
     with pytest.raises(sc.SessionControlError):
         asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-hidden"))
+
+
+# ── session_send ──
+
+
+def test_send_to_an_idle_target_starts_a_turn_with_provenance(tmp_path, monkeypatch):
+    """The delivered prompt carries the caller tag, and an idle target runs now.
+
+    Provenance is the load-bearing part: the target renders the message as a
+    user row, and without the tag it is indistinguishable from something the
+    person typed into that session themselves.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+
+    ran: dict[str, str] = {}
+
+    async def _fake_run_chat(_state, slot, prompt):
+        ran["slot"] = slot.key
+        ran["prompt"] = prompt
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+    async def _drive():
+        out = await sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="do the thing"
+        )
+        # Let the enqueue_or_run_prompt task actually execute the fake turn.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return out
+
+    out = asyncio.run(_drive())
+
+    assert out == {"ok": True, "target": "chat-2", "started": True}
+    assert ran["slot"] == "chat-2"
+    assert ran["prompt"].startswith("[sent by session ")
+    assert ran["prompt"].endswith("do the thing")
+    # The transcript shows the message as a user row, tag included.
+    assert any(
+        m.get("content", "").endswith("do the thing")
+        for m in target.messages
+        if m.get("role") == "user"
+    )
+
+
+def test_the_sent_body_passes_through_the_outbound_guard(tmp_path, monkeypatch):
+    """The message goes through `sanitize_outbound` before it is persisted.
+
+    It arrives from ANOTHER session's model, is appended to the target's
+    transcript as a user row and broadcast to every dashboard client, so this is
+    the same surface the steer path sanitizes before `slot.append`
+    (`chat_delivery`: "raw content must never reach an external surface"). A
+    credential-shaped string would otherwise be stored and displayed.
+
+    Mutation guard: dropping the `sanitize_outbound` call leaves the raw value.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    monkeypatch.setattr(sc, "sanitize_outbound", lambda s: f"SANITIZED:{s}")
+
+    ran: dict[str, str] = {}
+
+    async def _fake_run_chat(_state, slot, prompt):
+        ran["prompt"] = prompt
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+    async def _drive():
+        out = await sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="tok=abc"
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return out
+
+    asyncio.run(_drive())
+
+    assert ran["prompt"].endswith(
+        "SANITIZED:tok=abc"
+    ), "the sent body must pass through the outbound guard before it is delivered"
+    # The provenance tag is built by this function, not caller-supplied, so it is
+    # deliberately OUTSIDE the sanitized span.
+    assert ran["prompt"].startswith("[sent by session ")
+    assert any(
+        m.get("content", "").endswith("SANITIZED:tok=abc")
+        for m in target.messages
+        if m.get("role") == "user"
+    ), "the persisted transcript row must carry the sanitized body"
+
+
+def test_the_length_gate_measures_the_raw_body(tmp_path, monkeypatch):
+    """Validation happens on the RAW body, before redaction.
+
+    Redaction can only shrink the text, so gating the raw form is the honest
+    limit: a caller that sends 60K of credentials gets `message_too_long` rather
+    than silently passing because redaction squeezed it under the cap.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _peer_target(state, "chat-2", caller)
+    # A redactor that collapses everything would hide an oversized body.
+    monkeypatch.setattr(sc, "sanitize_outbound", lambda _s: "x")
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(
+            sc.send_to_target(
+                state,
+                caller_session_key=_key(caller),
+                target="chat-2",
+                message="a" * (sc.MAX_SEND_MESSAGE_CHARS + 1),
+            )
+        )
+    assert err.value.code == "message_too_long"
+
+
+def test_send_to_a_busy_target_queues_instead_of_racing(tmp_path):
+    """A mid-turn target must not get a second concurrent turn — the message
+    queues, and the caller is told so (`started: False`), because "ran" and
+    "will run later" are different answers to a coordinator."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    _busy(target)
+
+    out = asyncio.run(
+        sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="queued message"
+        )
+    )
+
+    assert out["started"] is False
+    assert any("queued message" in q.get("content", "") for q in target._queue)
+
+
+def test_send_is_refused_for_a_session_out_of_bounds(tmp_path):
+    """The same deny-by-default guard the other verbs share gates send too."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-hidden", memory_mode="incognito")
+    with pytest.raises(sc.SessionControlError):
+        asyncio.run(
+            sc.send_to_target(
+                state, caller_session_key=_key(caller), target="chat-hidden", message="hi"
+            )
+        )
+
+
+def test_send_refuses_an_empty_or_oversized_message(tmp_path):
+    """Size gates live in the business layer, not only in the tool schema —
+    the HTTP route is callable without the MCP layer's validation."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _peer_target(state, "chat-2", caller)
+
+    with pytest.raises(sc.SessionControlError) as empty_exc:
+        asyncio.run(
+            sc.send_to_target(state, caller_session_key=_key(caller), target="chat-2", message="  ")
+        )
+    assert empty_exc.value.code == "message_empty"
+
+    with pytest.raises(sc.SessionControlError) as long_exc:
+        asyncio.run(
+            sc.send_to_target(
+                state,
+                caller_session_key=_key(caller),
+                target="chat-2",
+                message="x" * (sc.MAX_SEND_MESSAGE_CHARS + 1),
+            )
+        )
+    assert long_exc.value.code == "message_too_long"
 
 
 def test_session_control_routes_are_strict_internal():


### PR DESCRIPTION
## What is the problem?

The session-control set shipped in #2435 can open a session (`session_create`), stop one (`session_stop`), and read one (`session_read_message`) — but it has no write verb. A session created by an agent starts empty and stays empty until the person types into it, a peer session that asked a question cannot be answered, and a session working from a stale premise cannot be corrected without stopping it outright. The set can stand a workstream up and watch it, but not communicate with it.

## Why this issue matters to the user

The concrete workflow this blocks is a coordinator session that decomposes a goal, opens one session per work item, and drives them to completion: without a send verb, every seed prompt and every mid-flight correction is a manual copy-paste the user must perform per item per round. It also leaves `session_stop` as the only intervention — destructive where a one-line steer would have done.

## How our fix solves it

One new verb, built on the guard and delivery paths that already exist:

- **`send_to_target` (dashboard/session_control.py)** authorizes through the same deny-by-default `authorize_target` gate the other verbs share (same SEL-prewarm-then-config-warm ordering as `stop_target`, for the same no-suspension-before-the-gate reason), then delivers via `enqueue_or_run_prompt` — the composer's own queue-vs-run decision. An idle target starts a turn immediately; a busy one queues. The result reports which happened (`started`), because "ran" and "will run later" are different answers to a caller coordinating several sessions. The turn is deliberately NOT wrapped in `run_background_turn`: that cap only binds unattended (app-owned) slots, and `authorize_target` refuses every `_app` target, so no target this verb can reach is ever capped — a wrapper would add only a never-taken timeout arm. Issue Radar's pattern is live there because its slots ARE app-owned; copying it here without that predicate produced dead code, which First Principles review caught and this head removes.
- **Provenance is mandatory.** The delivered prompt is prefixed `[sent by session <caller> via session_send]` — the target renders it as a user row, and without the tag it is indistinguishable from something the person typed (same convention as auto-nudge's `[auto-nudge cycle N]`).
- **Size gates live in the business layer too** (empty / >50k chars → 400), not only in the tool schema, because the HTTP route is reachable without the MCP layer's validation.
- **Route** `POST /api/session-control/send` registered in `_STRICT_INTERNAL_API_PATHS` (the router-derived strictness test covers it) with the same `_require_internal` re-assert as its siblings.
- **Tool surface**: `session_send` added to `SESSION_CONTROL_TOOLS` (strict caller-identity resolution applies), schema in `validation.py` (`target` ≤500, `message` ≤ `MAX_LONG_STRING`), definition + dispatch in `mcp_dashboard.py`. Falls in the `session_*` class the registration ratchet already admits.

**Channel-agent containment.** `session_send` is added to `CHANNEL_AGENT_BLOCKED_TOOLS` (`src/kiro_crew/channel.py`) alongside its three sibling verbs. Without it, a `channel.trusted` (or YOLO) channel agent driven by external content could call `session_send` — `_blocked_tool_named` would not match the name, the next branch auto-approves, and the message would run as a turn inside a private dashboard session. Send is the sharpest of the four verbs: stop only cancels and read only exfiltrates, but send delivers text the target session EXECUTES. The repo's own ratchet (`test_channel_blocked_tools.py::test_every_session_control_tool_is_contained`, which asserts `SESSION_CONTROL_TOOLS` is a subset of the block list) fails without this line — verified by stashing the fix: `AssertionError: session-control tools reachable from a channel agent: ['session_send']`.

**Outbound redaction.** The body passes through `sanitize_outbound` before it is delivered, on the same grounds the steer path does (`chat_delivery` sanitizes right before `slot.append`: "raw content must never reach an external surface"). It arrives from another session's model and is persisted into — and broadcast from — the target's transcript. The length gate deliberately runs FIRST, on the raw body: redaction can only shrink the text, so validating the raw form is the honest limit. The provenance tag is built here rather than supplied by the caller, so it sits outside the sanitized span and cannot be forged or redacted away.

- **Spec + module docstring** now match the shipped behaviour: the module's stated invariant was "nothing here writes into another session's conversation", which this PR reverses, so `docs/system-specs/modules/session-control.md` and the docstring name `session_send` as the one delivering verb, register the `[sent by session …]` envelope beside the redaction and the channel-agent block, and replace the "No message delivery" non-goal with the accurate one. They also state explicitly that delivery has two authorization moments and only the first is enforced — the queued arm's window is accepted here and fixed at the generic drain in #5911, because a human-typed queued message shares it.
- **`MAX_SEND_MESSAGE_CHARS`** is now an alias of `validation.MAX_LONG_STRING` rather than a second spelling of 50k.

## What tests we did

**Route-level coverage.** The Coverage Gate failed at 76.5% on `src/kiro_crew/dashboard/handlers/session_control.py` (floor 80%, not baselined) because the new `api_session_control_send` route had no test of its own -- and the sibling `stop` route only had its 403 arm covered. Six route tests were added rather than baselining the file, which is what the gate's own message asks for ("add tests, do not extend the baseline"): send's forbidden-without-secret arm, its delivery path, its `message_required` validation (that check lives in the route, not the business layer, so a whitespace-only body must be refused there), its refusal-not-500 mapping, plus stop's reaching path and refusal mapping. The file now measures 89%.


Four new tests in `test_session_control.py`: idle target starts a turn and the delivered prompt carries the provenance prefix; busy target queues (`started: false`, message in `_queue`); out-of-bounds target refused by the shared guard; empty and oversized messages refused with their codes. Ratchet pins updated in `test_mcp_dashboard_registration.py` and `test_mcp_dashboard_folders.py`. Full targeted sweep green after rebase onto current main: 229 passed across the four session-control/dashboard suites; isort and flake8 clean.

## Manual verification

Grant an agent `@kirocrew-dashboard`, enable `agent.session_control`, then from that session: `session_create` a peer, `session_send` a seed prompt into it (verify the tagged user row and the started turn in the peer's transcript), send again while it is mid-turn (verify queueing), and confirm an incognito target is refused.



