### PR TITLE
fix(cloud): sanitize bootstrap failure reason to printable ASCII (#5597)

### DIFF
--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -295,7 +295,18 @@ Resources:
       #   surface it. Quotes/backslashes are stripped because the fallback
       #   curl embeds the reason in hand-built JSON; an unescaped quote would
       #   malform the body and the WaitCondition would hang to timeout instead
-      #   of failing cleanly. The ${!tail_ctx} inside fail() is
+      #   of failing cleanly. Both the log tail and the caller's message are
+      #   then filtered to printable ASCII (space..tilde): CloudFormation
+      #   rejects a Reason carrying control or non-ASCII bytes ("Resource
+      #   status reason contains invalid characters"), which would replace
+      #   the real error with a charset complaint -- and dnf/git/npm/vite
+      #   routinely emit ANSI escapes and UTF-8 glyphs. Newlines fold to '|'
+      #   BEFORE the filter (newline is itself a control byte); the filter
+      #   drops ESC so an ANSI sequence degrades to printable residue, and an
+      #   all-ASCII payload means the byte-level 1000-byte cap can no longer
+      #   split a multi-byte UTF-8 sequence at the reason= point (an upstream
+      #   byte cap like fe_err's tail -c 500 may still split one, but the "$1"
+      #   filter drops the orphan continuation bytes). The ${!tail_ctx} inside fail() is
       #   CloudFormation's !Sub literal escape, NOT bash indirect expansion:
       #   !Sub renders it as the plain dollar-brace form, an ordinary bash
       #   expansion at runtime; without the "!" escape, !Sub would try to
@@ -416,9 +427,9 @@ Resources:
             echo "BOOTSTRAP FAILED: $1"
             tail_ctx=$(tail -n 25 "$LOG" 2>/dev/null | tr -d '\r"\\' \
               | grep -aviE 'Installing (npm|kirocrew and) depend|building React app' \
-              | tr '\n' '|' | tail -c 900)
+              | tr '\n' '|' | tr -cd '\40-\176' | tail -c 900)
             # NB: ${!tail_ctx} is the !Sub literal escape, not bash indirection.
-            reason="$(echo "$1" | tr -d '"\\') :: ...${!tail_ctx}"
+            reason="$(printf '%s' "$1" | tr -d '"\\' | tr '\n' '|' | tr -cd '\40-\176') :: ...${!tail_ctx}"
             /opt/aws/bin/cfn-signal -e 1 -r "$(echo "$reason" | head -c 1000)" "$HANDLE" || \
               curl -s -X PUT -H 'Content-Type:' --data-binary \
                 "{\"Status\":\"FAILURE\",\"Reason\":\"$(echo "$reason" | head -c 1000)\",\"UniqueId\":\"kirocrew\",\"Data\":\"fail\"}" "$HANDLE" || true

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -289,6 +289,82 @@ class TestTemplate:
         text = ec2.load_template()
         assert "${!tail_ctx}" in text
 
+    def test_failure_reason_is_filtered_to_printable_ascii(self):
+        # CloudFormation rejects a WaitCondition Reason carrying control or
+        # non-ASCII bytes ("Resource status reason contains invalid
+        # characters"), replacing the real bootstrap error with a charset
+        # complaint -- and the rollback then destroys the setup log, the only
+        # copy of that error. dnf/git/npm/vite routinely emit ANSI escapes and
+        # UTF-8 glyphs, so fail() must filter BOTH inputs of the reason (the
+        # folded log tail and the caller's "$1" message) to printable ASCII.
+        # Both delivery paths (cfn-signal -r and the curl PUT fallback) read
+        # the same variable, so the single-point filter covers both.
+        text = ec2.load_template()
+        # log tail + "$1" message; >= so a future third use doesn't fail this
+        assert text.count("tr -cd '\\40-\\176'") >= 2
+        # Order matters: newlines fold to '|' BEFORE the printable filter
+        # (newline is itself a control byte the filter would silently eat),
+        # and the byte cap stays AFTER it (an all-ASCII payload cannot have a
+        # multi-byte sequence for the cap to split).
+        assert "| tr '\\n' '|' | tr -cd '\\40-\\176' | tail -c 900" in text
+        assert "| tr -d '\"\\\\' | tr '\\n' '|' | tr -cd '\\40-\\176'" in text
+
+    def test_failure_reason_pipeline_replica_yields_clean_reason(self):
+        # Pure-python replica of fail()'s reason pipeline (no harness executes
+        # the template's bash). Each stage mirrors one command, in order:
+        # tail -n 25 -> tr -d '\r"\' -> grep -aviE <noise> -> tr '\n' '|'
+        # -> tr -cd '\40-\176' -> tail -c 900, then the "$1" half and the
+        # head -c 1000 cap. Feeds a log tail carrying an ANSI escape sequence,
+        # multi-byte UTF-8 glyphs, a raw control byte, and noise lines hitting
+        # both grep alternation branches in mixed case, and asserts the
+        # produced reason is entirely printable ASCII (0x20-0x7e) and at most
+        # 1000 bytes. A negative control (same pipeline WITHOUT the printable
+        # filter) proves the assertions can fail, so the test constrains the
+        # filter rather than its own construction.
+        log_lines = [b"padding line %d" % i for i in range(25)] + [
+            b'step one ok',
+            b'Installing npm dependencies for the dashboard',
+            b'INSTALLING KIROCREW AND DEPENDENCIES',
+            b'Building React App (vite)',
+            b'\x1b[31mnpm error\x1b[0m: build "failed"',
+            b'caf\xc3\xa9 \xe4\xb8\xad\xe6\x96\x87 glyphs',
+            b'bell\x07done back\\slash\r',
+        ]
+
+        def printable(data: bytes) -> bytes:
+            return bytes(b for b in data if 0x20 <= b <= 0x7E)
+
+        noise = re.compile(rb"Installing (npm|kirocrew and) depend|building React app", re.I)
+
+        def pipeline(lines: list[bytes], message: bytes, ascii_filter: bool) -> bytes:
+            step = printable if ascii_filter else (lambda data: data)
+            # tail_ctx=$(tail -n 25 "$LOG" | tr -d '\r"\' | grep -aviE <noise>
+            #            | tr '\n' '|' | tr -cd '\40-\176' | tail -c 900)
+            tail25 = b"\n".join(lines[-25:])
+            stripped = tail25.translate(None, delete=b'\r"\\')
+            kept = [ln for ln in stripped.split(b"\n") if not noise.search(ln)]
+            tail_ctx = step(b"|".join(kept))[-900:]
+            # reason="$(printf '%s' "$1" | tr -d '"\' | tr '\n' '|'
+            #           | tr -cd '\40-\176') :: ...<tail_ctx>"
+            msg = step(message.translate(None, delete=b'"\\').replace(b"\n", b"|"))
+            return (msg + b" :: ..." + tail_ctx)[:1000]  # head -c 1000
+
+        message = 'dashboard "build" missing: caf\u00e9 \x1b[1mnpm\x1b[0m err'.encode()
+
+        # Negative control: without the tr -cd stage the reason is dirty.
+        dirty = pipeline(log_lines, message, ascii_filter=False)
+        assert dirty != printable(dirty), "fixture lost its non-printable bytes"
+
+        reason = pipeline(log_lines, message, ascii_filter=True)
+        assert reason == printable(reason), f"non-printable byte survived: {reason!r}"
+        assert len(reason) <= 1000
+        # The real error text survives; the ANSI escape degrades to printable
+        # residue ("[31m") instead of poisoning the signal, and the noise
+        # filter dropped both alternation branches case-insensitively.
+        assert b"npm error" in reason and b"build failed" in reason
+        assert b"\x1b" not in reason
+        assert b"KIROCREW AND" not in reason and b"React App" not in reason
+
     def test_no_non_ascii_in_property_values(self):
         """EC2 rejects non-ASCII in values like GroupDescription — guard against it.
 


### PR DESCRIPTION
## Summary

When a cloud-launch bootstrap fails on the EC2 instance, `fail()` in the CloudFormation UserData folds the last 25 lines of `/var/log/kirocrew-setup.log` into the WaitCondition FAILURE Reason. Its sanitisation stripped only CR, double quotes and backslashes — a JSON-safety filter, not a charset filter. ANSI colour/erase escapes, other control bytes, and non-ASCII bytes from ordinary dnf/git/npm/vite output survived into Reason, and CloudFormation rejected the signal with `Resource status reason contains invalid characters`. The rollback then terminated the instance, destroying the setup log — the only copy of the real error. The user saw the charset complaint instead of the bootstrap failure.

## Change

Single-point fix at the `reason=` assignment in `fail()` (`src/kiro_crew/cloud/templates/kirocrew-ec2.yaml`), which both delivery paths (`cfn-signal -r` and the curl PUT fallback) read:

- Both reason inputs — the folded log tail and the caller's `$1` message — are filtered to printable ASCII (`tr -cd '\40-\176'`, space..tilde). ESC is dropped, so an ANSI sequence degrades to printable residue instead of poisoning the signal.
- Order preserved deliberately: newlines fold to `|` BEFORE the filter (newline is itself a control byte), and the existing quote/backslash strip stays for JSON safety on the curl fallback.
- `$1` now goes through `printf '%s'` instead of `echo` (removes option/backslash ambiguity) and gets its newlines folded, which also fixes a latent invalid-JSON case in the curl fallback body.
- The `head -c 1000` byte cap stays; with the payload single-byte ASCII by construction it can no longer split a multi-byte UTF-8 sequence.
- No new unescaped `${...}` introduced — the `${!tail_ctx}` !Sub literal escape is untouched.

Consumer side (`ec2.py` detail building, `wizard.py` hint) is deliberately untouched: it correctly surfaces whatever Reason arrives; the defect was entirely in the producer.

## Tests

`test/test_cloud_ec2.py` (no harness executes the template's bash, so two complementary guards):

- `test_failure_reason_is_filtered_to_printable_ascii` — template-content assertions pinning the sanitizing `tr -cd` stage on both inputs and the fold-before-filter, cap-after-filter pipeline order. Mutation-verified: fails on the unfixed template.
- `test_failure_reason_pipeline_replica_yields_clean_reason` — pure-python replica of the pipeline (faithful `tail -n 25` / `tr -d` / case-insensitive `grep -aviE` with both alternation branches / fold / filter / caps), fed ANSI escapes, multi-byte UTF-8, raw control bytes, and mixed-case noise lines. Includes a negative control (same pipeline without the printable stage produces a dirty reason), so the assertions are proven falsifiable.

Local gates: isort / flake8 / mypy clean, `test_cloud_ec2.py` 93/93.

Pre-push review: GPT lane (gpt-5.6-sol) PASS — 1 Low; Opus lane (claude-opus-5) PASS — 0 blocking, 2 Medium test-quality + 2 Low. All four findings adopted (faithful grep mirror + negative control, occurrence-count assertion relaxed to `>=`, NB comment clause on the upstream `fe_err` byte cap).

Out of scope: preserving the full bootstrap log via S3/console-output capture (feature); issue #5573 (AL2023 reboot mid-bootstrap) is separate.

Closes #5597
