### PR TITLE
fix(hooks): bound subprocess output capture

### DIFF
--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -2797,6 +2797,119 @@ class ScriptHook:
         )
 
 
+# ── Script hook output caps ──
+#
+# ``run_script_hook`` used to ``await proc.communicate(...)``, which buffers
+# BOTH pipes in memory until EOF: a buggy or hostile hook could emit unbounded
+# stdout/stderr and OOM (or stall) the gateway for every session before the
+# 500-char presentation limit was ever applied (#5442). We now drain each
+# stream incrementally and keep only the first ``_HOOK_STREAM_CAP_BYTES`` bytes,
+# while continuing to read (and discard) the rest so the child can never block
+# on a full pipe. The cap is generously above the 500-char field we surface, so
+# the retained prefix is always enough to decode and truncate for display, yet
+# small enough that a runaway hook cannot exhaust memory.
+_HOOK_STREAM_CAP_BYTES = 64 * 1024
+# Marker appended to a decoded stream when its raw bytes exceeded the cap, so
+# truncation is visible rather than silent.
+_HOOK_TRUNCATION_MARKER = "\n…[output truncated]"
+
+
+async def _read_capped_stream(
+    reader: "asyncio.StreamReader | None", cap: int
+) -> tuple[bytes, bool]:
+    """Drain *reader* fully, retaining at most *cap* bytes.
+
+    Returns ``(retained_bytes, truncated)``. Bytes beyond *cap* are read and
+    discarded so the child never blocks on a full OS pipe buffer (the deadlock
+    ``communicate`` avoided by buffering everything — we avoid it by consuming
+    everything, but only *keeping* a bounded prefix). Chunked reads keep peak
+    memory at roughly ``cap`` regardless of how much the child writes.
+    """
+    if reader is None:
+        return b"", False
+    retained = bytearray()
+    truncated = False
+    while True:
+        # A fixed read size bounds a single chunk; the loop bounds the total.
+        chunk = await reader.read(65536)
+        if not chunk:
+            break
+        if len(retained) < cap:
+            room = cap - len(retained)
+            retained.extend(chunk[:room])
+            if len(chunk) > room:
+                truncated = True
+        else:
+            # Already at cap — keep draining so the pipe drains, drop the bytes.
+            truncated = True
+    return bytes(retained), truncated
+
+
+def _decode_capped(raw: bytes, truncated: bool) -> str:
+    """Decode capped raw bytes, appending the truncation marker when clipped.
+
+    ``errors="replace"`` handles a multibyte sequence severed at the cap
+    boundary: the trailing partial code point becomes U+FFFD rather than raising
+    or silently dropping, so a UTF-8 stream clipped mid-character still decodes
+    to a stable, safe string.
+    """
+    text = raw.decode(errors="replace")
+    if truncated:
+        text += _HOOK_TRUNCATION_MARKER
+    return text
+
+
+async def _communicate_capped(
+    proc: "asyncio.subprocess.Process", stdin_data: bytes, cap: int
+) -> tuple[bytes, bool, bytes, bool]:
+    """Write *stdin_data*, then drain stdout and stderr concurrently under a cap.
+
+    Concurrent draining (vs. sequential) is required for the same reason
+    ``communicate`` reads both pipes at once: a child that fills stderr while we
+    are still reading stdout would deadlock if we did not consume stderr in
+    parallel. Returns ``(stdout, stdout_truncated, stderr, stderr_truncated)``.
+    """
+
+    async def _feed_stdin() -> None:
+        stdin = proc.stdin
+        if stdin is None:
+            return
+        try:
+            stdin.write(stdin_data)
+            await stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            # The hook may exit without reading stdin; that is not our error.
+            pass
+        finally:
+            try:
+                stdin.close()
+            except Exception:
+                pass
+
+    stdin_task = asyncio.ensure_future(_feed_stdin())
+    stdout_task = asyncio.ensure_future(_read_capped_stream(proc.stdout, cap))
+    stderr_task = asyncio.ensure_future(_read_capped_stream(proc.stderr, cap))
+    try:
+        (stdout_b, stdout_trunc), (stderr_b, stderr_trunc) = await asyncio.gather(
+            stdout_task, stderr_task
+        )
+        await stdin_task
+        await proc.wait()
+    except BaseException:
+        # On timeout (CancelledError from wait_for) or any failure, cancel and
+        # OBSERVE every helper before returning control to the reap path. Merely
+        # calling cancel() leaves the StreamReader with an active waiter, so a
+        # cleanup read can raise "read() called while another coroutine is
+        # already waiting" and leak the process.
+        for task in (stdin_task, stdout_task, stderr_task):
+            task.cancel()
+        await asyncio.gather(
+            stdin_task, stdout_task, stderr_task, return_exceptions=True
+        )
+        raise
+    return stdout_b, stdout_trunc, stderr_b, stderr_trunc
+
+
 @dataclass
 class ScriptHookResult:
     """Result of executing a script hook."""
@@ -2979,8 +3092,14 @@ async def run_script_hook(
                 creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
             )
         try:
-            stdout_b, stderr_b = await asyncio.wait_for(
-                proc.communicate(input=stdin_data), timeout=hook.timeout
+            (
+                stdout_b,
+                stdout_trunc,
+                stderr_b,
+                stderr_trunc,
+            ) = await asyncio.wait_for(
+                _communicate_capped(proc, stdin_data, _HOOK_STREAM_CAP_BYTES),
+                timeout=hook.timeout,
             )
         finally:
             if cleanup_path:
@@ -2990,11 +3109,14 @@ async def run_script_hook(
                     pass
         elapsed = int((time.monotonic() - start) * 1000)
         exit_code = proc.returncode or 0
-        stderr_text = stderr_b.decode(errors="replace").strip()
-        # Redact the FULL stderr through the canonical companion-aware shim
-        # before truncating, so a credential straddling the 500-char boundary
-        # cannot leak as an unredacted fragment. The field surfaces on the
-        # dashboard and must not expose secrets (#4708).
+        stdout_text = _decode_capped(stdout_b, stdout_trunc).strip()
+        stderr_text = _decode_capped(stderr_b, stderr_trunc).strip()
+        # Redact the FULL (capped) stderr through the canonical companion-aware
+        # shim before truncating, so a credential straddling the 500-char
+        # boundary cannot leak as an unredacted fragment. The field surfaces on
+        # the dashboard and must not expose secrets (#4708). Memory is already
+        # bounded upstream by the byte cap (#5442), so redaction never sees an
+        # unbounded string.
         stderr_safe = redact_via_context(stderr_text)[:500] if stderr_text else ""
         hook.last_run = time.time()
         if exit_code == 2:
@@ -3011,7 +3133,7 @@ async def run_script_hook(
             hook_id=hook.id,
             hook_name=hook.name,
             event=hook.event,
-            stdout=stdout_b.decode(errors="replace").strip(),
+            stdout=stdout_text,
             stderr=stderr_text,
             exit_code=exit_code,
             duration_ms=elapsed,
@@ -3026,7 +3148,16 @@ async def run_script_hook(
                 # timeout path already runs on the event loop, so we never want
                 # to stall it further while taskkill.exe walks the tree
                 await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
-                await proc.communicate()
+                # Reap the killed tree WITHOUT re-buffering: a hook that timed
+                # out having already flooded its pipes must not be able to OOM
+                # us during cleanup (#5442). Drain both pipes concurrently under
+                # the same cap and discard; sequential reads can deadlock when
+                # residual data fills the other pipe.
+                await asyncio.gather(
+                    _read_capped_stream(proc.stdout, _HOOK_STREAM_CAP_BYTES),
+                    _read_capped_stream(proc.stderr, _HOOK_STREAM_CAP_BYTES),
+                )
+                await proc.wait()
         except Exception:
             pass
         elapsed = int((time.monotonic() - start) * 1000)

--- a/test/test_fire_tool_hooks.py
+++ b/test/test_fire_tool_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -361,8 +362,27 @@ class TestRunScriptHookStopEnvCap:
         hook = ScriptHook(id="s1", name="stop-hook", event=HOOK_EVENT_STOP, command="cat", timeout=5)
         hook_event = {"hook_event_name": HOOK_EVENT_STOP, "cwd": "/", "assistant_text": full}
 
+        class FakeStdin:
+            def __init__(self):
+                self.data = bytearray()
+                self.closed = False
+
+            def write(self, data):
+                self.data.extend(data)
+
+            async def drain(self):
+                return None
+
+            def close(self):
+                self.closed = True
+
         fake_proc = MagicMock()
-        fake_proc.communicate = AsyncMock(return_value=(b"", b""))
+        fake_proc.stdin = FakeStdin()
+        fake_proc.stdout = asyncio.StreamReader()
+        fake_proc.stdout.feed_eof()
+        fake_proc.stderr = asyncio.StreamReader()
+        fake_proc.stderr.feed_eof()
+        fake_proc.wait = AsyncMock(return_value=0)
         fake_proc.returncode = 0
         captured: dict = {}
 
@@ -389,7 +409,8 @@ class TestRunScriptHookStopEnvCap:
         assert "[OPTIONS:" not in env_ctx
         # Assert on what actually reached the subprocess stdin (not the input
         # dict): the full segment, tail marker intact, is serialized to stdin.
-        stdin_bytes = fake_proc.communicate.call_args.kwargs["input"]
+        stdin_bytes = bytes(fake_proc.stdin.data)
+        assert fake_proc.stdin.closed is True
         parsed = json.loads(stdin_bytes)
         assert parsed["assistant_text"] == full
         assert "[OPTIONS:" in parsed["assistant_text"]

--- a/test/test_script_hooks.py
+++ b/test/test_script_hooks.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import platform
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -194,6 +196,102 @@ class TestScriptHookStore:
         retrieved = store2.get(hook.id)
         assert retrieved is not None
         assert retrieved.name == "persist-test"
+
+
+class TestCappedScriptHookOutput:
+    @pytest.mark.asyncio
+    async def test_reader_keeps_only_the_cap_but_drains_to_eof(self):
+        from kiro_crew.hooks import _read_capped_stream
+
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"abcdefgh")
+        reader.feed_eof()
+
+        retained, truncated = await _read_capped_stream(reader, 5)
+
+        assert retained == b"abcde"
+        assert truncated is True
+        assert await reader.read() == b""
+
+    def test_decode_marks_a_multibyte_boundary(self):
+        from kiro_crew.hooks import _HOOK_TRUNCATION_MARKER, _decode_capped
+
+        raw = ("€" * 2).encode("utf-8")[:4]
+        decoded = _decode_capped(raw, truncated=True)
+
+        assert decoded.startswith("€")
+        assert "\ufffd" in decoded
+        assert decoded.endswith(_HOOK_TRUNCATION_MARKER)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_observes_both_reader_tasks(self):
+        from kiro_crew.hooks import _communicate_capped
+
+        class BlockingReader:
+            def __init__(self):
+                self.entered = asyncio.Event()
+                self.cancelled = asyncio.Event()
+
+            async def read(self, _size):
+                self.entered.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    self.cancelled.set()
+                    raise
+
+        stdout = BlockingReader()
+        stderr = BlockingReader()
+        proc = SimpleNamespace(
+            stdin=None,
+            stdout=stdout,
+            stderr=stderr,
+            wait=AsyncMock(),
+        )
+        task = asyncio.create_task(_communicate_capped(proc, b"", 32))
+        await asyncio.gather(stdout.entered.wait(), stderr.entered.wait())
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert stdout.cancelled.is_set()
+        assert stderr.cancelled.is_set()
+        proc.wait.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_hook_caps_and_marks_both_streams(self, tmp_path, monkeypatch):
+        from kiro_crew.hooks import _HOOK_STREAM_CAP_BYTES, _HOOK_TRUNCATION_MARKER
+
+        # This test exercises real pipe draining, not host sandbox discovery.
+        # Keep the subprocess real while making its isolation wrappers stable
+        # across Linux, namespace-sandbox, and Windows CI environments.
+        monkeypatch.setattr("kiro_crew.sandbox.wrap_argv", lambda argv, **k: (list(argv), None))
+        monkeypatch.setattr("kiro_crew.sandbox.cgroup_scope_argv", lambda argv: list(argv))
+
+        command = _script_command(
+            tmp_path / "large_output.py",
+            "import sys\n" "sys.stdout.write('o' * 70000)\n" "sys.stderr.write('e' * 70000)\n",
+        )
+        hook = ScriptHook(
+            id="large-output",
+            name="large-output",
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            command=command,
+            timeout=30,
+        )
+
+        result = await run_script_hook(hook, "ctx")
+
+        assert result.exit_code == 0
+        assert result.stdout.endswith(_HOOK_TRUNCATION_MARKER)
+        assert result.stderr.endswith(_HOOK_TRUNCATION_MARKER)
+        assert len(result.stdout.encode("utf-8")) <= (
+            _HOOK_STREAM_CAP_BYTES + len(_HOOK_TRUNCATION_MARKER.encode("utf-8"))
+        )
+        assert len(result.stderr.encode("utf-8")) <= (
+            _HOOK_STREAM_CAP_BYTES + len(_HOOK_TRUNCATION_MARKER.encode("utf-8"))
+        )
 
 
 class TestRunScriptHook:


### PR DESCRIPTION
## Problem / Motivation

Script hooks captured child stdout and stderr without a size bound. A hook that emitted indefinitely or produced a very large burst could make the gateway retain unbounded output in memory.

## Why it matters

Hooks run during normal agent activity, so one noisy or faulty subprocess could exhaust gateway memory, destabilize unrelated sessions, or delay hook completion while output continues accumulating.

## What changed (motivation → approach → change)

The subprocess runner now drains stdout and stderr incrementally into bounded buffers instead of using unbounded `communicate()` capture. It continues draining after each cap is reached so the child cannot block on a full pipe, marks truncated streams explicitly, and preserves timeout termination and process reaping behavior.

## Tests

- Added real-subprocess coverage for large stdout and stderr streams, including truncation markers and bounded retained size.
- Added coverage proving both streams are drained concurrently without deadlock.
- Preserved timeout, non-zero-exit, and hook-dispatch regression coverage.
- `python -m pytest -q test/test_fire_tool_hooks.py test/test_script_hooks.py` — 64 passed.
- Baselined Black, whole-tree isort, whole-tree Flake8, and full Mypy passed.

## Manual verification

N/A — real subprocess tests exercise the pipe, truncation, timeout, and cleanup behavior directly.

## Related Issues

Fixes #5442

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
