### PR TITLE
feat(conductor): ship the conductor agent + acceptance-evaluator skill as built-ins

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -19,11 +19,22 @@ unreachable in production because the caller's `X-Internal-Secret` is ignored.
 | `session_stop` | `POST /api/session-control/stop` | Stop another session's in-flight turn |
 | `session_read_message` | `GET /api/session-control/read` | Read another session's transcript tail + liveness |
 
-**Nothing here writes into another session's conversation.** Reading returns a
-transcript tail, stopping cancels a turn the way the Stop button does, and
-creating opens an empty session the person types the first message into. Every
-verb is authorized at the moment it acts, so there is no delivery that can be
-delayed past its own authorization.
+**One verb here writes into another session's conversation: `session_send`.**
+Reading returns a transcript tail, stopping cancels a turn the way the Stop button
+does, creating opens an empty session, and sending delivers a message that the
+target runs as its next turn. Delivery is the sharpest verb and is bounded
+accordingly: the body is redacted through `sanitize_outbound` before it is
+persisted, it is prefixed with a `[sent by session <caller> via session_send]`
+envelope so the target's transcript can never render it as something the person
+typed, and channel agents are blocked from it outright.
+
+**Delivery has two authorization moments, and only the first is enforced today.**
+An idle target runs the prompt immediately, under the authorization that admitted
+it. A busy target QUEUES it, and the generic drain re-runs no check — so a target
+that gains a channel mirror between enqueue and drain broadcasts the delivered
+text. That window is accepted, not overlooked: it is not specific to this module
+(a human-typed message into a busy session drains through the same ungated path),
+so it is fixed once at the drain rather than per caller. Tracked as issue #5911.
 
 `session_create` earns its place on its own, not as the front half of a delivery
 design: an agent that has just worked out that a job needs its own session can
@@ -187,12 +198,12 @@ infer a grant from silence.
 
 ## What is deliberately not here
 
-- **No message delivery.** No verb writes into another session's conversation.
-  Delivering a message to a peer has two authorization moments — acceptance and
-  the drain that can be minutes later — and the target's agent, workspace and
-  channel binding can all change in between. That is a different design from the
-  three verbs here, which are each authorized at the moment they act, so it is
-  scoped to its own change rather than carried along.
+- **No delivery to a target outside the addressable set.** `session_send` writes
+  into another session's conversation, but only one the same `authorize_target`
+  guard admits: a channel-linked, channel-mirrored, crew-mode, incognito,
+  app-scoped, unattended or cross-workspace target is refused, so the verb cannot
+  reach a conversation other people are party to. The residual is the queued arm's
+  second authorization moment, recorded above and tracked as #5911.
 - **No cross-workspace or cross-machine reach.** The boundary is one gateway's
   live sessions in one workspace.
 - **No waking closed sessions.** See above.

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -42,6 +42,7 @@ from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import (
     AGENT_FILENAME,
 )
+from kiro_crew.agent_files import CONDUCTOR_AGENT_FILENAME as _CONDUCTOR_AGENT_FILENAME
 from kiro_crew.agent_files import HEARTBEAT_AGENT_FILENAME as _HEARTBEAT_AGENT_FILENAME
 from kiro_crew.agent_files import KNOWLEDGE_AGENT_FILENAME as _KNOWLEDGE_AGENT_FILENAME
 from kiro_crew.agent_files import LITE_AGENT_FILENAME as _LITE_AGENT_FILENAME
@@ -4146,6 +4147,12 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     except Exception:
         logger.debug("kirocrew-heartbeat agent install failed", exc_info=True)
 
+    # Install kirocrew-conductor agent (goal decomposition + session-control dispatch)
+    try:
+        _install_conductor_agent()
+    except Exception:
+        logger.debug("kirocrew-conductor agent install failed", exc_info=True)
+
     # Bidirectional sync: ensure packages installed for one provider
     # are also available for the other (agents↔plugins, skills).
     sync_aim_packages()
@@ -4383,6 +4390,171 @@ def _install_research_agent() -> None:
     path = kiro_agents_dir_path() / _RESEARCH_AGENT_FILENAME
     _atomic_json_write(path, config)
     logger.info("Installed research agent config: %s", path)
+
+
+_CONDUCTOR_SYSTEM_PROMPT = """# Kiro Crew Conductor
+
+You are `kirocrew-conductor`. You own a long-horizon goal: you decompose it
+into work items, stand up one top-level session per item, patrol their state,
+and decide each next round until the goal is met or a stop condition fires.
+
+**You never do a work item's work yourself.** If a task needs a file written,
+a build run, or a fix made, it is a work item for a child session — your four
+jobs are decomposition, dispatch, verification, and the next-round decision.
+You hold **no tool that can write a file** — that is a property of your spec,
+not a rule you are being asked to follow.
+Shell access exists solely to run the bundled acceptance evaluator
+(`goal-conductor` skill, `scripts/accept_eval.py`); acceptance is its
+deterministic verdict, never your reading of a child session's transcript.
+
+Your session-control tools are DEFERRED: `session_create`, `session_send`,
+`session_read_message`, `session_stop`, `chat_folder_*`, `session_ledger_*` and
+`monitor_start` are not in your tool list until you load them with
+`tool_search(tool_id="<server>::<name>")`. A first direct call failing with "a
+tool with the name ... does not exist" means DEFERRED, not missing — load it and
+repeat the call. That is what `tool_search` is mounted for.
+
+The `goal-conductor` skill carries the full operating procedure — the work-item
+tests, the dispatch steps, the patrol loop, the stop conditions. Read it
+before acting on a goal. The user can message you at any time; apply goal
+changes at the round boundary, except a message that directly invalidates an
+in-flight item, which you handle immediately.
+"""
+
+
+def _install_conductor_agent() -> None:
+    """Generate and install the kirocrew-conductor agent config.
+
+    Derives from the kirocrew agent (resolved MCP invocations, security hooks)
+    but narrows to the conductor's charter: session control + core tools +
+    shell for the bundled acceptance evaluator, and **no tool that can write a
+    file** — not ``fs_write``, and not ``code`` either, which governance classes
+    under ``filesystem.write`` because it writes files and can shell out. That
+    is what makes "never does a work item's work itself" a property of the spec
+    rather than of the prompt. The ``kirocrew-dashboard`` server is the opt-in
+    per-agent set (folder + session-control tools); this installer granting it IS
+    the explicit per-agent assignment that set requires — it is deliberately
+    absent from the default agent's spec.
+
+    ``@kirocrew-dashboard`` is NOT added to ``allowedTools``: its calls must
+    keep passing through ``hooks.on_tool_call`` where the deny floor and
+    governance ceiling apply, so every session-control call prompts. Neither is
+    ``execute_bash``, for the same reason — the evaluator run prompts too, which
+    is what actually bounds what an acceptance spec can execute.
+
+    The operating procedure ships as the ``goal-conductor`` builtin skill, NOT
+    ``conductor``: that skill name is owned by the generated delegation skill
+    (``conductor_skill.generate_conductor_skill``), and two existing code paths
+    delete ``<skills>/conductor/SKILL.md`` when ``agent.conductor_skill`` is
+    false — the default. Sharing the name would let ``kirocrew setup`` erase the
+    packaged skill on a stock install, and quarantine the user's delegation
+    skill when the flag is on.
+    """
+    config = build_agent_config()
+    config["name"] = "kirocrew-conductor"
+    config["description"] = (
+        "Owns a long-horizon goal: decomposes it into work items, stands up "
+        "a top-level session per item, patrols their state, and decides each "
+        "next round. Never does the work itself."
+    )
+    config["prompt"] = _CONDUCTOR_SYSTEM_PROMPT
+    config["tools"] = [
+        "execute_bash",
+        "fs_read",
+        # ``web_fetch`` serves the charter's own worked example (reading an issue
+        # list during triage). Deliberately NOT mounted: ``web_search`` (nothing
+        # names it), ``grep``/``glob`` (``fs_read`` covers every read the charter
+        # describes), and above all ``code`` — governance classes it under
+        # ``filesystem.write`` because it "writes files AND can shell out", so
+        # mounting it would make this spec's whole no-write property false.
+        # An unused grant is surface the charter cannot account for.
+        "web_fetch",
+        "session",
+        "report",
+        # Load-bearing, not decoration: with MCP Tool Search active the
+        # session-control specs are deferred, so the conductor cannot reach
+        # ``session_create`` / ``chat_folder_*`` / ``monitor_start`` at all until
+        # it loads them by id. Named in the prompt for that reason.
+        "tool_search",
+        "@kirocrew-core",
+        "@kirocrew-dashboard",
+    ]
+    # ``allowedTools`` is the ONE path that never reaches the PreToolUse gate, so
+    # every grant is filtered through the governance ceiling first — the same
+    # predicate ``rebuild_agent_config`` applies to the primary spec's assembled
+    # list, and the entry point ``may_skip_gate_now`` exists precisely so a new
+    # writer cannot re-open the bypass by restating a literal. A governed ref
+    # stays MOUNTED (it is still in ``tools``); it just prompts, and the gate
+    # then applies the ceiling's per-tool rule with the real arguments.
+    granted: list[str] = []
+    withheld: list[str] = []
+    for ref in ("session", "report", "@kirocrew-core"):
+        (granted if _may_auto_approve(ref) else withheld).append(ref)
+    config["allowedTools"] = granted
+    if withheld:
+        # Withholding a grant is a permission DECISION, and every other writer of
+        # an ``allowedTools`` list emits this same event for it — see
+        # ``strip_ungoverned_auto_approve``, whose comment names a silent pop as
+        # the one withhold path with no audit trail. Filtering silently here would
+        # make this installer exactly that path: on a governed host a ref loses its
+        # grant and the operator has no record of why the conductor now prompts.
+        # Same operation name so it lands in one feed, and the audit must never
+        # break the install.
+        try:
+            sel().log_api_access(
+                caller="system",
+                operation="mcp_auto_approve_withheld",
+                outcome="ok",
+                source="_install_conductor_agent",
+                resources=(
+                    f"{', '.join(withheld)} mounted without auto-approve "
+                    "(governance ceiling); calls go through the approval gate"
+                ),
+            )
+        except Exception:  # noqa: BLE001 — the audit must not break the install
+            logger.debug("SEL audit unavailable for withheld auto-approve", exc_info=True)
+    mcp = config.get("mcpServers", {}) or {}
+    core_entry = mcp.get("kirocrew-core")
+    narrowed: dict = {}
+    if core_entry:
+        narrowed["kirocrew-core"] = core_entry
+    dash_cmd, dash_args = _kirocrew_mcp_invocation("mcp-dashboard")
+    dash_entry: dict[str, Any] = {"command": dash_cmd, "args": dash_args}
+    # Same managed-server metadata `build_agent_config` stamps on every entry it
+    # emits, and the reason this entry needs it spelled out is that it is the one
+    # server hand-built here rather than inherited: without `"type": "registry"`
+    # a registry-mode client silently DROPS the entry, so the conductor's
+    # session-control tools never launch and its whole dispatch/patrol purpose is
+    # dead with no local error; without the `KIROCREW_HOME` pin the shim reads the
+    # DEFAULT data home while the gateway runs under an override, so session
+    # control would act on a different session store than the one it reports on.
+    # Both helpers return empty on a default install, so the emitted spec is
+    # unchanged there.
+    if _mcp_registry_mode():
+        dash_entry["type"] = _MCP_REGISTRY_TYPE
+    dash_env = _managed_mcp_env()
+    if dash_env:
+        dash_entry["env"] = dash_env
+    narrowed["kirocrew-dashboard"] = dash_entry
+    config["mcpServers"] = narrowed
+    # Derive the KAS policy from the FILTERED grant list instead of restating it
+    # as a literal: the rules come out byte-identical, a later edit to
+    # ``allowedTools`` carries through, and a ceiling that strips a grant strips
+    # its KAS rule with it (a hand-written ``kirocrew-core/*`` allow would have
+    # survived the filter on the KAS backend). ``{"rules": []}`` when nothing
+    # qualifies — the key's mere PRESENCE is what makes KAS load the spec at all.
+    from kiro_crew.acp.kas_permissions import (  # noqa: PLC0415 - circular import
+        allowed_tools_to_permissions,
+    )
+
+    derived = allowed_tools_to_permissions(
+        config["allowedTools"], agent_id=Path(_CONDUCTOR_AGENT_FILENAME).stem
+    )
+    config["permissions"] = derived if derived is not None else {"rules": []}
+    kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
+    path = kiro_agents_dir_path() / _CONDUCTOR_AGENT_FILENAME
+    _atomic_json_write(path, config)
+    logger.info("Installed conductor agent config: %s", path)
 
 
 _HEARTBEAT_SYSTEM_PROMPT = """# KiroCrew Heartbeat Worker

--- a/src/kiro_crew/agent_files.py
+++ b/src/kiro_crew/agent_files.py
@@ -21,6 +21,7 @@ AGENT_FILENAME = "kirocrew.json"
 
 # Background/auxiliary managed agent specs KiroCrew writes under ~/.kiro/agents/.
 LITE_AGENT_FILENAME = "kirocrew-lite.json"
+CONDUCTOR_AGENT_FILENAME = "kirocrew-conductor.json"
 KNOWLEDGE_AGENT_FILENAME = "kirocrew-knowledge.json"
 RESEARCH_AGENT_FILENAME = "kirocrew-research.json"
 HEARTBEAT_AGENT_FILENAME = "kirocrew-heartbeat.json"
@@ -35,6 +36,7 @@ CC_MCP_SIDECAR_FILENAME = "kirocrew.mcp.json"
 OWNED_KIRO_AGENT_FILES = (
     AGENT_FILENAME,
     LITE_AGENT_FILENAME,
+    CONDUCTOR_AGENT_FILENAME,
     KNOWLEDGE_AGENT_FILENAME,
     RESEARCH_AGENT_FILENAME,
     HEARTBEAT_AGENT_FILENAME,
@@ -50,8 +52,8 @@ OWNED_CC_AGENT_FILES = (CC_MCP_SIDECAR_FILENAME,)
 #     compaction, heartbeat), reached via ``SessionManager.get_bg_session``.
 # The remaining OWNED_KIRO_AGENT_FILES entries are deliberately excluded: their
 # installers in ``agent.py`` already degrade to ``logger.debug`` on failure
-# because each one only disables its own feature (Knowledge extraction, Research
-# Lab, unattended heartbeat polling).
+# because each one only disables its own feature (goal conducting, Knowledge
+# extraction, Research Lab, unattended heartbeat polling).
 REQUIRED_KIRO_AGENT_FILES = (
     AGENT_FILENAME,
     LITE_AGENT_FILENAME,

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: goal-conductor
+description: Own a long-horizon goal end to end - decompose it into work items, stand up one top-level session per item, patrol their state on a nudge loop, and decide each next round until the goal is met or a stop condition fires. Use when the user hands over a goal too large for one session ("clear the flaky-test backlog", "take this feature from design to PRs", "push these N PRs green") and wants to keep chatting to adjust it while it runs.
+---
+
+# Goal Conductor
+
+You own a goal. You do not do the goal's work.
+
+Your four jobs, none of which can be delegated to a work item:
+
+1. Decompose the goal into work items.
+2. Stand up a session per item and record it in the ledger.
+3. Verify what came back.
+4. Decide the next round, or stop.
+
+Everything else belongs in a work item. This spec has **no `fs_write`** — that
+is deliberate. If a task needs a file written, it is a work item, not something
+you do. `execute_bash` IS granted, for exactly one purpose: running the bundled
+acceptance evaluator (`scripts/accept_eval.py`). It is deliberately kept out of
+`allowedTools`, so every call prompts for approval — see "Known limits" for what
+that costs per patrol cycle.
+
+## What is a work item
+
+A candidate qualifies only if **all three** hold:
+
+1. **Independent** — it does not consume another candidate's output. Two
+   candidates that hand off to each other are one sequence inside a single item.
+2. **Assertable** — you can name its completion condition *now*, before
+   dispatching, as one of the evaluator's kinds: `pr_checks` (a PR's checks all
+   green via `gh`), `file` (a path existing), or `human_approval` (the user
+   accepts it — legitimate for design reviews and go/no-go gates, but never
+   machine-evaluated). **There is deliberately no "run this command" kind**, so
+   "the test suite passes" is expressed as `pr_checks` on the PR that carries the
+   work — CI runs the suite, and its verdict is the one that counts. If an item's
+   completion genuinely cannot be stated as one of these, it is not assertable:
+   say so and treat it as a needs-human item rather than inventing a condition.
+3. **Long-running** — long enough that the user would plausibly want to open it
+   and steer it while it runs.
+
+Fewer than two qualifying candidates means the goal does not need you. Say so
+and just do the work in this session.
+
+### The boundary rule
+
+**If a candidate's input is the ledger's current state, and its output is
+"what to do next" or "a summary of what happened", it is YOUR job, not a work
+item.**
+
+A work item's input is the outside world and its output is one assertable
+change to the outside world.
+
+Worked example — goal "resolve this repo's open issues":
+
+| Candidate | Verdict |
+|---|---|
+| Triage the open issues | Yours. One API read plus a classification; not worth a session's context. |
+| Queue the actionable ones | Not a task. It is triage's completion condition. |
+| Fix issue #N, label it | **Work item** — one per issue, not one for the batch. |
+| Check status and pick the next round | Yours. This is the control loop. |
+| Advise the user on issues nobody can action | Not a task. Stop exit 4. |
+| Write the summary report | Yours. A fold over the ledger. |
+
+## The loop
+
+### Round 0 — agree the plan
+
+Restate the goal, list the work items with their acceptance conditions, and say
+how many you will run per round. Wait for the user. Do not dispatch on a plan
+they have not seen.
+
+**Respect existing ownership signals during triage.** Other automation shares
+your work pool — Issue Radar crews label issues `claimed`, humans assign
+themselves. A candidate someone else already owns is excluded, listed in the
+plan as skipped with the reason, never dispatched over.
+
+Keep concurrency small and constant — two or three items per round. More rounds
+beats more parallelism: every open item is a session the user may have to read.
+
+### Dispatch a round
+
+For each item in the round:
+
+1. `chat_folder_create` once per goal (skip if it exists) so every session for
+   this goal lands in one place.
+2. `session_create` with a title that says what the item is FOR, and `agent` set
+   to the crew that fits. Call `select_crew` first and pass the agent it names —
+   the matched crew when the item is clearly a specialist's job, otherwise the
+   `default_agent` it returns. **Do NOT leave `agent` unset to "inherit the
+   default":** the value inherited is YOUR agent, `kirocrew-conductor`, whose
+   spec deliberately has no `fs_write` — so the child could not write a file even
+   though writing one is the work you dispatched it to do, and the item would
+   look stalled rather than misconfigured.
+3. `chat_folder_move_session` to file the new session under the goal's folder.
+4. `session_send` the seed prompt into the new session — the item's goal, its
+   acceptance condition, and where to report. The seed is the item's whole
+   contract: the child session gets no other context from you.
+5. `session_ledger_record` the item: its goal text, the round number, and — in
+   `artifacts`, under an `item-<n>` key, as a JSON-serialized STRING — the durable
+   item entry carrying its acceptance spec, session key, round, status and read
+   cursor (see "What goes where" below for the encoding, its string requirement,
+   and its bounds). That entry is the ONLY place the acceptance spec survives
+   compaction; `next` carries the resumable intent.
+
+Send the seed BEFORE recording the ledger row as dispatched — a ledger row that
+says "running" for a session that never got its seed is the worse failure.
+
+### Patrol
+
+After dispatching, arm a loop on your own session with `monitor_start`. Put the
+check AND the exit condition in the message. Then end your turn.
+
+Each cycle:
+
+1. `session_ledger_read` to get the full record. Do this every cycle — see
+   "How the ledger actually behaves" below for why the injected snapshot is not
+   a substitute.
+2. **Evaluate every open item's acceptance condition with the bundled
+   evaluator — never by reading the child's transcript and judging.** Build
+   the items JSON from your ledger and run:
+
+   ```bash
+   printf '%s' '{"items":[{"id":"item-1","accept":{"kind":"pr_checks","pr":123,"repo":"owner/name"}}]}' \
+     | python3 <this skill's dir>/scripts/accept_eval.py
+   ```
+
+   **Resolve `<this skill's dir>` from where this SKILL.md was actually loaded
+   from** — the skill index names its absolute path. Do NOT hardcode
+   `~/.kiro/crew/skills/goal-conductor`: a `KIROCREW_HOME` override moves the
+   skills root, so on such an install that path does not exist and every
+   evaluator call would fail before patrol ever ran.
+
+   Build the items JSON from the `item-*` entries in your ledger's `artifacts`,
+   and evaluate **every open item in ONE call** — each invocation costs one
+   approval prompt.
+
+   Verdicts: `pass` / `fail` are final for this cycle. `pending` means keep
+   waiting. `refused` means the spec asked for something the evaluator will not
+   do — most often naming a command, which it does not accept from a spec at all.
+   Re-express the condition as `pr_checks` (or ask the user for a purpose-built
+   kind); never try to route around a refusal. `error` is a broken spec or
+   environment — fix the spec or ask.
+
+   **Two-phase acceptance.** A condition may name a value that only exists
+   after the item starts — a PR number for `pr_checks` is the common case.
+   Record the condition with the value marked TBD at dispatch, tell the child
+   in its seed prompt to report the value, and the first patrol cycle that
+   learns it (via `session_read_message`) rewrites the ledger entry to the
+   concrete spec. **Until the value is known, leave that item OUT of the
+   evaluator batch entirely** and treat it as waiting in your own bookkeeping —
+   do not send it with a placeholder. A spec whose `pr` is not an integer is an
+   `error` verdict, not `pending`, and that is deliberate: the evaluator refuses
+   to read a missing field as "wait", because doing so would make a genuinely
+   malformed spec indistinguishable from one that is merely early. Never fake
+   the gap with a search-style command either — list commands exit 0 on empty
+   results, so they cannot carry the verdict.
+3. For items still running, `session_read_message` with the `since` cursor you
+   stored last cycle — this answers "is it moving / did it ask a question",
+   never "did it succeed". Store the returned `next_since` back into that item's
+   `artifacts` entry — held only in context it is lost on compaction, and the
+   next cycle then re-reads the transcript from the top.
+4. `session_ledger_record` only what changed — but an item's `artifacts` entry is
+   rewritten whole, so include the fields you are not changing.
+5. **Say nothing unless there is a real signal.** An item passing acceptance,
+   failing it, asking a question, or stalling. Never post "nothing changed".
+
+**Shell exists for the evaluator, not for work.** `execute_bash` is granted so
+this patrol step can run `accept_eval.py`. Running a work item's build, test,
+or fix yourself through it is the boundary violation this skill exists to
+prevent — if you need a command run to MAKE something true, that is a work
+item; the evaluator only CHECKS what is already true.
+
+### Close the round
+
+When every item in the round has landed, in one turn: report what each item
+produced, name which acceptance conditions you believe are met and on what
+evidence, and propose the next round. Then wait.
+
+Re-planning between rounds is expected — acceptance evidence is information the
+original plan did not have. Re-planning mid-round is not: let the round finish.
+
+### Goal changes mid-flight
+
+The user can message you any time. Apply a changed goal **at the round
+boundary** — that is the re-plan point, and cancelling mid-round throws away
+finished work.
+
+One exception: if their message directly invalidates an item that is still
+running, deal with that item now — `session_stop` it, or `session_send` the
+correction straight into it. Do not tear down the whole round for one item.
+
+## Stop conditions
+
+Stop and report when ANY of these fire. Do not push past one.
+
+1. Every item is accepted — the goal is met.
+2. The same item has failed acceptance three times.
+3. The round or time budget the user set is spent.
+4. **A decision is needed that no acceptance condition can settle.** Stopping to
+   ask is correct here. Guessing is the failure.
+
+Call `autonudge_stop` when you stop. Reaching `max_cycles` is a runaway
+backstop, not a finish.
+
+## How the ledger actually behaves
+
+Three mechanics decide how you must use it. All three are load-bearing.
+
+**The injected snapshot is a teaser, not the record.** On a nudge-driven turn the
+composer prefixes a `[work ledger]` block, capped at **1600 chars total**, with
+each field truncated to **300 chars** and only the **last 3** `tried` entries.
+A round's work-item table does not fit. So the snapshot tells you *what you were
+doing*; `session_ledger_read` is how you get *the items*. Read it every cycle —
+that read is O(record), not O(loop history), which is exactly why the loop's cost
+stops growing.
+
+**The snapshot only arrives on nudge turns.** It is rendered from one call site
+in the autonudge handler. When the USER messages you mid-flight, there is no
+snapshot — read the ledger yourself before answering anything about item state.
+
+**A terminal phase silences the snapshot.** `render_snapshot` returns empty when
+the phase is terminal. Do NOT mark your ledger's phase terminal until the goal
+is genuinely finished, or you will silently stop receiving your own state on
+every later cycle.
+
+What goes where:
+
+- `goal` — the user's goal, one line.
+- `phase` — which round you are in and what it is waiting on.
+- `next` — a resumable intent, not a status. "round 2: A awaiting acceptance,
+  B still running" beats "monitoring".
+- `artifacts` — **the durable home for every active work item.** One entry per
+  item, and the entry must carry everything patrol needs to run a cycle without
+  the conversation: the acceptance spec, the session key, the round, the status,
+  and the read cursor. Nothing else is durable — the transcript is gone after
+  compaction, and judging an item from its transcript is forbidden anyway — so an
+  acceptance spec that lives only in your context is a spec patrol cannot rebuild.
+
+  **`artifacts` is a map of string to STRING.** The value must be a
+  JSON-*serialized* string, not a nested object: a non-string value is rejected
+  outright with `artifacts_not_string_map` (HTTP 400), so an entry sent as a real
+  object does not persist at all — which loses exactly the state this entry
+  exists to keep. Key it `item-<n>`, and serialize the object into one line:
+
+  ```
+  item-1 -> "{\"accept\":{\"kind\":\"pr_checks\",\"pr\":123,\"repo\":\"o/r\"},\"session\":\"<session key>\",\"round\":2,\"status\":\"running\",\"since\":\"<next_since cursor>\"}"
+  ```
+
+  Parse it back with a JSON decode when you read the ledger, and treat a value
+  that fails to decode as a lost item — re-derive it from the child session
+  rather than guessing.
+
+  The field's real bounds make this fit and also bound it: **32 entries, key
+  ≤128 chars, value ≤2000 chars** — ample for one item's serialized spec, far too
+  small for prose or a transcript excerpt. So keep values to this encoding, and
+  **rotate**: when an item reaches a terminal verdict, collapse its entry to a
+  one-line outcome (`"{\"status\":\"pass\",\"round\":2}"`) or drop it, so a long
+  goal's finished items cannot age an ACTIVE item out of the 32-entry cap. Record
+  the entry in the same `session_ledger_record` call that marks the item
+  dispatched, and rewrite it whenever the spec concretizes (the two-phase TBD
+  case) or the cursor advances.
+- `tried` — approaches you rejected and why, so a later round does not repeat them.
+
+## Cost discipline
+
+A patrol loop that re-reads transcripts every cycle costs more than the work it
+watches, and that cost grows with the loop's own history.
+
+- Read transcripts with `since`, never from the top. Store `next_since`.
+- Write only deltas to the ledger.
+- Stay silent on a quiet cycle.
+- The ledger read is cheap and bounded — that one you do every cycle.
+
+## Known limits of this version
+
+- **The whole surface sits behind one config switch.** `agent.session_control`
+  defaults to OFF and fails closed — every session tool answers
+  `session_control_disabled` until the user sets it to `true` in config.json.
+  If you see that error, say which switch to flip; do not retry.
+- **Every dashboard tool call prompts for approval, and so does every evaluator
+  run.** That is deliberate: both `@kirocrew-dashboard` and `execute_bash` are
+  withheld from auto-approve so their calls still pass through the tool-call hook
+  where the deny floor and governance ceiling apply. The steady-state cost is
+  concrete and worth planning for: **each patrol cycle blocks on one approval for
+  the `accept_eval.py` invocation**, plus one per session-control call in a
+  dispatch round. Patrol is therefore attended-unattended — the loop wakes itself,
+  but a cycle that finds nobody at the keyboard waits rather than proceeding. Size
+  the nudge interval for that, and prefer one evaluator call per cycle carrying
+  every open item over one call per item.
+- **`session_send` reports delivery, not completion.** `started: true` means the
+  target began a turn on your message; `started: false` means it queued. Neither
+  says the work succeeded — acceptance is still the domain assertion's job.
+- **Some targets are out of bounds by design.** Incognito/temporary sessions,
+  app-scoped sessions, channel-linked or mirrored sessions, crew-mode sessions,
+  and sessions in another workspace are all refused by the shared guard. Plan
+  work items onto plain persistent dashboard sessions only.
+- **Shell is for the evaluator only, and the evaluator runs no command you
+  name.** `execute_bash` exists so patrol can run `accept_eval.py`; every call is
+  audit-logged and every call prompts. The evaluator accepts **no command,
+  argv array, or shell string from a spec** — it builds every argv it runs from a
+  fixed template, so `pr_checks` becomes `gh pr checks <n>` and nothing else
+  executes. That is deliberate and load-bearing: this script is invoked as an
+  approved wrapper, so a spec that could name a command would turn it into a
+  general way to run one, and Kiro Crew's denied-command floor cannot see inside
+  it (the floor reads the `execute_bash` string, which says `python3
+  accept_eval.py`). Widening happens by adding a purpose-built kind that
+  constructs its own argv — never by accepting one. A `refused` verdict is a
+  spec to re-express, never a list to route around.

--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""AcceptSpec evaluator - the deterministic half of the conductor's patrol.
+
+The conductor NEVER judges whether a work item succeeded; this script does,
+and the conductor only reads its verdicts. Script-first: the decision is an
+exit code and a JSON document, not a model's impression of a transcript.
+
+Usage:
+    python3 accept_eval.py < items.json
+
+stdin (JSON):
+    {"items": [
+        {"id": "item-1", "accept": {"kind": "pr_checks", "pr": 123,
+                                     "repo": "owner/name"}},
+        {"id": "item-2", "accept": {"kind": "file", "path": "/abs/path",
+                                     "exists": true}},
+        {"id": "item-3", "accept": {"kind": "human_approval"}}
+    ]}
+
+stdout (JSON):
+    {"results": [{"id": "...", "verdict": "pass|fail|pending|refused|error",
+                  "evidence": "..."}]}
+
+Exit code: 0 when evaluation ran (verdicts carry the outcome); 2 on malformed
+input. A per-item problem is a verdict, never a crash - one bad spec must not
+hide the others' results.
+
+THE SECURITY INVARIANT (deliberate, do not weaken):
+
+    No model-authored argv ever reaches subprocess.
+
+A spec is written by a model, and this script runs as an approved wrapper, so a
+spec that could name a command would make this script a general way to run one.
+That is not a hypothetical: an earlier revision accepted a generic ``cmd`` kind
+with an allowlist, and it took three review rounds to establish that no
+constraint on ``argv`` fixes the shape. In order, the allowlist was defeated by
+(1) bare interpreters on it, so ``python -c <payload>`` ran anything;
+(2) a basename-only check, so ``/tmp/git`` executed an arbitrary binary under an
+allowlisted name; and (3) plain ``git reset --hard`` - allowlisted, and
+destructive. (3) is the one that settles it. Kiro Crew's denied-command floor
+inspects the ``execute_bash`` command string, which here reads
+``python3 .../accept_eval.py``; the real argv arrives on stdin and is executed
+with ``shell=False``, so a denied command never appears in any string the hook
+examines. A generic executor behind an approved wrapper therefore REMOVES the
+deny floor for whatever it accepts, and the bypass is the wrapper rather than
+the list - which is why the list was dropped and not tightened again.
+
+So every argv this script runs is built HERE, from a fixed template, out of
+narrowly-typed spec fields. ``_SELF_BUILT_COMMANDS`` is the internal assertion
+that this stayed true: it is not a model-facing allowlist, it is a fail-closed
+check that a handler did not start passing through something it was given.
+
+HOW TO WIDEN IT (the supported path):
+
+    Add a new ``kind`` whose handler builds its own argv. Never re-introduce a
+    kind that takes a command, an argv array, or a shell string from the spec.
+
+A ``pytest`` kind would take test paths and build ``["pytest", *paths]``; an
+``npm_script`` kind would take a script name and build ``["npm", "run", name]``.
+Each such addition is a deliberate, reviewable decision about one more binary,
+and it keeps the invariant above intact by construction. Start narrow and add
+kinds as real work items need them.
+
+Other properties:
+- No shell. argv arrays only, subprocess.run(shell=False).
+- Per-check timeout (TIMEOUT_SECS). A hung check is an "error" verdict.
+- Evidence is tail-capped so a chatty check cannot flood the conductor's turn.
+- A ``refused`` verdict is one the conductor must surface to the user, never
+  retry around.
+
+Stdlib-only, Python 3.8+.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+#: Binaries this script itself invokes, from argv it builds. NOT a spec-facing
+#: allowlist - nothing in a spec can name a command at all. This exists so a
+#: handler that ever passes spec input into `_run` fails closed instead of
+#: executing it, which is the regression the `cmd` kind's removal prevents.
+_SELF_BUILT_COMMANDS = {"gh"}
+
+TIMEOUT_SECS = 300
+EVIDENCE_TAIL_CHARS = 500
+
+#: gh pr checks exits 8 when checks are still running (gh >= 2.30).
+_GH_PENDING_EXIT = 8
+
+
+def _tail(text: str) -> str:
+    text = (text or "").strip()
+    return text[-EVIDENCE_TAIL_CHARS:] if len(text) > EVIDENCE_TAIL_CHARS else text
+
+
+def _run(argv, cwd=None):
+    """Run one SCRIPT-BUILT check without a shell; return (verdict, evidence).
+
+    Every caller must pass an argv it constructed itself. The guard below is an
+    internal invariant, not a spec gate: reaching it with something outside
+    ``_SELF_BUILT_COMMANDS`` means a handler leaked spec input into an exec path,
+    so it refuses rather than runs.
+    """
+    raw = str(argv[0])
+    if raw not in _SELF_BUILT_COMMANDS:
+        return (
+            "refused",
+            f"evaluator bug: {raw!r} is not a command this script builds; "
+            "no spec field may name a command",
+        )
+    try:
+        proc = subprocess.run(  # noqa: S603 - argv array, no shell, script-built
+            [str(a) for a in argv],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            # Pin the decode instead of inheriting the locale: on Windows the
+            # default is the ANSI code page, which mangles a check's UTF-8
+            # output, and `errors="replace"` keeps genuinely undecodable bytes
+            # from raising - a check's OUTPUT must never turn its verdict into a
+            # crash, since the evidence is only ever read by a human.
+            encoding="utf-8",
+            errors="replace",
+            timeout=TIMEOUT_SECS,
+        )
+    except subprocess.TimeoutExpired:
+        return ("error", f"timed out after {TIMEOUT_SECS}s")
+    except FileNotFoundError:
+        return ("error", f"{raw!r} not found on PATH")
+    except OSError as exc:
+        return ("error", f"could not run: {exc}")
+    output = _tail(proc.stdout + "\n" + proc.stderr)
+    if proc.returncode == 0:
+        return ("pass", output or "exit 0")
+    if raw == "gh" and proc.returncode == _GH_PENDING_EXIT:
+        return ("pending", output or "checks still running")
+    return ("fail", f"exit {proc.returncode}: {output}")
+
+
+def _evaluate(item):
+    accept = item.get("accept") or {}
+    kind = accept.get("kind")
+    if kind == "pr_checks":
+        pr = accept.get("pr")
+        # bool is an int subclass, and `{"pr": true}` must not become `gh pr
+        # checks True`; reject it with the same message as any other non-int.
+        if not isinstance(pr, int) or isinstance(pr, bool):
+            return ("error", "pr_checks spec needs an integer pr")
+        argv = ["gh", "pr", "checks", str(pr)]
+        repo = accept.get("repo")
+        if repo:
+            argv += ["--repo", str(repo)]
+        return _run(argv)
+    if kind == "file":
+        path = accept.get("path")
+        if not isinstance(path, str) or not path:
+            return ("error", "file spec needs a path")
+        want = bool(accept.get("exists", True))
+        have = Path(path).exists()
+        verdict = "pass" if have == want else "fail"
+        return (verdict, f"{path} {'exists' if have else 'does not exist'}")
+    if kind == "human_approval":
+        # Never machine-evaluated; the conductor asks the person.
+        return ("pending", "awaiting human approval - not machine-checkable")
+    if kind == "cmd":
+        # Named explicitly so the removal reads as a decision rather than a gap:
+        # a conductor carrying an older skill gets a message that tells it what
+        # to do instead, not a bare "unknown kind".
+        return (
+            "refused",
+            "the 'cmd' kind was removed: a spec may not name a command to run. "
+            "Use 'pr_checks' for CI-backed acceptance (it covers 'the tests "
+            "pass', since CI runs them), or ask for a new purpose-built kind",
+        )
+    return ("error", f"unknown accept kind {kind!r}")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        items = payload["items"]
+        assert isinstance(items, list)
+    except Exception:
+        print(json.dumps({"error": 'stdin must be JSON: {"items": [...]}'}))
+        return 2
+    results = []
+    for position, item in enumerate(items):
+        # ID extraction happens INSIDE the guard. A non-object entry
+        # (``{"items": [1, {"id": "valid"}]}``) raises on ``.get`` before the
+        # handler runs, and an uncaught raise here would abort the whole
+        # evaluation and hide every sibling verdict - the exact failure the
+        # per-item try exists to prevent. The positional fallback keeps a
+        # malformed entry identifiable in the output.
+        item_id = f"#{position}"
+        try:
+            if not isinstance(item, dict):
+                raise TypeError(f"item must be a JSON object, got {type(item).__name__}")
+            item_id = str(item.get("id", item_id))
+            verdict, evidence = _evaluate(item)
+        except Exception as exc:  # one bad spec must not hide the rest
+            verdict, evidence = "error", f"evaluator bug on this item: {exc}"
+        results.append({"id": item_id, "verdict": verdict, "evidence": evidence})
+    print(json.dumps({"results": results}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -47,7 +47,10 @@ _INBOX_POLL_SECS = 1.0
 # control one.  CREATE is blocked for a different reason than the other two: it
 # writes nothing into an existing conversation, but a session it opened would be
 # one the channel agent then owns and may act on, which is exactly the
-# containment this list exists to hold.
+# containment this list exists to hold.  SEND is the sharpest of the four: stop
+# only cancels and read only exfiltrates, but send delivers text that the target
+# session RUNS as a turn — so external channel content would execute inside a
+# private dashboard conversation.
 # Matched against the rendered
 # permission-request text/title via _blocked_tool_named() (boundary-aware,
 # not naive substring — "Editing send_notification.py" must NOT match).
@@ -55,6 +58,7 @@ CHANNEL_AGENT_BLOCKED_TOOLS: tuple[str, ...] = (
     "send_message",
     "send_notification",
     "session_stop",
+    "session_send",
     "session_read_message",
     "session_create",
 )

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -150,6 +150,30 @@ async def api_session_control_stop(request: web.Request) -> web.Response:
     return web.json_response(result)
 
 
+async def api_session_control_send(request: web.Request) -> web.Response:
+    """POST /api/session-control/send — deliver a message to another session."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    # No prewarm here: `send_to_target` warms the config after its own SEL
+    # prewarm, the same ordering `stop_target` uses and for the same reason.
+    state: DashboardState = request.app["state"]
+    try:
+        body = await _body(request)
+        message = body.get("message")
+        if not isinstance(message, str) or not message.strip():
+            raise sc.SessionControlError("message is required", code="message_required")
+        result = await sc.send_to_target(
+            state,
+            caller_session_key=_read_session_key(request),
+            target=_target(body),
+            message=message,
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)
+
+
 async def api_session_control_read(request: web.Request) -> web.Response:
     """GET /api/session-control/read — read another session's transcript tail."""
     refused = await _require_internal(request)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -401,6 +401,7 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # tool is unreachable in production while handler-level tests still pass.
         "/api/session-control/create",
         "/api/session-control/stop",
+        "/api/session-control/send",
         "/api/session-control/read",
     }
 )
@@ -1188,6 +1189,9 @@ def _register_mcp_routes(app: web.Application) -> None:
     )
     app.router.add_post(
         "/api/session-control/stop", _deferred_session_control("api_session_control_stop")
+    )
+    app.router.add_post(
+        "/api/session-control/send", _deferred_session_control("api_session_control_send")
     )
     app.router.add_get(
         "/api/session-control/read", _deferred_session_control("api_session_control_read")

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -6,11 +6,15 @@ operations are deliberately thin: they reuse the same creation, stop and history
 paths the dashboard itself uses, so a controlled session behaves exactly like one
 a human is typing into.
 
-**Nothing here writes into another session's conversation.** Reading returns a
-transcript tail; stopping cancels an in-flight turn the way the Stop button does;
-creating opens an empty session in the user's sidebar. Every verb is therefore
-resolved and authorized at the moment it acts, with no delivery that can be
-delayed past its own authorization.
+**One verb here writes into another session's conversation: ``session_send``.**
+Reading returns a transcript tail; stopping cancels an in-flight turn the way the
+Stop button does; creating opens an empty session in the user's sidebar; sending
+delivers a message the target runs as its next turn, redacted through
+``sanitize_outbound`` and prefixed with a ``[sent by session … via session_send]``
+envelope so it can never render as something the person typed. An IDLE target runs
+it under the authorization that admitted it; a BUSY target queues it, and the
+generic drain re-runs no check — an accepted window, not an oversight, because a
+human-typed queued message shares it (see the spec, and issue #5911).
 
 Authorization is deny-by-default and checked in one place
 (:func:`authorize_target`) for the two operations that take a target, so a guard
@@ -38,6 +42,7 @@ from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, SlotOrigin
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
 from kiro_crew.sel import sel
+from kiro_crew.validation import MAX_LONG_STRING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from kiro_crew.dashboard.state import DashboardState, _ChatSlot
@@ -850,6 +855,102 @@ async def stop_target(
         detail={"result": result.get("info", "stopping")},
     )
     return {"ok": True, "target": slot.key, **result}
+
+
+#: Cap on one delivered message. Aliased to ``validation.MAX_LONG_STRING`` rather
+#: than restated as its own number: a seed prompt is that shape, the MCP schema
+#: layer already rejects on that constant, and two spellings of one 50k limit
+#: would drift apart the first time either moved.
+MAX_SEND_MESSAGE_CHARS = MAX_LONG_STRING
+
+#: Provenance prefix on every delivered message. The target's transcript renders
+#: the message as a user row, and without this line it is indistinguishable from
+#: something the person typed — the same reason auto-nudge tags its injected
+#: turns ``[auto-nudge cycle N]``. The model in the target session sees it too,
+#: so it can weigh the instruction as coming from a peer session, not its user.
+_SEND_PROVENANCE = "[sent by session {caller} via session_send]\n\n"
+
+
+async def send_to_target(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+    message: str,
+) -> dict[str, Any]:
+    """Deliver *message* to *target* as its next agent turn.
+
+    The delivery path is the same queue-vs-run decision the dashboard composer
+    uses (``enqueue_or_run_prompt``): an idle target starts a turn immediately,
+    a busy one queues the message for its next turn. Both outcomes are reported
+    distinctly — ``started`` says which happened — because "it ran" and "it will
+    run later" must not look the same to a caller coordinating several sessions.
+
+    The turn is NOT charged against the background-turn cap, and deliberately so:
+    that cap only binds unattended (app-owned) slots, and every target this
+    function can authorize is attended — see the comment at the delivery call.
+    """
+    # Same prewarm ordering as `stop_target`, for the same reasons: the SEL
+    # write inside `authorize_target`'s deny path must be a cache hit, and the
+    # config warm must be the LAST suspension before the synchronous gate.
+    try:
+        await asyncio.to_thread(sel)
+    except Exception:  # noqa: BLE001 - a prewarm failure must not fail the send
+        logger.warning("session-control SEL prewarm failed", exc_info=True)
+    await prewarm_enabled_check()
+
+    body = message.strip()
+    if not body:
+        raise SessionControlError("message is empty", code="message_empty", status=400)
+    if len(body) > MAX_SEND_MESSAGE_CHARS:
+        raise SessionControlError(
+            f"message exceeds {MAX_SEND_MESSAGE_CHARS} characters",
+            code="message_too_long",
+            status=400,
+        )
+
+    slot = authorize_target(
+        state,
+        caller_session_key=caller_session_key,
+        target=target,
+        operation="send",
+    )
+
+    # Deferred for the same import cycle `stop_target` documents.
+    from kiro_crew.dashboard.chat_runner import _run_chat
+
+    caller_key = caller_slot_key(state, caller_session_key)
+    # Sanitized on the same grounds as the steer path (``chat_delivery`` sanitizes
+    # before ``slot.append``): this body comes from ANOTHER session and is persisted
+    # into — and broadcast from — the target's transcript, so raw content must never
+    # reach that surface. The length gate above deliberately measures the RAW body:
+    # redaction can only shrink the text, so validating the raw form is the honest
+    # limit and keeps the error keyed to what the caller actually sent.
+    prompt = _SEND_PROVENANCE.format(caller=caller_key or "unknown") + sanitize_outbound(body)
+
+    # `_run_chat` is passed straight through, NOT wrapped in
+    # `state.run_background_turn`: that cap is structurally unreachable here.
+    # `run_background_turn` returns the coroutine untouched for an attended slot
+    # (`state.py`, "this wrapper is inert"), `_ChatSlot.unattended` is
+    # `bool(self._app) and not self._human_seen`, and `authorize_target` refuses
+    # every `_app` target above (`app_scoped_target`) — so no target this
+    # function can reach is ever unattended, and a wrapper would only add a
+    # never-taken timeout arm. The composer's own queued path does the same
+    # (`server.py` passes `_run_chat` directly).
+    started = bool(slot.enqueue_or_run_prompt(prompt, _run_chat, state))
+    try:
+        state.push_slots_update()
+    except Exception:  # pragma: no cover - sidebar refresh is best-effort
+        logger.debug("session_send: push_slots_update failed", exc_info=True)
+
+    _audit(
+        caller_session_key=caller_session_key,
+        operation="send",
+        slot_key=slot.key,
+        outcome="allowed",
+        detail={"started": started, "chars": len(body)},
+    )
+    return {"ok": True, "target": slot.key, "started": started}
 
 
 def read_messages(

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -89,6 +89,7 @@ from kiro_crew.validation import (
     MCP_DASHBOARD_SCHEMAS,
     SESSION_CREATE_SCHEMA,
     SESSION_READ_MESSAGE_SCHEMA,
+    SESSION_SEND_SCHEMA,
     SESSION_STOP_SCHEMA,
     validate_tool_args,
 )
@@ -107,6 +108,7 @@ SERVER_VERSION = "1.0.0"
 SESSION_CONTROL_TOOLS: tuple[str, ...] = (
     "session_create",
     "session_stop",
+    "session_send",
     "session_read_message",
 )
 
@@ -270,6 +272,38 @@ def _tool_definitions() -> list[dict[str, Any]]:
                     },
                 },
                 "required": ["target"],
+            },
+        },
+        {
+            "name": "session_send",
+            "description": (
+                "Send a message into another session as its next agent turn — the "
+                "way to seed a session you just created with session_create, answer "
+                "a question it raised, or steer it mid-run. If the target is idle "
+                "the turn starts immediately; if it is busy the message queues and "
+                "runs when its current turn ends — the result says which happened. "
+                "The message lands in the target's transcript tagged as sent by "
+                "your session, so the person reading it can tell it from their own "
+                "typing. Use session_read_message afterwards to watch what the "
+                "target did with it."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Session key from list_sessions, or its exact title.",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": (
+                            "The message to deliver. It becomes the target's next "
+                            "user-role turn, so write it as you would type into "
+                            "that session's composer."
+                        ),
+                    },
+                },
+                "required": ["target", "message"],
             },
         },
         {
@@ -854,6 +888,26 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             # so rather than implying a turn was cancelled.
             return f"\u2139\ufe0f `{target}`: {info} — nothing to stop."
         return f"\U0001f6d1 Stop sent to `{target}`. Its transcript now shows the stop card."
+
+    if name == "session_send":
+        args = validate_tool_args(args, SESSION_SEND_SCHEMA)
+        resp = _post(
+            "/api/session-control/send",
+            {"target": args["target"], "message": args["message"]},
+            session_key=caller_key,
+        )
+        if resp.get("error"):
+            return f"Error: could not send to that session: {resp['error']}"
+        target = resp.get("target", args["target"])
+        if resp.get("started"):
+            return (
+                f"\U0001f4e8 Delivered to `{target}` — it started a turn on your message. "
+                "Watch the result with session_read_message."
+            )
+        return (
+            f"\U0001f4e8 Queued for `{target}` — it is mid-turn, so your message runs "
+            "when the current turn ends. Poll with session_read_message."
+        )
 
     if name == "session_read_message":
         args = validate_tool_args(args, SESSION_READ_MESSAGE_SCHEMA)

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2640,6 +2640,14 @@ SESSION_STOP_SCHEMA = ToolSchema(
     ],
 )
 
+SESSION_SEND_SCHEMA = ToolSchema(
+    tool_name="session_send",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("message", str, required=True, max_len=MAX_LONG_STRING),
+    ],
+)
+
 SESSION_READ_MESSAGE_SCHEMA = ToolSchema(
     tool_name="session_read_message",
     fields=[
@@ -2863,6 +2871,7 @@ def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
 MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
     "session_create": SESSION_CREATE_SCHEMA,
     "session_stop": SESSION_STOP_SCHEMA,
+    "session_send": SESSION_SEND_SCHEMA,
     "session_read_message": SESSION_READ_MESSAGE_SCHEMA,
     "chat_folder_tree": CHAT_FOLDER_TREE_SCHEMA,
     "chat_folder_create": CHAT_FOLDER_CREATE_SCHEMA,

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -1,0 +1,402 @@
+"""Conductor agent installer + bundled acceptance evaluator.
+
+The installer test mirrors the research-agent installer test's shape: stub the
+agents dir and ``build_agent_config``, run the installer, assert on the JSON it
+wrote. The evaluator tests run the real script over stdin/stdout — it is the
+deterministic half of the conductor's patrol, so its verdict vocabulary is
+pinned here.
+
+The ``cmd`` fixtures deliberately use ``git`` rather than ``sys.executable``:
+bare interpreters are NOT on the evaluator's allowlist (a spec could otherwise
+name ``python -c <payload>``), and pinning that is one of the tests below.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from kiro_crew import agent
+from kiro_crew.agent_files import CONDUCTOR_AGENT_FILENAME, OWNED_KIRO_AGENT_FILES
+from kiro_crew.skills import _BUILTIN_SKILLS_DIR
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "builtin_skills" / "goal-conductor"
+)
+SCRIPT = SKILL_DIR / "scripts" / "accept_eval.py"
+
+#: An allowlisted command that always exits 0 — the "pass" fixture.
+
+
+class TestConductorInstaller:
+    def _install(self, tmp_path, monkeypatch, *, may_auto_approve=None):
+        monkeypatch.setattr(agent, "kiro_agents_dir_path", lambda: tmp_path)
+        monkeypatch.setattr(
+            agent,
+            "build_agent_config",
+            lambda: {
+                "name": "kirocrew",
+                "prompt": "file://x",
+                "mcpServers": {
+                    "kirocrew-core": {"command": "/resolved/kirocrew", "args": ["mcp-core"]},
+                    "builder-mcp": {"command": "/x/builder", "args": []},
+                },
+                "tools": ["fs_write", "@kirocrew-core"],
+                "allowedTools": ["@kirocrew-core"],
+            },
+        )
+        monkeypatch.setattr(
+            agent,
+            "_kirocrew_mcp_invocation",
+            lambda sub: ("/resolved/kirocrew", [sub]),
+        )
+        # Pin the ceiling predicate: the default is an ungoverned host (keep every
+        # grant), and the governed case gets its own test below.
+        monkeypatch.setattr(agent, "_may_auto_approve", may_auto_approve or (lambda ref: True))
+        agent._install_conductor_agent()
+        return json.loads((tmp_path / CONDUCTOR_AGENT_FILENAME).read_text(encoding="utf-8"))
+
+    def test_identity_and_charter(self, tmp_path, monkeypatch):
+        data = self._install(tmp_path, monkeypatch)
+        assert data["name"] == "kirocrew-conductor"
+        assert "work item" in data["prompt"]
+
+    def test_no_write_tool_and_dashboard_not_preapproved(self, tmp_path, monkeypatch):
+        """The two deliberate security properties of the spec.
+
+        No ``fs_write``: the conductor cannot do a work item's work itself.
+        ``@kirocrew-dashboard`` and ``execute_bash`` reachable but NOT in
+        ``allowedTools``: their calls must keep passing through the tool-call
+        hook where the deny floor and governance ceiling apply.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        assert "fs_write" not in data["tools"]
+        assert "@kirocrew-dashboard" in data["tools"]
+        assert "@kirocrew-dashboard" not in data["allowedTools"]
+        assert "execute_bash" in data["tools"]
+        assert "execute_bash" not in data["allowedTools"]
+
+    def test_mounts_no_tool_the_charter_never_names(self, tmp_path, monkeypatch):
+        """An unused grant is surface the charter cannot account for.
+
+        `web_fetch` serves the skill's worked example (reading an issue list
+        during triage). `web_search`, `grep` and `glob` appeared in neither the
+        prompt nor the skill and were dropped — `fs_read` covers every read the
+        charter describes. `tool_search` stays and is now NAMED in the prompt:
+        with MCP Tool Search active the session-control specs are deferred, so
+        without it the conductor cannot reach `session_create` at all.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        for absent in ("web_search", "grep", "glob"):
+            assert absent not in data["tools"], absent
+        assert "web_fetch" in data["tools"]
+        assert "tool_search" in data["tools"]
+        assert "tool_search" in data["prompt"]
+
+    def test_mounts_no_tool_that_can_write_a_file(self, tmp_path, monkeypatch):
+        """The no-write property must hold against the tool list, not the prose.
+
+        `fs_write` is the obvious one, but `code` is the trap: governance maps it
+        to `filesystem.write` because it "writes files AND can shell out"
+        (`platform/governance.py` BUILTIN_TOOL_SCOPES), and it sits in
+        `WITHHELD_FROM_AUTO_APPROVE` for the same reason. Mounting it would make
+        "never does a work item's work itself" false while the docstring still
+        claimed it, so both are pinned here together.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        for writer in ("fs_write", "code"):
+            assert writer not in data["tools"], writer
+
+    def test_mcp_surface_is_narrowed_to_core_plus_dashboard(self, tmp_path, monkeypatch):
+        """Inherited servers the conductor has no charter for are dropped."""
+        data = self._install(tmp_path, monkeypatch)
+        assert set(data["mcpServers"]) == {"kirocrew-core", "kirocrew-dashboard"}
+        assert data["mcpServers"]["kirocrew-dashboard"]["args"] == ["mcp-dashboard"]
+
+    def test_dashboard_entry_omits_managed_metadata_on_a_default_install(
+        self, tmp_path, monkeypatch
+    ):
+        """Neither helper contributes by default, so the emitted entry stays minimal.
+
+        Pinned explicitly rather than read off the ambient environment: the
+        repo-root conftest pins ``KIROCREW_HOME`` for every test, so the real
+        ``_managed_mcp_env()`` legitimately returns a pin in-suite.
+        """
+        monkeypatch.setattr(agent, "_mcp_registry_mode", lambda: False)
+        monkeypatch.setattr(agent, "_managed_mcp_env", dict)
+        dash = self._install(tmp_path, monkeypatch)["mcpServers"]["kirocrew-dashboard"]
+        assert dash == {"command": "/resolved/kirocrew", "args": ["mcp-dashboard"]}
+
+    def test_dashboard_entry_carries_managed_server_metadata(self, tmp_path, monkeypatch):
+        """The hand-built dashboard entry is enriched like every managed server.
+
+        Without ``"type": "registry"`` a registry-mode client silently drops the
+        entry, so the conductor's session-control tools never launch. Without the
+        ``KIROCREW_HOME`` pin the shim reads the default data home while the
+        gateway runs under an override, so session control acts on a different
+        session store than it reports on.
+        """
+        monkeypatch.setattr(agent, "_mcp_registry_mode", lambda: True)
+        monkeypatch.setattr(agent, "_managed_mcp_env", lambda: {"KIROCREW_HOME": "/tmp/override"})
+        data = self._install(tmp_path, monkeypatch)
+        dash = data["mcpServers"]["kirocrew-dashboard"]
+        assert dash["type"] == "registry"
+        assert dash["env"] == {"KIROCREW_HOME": "/tmp/override"}
+
+    def test_grants_pass_through_the_governance_ceiling(self, tmp_path, monkeypatch):
+        """``allowedTools`` never reaches the PreToolUse gate, so it is filtered.
+
+        A ceiling with an opinion about ``@kirocrew-core`` must not be silently
+        bypassed by a static grant list: the ref stays MOUNTED (still in
+        ``tools``) but loses its blanket auto-approve, so its calls prompt and
+        the gate applies the real per-tool rule.
+        """
+        data = self._install(
+            tmp_path,
+            monkeypatch,
+            may_auto_approve=lambda ref: ref != "@kirocrew-core",
+        )
+        assert "@kirocrew-core" in data["tools"]
+        assert "@kirocrew-core" not in data["allowedTools"]
+        assert data["allowedTools"] == ["session", "report"]
+
+    def test_kas_permissions_are_derived_from_the_filtered_grants(self, tmp_path, monkeypatch):
+        """The KAS block is derived, not restated — so the ceiling reaches it too.
+
+        Ungoverned: the ``@kirocrew-core`` grant projects to an ``mcp`` allow
+        rule. Governed: the grant is gone, so the rule is too — and the key is
+        still present, because its mere presence is what makes KAS load the spec.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        assert data["permissions"] == {
+            "rules": [{"capability": "mcp", "match": ["kirocrew-core/*"], "effect": "allow"}]
+        }
+
+        governed = self._install(
+            tmp_path,
+            monkeypatch,
+            may_auto_approve=lambda ref: ref != "@kirocrew-core",
+        )
+        assert governed["permissions"] == {"rules": []}
+
+    def test_withholding_a_grant_is_audit_logged(self, tmp_path, monkeypatch):
+        """A withheld grant is a permission DECISION and must leave a record.
+
+        Every other writer of an ``allowedTools`` list emits this event;
+        ``strip_ungoverned_auto_approve`` names a silent pop as the one withhold
+        path with no audit trail. Filtering silently here would make this
+        installer exactly that path.
+        """
+        calls: list[dict] = []
+
+        class _Recorder:
+            def log_api_access(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr(agent, "sel", lambda: _Recorder())
+        self._install(tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core")
+        withheld = [c for c in calls if c.get("operation") == "mcp_auto_approve_withheld"]
+        assert len(withheld) == 1
+        assert "@kirocrew-core" in withheld[0]["resources"]
+        assert withheld[0]["source"] == "_install_conductor_agent"
+
+    def test_no_audit_event_when_nothing_is_withheld(self, tmp_path, monkeypatch):
+        """An ungoverned host withholds nothing, so it records no decision."""
+        calls: list[dict] = []
+
+        class _Recorder:
+            def log_api_access(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr(agent, "sel", lambda: _Recorder())
+        self._install(tmp_path, monkeypatch)
+        assert [c for c in calls if c.get("operation") == "mcp_auto_approve_withheld"] == []
+
+    def test_audit_failure_does_not_break_the_install(self, tmp_path, monkeypatch):
+        """The spec still lands when the audit sink is unavailable."""
+
+        class _Broken:
+            def log_api_access(self, **kw):
+                raise RuntimeError("sel down")
+
+        monkeypatch.setattr(agent, "sel", lambda: _Broken())
+        data = self._install(
+            tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core"
+        )
+        assert data["allowedTools"] == ["session", "report"]
+
+    def test_skill_documents_artifacts_as_a_string_map(self):
+        """The ledger's ``artifacts`` values MUST be JSON-serialized strings.
+
+        ``session_ledger`` handler validation rejects a non-string value with
+        ``artifacts_not_string_map`` (HTTP 400), so a skill that told the
+        conductor to send a nested object would lose every dispatched item's
+        state — the exact durability this entry exists to provide. Pinned as a
+        doc ratchet because the instruction, not the code, is what would drift.
+        """
+        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert "artifacts_not_string_map" in text
+        assert "map of string to STRING" in text
+        # The worked example must show an escaped-quote string value, never a
+        # bare `item-1 -> {` object literal.
+        assert 'item-1 -> "{\\"accept\\"' in text
+        assert "item-1 -> {" not in text
+
+    def test_spec_is_registered_as_kirocrew_owned(self):
+        """Every managed spec registers in ``OWNED_KIRO_AGENT_FILES``.
+
+        Three consumers key off that tuple (the Playwright convergence sweep,
+        ``doctor``'s dead-path repair, connection minting). Absent from it, a
+        conductor spec whose resolved MCP command path dies is classified as a
+        foreign file and reported as unfixable instead of being repaired.
+        """
+        assert CONDUCTOR_AGENT_FILENAME in OWNED_KIRO_AGENT_FILES
+
+    def test_builtin_skill_does_not_collide_with_the_delegation_skill(self):
+        """The packaged skill must NOT be named ``conductor``.
+
+        ``conductor_skill.generate_conductor_skill`` owns
+        ``<skills>/conductor/SKILL.md``, and two paths DELETE that file when
+        ``agent.conductor_skill`` is false (the default): ``cli_setup`` on every
+        setup run and the dashboard config handler on toggle-off. A packaged
+        skill sharing the name would be erased on a stock install.
+        """
+        assert SKILL_DIR.is_dir()
+        assert not (_BUILTIN_SKILLS_DIR / "conductor").exists()
+        assert "name: goal-conductor" in (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _load_evaluator():
+    """Import the bundled script as a module so its internals are addressable.
+
+    It ships inside a skill directory rather than the package, so there is no
+    import path to it; loading it by file location is what lets a test assert the
+    argv a handler BUILDS without executing anything.
+    """
+    spec = importlib.util.spec_from_file_location("_accept_eval_under_test", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestAcceptEvaluatorInvariant:
+    """No model-authored argv may reach subprocess.
+
+    This is the property three review rounds converged on: constraining a
+    spec-supplied argv (allowlist, basename check) never closes the class,
+    because the script runs as an approved wrapper and Kiro Crew's
+    denied-command floor cannot see the argv it receives on stdin. The fix was
+    to stop accepting one at all.
+    """
+
+    def test_pr_checks_builds_its_own_argv(self):
+        """The only exec path constructs argv from narrowly-typed fields."""
+        mod = _load_evaluator()
+        seen = []
+        mod._run = lambda argv, cwd=None: (seen.append((argv, cwd)), ("pass", "ok"))[1]
+        verdict, _ = mod._evaluate(
+            {"accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}}
+        )
+        assert verdict == "pass"
+        assert seen == [(["gh", "pr", "checks", "123", "--repo", "owner/name"], None)]
+
+    def test_run_refuses_a_command_it_did_not_build(self):
+        """The internal guard fails closed if a handler ever leaks spec input."""
+        mod = _load_evaluator()
+        verdict, evidence = mod._run(["git", "--version"])
+        assert verdict == "refused"
+        assert "not a command this script builds" in evidence
+        assert mod._SELF_BUILT_COMMANDS == {"gh"}
+
+    def test_no_spec_field_can_name_a_command(self):
+        """Source ratchet: no handler may read an argv/command/shell spec field.
+
+        A behavioural test only covers the kinds that exist today; this one fails
+        if a future kind re-introduces the shape, which is the actual regression
+        to prevent.
+        """
+        src = SCRIPT.read_text(encoding="utf-8")
+        for banned in ('accept.get("argv")', 'accept.get("command")', 'accept.get("shell")'):
+            assert banned not in src, f"a spec field must never name a command: {banned}"
+
+    def test_pr_checks_rejects_a_non_integer_pr(self):
+        """Including bool, which is an int subclass and would render as 'True'."""
+        mod = _load_evaluator()
+        for bad in ("123", True, None, 12.5):
+            verdict, evidence = mod._evaluate({"accept": {"kind": "pr_checks", "pr": bad}})
+            assert verdict == "error", bad
+            assert "integer pr" in evidence
+
+
+class TestAcceptEvaluator:
+    def _run(self, items):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps({"items": items}),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return {r["id"]: r for r in json.loads(proc.stdout)["results"]}
+
+    def test_verdict_vocabulary_across_kinds(self, tmp_path):
+        exists = tmp_path / "made"
+        exists.write_text("x", encoding="utf-8")
+        out = self._run(
+            [
+                {"id": "have", "accept": {"kind": "file", "path": str(exists), "exists": True}},
+                {
+                    "id": "miss",
+                    "accept": {"kind": "file", "path": str(tmp_path / "no"), "exists": True},
+                },
+                {"id": "human", "accept": {"kind": "human_approval"}},
+                {"id": "junk", "accept": {"kind": "wat"}},
+                {"id": "nopath", "accept": {"kind": "file"}},
+            ]
+        )
+        assert out["have"]["verdict"] == "pass"
+        assert out["miss"]["verdict"] == "fail"
+        assert out["human"]["verdict"] == "pending"
+        assert out["junk"]["verdict"] == "error"
+        assert out["nopath"]["verdict"] == "error"
+
+    def test_the_cmd_kind_is_refused_and_says_what_to_use(self):
+        """A conductor carrying an older skill gets guidance, not 'unknown kind'.
+
+        `cmd` used to exist, so the removal is named explicitly: the refusal
+        points at `pr_checks` and notes it already covers "the tests pass",
+        since CI runs them.
+        """
+        out = self._run(
+            [{"id": "old", "accept": {"kind": "cmd", "argv": ["git", "reset", "--hard"]}}]
+        )
+        assert out["old"]["verdict"] == "refused"
+        assert "may not name a command" in out["old"]["evidence"]
+        assert "pr_checks" in out["old"]["evidence"]
+
+    def test_a_non_object_item_does_not_abort_the_run(self):
+        """ID extraction is inside the per-item guard.
+
+        ``{"items": [1, {...}]}`` raises on ``.get`` before the handler runs; if
+        that raise escaped, every sibling verdict would be lost.
+        """
+        out = self._run([1, "nope", {"id": "fine", "accept": {"kind": "human_approval"}}])
+        assert out["fine"]["verdict"] == "pending"
+        assert out["#0"]["verdict"] == "error"
+        assert out["#1"]["verdict"] == "error"
+        assert "JSON object" in out["#0"]["evidence"]
+
+    def test_malformed_stdin_is_a_clean_exit_2(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input="not json",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        assert proc.returncode == 2

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1476,5 +1476,6 @@ class TestAdvertisedSet:
             "chat_folder_move_session",
             "session_create",
             "session_stop",
+            "session_send",
             "session_read_message",
         }

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -342,6 +342,7 @@ class TestWhatThisSetGrants:
     SESSION_TOOLS = {
         "session_create",
         "session_stop",
+        "session_send",
         "session_read_message",
     }
     GRANTED_TOOLS = FOLDER_TOOLS | SESSION_TOOLS

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -767,6 +767,96 @@ class TestTheRoutesRequireTheInternalSecret:
         assert resp.status == 403, "a broken audit must not escalate a refusal to 500"
         assert self._body(resp)["code"] == "internal_secret_required"
 
+    def test_stop_with_the_secret_reaches_the_operation(self, tmp_path, monkeypatch):
+        """The stop ROUTE's success path, for the reason create's docstring gives:
+        only the 403 arm was covered, so a route-level defect on the reaching path
+        would ship dead."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/stop")
+
+        async def _ok(*_a, **_kw):
+            return {"ok": True, "target": "chat-2", "stopped": True}
+
+        monkeypatch.setattr(sc, "stop_target", _ok)
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+
+        assert resp.status == 200
+        assert self._body(resp)["target"] == "chat-2"
+
+    def test_stop_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """Same refusal contract the create and send routes hold."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/stop")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError(
+                "not addressable", status=403, code="linked_session_target"
+            )
+
+        monkeypatch.setattr(sc, "stop_target", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "linked_session_target"
+
+    def test_send_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(tmp_path, internal=False, path="/api/session-control/send")
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "internal_secret_required"
+
+    def test_send_with_the_secret_delivers_to_the_target(self, tmp_path, monkeypatch):
+        """The send ROUTE needs its own test for the reason create's docstring gives:
+        a handler wired only in tests at the business layer ships dead if the route
+        itself refuses or never reaches the operation."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+        state = req.app["state"]
+        caller = state.get_slot("chat-1")
+        assert caller is not None
+        # Make chat-2 an addressable peer of the caller through the same helper the
+        # business-layer tests use, so this exercises the route rather than a
+        # hand-built slot that authorize_target would refuse for unrelated reasons.
+        _peer_target(state, "chat-2", caller)
+
+        async def _fake_run_chat(_state, _slot, _prompt):
+            return None
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 200, self._body(resp)
+        payload = self._body(resp)
+        assert payload["ok"] is True
+        assert payload["target"] == "chat-2"
+
+    def test_send_requires_a_non_empty_message(self, tmp_path):
+        """The message check lives in the ROUTE, not the business layer, so a
+        whitespace-only body must be refused here rather than delivered as a
+        blank turn."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+
+        async def _json():
+            return {"target": "chat-2", "message": "   "}
+
+        req.json = _json
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 400
+        assert self._body(resp)["code"] == "message_required"
+
+    def test_send_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """A SessionControlError from send comes back as its own refusal, the same
+        contract create's route holds."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/send")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError("busy", status=409, code="target_busy")
+
+        monkeypatch.setattr(sc, "send_to_target", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_send(req))
+
+        assert resp.status == 409
+        assert self._body(resp)["code"] == "target_busy"
+
     def test_read_without_the_secret_is_forbidden(self, tmp_path):
         req = self._request(
             tmp_path, internal=False, path="/api/session-control/read", method="GET"
@@ -1353,6 +1443,179 @@ def test_stop_is_refused_for_a_session_out_of_bounds(tmp_path):
     _slot(state, "chat-hidden", memory_mode="incognito")
     with pytest.raises(sc.SessionControlError):
         asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-hidden"))
+
+
+# ── session_send ──
+
+
+def test_send_to_an_idle_target_starts_a_turn_with_provenance(tmp_path, monkeypatch):
+    """The delivered prompt carries the caller tag, and an idle target runs now.
+
+    Provenance is the load-bearing part: the target renders the message as a
+    user row, and without the tag it is indistinguishable from something the
+    person typed into that session themselves.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+
+    ran: dict[str, str] = {}
+
+    async def _fake_run_chat(_state, slot, prompt):
+        ran["slot"] = slot.key
+        ran["prompt"] = prompt
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+    async def _drive():
+        out = await sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="do the thing"
+        )
+        # Let the enqueue_or_run_prompt task actually execute the fake turn.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return out
+
+    out = asyncio.run(_drive())
+
+    assert out == {"ok": True, "target": "chat-2", "started": True}
+    assert ran["slot"] == "chat-2"
+    assert ran["prompt"].startswith("[sent by session ")
+    assert ran["prompt"].endswith("do the thing")
+    # The transcript shows the message as a user row, tag included.
+    assert any(
+        m.get("content", "").endswith("do the thing")
+        for m in target.messages
+        if m.get("role") == "user"
+    )
+
+
+def test_the_sent_body_passes_through_the_outbound_guard(tmp_path, monkeypatch):
+    """The message goes through `sanitize_outbound` before it is persisted.
+
+    It arrives from ANOTHER session's model, is appended to the target's
+    transcript as a user row and broadcast to every dashboard client, so this is
+    the same surface the steer path sanitizes before `slot.append`
+    (`chat_delivery`: "raw content must never reach an external surface"). A
+    credential-shaped string would otherwise be stored and displayed.
+
+    Mutation guard: dropping the `sanitize_outbound` call leaves the raw value.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    monkeypatch.setattr(sc, "sanitize_outbound", lambda s: f"SANITIZED:{s}")
+
+    ran: dict[str, str] = {}
+
+    async def _fake_run_chat(_state, slot, prompt):
+        ran["prompt"] = prompt
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_runner._run_chat", _fake_run_chat)
+
+    async def _drive():
+        out = await sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="tok=abc"
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return out
+
+    asyncio.run(_drive())
+
+    assert ran["prompt"].endswith(
+        "SANITIZED:tok=abc"
+    ), "the sent body must pass through the outbound guard before it is delivered"
+    # The provenance tag is built by this function, not caller-supplied, so it is
+    # deliberately OUTSIDE the sanitized span.
+    assert ran["prompt"].startswith("[sent by session ")
+    assert any(
+        m.get("content", "").endswith("SANITIZED:tok=abc")
+        for m in target.messages
+        if m.get("role") == "user"
+    ), "the persisted transcript row must carry the sanitized body"
+
+
+def test_the_length_gate_measures_the_raw_body(tmp_path, monkeypatch):
+    """Validation happens on the RAW body, before redaction.
+
+    Redaction can only shrink the text, so gating the raw form is the honest
+    limit: a caller that sends 60K of credentials gets `message_too_long` rather
+    than silently passing because redaction squeezed it under the cap.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _peer_target(state, "chat-2", caller)
+    # A redactor that collapses everything would hide an oversized body.
+    monkeypatch.setattr(sc, "sanitize_outbound", lambda _s: "x")
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(
+            sc.send_to_target(
+                state,
+                caller_session_key=_key(caller),
+                target="chat-2",
+                message="a" * (sc.MAX_SEND_MESSAGE_CHARS + 1),
+            )
+        )
+    assert err.value.code == "message_too_long"
+
+
+def test_send_to_a_busy_target_queues_instead_of_racing(tmp_path):
+    """A mid-turn target must not get a second concurrent turn — the message
+    queues, and the caller is told so (`started: False`), because "ran" and
+    "will run later" are different answers to a coordinator."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    _busy(target)
+
+    out = asyncio.run(
+        sc.send_to_target(
+            state, caller_session_key=_key(caller), target="chat-2", message="queued message"
+        )
+    )
+
+    assert out["started"] is False
+    assert any("queued message" in q.get("content", "") for q in target._queue)
+
+
+def test_send_is_refused_for_a_session_out_of_bounds(tmp_path):
+    """The same deny-by-default guard the other verbs share gates send too."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-hidden", memory_mode="incognito")
+    with pytest.raises(sc.SessionControlError):
+        asyncio.run(
+            sc.send_to_target(
+                state, caller_session_key=_key(caller), target="chat-hidden", message="hi"
+            )
+        )
+
+
+def test_send_refuses_an_empty_or_oversized_message(tmp_path):
+    """Size gates live in the business layer, not only in the tool schema —
+    the HTTP route is callable without the MCP layer's validation."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _peer_target(state, "chat-2", caller)
+
+    with pytest.raises(sc.SessionControlError) as empty_exc:
+        asyncio.run(
+            sc.send_to_target(state, caller_session_key=_key(caller), target="chat-2", message="  ")
+        )
+    assert empty_exc.value.code == "message_empty"
+
+    with pytest.raises(sc.SessionControlError) as long_exc:
+        asyncio.run(
+            sc.send_to_target(
+                state,
+                caller_session_key=_key(caller),
+                target="chat-2",
+                message="x" * (sc.MAX_SEND_MESSAGE_CHARS + 1),
+            )
+        )
+    assert long_exc.value.code == "message_too_long"
 
 
 def test_session_control_routes_are_strict_internal():


### PR DESCRIPTION
> **Stacked on #5650** (`session_send`) — the skill's dispatch step sends seed prompts through that verb. Retargets to `main` automatically when #5650 merges.

## Problem / Motivation

Kiro Crew can automate work inside one session, but a goal too large for one session — "triage N issues and publish fix PRs", "take this feature from design to merged PRs" — still requires the user to decompose it by hand, open a session per piece, paste context into each, poll them all, and decide every next step. The pieces to automate this already exist (#2435 session control, #5198 session ledger, #5650 `session_send`) but nothing assembles them into a usable role.

## Why it matters

With dozens of concurrent sessions the marginal cost of supervision grows linearly: every open workstream is a tab the user must remember, re-read, and re-decide. The pain is no longer *running* parallel work — it is being the only coordinator of it.

## What changed (motivation → approach → change)

Goal: one agent that owns a long-horizon goal and does only the four things a work item cannot do for itself — decompose, dispatch, verify, decide the next round. Approach: assemble the merged mechanisms rather than build new ones, and put the charter in the *spec* wherever a prompt sentence would otherwise be the only thing enforcing it.

**Why not the dynamic-workflow engine.** `src/kiro_crew/workflows/` is the nearest existing mechanism — it already "orchestrates several Kiro Crew agents through ordered phases" — so it is worth saying why this is not a second spelling of it. A workflow is an authored script executed to completion: its phases are fixed before it starts, its agents are sub-agents rather than sessions the user can open, and there is no point at which a human re-plans it mid-run. The conductor is the opposite on all three: it dispatches **top-level, steerable sessions** the user can read and redirect while they run, it treats `human_approval` as a first-class acceptance kind, and re-planning between rounds is the normal path rather than a failure. A goal whose next round genuinely depends on what the last round produced cannot be a workflow script, because the script would have to be written before that information exists.

**1. `kirocrew-conductor` agent** — `_install_conductor_agent()` in `src/kiro_crew/agent.py`, following the `_install_research_agent` pattern: generated at install time from `build_agent_config()`, so MCP invocations resolve to the machine's real paths (a static spec cannot ship). What the spec enforces structurally:

- **No `fs_write`.** A task needing a write is a work item for a child session, never the conductor's own work.
- **No tool that can write a file.** Not `fs_write`, and **not `code` either** — governance maps `code` to `filesystem.write` because it "writes files and can shell out" (`platform/governance.py` `BUILTIN_TOOL_SCOPES`), and it sits in `WITHHELD_FROM_AUTO_APPROVE` for the same reason. That is what makes "never does a work item's work itself" a property of the spec rather than of the prompt, and it is pinned by `test_mounts_no_tool_that_can_write_a_file` so the claim cannot outlive the tool list.
- **MCP surface narrowed** to `kirocrew-core` + `kirocrew-dashboard`; inherited servers the charter has no use for are dropped. The builtin set is narrowed on the same rule — an unused grant is surface the charter cannot account for: `web_fetch` stays because the skill's worked example reads an issue list, while `web_search`, `grep` and `glob` are **not** mounted (`fs_read` covers every read the charter describes). `tool_search` is the one apparent exception and is load-bearing rather than unused: with MCP Tool Search active the session-control verbs are **deferred**, so without it the conductor cannot reach `session_create` / `chat_folder_*` / `monitor_start` at all. The prompt names that use explicitly.
- **Neither `@kirocrew-dashboard` nor `execute_bash` is in `allowedTools`.** Auto-approve is the one path that never reaches the PreToolUse gate, so both stay off it and every session-control call — and every evaluator run — passes through `hooks.on_tool_call` where the deny floor and governance ceiling apply. Granting the opt-in dashboard set in this spec *is* the explicit per-agent assignment that set requires.
- **The grants that remain are filtered through the governance ceiling.** `allowedTools` is built through `_may_auto_approve()` (`may_skip_gate_now`), the entry point whose whole purpose is that a new writer cannot reopen the bypass by restating a literal list. A ceiling with an opinion about `@kirocrew-core` now leaves it *mounted* but not pre-approved.
- **The KAS `permissions` block is derived from that filtered list**, via `allowed_tools_to_permissions()`, instead of restating a blanket `kirocrew-core/*` allow. The rules come out identical on an ungoverned host, a later `allowedTools` edit carries through, and a ceiling that strips a grant strips its KAS rule with it. `{"rules": []}` when nothing qualifies, because the key's mere presence is what makes KAS load the spec.
- **The hand-built `kirocrew-dashboard` entry carries the managed-server metadata** every entry `build_agent_config` emits gets: the conditional `"type": "registry"` marker and the `KIROCREW_HOME` `env` pin. Without the marker a registry-mode client silently drops the entry and the conductor's session-control tools never launch; without the pin the shim reads the default data home while the gateway runs under an override. Both helpers return empty on a default install, so the emitted spec is unchanged there.
- **`CONDUCTOR_AGENT_FILENAME` is registered in `OWNED_KIRO_AGENT_FILES`** (`src/kiro_crew/agent_files.py`), the tuple whose docstring says every managed spec registers there. Absent from it, three consumers (the Playwright convergence sweep, `doctor`'s dead-path repair, connection minting) classify Kiro Crew's own spec as a third-party file, so a dead resolved command path is reported as unfixable instead of repaired.

**2. `goal-conductor` built-in skill** (wheel-shipped under `src/kiro_crew/builtin_skills/`) carrying the operating procedure: the three work-item tests (independent / assertable / long-running), the conductor-vs-work-item boundary rule, dispatch steps (folder → `session_create` → `session_send` seed → ledger record), a patrol loop over `monitor_start`, two-phase acceptance for values that only exist after an item starts (PR numbers), ownership-signal respect during triage (`claimed` labels), and four stop conditions including an explicit needs-human exit.

- **Named `goal-conductor`, not `conductor`.** That name is owned by the generated delegation skill (`conductor_skill.generate_conductor_skill`), and two existing paths *delete* `<skills>/conductor/SKILL.md` when `agent.conductor_skill` is false — the default: `cli_setup.py` on every setup run and the dashboard config handler on toggle-off. Sharing the name would let `kirocrew setup` erase the packaged skill on a stock install, and quarantine the user's delegation skill when the flag is on.
- **Active work-item state has a durable home.** The procedure now records each open item as one compact `item-<n>` entry in the ledger's `artifacts` map — acceptance spec, session key, round, status, and read cursor — and rotates finished items out. The ledger is the only store that survives compaction and judging an item from its transcript is forbidden, so a spec held only in context is a spec patrol cannot rebuild. The encoding fits the field's real bounds (32 entries, key ≤128 chars, value ≤2000 chars), which are also what keeps it to pointers-plus-spec rather than prose.
- **The evaluator is invoked at the skill's resolved install path**, not a hardcoded `~/.kiro/crew/skills/...` — a `KIROCREW_HOME` override moves the skills root, so the hardcoded form would fail every call before patrol ran.
- **The per-cycle approval cost is documented** rather than implied: each patrol cycle blocks on one approval for the evaluator, plus one per session-control call, so patrol is attended-unattended and the skill says to batch every open item into one evaluator call.

**3. `scripts/accept_eval.py`** (stdlib-only, Python 3.8+), the deterministic half of patrol: reads acceptance specs on stdin, emits `pass|fail|pending|refused|error`. Acceptance is never the model reading a child transcript — it is this script's verdict. Per-check timeout, evidence tail-capped, `gh pr checks`' pending exit code (8) mapped to `pending` rather than `fail`, decode pinned to UTF-8 with `errors="replace"` so a check's output cannot turn its verdict into a crash.

- **The security invariant is structural: no model-authored argv ever reaches `subprocess`.** The evaluator accepts **no command, argv array, or shell string from a spec**. Every argv it runs is built here from a fixed template out of narrowly-typed fields, so `pr_checks` becomes `gh pr checks <n>` and nothing else executes. `_SELF_BUILT_COMMANDS` (`{"gh"}`) is the internal fail-closed assertion that this stayed true — it is not a spec-facing allowlist.
- **Why the allowlist was dropped rather than tightened again.** An earlier revision of this PR carried a generic `cmd` kind behind an allowlist, and three review rounds established that no constraint on `argv` fixes the shape: bare interpreters on the list let `python -c <payload>` run anything; a basename-only check let `/tmp/git` execute an arbitrary binary under an allowlisted name; and then plain `git reset --hard` — allowlisted, and destructive. The third is decisive, because this script is invoked as an *approved wrapper*: Kiro Crew's denied-command floor reads the `execute_bash` string, which says `python3 accept_eval.py`, while the real argv arrives on stdin and runs with `shell=False`. A generic executor there **removes the deny floor** for whatever it accepts, so the bypass was the wrapper rather than the list.
- **Widening is additive and reviewable.** Adding a capability means adding a `kind` whose handler builds its own argv (a `pytest` kind taking test paths, an `npm_script` kind taking a script name) — never a kind that accepts a command. The script's docstring states this as the supported path so the next contributor does not re-open the generic form. `cmd` is still recognised and answered with a `refused` verdict naming what to use instead, so a conductor carrying an older skill gets guidance rather than "unknown kind".
- **What the removal costs, and why it is acceptable.** "The test suite passes" is no longer a local acceptance condition; it is expressed as `pr_checks` on the PR carrying the work, which covers it transitively because CI runs the suite. The skill's own worked example is already issue → PR → checks green.
- **A malformed item cannot hide its siblings.** Item validation and id extraction moved inside the per-item `try`: a non-object entry (`{"items": [1, {...}]}`) raised on `.get` *before* the handler, aborting the run and discarding every sibling verdict. It now yields a positional `error` verdict.

## Tests

`test/test_conductor_agent.py` — 22 tests. Installer: identity + charter; `fs_write` absent while `execute_bash`/`@kirocrew-dashboard` are reachable but not pre-approved; no tool the charter never names (`web_search` absent, `web_fetch` present); MCP narrowing; the dashboard entry carrying `type`/`env` under registry mode + home override and staying minimal without them; a ceiling-governed ref keeping its mount and losing its grant; `permissions` derived from the filtered list (collapsing to `{"rules": []}` when the grant is withheld); the withheld grant emitting one `mcp_auto_approve_withheld` SEL event, no event when nothing is withheld, and a raising audit sink still letting the spec land; `CONDUCTOR_AGENT_FILENAME` in `OWNED_KIRO_AGENT_FILES`; the packaged skill not colliding with the delegation skill's name; the ledger item encoding documented as a string map.

Evaluator — the invariant gets its own class: `pr_checks` builds its own argv (asserted exactly, with `_run` captured rather than executed); `_run` refuses a command it did not build; a **source ratchet** fails if any handler ever reads an `argv`/`command`/`shell` spec field, which is the regression a behavioural test cannot cover; `pr_checks` rejects a non-integer `pr` including `bool`. Behaviour: verdict vocabulary across the remaining kinds, the removed `cmd` kind refused with guidance naming `pr_checks`, a non-object item not aborting the run, malformed stdin as a clean exit 2.

Full run: 1400 passed / 3 skipped across the affected modules (agent, agent_files, skills, doctor dead-path, connections mint, session control, ledger, MCP dashboard, spawn roster). Gates green: black, isort, flake8, mypy, subprocess-encoding, brand-name, changelog-history, focus-cue, harness-parity, vendor-manifest, loop-bound-locks. `accept_eval.py` needs no `security_posture` registration (reads local state and prints; no redactor or egress calls).

## Manual verification

After install, `~/.kiro/agents/kirocrew-conductor.json` exists with resolved command paths. Open a session on the conductor agent and hand it a multi-item goal: it should present a plan before dispatching, seed children via `session_send`, evaluate acceptance through the bundled script (one approval prompt per evaluator call — by design), and surface non-assertable items instead of dispatching them. A logic dry-run against 10 real repo issues was performed and its two findings (two-phase acceptance, `claimed`-label exclusion) are folded into the skill. Note the runtime preconditions: `agent.session_control` must be `true`, and strict session identity must resolve for the reflexive tools.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only — a generated agent spec, a wheel-shipped skill, a stdlib script and tests. No frontend path is touched and nothing renders differently.

## Related Issues

no linked issue: this assembles already-merged mechanisms (#2435, #5198, #5650) into a new role; there is no filed issue it resolves. Those references are context, not closing trailers.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff



