### PR TITLE
fix: move _old_item_ids reads into the off-loop dupe-gate hop (#4441)

### DIFF
--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -262,6 +262,19 @@ class IngestionPipeline:
         self.embedder = embedder
         self._dedup_enabled = dedup_enabled
 
+    def _resolve_old_item_ids(self, source_id: str | None) -> list[str]:
+        """The source's full pre-existing item group: the ids a replace-all
+        ingest supersedes and must delete.
+
+        Materializes one row per item in the source -- tens of thousands on a
+        large library, over a second of blocking SQLite -- so callers MUST run
+        it on a worker thread (``store.db`` is thread-local), never on the
+        event loop. The ingest paths fold it into the duplicate-gate hop, just
+        ahead of the gate's own transaction.
+        """
+        return [row['id'] for row in self.store.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()]
+
     def _skip_as_duplicate(self, content_hash: str, source_id: str | None,
                            old_item_ids: list[str] | None = None,
                            on_duplicate: Callable[[], None] | None = None) -> str | None:
@@ -546,12 +559,15 @@ class IngestionPipeline:
         # 2. Hash check + source resolution
         content_hash = hashlib.sha256(text.encode()).hexdigest()
         _old_item_ids: list[str] = old_item_ids if old_item_ids is not None else []
+        # Replace-all paths defer the full-source _old_item_ids read into the
+        # off-loop gate hop below: it materializes the source's whole item-id
+        # set, which is seconds of blocking SQLite on a large library.
+        resolve_old_group = False
         if source_id:
             # Ingest into existing source (remote sync path)
             if old_item_ids is None:
                 # Single-file/remote source: replace all items for this source
-                _old_item_ids = [row['id'] for row in self.store.db.execute(
-                    "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()]
+                resolve_old_group = True
             props: dict[str, object] = {}
             existing: dict | None = {"id": source_id}  # sentinel — source already exists
             src_row = self.store.db.execute(
@@ -567,8 +583,7 @@ class IngestionPipeline:
                 if props.get('content_hash') == content_hash:
                     return None
                 source_id = existing['id']
-                _old_item_ids = [row['id'] for row in self.store.db.execute(
-                    "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()]
+                resolve_old_group = True
             else:
                 props = {}
                 source_id = self.store.add_source(
@@ -577,12 +592,17 @@ class IngestionPipeline:
                 )
 
         # 3. Job record
-        # One hop for the whole gate: it deletes the superseded items, attaches
-        # the location and writes the terminal job row, and its delete rebuilds
-        # the entity graph — seconds of blocking SQLite on a large library.
-        dupe_job = await run_to_completion(
-            lambda: self._skip_as_duplicate(
-                            content_hash, source_id, _old_item_ids, on_duplicate=on_duplicate))
+        # One hop for the whole gate: it resolves the pre-existing item group
+        # (a full-source read, just ahead of the gate's own transaction),
+        # deletes the superseded items, attaches the location and writes the
+        # terminal job row, and its delete rebuilds the entity graph — seconds
+        # of blocking SQLite on a large library.
+        def _gate() -> tuple[str | None, list[str]]:
+            ids = self._resolve_old_item_ids(source_id) if resolve_old_group else _old_item_ids
+            return self._skip_as_duplicate(
+                content_hash, source_id, ids, on_duplicate=on_duplicate), ids
+
+        dupe_job, _old_item_ids = await run_to_completion(_gate)
         if dupe_job:
             return dupe_job
         job_id = uuid4().hex[:12]
@@ -783,6 +803,10 @@ class IngestionPipeline:
 
         # Resolve the source and the prior item ids this call should replace.
         _old_item_ids: list[str] = old_item_ids if old_item_ids is not None else []
+        # Replace-all paths defer the full-source _old_item_ids read into the
+        # off-loop gate hop below: it materializes the source's whole item-id
+        # set, which is seconds of blocking SQLite on a large library.
+        resolve_old_group = False
         if source_id is None:
             uri = f"{source_type}://{content_hash[:16]}"
             existing = self.store.get_source_by_uri(uri)
@@ -791,8 +815,7 @@ class IngestionPipeline:
                 if props.get('content_hash') == content_hash:
                     return None  # unchanged
                 source_id = existing['id']
-                _old_item_ids = [row['id'] for row in self.store.db.execute(
-                    "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()]
+                resolve_old_group = True
             else:
                 source_id = self.store.add_source(
                     name=title, source_type=source_type, uri=uri,
@@ -800,15 +823,19 @@ class IngestionPipeline:
                 )
         elif old_item_ids is None:
             # Existing source, replace-all (single-text / remote-sync source).
-            _old_item_ids = [row['id'] for row in self.store.db.execute(
-                "SELECT id FROM items WHERE source_id = ?", (source_id,)).fetchall()]
+            resolve_old_group = True
 
-        # One hop for the whole gate: it deletes the superseded items, attaches
-        # the location and writes the terminal job row, and its delete rebuilds
-        # the entity graph — seconds of blocking SQLite on a large library.
-        dupe_job = await run_to_completion(
-            lambda: self._skip_as_duplicate(
-                            content_hash, source_id, _old_item_ids, on_duplicate=on_duplicate))
+        # One hop for the whole gate: it resolves the pre-existing item group
+        # (a full-source read, just ahead of the gate's own transaction),
+        # deletes the superseded items, attaches the location and writes the
+        # terminal job row, and its delete rebuilds the entity graph — seconds
+        # of blocking SQLite on a large library.
+        def _gate() -> tuple[str | None, list[str]]:
+            ids = self._resolve_old_item_ids(source_id) if resolve_old_group else _old_item_ids
+            return self._skip_as_duplicate(
+                content_hash, source_id, ids, on_duplicate=on_duplicate), ids
+
+        dupe_job, _old_item_ids = await run_to_completion(_gate)
         if dupe_job:
             return dupe_job
 

--- a/test/test_knowledge_delete_off_loop.py
+++ b/test/test_knowledge_delete_off_loop.py
@@ -156,6 +156,28 @@ def test_delete_items_batch_is_never_called_on_the_event_loop():
     )
 
 
+def test_resolve_old_item_ids_is_never_called_on_the_event_loop():
+    """Ratchet: the full-source _old_item_ids read stays on a worker thread.
+
+    ``_resolve_old_item_ids`` materializes one row per item in the source --
+    tens of thousands on a large library, over a second of blocking SQLite --
+    so the ingest paths resolve it inside the off-loop duplicate-gate hop. A
+    call added straight to a coroutine body reintroduces the per-ingest loop
+    stall this helper exists to prevent, so it must fail here rather than in
+    production. Nested closures handed to ``run_to_completion`` (the gate
+    hops) are not coroutine bodies and correctly do not trip this.
+    """
+    offenders = _on_loop_call_sites("_resolve_old_item_ids")
+    assert offenders == [], (
+        "_resolve_old_item_ids is reached from the event loop at:\n  "
+        + "\n  ".join(offenders)
+        + "\nResolve the group inside the off-loop duplicate-gate hop (the "
+          "run_to_completion(_gate) closure) as ingest_file/ingest_text do, or "
+          "wrap the call in asyncio.to_thread. The read is a full-source scan "
+          "and must never run on the loop thread."
+    )
+
+
 @pytest.mark.asyncio
 async def test_handle_deleted_runs_the_delete_off_the_loop_thread(tmp_path, monkeypatch):
     """The offload is real: the delete executes on some other thread."""

--- a/test/test_knowledge_ingest_created_ids.py
+++ b/test/test_knowledge_ingest_created_ids.py
@@ -25,14 +25,17 @@ This file ratchets the conversion for the three sites:
 
 The ``_old_item_ids`` reads that share the query TEXT but mean "the
 pre-existing item group this call must delete" are deliberately out of scope
-(no callback can supply them); the ratchet pins their count so a re-introduced
-snapshot still fails the test.
+(no callback can supply them); they live in ``_resolve_old_item_ids`` and run
+inside the off-loop duplicate-gate hop (#4441). The ratchet pins the literal
+to that helper alone so a re-introduced snapshot still fails the test.
 """
 
 from __future__ import annotations
 
 import ast
+import hashlib
 import pathlib
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -49,9 +52,10 @@ from kiro_crew.knowledge.store import KnowledgeStore
 
 _KNOWLEDGE_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "knowledge"
 
-# The retired snapshot's query text. The remaining occurrences pinned below are
-# the _old_item_ids reads: same text, different meaning (the PRIOR group this
-# call must delete -- not what it created), tracked separately from #4431.
+# The retired snapshot's query text. The one occurrence pinned below is the
+# _old_item_ids resolver: same text, different meaning (the PRIOR group this
+# call must delete -- not what it created), tracked separately from #4431 and
+# run off-loop inside the duplicate-gate hop since #4441.
 _SNAPSHOT_QUERY = "SELECT id FROM items WHERE source_id"
 
 
@@ -369,16 +373,36 @@ class TestSnapshotQueryRatchet:
             "import_bundle writes."
         )
 
-    def test_ingest_text_keeps_only_the_old_group_reads(self):
+    def test_ingest_text_has_no_on_loop_group_read(self):
         tree = ast.parse((_KNOWLEDGE_SRC / "ingestion.py").read_text(errors="replace"))
         hits = _count_snapshot_literals(_find_def(tree, "ingest_text"))
-        assert len(hits) == 2, (
-            f"ingest_text contains {len(hits)} '{_SNAPSHOT_QUERY}' literals at "
-            f"lines {hits}; exactly 2 are expected -- the _old_item_ids "
-            "resolution reads (the PRIOR group this call replaces, which no "
-            "callback can supply). More means the before/after created-ids "
-            "snapshot came back; fewer means the old-group reads moved and "
-            "this ratchet must be repointed."
+        assert hits == [], (
+            f"ingest_text contains '{_SNAPSHOT_QUERY}' literals at lines "
+            f"{hits}; it must contain none. Both the created-ids snapshot "
+            "(#4431) and the inline _old_item_ids resolution (#4441) are "
+            "retired here: the old-group read lives in _resolve_old_item_ids "
+            "and runs inside the off-loop duplicate-gate hop."
+        )
+
+    def test_ingest_file_has_no_on_loop_group_read(self):
+        tree = ast.parse((_KNOWLEDGE_SRC / "ingestion.py").read_text(errors="replace"))
+        hits = _count_snapshot_literals(_find_def(tree, "ingest_file"))
+        assert hits == [], (
+            f"ingest_file contains '{_SNAPSHOT_QUERY}' literals at lines "
+            f"{hits}; it must contain none. The _old_item_ids resolution "
+            "(#4441) lives in _resolve_old_item_ids and runs inside the "
+            "off-loop duplicate-gate hop -- an inline read here lands on the "
+            "asyncio event loop (~20k rows per read on a large source)."
+        )
+
+    def test_resolver_is_the_single_group_read(self):
+        tree = ast.parse((_KNOWLEDGE_SRC / "ingestion.py").read_text(errors="replace"))
+        hits = _count_snapshot_literals(_find_def(tree, "_resolve_old_item_ids"))
+        assert len(hits) == 1, (
+            f"_resolve_old_item_ids contains {len(hits)} '{_SNAPSHOT_QUERY}' "
+            f"literals at lines {hits}; exactly 1 is expected. Zero means the "
+            "old-group read moved and every ratchet in this class must be "
+            "repointed; more means the query was duplicated inside the helper."
         )
 
     def test_ingest_artifact_has_no_source_snapshot(self):
@@ -390,3 +414,107 @@ class TestSnapshotQueryRatchet:
             "through on_committed from inside the finalize hop that commits "
             "them -- the same contract agent_source.py consumes."
         )
+
+
+class TestOldGroupReadRunsOffLoop:
+    """The _old_item_ids full-source reads run on a worker thread (#4441).
+
+    One test per original on-loop read site: ingest_file's replace-all and
+    existing-local-file paths, ingest_text's changed-existing (URI hit, hash
+    mismatch) and replace-all paths. Each spies on the resolver to record the
+    thread it ran on, and pins the semantics (the resolved group still drives
+    the replace) so the off-loop move cannot silently drop the read.
+    """
+
+    @staticmethod
+    def _spy_resolver(pipeline):
+        calls: list[int] = []
+        real = pipeline._resolve_old_item_ids
+
+        def _spy(source_id):
+            calls.append(threading.get_ident())
+            return real(source_id)
+
+        pipeline._resolve_old_item_ids = _spy
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_ingest_file_replace_all_resolves_off_loop(self, pipeline, kstore, tmp_path):
+        source_id = kstore.add_source("remote", "url", "https://example.test/doc")
+        stale = kstore.add_item("old", "superseded", "document", source_id=source_id)
+        calls = self._spy_resolver(pipeline)
+        loop_thread = threading.get_ident()
+
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nbody text long enough to split", encoding="utf-8")
+        job_id = await pipeline.ingest_file(str(f), source_id=source_id)
+
+        assert job_id is not None
+        assert calls, "the replace-all group read never ran"
+        assert all(t != loop_thread for t in calls), (
+            "_resolve_old_item_ids ran on the event-loop thread -- the "
+            "full-source read blocks the loop for >1s on a large library"
+        )
+        # The resolved group actually drove the replace: the stale item is gone.
+        assert stale not in _item_ids(kstore, source_id)
+
+    @pytest.mark.asyncio
+    async def test_ingest_file_changed_local_file_resolves_off_loop(
+        self, pipeline, kstore, tmp_path
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("# heading\nfirst version body text", encoding="utf-8")
+        assert await pipeline.ingest_file(str(f)) is not None
+        source = kstore.get_source_by_uri(str(f.resolve()))
+        assert source is not None
+        before = _item_ids(kstore, source["id"])
+        assert before != set()
+
+        calls = self._spy_resolver(pipeline)
+        loop_thread = threading.get_ident()
+        f.write_text("# heading\nsecond version body text", encoding="utf-8")
+        assert await pipeline.ingest_file(str(f)) is not None
+
+        assert calls, "the existing-local-file group read never ran"
+        assert all(t != loop_thread for t in calls)
+        # The prior version's group was replaced, not accumulated.
+        assert _item_ids(kstore, source["id"]).isdisjoint(before)
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_changed_existing_resolves_off_loop(self, pipeline, kstore):
+        text = "body text long enough to split"
+        content_hash = hashlib.sha256(text.encode()).hexdigest()
+        # A source at the hash-derived URI whose recorded hash DIFFERS forces
+        # the changed-content branch of the no-source_id path.
+        source_id = kstore.add_source(
+            "Doc",
+            "manual",
+            f"manual://{content_hash[:16]}",
+            properties={"content_hash": "stale"},
+        )
+        stale = kstore.add_item("old", "superseded", "document", source_id=source_id)
+        calls = self._spy_resolver(pipeline)
+        loop_thread = threading.get_ident()
+
+        job_id = await pipeline.ingest_text(text, "Doc")
+
+        assert job_id is not None
+        assert calls, "the changed-existing group read never ran"
+        assert all(t != loop_thread for t in calls)
+        assert stale not in _item_ids(kstore, source_id)
+
+    @pytest.mark.asyncio
+    async def test_ingest_text_replace_all_resolves_off_loop(self, pipeline, kstore):
+        source_id = kstore.add_source("notes", "manual", "manual://fixed-uri")
+        stale = kstore.add_item("old", "superseded", "document", source_id=source_id)
+        calls = self._spy_resolver(pipeline)
+        loop_thread = threading.get_ident()
+
+        job_id = await pipeline.ingest_text(
+            "body text long enough to split", "Doc", source_id=source_id
+        )
+
+        assert job_id is not None
+        assert calls, "the replace-all group read never ran"
+        assert all(t != loop_thread for t in calls)
+        assert stale not in _item_ids(kstore, source_id)


### PR DESCRIPTION
## Summary

Fixes #4441: four synchronous full-source reads (`SELECT id FROM items WHERE source_id = ?`) resolving `_old_item_ids` ran directly on the asyncio event loop inside async `ingest_file` (replace-all and existing-local-file paths) and `ingest_text` (changed-existing and replace-all paths). On a large library each materializes ~20k rows — over a second of blocking SQLite per call. This is the same cost profile PR #4443 retired for the created-ids reads, but these reads compute the pre-existing group to DELETE, so the created-ids callback substitution cannot cover them; #4443 explicitly scoped them out.

## What changed

- **`src/kiro_crew/knowledge/ingestion.py`** — new `_resolve_old_item_ids` helper carries the query; each ingest path's duplicate-gate hop (`run_to_completion(_gate)`) now resolves the group on the worker thread (thread-local sqlite connection) just ahead of the gate's own `BEGIN IMMEDIATE`, returning `(dupe_job, ids)` so the resolved group still reaches both the gate's in-txn delete and `_finalize`'s `delete_items_batch`. The read keeps its logical position relative to the gate/finalize hops — closing the read-to-delete slip window is a separate shape change tracked by #4457 and deliberately out of scope here.
- **`test/test_knowledge_ingest_created_ids.py`** — the occurrence ratchet is repointed: `ingest_file` and `ingest_text` now pin **zero** query literals, `_resolve_old_item_ids` pins exactly one. New `TestOldGroupReadRunsOffLoop` adds one test per original read site: each spies on the resolver, asserts it ran off the loop thread, and pins that the resolved group still drives the replace (stale items deleted).
- **`test/test_knowledge_delete_off_loop.py`** — new AST ratchet `test_resolve_old_item_ids_is_never_called_on_the_event_loop`: any future call site added straight to a coroutine body fails the suite instead of reintroducing the stall.

## Verification

- Targeted: 10 knowledge test files, 385 passed + the new/repointed tests (29 in the two touched files).
- Mutation-verified twice: moving the resolution back on-loop fails all 4 new behavioral tests AND the new AST ratchet; the real fix passes both.
- Local gates: black-check, subprocess-encoding, isort, flake8 (full), mypy (full), brand-name gate, harness-parity gate — all green.
- Pre-push review: GPT lane (gpt-5.6-sol) no findings; Opus lane (claude-opus-5) 0 blocking, 5 advisory — adopted the on-loop-call-site ratchet and a misleading test name fix; declined the store-method query consolidation and `str`-narrowing as out-of-scope surface (both call sites are truthy-guarded; noted for follow-up).

No UI changes (backend-only), so no screenshots.

Closes #4441
