### PR TITLE
fix: smooth notification sound dynamics

### DIFF
--- a/website/src/hooks/useNotificationSound.ts
+++ b/website/src/hooks/useNotificationSound.ts
@@ -103,6 +103,39 @@ const PRESETS: Record<Exclude<SoundPreset, 'none'>, ToneStep[]> = {
   ],
 }
 
+const ATTACK_DURATION = 0.005
+const RELEASE_DURATION = 0.005
+const ENVELOPE_FLOOR_RATIO = 0.01
+const VOLUME_EXPONENT = 1.5
+const CURVE_POINTS = 32
+
+/** Chime partials overlap and can otherwise exceed full scale. Single-voice
+ * presets retain almost all of their existing level while sharing a little
+ * output headroom. */
+const PRESET_OUTPUT_GAIN: Record<Exclude<SoundPreset, 'none'>, number> = {
+  chime: 0.89,
+  ding: 0.98,
+  blip: 0.98,
+  pop: 0.98,
+  pulse: 0.98,
+}
+
+function smoothstepCurve(from: number, to: number): Float32Array {
+  return Float32Array.from({ length: CURVE_POINTS }, (_, i) => {
+    const x = i / (CURVE_POINTS - 1)
+    const smooth = x * x * (3 - 2 * x)
+    return from + (to - from) * smooth
+  })
+}
+
+function scheduleEnvelope(gain: AudioParam, start: number, duration: number, peak: number): void {
+  const floor = peak * ENVELOPE_FLOOR_RATIO
+  const releaseStart = start + duration - RELEASE_DURATION
+  gain.setValueCurveAtTime(smoothstepCurve(0, peak), start, ATTACK_DURATION)
+  gain.exponentialRampToValueAtTime(floor, releaseStart)
+  gain.setValueCurveAtTime(smoothstepCurve(floor, 0), releaseStart, RELEASE_DURATION)
+}
+
 export function playPreset(preset: SoundPreset, volume: number): void {
   if (preset === 'none' || volume <= 0) return
   // Backoff guard: once MAX_CLOSED_RECOVERIES consecutive 'closed' hits occur,
@@ -150,14 +183,14 @@ function scheduleTones(ctx: AudioContext, preset: Exclude<SoundPreset, 'none'>, 
   // close events over the page lifetime.
   closedRecoveryCount = 0
   const now = ctx.currentTime
+  const perceptualVolume = Math.min(1, Math.max(0, volume)) ** VOLUME_EXPONENT
   for (const step of PRESETS[preset]) {
     const osc = ctx.createOscillator()
     const g = ctx.createGain()
     osc.type = 'sine'
     osc.frequency.value = step.freq
-    const peak = Math.max(0.001, volume * step.gain)
-    g.gain.setValueAtTime(peak, now + step.start)
-    g.gain.exponentialRampToValueAtTime(0.01, now + step.start + step.dur)
+    const peak = Math.max(0.001, perceptualVolume * step.gain * PRESET_OUTPUT_GAIN[preset])
+    scheduleEnvelope(g.gain, now + step.start, step.dur, peak)
     osc.connect(g)
     g.connect(ctx.destination)
     osc.onended = () => { osc.disconnect(); g.disconnect() }

--- a/website/src/test/useNotificationSound.test.ts
+++ b/website/src/test/useNotificationSound.test.ts
@@ -29,7 +29,7 @@ const mockCtx = {
     return o
   }),
   createGain: vi.fn(() => ({
-    gain: { setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
+    gain: { setValueCurveAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
     connect: vi.fn(),
     disconnect: vi.fn(),
   })),
@@ -231,6 +231,48 @@ describe('playPreset', () => {
   it('schedules oscillators for a valid preset when running', () => {
     playPreset('ding', 0.5)
     expect(mockCtx.createOscillator).toHaveBeenCalled()
+  })
+
+  it('schedules a perceptual-volume envelope with smooth attack and release', () => {
+    mockCtx.currentTime = 2
+    playPreset('ding', 0.5)
+
+    const gainNode = mockCtx.createGain.mock.results.at(-1)!.value as {
+      gain: {
+        setValueCurveAtTime: ReturnType<typeof vi.fn>
+        exponentialRampToValueAtTime: ReturnType<typeof vi.fn>
+      }
+    }
+    const expectedPeak = (0.5 ** 1.5) * 0.98
+    const expectedFloor = expectedPeak * 0.01
+    const attack = gainNode.gain.setValueCurveAtTime.mock.calls[0][0] as Float32Array
+    const release = gainNode.gain.setValueCurveAtTime.mock.calls[1][0] as Float32Array
+
+    expect(attack[0]).toBe(0)
+    expect(attack.at(-1)).toBeCloseTo(expectedPeak)
+    const quarterIndex = Math.round((attack.length - 1) * 0.25)
+    const threeQuarterIndex = Math.round((attack.length - 1) * 0.75)
+    expect(attack[quarterIndex]).toBeLessThan(expectedPeak * 0.25)
+    expect(attack[threeQuarterIndex]).toBeGreaterThan(expectedPeak * 0.75)
+    expect(gainNode.gain.setValueCurveAtTime).toHaveBeenNthCalledWith(1, attack, 2, 0.005)
+    const decay = gainNode.gain.exponentialRampToValueAtTime.mock.calls[0]
+    const releaseCall = gainNode.gain.setValueCurveAtTime.mock.calls[1]
+    expect(decay[0]).toBeCloseTo(expectedFloor)
+    expect(decay[1]).toBeCloseTo(2.445)
+    expect(release[0]).toBeCloseTo(expectedFloor)
+    expect(release.at(-1)).toBe(0)
+    expect(releaseCall[0]).toBe(release)
+    expect(releaseCall[1]).toBeCloseTo(2.445)
+    expect(releaseCall[2]).toBe(0.005)
+  })
+
+  it('applies extra headroom to the overlapping chime preset', () => {
+    playPreset('chime', 0.5)
+    const gainNode = mockCtx.createGain.mock.results[0]!.value as {
+      gain: { setValueCurveAtTime: ReturnType<typeof vi.fn> }
+    }
+    const attack = gainNode.gain.setValueCurveAtTime.mock.calls[0][0] as Float32Array
+    expect(attack.at(-1)).toBeCloseTo((0.5 ** 1.5) * 0.89)
   })
 
   it('disconnects oscillator and gain when onended fires (memory-leak guard)', () => {


### PR DESCRIPTION
## Problem / Motivation

Notification sounds start at full gain and stop without a release envelope. This is jarring even at low volumes and can produce audible clicks at the start and end of a tone.

The decay uses a fixed gain floor of `0.01`. This floor becomes disproportionately loud at low volume settings. The volume control also uses linear amplitude scaling, which does not match perceived loudness. Overlapping chime voices can exceed the intended output level.

## Why it matters

Notification sounds can play frequently during normal use. Clicks and inconsistent loudness make repeated notifications distracting, particularly at low volume settings or when the chime preset is selected.

## What changed (motivation → approach → change)

The gain envelope now uses a 5 ms smoothstep attack and a 5 ms smoothstep release. The release reaches zero before the oscillator stops, which removes the abrupt gain transition.

The exponential decay floor is now 1% of each tone's peak gain. This preserves the envelope shape across volume settings instead of applying the same absolute floor to every tone.

Volume scaling now uses `volume ** 1.5` to produce a more gradual perceived loudness response. Preset output gains provide headroom for overlapping voices. The chime preset uses a gain factor of `0.89`, while the single-voice presets use `0.98`.

The Web Audio automation events meet at exact curve boundaries. The Web Audio specification permits this scheduling pattern.

## Tests

The notification-sound tests now verify:

- The 5 ms smoothstep attack and release timing.
- The non-linear shape of the attack curve at its quarter and three-quarter points.
- Perceptual `volume ** 1.5` scaling.
- The volume-relative 1% decay floor.
- Release to zero before oscillator termination.
- Additional headroom for the overlapping chime preset.

The focused notification-sound suite passes with 30 tests. The full website test suite, TypeScript compilation, production build, and `git diff --check` also pass.

The repository local gate reaches an unrelated existing Electron test failure under Node.js `v22.23.1`. The test `stopGatewayGracefully: a HUNG tree kill still resolves, and never pre-empts itself` leaves a promise pending and causes 26 subsequent cancellations. An isolated run reproduces 11 passes, 1 skip, and 26 cancellations. No assertion failure is attributable to this change.

## Manual verification

Generated WAV comparisons were auditioned with the relative decay floor, perceptual volume scaling, smoothstep attack, smoothstep release, and preset headroom enabled. The combined envelope removed the audible click while preserving the intended notification character.

## Related Issues

N/A. No related issue is linked.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->