### PR TITLE
fix: note pending embedding in learn add saved output (#2156)

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1705,6 +1705,33 @@ async def _run_eval(args: argparse.Namespace) -> None:
     print(f"\nResults saved to:\n  {report_path}\n  {json_path}")
 
 
+# Appended to every `learn add` output that wrote something. This command builds
+# its store with no embed_fn (loading the embedding model would add its startup
+# cost to every CLI invocation), so an insert lands with a NULL vector and an
+# enrichment CLEARS the stored one (the upsert keeps a vector only when the value
+# is unchanged). Either way the row is repaired by the gateway's boot-time
+# re-embed sweep, not by this process — an unqualified success message would
+# overstate what happened, and a user searching semantically before the next
+# gateway start would not find the lesson they were just told was saved.
+# "once its embedding backend is ready" is the sweep's own guarantee, not
+# hedging: _wait_then_backfill defers the sweep to a later boot when the
+# embedding model has not landed, so "on its next start" would over-promise.
+_LEARN_EMBED_NOTE = (
+    "  Stored and keyword-searchable now; the embedding vector is filled by the\n"
+    "  gateway's re-embed sweep after it next starts, once its embedding backend\n"
+    "  is ready."
+)
+
+# INSERTED only. An enrichment resolves against the ONE existing row it rewrites
+# (write_lesson pass 1 sets ``matched`` and pass 2's generic scan runs over
+# ``[] if matched else lesson_rows``), so the substring/topic-overlap claim is
+# true only for an insert — printing it on ENRICHED would report checks that
+# never ran, the same defect this change fixes.
+_LEARN_DEDUP_NOTE = (
+    "  (Semantic dedup did not run at write time; substring/topic-overlap dedup\n" "  still did.)"
+)
+
+
 def _learn(args: argparse.Namespace) -> None:
     """Save, list, or remove learned corrections."""
 
@@ -1746,11 +1773,16 @@ def _learn(args: argparse.Namespace) -> None:
             # the same defect this PR fixes on the reporting side. `learn list` is
             # where stored values belong.
             if result.outcome is LessonWriteOutcome.INSERTED:
-                print(f"Saved: {rule}{neg} [{category}]")
+                print(f"Saved: {rule}{neg} [{category}]\n{_LEARN_EMBED_NOTE}\n{_LEARN_DEDUP_NOTE}")
             elif result.outcome is LessonWriteOutcome.ENRICHED:
+                # No _LEARN_DEDUP_NOTE here: an enrichment matched its existing row in
+                # pass 1, which SKIPS the generic dedup scan. Instead say what the
+                # rewrite cost — the upsert cleared the vector the row already had.
                 print(
                     f"Updated the stored lesson with this clause: {rule}{neg}\n"
-                    "  The stored category is kept; `learn list` shows it."
+                    "  The stored category is kept; `learn list` shows it.\n"
+                    "  This rewrite cleared the row's existing embedding vector.\n"
+                    + _LEARN_EMBED_NOTE
                 )
             elif result.outcome is LessonWriteOutcome.UNCHANGED:
                 # Nothing was written, and the store keeps the stored category and

--- a/test/test_lesson_write_outcome.py
+++ b/test/test_lesson_write_outcome.py
@@ -262,6 +262,64 @@ class TestCliLearnAddReportsTheOutcome:
         assert exited is None
         assert capsys.readouterr().out.startswith("Saved: prefer ruff over flake8")
 
+    def test_an_insert_qualifies_saved_with_the_embedding_note(self, tmp_path, capsys):
+        """A CLI insert says the vector is pending, not an unqualified success.
+
+        The CLI builds its store with no ``embed_fn``, so every row it inserts
+        lands with a NULL embedding and only becomes vector-searchable after the
+        gateway's boot-time re-embed sweep. An unqualified ``Saved:`` told the
+        user the lesson was fully indexed when it was not.
+        """
+        jsonl, exited = self._run(tmp_path)
+        assert exited is None
+        out = capsys.readouterr().out
+        assert "Saved: prefer ruff over flake8" in out
+        assert "keyword-searchable now" in out
+        assert "re-embed sweep" in out
+        assert "once its embedding backend" in out
+        assert "Semantic dedup did not run" in out
+
+    def test_an_enrichment_carries_the_same_embedding_note(self, tmp_path, capsys):
+        """An enrichment changes the stored value, which CLEARS the row's vector.
+
+        The semantic upsert keeps an embedding only when the value is unchanged,
+        so attaching a clause leaves the row NULL for the same sweep an insert
+        waits on — the note applies to both write outcomes. But NOT the dedup
+        clause: an enrichment matched its row in write_lesson's pass 1, which
+        skips the generic substring/topic-overlap scan (pass 2 iterates
+        ``[] if matched else lesson_rows``), so claiming that scan ran would
+        report a check that never happened.
+        """
+        jsonl, exited = self._run(
+            tmp_path,
+            negative="not for typing",
+            pre=("prefer ruff over flake8", "knowledge", None),
+        )
+        assert exited is None
+        out = capsys.readouterr().out
+        assert "Updated the stored lesson with this clause" in out
+        assert "re-embed sweep" in out
+        assert "cleared the row's existing embedding vector" in out
+        assert "Semantic dedup did not run" not in out
+
+    def test_non_writing_outcomes_do_not_carry_the_embedding_note(self, tmp_path, capsys):
+        """The note describes a row this call wrote; a decline wrote none.
+
+        A no-op re-submit and a dedup decline leave the store exactly as it was,
+        so promising a backfill would attribute a pending repair to a write that
+        never happened.
+        """
+        jsonl, exited = self._run(tmp_path, pre=("prefer ruff over flake8", "tool", None))
+        assert exited is None
+        assert "re-embed sweep" not in capsys.readouterr().out
+        jsonl, exited = self._run(
+            tmp_path,
+            rule="run the linter",
+            pre=("always run the linter before pushing a branch", "tool", None),
+        )
+        assert exited is None
+        assert "re-embed sweep" not in capsys.readouterr().out
+
     def test_an_enrichment_does_not_echo_the_submitted_category(self, tmp_path, capsys):
         """Only an INSERT may echo the category, because only then is it what is stored.
 


### PR DESCRIPTION
## Summary

`kirocrew learn add` builds its `VectorMemoryStore` with no `embed_fn` (loading the embedding model would add its startup cost to every CLI invocation), so an insert lands with a NULL embedding and an enrichment clears the stored vector (the semantic upsert keeps one only when the value is unchanged). The row only becomes vector-searchable after the gateway's boot-time re-embed sweep — yet the command printed an unqualified `Saved:` as if the lesson were fully indexed. A user searching semantically before the next gateway start would not find the lesson they were just told was saved.

The architectural half is already resolved on main: `_auto_migrate_memory` Phase 2 probes `has_pending_embeddings()` (which includes `key LIKE 'lesson.%'` rows) and `backfill_missing_embeddings()` repairs lesson vectors first. The remaining defect is only the dishonest CLI output. This PR fixes the message.

## Changes

- `src/kiro_crew/cli_commands.py` — appends `_LEARN_EMBED_NOTE` to both writing outcomes (INSERTED and ENRICHED): stored and keyword-searchable now; the embedding vector is filled by the gateway's re-embed sweep after it next starts, **once its embedding backend is ready** (`_wait_then_backfill` defers the sweep to a later boot when the model has not landed, so "on its next start" would over-promise).
- The dedup clause (`_LEARN_DEDUP_NOTE`: semantic dedup did not run at write time; substring/topic-overlap dedup still did) prints on **INSERTED only**: an enrichment resolves against the one existing row it rewrites in `write_lesson` pass 1, which skips the generic dedup scan (pass 2 iterates `[] if matched else lesson_rows`), so printing that clause there would report checks that never ran — the same defect this PR fixes on the reporting side.
- The ENRICHED branch instead states that the rewrite cleared the row's existing embedding vector (the upsert keeps a vector only when `value_json` is unchanged).
- Declining outcomes (unchanged/deduped/refused) wrote no row, so they carry no note.
- `test/test_lesson_write_outcome.py` — three tests pinning the note on INSERTED (with the dedup clause), on ENRICHED (without it, with the cleared-vector line), and its absence on non-writing outcomes.

Message-only change: no new trust boundary, no model load in the CLI, no gateway delegation.

## Testing

- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1099 files) — clean
- Targeted suites: `test_lesson_write_outcome.py`, `test_cli_commands_coverage.py`, `test_learn.py`, `test_lesson_project_scope.py`, `test_vector_memory.py` — 488 passed
- Two pre-push model-pinned review lanes (GPT + Opus) converged on two real findings, both fixed: the ENRICHED-path dedup claim was false (clause now INSERTED-only), and the unconditional sweep-timing promise over-stated the sweep's own guarantee (now keyed to embedder readiness). Opus's cleared-vector advisory adopted.

No UI changes, no screenshots required.

Closes #2156
