### PR TITLE
fix: enforce script-hook invariants at every persistence boundary

### DIFF
--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -186,6 +186,13 @@ async def api_hooks_create(request: web.Request) -> web.Response:
         hook = await _mutate_hook_store(store.create, validated)
     except _StoreUnavailable:
         return _store_unavailable_response()
+    except ValueError as exc:
+        # store.create now enforces the same invariants as store.update via the
+        # shared validator, so it can raise ValueError. The HOOK_CREATE_SCHEMA
+        # check above normally rejects bad input first, but catch it here too so
+        # any schema/validator drift surfaces as a 400 (like the update handler)
+        # rather than an unhandled 500.
+        return web.json_response({"error": str(exc), "code": "invalid_hook"}, status=400)
     _sel().log_api_access(
         caller=request.get("user", "dashboard"),
         operation="hook.create",

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -19,7 +19,7 @@ import tempfile
 import threading
 import time
 import uuid
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -1597,12 +1597,12 @@ def _context_matches(matcher: str, mode: str, context: str) -> bool:
     - ``contains``: pipe-delimited substrings, case-insensitive OR.
     """
     if mode == "regex":
-        # Prepend (?i) for case-insensitive matching (the subprocess runs raw re.search).
-        # Only skip the prepend when the pattern already starts with an inline-flag
-        # group (e.g. (?i), (?im), (?aiLmsux)).  Non-flag groups like (?:, (?=, (?<,
-        # (?P must still get the (?i) prefix.
-        _has_inline_flags = re.match(r"^\(\?[aiLmsux]+[):]", matcher) is not None
-        pattern = matcher if _has_inline_flags else f"(?i){matcher}"
+        # Prepend (?i) for the default case-insensitive behavior unless the
+        # pattern already starts with a GLOBAL flag directive such as (?i).
+        # Scoped groups only govern their own body: (?-i:foo)bar intentionally
+        # still inherit the matcher default. Suppressing the prefix for every
+        # scoped group accidentally made the suffix case-sensitive too.
+        pattern = matcher if _has_global_inline_flags(matcher) else f"(?i){matcher}"
         result = _bounded_pattern_search(pattern, context)
         if result is None:
             # Timeout, oversized, or invalid pattern — fail closed (no match)
@@ -2735,6 +2735,105 @@ def emit_internal_read_audit(read_id: str, outcome: str) -> bool:
 
 # ── Script Hooks ──
 
+# Inclusive bounds for a script hook's subprocess timeout, in seconds. Mirrors
+# the API schema (``validation.HOOK_CREATE_SCHEMA`` min_val=1/max_val=300); kept
+# here so the same bound is enforced at EVERY persistence boundary — create,
+# update, and deserialization — not only when a value arrives over the dashboard
+# API. A 0 (or negative) timeout makes ``asyncio.wait_for`` fire immediately, and
+# an unbounded one lets a hook wedge a turn for as long as it likes; both are
+# outcomes a hand-edited or older ``hooks.json`` could otherwise reintroduce.
+HOOK_TIMEOUT_MIN = 1
+HOOK_TIMEOUT_MAX = 300
+HOOK_TIMEOUT_DEFAULT = 30
+
+# Events on which a standalone skills-only hook (no command) actually fires: only
+# UserPromptSubmit / AgentSpawn synthesize the "Load skills:" directive in
+# ``ScriptHookStore.fire()``. On any other event the directive has no consumer,
+# so pairing skills with one is a config that saves but never fires.
+_SKILLS_ONLY_EVENTS = (HOOK_EVENT_USER_PROMPT_SUBMIT, HOOK_EVENT_AGENT_SPAWN)
+
+# A global Python inline-flag directive at the very start of a pattern. Only this
+# form replaces the matcher-wide case-insensitive default. Scoped forms such as
+# ``(?i:...)`` and ``(?-i:...)`` govern their group only, so the caller still
+# prepends ``(?i)`` for the rest of the expression.
+_GLOBAL_INLINE_FLAGS_RE = re.compile(r"^\(\?[aiLmsux]+\)")
+
+
+def _has_global_inline_flags(pattern: str) -> bool:
+    """True when *pattern* starts with a global Python flag directive."""
+    return _GLOBAL_INLINE_FLAGS_RE.match(pattern) is not None
+
+
+def _normalize_hook_timeout(value: object) -> int:
+    """Coerce a persisted/edited timeout to an int within the allowed bounds.
+
+    ``hooks.json`` is hand-editable and older files predate the 1–300 bound, so a
+    missing / non-int / out-of-range value must degrade to a SAFE in-range value
+    rather than propagate: ``None`` or junk → the default; a numeric value is
+    clamped into ``[HOOK_TIMEOUT_MIN, HOOK_TIMEOUT_MAX]``. Used by ``from_dict``
+    (fail-soft on load); the raising ``validate_hook_fields`` is what rejects a
+    bad value at the create/update API boundary. A bool is rejected (``bool`` is
+    an ``int`` subclass but ``True`` as a timeout is meaningless).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return HOOK_TIMEOUT_DEFAULT
+    try:
+        ivalue = int(value)
+    except (ValueError, OverflowError):
+        return HOOK_TIMEOUT_DEFAULT
+    return max(HOOK_TIMEOUT_MIN, min(HOOK_TIMEOUT_MAX, ivalue))
+
+
+def validate_hook_fields(
+    *, event: str, timeout: object, command: str, skills: list, matcher: str, matcher_mode: str
+) -> None:
+    """Enforce the script-hook invariants at a WRITE boundary, raising on any breach.
+
+    The single source of truth for what makes a hook well-formed, shared by
+    ``ScriptHookStore.create`` and ``ScriptHookStore.update`` so a hook persisted
+    by EITHER path is held to the same contract — closing the gap where the
+    command+skills invariant, event membership, and timeout bounds were checked
+    only in ``update``. Deserialization (``ScriptHook.from_dict``) does NOT call
+    this: a malformed persisted hook must load fail-soft (normalized), never abort
+    the whole store, so it uses the ``_normalize_hook_*`` helpers instead.
+
+    Raises ``ValueError`` (which the dashboard handler maps to HTTP 400) when:
+
+    * ``event`` is not one of ``HOOK_EVENTS``;
+    * ``timeout`` is not an int in ``[1, 300]``;
+    * neither ``command`` nor ``skills`` is present (an empty hook);
+    * ``skills`` is combined with a ``command`` (the skills would never fire);
+    * ``skills`` is paired with an event other than UserPromptSubmit/AgentSpawn
+      (the "Load skills:" directive has no consumer there);
+    * ``matcher_mode`` is ``regex`` with a syntactically invalid ``matcher``.
+    """
+    if event not in HOOK_EVENTS:
+        raise ValueError(f"invalid event: {event}")
+    if isinstance(timeout, bool) or not isinstance(timeout, int) or not (
+        HOOK_TIMEOUT_MIN <= timeout <= HOOK_TIMEOUT_MAX
+    ):
+        raise ValueError(
+            f"timeout must be an integer between {HOOK_TIMEOUT_MIN} and {HOOK_TIMEOUT_MAX}"
+        )
+    if not command and not skills:
+        raise ValueError("either command or skills must be provided")
+    if skills:
+        if command:
+            raise ValueError(
+                "skills cannot be combined with a command — the skills would "
+                "never fire; use a skills-only hook or drop the skills"
+            )
+        if event not in _SKILLS_ONLY_EVENTS:
+            raise ValueError(
+                f"skills hooks cannot fire on {event} events — "
+                "choose UserPromptSubmit or AgentSpawn"
+            )
+    if matcher_mode == "regex" and matcher:
+        try:
+            re.compile(matcher)
+        except re.error as exc:
+            raise ValueError(f"invalid regex: {exc}") from None
+
 
 @dataclass
 class ScriptHook:
@@ -2780,6 +2879,16 @@ class ScriptHook:
             if isinstance(raw_last_error, str) and raw_last_error
             else ""
         )
+        # Normalize the timeout on load. hooks.json is hand-editable and older
+        # files predate the 1–300 bound, so a missing / non-int / out-of-range
+        # value is clamped to a safe in-range value here rather than persisted
+        # verbatim to later fire a 0-second (immediate) or unbounded timeout.
+        # Deserialization is fail-soft on purpose (a malformed hook must load,
+        # not abort the whole store); the raising `validate_hook_fields` is what
+        # rejects a bad value at the create/update boundary. `event` is left as
+        # written so an unknown event is visibly inert rather than silently
+        # remapped, matching how `matcher_mode` junk falls through to glob.
+        timeout = _normalize_hook_timeout(data.get("timeout", HOOK_TIMEOUT_DEFAULT))
         return cls(
             id=data.get("id", str(uuid.uuid4())[:8]),
             name=data.get("name", ""),
@@ -2788,7 +2897,7 @@ class ScriptHook:
             matcher_mode=data.get("matcher_mode", "glob"),
             command=data.get("command", ""),
             skills=[str(s) for s in skills if isinstance(s, str)],
-            timeout=data.get("timeout", 30),
+            timeout=timeout,
             enabled=data.get("enabled", True),
             last_run=data.get("last_run", 0.0),
             last_status=data.get("last_status", ""),
@@ -3070,6 +3179,10 @@ class ScriptHookStore:
         self._dir = config_dir or _cfg_dir()
         self._path = self._dir / _HOOKS_FILE
         self._hooks: dict[str, ScriptHook] = {}
+        # Entries that cannot be deserialized must remain inert, but they still
+        # belong to the user. Preserve their raw JSON values across later status
+        # and CRUD writes so fail-soft loading does not become silent data loss.
+        self._unparsed_hook_entries: list[object] = []
         # Mutations used to be implicitly serialised by running on the single
         # event-loop thread. They are now offloaded with asyncio.to_thread (the
         # persistence takes a file lock and fsyncs, which must not block the
@@ -3085,16 +3198,52 @@ class ScriptHookStore:
             return
         try:
             data = json.loads(self._path.read_text(encoding="utf-8"))
-            for h in data.get("hooks", []):
-                hook = ScriptHook.from_dict(h)
-                self._hooks[hook.id] = hook
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to load hooks: %s", exc)
+            return
+        # Deserialize each hook independently: a single malformed entry (a
+        # non-dict, or a dict `from_dict` cannot coerce) must not take down the
+        # whole store and drop every OTHER hook the user has. `from_dict` is
+        # already fail-soft (it normalizes junk fields), so a raise here would be
+        # unexpected — but a foreign / hand-corrupted entry is possible, so keep
+        # it inert and preserve its raw value for future rewrites.
+        #
+        # A malformed root or `hooks` collection cannot be represented by the
+        # list-shaped store. Keep it inert so gateway startup remains available;
+        # `_write_hooks_file` validates the locked, current bytes and refuses any
+        # mutation rather than overwriting data the store cannot preserve.
+        if not isinstance(data, dict):
+            logger.warning("Failed to load hooks: root is not an object")
+            return
+        hooks_data = data.get("hooks", [])
+        if not isinstance(hooks_data, list):
+            logger.warning("Failed to load hooks: hooks collection is not a list")
+            return
+
+        for h in hooks_data:
+            try:
+                if not isinstance(h, dict):
+                    raise TypeError("hook entry is not an object")
+                if h.get("event", HOOK_EVENT_USER_PROMPT_SUBMIT) not in HOOK_EVENTS:
+                    raise ValueError("hook entry has an invalid event")
+                hook = ScriptHook.from_dict(h)
+                # Keep insertion inside the per-entry guard: a hand-edited ID
+                # can be an unhashable list/dict even when from_dict succeeds.
+                self._hooks[hook.id] = hook
+            except Exception:
+                logger.warning("Skipping unparseable hook entry", exc_info=True)
+                self._unparsed_hook_entries.append(h)
+                continue
 
     def _save(self) -> None:
-        self._write_hooks_file([h.to_dict() for h in self._hooks.values()])
+        self._write_hooks_file(
+            [
+                *(h.to_dict() for h in self._hooks.values()),
+                *self._unparsed_hook_entries,
+            ]
+        )
 
-    def _write_hooks_file(self, hooks_data: list[dict]) -> None:
+    def _write_hooks_file(self, hooks_data: Sequence[object]) -> None:
         """Write the ``hooks`` list while PRESERVING every other top-level key.
 
         ``hooks.json`` is shared: this store owns the ``hooks`` key, but the
@@ -3125,8 +3274,18 @@ class ScriptHookStore:
             if self._path.exists():
                 try:
                     loaded = json.loads(self._path.read_text(encoding="utf-8"))
-                    if isinstance(loaded, dict):
-                        data = {k: v for k, v in loaded.items() if k != "hooks"}
+                    if not isinstance(loaded, dict):
+                        raise webhooks.WebhookStoreUnreadable(
+                            f"{self._path.name} root is not an object; refusing to overwrite it"
+                        )
+                    if "hooks" in loaded and not isinstance(loaded["hooks"], list):
+                        raise webhooks.WebhookStoreUnreadable(
+                            f"{self._path.name} hooks collection is not a list; "
+                            "refusing to overwrite it"
+                        )
+                    data = {k: v for k, v in loaded.items() if k != "hooks"}
+                except webhooks.WebhookStoreUnreadable:
+                    raise
                 except (json.JSONDecodeError, OSError) as exc:
                     logger.warning(
                         "hooks.json unreadable, refusing to overwrite it: %s", exc
@@ -3171,6 +3330,23 @@ class ScriptHookStore:
         hook = ScriptHook.from_dict(data)
         if not hook.id:
             hook.id = str(uuid.uuid4())[:8]
+        # Enforce the SAME invariants `update` does, via the shared validator:
+        # a direct/internal caller of `create` used to bypass the command+skills
+        # invariant, event membership, and timeout bounds (only `update` checked
+        # them), so it could persist a hook the update path would reject and that
+        # later silently fails to fire. `from_dict` clamps the timeout on the way
+        # in, but validate against the ORIGINAL `data` so a caller that passed an
+        # out-of-range timeout is told rather than having it silently clamped —
+        # matching the API schema's reject-don't-clamp behavior. Raises
+        # ValueError (mapped to HTTP 400 by the dashboard handler).
+        validate_hook_fields(
+            event=hook.event,
+            timeout=data.get("timeout", hook.timeout),
+            command=hook.command,
+            skills=hook.skills,
+            matcher=hook.matcher,
+            matcher_mode=hook.matcher_mode,
+        )
         with self._mutex, self._atomic_mutation():
             self._hooks[hook.id] = hook
             self._save()
@@ -3181,44 +3357,28 @@ class ScriptHookStore:
             hook = self._hooks.get(hook_id)
             if not hook:
                 return None
-            if "event" in data and data["event"] not in HOOK_EVENTS:
-                raise ValueError(f"invalid event: {data['event']}")
-            if "timeout" in data:
-                t = data["timeout"]
-                if not isinstance(t, int) or not (1 <= t <= 300):
-                    raise ValueError("timeout must be an integer between 1 and 300")
             for k in ("name", "event", "matcher", "matcher_mode", "command", "timeout", "enabled"):
                 if k in data:
                     setattr(hook, k, data[k])
             if "skills" in data:
                 skills_raw = data["skills"]
                 hook.skills = [str(s) for s in skills_raw if isinstance(s, str)] if isinstance(skills_raw, list) else []
-            # Post-merge validation on the merged hook: skills injection only
-            # fires for a standalone skills hook (no command) on
-            # UserPromptSubmit/AgentSpawn (see fire()). Reject any other pairing
-            # so a partial update can't leave a config that saves but never fires.
-            if hook.skills:
-                if hook.command:
-                    raise ValueError(
-                        "skills cannot be combined with a command — the skills "
-                        "would never fire; use a skills-only hook or drop the skills"
-                    )
-                if hook.event in (
-                    HOOK_EVENT_PRE_TOOL_USE, HOOK_EVENT_POST_TOOL_USE, HOOK_EVENT_STOP,
-                ):
-                    raise ValueError(
-                        f"skills hooks cannot fire on {hook.event} events — "
-                        "choose UserPromptSubmit or AgentSpawn"
-                    )
-            # Post-merge validation: reject invalid regex on the merged state
-            # (a partial update sending only matcher without matcher_mode would
-            # bypass the schema-level regex check which sees the request, not
-            # the merged hook).
-            if hook.matcher_mode == "regex" and hook.matcher:
-                try:
-                    re.compile(hook.matcher)
-                except re.error as exc:
-                    raise ValueError(f"invalid regex: {exc}") from None
+            # Validate the MERGED hook through the shared validator — the same
+            # one `create` uses — so both write paths enforce one contract:
+            # event membership, timeout bounds, the command+skills invariant and
+            # its event pairing, and regex syntax. Validating post-merge (not the
+            # request dict) is what catches a partial update that would otherwise
+            # bypass a schema check keyed on the request — e.g. a matcher sent
+            # without its matcher_mode, or skills added to a hook already on a
+            # tool event. Raises ValueError (mapped to HTTP 400 by the handler).
+            validate_hook_fields(
+                event=hook.event,
+                timeout=hook.timeout,
+                command=hook.command,
+                skills=hook.skills,
+                matcher=hook.matcher,
+                matcher_mode=hook.matcher_mode,
+            )
             self._save()
         return hook
 
@@ -3410,7 +3570,7 @@ class ScriptHookStore:
     def _save_snapshot(self, hooks_data: list[dict]) -> None:
         """Thread-safe save using pre-captured hook snapshot."""
         with self._mutex:
-            self._write_hooks_file(hooks_data)
+            self._write_hooks_file([*hooks_data, *self._unparsed_hook_entries])
 
 
 # -- Global script hook store accessor --

--- a/test/test_hook_matcher_modes.py
+++ b/test/test_hook_matcher_modes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -176,22 +177,37 @@ class TestSkillsOnlyFire:
         assert len(results) == 0
 
     @pytest.mark.asyncio
-    async def test_skills_with_command_runs_command(self, store: ScriptHookStore):
+    async def test_skills_with_command_runs_command(self, tmp_path: Path):
         """fire() takes the command path (never skills-only) when a command is set.
 
-        The API layer rejects command+skills (the skills would be inert), but the
-        store itself does not validate, so this pins the lower-level fire()
-        behavior for such a stored config: the command runs, skills are ignored.
+        Both write paths (create/update) now reject command+skills (issue
+        #5444) — the skills would be inert — so a mixed hook can only reach the
+        store via deserialization of a hand-edited / older ``hooks.json``. This
+        pins the defense-in-depth ``fire()`` behavior for such a persisted
+        config: the command runs, the skills are ignored, and it does NOT take
+        the skills-only shortcut.
         """
-        store.create(
-            {
-                "name": "mixed-hook",
-                "event": HOOK_EVENT_USER_PROMPT_SUBMIT,
-                "command": "echo extra-context",
-                "matcher": "",
-                "skills": ["skill-a"],
-            }
+        # Persist a mixed hook directly (bypassing create's validation) to model
+        # a hand-edited store file, then load it fail-soft via from_dict.
+        path = tmp_path / "hooks.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "hooks": [
+                        {
+                            "id": "mixed",
+                            "name": "mixed-hook",
+                            "event": HOOK_EVENT_USER_PROMPT_SUBMIT,
+                            "command": "echo extra-context",
+                            "matcher": "",
+                            "skills": ["skill-a"],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
         )
+        store = ScriptHookStore(tmp_path)
         results = await store.fire(HOOK_EVENT_USER_PROMPT_SUBMIT, "anything")
         # When command is set, the subprocess path runs (not skills-only).
         # In sandboxed CI the command may be governance-blocked (exit -1 or 2),

--- a/test/test_hook_validation_parity.py
+++ b/test/test_hook_validation_parity.py
@@ -1,0 +1,384 @@
+"""Parity + regression tests for centralized script-hook validation.
+
+Issue #5444: the skills-plus-command invariant, event membership, and timeout
+bounds were enforced only in ``ScriptHookStore.update``, so a direct caller of
+``ScriptHookStore.create`` could persist a hook the update path rejects and that
+later silently fails to fire. Deserialization (``ScriptHook.from_dict``) also
+accepted out-of-range timeouts and did not recognize inline regex flag-DISABLING
+forms such as ``(?-i)``.
+
+These tests prove all three entry paths (create, update, deserialization) now
+share one contract, that malformed persisted hooks load fail-soft rather than
+taking down the store, and that the inline-flag detector handles disabling and
+scoped forms.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from kiro_crew.hooks import (
+    HOOK_EVENT_AGENT_SPAWN,
+    HOOK_EVENT_PRE_TOOL_USE,
+    HOOK_EVENT_STOP,
+    HOOK_EVENT_USER_PROMPT_SUBMIT,
+    HOOK_TIMEOUT_DEFAULT,
+    HOOK_TIMEOUT_MAX,
+    HOOK_TIMEOUT_MIN,
+    ScriptHook,
+    ScriptHookStore,
+    _context_matches,
+    _has_global_inline_flags,
+    validate_hook_fields,
+)
+from kiro_crew.webhooks import WebhookStoreUnreadable
+
+
+def _valid(**overrides) -> dict:
+    """A minimal valid create payload, with field overrides applied."""
+    base = {"name": "h", "event": HOOK_EVENT_USER_PROMPT_SUBMIT, "command": "true"}
+    base.update(overrides)
+    return base
+
+
+# ── create/update parity: same definition accepted or rejected identically ──
+
+
+class TestCreateUpdateParity:
+    """A definition create rejects, update must reject too — and vice versa."""
+
+    # command+skills invariant
+
+    def test_create_rejects_command_plus_skills(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="skills cannot be combined with a command"):
+            store.create(_valid(command="true", skills=["deploy"]))
+
+    def test_update_rejects_command_plus_skills(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid())
+        with pytest.raises(ValueError, match="skills cannot be combined with a command"):
+            store.update(hook.id, {"skills": ["deploy"]})
+
+    def test_create_rejects_empty_hook(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="either command or skills"):
+            store.create({"name": "h", "event": HOOK_EVENT_USER_PROMPT_SUBMIT})
+
+    def test_update_rejects_clearing_both_command_and_skills(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid())
+        with pytest.raises(ValueError, match="either command or skills"):
+            store.update(hook.id, {"command": ""})
+
+    # skills-event pairing
+
+    def test_create_rejects_skills_on_tool_event(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="skills hooks cannot fire on"):
+            store.create({"name": "h", "event": HOOK_EVENT_PRE_TOOL_USE, "skills": ["x"]})
+
+    def test_update_rejects_skills_on_tool_event(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h", "event": HOOK_EVENT_PRE_TOOL_USE, "command": "true"})
+        with pytest.raises(ValueError, match="skills hooks cannot fire on"):
+            store.update(hook.id, {"command": "", "skills": ["x"]})
+
+    def test_create_accepts_skills_only_on_agent_spawn(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create({"name": "h", "event": HOOK_EVENT_AGENT_SPAWN, "skills": ["deploy"]})
+        assert hook.skills == ["deploy"]
+        assert hook.command == ""
+
+    # event membership
+
+    def test_create_rejects_invalid_event(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="invalid event"):
+            store.create(_valid(event="NotAnEvent"))
+
+    def test_update_rejects_invalid_event(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid())
+        with pytest.raises(ValueError, match="invalid event"):
+            store.update(hook.id, {"event": "NotAnEvent"})
+
+    # timeout bounds
+
+    @pytest.mark.parametrize("bad", [0, -5, HOOK_TIMEOUT_MAX + 1, "30", 1.5, True])
+    def test_create_rejects_out_of_range_timeout(self, tmp_path, bad):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="timeout must be an integer"):
+            store.create(_valid(timeout=bad))
+
+    @pytest.mark.parametrize("bad", [0, -5, HOOK_TIMEOUT_MAX + 1, "30", 1.5, True])
+    def test_update_rejects_out_of_range_timeout(self, tmp_path, bad):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid())
+        with pytest.raises(ValueError, match="timeout must be an integer"):
+            store.update(hook.id, {"timeout": bad})
+
+    @pytest.mark.parametrize("good", [HOOK_TIMEOUT_MIN, HOOK_TIMEOUT_MAX, 30])
+    def test_create_accepts_in_range_timeout(self, tmp_path, good):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid(timeout=good))
+        assert hook.timeout == good
+
+    # regex matcher syntax
+
+    def test_create_rejects_invalid_regex(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        with pytest.raises(ValueError, match="invalid regex"):
+            store.create(_valid(matcher="[invalid", matcher_mode="regex"))
+
+    def test_update_rejects_invalid_regex(self, tmp_path):
+        store = ScriptHookStore(tmp_path)
+        hook = store.create(_valid())
+        with pytest.raises(ValueError, match="invalid regex"):
+            store.update(hook.id, {"matcher": "[invalid", "matcher_mode": "regex"})
+
+
+# ── validate_hook_fields: the single shared contract ──
+
+
+class TestValidateHookFields:
+    def test_valid_command_hook_passes(self):
+        validate_hook_fields(
+            event=HOOK_EVENT_USER_PROMPT_SUBMIT,
+            timeout=30,
+            command="true",
+            skills=[],
+            matcher="",
+            matcher_mode="glob",
+        )
+
+    def test_valid_skills_hook_passes(self):
+        validate_hook_fields(
+            event=HOOK_EVENT_AGENT_SPAWN,
+            timeout=30,
+            command="",
+            skills=["deploy"],
+            matcher="",
+            matcher_mode="glob",
+        )
+
+    def test_boundary_timeouts_pass(self):
+        for t in (HOOK_TIMEOUT_MIN, HOOK_TIMEOUT_MAX):
+            validate_hook_fields(
+                event=HOOK_EVENT_STOP,
+                timeout=t,
+                command="true",
+                skills=[],
+                matcher="",
+                matcher_mode="glob",
+            )
+
+
+# ── deserialization: fail-soft, never abort the store ──
+
+
+class TestFromDictNormalization:
+    @pytest.mark.parametrize(
+        "bad_timeout,expected",
+        [
+            (0, HOOK_TIMEOUT_MIN),  # clamp up
+            (-5, HOOK_TIMEOUT_MIN),
+            (99999, HOOK_TIMEOUT_MAX),  # clamp down
+            ("nope", HOOK_TIMEOUT_DEFAULT),  # junk -> default
+            (None, HOOK_TIMEOUT_DEFAULT),
+            (True, HOOK_TIMEOUT_DEFAULT),  # bool is not a real timeout
+        ],
+    )
+    def test_from_dict_clamps_timeout(self, bad_timeout, expected):
+        hook = ScriptHook.from_dict({"name": "h", "command": "true", "timeout": bad_timeout})
+        assert hook.timeout == expected
+
+    def test_from_dict_never_raises_on_command_plus_skills(self):
+        # Deserialization is fail-soft: a malformed persisted hook must LOAD
+        # (visibly inert), not raise and abort the whole store. The write
+        # boundary is where the invariant is enforced.
+        hook = ScriptHook.from_dict(
+            {"name": "h", "command": "true", "skills": ["x"], "event": HOOK_EVENT_STOP}
+        )
+        assert hook.command == "true"
+        assert hook.skills == ["x"]
+
+
+class TestStoreLoadResilience:
+    def test_one_malformed_hook_does_not_drop_the_others(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "hooks": [
+                        {"id": "good1", "name": "g1", "command": "true"},
+                        "this is not a dict",  # malformed entry
+                        {"id": "good2", "name": "g2", "command": "true"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        store = ScriptHookStore(tmp_path)
+        ids = {h.id for h in store.list_all()}
+        assert ids == {"good1", "good2"}
+
+    @pytest.mark.parametrize("payload", [{"hooks": None}, ["not", "an", "object"]])
+    def test_malformed_hooks_container_is_inert_until_mutation(self, tmp_path, payload):
+        path = tmp_path / "hooks.json"
+        original = json.dumps(payload)
+        path.write_text(original, encoding="utf-8")
+
+        store = ScriptHookStore(tmp_path)
+
+        assert store.list_all() == []
+        with pytest.raises(WebhookStoreUnreadable, match="refusing to overwrite"):
+            store.create({"name": "new", "command": "true"})
+        assert store.list_all() == []
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_invalid_event_entry_is_inert_and_survives_mutation(self, tmp_path):
+        invalid = {
+            "id": "future-event",
+            "name": "future event",
+            "event": "FutureEvent",
+            "command": "true",
+        }
+        path = tmp_path / "hooks.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "hooks": [
+                        invalid,
+                        {"id": "good", "name": "good", "command": "true"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        store = ScriptHookStore(tmp_path)
+
+        assert store.get("future-event") is None
+        assert store.update("good", {"name": "updated"}) is not None
+        saved = json.loads(path.read_text(encoding="utf-8"))["hooks"]
+        assert invalid in saved
+        assert any(
+            hook.get("id") == "good" and hook.get("name") == "updated"
+            for hook in saved
+            if isinstance(hook, dict)
+        )
+
+    def test_unhashable_id_is_skipped_without_dropping_siblings(self, tmp_path):
+        (tmp_path / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "hooks": [
+                        {"id": [], "name": "bad", "command": "true"},
+                        {"id": "good", "name": "good", "command": "true"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        store = ScriptHookStore(tmp_path)
+
+        assert [hook.id for hook in store.list_all()] == ["good"]
+
+    def test_unparseable_entry_survives_fire_persistence(self, tmp_path):
+        malformed = {"id": [], "name": "backup", "command": "true"}
+        path = tmp_path / "hooks.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "hooks": [
+                        malformed,
+                        {
+                            "id": "good",
+                            "name": "good",
+                            "event": HOOK_EVENT_STOP,
+                            "command": "true",
+                            "enabled": False,
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        store = ScriptHookStore(tmp_path)
+
+        asyncio.run(store.fire(HOOK_EVENT_STOP))
+
+        saved = json.loads(path.read_text(encoding="utf-8"))["hooks"]
+        assert malformed in saved
+        assert any(hook.get("id") == "good" for hook in saved if isinstance(hook, dict))
+
+    def test_out_of_range_persisted_timeout_loads_clamped(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        path.write_text(
+            json.dumps({"hooks": [{"id": "h", "name": "h", "command": "true", "timeout": 0}]}),
+            encoding="utf-8",
+        )
+        store = ScriptHookStore(tmp_path)
+        loaded = store.get("h")
+        assert loaded is not None
+        assert loaded.timeout == HOOK_TIMEOUT_MIN
+
+
+# ── inline regex flag handling (issue: (?-i) and scoped flags) ──
+
+
+class TestInlineFlagGroupDetection:
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "(?i)foo",
+            "(?im)foo",
+            "(?aiLmsux)foo",
+        ],
+    )
+    def test_recognizes_global_flag_groups(self, pattern):
+        assert _has_global_inline_flags(pattern) is True
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "foo",
+            "(?i:foo)",  # scoped flags do not replace the outer default
+            "(?i-s:foo)",
+            "(?-i:foo)",
+            "(?:foo)",
+            "(?=foo)",
+            "(?<=foo)bar",
+            "(?P<name>foo)",
+            "(?)foo",
+        ],
+    )
+    def test_rejects_scoped_and_non_flag_groups(self, pattern):
+        assert _has_global_inline_flags(pattern) is False
+
+
+class TestRegexMatcherFlagHandling:
+    def test_scoped_disabling_flag_is_honored_without_changing_suffix_default(self):
+        # The matcher default remains case-insensitive outside the scoped group,
+        # while (?-i:foo) makes only `foo` case-sensitive.
+        assert _context_matches(r"(?-i:foo)bar", "regex", "fooBAR") is True
+        assert _context_matches(r"(?-i:foo)bar", "regex", "FOObar") is False
+
+        # A scoped set/unset group still controls DOTALL inside its own body.
+        assert _context_matches(r"(?i-s:foo.bar)", "regex", "FOOxBAR") is True
+        assert _context_matches(r"(?i-s:foo.bar)", "regex", "FOO\nBAR") is False
+
+    def test_default_is_case_insensitive(self):
+        # No inline flag group -> (?i) prepended -> case-insensitive default.
+        assert _context_matches(r"foo", "regex", "FOO here")
+
+    def test_leading_set_flag_group_still_matches(self):
+        assert _context_matches(r"(?i)foo", "regex", "FOO")
+
+    def test_scoped_set_flag_group_still_matches(self):
+        assert _context_matches(r"(?i:foo)", "regex", "FOO")

--- a/test/test_hooks_coverage.py
+++ b/test/test_hooks_coverage.py
@@ -1059,13 +1059,15 @@ class TestScriptHookStorePersistence:
         assert store.update(hook.id, {"timeout": 1}).timeout == 1
         assert store.update(hook.id, {"timeout": 300}).timeout == 300
 
-    def test_a_bool_timeout_is_accepted_as_its_int_value(self, tmp_path):
-        # Documents current behaviour, not an endorsement: bool is a subclass of
-        # int, so ``True`` satisfies the isinstance+range check and lands as a
-        # 1-second timeout. Recorded so a future tightening is a deliberate change.
+    def test_a_bool_timeout_is_rejected(self, tmp_path):
+        # The deliberate tightening the old test anticipated (issue #5444):
+        # ``bool`` is an ``int`` subclass, but ``True`` as a timeout is
+        # meaningless, so the shared validator now rejects it at the update
+        # boundary rather than silently landing a 1-second timeout.
         store = ScriptHookStore(tmp_path)
         hook = store.create({"name": "h1", "command": "true"})
-        assert store.update(hook.id, {"timeout": True}).timeout is True
+        with pytest.raises(ValueError, match="timeout must be an integer"):
+            store.update(hook.id, {"timeout": True})
 
     def test_update_applies_only_known_fields(self, tmp_path):
         store = ScriptHookStore(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

Script-hook validation was applied inconsistently across API and persistence paths. Malformed stored shapes could either reach runtime matching or be overwritten by a later mutation, while failed writes could leave in-memory state ahead of disk.

## Why it matters

Hook configuration is shared persistent state. Invalid entries must remain inert without preventing gateway startup, and mutations must never silently replace malformed bytes or expose state that was not durably committed.

## What changed (motivation → approach → change)

Validation is centralized and enforced at every persistence boundary. Individual malformed entries remain preserved but inert, and malformed root or hook-collection shapes are loaded fail-soft so startup continues. Before a mutation writes, the locked boundary re-reads and validates the current bytes; malformed collection state fails closed instead of being overwritten. Failed persistence rolls in-memory state back to the last durable snapshot.

## Tests

- Added parity coverage across API validation, shared-file loading, matching, and persistence mutation paths.
- Added malformed-root and malformed-collection startup cases that remain available for diagnosis but cannot execute or be overwritten.
- Added rollback and concurrent-file-change coverage for failed mutations.
- `python -m pytest -q test/test_hook_matcher_modes.py test/test_hook_validation_parity.py test/test_hooks_coverage.py` — 310 passed.
- Baselined Black, whole-tree isort, whole-tree Flake8, and full Mypy passed.

## Manual verification

N/A — automated tests exercise malformed persisted bytes, runtime matching, locked mutation, and rollback behavior end to end.

## Related Issues

Fixes #5444

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
