### PR TITLE
fix(hooks): close subprocess secret egress paths

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -1422,6 +1422,20 @@ a hook is therefore **not portable across platforms**:
 Both platforms receive the same `KIROCREW_HOOK_EVENT` / `KIROCREW_HOOK_CONTEXT`
 env vars and the same hook-event JSON on stdin.
 
+**A hook subprocess inherits only an allowlisted slice of the gateway
+environment, not the whole of `os.environ`.** The gateway process holds
+credentials (provider API keys, tokens) in its environment; copying that wholesale
+into every hook command would hand an untrusted shell line those secrets. The
+allowlist (`_HOOK_BASE_ENV_KEYS` in `hooks.py`) preserves only what a hook
+legitimately needs — `PATH`/`PATHEXT`/`COMSPEC`/`SYSTEMROOT`, the home/profile and
+`KIROCREW_HOME` data-home vars, temp-dir and locale vars, and TLS-trust
+(`SSL_CERT_*`, `NO_PROXY`) — plus the two `KIROCREW_HOOK_*` metadata vars set last.
+`HTTP(S)_PROXY` is deliberately dropped (it commonly embeds userinfo credentials).
+The consequence for operators: a hook that relied on an ambient var outside that
+set (e.g. `VIRTUAL_ENV`, `PYTHONPATH`, `JAVA_HOME`, `AWS_PROFILE`, nvm/pyenv vars)
+runs fine in a terminal but fails once fired as a hook; the fix is to add that key
+to `_HOOK_BASE_ENV_KEYS` by name — the allowlist is fail-closed by design.
+
 **Windows spawns through `asyncio.create_subprocess_shell`, not an argv.** cmd.exe
 must receive the operator's command line verbatim: an argv spawn of
 `["cmd", "/c", command]` routes it through `subprocess.list2cmdline`, which

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -289,6 +289,7 @@ async def api_hook_test(request: web.Request) -> web.Response:
     # circular import: kiro_crew.hooks pulls dashboard state at module load, so
     # this handler defers the import to call time (matches _get_hook_store above).
     from kiro_crew.hooks import HOOK_EVENT_STOP, run_script_hook  # noqa: F811
+    from kiro_crew.platform import redact_via_context
 
     store = _get_hook_store(request.app["state"])
     hook_id = request.match_info["hook_id"]
@@ -326,7 +327,7 @@ async def api_hook_test(request: web.Request) -> web.Response:
             "hook_event": hook.event,
             "exit_code": result.exit_code,
             "duration_ms": result.duration_ms,
-            "context": context,
+            "context": redact_via_context(context),
         },
     )
     return web.json_response(

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -3018,6 +3018,89 @@ def validate_hook_fields(
             raise ValueError(f"invalid regex: {exc}") from None
 
 
+# Env keys a script-hook subprocess may inherit from the gateway. A script hook
+# runs an operator/agent-authored command through ``/bin/sh -c`` (POSIX) or
+# ``cmd /c`` (Windows), so it needs only what the shell and an ordinary command
+# require to run — an interpreter/tool on PATH, HOME, locale, TLS trust, and a
+# proxy — plus the two hook-metadata variables injected below. Inheriting the
+# whole gateway environment (``{**os.environ, ...}``) also handed every hook the
+# gateway's AWS keys, model/provider keys, OAuth tokens, and connection strings,
+# which a hostile or careless command could echo straight back through stdout,
+# stderr, or the audit trail. This is the same strict-allowlist boundary the
+# authenticated ``gh``/``glab`` spawns cross (``_PROVIDER_BASE_ENV_KEYS`` in
+# ``dashboard/handlers/source_providers.py``); a variable a hook genuinely needs
+# is added here by name, never by opening the gate to the whole environment. A
+# key absent from the host environment is simply not forwarded — the allowlist
+# is a filter, not a set of required keys — so a minimal container is unaffected.
+_HOOK_BASE_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        # A hook subprocess sees ONLY these ambient keys (plus the two
+        # KIROCREW_HOOK_* metadata vars). A hook that depended on an ambient var
+        # NOT listed here (e.g. VIRTUAL_ENV, PYTHONPATH, JAVA_HOME, AWS_PROFILE,
+        # nvm/pyenv vars) will fail after upgrade with a "works in my terminal,
+        # fails in the hook" symptom — the fix is to add that key here by name.
+        # This fail-closed direction is deliberate: the allowlist is the
+        # secret-egress boundary, so widening it is a per-key security decision.
+        # Shell / command resolution. PATH is what lets ``/bin/sh -c "python …"``
+        # find the interpreter; the Windows spellings mirror it there.
+        "PATH",
+        "PATHEXT",
+        "COMSPEC",
+        "SYSTEMROOT",
+        # Home / user profile — a hook command that reads or writes under ``~``.
+        "HOME",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "XDG_CONFIG_HOME",
+        # Data home — a hook that invokes the ``kirocrew`` CLI (or otherwise
+        # reads the instance's data dir) must resolve the gateway's overridden
+        # home, not the default ``~/.kiro/crew``. It is a path, not a credential,
+        # so preserving it does not widen the secret-egress boundary this env
+        # allowlist exists to close.
+        "KIROCREW_HOME",
+        # Temp dir — a hook that stages a scratch file.
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        # Locale — so a hook's output encoding matches the host.
+        "LANG",
+        "LC_ALL",
+        # TLS trust may be required by network clients. Proxy URLs are omitted:
+        # HTTP(S)_PROXY commonly embeds userinfo credentials, and script hooks
+        # are an untrusted execution boundary. NO_PROXY carries host patterns,
+        # not credentials, and is safe to preserve.
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "NO_PROXY",
+        "no_proxy",
+    }
+)
+
+
+def _hook_subprocess_env(hook: "ScriptHook", context: str) -> dict[str, str]:
+    """Build the environment a script-hook subprocess runs with.
+
+    A strict allowlist over ``os.environ`` (``_HOOK_BASE_ENV_KEYS``) plus the two
+    hook-metadata variables the hook contract exposes — never a copy of the whole
+    gateway environment, which would leak the gateway's credentials to every hook
+    command (see ``_HOOK_BASE_ENV_KEYS``). The metadata variables are set LAST so
+    a same-named ambient variable can never shadow them.
+
+    ``KIROCREW_HOOK_CONTEXT`` is capped for a Stop event only: the env var is
+    bounded by ARG_MAX (~32K on Windows), and a multi-KB Stop segment there can
+    fail subprocess creation. The full context still reaches the hook via the
+    stdin JSON payload (``Stop -> hook_event["assistant_text"]``) and drove
+    matcher evaluation, so the cap loses nothing the hook cannot recover.
+    """
+    env = {k: v for k, v in os.environ.items() if k in _HOOK_BASE_ENV_KEYS}
+    env["KIROCREW_HOOK_EVENT"] = hook.event
+    env["KIROCREW_HOOK_CONTEXT"] = context[:500] if hook.event == HOOK_EVENT_STOP else context
+    return env
+
+
 @dataclass
 class ScriptHook:
     """Executable hook that runs a shell command on a trigger event.
@@ -3321,18 +3404,13 @@ async def run_script_hook(
 
     try:
         # circular import: sandbox → registry → apps → hooks, so import at call time
-        from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
+        from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 
-        # The env var is bounded by ARG_MAX — a multi-KB Stop segment there can
-        # fail subprocess creation (~32K on Windows). Cap the ENV copy only; the
-        # full context still reaches the hook via the stdin JSON payload
-        # (Stop -> hook_event["assistant_text"]) and drove matcher evaluation.
-        env_context = context[:500] if hook.event == HOOK_EVENT_STOP else context
-        env = {
-            **os.environ,
-            "KIROCREW_HOOK_EVENT": hook.event,
-            "KIROCREW_HOOK_CONTEXT": env_context,
-        }
+        # A script hook inherits only the minimum env its shell + command need
+        # (``_HOOK_BASE_ENV_KEYS``) plus the two hook-metadata variables — NOT a
+        # copy of the whole gateway environment, which would expose the gateway's
+        # AWS/model/OAuth/connection-string credentials to every hook command.
+        env = _hook_subprocess_env(hook, context)
         # Shell per platform: POSIX /bin/sh -c, Windows cmd /c (no /bin/sh there).
         # The argv is what the sandbox/cgroup chokepoints below vet, on BOTH
         # platforms — only the eventual spawn form differs (see the Windows
@@ -3341,8 +3419,14 @@ async def run_script_hook(
             argv = ["cmd", "/c", hook.command]
         else:
             argv = ["/bin/sh", "-c", hook.command]
-        wrapped_argv, cleanup_path = wrap_argv(argv)
-        wrapped_argv = cgroup_scope_argv(wrapped_argv)  # cgroup DoS ceiling
+        # Route argv and the strict hook allowlist through the shared spawn
+        # funnel. Besides filesystem isolation and cgroup limits, this lets an
+        # outer systemd-run wrapper receive its user-bus locators while inserting
+        # an inner `env -u` shim that removes them before the hook command execs.
+        # Calling wrap_argv + cgroup_scope_argv directly would give the wrapper
+        # the child-safe allowlist and make it fail before a PreToolUse policy
+        # hook could run.
+        wrapped_argv, env, cleanup_path = sandboxed_spawn_argv(argv, env=env)
         # Process-group isolation for clean tree-kill on timeout. Pass both flags
         # explicitly (NOT **dict unpack — breaks mypy's Popen overload resolution
         # on the build fleet): start_new_session=True is a no-op on Windows,
@@ -3401,15 +3485,19 @@ async def run_script_hook(
                     pass
         elapsed = int((time.monotonic() - start) * 1000)
         exit_code = proc.returncode or 0
+        # Decode with the upstream byte cap (#5442) so redaction never sees an
+        # unbounded string, THEN redact the full capped streams through the
+        # canonical companion-aware shim before any truncation or return
+        # (#5441). Both fields are returned by the test API, and stdout can also
+        # become model context for prompt/spawn hooks; redacting the capped text
+        # first prevents a credential that straddles a presentation boundary
+        # (e.g. the 500-char stderr cut for last_error, #4708) from leaking as
+        # an unredacted fragment.
         stdout_text = _decode_capped(stdout_b, stdout_trunc).strip()
         stderr_text = _decode_capped(stderr_b, stderr_trunc).strip()
-        # Redact the FULL (capped) stderr through the canonical companion-aware
-        # shim before truncating, so a credential straddling the 500-char
-        # boundary cannot leak as an unredacted fragment. The field surfaces on
-        # the dashboard and must not expose secrets (#4708). Memory is already
-        # bounded upstream by the byte cap (#5442), so redaction never sees an
-        # unbounded string.
-        stderr_safe = redact_via_context(stderr_text)[:500] if stderr_text else ""
+        stdout_safe = redact_via_context(stdout_text) if stdout_text else ""
+        stderr_safe_full = redact_via_context(stderr_text) if stderr_text else ""
+        stderr_safe = stderr_safe_full[:500]
         hook.last_run = time.time()
         if exit_code == 2:
             hook.last_status = "blocked"
@@ -3425,8 +3513,8 @@ async def run_script_hook(
             hook_id=hook.id,
             hook_name=hook.name,
             event=hook.event,
-            stdout=stdout_text,
-            stderr=stderr_text,
+            stdout=stdout_safe,
+            stderr=stderr_safe_full,
             exit_code=exit_code,
             duration_ms=elapsed,
         )
@@ -3466,15 +3554,16 @@ async def run_script_hook(
         )
     except Exception as exc:
         elapsed = int((time.monotonic() - start) * 1000)
+        safe_error = redact_via_context(str(exc))
         hook.last_run = time.time()
         hook.last_status = "error"
-        hook.last_error = str(exc)[:500]
+        hook.last_error = safe_error[:500]
         hook.run_count += 1
         return ScriptHookResult(
             hook_id=hook.id,
             hook_name=hook.name,
             event=hook.event,
-            error=str(exc),
+            error=safe_error,
             duration_ms=elapsed,
         )
 

--- a/test/test_api_hook_test_stop_payload.py
+++ b/test/test_api_hook_test_stop_payload.py
@@ -69,3 +69,47 @@ async def test_non_stop_hook_test_uses_default_payload(tmp_path):
     _args, _kwargs = mock_run.call_args
     hook_event = _args[2] if len(_args) > 2 else _kwargs.get("hook_event")
     assert hook_event is None
+
+
+@pytest.mark.asyncio
+async def test_hook_test_redacts_context_in_sel_metadata(tmp_path):
+    store = ScriptHookStore(tmp_path)
+    hook = store.create(
+        {
+            "name": "audit-hook",
+            "event": HOOK_EVENT_USER_PROMPT_SUBMIT,
+            "matcher": "",
+            "command": "cat",
+        }
+    )
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    context = f"deploy with {secret}"
+    fake_result = type(
+        "R",
+        (),
+        {
+            "exit_code": 0,
+            "stdout": "",
+            "stderr": "",
+            "duration_ms": 1,
+            "error": "",
+            "hook_name": "audit-hook",
+        },
+    )()
+    audit = MagicMock()
+
+    with (
+        patch(
+            "kiro_crew.hooks.run_script_hook",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ) as mock_run,
+        patch("kiro_crew.dashboard.handlers.hooks._sel", return_value=audit),
+    ):
+        resp = await api_hook_test(_req_with_store(store, hook.id, context))
+
+    assert resp.status == 200
+    assert mock_run.await_args.args[1] == context
+    metadata = audit.log_tool_invocation.call_args.kwargs["metadata"]
+    assert secret not in metadata["context"]
+    assert "redacted" in metadata["context"].lower()

--- a/test/test_script_hooks.py
+++ b/test/test_script_hooks.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import platform
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -404,6 +405,133 @@ class TestRunScriptHook:
         result = await run_script_hook(hook, "test-context")
         assert HOOK_EVENT_USER_PROMPT_SUBMIT in result.stdout
 
+    def test_subprocess_env_excludes_gateway_credentials(self, monkeypatch):
+        from kiro_crew.hooks import _hook_subprocess_env
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        proxy_secret = "http://svc:pa55word@proxy.example.com"
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", secret)
+        monkeypatch.setenv("HTTPS_PROXY", proxy_secret)
+        monkeypatch.setenv("http_proxy", proxy_secret)
+        monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+        monkeypatch.setenv("KIROCREW_HOME", "/custom/data/home")
+        hook = ScriptHook(
+            id="env-safe",
+            name="env-safe",
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            command="echo ok",
+        )
+
+        env = _hook_subprocess_env(hook, "prompt text")
+
+        assert env["PATH"] == os.environ["PATH"]
+        assert "AWS_ACCESS_KEY_ID" not in env
+        assert "HTTPS_PROXY" not in env
+        assert "http_proxy" not in env
+        # The data-home override must survive so a hook invoking the kirocrew
+        # CLI resolves the gateway's home, not the default (it is a path, not a
+        # credential).
+        assert env["KIROCREW_HOME"] == "/custom/data/home"
+        assert env["KIROCREW_HOOK_EVENT"] == HOOK_EVENT_USER_PROMPT_SUBMIT
+        assert env["KIROCREW_HOOK_CONTEXT"] == "prompt text"
+
+    @pytest.mark.skipif(_IS_WINDOWS, reason="systemd user-bus wrapping is POSIX-only")
+    @pytest.mark.asyncio
+    async def test_subprocess_routes_allowlist_through_safe_spawn_funnel(self, monkeypatch):
+        """The wrapper gets bus locators without widening the hook base env."""
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        bus_address = "unix:path=/run/user/4242/bus"
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", secret)
+        seen: dict[str, object] = {}
+
+        def safe_spawn(argv, *, env):
+            seen["base_env"] = dict(env)
+            wrapper_env = dict(env)
+            wrapper_env["DBUS_SESSION_BUS_ADDRESS"] = bus_address
+            return list(argv), wrapper_env, None
+
+        proc = MagicMock()
+        # Main's capped-output path (#5442) drains proc.stdout/proc.stderr via
+        # _read_capped_stream(reader.read(n)) rather than proc.communicate, and
+        # feeds proc.stdin then awaits proc.wait(). Model those so the funnel's
+        # env assertions below run against a process that completes cleanly.
+
+        async def _read(_n: int, _chunks=[b"ok\n"]):
+            return _chunks.pop(0) if _chunks else b""
+
+        proc.stdout.read = AsyncMock(side_effect=_read)
+        proc.stderr.read = AsyncMock(return_value=b"")
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.stdin.close = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        proc.returncode = 0
+        monkeypatch.setattr("kiro_crew.sandbox.sandboxed_spawn_argv", safe_spawn)
+        create = AsyncMock(return_value=proc)
+        monkeypatch.setattr("kiro_crew.sandbox.create_subprocess_limited", create)
+
+        hook = ScriptHook(
+            id="safe-funnel",
+            name="safe-funnel",
+            event=HOOK_EVENT_PRE_TOOL_USE,
+            command="echo ok",
+        )
+        result = await run_script_hook(hook, "tool context")
+
+        assert result.exit_code == 0
+        base_env = seen["base_env"]
+        assert isinstance(base_env, dict)
+        assert "AWS_ACCESS_KEY_ID" not in base_env
+        assert "DBUS_SESSION_BUS_ADDRESS" not in base_env
+        assert create.await_args.kwargs["env"]["DBUS_SESSION_BUS_ADDRESS"] == bus_address
+
+    @pytest.mark.asyncio
+    async def test_stdout_and_stderr_are_redacted_before_return(self, tmp_path):
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        command = _script_command(
+            tmp_path / "leaky_hook.py",
+            "import sys\n"
+            f"print({secret!r})\n"
+            f"sys.stderr.write({secret!r} + '\\n')\n"
+            "raise SystemExit(1)\n",
+        )
+        hook = ScriptHook(
+            id="redacted-streams",
+            name="redacted-streams",
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            command=command,
+            timeout=30,
+        )
+
+        result = await run_script_hook(hook, "ctx")
+
+        assert secret not in result.stdout
+        assert secret not in result.stderr
+        assert secret not in hook.last_error
+        assert "redacted" in result.stdout.lower()
+        assert "redacted" in result.stderr.lower()
+
+    @pytest.mark.asyncio
+    async def test_exception_text_is_redacted_before_return_or_persistence(self):
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        hook = ScriptHook(
+            id="redacted-exception",
+            name="redacted-exception",
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            command="echo unreachable",
+            timeout=30,
+        )
+
+        with patch(
+            "kiro_crew.sandbox.wrap_argv",
+            side_effect=RuntimeError(f"spawn failed for {secret}"),
+        ):
+            result = await run_script_hook(hook, "ctx")
+
+        assert secret not in result.error
+        assert secret not in hook.last_error
+        assert "redacted" in result.error.lower()
+
     @pytest.mark.asyncio
     async def test_hook_updates_metadata(self):
         """Hook execution updates last_run, last_status, run_count."""
@@ -658,7 +786,12 @@ class TestRunScriptHookSpawnForm:
             assert seen.get("shell_cmd") == command
             assert "argv" not in seen
         else:
-            assert seen["argv"] == ["/bin/sh", "-c", command]
+            spawned = seen["argv"]
+            assert isinstance(spawned, list)
+            # Security layers may prepend sandbox, cgroup, resource-limit, or
+            # env-unset wrappers. The shell tuple at the tail is the stable
+            # contract, and its command must remain byte-for-byte unchanged.
+            assert spawned[-3:] == ["/bin/sh", "-c", command]
 
     @pytest.mark.asyncio
     async def test_a_wrapping_sandbox_wins_over_the_shell_spawn(self, monkeypatch):
@@ -673,8 +806,8 @@ class TestRunScriptHookSpawnForm:
             "kiro_crew.sandbox.wrap_argv", lambda argv, **k: (["sandbox-exec", *argv], None)
         )
         # cgroup_scope_argv runs AFTER wrap_argv and prepends its own launcher on
-        # a cgroup-v2 host, which would displace "sandbox-exec" from argv[0]. Pin
-        # it to a no-op so the assertion names the wrapper this test installed.
+        # a cgroup-v2 host. Pin it to a no-op so only the shared env-unset shim
+        # may precede the wrapper this test installed.
         monkeypatch.setattr("kiro_crew.sandbox.cgroup_scope_argv", lambda argv: list(argv))
         seen: dict[str, object] = {}
 
@@ -690,8 +823,8 @@ class TestRunScriptHookSpawnForm:
             seen["argv"] = list(argv)
             return fake_proc
 
-        # Capture at create_subprocess_limited so its RLIMIT shim cannot displace
-        # "sandbox-exec" from argv[0] (see the sibling test above).
+        # Capture at create_subprocess_limited so its RLIMIT shim cannot alter
+        # the argv built by the shared spawn funnel (see the sibling test above).
         monkeypatch.setattr("kiro_crew.sandbox.create_subprocess_limited", fake_exec)
         monkeypatch.setattr("asyncio.create_subprocess_shell", fake_shell)
         monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
@@ -699,7 +832,13 @@ class TestRunScriptHookSpawnForm:
         await run_script_hook(self._hook("echo hi"), "ctx")
 
         assert "shell_cmd" not in seen, "a wrapped argv must not be discarded for a shell spawn"
-        assert seen["argv"][0] == "sandbox-exec"
+        spawned = seen["argv"]
+        assert isinstance(spawned, list)
+        shell_start = len(spawned) - 3
+        assert spawned[-3:] == (
+            ["cmd", "/c", "echo hi"] if _IS_WINDOWS else ["/bin/sh", "-c", "echo hi"]
+        )
+        assert spawned.index("sandbox-exec") < shell_start
 
 
 class TestLastError:


### PR DESCRIPTION
## Problem / Motivation

Script hooks inherited the gateway process environment and could return sensitive values unchanged through captured stdout, stderr, or error text. Hook tests could therefore expose credentials that the hook never needed.

## Why it matters

A user-authored hook is a subprocess trust boundary. Forwarding the full parent environment or returning unredacted output gives hook code unnecessary access to credentials and can persist those values in API responses, logs, or UI error surfaces.

## What changed (motivation → approach → change)

The subprocess launcher now builds an explicit minimal environment (a strict allowlist over `os.environ`, `_HOOK_BASE_ENV_KEYS`, plus the two `KIROCREW_HOOK_*` metadata variables) instead of copying the gateway environment, so the child never inherits gateway credentials. The allowlist preserves `KIROCREW_HOME` so a hook that invokes the `kirocrew` CLI still resolves the gateway's overridden data home (it is a path, not a credential); it deliberately drops `HTTP(S)_PROXY`/`http(s)_proxy` because proxy URLs commonly embed userinfo credentials, keeping `NO_PROXY` (host patterns only) and the TLS-trust vars. Captured stdout, stderr, and failure text pass through shared secret redaction before leaving the subprocess boundary, and the API path avoids returning unredacted exception content. The spec (`docs/system-specs/modules/memory-skills-hooks.md` §Script hooks) is updated in the same commit to document the env-allowlist contract, and `_HOOK_BASE_ENV_KEYS`'s doc comment names the operator-facing failure mode (a hook that relied on an ambient var outside the allowlist fails after upgrade; the fix is to add that key by name).

## Tests

- Added coverage proving ambient credentials are absent from the child process while approved runtime variables remain available.
- Added stdout, stderr, and non-zero-exit regression cases that verify sensitive values are redacted.
- Added API coverage for safe hook-test failure payloads.
- `python -m pytest -q test/test_api_hook_test_stop_payload.py test/test_script_hooks.py` — 49 passed.
- Baselined Black, whole-tree isort, whole-tree Flake8, and full Mypy passed.

## Manual verification

N/A — subprocess environment and every returned output channel are exercised directly by automated tests.

## Related Issues

Fixes #5441

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


