### PR TITLE
fix(scripts): release the browser and server when a capture fails

### DIFF
--- a/website/scripts/capture-folder-suggestion-expiry.mjs
+++ b/website/scripts/capture-folder-suggestion-expiry.mjs
@@ -105,84 +105,102 @@ async function main() {
     return false
   }
 
-  const page = await context.newPage()
-  logPageProblems(page)
-  await stubDashboardApi(page, { folders, slots, theme: 'dark', extra })
-  await page.routeWebSocket(/\/api\/ws/, ws => { wsServer = ws })
-  await page.addInitScript(slot => localStorage.setItem('mc-active-slot', slot), SLOT)
-  await page.goto(base + '/', { waitUntil: 'domcontentloaded' })
-  await page.waitForTimeout(2500)
-
-  // Push the card exactly as the backend broadcasts it.
-  wsServer.send(JSON.stringify({
-    type: 'slot_folder_suggestion',
-    data: { slot: SLOT, folder_id: 'f-i18n', folder_name: 'i18n', breadcrumb: 'Kiro Crew › i18n', ts: Date.now() / 1000 },
-  }))
-  await page.waitForTimeout(900)
-
-  const cardCount = () => page.getByTestId('folder-suggestion-card').count()
-  const shot = async name => {
-    await page.screenshot({ path: `${OUT}/${name}.png` })
-    console.log('wrote', `${OUT}/${name}.png`)
+  /** Best-effort teardown for EVERY exit path. An assertion failure that
+   *  leaves the browser or the static server alive keeps this event loop
+   *  spinning forever, so a failing run would hang instead of exiting
+   *  non-zero — the worst failure mode for a regression proof. Idempotent:
+   *  the success path tears down explicitly too, because the recording file
+   *  is only flushed when the context closes and the exactly-one-recording
+   *  check must run after that. */
+  async function cleanup() {
+    try { await context.close() } catch { /* already closed */ }
+    try { await browser.close() } catch { /* already closed */ }
+    try { srv.close() } catch { /* already closed */ }
   }
 
-  const survived = []
-  if (await cardCount() !== 1) {
-    // Throw, never process.exit(): exit() would skip the .finally() that
-    // removes the run-private capture dir. Same rule for every FAIL below.
-    throw new Error('FAIL: card never appeared')
+  let page
+  try {
+    page = await context.newPage()
+    logPageProblems(page)
+    await stubDashboardApi(page, { folders, slots, theme: 'dark', extra })
+    await page.routeWebSocket(/\/api\/ws/, ws => { wsServer = ws })
+    await page.addInitScript(slot => localStorage.setItem('mc-active-slot', slot), SLOT)
+    await page.goto(base + '/', { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(2500)
+
+    // Push the card exactly as the backend broadcasts it.
+    wsServer.send(JSON.stringify({
+      type: 'slot_folder_suggestion',
+      data: { slot: SLOT, folder_id: 'f-i18n', folder_name: 'i18n', breadcrumb: 'Kiro Crew › i18n', ts: Date.now() / 1000 },
+    }))
+    await page.waitForTimeout(900)
+
+    const cardCount = () => page.getByTestId('folder-suggestion-card').count()
+    const shot = async name => {
+      await page.screenshot({ path: `${OUT}/${name}.png` })
+      console.log('wrote', `${OUT}/${name}.png`)
+    }
+
+    const survived = []
+    if (await cardCount() !== 1) {
+      // Throw, never process.exit(): exit() would skip the cleanup that
+      // releases the browser and server. Same rule for every FAIL below.
+      throw new Error('FAIL: card never appeared')
+    }
+    await shot('01-card-offered')
+
+    /** One real composer send, then end the turn the way the backend does. */
+    async function send(n) {
+      const box = page.locator('textarea').first()
+      await box.fill(`user turn ${n} — ignoring the folder offer`)
+      await box.press('Enter')
+      await page.waitForTimeout(600)
+      // End the turn: assistant reply + chat_done, the frames a real turn ends with.
+      wsServer.send(JSON.stringify({ type: 'chat_message', data: { slot: SLOT, role: 'assistant', content: `reply ${n}`, ts: new Date().toISOString() } }))
+      wsServer.send(JSON.stringify({ type: 'chat_done', data: { slot: SLOT } }))
+      await page.waitForTimeout(700)
+    }
+
+    for (let n = 1; n <= MAX_TURNS; n++) {
+      await send(n)
+      const alive = (await cardCount()) === 1
+      survived.push(alive)
+      await shot(`0${n + 1}-after-send-${n}${alive ? '-still-offered' : '-GONE-EARLY'}`)
+    }
+
+    await send(MAX_TURNS + 1)
+    const goneAfterExpiry = (await cardCount()) === 0
+    await shot(`0${MAX_TURNS + 2}-after-send-${MAX_TURNS + 1}-expired`)
+
+    console.log('--- assertions ---')
+    console.log(`card survived sends 1..${MAX_TURNS}:`, survived)
+    console.log(`card gone after send ${MAX_TURNS + 1}:`, goneAfterExpiry)
+    console.log('real sends reached the API:', sends.length)
+
+    // The recording is finalised when the context closes, so teardown comes
+    // BEFORE the exactly-one check and its move.
+    await cleanup()
+
+    const ok = survived.every(Boolean) && goneAfterExpiry && sends.length === MAX_TURNS + 1
+    if (!ok) {
+      throw new Error('FAIL: expiry did not behave as documented')
+    }
+
+    // Exactly one webm can exist in the run-private VIDEO_DIR — this run's
+    // recording. Anything else is a recording failure, never a stale leftover.
+    // The move is the TRUE last step, after every assertion above passed, so the
+    // canonical name only ever holds a recording of a successful run (its prior
+    // content was invalidated up top, before anything fallible).
+    const vids = readdirSync(VIDEO_DIR).filter(f => f.endsWith('.webm'))
+    if (vids.length !== 1) {
+      throw new Error(`FAIL: expected exactly 1 fresh recording, found ${vids.length}`)
+    }
+    renameSync(`${VIDEO_DIR}/${vids[0]}`, `${OUT}/expiry-sequence.webm`)
+    console.log('OK')
+  } catch (err) {
+    await cleanup()
+    throw err
   }
-  await shot('01-card-offered')
-
-  /** One real composer send, then end the turn the way the backend does. */
-  async function send(n) {
-    const box = page.locator('textarea').first()
-    await box.fill(`user turn ${n} — ignoring the folder offer`)
-    await box.press('Enter')
-    await page.waitForTimeout(600)
-    // End the turn: assistant reply + chat_done, the frames a real turn ends with.
-    wsServer.send(JSON.stringify({ type: 'chat_message', data: { slot: SLOT, role: 'assistant', content: `reply ${n}`, ts: new Date().toISOString() } }))
-    wsServer.send(JSON.stringify({ type: 'chat_done', data: { slot: SLOT } }))
-    await page.waitForTimeout(700)
-  }
-
-  for (let n = 1; n <= MAX_TURNS; n++) {
-    await send(n)
-    const alive = (await cardCount()) === 1
-    survived.push(alive)
-    await shot(`0${n + 1}-after-send-${n}${alive ? '-still-offered' : '-GONE-EARLY'}`)
-  }
-
-  await send(MAX_TURNS + 1)
-  const goneAfterExpiry = (await cardCount()) === 0
-  await shot(`0${MAX_TURNS + 2}-after-send-${MAX_TURNS + 1}-expired`)
-
-  console.log('--- assertions ---')
-  console.log(`card survived sends 1..${MAX_TURNS}:`, survived)
-  console.log(`card gone after send ${MAX_TURNS + 1}:`, goneAfterExpiry)
-  console.log('real sends reached the API:', sends.length)
-
-  await page.close()
-  await context.close()
-  await browser.close()
-  srv.close()
-
-  const ok = survived.every(Boolean) && goneAfterExpiry && sends.length === MAX_TURNS + 1
-  if (!ok) {
-    throw new Error('FAIL: expiry did not behave as documented')
-  }
-
-  // Exactly one webm can exist in the run-private VIDEO_DIR — this run's
-  // recording. Anything else is a recording failure, never a stale leftover.
-  // The move is the TRUE last step, after every assertion above passed, so the
-  // canonical name only ever holds a recording of a successful run (its prior
-  // content was invalidated up top, before anything fallible).
-  const vids = readdirSync(VIDEO_DIR).filter(f => f.endsWith('.webm'))
-  if (vids.length !== 1) {
-    throw new Error(`FAIL: expected exactly 1 fresh recording, found ${vids.length}`)
-  }
-  renameSync(`${VIDEO_DIR}/${vids[0]}`, `${OUT}/expiry-sequence.webm`)
-  console.log('OK')
 }
 
 // The run-private capture dir dies with the run, success or failure — only the

--- a/website/scripts/capture-folder-suggestion.mjs
+++ b/website/scripts/capture-folder-suggestion.mjs
@@ -98,6 +98,18 @@ async function main() {
   let page = null
   let wsServer = null
 
+  /** Best-effort teardown for EVERY exit path: an assertion failure that left
+   *  the browser or the static server alive kept this event loop spinning, so
+   *  a failing run hung instead of exiting non-zero. Idempotent — the success
+   *  path tears down explicitly too, right before its final assertions. */
+  async function cleanup() {
+    try { await context.close() } catch { /* already closed */ }
+    try { await browser.close() } catch { /* already closed */ }
+    try { srv.close() } catch { /* already closed */ }
+  }
+
+  try {
+
   /**
    * A FRESH page per theme. stubDashboardApi installs one `**\/api\/**` handler
    * and bakes the theme into /api/theme/boot, so calling it twice on one page
@@ -200,8 +212,7 @@ async function main() {
   console.log('decline cleared the card:', goneAfterDecline)
   console.log('decline made no extra API call:', moves.length === movesBefore)
 
-  await browser.close()
-  srv.close()
+  await cleanup()
 
   const ok = goneAfterAccept
     && goneAfterDecline
@@ -209,10 +220,15 @@ async function main() {
     && moves[0].body?.folder_id === 'f-i18n'
     && moves[0].path.endsWith(`/${SLOT}/folder`)
   if (!ok) {
-    console.error('FAIL: the card did not behave as documented')
-    process.exit(1)
+    // Throw, never process.exit(): exit() would skip the catch below, whose
+    // cleanup releases the browser and server this run still holds.
+    throw new Error('FAIL: the card did not behave as documented')
   }
   console.log('OK')
+  } catch (err) {
+    await cleanup()
+    throw err
+  }
 }
 
 main().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
## Problem / Motivation

The two folder-suggestion capture harnesses closed their browser, context, and static server only on the happy path. An assertion failure earlier in a run - exactly the "card never appeared" case they exist to catch - threw past those closes: the still-open Chromium and HTTP server kept node's event loop alive, so a failing run **hung forever instead of exiting non-zero**. `capture-folder-suggestion.mjs` compounded it by calling `process.exit(1)` on its failure branch, which skips deferred work entirely (fixes #5514).

A regression proof's worst failure mode is reporting nothing while blocking whatever invoked it. This makes both harnesses fail loudly and promptly.

## Why it matters

Anyone who runs these evidence harnesses hits this the first time the feature actually regresses: the developer waiting on the script (or the automation driving it) gets a silently hung terminal instead of a red result, and has to find and kill the orphaned Chromium and static-server processes by hand before rerunning. Because the harnesses are the visual proof that the slot-folder-suggestion flow works, a proof that cannot report failure is worse than no proof - it converts "regression found" into "tooling stuck", hiding the very signal they exist to produce. On top of the hang, the `process.exit(1)` path skipped the deferred removal of the run-private capture directory, leaving stray artifacts behind on exactly the runs that matter most to inspect.

## What changed (motivation → approach → change)

One shape, applied to both scripts (`capture-folder-suggestion-expiry.mjs`, `capture-folder-suggestion.mjs`):

- an idempotent `cleanup()` helper closes context → browser → server, each guarded;
- the success path calls it explicitly **before** the recording-flush / final-artifact checks (the webm is only finalized when the context closes);
- the whole fallible body sits in `try`, with `catch { await cleanup(); throw }`;
- `capture-folder-suggestion.mjs`'s terminal `process.exit(1)` becomes a throw, so the failure path reaches the cleanup too.

Scenario bodies, routes, stubs, assertions, and artifact naming are untouched - the diff is the teardown shape plus the exit-path comments that explain it.

## Tests

These are Playwright evidence harnesses, not unit-tested modules; there is no unit-test seam for them, so coverage is structural plus the existing repo gates, which pass unchanged:

```
node --check scripts/capture-folder-suggestion.mjs          → OK
node --check scripts/capture-folder-suggestion-expiry.mjs   → OK
```

The teardown property itself is pinned by construction (every fallible statement sits inside the `try`, and both exits funnel through `cleanup()`); no assertions were weakened or removed.

## Manual verification

Behavioural proof of the fixed property on any machine with Playwright installed:

```
node scripts/capture-folder-suggestion-expiry.mjs some-out-dir   # success path exits 0
# force a failure (e.g. temporarily break a testid) → process now EXITS non-zero
# instead of hanging; browser/server processes are gone afterwards
```

Screenshots/video: N/A - no product surface changes, dev-tooling only.

## Related Issues

Fixes #5514

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass (harness syntax + gate suites green)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) - N/A: dev-tooling only
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
