### PR TITLE
fix: bound lifecycle startup hooks

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -353,6 +353,64 @@ skills/crons/MCP registration overwrite in place.
 
 Writer: `apps/bridges.py::reconcile_enabled_app_resources`.
 
+### 7.1 A hung startup lifecycle hook is bounded at the dispatch boundary
+
+`LifecycleDispatcher` invokes startup hooks **serially** in lexicographic app-name
+order, so one hook that never returns would stall the whole loop and keep the
+gateway from ever reaching readiness. An awaited startup coroutine is therefore
+bounded by a per-hook deadline (`lifecycle._HOOK_TIMEOUT_SEC`, 30s). The task
+is registered in the dispatcher-owned map keyed by app immediately when it is
+created, before the dispatcher first awaits it, so parent cancellation cannot
+orphan live work during the pre-deadline window. A completion observer retrieves
+its result and removes proven-terminal ownership. On deadline expiry the same
+owned task remains tracked while startup continues; the dispatcher does not wait
+indefinitely for it to settle and does not cancel it. Cancelling an asyncio task
+awaiting `asyncio.to_thread` makes the wrapper terminal while its worker thread
+still executes app code, so any observed child cancellation records a
+process-lifetime residual marker before releasing the task reference. The timeout
+is treated as a hook failure (the app is marked degraded and the event is
+SEL-recorded with `outcome="timeout"`), and startup **continues with the remaining
+apps**. The deadline is a safety net against a hang, not a performance budget,
+which is why it is generous.
+
+The per-app ownership is also a teardown contract. Dashboard disable, local or
+registry install, update, uninstall, and registry replacement perform a bounded
+ownership preflight and return a retryable refusal without mutating app state when
+retained startup execution cannot be proven stopped. Trust withdrawal also remains
+bounded, but if the hook continues executing, teardown fails and revocation leaves
+the trust grant in place for a retry rather than claiming the app stopped while its
+code remains live. In that failure case an app-declared `on_shutdown` is skipped:
+it is unbounded third-party code and must not overlap the still-running startup
+hook against partially initialized state.
+
+Normal recovery is to retry after retained startup execution exits. If a startup
+hook is permanently wedged, the operator must **stop the gateway completely**,
+run `kirocrew app disable <name>` while no gateway process can execute app code,
+and then restart the gateway. The CLI command only writes `enabled=false` to
+installed-app metadata; it is not runtime teardown and must not be run against a
+live gateway as evidence that old app code stopped. The disabled app is skipped
+on the next startup, allowing the operator to repair or remove it without
+re-entering the wedged hook.
+
+Graceful gateway shutdown sweeps retained startup ownership for **every enabled
+app**, including apps with no `on_shutdown` declaration. All ownership checks
+start concurrently and are non-blocking: ownership that is already terminal
+permits that app's shutdown hook, while active or residual startup work skips only
+the affected hook fail-closed. The sweep consumes none of the gateway's remaining
+10-second cooperative shutdown window, preserving time for unaffected app hooks
+after the existing bounded slot-history save; the service manager's separate
+10-second signal margin is not hook-execution time. An app's `on_shutdown` is
+invoked in reverse lexicographic order only after that app's startup ownership
+settled; otherwise the hook is skipped rather than running concurrently against
+partially initialized state. Once an `on_shutdown` hook is invoked, it is
+intentionally not detached at the deadline: the task still owns its `AppContext`
+capabilities, so teardown awaits it to completion. The startup deadline governs
+**async hooks only**: a synchronous hook returns before the
+`asyncio.iscoroutine` check and runs to completion outside the timeout; a
+successful async startup hook that returns within the deadline is unaffected.
+
+Writer: `apps/lifecycle.py::LifecycleDispatcher._invoke`.
+
 ## 8. An app's EventBus only exists with a real broadcast function
 
 `build_app_context` returns `events=None` when `broadcast_fn` is None, and

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -76,6 +76,21 @@ def get_lifecycle_dispatcher() -> LifecycleDispatcher | None:
     return _lifecycle_dispatcher
 
 
+async def stop_retained_startup_hooks(
+    app_name: str, *, bounded: bool
+) -> bool:
+    """Wait for retained startup execution, failing closed on ownership errors."""
+    if _lifecycle_dispatcher is None:
+        return True
+    try:
+        return await _lifecycle_dispatcher.stop_detached_startup_hooks(
+            app_name, bounded=bounded
+        )
+    except Exception:  # noqa: BLE001 - destructive lifecycle work must fail closed
+        logger.exception("Could not verify detached startup-hook cleanup for %s", app_name)
+        return False
+
+
 def _app_hook_root(app_name: str) -> Path:
     """Return the immutable shipped root when one owns this app name."""
     return shipped_builtin_app_root(app_name) or app_dir(app_name)
@@ -191,7 +206,9 @@ async def on_app_enable(
     # Invoke on_startup hook if declared
     startup_hook = hooks.get("on_startup", "")
     if startup_hook and _lifecycle_dispatcher:
-        success = await _lifecycle_dispatcher._invoke(app_name, startup_hook, ctx)
+        success = await _lifecycle_dispatcher._invoke(
+            app_name, startup_hook, ctx, phase="startup"
+        )
         result["hooks_startup"] = "ok" if success else "failed"
 
     # Report health status
@@ -207,8 +224,24 @@ async def on_app_enable(
     return result
 
 
+async def stop_app_startup_hooks(
+    app_name: str, *, bounded: bool = False
+) -> bool:
+    """Prove retained startup ownership clear before teardown mutates state."""
+    if not _lifecycle_dispatcher:
+        return True
+    return await _lifecycle_dispatcher.stop_detached_startup_hooks(
+        app_name, bounded=bounded
+    )
+
+
 async def on_app_disable(
-    app_name: str, app_info: dict[str, Any], *, run_app_hooks: bool = True
+    app_name: str,
+    app_info: dict[str, Any],
+    *,
+    run_app_hooks: bool = True,
+    bounded_startup_cleanup: bool = False,
+    startup_stopped: bool | None = None,
 ) -> dict[str, Any]:
     """Called before an app is disabled — deregister routes and invoke shutdown hook.
 
@@ -217,13 +250,34 @@ async def on_app_disable(
     caller passes it when there is no reason to believe the app is running: its
     shutdown hook is third-party code, and *starting* that code as part of
     withdrawing its permission to run would turn the security operation into an
-    execution vector. Nothing that STOPS something is ever skipped by this flag —
-    see the split in ``apps/teardown.py``.
+    execution vector. Nothing that STOPS something is ever skipped by this flag.
+
+    ``bounded_startup_cleanup`` distinguishes trust withdrawal from ordinary
+    disable. Ordinary disable waits until an owned detached startup task exits;
+    trust withdrawal stays bounded and reports residual execution as a hard
+    failure so the grant remains in place for a retry. Shared teardown passes a
+    pre-established ``startup_stopped`` result so this function cannot repeat the
+    ownership wait after other teardown work has begun.
     """
     result: dict[str, Any] = {}
     manifest = app_info.get("manifest", {})
     backend = manifest.get("backend", {})
     hooks = backend.get("hooks", {})
+
+    # A startup hook may have been detached after its readiness deadline. It is
+    # still third-party code with a live AppContext, so disable/revocation must
+    # stop it even if the current manifest no longer declares hooks. A resistant
+    # task becomes a hard teardown failure; callers keep trust in place rather
+    # than falsely claiming all app code stopped.
+    if startup_stopped is None:
+        startup_stopped = await stop_app_startup_hooks(
+            app_name, bounded=bounded_startup_cleanup
+        )
+    if not startup_stopped:
+        result["startup_cleanup"] = (
+            "failed: detached startup hook is still running; teardown not started"
+        )
+        return result
 
     if hooks:
         sel().log_api_access(
@@ -233,13 +287,16 @@ async def on_app_disable(
             resources=app_name,
         )
 
-    # Invoke on_shutdown hook if declared
+    # Invoke on_shutdown only after retained startup ownership is proven clear.
+    # Trust withdrawal must stay bounded and must never overlap partially
+    # initialized startup state with an unbounded third-party shutdown hook.
     shutdown_hook = hooks.get("on_shutdown", "")
-    if shutdown_hook and _lifecycle_dispatcher and run_app_hooks:
+    if shutdown_hook and _lifecycle_dispatcher and run_app_hooks and startup_stopped:
         success = await _lifecycle_dispatcher._invoke(
             app_name,
             shutdown_hook,
             _lifecycle_dispatcher._build_context(app_info),
+            phase="shutdown",
         )
         result["hooks_shutdown"] = "ok" if success else "failed"
 
@@ -370,7 +427,9 @@ async def on_gateway_startup(
         # Invoke on_startup hook (if declared)
         startup_hook = hooks.get("on_startup", "")
         if startup_hook and _lifecycle_dispatcher:
-            success = await _lifecycle_dispatcher._invoke(name, startup_hook, ctx)
+            success = await _lifecycle_dispatcher._invoke(
+                name, startup_hook, ctx, phase="startup"
+            )
             if success:
                 logger.info("Startup hook invoked for: %s", name)
 
@@ -383,13 +442,7 @@ async def on_gateway_shutdown() -> None:
     # list_apps() walks the apps dir (two file reads per app) — off the loop.
     installed = await asyncio.to_thread(list_apps)
     enabled = [a for a in installed if a.get("enabled")]
-    apps_with_hooks = [
-        a
-        for a in enabled
-        if a.get("manifest", {}).get("backend", {}).get("hooks", {}).get("on_shutdown")
-    ]
-
-    if apps_with_hooks:
-        invoked = await _lifecycle_dispatcher.dispatch_shutdown(apps_with_hooks)
+    if enabled:
+        invoked = await _lifecycle_dispatcher.dispatch_shutdown(enabled)
         if invoked:
             logger.info("Shutdown hooks invoked for: %s", ", ".join(invoked))

--- a/src/kiro_crew/apps/lifecycle.py
+++ b/src/kiro_crew/apps/lifecycle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+from functools import partial
 from typing import Any
 
 from kiro_crew.apps.context import AppContext, build_app_context
@@ -18,6 +19,83 @@ from kiro_crew.apps.module_loader import load_app_module
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
+
+#: Per-hook wall-clock deadline (seconds) applied to async startup hooks.
+#:
+#: An ``on_startup`` hook awaiting a wedged resource would otherwise stall the
+#: serial dispatch loop and keep the gateway from ever reaching readiness. The
+#: timeout bounds that startup wait so independent apps still get their turn.
+#: Shutdown is deliberately different: teardown must not report trust revoked
+#: while third-party hook code still retains its ``AppContext`` capabilities, so
+#: an ``on_shutdown`` task is awaited to completion and never detached. The
+#: startup deadline is generous because legitimate setup may do real work; it is
+#: a safety net against a hang, not a performance budget. Synchronous hooks run
+#: to completion before the dispatcher awaits, so this deadline governs async
+#: startup hooks only.
+_HOOK_TIMEOUT_SEC = 30.0
+
+#: Slot-history persistence may consume half of the gateway's cooperative
+#: shutdown deadline before app cleanup begins. Ownership checks therefore only
+#: observe tasks that are already terminal; active startup work is skipped
+#: fail-closed so shutdown hooks for unaffected apps retain the remaining budget.
+_GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC = 0.0
+
+# Async startup hook tasks are owned from creation, before the first await.
+# Cancelling an asyncio wrapper is not proof that execution stopped: a coroutine
+# awaiting ``asyncio.to_thread`` becomes terminal while its worker thread keeps
+# running. Hold a strong reference keyed by owning app so every destructive
+# boundary sees active work even before the readiness deadline. Successfully
+# completed tasks are removed by their observer; timed-out tasks remain owned
+# until actual completion (or become a fail-closed residual on cancellation).
+_DETACHED_HOOK_TASKS: dict[str, set[asyncio.Task[Any]]] = {}
+
+# Cancellation makes an asyncio task terminal but does not prove work delegated
+# through ``asyncio.to_thread`` stopped. Once a startup hook is observed
+# cancelled, preserve an app-scoped residual marker for the rest of the process:
+# no independent worker handle exists from which true completion can be proven.
+# Destructive lifecycle operations therefore fail closed instead of withdrawing
+# trust or replacing files while that worker may still hold AppContext powers.
+_DETACHED_HOOK_RESIDUALS: set[str] = set()
+
+
+def _mark_cancelled_startup_residual(app_name: str) -> None:
+    """Record cancellation before releasing ownership of a startup task."""
+    if app_name in _DETACHED_HOOK_RESIDUALS:
+        return
+    _DETACHED_HOOK_RESIDUALS.add(app_name)
+    logger.error(
+        "Lifecycle startup hook for app %s was cancelled; residual execution "
+        "cannot be disproven",
+        app_name,
+    )
+
+
+def _observe_detached_hook_task(
+    app_name: str,
+    observation: dict[str, bool],
+    task: asyncio.Task[Any],
+) -> None:
+    """Observe terminal state without mistaking cancellation for completion."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        # Set the residual marker BEFORE releasing the task reference so no
+        # cleanup caller can observe a false ownership-free gap.
+        _mark_cancelled_startup_residual(app_name)
+    except Exception:
+        # A pre-deadline failure is reported by the awaiting _invoke path. Once
+        # readiness has moved on, this observer is the only remaining reporter.
+        if observation["timed_out"]:
+            logger.exception(
+                "Lifecycle startup hook for app %s later failed after the deadline",
+                app_name,
+            )
+    finally:
+        owned = _DETACHED_HOOK_TASKS.get(app_name)
+        if owned is not None:
+            owned.discard(task)
+            if not owned:
+                _DETACHED_HOOK_TASKS.pop(app_name, None)
 
 
 class LifecycleDispatcher:
@@ -54,24 +132,48 @@ class LifecycleDispatcher:
             if not hook_path:
                 continue
             ctx = self._build_context(app_info)
-            success = await self._invoke(name, hook_path, ctx)
+            success = await self._invoke(name, hook_path, ctx, phase="startup")
             if success:
                 invoked.append(name)
         return invoked
 
     async def dispatch_shutdown(self, enabled_apps: list[dict[str, Any]]) -> list[str]:
-        """Call on_shutdown hooks for all enabled apps (reverse order).
+        """Join startup ownership, then call shutdown hooks in reverse order.
+
+        Every enabled app participates in one concurrent ownership sweep, even
+        when it has no shutdown hook. Starting all waits before awaiting any one
+        app keeps the sweep within a single gateway-shutdown deadline rather than
+        multiplying that deadline by the number of apps.
 
         Returns list of app names whose hooks were invoked successfully.
         """
+        ordered = sorted(enabled_apps, key=lambda a: a.get("name", ""), reverse=True)
+        ownership = await asyncio.gather(
+            *(
+                self.stop_detached_startup_hooks(
+                    app_info.get("name", ""),
+                    bounded=True,
+                    timeout=_GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC,
+                )
+                for app_info in ordered
+            )
+        )
+
         invoked: list[str] = []
-        for app_info in sorted(enabled_apps, key=lambda a: a.get("name", ""), reverse=True):
+        for app_info, startup_stopped in zip(ordered, ownership):
             name = app_info.get("name", "")
             hook_path = self._get_hook(app_info, "on_shutdown")
+            if not startup_stopped:
+                logger.error(
+                    "Skipping shutdown hook for %s because retained startup "
+                    "execution is still active",
+                    name,
+                )
+                continue
             if not hook_path:
                 continue
             ctx = self._build_context(app_info)
-            success = await self._invoke(name, hook_path, ctx)
+            success = await self._invoke(name, hook_path, ctx, phase="shutdown")
             if success:
                 invoked.append(name)
         return invoked
@@ -86,7 +188,7 @@ class LifecycleDispatcher:
         if not hook_path:
             return True
         ctx = self._build_context(app_info)
-        return await self._invoke(name, hook_path, ctx)
+        return await self._invoke(name, hook_path, ctx, phase="startup")
 
     async def dispatch_disable(self, app_info: dict[str, Any]) -> bool:
         """Call on_shutdown hook for a single app being disabled.
@@ -98,7 +200,62 @@ class LifecycleDispatcher:
         if not hook_path:
             return True
         ctx = self._build_context(app_info)
-        return await self._invoke(name, hook_path, ctx)
+        return await self._invoke(name, hook_path, ctx, phase="shutdown")
+
+    async def stop_detached_startup_hooks(
+        self,
+        app_name: str,
+        *,
+        bounded: bool = False,
+        timeout: float | None = None,
+    ) -> bool:
+        """Wait for retained startup hooks before teardown succeeds.
+
+        Ordinary disable waits until tracked code terminates, so it cannot return
+        success with a live AppContext. Trust withdrawal uses ``bounded=True``:
+        if execution does not settle by the deadline, ``False`` tells teardown to
+        retain trust and return a retryable failure. ``timeout`` is a test seam and
+        overrides the normal bounded deadline when supplied.
+
+        Tasks are not cancelled here. Cancellation can make an asyncio wrapper
+        awaiting ``to_thread`` look terminal while the worker still executes app
+        code. A cancelled retained task therefore leaves a process-lifetime
+        residual marker, and every later cleanup attempt fails closed because no
+        independent worker handle exists to prove completion.
+        """
+        if app_name in _DETACHED_HOOK_RESIDUALS:
+            logger.error(
+                "App %s has residual startup-hook execution after cancellation",
+                app_name,
+            )
+            return False
+
+        tasks = tuple(_DETACHED_HOOK_TASKS.get(app_name, ()))
+        if not tasks:
+            return True
+
+        wait_timeout = timeout if timeout is not None else (_HOOK_TIMEOUT_SEC if bounded else None)
+        done, pending = await asyncio.wait(tasks, timeout=wait_timeout)
+        if done:
+            # Do not rely on done-callback scheduling order: asyncio.wait may
+            # resume before `_observe_detached_hook_task` runs.
+            if any(task.cancelled() for task in done):
+                _DETACHED_HOOK_RESIDUALS.add(app_name)
+            await asyncio.gather(*done, return_exceptions=True)
+        if app_name in _DETACHED_HOOK_RESIDUALS:
+            logger.error(
+                "App %s has residual startup-hook execution after cancellation",
+                app_name,
+            )
+            return False
+        if pending:
+            logger.error(
+                "App %s still has %d detached startup hook(s) after the cleanup wait",
+                app_name,
+                len(pending),
+            )
+            return False
+        return True
 
     def _get_hook(self, app_info: dict[str, Any], hook_name: str) -> str:
         """Extract a hook path from app info."""
@@ -159,13 +316,57 @@ class LifecycleDispatcher:
             app_config=manifest.get("extra", {}),
         )
 
-    async def _invoke(self, app_name: str, hook_path: str, ctx: AppContext) -> bool:
+    async def _invoke(self, app_name: str, hook_path: str, ctx: AppContext, *, phase: str) -> bool:
         """Import and call a hook via module_loader (same isolation as routes).
+
+        ``phase`` is ``"startup"`` or ``"shutdown"``. Async startup hooks are
+        bounded because one app must not hold gateway readiness forever. Async
+        shutdown hooks are instead awaited to completion: returning from trust
+        revocation while an in-process task still owns ``AppContext`` capabilities
+        would leave third-party code running after teardown reports success.
+
+        Startup uses ``asyncio.wait`` rather than ``wait_for``: ``wait_for``
+        cancels on expiry and then waits for cancellation to finish, so a hook
+        that catches ``CancelledError`` can still hold gateway startup forever.
+        On expiry the dispatcher retains and observes the task in the background
+        without cancelling it, records the timeout, and continues. Synchronous
+        hooks return before the ``iscoroutine`` check and are unaffected.
 
         Returns True on success, False on failure.
         """
 
         try:
+            # The readiness deadline releases the caller while retaining the live
+            # task. A later enable/retry may hold the lifecycle lock correctly and
+            # still arrive after that release, so caller-side serialization alone
+            # cannot prevent duplicate startup work. Check and register without an
+            # intervening await: event-loop atomicity makes this the final admission
+            # point for boot, dashboard enable, and direct dispatcher callers.
+            if phase == "startup":
+                owned = tuple(_DETACHED_HOOK_TASKS.get(app_name, ()))
+                for owned_task in owned:
+                    if owned_task.cancelled():
+                        _mark_cancelled_startup_residual(app_name)
+                if app_name in _DETACHED_HOOK_RESIDUALS or any(
+                    not owned_task.done() for owned_task in owned
+                ):
+                    detail = "retained startup hook is already active"
+                    logger.error(
+                        "Refusing duplicate lifecycle startup hook %s for app %s: %s",
+                        hook_path,
+                        app_name,
+                        detail,
+                    )
+                    ctx.health.mark_degraded(f"Lifecycle hook refused during {phase}: {hook_path}")
+                    sel().log_api_access(
+                        caller=f"app:{app_name}",
+                        operation="lifecycle_hook_invoke",
+                        outcome="failed",
+                        resources=hook_path,
+                        error=detail,
+                    )
+                    return False
+
             # Through _resolve_hook, NOT load_app_module directly: for a shipped
             # builtin the latter does a file-path load and registers a SECOND
             # module object (`_kirocrew_app_<app>.<mod>`), so an on_startup hook
@@ -178,7 +379,61 @@ class LifecycleDispatcher:
                 raise ImportError(f"hook {hook_path!r} did not resolve for app {app_name!r}")
             result = func(ctx)
             if asyncio.iscoroutine(result):
-                await result
+                task = asyncio.ensure_future(result)
+                if phase == "startup":
+                    observation = {"timed_out": False}
+                    _DETACHED_HOOK_TASKS.setdefault(app_name, set()).add(task)
+                    task.add_done_callback(
+                        partial(
+                            _observe_detached_hook_task,
+                            app_name,
+                            observation,
+                        )
+                    )
+                    done, _pending = await asyncio.wait({task}, timeout=_HOOK_TIMEOUT_SEC)
+                    if task not in done:
+                        observation["timed_out"] = True
+                        logger.error(
+                            "Lifecycle hook %s for app %s timed out after %.0fs during %s; "
+                            "task retained — continuing with remaining apps",
+                            hook_path,
+                            app_name,
+                            _HOOK_TIMEOUT_SEC,
+                            phase,
+                        )
+                        ctx.health.mark_degraded(
+                            f"Lifecycle hook timed out during {phase}: {hook_path}"
+                        )
+                        sel().log_api_access(
+                            caller=f"app:{app_name}",
+                            operation="lifecycle_hook_invoke",
+                            outcome="timeout",
+                            resources=hook_path,
+                        )
+                        return False
+                    if task.cancelled():
+                        # The observer may not have run yet. Mark the residual
+                        # synchronously so the caller cannot release its lifecycle
+                        # lock through an ownership-free gap.
+                        _mark_cancelled_startup_residual(app_name)
+                        ctx.health.mark_degraded(
+                            f"Lifecycle hook cancelled during {phase}: {hook_path}"
+                        )
+                        sel().log_api_access(
+                            caller=f"app:{app_name}",
+                            operation="lifecycle_hook_invoke",
+                            outcome="failed",
+                            resources=hook_path,
+                        )
+                        return False
+                    # Retrieve a completed startup hook's result here so ordinary
+                    # failures follow the shared exception path below.
+                    task.result()
+                else:
+                    # A shutdown task still owns its AppContext capabilities.
+                    # Teardown/trust revocation cannot complete while that code
+                    # remains live, even if it ignores cancellation.
+                    await task
             logger.info("Lifecycle hook %s succeeded for app %s", hook_path, app_name)
             sel().log_api_access(
                 caller=f"app:{app_name}",
@@ -188,7 +443,9 @@ class LifecycleDispatcher:
             )
             return True
         except Exception:
-            logger.exception("Lifecycle hook %s failed for app %s", hook_path, app_name)
+            logger.exception(
+                "Lifecycle hook %s failed for app %s during %s", hook_path, app_name, phase
+            )
             ctx.health.mark_degraded(f"Lifecycle hook failed: {hook_path}")
             sel().log_api_access(
                 caller=f"app:{app_name}",

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -427,10 +427,12 @@ def app_lifecycle_lock(name: str) -> LoopBoundLock:
 # ---------------------------------------------------------------------------
 
 
-def install_app(source: str | Path) -> AppResult:
+def install_app(
+    source: str | Path, *, expected_name: str | None = None
+) -> AppResult:
     """Install an app from a local directory path.
 
-    1. Validate manifest
+    1. Validate manifest and any caller-pinned app identity
     2. Copy to ``~/.kiro/crew/apps/{name}/``
     3. Write ``installed.json``
 
@@ -461,6 +463,24 @@ def install_app(source: str | Path) -> AppResult:
 
     manifest = AppManifest.from_json_file(source / APP_MANIFEST_FILENAME)
     name = manifest.name
+    if expected_name is not None and name != expected_name:
+        detail = (
+            f"app identity changed during install: expected {expected_name!r}, "
+            f"found {name!r}"
+        )
+        sel().log_api_access(
+            caller="app_install",
+            operation="install",
+            outcome="failed",
+            resources=f"source={source!s}",
+            error=detail,
+        )
+        return AppResult(
+            ok=False,
+            name=name,
+            error=detail,
+            error_code="app_identity_changed",
+        )
     dest = app_dir(name)
 
     # Guard against path traversal in manifest name

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -5220,6 +5220,31 @@ def _report_retained_stale_checkouts(
         logger.info("Retained stale checkout: %s", stale)
 
 
+async def _retained_startup_refusal(
+    name: str, log_lines: list[str]
+) -> dict[str, Any] | None:
+    """Return a retryable refusal while old-version startup code remains live."""
+    # Deferred to avoid registry -> hooks_integration -> manager import cycles at
+    # module load. The dispatcher exists only in the gateway process; without it
+    # there is no in-process retained startup task to own.
+    from kiro_crew.apps.hooks_integration import stop_retained_startup_hooks
+
+    if await stop_retained_startup_hooks(name, bounded=True):
+        return None
+    message = (
+        f"cannot reinstall {name!r} while its timed-out startup hook is still "
+        "running; retry after it exits"
+    )
+    log_lines.append(message)
+    return {
+        "ok": False,
+        "name": name,
+        "error": message,
+        "code": "startup_hook_still_running",
+        "retryable": True,
+    }
+
+
 async def install_from_registry(
     name: str,
     log_lines: list[str] | None = None,
@@ -5451,6 +5476,10 @@ async def install_from_registry(
     is_self_managed = entry.get("resources") == "app"
     if log_lines is None:
         log_lines = []
+
+    startup_refusal = await _retained_startup_refusal(name, log_lines)
+    if startup_refusal is not None:
+        return startup_refusal
 
     # Validate minKiroCrewVersion if declared
     min_version = (manifest or {}).get("minKiroCrewVersion", "")
@@ -5922,6 +5951,15 @@ async def install_from_registry(
                 )
             if dep_result.missing:
                 log_lines.append(f"Missing commands: {', '.join(dep_result.missing)}")
+
+        # A clone/build/install script can take minutes. Recheck at the shared
+        # replacement boundary so startup execution that became retained during
+        # that work cannot overlap either managed file replacement or
+        # self-managed metadata replacement.
+        startup_refusal = await _retained_startup_refusal(name, log_lines)
+        if startup_refusal is not None:
+            outcome = startup_refusal
+            return outcome
 
         # Step 4: Register with KiroCrew
         if is_self_managed:

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import time
 import urllib.parse
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -51,7 +52,10 @@ from kiro_crew.apps.dependency_ledger import (
 )
 from kiro_crew.apps.event_bus import build_broadcast_fn
 from kiro_crew.apps.execution import app_execution_denied
-from kiro_crew.apps.hooks_integration import on_app_enable
+from kiro_crew.apps.hooks_integration import (
+    on_app_enable,
+    stop_retained_startup_hooks,
+)
 
 # Aliased to keep `routes._run_lifecycle_script` patchable, which several tests rely on.
 from kiro_crew.apps.lifecycle_scripts import run_lifecycle_script as _run_lifecycle_script
@@ -533,8 +537,27 @@ async def handle_install_app(request: web.Request) -> web.Response:
 
     # Check minKiroCrewVersion before installing
     source_path = Path(source).expanduser().resolve()
+    if not source_path.is_dir():
+        detail = f"source is not a directory: {source_path}"
+        sel().log_api_access(
+            caller="dashboard",
+            operation="app_install",
+            outcome="failed",
+            resources=str(source_path),
+            error=detail,
+        )
+        return web.json_response(
+            {
+                "ok": False,
+                "name": "",
+                "error": detail,
+                "code": "source_not_directory",
+            },
+            status=400,
+        )
+
     manifest_path = source_path / "app.json"
-    lock_name = str(source_path)  # fallback lock key when manifest is unreadable
+    lock_name: str | None = None
     if manifest_path.is_file():
         try:
             manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -542,24 +565,51 @@ async def handle_install_app(request: web.Request) -> web.Response:
             if ver_err:
                 return web.json_response({"error": ver_err}, status=400)
             raw_name = manifest_data.get("name")
-            # Only a nonempty string is a usable lock key — anything else
-            # (list, dict, number) keeps the path fallback and is rejected
-            # by manifest validation inside install_app.
             if isinstance(raw_name, str) and raw_name:
                 lock_name = raw_name
         except (json.JSONDecodeError, OSError):
             pass
+
+    # A path is not an app identity: install_app may observe a manifest created
+    # or replaced after this preflight and target a different lifecycle lock.
+    if lock_name is None:
+        detail = "app manifest identity is unavailable or unreadable"
+        sel().log_api_access(
+            caller="dashboard",
+            operation="app_install",
+            outcome="denied",
+            resources=str(source_path),
+            error=detail,
+        )
+        return web.json_response(
+            {
+                "error": (
+                    "cannot install while app.json has no readable app identity; "
+                    "retry after the source manifest is stable"
+                ),
+                "code": "app_identity_unavailable",
+                "retryable": True,
+            },
+            status=409,
+        )
 
     # Per-app lifecycle lock (shared with registry installs), held across
     # the whole install transaction — copy, registration, and backend start —
     # so a concurrent uninstall cannot deregister between our copy and our
     # register, leaving a running backend for a removed app.
     async with app_lifecycle_lock(lock_name):
+        startup_refusal = await _refuse_while_startup_hook_runs(
+            lock_name, action="install"
+        )
+        if startup_refusal is not None:
+            return startup_refusal
+
         # Off-loop: the copy in install_app is blocking filesystem I/O that can
         # take minutes on large source trees — running it on the loop would trip
         # the loop-stall watchdog and kill the gateway.
         result = await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), install_app, source
+            subprocess_executor(),
+            partial(install_app, source, expected_name=lock_name),
         )
         if not result.ok:
             sel().log_api_access(
@@ -586,6 +636,36 @@ async def handle_install_app(request: web.Request) -> web.Response:
             "registration": reg.to_dict(),
         },
         status=201,
+    )
+
+
+async def _refuse_while_startup_hook_runs(
+    name: str, *, action: str
+) -> web.Response | None:
+    """Refuse destructive lifecycle work while retained app code is still live."""
+    stopped = await stop_retained_startup_hooks(name, bounded=True)
+    if stopped:
+        return None
+
+    detail = "detached startup hook is still running or cleanup could not be verified"
+    sel().log_api_access(
+        caller="dashboard",
+        operation=f"app_{action}",
+        outcome="denied",
+        resources=name,
+        error=detail,
+    )
+    return web.json_response(
+        {
+            "error": (
+                f"cannot {action} {name!r} while its timed-out startup hook "
+                "is still running; retry after it exits"
+            ),
+            "code": "startup_hook_still_running",
+            "retryable": True,
+            "app": name,
+        },
+        status=409,
     )
 
 
@@ -618,8 +698,6 @@ async def handle_update_app(request: web.Request) -> web.Response:
     # to avoid leaving the app in a broken state on failure.
     if is_registry_source(source):
         registry_name = registry_name_from_source(source)
-        # One lock across re-install + resource swap + backend restart
-        # (install_from_registry is lock-free internally).
         async with app_lifecycle_lock(name):
             reg_install = await install_from_registry(registry_name)
             if not reg_install.get("ok"):
@@ -657,8 +735,14 @@ async def handle_update_app(request: web.Request) -> web.Response:
     # sequence must not interleave with another update/install/uninstall of
     # the same app — update_app moves user data through a shared
     # ``.{name}-data-tmp`` path, so an interleaving can destroy it.
-    # (The registry branch above locks inside install_from_registry.)
+    # (The registry branch above holds the same lock around install_from_registry.)
     async with app_lifecycle_lock(name):
+        startup_refusal = await _refuse_while_startup_hook_runs(
+            name, action="update"
+        )
+        if startup_refusal is not None:
+            return startup_refusal
+
         # Deregister old resources before update
         await _deregister_app_off_loop(name)
         await asyncio.get_running_loop().run_in_executor(
@@ -893,6 +977,15 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
     # timeout — acceptable, since those ops genuinely conflict and the lock is
     # per-app (other apps are unaffected).
     async with app_lifecycle_lock(name):
+        # A retained startup hook still owns the old app's AppContext. Bound the
+        # wait and refuse the uninstall if it remains live; deleting files or
+        # withdrawing trust first would falsely report that old code is gone.
+        startup_refusal = await _refuse_while_startup_hook_runs(
+            name, action="uninstall"
+        )
+        if startup_refusal is not None:
+            return startup_refusal
+
         # Step 0: the execution grant must be removable before anything is
         # destroyed. A grant is keyed on the app NAME alone, so one left behind
         # admits a DIFFERENT app later installed under this name — code execution
@@ -1389,6 +1482,12 @@ async def handle_disable_app(request: web.Request) -> web.Response:
     # resources — must not interleave with a concurrent install/update/
     # uninstall/enable of the same app.
     async with app_lifecycle_lock(name):
+        startup_refusal = await _refuse_while_startup_hook_runs(
+            name, action="disable"
+        )
+        if startup_refusal is not None:
+            return startup_refusal
+
         # `onDisable` is NOT run here: it runs inside `teardown_app_runtime`
         # below, so that revoking an app's execution grant runs it too. Keeping it
         # handler-only would make revoke weaker than disable — see the ordering

--- a/src/kiro_crew/apps/teardown.py
+++ b/src/kiro_crew/apps/teardown.py
@@ -46,7 +46,10 @@ from kiro_crew.apps.backend import (
     unstopped_backend_port,
 )
 from kiro_crew.apps.bridges import deregister_app
-from kiro_crew.apps.hooks_integration import on_app_disable
+from kiro_crew.apps.hooks_integration import (
+    on_app_disable,
+    stop_app_startup_hooks,
+)
 from kiro_crew.apps.lifecycle_scripts import run_lifecycle_script
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.security import redact
@@ -85,10 +88,11 @@ async def teardown_app_runtime(
 ) -> TeardownResult:
     """Stop *name*'s running code.
 
-    Never raises for a failing step: a teardown that aborts halfway leaves the app
-    in a worse state than one that pushes through and reports. Each failure is
-    logged, collected into ``failures``, and the next step still runs — stopping the
-    backend matters even when a shutdown hook threw.
+    Never raises for a failing step: once teardown starts, aborting halfway leaves
+    the app in a worse state than pushing through and reporting. The sole preflight
+    is retained startup ownership: if it cannot be proven clear, this function
+    returns a retryable failure before stopping workers, running app shutdown code,
+    or mutating routes, crons, backend state, and registrations.
 
     ``record`` is the app's installed metadata (``manager.get_app``) and is passed
     straight to the app's own shutdown hooks. Hooks and the backend stop run for
@@ -113,6 +117,23 @@ async def teardown_app_runtime(
     warnings: list[str] = []
     failures: list[str] = []
     loop = asyncio.get_running_loop()
+
+    # A retained startup hook can recreate every resource this function removes.
+    # Trust withdrawal therefore checks ownership under the caller's lifecycle lock
+    # and refuses BEFORE any teardown mutation. Ordinary disable keeps its existing
+    # unbounded wait contract. The proven result is passed into on_app_disable so
+    # ownership cannot be checked a second time after teardown has begun.
+    startup_stopped = await stop_app_startup_hooks(
+        name, bounded=withdrawing_trust
+    )
+    if not startup_stopped:
+        return TeardownResult(
+            warnings=[],
+            failures=[
+                "startup cleanup incomplete: detached startup hook is still running; "
+                "teardown made no runtime changes"
+            ],
+        )
 
     # Stand the app's in-process workers down FIRST, before anything here can block.
     #
@@ -244,15 +265,21 @@ async def teardown_app_runtime(
 
     try:
         hooks_result = await on_app_disable(
-            name, record, run_app_hooks=app_may_be_running
+            name,
+            record,
+            run_app_hooks=app_may_be_running,
+            bounded_startup_cleanup=withdrawing_trust,
+            startup_stopped=True,
         )
         # Two outcome fields, deliberately classified DIFFERENTLY, because they say
         # different things about the postcondition this teardown exists to reach:
         #
-        # ``cron_cleanup`` failing means the app's scheduled jobs MAY STILL FIRE —
-        # third-party code can still execute — so the postcondition is not met and
-        # this is a FAILURE. The caller leaves the grant in place and the client
-        # retries. The "failed:" marker is the contract in hooks_integration.py.
+        # ``cron_cleanup`` failing means scheduled jobs MAY STILL FIRE, while
+        # ``startup_cleanup`` failing means a detached startup hook IS STILL
+        # RUNNING. Both are residual third-party execution, so the postcondition
+        # is not met and this is a FAILURE. The caller leaves the grant in place
+        # and the client retries. The "failed:" marker is the contract in
+        # hooks_integration.py.
         #
         # ``hooks_shutdown`` failing means the app's OWN ``on_shutdown`` hook did not
         # succeed, so anything it was buffering may be lost. That is data loss, not
@@ -266,9 +293,10 @@ async def teardown_app_runtime(
         # on and the operator had no way to learn state was dropped.
         if hooks_result:
             for key, value in hooks_result.items():
-                if key == "cron_cleanup" and isinstance(value, str) and value:
+                if key in {"cron_cleanup", "startup_cleanup"} and isinstance(value, str):
                     if value.startswith("failed:"):
-                        _fail(f"cron cleanup incomplete: {value}")
+                        label = "cron cleanup" if key == "cron_cleanup" else "startup cleanup"
+                        _fail(f"{label} incomplete: {value}")
                     else:
                         _warn(value)
                 elif key == "hooks_shutdown" and value == "failed":

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -481,6 +481,122 @@ async def test_provenance_signer_comes_from_cloned_manifest(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_registry_fresh_reinstall_checks_retained_startup_before_clone(
+    monkeypatch, tmp_path
+):
+    """Missing metadata must not hide retained old-version startup ownership."""
+    src = tmp_path / "app-sources" / "demoapp"
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "version": "2.0.0"},
+    )
+    monkeypatch.setattr(registry, "get_app", lambda _name: None)
+
+    from kiro_crew.apps import hooks_integration
+
+    cleanup_calls: list[tuple[str, bool]] = []
+
+    async def _cleanup(app_name: str, *, bounded: bool) -> bool:
+        cleanup_calls.append((app_name, bounded))
+        return False
+
+    monkeypatch.setattr(
+        hooks_integration, "stop_retained_startup_hooks", _cleanup
+    )
+
+    async def _must_not_clone(*args, **kwargs):
+        raise AssertionError("fresh reinstall must not clone while old code runs")
+
+    monkeypatch.setattr(registry, "_clone_build_app", _must_not_clone)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert result["code"] == "startup_hook_still_running"
+    assert result["retryable"] is True
+    assert cleanup_calls == [("demoapp", True)]
+
+
+@pytest.mark.asyncio
+async def test_registry_fresh_reinstall_rechecks_retained_startup_before_replacement(
+    monkeypatch, tmp_path
+):
+    """A fresh-looking reinstall must recheck ownership after clone and build."""
+    src = tmp_path / "app-sources" / "demoapp"
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "version": "2.0.0"},
+    )
+    monkeypatch.setattr(registry, "get_app", lambda _name: None)
+
+    from kiro_crew.apps import hooks_integration
+
+    cleanup_calls: list[tuple[str, bool]] = []
+
+    async def _cleanup(app_name: str, *, bounded: bool) -> bool:
+        cleanup_calls.append((app_name, bounded))
+        return len(cleanup_calls) == 1
+
+    monkeypatch.setattr(
+        hooks_integration, "stop_retained_startup_hooks", _cleanup
+    )
+
+    def _must_not_replace(*args, **kwargs):
+        raise AssertionError("fresh reinstall must not replace files while old code runs")
+
+    monkeypatch.setattr(registry, "install_app", _must_not_replace)
+    monkeypatch.setattr(registry, "update_app", _must_not_replace)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert result["code"] == "startup_hook_still_running"
+    assert result["retryable"] is True
+    assert cleanup_calls == [("demoapp", True), ("demoapp", True)]
+
+
+@pytest.mark.asyncio
+async def test_registry_reinstall_rechecks_retained_startup_before_replacement(
+    monkeypatch, tmp_path
+):
+    """A hook retained during clone/build must still block old-file replacement."""
+    src = tmp_path / "app-sources" / "demoapp"
+    _identity_harness(
+        monkeypatch,
+        src,
+        cloned_manifest={"name": "demoapp", "version": "2.0.0"},
+    )
+    monkeypatch.setattr(registry, "get_app", lambda _name: {"name": "demoapp"})
+
+    from kiro_crew.apps import hooks_integration
+
+    cleanup_calls: list[tuple[str, bool]] = []
+
+    async def _cleanup(app_name: str, *, bounded: bool) -> bool:
+        cleanup_calls.append((app_name, bounded))
+        # No task at admission time; one becomes retained while clone/build runs.
+        return len(cleanup_calls) == 1
+
+    monkeypatch.setattr(
+        hooks_integration, "stop_retained_startup_hooks", _cleanup
+    )
+
+    def _must_not_update(*args, **kwargs):
+        raise AssertionError("registry reinstall must not replace old files")
+
+    monkeypatch.setattr(registry, "update_app", _must_not_update)
+
+    result = await registry.install_from_registry("demoapp")
+
+    assert result["ok"] is False
+    assert result["code"] == "startup_hook_still_running"
+    assert result["retryable"] is True
+    assert cleanup_calls == [("demoapp", True), ("demoapp", True)]
+
+
+@pytest.mark.asyncio
 async def test_identity_gate_runs_before_the_build(monkeypatch, tmp_path):
     """A mismatched repo must be refused BEFORE _run_app_build executes — build
     ecosystems run repo-authored lifecycle scripts (npm preinstall, setup.py),

--- a/test/test_apps_routes_coverage.py
+++ b/test/test_apps_routes_coverage.py
@@ -382,19 +382,50 @@ class TestInstallValidation:
         assert not (home / "apps" / APP).exists()
 
     @pytest.mark.asyncio
-    async def test_unreadable_manifest_falls_back_to_path_lock(
+    async def test_unreadable_manifest_refuses_without_ownership_identity(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # A corrupt app.json must not 500 in the pre-flight version check —
-        # it falls through to install_app, which rejects it as a bad manifest.
         _setup_env(tmp_path, monkeypatch)
         src = tmp_path / "source" / APP
         src.mkdir(parents=True)
         (src / APP_MANIFEST_FILENAME).write_text("{ corrupt", encoding="utf-8")
+
+        def _must_not_install(*args: Any, **kwargs: Any) -> AppResult:
+            raise AssertionError("install must not proceed without a stable app identity")
+
+        monkeypatch.setattr(routes_mod, "install_app", _must_not_install)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post("/api/apps/install", json={"source": str(src)})
+            assert resp.status == 409
+            body = await resp.json()
+        assert body["code"] == "app_identity_unavailable"
+        assert body["retryable"] is True
+
+    @pytest.mark.asyncio
+    async def test_manifest_name_change_refuses_before_copy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = _setup_env(tmp_path, monkeypatch)
+        src = _make_app_source(tmp_path)
+        real_install = routes_mod.install_app
+
+        def _change_identity_then_install(
+            source: str, *, expected_name: str | None = None
+        ) -> AppResult:
+            manifest_path = Path(source) / APP_MANIFEST_FILENAME
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["name"] = "other-app"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            return real_install(source, expected_name=expected_name)
+
+        monkeypatch.setattr(routes_mod, "install_app", _change_identity_then_install)
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.post("/api/apps/install", json={"source": str(src)})
             assert resp.status == 400
-            assert (await resp.json())["ok"] is False
+            body = await resp.json()
+        assert body["code"] == "app_identity_changed"
+        assert not (home / "apps" / APP).exists()
+        assert not (home / "apps" / "other-app").exists()
 
     @pytest.mark.asyncio
     async def test_install_failure_is_reported_as_400(
@@ -406,6 +437,38 @@ class TestInstallValidation:
                 "/api/apps/install", json={"source": str(tmp_path / "nope")}
             )
             assert resp.status == 400
+            assert (await resp.json())["code"] == "source_not_directory"
+
+    @pytest.mark.asyncio
+    async def test_live_detached_startup_hook_refuses_fresh_reinstall(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(tmp_path, monkeypatch)
+        source = _make_app_source(tmp_path)
+        calls: list[tuple[str, bool]] = []
+
+        async def _stop_retained(app_name: str, *, bounded: bool) -> bool:
+            calls.append((app_name, bounded))
+            return False
+
+        monkeypatch.setattr(
+            routes_mod, "stop_retained_startup_hooks", _stop_retained
+        )
+
+        def _must_not_install(*args: Any, **kwargs: Any) -> AppResult:
+            raise AssertionError("install must not replace files while old code runs")
+
+        monkeypatch.setattr(routes_mod, "install_app", _must_not_install)
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post(
+                "/api/apps/install", json={"source": str(source)}
+            )
+            assert resp.status == 409
+            body = await resp.json()
+        assert body["code"] == "startup_hook_still_running"
+        assert body["retryable"] is True
+        assert calls == [(APP, True)]
 
 
 # ---------------------------------------------------------------------------
@@ -534,12 +597,50 @@ class TestUpdateApp:
             assert "source path required" in (await resp.json())["error"]
 
     @pytest.mark.asyncio
-    async def test_registry_update_failure_keeps_resources(
+    async def test_live_detached_startup_hook_refuses_update(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(tmp_path, monkeypatch)
+        _install(tmp_path)
+        calls: list[tuple[str, bool]] = []
+
+        async def _stop_retained(
+            app_name: str, *, bounded: bool
+        ) -> bool:
+            calls.append((app_name, bounded))
+            return False
+
+        monkeypatch.setattr(
+            routes_mod, "stop_retained_startup_hooks", _stop_retained
+        )
+
+        def _must_not_update(*args: Any, **kwargs: Any) -> AppResult:
+            raise AssertionError("update must not replace files while old code runs")
+
+        monkeypatch.setattr(routes_mod, "update_app", _must_not_update)
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post(f"/api/apps/{APP}/update", json={})
+            assert resp.status == 409
+            body = await resp.json()
+        assert body["code"] == "startup_hook_still_running"
+        assert body["retryable"] is True
+        assert calls == [(APP, True)]
+
+    @pytest.mark.asyncio
+    async def test_registry_update_delegates_admission_and_keeps_resources(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _setup_env(tmp_path, monkeypatch)
         _install(tmp_path)
         deregistered: list[str] = []
+
+        async def _must_not_preflight(*args: Any, **kwargs: Any) -> bool:
+            raise AssertionError("registry admission belongs to install_from_registry")
+
+        monkeypatch.setattr(
+            routes_mod, "stop_retained_startup_hooks", _must_not_preflight
+        )
 
         async def _failed_install(name: str, **kwargs: Any) -> dict[str, Any]:
             return {"ok": False, "name": name, "error": "clone failed"}
@@ -752,6 +853,37 @@ class TestUninstallRefusals:
             resp = await client.post("/api/apps/locked-app/uninstall")
             assert resp.status == 400
             assert "lifecycle=locked" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_live_detached_startup_hook_refuses_uninstall(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(tmp_path, monkeypatch)
+        _install(tmp_path)
+        calls: list[tuple[str, bool]] = []
+
+        async def _stop_retained(
+            app_name: str, *, bounded: bool
+        ) -> bool:
+            calls.append((app_name, bounded))
+            return False
+
+        monkeypatch.setattr(
+            routes_mod, "stop_retained_startup_hooks", _stop_retained
+        )
+
+        def _must_not_uninstall(*args: Any, **kwargs: Any) -> AppResult:
+            raise AssertionError("uninstall must not delete files while old code runs")
+
+        monkeypatch.setattr(routes_mod, "uninstall_app", _must_not_uninstall)
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post(f"/api/apps/{APP}/uninstall", json={})
+            assert resp.status == 409
+            body = await resp.json()
+        assert body["code"] == "startup_hook_still_running"
+        assert body["retryable"] is True
+        assert calls == [(APP, True)]
 
     @pytest.mark.asyncio
     async def test_removable_dependencies_are_cleaned_and_reported(
@@ -971,6 +1103,42 @@ class TestEnableBranches:
 
 class TestDisableBranches:
     @pytest.mark.asyncio
+    async def test_live_detached_startup_hook_refuses_disable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_env(tmp_path, monkeypatch)
+        _install(tmp_path)
+        enable_app(APP)
+        calls: list[tuple[str, bool]] = []
+
+        async def _stop_retained(app_name: str, *, bounded: bool) -> bool:
+            calls.append((app_name, bounded))
+            return False
+
+        monkeypatch.setattr(
+            routes_mod, "stop_retained_startup_hooks", _stop_retained
+        )
+
+        async def _must_not_teardown(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("disable must not wait on retained startup work")
+
+        def _must_not_disable(*args: Any, **kwargs: Any) -> AppResult:
+            raise AssertionError("disable metadata must remain unchanged on refusal")
+
+        monkeypatch.setattr(routes_mod, "teardown_app_runtime", _must_not_teardown)
+        monkeypatch.setattr(routes_mod, "disable_app", _must_not_disable)
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post(f"/api/apps/{APP}/disable")
+            assert resp.status == 409
+            body = await resp.json()
+            app_resp = await client.get(f"/api/apps/{APP}")
+            assert (await app_resp.json())["enabled"] is True
+        assert body["code"] == "startup_hook_still_running"
+        assert body["retryable"] is True
+        assert calls == [(APP, True)]
+
+    @pytest.mark.asyncio
     async def test_not_installed_is_404(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1059,6 +1227,7 @@ class TestDisableBranches:
         enable_app(APP)
 
         async def _hooks(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["bounded_startup_cleanup"] is False
             return {"cron_cleanup": "2 job(s) left enabled", "other": 1}
 
         # Patched on the SHARED teardown, not on `routes`: this PR routes the

--- a/test/test_lifecycle_hooks.py
+++ b/test/test_lifecycle_hooks.py
@@ -114,7 +114,9 @@ class TestLifecycleHookOrdering:
         # Track invocation order by patching _invoke
         invocation_order: list[str] = []
 
-        async def tracking_invoke(app_name: str, hook_path: str, ctx: Any) -> bool:
+        async def tracking_invoke(
+            app_name: str, hook_path: str, ctx: Any, *, phase: str = ""
+        ) -> bool:
             invocation_order.append(app_name)
             return True
 
@@ -137,7 +139,9 @@ class TestLifecycleHookOrdering:
 
         invocation_order: list[str] = []
 
-        async def tracking_invoke(app_name: str, hook_path: str, ctx: Any) -> bool:
+        async def tracking_invoke(
+            app_name: str, hook_path: str, ctx: Any, *, phase: str = ""
+        ) -> bool:
             invocation_order.append(app_name)
             return True
 
@@ -247,3 +251,813 @@ class TestLifecycleDispatcherEdgeCases:
             assert result == []
         finally:
             loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-hook timeout at the dispatch boundary (issue #5443)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleHookTimeout:
+    """A hung async hook is bounded, cancelled, observed, and does not block peers.
+
+    See app-kit-platform.md §7.1. These exercise the real ``_invoke`` (including
+    the SEL record and health bookkeeping); only ``_resolve_hook`` — the import —
+    is stubbed, so the timeout/cancellation path is under test, not mocked away.
+    """
+
+    @staticmethod
+    def _app_info(name: str, hook: str = "backend.hooks:on_startup") -> dict[str, Any]:
+        return _make_app_info(name, on_startup=hook)
+
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _build_context → app_dir(name)/"data".mkdir(); pin it off the real home.
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+
+    def test_gateway_cleanup_does_not_spend_shutdown_hook_budget(self) -> None:
+        """Gateway cleanup must check retained startup ownership without waiting."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        assert lifecycle_mod._GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC == 0.0
+
+    @pytest.mark.asyncio
+    async def test_gateway_shutdown_runs_after_retained_startup_already_settled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A settled retained startup permits its app's shutdown hook."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+        release = asyncio.Event()
+        events: list[str] = []
+
+        async def startup(_ctx: Any) -> None:
+            events.append("startup-start")
+            await release.wait()
+            events.append("startup-finish")
+
+        async def shutdown(_ctx: Any) -> None:
+            events.append("shutdown")
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher,
+            "_resolve_hook",
+            lambda _name, path: startup if path == "hooks:on_startup" else shutdown,
+        )
+        app = _make_app_info(
+            "ordered-app",
+            on_startup="hooks:on_startup",
+            on_shutdown="hooks:on_shutdown",
+        )
+
+        assert await dispatcher.dispatch_startup([app]) == []
+        assert events == ["startup-start"]
+        release.set()
+        assert await asyncio.wait_for(
+            dispatcher.stop_detached_startup_hooks("ordered-app"), timeout=1
+        )
+
+        assert await dispatcher.dispatch_shutdown([app]) == ["ordered-app"]
+        assert events == ["startup-start", "startup-finish", "shutdown"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_shutdown_skips_hook_when_startup_remains_owned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bounded ownership failure must not overlap shutdown with startup."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.02)
+        monkeypatch.setattr(
+            lifecycle_mod, "_GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC", 0.02
+        )
+        release = asyncio.Event()
+        shutdown_called = False
+
+        async def startup(_ctx: Any) -> None:
+            await release.wait()
+
+        async def shutdown(_ctx: Any) -> None:
+            nonlocal shutdown_called
+            shutdown_called = True
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher,
+            "_resolve_hook",
+            lambda _name, path: startup if path == "hooks:on_startup" else shutdown,
+        )
+        app = _make_app_info(
+            "still-starting-app",
+            on_startup="hooks:on_startup",
+            on_shutdown="hooks:on_shutdown",
+        )
+
+        assert await dispatcher.dispatch_startup([app]) == []
+        try:
+            assert await asyncio.wait_for(
+                dispatcher.dispatch_shutdown([app]), timeout=0.25
+            ) == []
+            assert shutdown_called is False
+        finally:
+            release.set()
+            await asyncio.wait_for(
+                dispatcher.stop_detached_startup_hooks("still-starting-app"),
+                timeout=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_gateway_shutdown_sweeps_all_apps_under_one_deadline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ownership checks include hookless apps and begin concurrently."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(
+            lifecycle_mod, "_GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC", 0.05
+        )
+        started: set[str] = set()
+        all_started = asyncio.Event()
+        invoked: list[str] = []
+
+        dispatcher = LifecycleDispatcher()
+
+        async def stop(
+            app_name: str, *, bounded: bool = False, timeout: float | None = None
+        ) -> bool:
+            assert bounded is True
+            assert timeout == 0.05
+            started.add(app_name)
+            if len(started) == 2:
+                all_started.set()
+            await asyncio.wait_for(all_started.wait(), timeout=0.2)
+            return True
+
+        async def invoke(
+            app_name: str, _hook_path: str, _ctx: Any, *, phase: str
+        ) -> bool:
+            assert phase == "shutdown"
+            invoked.append(app_name)
+            return True
+
+        monkeypatch.setattr(dispatcher, "stop_detached_startup_hooks", stop)
+        monkeypatch.setattr(dispatcher, "_invoke", invoke)
+        hookless = _make_app_info("a-hookless")
+        with_hook = _make_app_info("b-hook", on_shutdown="hooks:on_shutdown")
+
+        assert await asyncio.wait_for(
+            dispatcher.dispatch_shutdown([hookless, with_hook]), timeout=0.3
+        ) == ["b-hook"]
+        assert started == {"a-hookless", "b-hook"}
+        assert invoked == ["b-hook"]
+
+    @pytest.mark.asyncio
+    async def test_hung_async_hook_times_out_and_is_reported_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A startup hook can outlive readiness but remains owned until completion."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hangs(_ctx: Any) -> None:
+            started.set()
+            await release.wait()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: hangs)
+        ctx = dispatcher._build_context(self._app_info("hang-app"))
+
+        ok = await dispatcher._invoke("hang-app", "backend.hooks:on_startup", ctx, phase="startup")
+
+        assert ok is False
+        assert started.is_set(), "hook must actually have started before timing out"
+        assert "hang-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+        assert ctx.health.status == "degraded"
+        assert any("timed out" in issue for issue in ctx.health.to_dict()["issues"])
+
+        release.set()
+        assert await asyncio.wait_for(
+            dispatcher.stop_detached_startup_hooks("hang-app"), timeout=1
+        )
+        await asyncio.sleep(0)
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_cancel_cooperative_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Timeout preserves ownership instead of asking the hook to cancel."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+
+        release = asyncio.Event()
+        finished = asyncio.Event()
+        saw_cancel = False
+
+        async def waits_for_release(_ctx: Any) -> None:
+            nonlocal saw_cancel
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                saw_cancel = True
+                raise
+            finally:
+                finished.set()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: waits_for_release)
+        ctx = dispatcher._build_context(self._app_info("cleanup-app"))
+
+        ok = await dispatcher._invoke(
+            "cleanup-app", "backend.hooks:on_startup", ctx, phase="startup"
+        )
+
+        assert ok is False
+        assert saw_cancel is False
+        assert "cleanup-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+        release.set()
+        await asyncio.wait_for(finished.wait(), timeout=1)
+        assert await asyncio.wait_for(
+            dispatcher.stop_detached_startup_hooks("cleanup-app"), timeout=1
+        )
+        await asyncio.sleep(0)
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_retry_refuses_while_startup_hook_remains_owned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A timed-out startup task remains the sole invocation until it exits."""
+        from unittest.mock import MagicMock
+
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+        audit = MagicMock()
+        monkeypatch.setattr(lifecycle_mod, "sel", lambda: audit)
+        release = asyncio.Event()
+        invocations = 0
+
+        async def retained(_ctx: Any) -> None:
+            nonlocal invocations
+            invocations += 1
+            await release.wait()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: retained)
+        first_ctx = dispatcher._build_context(self._app_info("retry-app"))
+        retry_ctx = dispatcher._build_context(self._app_info("retry-app"))
+
+        try:
+            assert await dispatcher._invoke(
+                "retry-app", "backend.hooks:on_startup", first_ctx, phase="startup"
+            ) is False
+            assert invocations == 1
+            assert len(lifecycle_mod._DETACHED_HOOK_TASKS["retry-app"]) == 1
+
+            assert await dispatcher._invoke(
+                "retry-app", "backend.hooks:on_startup", retry_ctx, phase="startup"
+            ) is False
+            assert invocations == 1
+            assert len(lifecycle_mod._DETACHED_HOOK_TASKS["retry-app"]) == 1
+            assert any(
+                call.kwargs.get("outcome") == "failed"
+                and call.kwargs.get("error") == "retained startup hook is already active"
+                for call in audit.log_api_access.call_args_list
+            )
+        finally:
+            release.set()
+            await asyncio.wait_for(
+                dispatcher.stop_detached_startup_hooks("retry-app"), timeout=1
+            )
+            await asyncio.sleep(0)
+
+        assert "retry-app" not in lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_to_thread_worker_remains_owned_until_worker_finishes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A terminal awaiter must never hide a still-running app worker thread."""
+        import threading
+
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def worker() -> None:
+            started.set()
+            release.wait()
+            finished.set()
+
+        async def waits_on_worker(_ctx: Any) -> None:
+            await asyncio.to_thread(worker)
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: waits_on_worker)
+        ctx = dispatcher._build_context(self._app_info("thread-app"))
+
+        try:
+            ok = await dispatcher._invoke(
+                "thread-app", "backend.hooks:on_startup", ctx, phase="startup"
+            )
+
+            assert ok is False
+            assert started.is_set()
+            assert not finished.is_set()
+            assert "thread-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+            assert await dispatcher.stop_detached_startup_hooks(
+                "thread-app", bounded=True, timeout=0.05
+            ) is False
+            assert "thread-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+        finally:
+            release.set()
+            if started.is_set():
+                await asyncio.to_thread(finished.wait, 1)
+            await asyncio.wait_for(
+                dispatcher.stop_detached_startup_hooks("thread-app"), timeout=1
+            )
+            await asyncio.sleep(0)
+
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_pre_timeout_cancelled_thread_worker_leaves_residual_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Child cancellation before the deadline must remain fail-closed."""
+        import threading
+
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 1.0)
+        app_name = "early-cancel-app"
+        lifecycle_mod._DETACHED_HOOK_RESIDUALS.discard(app_name)
+        worker_started = threading.Event()
+        worker_release = threading.Event()
+        worker_finished = threading.Event()
+
+        def worker() -> None:
+            worker_started.set()
+            worker_release.wait()
+            worker_finished.set()
+
+        async def self_cancelling_hook(_ctx: Any) -> None:
+            task = asyncio.current_task()
+            assert task is not None
+            asyncio.get_running_loop().call_soon(task.cancel)
+            await asyncio.to_thread(worker)
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher, "_resolve_hook", lambda *_a, **_k: self_cancelling_hook
+        )
+        ctx = dispatcher._build_context(self._app_info(app_name))
+
+        try:
+            assert await dispatcher._invoke(
+                app_name, "backend.hooks:on_startup", ctx, phase="startup"
+            ) is False
+            assert await asyncio.to_thread(worker_started.wait, 1)
+            await asyncio.sleep(0)
+            assert app_name in lifecycle_mod._DETACHED_HOOK_RESIDUALS
+            assert app_name not in lifecycle_mod._DETACHED_HOOK_TASKS
+            assert worker_finished.is_set() is False
+            assert await dispatcher.stop_detached_startup_hooks(
+                app_name, bounded=True, timeout=0.01
+            ) is False
+        finally:
+            worker_release.set()
+            await asyncio.to_thread(worker_finished.wait, 1)
+            lifecycle_mod._DETACHED_HOOK_TASKS.pop(app_name, None)
+            lifecycle_mod._DETACHED_HOOK_RESIDUALS.discard(app_name)
+
+    @pytest.mark.asyncio
+    async def test_parent_cancellation_propagates_while_startup_remains_owned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancelling the dispatcher must not cancel or orphan its child hook."""
+        import threading
+
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 1.0)
+        app_name = "parent-cancel-app"
+        worker_started = threading.Event()
+        worker_release = threading.Event()
+        worker_finished = threading.Event()
+
+        def worker() -> None:
+            worker_started.set()
+            worker_release.wait()
+            worker_finished.set()
+
+        async def waits_on_worker(_ctx: Any) -> None:
+            await asyncio.to_thread(worker)
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher, "_resolve_hook", lambda *_a, **_k: waits_on_worker
+        )
+        ctx = dispatcher._build_context(self._app_info(app_name))
+        invoke_task = asyncio.create_task(
+            dispatcher._invoke(
+                app_name, "backend.hooks:on_startup", ctx, phase="startup"
+            )
+        )
+
+        try:
+            assert await asyncio.to_thread(worker_started.wait, 1)
+            assert app_name in lifecycle_mod._DETACHED_HOOK_TASKS
+            invoke_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await invoke_task
+            assert app_name in lifecycle_mod._DETACHED_HOOK_TASKS
+            assert app_name not in lifecycle_mod._DETACHED_HOOK_RESIDUALS
+            assert await dispatcher.stop_detached_startup_hooks(
+                app_name, bounded=True, timeout=0.01
+            ) is False
+        finally:
+            worker_release.set()
+            await asyncio.to_thread(worker_finished.wait, 1)
+            await asyncio.wait_for(
+                dispatcher.stop_detached_startup_hooks(app_name), timeout=1
+            )
+            lifecycle_mod._DETACHED_HOOK_TASKS.pop(app_name, None)
+            lifecycle_mod._DETACHED_HOOK_RESIDUALS.discard(app_name)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_retained_hook_leaves_fail_closed_residual_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-cancellation cannot make a live to_thread worker look stopped."""
+        import threading
+
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+        app_name = "cancel-app"
+        lifecycle_mod._DETACHED_HOOK_RESIDUALS.discard(app_name)
+        arm_cancel = asyncio.Event()
+        worker_started = threading.Event()
+        worker_release = threading.Event()
+        worker_finished = threading.Event()
+
+        def worker() -> None:
+            worker_started.set()
+            worker_release.wait()
+            worker_finished.set()
+
+        async def self_cancelling_hook(_ctx: Any) -> None:
+            task = asyncio.current_task()
+            assert task is not None
+            await arm_cancel.wait()
+            asyncio.get_running_loop().call_soon(task.cancel)
+            await asyncio.to_thread(worker)
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(
+            dispatcher, "_resolve_hook", lambda *_a, **_k: self_cancelling_hook
+        )
+        ctx = dispatcher._build_context(self._app_info(app_name))
+
+        try:
+            assert await dispatcher._invoke(
+                app_name, "backend.hooks:on_startup", ctx, phase="startup"
+            ) is False
+            assert app_name in lifecycle_mod._DETACHED_HOOK_TASKS
+
+            arm_cancel.set()
+            assert await asyncio.to_thread(worker_started.wait, 1)
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if app_name in lifecycle_mod._DETACHED_HOOK_RESIDUALS:
+                    break
+
+            assert app_name in lifecycle_mod._DETACHED_HOOK_RESIDUALS
+            assert app_name not in lifecycle_mod._DETACHED_HOOK_TASKS
+            assert worker_finished.is_set() is False
+            assert await dispatcher.stop_detached_startup_hooks(
+                app_name, bounded=True, timeout=0.01
+            ) is False
+
+            worker_release.set()
+            assert await asyncio.to_thread(worker_finished.wait, 1)
+            # Actual worker completion cannot be inferred from the cancelled
+            # asyncio wrapper, so ownership remains fail-closed.
+            assert await dispatcher.stop_detached_startup_hooks(app_name) is False
+        finally:
+            worker_release.set()
+            await asyncio.to_thread(worker_finished.wait, 1)
+            lifecycle_mod._DETACHED_HOOK_TASKS.pop(app_name, None)
+            lifecycle_mod._DETACHED_HOOK_RESIDUALS.discard(app_name)
+
+    @pytest.mark.asyncio
+    async def test_hook_continuing_after_deadline_cannot_extend_readiness(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Readiness proceeds, while teardown still waits for true completion."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+        release = asyncio.Event()
+        finished = asyncio.Event()
+
+        async def waits_for_release(_ctx: Any) -> None:
+            await release.wait()
+            finished.set()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: waits_for_release)
+        ctx = dispatcher._build_context(self._app_info("stubborn-app"))
+
+        ok = await asyncio.wait_for(
+            dispatcher._invoke(
+                "stubborn-app", "backend.hooks:on_startup", ctx, phase="startup"
+            ),
+            timeout=0.25,
+        )
+
+        assert ok is False
+        assert "stubborn-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+
+        stopped = await dispatcher.stop_detached_startup_hooks(
+            "stubborn-app", bounded=True, timeout=0.05
+        )
+        assert stopped is False
+        assert "stubborn-app" in lifecycle_mod._DETACHED_HOOK_TASKS
+
+        ordinary_stop = asyncio.create_task(
+            dispatcher.stop_detached_startup_hooks("stubborn-app")
+        )
+        await asyncio.sleep(0.05)
+        assert not ordinary_stop.done(), "ordinary disable must wait for terminal cleanup"
+
+        release.set()
+        assert await asyncio.wait_for(ordinary_stop, timeout=1) is True
+        await asyncio.wait_for(finished.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_shutdown_hook_cannot_outlive_teardown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shutdown stays pending until third-party hook code has actually stopped."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.01)
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def shutdown_hook(_ctx: Any) -> None:
+            started.set()
+            await release.wait()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: shutdown_hook)
+        ctx = dispatcher._build_context(self._app_info("shutdown-app"))
+        invocation = asyncio.create_task(
+            dispatcher._invoke(
+                "shutdown-app", "backend.hooks:on_shutdown", ctx, phase="shutdown"
+            )
+        )
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await asyncio.sleep(0.05)  # well beyond the startup-only deadline
+        assert not invocation.done()
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+        release.set()
+        assert await asyncio.wait_for(invocation, timeout=1) is True
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_disable_reports_detached_startup_hook_that_did_not_stop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The shared teardown receives a hard-failure marker for residual code."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        class _Dispatcher:
+            _cron_service = None
+
+            async def stop_detached_startup_hooks(
+                self, app_name: str, *, bounded: bool = False
+            ) -> bool:
+                assert app_name == "residual-app"
+                assert bounded is True
+                return False
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _Dispatcher())
+        monkeypatch.setattr(integration, "_route_registry", None)
+
+        result = await integration.on_app_disable(
+            "residual-app",
+            self._app_info("residual-app"),
+            run_app_hooks=False,
+            bounded_startup_cleanup=True,
+        )
+
+        assert result["startup_cleanup"].startswith("failed:")
+
+    @pytest.mark.asyncio
+    async def test_disable_skips_shutdown_hook_when_startup_cleanup_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A retryable teardown failure must not start unbounded app code."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        invoked = False
+
+        class _Dispatcher:
+            _cron_service = None
+
+            async def stop_detached_startup_hooks(
+                self, app_name: str, *, bounded: bool = False
+            ) -> bool:
+                assert app_name == "residual-app"
+                assert bounded is True
+                return False
+
+            async def _invoke(self, *_args: Any, **_kwargs: Any) -> bool:
+                nonlocal invoked
+                invoked = True
+                return True
+
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _Dispatcher())
+        monkeypatch.setattr(integration, "_route_registry", None)
+
+        result = await integration.on_app_disable(
+            "residual-app",
+            _make_app_info("residual-app", on_shutdown="hooks:on_shutdown"),
+            run_app_hooks=True,
+            bounded_startup_cleanup=True,
+        )
+
+        assert result["startup_cleanup"].startswith("failed:")
+        assert "hooks_shutdown" not in result
+        assert invoked is False
+
+    @pytest.mark.asyncio
+    async def test_gateway_shutdown_forwards_hookless_enabled_apps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The integration layer must not filter ownership by hook presence."""
+        import kiro_crew.apps.hooks_integration as integration
+
+        seen: list[str] = []
+
+        class _Dispatcher:
+            async def dispatch_shutdown(self, apps: list[dict[str, Any]]) -> list[str]:
+                seen.extend(app["name"] for app in apps)
+                return []
+
+        apps = [
+            _make_app_info("hookless"),
+            _make_app_info("with-hook", on_shutdown="hooks:on_shutdown"),
+        ]
+        monkeypatch.setattr(integration, "_lifecycle_dispatcher", _Dispatcher())
+        monkeypatch.setattr(integration, "list_apps", lambda: apps)
+
+        await integration.on_gateway_shutdown()
+
+        assert seen == ["hookless", "with-hook"]
+
+    @pytest.mark.asyncio
+    async def test_synchronous_hook_is_never_subject_to_the_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync hook returns before the iscoroutine check → runs to completion."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        # Even with a zero deadline, a sync hook is unaffected: it never awaits.
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.0)
+
+        ran = False
+
+        def sync_hook(_ctx: Any) -> None:
+            nonlocal ran
+            ran = True
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: sync_hook)
+        ctx = dispatcher._build_context(self._app_info("sync-app"))
+
+        ok = await dispatcher._invoke("sync-app", "backend.hooks:on_startup", ctx, phase="startup")
+
+        assert ok is True
+        assert ran is True
+        assert ctx.health.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_successful_async_hook_within_deadline_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An async hook that returns inside the deadline is unaffected → True."""
+        ran = False
+
+        async def quick_hook(_ctx: Any) -> None:
+            nonlocal ran
+            await asyncio.sleep(0)
+            ran = True
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: quick_hook)
+        ctx = dispatcher._build_context(self._app_info("quick-app"))
+
+        ok = await dispatcher._invoke(
+            "quick-app", "backend.hooks:on_startup", ctx, phase="startup"
+        )
+
+        assert ok is True
+        assert ran is True
+        assert ctx.health.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_one_apps_timeout_does_not_block_subsequent_apps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """dispatch_startup continues past a hung app; independent apps still start."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+
+        invoked_names: list[str] = []
+        release = asyncio.Event()
+
+        async def hangs(_ctx: Any) -> None:
+            await release.wait()
+
+        async def quick(_ctx: Any) -> None:
+            return None
+
+        # Lexicographic order puts "a-hang" before "b-ok"; the hang must not
+        # prevent "b-ok" from being invoked and reported successful.
+        def resolve(app_name: str, _hook: str) -> Any:
+            invoked_names.append(app_name)
+            return hangs if app_name == "a-hang" else quick
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", resolve)
+
+        apps = [self._app_info("b-ok"), self._app_info("a-hang")]
+        succeeded = await dispatcher.dispatch_startup(apps)
+
+        assert invoked_names == ["a-hang", "b-ok"], "both hooks were attempted, in order"
+        assert succeeded == ["b-ok"], "the hung app is excluded; the healthy one starts"
+        release.set()
+        assert await asyncio.wait_for(
+            dispatcher.stop_detached_startup_hooks("a-hang"), timeout=1
+        )
+        await asyncio.sleep(0)
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS
+
+    @pytest.mark.asyncio
+    async def test_timeout_preserves_sel_resource_shape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The timeout outcome keeps the established hook-path resource value."""
+        import kiro_crew.apps.lifecycle as lifecycle_mod
+
+        monkeypatch.setattr(lifecycle_mod, "_HOOK_TIMEOUT_SEC", 0.05)
+
+        calls: list[dict[str, Any]] = []
+        release = asyncio.Event()
+
+        class _Sel:
+            def log_api_access(self, **kwargs: Any) -> None:
+                calls.append(kwargs)
+
+        monkeypatch.setattr(lifecycle_mod, "sel", lambda: _Sel())
+
+        async def hangs(_ctx: Any) -> None:
+            await release.wait()
+
+        dispatcher = LifecycleDispatcher()
+        monkeypatch.setattr(dispatcher, "_resolve_hook", lambda *_a, **_k: hangs)
+        ctx = dispatcher._build_context(self._app_info("sel-app"))
+
+        await dispatcher._invoke("sel-app", "backend.hooks:on_startup", ctx, phase="startup")
+
+        assert len(calls) == 1
+        record = calls[0]
+        assert record["outcome"] == "timeout"
+        assert record["caller"] == "app:sel-app"
+        assert record["resources"] == "backend.hooks:on_startup"
+        release.set()
+        assert await asyncio.wait_for(
+            dispatcher.stop_detached_startup_hooks("sel-app"), timeout=1
+        )
+        await asyncio.sleep(0)
+        assert not lifecycle_mod._DETACHED_HOOK_TASKS

--- a/test/test_trusted_apps_api.py
+++ b/test/test_trusted_apps_api.py
@@ -577,6 +577,7 @@ async def test_revoke_runs_the_full_teardown_in_order(home: Path, tmp_path: Path
     calls: list[str] = []
 
     async def _on_app_disable(name: str, record: dict, **_kw: object) -> dict:
+        assert _kw["bounded_startup_cleanup"] is True
         calls.append(f"on_app_disable:{name}")
         return {}
 
@@ -615,6 +616,51 @@ async def test_revoke_runs_the_full_teardown_in_order(home: Path, tmp_path: Path
         f"stop_app_backend:{_APP}",
         f"deregister_app:{_APP}",
         f"disable_app:{_APP}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trust_withdrawal_refuses_before_teardown_when_startup_is_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Residual startup ownership leaves every runtime surface unchanged."""
+    import kiro_crew.apps.teardown as appteardown
+
+    calls: list[str] = []
+
+    async def _startup_preflight(name: str, *, bounded: bool = False) -> bool:
+        assert name == _APP
+        assert bounded is True
+        calls.append("startup_preflight")
+        return False
+
+    async def _must_not_run(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("teardown mutated runtime state after ownership refusal")
+
+    monkeypatch.setattr(appteardown, "stop_app_startup_hooks", _startup_preflight)
+    monkeypatch.setattr(appteardown, "notify_app_disabled", _must_not_run)
+    monkeypatch.setattr(appteardown, "on_app_disable", _must_not_run)
+    monkeypatch.setattr(
+        appteardown,
+        "stop_app_backend",
+        lambda _name: pytest.fail("backend stop ran after ownership refusal"),
+    )
+    monkeypatch.setattr(
+        appteardown,
+        "deregister_app",
+        lambda _name: pytest.fail("deregistration ran after ownership refusal"),
+    )
+
+    result = await appteardown.teardown_app_runtime(
+        _APP, {"manifest": {}, "enabled": True}, withdrawing_trust=True
+    )
+
+    assert result.ok is False
+    assert calls == ["startup_preflight"]
+    assert result.warnings == []
+    assert result.failures == [
+        "startup cleanup incomplete: detached startup hook is still running; "
+        "teardown made no runtime changes"
     ]
 
 
@@ -1661,6 +1707,37 @@ async def test_failed_cron_cleanup_does_not_report_a_successful_revoke(
             assert resp.status == 200
             assert (await resp.json())["disabled"] is True
     assert _APP not in _stored(home).get("apps_trusted", [])
+
+
+@pytest.mark.asyncio
+async def test_live_detached_startup_hook_does_not_report_successful_revoke(
+    home: Path, tmp_path: Path, mock_sel
+):
+    """Residual startup code is a hard, retryable teardown failure."""
+    import kiro_crew.apps.teardown as appteardown
+
+    async def _still_running(name: str, record: dict, **_kw: object) -> dict:
+        return {
+            "startup_cleanup": (
+                "failed: detached startup hook is still running after cancellation"
+            )
+        }
+
+    _install(tmp_path, _APP, enabled=True)
+    with (
+        patch.object(appteardown, "on_app_disable", _still_running),
+        patch.object(appteardown, "stop_app_backend", lambda name: True),
+        patch.object(appteardown, "deregister_app", lambda name: None),
+    ):
+        async with _client() as client:
+            assert (await client.post(f"/api/security/trusted-apps/{_APP}")).status == 200
+            resp = await client.delete(f"/api/security/trusted-apps/{_APP}")
+            assert resp.status == 409
+            body = await resp.json()
+            assert body["code"] == "teardown_incomplete"
+            assert any("startup cleanup incomplete" in f for f in body["failures"])
+
+    assert _APP in _stored(home).get("apps_trusted", [])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

An app lifecycle startup hook could block gateway readiness indefinitely. Applying a timeout naively is unsafe because cancelling an `asyncio.Task` that awaits `asyncio.to_thread()` does not stop the underlying worker, so execution ownership can outlive the visible task.

## Why it matters

One faulty app must not prevent the gateway from becoming ready. At the same time, disable, trust withdrawal, install, update, uninstall, registry replacement, or graceful gateway shutdown must never overlap lifecycle work while startup code may still be running, because that can expose partially initialized state or let old code recreate torn-down resources.

## What changed (motivation → approach → change)

Startup hooks now have a bounded readiness deadline while retaining explicit ownership of work that may continue after timeout. Ownership is registered immediately when each async startup task is created, before the dispatcher first awaits it, so parent cancellation cannot orphan pre-deadline work. Before every startup invocation, the dispatcher refuses while that app already owns a nonterminal task or residual marker, preventing an enable retry from launching duplicate startup state. Child cancellation records a process-lifetime residual marker before releasing the task reference when worker completion cannot be proven.

Disable, trust withdrawal, local install, update, uninstall, registry replacement, and teardown paths fail closed while ownership remains active or cannot be disproven. Shared teardown establishes startup ownership once before worker notification, app shutdown code, route/cron mutation, backend stop, or deregistration; a bounded trust-withdrawal refusal therefore leaves every runtime surface unchanged for a safe retry. Local installs refuse when the manifest identity is unavailable and pin the identity protected by the lifecycle lock through the manager's pre-copy check, closing a manifest replacement race. Registry reinstalls use `install_from_registry()` as the single ownership admission guard, including metadata-absent reinstalls.

Graceful gateway shutdown forwards every enabled app, including apps without `on_shutdown`, into one concurrent, non-blocking startup-ownership sweep. Already-settled ownership permits that app's shutdown hook; active or residual startup work skips only that app's hook fail-closed. The sweep consumes none of the gateway's remaining 10-second cooperative shutdown window, preserving time for unaffected app hooks after the existing bounded slot-history save.

Lifecycle SEL records preserve the established `resources=<module>:<function>` wire shape. The app platform specification documents the timeout, retained-ownership contract, and safe offline recovery for a permanently wedged startup hook: fully stop the gateway, disable the app, then restart. Metadata-only disable is not runtime teardown and is not proof that old code stopped.

## Tests

- Added lifecycle ordering and timeout coverage, including thread work that continues after readiness proceeds, duplicate startup retries remaining single-invocation, and exact SEL resource compatibility.
- Added pre-deadline cancellation coverage proving child cancellation leaves a fail-closed residual and parent cancellation propagates without orphaning the child hook.
- Added graceful-shutdown coverage proving ownership checks are non-blocking, settled startup work permits shutdown, active or residual work skips only the affected hook, and hookless apps still participate in the sweep.
- Added destructive-boundary coverage for disable, install, update, uninstall, trust withdrawal, registry replacement, and teardown, including proof that failed startup-ownership admission performs no runtime mutation.
- Added registry route coverage proving registry updates delegate ownership admission to `install_from_registry()` exactly once.
- Added local-install regressions proving unreadable identities are refused and manifest identity changes are rejected before any app data is copied.
- Added a machine-readable `source_not_directory` code to the absent-source 400 response and pinned it with the repository error-code ratchet.
- Each original affected test file was run in an isolated pytest process to avoid the proven pre-existing `sys.modules` leak: aggregate 691 passed, 4 skipped.
- Final identity-fix validation: `test/test_apps_routes_coverage.py` — 159 passed; `test/test_app_manager.py` — 102 passed; focused install validation — 12 passed.
- After rebasing onto `d23c63c8ecd283090abe2405f5b11e81de5697f2`, the full trusted-app suite passed (84 tests) and lifecycle/disable/install/uninstall/error-contract plus isolated watchdog coverage passed (44 tests).
- Canonical `python3 scripts/check_black_formatting.py`, changed-file isort and Flake8, full Mypy (1,101 source files), and `git diff --check` passed.
- Exact-SHA GPT 5.6-sol and Opus 4.8 reviews of `d23c63c8ecd283090abe2405f5b11e81de5697f2...2e483d6cf5fdc685d2954a63cec4c8a1f6db0971` returned no findings.

## Manual verification

N/A — deterministic lifecycle, route, registry, teardown, and manager tests exercise the timeout, retained execution, cancellation, every destructive boundary, identity pinning, shutdown ordering, eventual cleanup, and offline-recovery contract.

## Related Issues

Fixes #5443

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff





