### PR TITLE
test(instances): pin the _mark_recovered forwarder-identity branch

### DIFF
--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -38,7 +38,8 @@ import kiro_crew.apps.bridges as bridges_mod
 import kiro_crew.apps.hooks_integration as hooks_mod
 import kiro_crew.apps.routes as routes_mod
 import kiro_crew.dashboard.handlers_instances as handlers_instances_mod
-from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+import kiro_crew.instances.ssh_tunnel_manager as ssh_tunnel_manager_mod
+from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager, TunnelStatus
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,6 +74,36 @@ class _RecordingRegistry:
 
     def set_last_active(self, instance_id: str) -> None:
         self.write_threads.append(threading.current_thread())
+
+
+def _tunnel_double(instance_id: str, *, pid: int = 4321, local_port: int = 18022) -> Any:
+    """Stand-in for ``_SshTunnel`` carrying every attribute ``_mark_recovered`` reads.
+
+    ``_SshTunnel.__init__`` assigns ``self.status`` (a real ``TunnelStatus``)
+    unconditionally, before any I/O, so a double that omits it can only produce
+    failures the production object cannot — and ``_mark_recovered`` does read
+    ``tunnel.status.local_port`` when it refreshes the forwarder identity.
+    """
+    return SimpleNamespace(
+        pid=pid, status=TunnelStatus(instance_id=instance_id, local_port=local_port)
+    )
+
+
+def _pin_forwarder_identity(monkeypatch: pytest.MonkeyPatch, *, reachable: bool) -> None:
+    """Pin whether ``_mark_recovered`` takes its forwarder-identity branch.
+
+    Unpinned, the branch is gated on ``process_start_time(pid)`` being truthy,
+    which holds iff that pid names a live, queryable process on the machine
+    running the test. That makes the code path a function of runner state rather
+    than of the test, so each test below pins the branch it means to exercise.
+    """
+    monkeypatch.setattr(
+        ssh_tunnel_manager_mod.platform_compat,
+        "process_start_time",
+        lambda pid: "pinned-start-time" if reachable else None,
+    )
+    if reachable:
+        monkeypatch.setattr(ssh_tunnel_manager_mod, "_reclaim_identity_key", lambda: b"k" * 32)
 
 
 # ---------------------------------------------------------------------------
@@ -171,14 +202,20 @@ async def test_disconnect_registry_write_off_the_loop_thread() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mark_recovered_registry_write_off_the_loop_thread() -> None:
+async def test_mark_recovered_registry_write_off_the_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A tracked instance's recovery hint is persisted, on a worker thread."""
     loop_thread = threading.current_thread()
     registry = _RecordingRegistry()
     mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
     # The double carries a pid: _mark_recovered persists the rebuilt child's
     # forwarder_pid alongside was_connected in its single hint write.
-    mgr._tunnels["some-instance"] = SimpleNamespace(pid=4321)  # type: ignore[assignment]
+    mgr._tunnels["some-instance"] = _tunnel_double("some-instance")
+    # Pin the forwarder-identity branch REACHABLE: it is the widest route to the
+    # hint write, and the only one that reads tunnel.status.local_port, so the
+    # offload assertion below covers the whole write path on every platform.
+    _pin_forwarder_identity(monkeypatch, reachable=True)
 
     await mgr._mark_recovered("some-instance")
 
@@ -216,14 +253,22 @@ class _BlockingRegistry(_RecordingRegistry):
 
 
 @pytest.mark.asyncio
-async def test_cancelled_persist_waits_for_the_worker_write() -> None:
+async def test_cancelled_persist_waits_for_the_worker_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Cancelling a caller mid-persist must NOT unwind the frame (and release
     the manager lock) while the worker write is still running — a cancelled
     to_thread await does not stop the thread, so an early unwind would let the
     late write race a subsequent locked write (e.g. a disconnect's reset)."""
     registry = _BlockingRegistry()
     mgr = SshTunnelManager(registry)  # type: ignore[arg-type]
-    mgr._tunnels["inst"] = SimpleNamespace(pid=4321)  # type: ignore[assignment]
+    mgr._tunnels["inst"] = _tunnel_double("inst")
+    # Pin the forwarder-identity branch UNREACHABLE: the subject here is the
+    # cancellation window around the BLOCKED registry write, so this wants the
+    # shortest deterministic route to it. Taking the identity branch instead
+    # would add two more to_thread hops ahead of that write, narrowing the
+    # sleep window below for no gain — test 1 above covers that branch.
+    _pin_forwarder_identity(monkeypatch, reachable=False)
 
     task = asyncio.create_task(mgr._mark_recovered("inst"))
     await asyncio.sleep(0.05)  # the worker write is submitted and blocked


### PR DESCRIPTION
## Problem / Motivation

Two tests in `test/test_apps_instances_loop_offload.py` fail intermittently on Windows CI,
roughly one run in four:

```
FAILED test_mark_recovered_registry_write_off_the_loop_thread
  - AttributeError: 'types.SimpleNamespace' object has no attribute 'status'
FAILED test_cancelled_persist_waits_for_the_worker_write
  - assert not task.done()
```

The second is a consequence of the first: the same `AttributeError` kills the task before the
cancellation window opens, so `task.done()` is already true.

`SshTunnelManager._mark_recovered` reads `tunnel.status.local_port` when it refreshes the
recorded forwarder identity (`ssh_tunnel_manager.py:1838`). That read sits behind a gate:

```python
if forwarder_pid > 0:
    started = await asyncio.to_thread(platform_compat.process_start_time, forwarder_pid)
    forwarder_start = started or ""
if forwarder_pid > 0 and forwarder_start:          # <- the gate
    key = await asyncio.to_thread(_reclaim_identity_key)
    if key is not None:
        forwarder_sig = _forwarder_identity_sig(..., tunnel.status.local_port)
```

Both tests seeded the tunnel double as `SimpleNamespace(pid=4321)` with **no `status`**. On
Windows, `platform_compat.process_start_time` returns `None` unless
`_open_process_query_handle(pid)` succeeds — i.e. it is truthy **iff a process with PID 4321 is
live and queryable on that runner**. So whether these tests crashed was decided by runner state,
not by anything in the tests. Hence the intermittency, and hence the Windows bias (the Linux
branch reads `/proc/<pid>/stat`, so it is the same class of dependence, merely less likely to hit
at that particular PID).

Introduced by `388b0367b` (#5381), which added both the `tunnel.status.local_port` read and the
status-less `pid=4321` fixtures. It is in the merge-base of every open PR, so it is base-side
rather than caused by any one branch. Observed on #5577 (`1f9b7194c`, Windows shard 1) and
reported on #5579.

Note for anyone reading the CI annotation: it says `Event loop is closed`, which is a red herring
(an unrelated unraisable warning from `autonudge.py`). The real failure is only in the pytest
short summary.

## Why it matters

A base-side flake at ~25% on one shard taxes every open PR, and the cost is not just a re-run:
**the five fork AI review lanes gate on `workflow_run.conclusion == 'success'`**, so a red Windows
shard makes all five skip and no AI verdict can arrive at all. A PR can therefore be structurally
un-reviewable because of a fixture defect unrelated to it.

It is also a correctness problem in the tests themselves even when they pass. The identity branch
that `388b0367b` added had no deterministic coverage in this file — it was exercised only when a
runner happened to have PID 4321 live. Deterministic result, non-deterministic coverage.

## What changed

Test-only, one file. No source change: `_SshTunnel.__init__` assigns `self.status` (a
`TunnelStatus`) unconditionally, before any I/O, so the production object cannot fail this way.
The double was simply incomplete, so hardening `_mark_recovered` would be defending against a
state that does not occur.

- `_tunnel_double(instance_id, *, pid=4321, local_port=18022)` — a shared factory for the double,
  now carrying a **real `TunnelStatus`** rather than another `SimpleNamespace`, so a rename or
  retype of `local_port` surfaces here. Its docstring records the invariant (`_SshTunnel` always
  has `.status`) so the next author does not re-omit it. Returning `Any` also lets two
  `# type: ignore[assignment]` comments go.
- `_pin_forwarder_identity(monkeypatch, *, reachable=)` — pins `process_start_time` (and, when
  reachable, `_reclaim_identity_key`) so the branch taken is chosen by the test, not by the runner.

**The judgement call, and why the pins are not uniform.** Completing the fixture alone would fix
the crash but leave the exercised path runner-dependent, so the `status` read would go back to
being covered by luck. Pinning both tests the *same* way is worse in either direction: a uniform
*open* pin adds two extra `to_thread` hops ahead of the cancellation test's blocked write,
narrowing the 50 ms window it depends on — trading one flake for another on a loaded runner. A
uniform *closed* pin leaves `tunnel.status.local_port` unread anywhere in this file, so the
fixture's `status` becomes deletable-looking dead weight and the defect can return unseen. So each
test pins the branch matching its own subject:

| Test | Pin | Why |
|:--|:--|:--|
| `..._registry_write_off_the_loop_thread` | reachable | Widest route to the hint write and the only one reading `status.local_port`, so the fixture's completeness is load-bearing on every platform and every run. |
| `test_cancelled_persist_waits_for_the_worker_write` | unreachable | Its subject is the cancellation window around the **blocked** registry write, so it wants the shortest deterministic route there — one `to_thread` hop, matching the timing profile that already passes reliably. |

Neither test's assertions changed. Nothing is skipped, xfailed, weakened, or baselined.

One thing the diagnosis turned up that is worth recording: the `.status` read is gated on **two**
conditions, not one — a truthy start time *and* `_reclaim_identity_key()` returning non-`None`
(it reads the SEL trust root and returns `None` on `OSError` or a short key). So the Windows
failure needed a live PID *and* a readable SEL key on the runner, and a deterministic open pin has
to control both.

Also checked and deliberately left alone: the sibling gate at `ssh_tunnel_manager.py:1491-1504`
has the same shape but passes a **local** `local_port` variable, not `tunnel.status.local_port`,
so it does not share this defect.

## Tests

A plain run proves nothing here — on any machine where PID 4321 is not live, both tests pass
before and after. All verification below forces the gate.

**Before the change**, with `process_start_time` pinned truthy and `_reclaim_identity_key` pinned
via a temporary session plugin (simulating a Windows runner where PID 4321 is live), the two tests
reproduce the CI symptom pair exactly:

```
2 failed, 1 passed
FAILED test_mark_recovered_registry_write_off_the_loop_thread
  - AttributeError: 'types.SimpleNamespace' object has no attribute 'status'
    at src/kiro_crew/instances/ssh_tunnel_manager.py:1838
FAILED test_cancelled_persist_waits_for_the_worker_write
  - assert not task.done()  where the Task finished with exception=AttributeError(
    "'types.SimpleNamespace' object has no attribute 'status'")
```

`test_mark_recovered_skips_the_write_for_an_untracked_instance` passes throughout — it returns
before the pid path.

**After the change:**

| Run | Result |
|:--|:--|
| Same forced-gate plugin (simulated live PID 4321) | 3 passed |
| `test/test_apps_instances_loop_offload.py`, plain | 14 passed |
| Same file, random order, 5 consecutive repeats | 14 passed x5 |
| `test/test_instances.py -k "mark_recovered or forwarder_identity"` | 3 passed |

**Negative control, proving the pins are not vacuous.** Temporarily stripped `status=` back out of
`_tunnel_double` and re-ran:

- the hint-write test **failed** with the original `AttributeError` — so `reachable=True` really
  does open the gate and reach `tunnel.status.local_port`, and the fixture's completeness is
  genuinely load-bearing rather than decorative;
- the cancellation test **passed** — so `reachable=False` really does keep the gate closed.

**Gates.** `mypy`: clean. `isort`: clean. `black`: this file is already in
`.github/black-baseline.txt` (line 507) and its pre-change form is equally unclean under
`--target-version py310`, so the exemption is pre-existing and main-owned; `black --diff` requests
no change to any line this PR adds. Nothing was formatted and the baseline is untouched. The one
offender `scripts/check_black_formatting.py` reports, `test/test_config_loader.py`, is unclean at
the merge-base too and is not touched here.
