### PR TITLE
fix(website): enforce edition overlay precedence with a writeBundle byte check

### DIFF
--- a/website/scripts/lib/editionShell.mjs
+++ b/website/scripts/lib/editionShell.mjs
@@ -53,6 +53,59 @@ export function parseBrandingConfig(text) {
   return parsed
 }
 
+/**
+ * Enforce the emitFile-over-publicDir precedence the overlay relies on.
+ *
+ * The edition overlay (editionExtensionPlugin.generateBundle) emits each
+ * allowlisted `public/` asset with a pinned `fileName` on the assumption that an
+ * emitted asset WINS over the same-named `publicDir` copy. That precedence is
+ * empirical (verified on Vite 8 / Rolldown), not a documented contract: if a
+ * future bundler upgrade flips it, an edition build would silently ship the
+ * stock icons/manifest on a green build — and because edition builds run
+ * downstream, outside this repo's CI, nothing automated would observe it. That
+ * is exactly the silent-degrade class the seam's fail-loud contract bans.
+ *
+ * This turns the assumption into an enforced build-time invariant: after the
+ * bundle is written, byte-compare each overlaid dist file against its edition
+ * `public/` source and throw on any mismatch (or a missing dist file). Pure and
+ * build-free: the caller injects a `readFile` (Buffer-returning, e.g.
+ * `fs.readFileSync`) and a `join` (e.g. `path.join`), so it is unit-testable
+ * without running a real build — the same layout as the rest of this module.
+ *
+ * @param {object} args
+ * @param {string} args.distDir - the written bundle output dir (build.outDir).
+ * @param {string} args.editionPublicDir - the edition's `public/` source dir.
+ * @param {string[]} args.overlayFiles - the overlaid file names (allowlisted).
+ * @param {(p: string) => Buffer} args.readFile - reads a file to a Buffer; may throw ENOENT.
+ * @param {(...parts: string[]) => string} args.join - path join.
+ * @throws {Error} fail-loud on a missing dist file or a byte mismatch.
+ */
+export function verifyOverlayBytes({ distDir, editionPublicDir, overlayFiles, readFile, join }) {
+  for (const file of overlayFiles) {
+    const src = readFile(join(editionPublicDir, file))
+    let dist
+    try {
+      dist = readFile(join(distDir, file))
+    } catch (e) {
+      throw new Error(
+        `[kirocrew-edition] overlaid asset '${file}' is missing from the build output ` +
+          `(${join(distDir, file)}): ${e instanceof Error ? e.message : e}. ` +
+          'The emitFile overlay should have written it — the emitFile-over-publicDir ' +
+          'precedence this seam relies on may have changed.'
+      )
+    }
+    if (!src.equals(dist)) {
+      throw new Error(
+        `[kirocrew-edition] overlaid asset '${file}' in the build output does not match the ` +
+          `edition source (${join(editionPublicDir, file)}): the stock publicDir copy appears to ` +
+          'have won over the emitted edition asset. The emitFile-over-publicDir precedence this ' +
+          'seam relies on is not a documented bundler contract; a Vite/Rolldown upgrade may have ' +
+          'flipped it. Edition builds run downstream, so this check is the only thing that catches it.'
+      )
+    }
+  }
+}
+
 /** Minimal HTML escape for text/attribute interpolation into index.html. */
 export function escapeHtml(s) {
   return String(s)

--- a/website/src/test/editionShell.test.ts
+++ b/website/src/test/editionShell.test.ts
@@ -5,6 +5,7 @@ import {
   escapeHtml,
   BRANDING_KEYS,
   SHELL_OVERLAY_ALLOWLIST,
+  verifyOverlayBytes,
 } from '../../scripts/lib/editionShell.mjs'
 
 // A trimmed copy of the real shell — the tags the seam patches, in the real order.
@@ -134,5 +135,84 @@ describe('SHELL_OVERLAY_ALLOWLIST', () => {
       'icon-512.png',
       'manifest.json',
     ])
+  })
+})
+
+describe('verifyOverlayBytes', () => {
+  // An in-memory filesystem: path -> bytes. A missing path throws like ENOENT,
+  // so the helper's missing-dist-file branch is exercised without touching disk.
+  const fakeFs = (files: Record<string, string>) => (p: string) => {
+    if (!(p in files)) {
+      const err = new Error(`ENOENT: no such file, open '${p}'`)
+      throw err
+    }
+    return Buffer.from(files[p])
+  }
+  // Deterministic, forward-slash join so assertions read the same on every OS.
+  const join = (...parts: string[]) => parts.join('/')
+
+  it('passes when every overlaid dist file matches its edition source', () => {
+    const readFile = fakeFs({
+      'edition/public/manifest.json': '{"name":"Acme"}',
+      'dist/manifest.json': '{"name":"Acme"}',
+      'edition/public/icon-192.png': 'PNGBYTES192',
+      'dist/icon-192.png': 'PNGBYTES192',
+    })
+    expect(() =>
+      verifyOverlayBytes({
+        distDir: 'dist',
+        editionPublicDir: 'edition/public',
+        overlayFiles: ['manifest.json', 'icon-192.png'],
+        readFile,
+        join,
+      })
+    ).not.toThrow()
+  })
+
+  it('throws loudly when a dist file has stock bytes (precedence flipped)', () => {
+    // The publicDir copy won over the emitted edition asset — the exact silent
+    // degrade this check exists to catch.
+    const readFile = fakeFs({
+      'edition/public/manifest.json': '{"name":"Acme"}',
+      'dist/manifest.json': '{"name":"Kiro Crew"}',
+    })
+    expect(() =>
+      verifyOverlayBytes({
+        distDir: 'dist',
+        editionPublicDir: 'edition/public',
+        overlayFiles: ['manifest.json'],
+        readFile,
+        join,
+      })
+    ).toThrow(/does not match the edition source/)
+  })
+
+  it('throws when an overlaid file is missing from the build output', () => {
+    const readFile = fakeFs({ 'edition/public/manifest.json': '{"name":"Acme"}' })
+    expect(() =>
+      verifyOverlayBytes({
+        distDir: 'dist',
+        editionPublicDir: 'edition/public',
+        overlayFiles: ['manifest.json'],
+        readFile,
+        join,
+      })
+    ).toThrow(/missing from the build output/)
+  })
+
+  it('is a no-op when there are no overlay files (stock build)', () => {
+    // A stock build resolves overlayFiles to [] and never reads anything.
+    const readFile = () => {
+      throw new Error('readFile should not be called for a stock build')
+    }
+    expect(() =>
+      verifyOverlayBytes({
+        distDir: 'dist',
+        editionPublicDir: 'edition/public',
+        overlayFiles: [],
+        readFile,
+        join,
+      })
+    ).not.toThrow()
   })
 })

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -24,6 +24,7 @@ import {
   parseBrandingConfig,
   applyBrandingToHtml,
   SHELL_OVERLAY_ALLOWLIST,
+  verifyOverlayBytes,
 } from './scripts/lib/editionShell.mjs'
 
 /** Shape produced by parseBrandingConfig (editionShell.mjs is untyped .mjs). */
@@ -346,6 +347,26 @@ function editionExtensionPlugin(): Plugin {
           source: readFileSync(path.join(path.dirname(editionEntry as string), 'public', file)),
         })
       }
+    },
+    // Enforce the emitFile-over-publicDir precedence generateBundle relies on.
+    // The overlay above assumes an emitted asset with a pinned fileName wins
+    // over the same-named publicDir copy; that is empirical (Vite 8 / Rolldown),
+    // not a documented bundler contract. writeBundle runs AFTER the bundle is
+    // written to disk, so it sees what actually landed: byte-compare each
+    // overlaid dist file against its edition source and fail loud on a mismatch
+    // or a missing file. A future bundler upgrade that flips the precedence
+    // would silently ship stock icons/manifest on a green build — and edition
+    // builds run downstream, outside this repo's CI, so this check is the only
+    // thing that would catch it. No-op for stock builds (overlayFiles is empty).
+    writeBundle(options) {
+      if (overlayFiles.length === 0) return
+      verifyOverlayBytes({
+        distDir: options.dir ?? path.resolve('dist'),
+        editionPublicDir: path.join(path.dirname(editionEntry as string), 'public'),
+        overlayFiles,
+        readFile: readFileSync,
+        join: path.join,
+      })
     },
     config() {
       if (editionDir) {


### PR DESCRIPTION
## Problem / Motivation

The edition pre-boot shell overlay (#2202) overlays allowlisted PWA assets
(manifest.json, icon-192.png, icon-512.png) onto dist by emitting each with a
pinned fileName via generateBundle/emitFile. It relies on an emitted asset
winning over the same-named publicDir copy -- a precedence verified empirically
on Vite 8 / Rolldown but NOT a documented bundler contract. If a future
Vite/Rolldown upgrade flips it, an edition build would silently ship the stock
icons/manifest on a green build. Edition builds run downstream, outside this
repo's CI, so nothing automated observes the regression -- exactly the
silent-degrade class the seam's fail-loud contract bans. Today the invariant is
guarded only by a code comment in website/vite.config.ts.

## Why it matters

A branded edition that silently ships stock PWA icons/manifest is a shipped,
user-visible defect that no gate catches, discovered only in the field. This
converts the assumption into an enforced build-time invariant at near-zero cost.

## What changed (motivation -> approach -> change)

Implements the Design Review advisory raised on #2202.

- Added verifyOverlayBytes to website/scripts/lib/editionShell.mjs: a pure,
  injectable helper that, given the dist dir, the edition public/ dir, and the
  overlay file list, byte-compares each overlaid dist file against its edition
  source and throws loudly on a mismatch or a missing dist file. readFile and
  join are injected so it is unit-testable without running a real build,
  mirroring the module's existing "testable without a build" layout.
- Added a writeBundle hook to editionExtensionPlugin in website/vite.config.ts.
  writeBundle runs after the bundle is written to disk, so it sees what actually
  landed; it calls verifyOverlayBytes with the resolved output dir. No-op for
  stock builds (overlayFiles is empty); edition-only, gated on
  KIROCREW_EDITION_DIR. This is edition build code, not a CI workflow or
  review-gate rule file.

## Tests

Added a verifyOverlayBytes describe block to
website/src/test/editionShell.test.ts (uses an in-memory fake reader):
- matching bytes for every overlaid file pass;
- a dist file with stock bytes throws (precedence flipped);
- a missing overlaid dist file throws;
- an empty overlay list (stock build) is a no-op and never reads.

Fail-before/pass-after: the mismatch and missing-file cases exercise the new
helper's throw paths and fail by construction without it (the imported symbol
would not exist); they pass with it. Local runs (exit codes seen):
- `vitest run src/test/editionShell.test.ts` -- 22 passed (18 pre-existing + 4 new).
- `tsc -b` (typecheck) -- clean, exit 0.
- `eslint src` -- exit 0 (0 errors; the 647 warnings are pre-existing and none in the changed files).

## Manual verification

N/A -- unit coverage is sufficient for the helper; the writeBundle wiring is a
thin call into the tested helper. A full edition build needs a downstream
edition dir this repo does not contain.

## Related Issues

Fixes #3623

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
