### PR TITLE
fix(dashboard): refresh spec tasks when checkboxes change on disk

### DIFF
--- a/website/src/apps/spec-builder/api.ts
+++ b/website/src/apps/spec-builder/api.ts
@@ -401,3 +401,47 @@ export function phaseLabel(phase: string): string {
     ? i18nT(PHASE_LABEL_KEY[phase])
     : phase
 }
+
+// ── detail poll cadence ──────────────────────────────────────────────────────
+// The Tasks panel is a progress view over tasks.md. That file is also written by
+// the agent and by hand in an editor, neither of which goes through a Spec
+// Builder mutation — so a poll armed only by last-dispatch / slot.running sits
+// idle while checkboxes flip on disk. These constants are the single owner of
+// the cadences SpecDetail reads.
+
+/** Fast poll while a turn is in flight, the Tasks tab is open, or tasks.md just changed. */
+export const SPEC_DETAIL_FAST_POLL_MS = 2500
+/** Catch the worker slot coming up after a dispatch (running is still false). */
+export const SPEC_DETAIL_DISPATCH_POLL_MS = 1200
+/** Idle poll when nothing is writing and the user is not watching Tasks. */
+export const SPEC_DETAIL_IDLE_POLL_MS = 6000
+/** How long a dispatch or an observed tasks.md hash change keeps the fast window. */
+export const SPEC_DETAIL_FOLLOWUP_MS = 20000
+
+export interface SpecDetailPollInput {
+  running?: boolean
+  status?: string
+  /** True while the document tab showing the checklist is selected. */
+  watchingTasks?: boolean
+  msSinceDispatch?: number
+  msSinceTasksChange?: number
+}
+
+/** Interval for the spec-detail React Query poll.
+ *
+ *  Fast while the worker is active, for a follow-up window after THIS view
+ *  dispatched an instruction, while the user is looking at the Tasks panel,
+ *  and for the same follow-up window after tasks.md's content hash changes
+ *  (an agent or a hand edit that never hit lastSendAt). Otherwise idle.
+ */
+export function specDetailPollMs(input: SpecDetailPollInput): number {
+  if (input.running || input.status === 'executing') return SPEC_DETAIL_FAST_POLL_MS
+  if ((input.msSinceDispatch ?? Number.POSITIVE_INFINITY) < SPEC_DETAIL_FOLLOWUP_MS) {
+    return SPEC_DETAIL_DISPATCH_POLL_MS
+  }
+  if (input.watchingTasks) return SPEC_DETAIL_FAST_POLL_MS
+  if ((input.msSinceTasksChange ?? Number.POSITIVE_INFINITY) < SPEC_DETAIL_FOLLOWUP_MS) {
+    return SPEC_DETAIL_FAST_POLL_MS
+  }
+  return SPEC_DETAIL_IDLE_POLL_MS
+}

--- a/website/src/apps/spec-builder/components/SpecDetail.tsx
+++ b/website/src/apps/spec-builder/components/SpecDetail.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react'
 import { ADVANCE_PROMPT } from '../prompts'
 import {
-  specApi, LS, phaseLabel, PHASE_BUILDING_KEY,
+  specApi, LS, phaseLabel, PHASE_BUILDING_KEY, specDetailPollMs,
   type SpecDetail as SpecDetailData, type SpecTask,
 } from '../api'
 import { Input } from '../../../components/ui'
@@ -51,11 +51,6 @@ const DOC_TABS = [
 
 type DocTabId = (typeof DOC_TABS)[number]['id']
 
-/** How long after a dispatched instruction the detail poll stays fast. The slot's
- *  ``running`` flag is what normally selects the fast cadence, and it is still
- *  false when the POST returns, so this window covers the gap. */
-const SEND_FOLLOWUP_MS = 20000
-
 // The button label is copy and is translated; ``msg`` is the instruction sent to
 // the agent and lives in prompts.ts, deliberately untranslated. ``target`` is the
 // document the agent will write next: approving switches to it, so the drafting
@@ -94,30 +89,57 @@ export default function SpecDetail({ name, setErr, onDuplicated }: SpecDetailPro
   // so a slow 2.5s request landing after a faster later one reverted the docs
   // pane and the phase pill to stale content. React Query keeps one in-flight
   // request per key and discards superseded results. The poll stays fast while
-  // the agent works and slows down when it is idle.
+  // the agent works, while the Tasks tab is open, and for a follow-up window
+  // after a dispatch or a tasks.md hash change; otherwise it idles.
   // The identity every mutation carries: what THIS view rendered.
   const specId = () => ({ spec_dir: detail?.spec_dir, slot_key: detail?.slot_key })
 
   // When this view last dispatched an instruction. ``running`` is derived from the
   // worker slot, and the slot is not running yet when the POST returns — the turn
-  // is dispatched, not awaited. On the idle 6s cadence the whole UI therefore sat
+  // is dispatched, not awaited. On the idle cadence the whole UI therefore sat
   // unchanged for seconds after a click, so the approval looked like it had not
   // registered. A ref, not state: refetchInterval is read per fetch and this must
   // not itself trigger a render.
   const lastSendAt = useRef(0)
+  // tasks.md is written by the agent and by hand, neither of which hits lastSendAt.
+  // Remember the last hash we rendered so a disk change re-arms the fast window
+  // even when the user is not on the Tasks tab (they come back to a fresh list).
+  const lastTasksHash = useRef<string | undefined>(undefined)
+  const lastTasksChangeAt = useRef(0)
 
   const detailQuery = useQuery({
     queryKey: ['spec-builder', 'spec', name],
     queryFn: ({ signal }) => specApi.get(name, signal),
+    // An agent editing tasks.md from the main chat (or an editor) does not
+    // focus this window. The default pauses the interval in the background, so
+    // the progress view froze until a focus event that Electron does not always
+    // deliver.
+    refetchIntervalInBackground: true,
     refetchInterval: (q) => {
       const d = q.state.data
-      if (d?.running || d?.status === 'executing') return 2500
-      // Catch the slot coming up after a dispatch, then fall back to idle.
-      if (Date.now() - lastSendAt.current < SEND_FOLLOWUP_MS) return 1200
-      return 6000
+      const hash = d?.docs?.['tasks.md']?.hash
+      if (hash && lastTasksHash.current && hash !== lastTasksHash.current) {
+        lastTasksChangeAt.current = Date.now()
+      }
+      if (hash) lastTasksHash.current = hash
+      return specDetailPollMs({
+        running: d?.running,
+        status: d?.status,
+        watchingTasks: tab === 'tasks',
+        msSinceDispatch: Date.now() - lastSendAt.current,
+        msSinceTasksChange: Date.now() - lastTasksChangeAt.current,
+      })
     },
   })
   const detail: SpecDetailData | null = detailQuery.data ?? null
+
+  // Opening the progress view is itself a reason to read disk now, not at the
+  // next idle tick. The interval below keeps it fresh; this is the first look.
+  const prevTab = useRef(tab)
+  useEffect(() => {
+    if (tab === 'tasks' && prevTab.current !== 'tasks') void detailQuery.refetch()
+    prevTab.current = tab
+  }, [tab, detailQuery])
 
   // Surface a fetch error without clobbering the last good document content.
   useEffect(() => {

--- a/website/src/test/SpecBuilderPollInterval.test.ts
+++ b/website/src/test/SpecBuilderPollInterval.test.ts
@@ -1,0 +1,52 @@
+// Spec-detail poll cadence: the Tasks panel is a progress view over tasks.md,
+// which the agent and a hand editor write without going through lastSendAt.
+import { describe, it, expect } from 'vitest'
+import {
+  specDetailPollMs,
+  SPEC_DETAIL_FAST_POLL_MS,
+  SPEC_DETAIL_DISPATCH_POLL_MS,
+  SPEC_DETAIL_IDLE_POLL_MS,
+  SPEC_DETAIL_FOLLOWUP_MS,
+} from '../apps/spec-builder/api'
+
+describe('specDetailPollMs', () => {
+  it('stays fast while the worker is running or executing, even when idle otherwise', () => {
+    expect(specDetailPollMs({ running: true })).toBe(SPEC_DETAIL_FAST_POLL_MS)
+    expect(specDetailPollMs({ status: 'executing' })).toBe(SPEC_DETAIL_FAST_POLL_MS)
+  })
+
+  it('uses the dispatch window to catch the slot coming up after a POST', () => {
+    expect(specDetailPollMs({ msSinceDispatch: 0 })).toBe(SPEC_DETAIL_DISPATCH_POLL_MS)
+    expect(specDetailPollMs({ msSinceDispatch: SPEC_DETAIL_FOLLOWUP_MS - 1 }))
+      .toBe(SPEC_DETAIL_DISPATCH_POLL_MS)
+    expect(specDetailPollMs({ msSinceDispatch: SPEC_DETAIL_FOLLOWUP_MS }))
+      .toBe(SPEC_DETAIL_IDLE_POLL_MS)
+  })
+
+  it('stays fast while the Tasks tab is open, which is the progress view', () => {
+    expect(specDetailPollMs({ watchingTasks: true })).toBe(SPEC_DETAIL_FAST_POLL_MS)
+    // A closed Tasks tab with no other signal is the idle case the bug lived in:
+    // an agent flipping checkboxes never re-armed lastSendAt.
+    expect(specDetailPollMs({ watchingTasks: false })).toBe(SPEC_DETAIL_IDLE_POLL_MS)
+  })
+
+  it('re-arms the fast window after tasks.md itself changes on disk', () => {
+    expect(specDetailPollMs({ msSinceTasksChange: 0 })).toBe(SPEC_DETAIL_FAST_POLL_MS)
+    expect(specDetailPollMs({ msSinceTasksChange: SPEC_DETAIL_FOLLOWUP_MS - 1 }))
+      .toBe(SPEC_DETAIL_FAST_POLL_MS)
+    expect(specDetailPollMs({ msSinceTasksChange: SPEC_DETAIL_FOLLOWUP_MS }))
+      .toBe(SPEC_DETAIL_IDLE_POLL_MS)
+  })
+
+  it('prefers the worker/dispatch signals over the Tasks-tab cadence', () => {
+    expect(specDetailPollMs({
+      running: true,
+      watchingTasks: true,
+      msSinceDispatch: 0,
+    })).toBe(SPEC_DETAIL_FAST_POLL_MS)
+    expect(specDetailPollMs({
+      watchingTasks: true,
+      msSinceDispatch: 100,
+    })).toBe(SPEC_DETAIL_DISPATCH_POLL_MS)
+  })
+})

--- a/website/src/test/SpecBuilderSpecDetailCoverage.test.tsx
+++ b/website/src/test/SpecBuilderSpecDetailCoverage.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../apps/spec-builder/components/SpecStatePanel', () => ({
 }))
 
 import SpecDetail from '../apps/spec-builder/components/SpecDetail'
-import { LS } from '../apps/spec-builder/api'
+import { LS, SPEC_DETAIL_FAST_POLL_MS, SPEC_DETAIL_IDLE_POLL_MS } from '../apps/spec-builder/api'
 
 interface Call { url: string; method: string; body: string }
 
@@ -688,5 +688,49 @@ describe('SpecDetail error surfacing', () => {
     // No detail: the chat stays withheld and the phase pill falls back.
     expect(screen.queryByTestId('chat-column')).not.toBeInTheDocument()
     expect(screen.getByText('…')).toBeInTheDocument()
+  })
+})
+
+describe('SpecDetail tasks-panel poll (#5361)', () => {
+  const withTasks = {
+    ...BASE,
+    files: { 'requirements.md': '# r', 'tasks.md': '- [ ] one' },
+    docs: { 'tasks.md': { hash: 'b'.repeat(64) } },
+    tasks: [{ index: 0, text: 'one', done: false, hash: 'c'.repeat(64) }],
+  }
+
+  it('refetches as soon as the Tasks tab opens, then keeps the fast cadence while idle', async () => {
+    let gets = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      gets += 1
+      return Promise.resolve(okRes(JSON.stringify(withTasks)))
+    }))
+    renderDetail()
+    await screen.findByTestId('chat-column')
+    const afterMount = gets
+
+    await selectTab('Tasks')
+    await waitFor(() => expect(gets).toBeGreaterThan(afterMount))
+    const afterOpen = gets
+
+    await vi.advanceTimersByTimeAsync(SPEC_DETAIL_FAST_POLL_MS)
+    expect(gets).toBeGreaterThan(afterOpen)
+  })
+
+  it('stays on the idle cadence on Requirements when nothing is running', async () => {
+    let gets = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      gets += 1
+      return Promise.resolve(okRes(JSON.stringify(BASE)))
+    }))
+    renderDetail()
+    await screen.findByTestId('chat-column')
+    const afterMount = gets
+
+    await vi.advanceTimersByTimeAsync(SPEC_DETAIL_FAST_POLL_MS)
+    expect(gets).toBe(afterMount)
+
+    await vi.advanceTimersByTimeAsync(SPEC_DETAIL_IDLE_POLL_MS - SPEC_DETAIL_FAST_POLL_MS)
+    expect(gets).toBeGreaterThan(afterMount)
   })
 })


### PR DESCRIPTION
## Problem / Motivation

When working a Kiro spec, the agent (or a hand edit) flips task checkboxes from `- [ ]` to `- [x]` in `.kiro/specs/<feature>/tasks.md`, but Spec Builder's Tasks panel keeps showing those tasks as incomplete. The file on disk is correct; the progress view is not.

## Why it matters

The Tasks panel is the progress view for a spec. If it does not track on-disk checkbox state, users cannot trust it and have to ask "is task N done?" or read the file themselves.

## What changed (motivation → approach → change)

The detail poll was already React Query, but the fast cadence was armed only by a UI-dispatched instruction (`lastSendAt`) or the spec slot's `running` / `executing` flags. An agent writing `tasks.md` from the main chat — or a hand edit in an editor — never re-armed that window, so the panel sat on the 6s idle interval. A backgrounded Electron/browser window also paused the interval entirely (`refetchIntervalInBackground` defaults off).

- Keep the 2.5s poll while the Tasks tab is open.
- Re-arm the same fast window for 20s after the `tasks.md` content hash changes.
- Refetch immediately when switching to Tasks, so the first look is not an idle tick old.
- Set `refetchIntervalInBackground: true` so a visible-but-unfocused dashboard still picks up checkbox writes.
- Own the cadences in `specDetailPollMs` so the contract is unit-tested.

No task-run, approval, or successful-start behavior changes. Frontend only.

## Tests

- `SpecBuilderPollInterval.test.ts` pins the helper: running/executing stay fast, the dispatch window is 1.2s, Tasks-tab and hash-change stay fast, idle is 6s. Mutation-verified: dropping the Tasks-tab branch reds that test.
- Two SpecDetail coverage tests: opening Tasks refetches immediately and then stays on the fast cadence while idle; Requirements stays on the idle cadence when nothing is running.

`npx tsc -b` and eslint on the touched files are clean. The two vitest files: 40 passed.

## Manual verification

N/A for a live dashboard in this environment — no gateway was running. The poll cadence is asserted at the helper and at the SpecDetail fetch interval (immediate Tasks refetch + 2.5s vs 6s). A reviewer with a spec can confirm by opening Tasks, flipping a checkbox in `tasks.md`, and watching the row update without a dispatch.

## Related Issues

Fixes #5361

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


Made with [Cursor](https://cursor.com)