### PR TITLE
fix(dashboard): offer dot-prefixed directories in the @-mention file picker

### DIFF
--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -12,12 +12,28 @@ from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
 
-# Dot-prefixed dirs (.kirocrew, .kiro, .aim, .git) are already excluded by
-# the ``not d.startswith(".")`` guard in _walk(), so only non-dot dirs here.
-_SKIP_DIRS = frozenset({
-    "node_modules", "__pycache__", "venv",
-    "dist", "build", "env", "out", "target",
-})
+# Directory names never offered as @-mention candidates and never descended
+# into, by either search path. This is the SINGLE source of truth: the walk
+# fallback in dashboard/handlers/files.py imports it, so the indexed fast path
+# and the fallback cannot diverge. Dot-prefixed noise dirs (.git, .cache,
+# .venv) are listed EXPLICITLY here -- the candidate collection no longer
+# filters on a leading dot (that would hide the .github/.kiro/.claude dirs
+# issue #5677 wants offered), so each dot-dir to suppress must be named.
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".cache",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        "venv",
+        "dist",
+        "build",
+        "env",
+        "out",
+        "target",
+    }
+)
 
 _REFRESH_SECS = 30
 _MAX_ENTRIES = 100_000
@@ -120,12 +136,29 @@ class FileIndex:
         # a dismissed consent dialog would be re-triggered on every refresh --
         # which is how one prompt becomes a recurring stream of them.
         for dirpath, dirnames, filenames in os.walk(self.root):
-            dirnames[:] = platform_compat.tcc_prune_walk_dirs(
+            # A dot-prefixed directory (.github, .kiro, .claude) should be
+            # OFFERED as a search candidate even though we must not DESCEND into
+            # it -- the two concerns were previously conflated by pruning
+            # ``dirnames`` in place before the collection loop below.
+            #
+            # Build the candidate list (what we offer AND stat) first, then
+            # derive the narrower descent list from it. Both must honour:
+            #   * _SKIP_DIRS (.git, node_modules, ...) -- never offered, never
+            #     descended.
+            #   * tcc_prune_walk_dirs -- on macOS from a $HOME root the TCC-gated
+            #     folders (Downloads, Desktop, Library, ...) must be dropped from
+            #     candidates too: merely offering one means os.stat-ing it, which
+            #     pops a consent modal. So it is applied to candidate_dirs.
+            # Only the leading-dot rule differs: a dot-dir is a valid candidate
+            # but must not be descended into, so it is removed from the descent
+            # list alone.
+            candidate_dirs = platform_compat.tcc_prune_walk_dirs(
                 self.root,
                 dirpath,
-                [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS],
+                [d for d in dirnames if d not in _SKIP_DIRS],
             )
-            for dname in dirnames:
+            dirnames[:] = [d for d in candidate_dirs if not d.startswith(".")]
+            for dname in candidate_dirs:
                 if len(entries) >= _MAX_ENTRIES:
                     truncated = True
                     break

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -30,6 +30,7 @@ from aiohttp.multipart import BodyPartReader
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.hooks import safe_read_prefix
 from kiro_crew.messaging.link import is_channel_session_key
@@ -2353,11 +2354,13 @@ async def api_file_search(request: web.Request) -> web.Response:
             return web.json_response({"results": trimmed, "root": safe_roots[0]})
 
     # Fallback: walk filesystem per request
-    # Dot-prefixed dirs (.kirocrew, .kiro, .aim) excluded by startswith(".") guard below.
-    skip_dirs = {
-        ".git", "node_modules", "__pycache__", ".cache", ".venv", "venv",
-        "dist", "build", "env", "out", "target",
-    }
+    # Dot-prefixed FILES stay excluded (startswith(".") guard in _collect).
+    # Dot-prefixed DIRECTORIES (.github, .kiro, .claude) ARE offered as
+    # candidates; only skip_dirs below are dropped from both descent and results.
+    # skip_dirs is the SAME shared set the indexed fast path uses (imported from
+    # file_index), so the two paths of this endpoint cannot diverge on which
+    # directories are suppressed -- see #5677.
+    skip_dirs = _WALK_SKIP_DIRS
 
     max_scan = _WALK_MAX_SCAN_SCOPED if scoped else _WALK_MAX_SCAN_UNSCOPED
     max_collect = max_results * 10  # collect enough candidates for good scoring, then stop
@@ -2432,17 +2435,32 @@ async def api_file_search(request: web.Request) -> web.Response:
                 # Bounds the traversal; the per-kind counters stop advancing once
                 # their kind is done.
                 dirs_visited += 1
-                pruned = [
-                    d for d in dirnames
-                    if not d.startswith(".") and d not in skip_dirs
-                ]
-                dirnames[:] = pruned if scoped else platform_compat.tcc_prune_walk_dirs(
-                    root_dir, dirpath, pruned
-                )
+                # A dot-prefixed directory (.github, .kiro, .claude) should be
+                # OFFERED as a candidate even though we must not DESCEND into it.
+                # These were previously conflated: ``dirnames`` was pruned in
+                # place (dropping dot-dirs) before _collect saw it.
+                #
+                # Build the candidate list (offered AND stat'd) first, then
+                # derive the narrower descent list from it. Both drop skip_dirs
+                # (.git, node_modules, ...). On an UNSCOPED root the TCC-gated
+                # folders (Downloads, Desktop, Library, ... from a $HOME root on
+                # macOS) must also be dropped from candidates -- merely offering
+                # one means os.stat-ing it, which pops a consent modal; a scoped
+                # root is deliberate and is never TCC-pruned, matching the
+                # descent rule below. Only the leading-dot rule differs: a dot-
+                # dir is a valid candidate but is removed from the descent list.
+                base_dirs = [d for d in dirnames if d not in skip_dirs]
+                if scoped:
+                    candidate_dirs = base_dirs
+                else:
+                    candidate_dirs = platform_compat.tcc_prune_walk_dirs(
+                        root_dir, dirpath, base_dirs
+                    )
+                dirnames[:] = [d for d in candidate_dirs if not d.startswith(".")]
                 # Files first: under a tight scan budget the file candidates are
                 # the ones that survive.
                 _collect("file", dirpath, filenames, root_dir)
-                _collect("dir", dirpath, dirnames, root_dir)
+                _collect("dir", dirpath, candidate_dirs, root_dir)
                 if _full():
                     break
         return found["file"] + found["dir"]

--- a/test/test_file_search_dirs.py
+++ b/test/test_file_search_dirs.py
@@ -47,11 +47,17 @@ def _populate(tmp_path):
     (nested / "leaf.py").write_text("z")
     # An empty directory: proof dirs are walked, not derived from file paths.
     (tmp_path / "widgetsempty").mkdir()
-    # Excluded: dot-prefixed and skip-listed dirs
+    # A dot-prefixed dir IS offered as a candidate (issue #5677): it must not be
+    # descended into, but the directory itself is a valid @-mention target.
     (tmp_path / ".widgetshidden").mkdir()
+    # Skip-listed dirs stay excluded from both descent and results -- including
+    # the dot-prefixed skip-listed ones (.git, .cache, .venv), which the shared
+    # _SKIP_DIRS names explicitly now that candidacy no longer filters on a dot.
     nm = tmp_path / "node_modules"
     nm.mkdir()
     (nm / "widgetsdep").mkdir()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".cache").mkdir()
 
 
 def _scorer(q, name, rel):
@@ -112,15 +118,49 @@ class TestFileIndexDirs:
             idx.stop()
 
     @pytest.mark.asyncio
-    async def test_index_excludes_hidden_and_skip_dirs(self, tmp_path):
+    async def test_index_offers_dot_dirs_but_not_skip_dirs(self, tmp_path):
+        """Dot-prefixed dirs ARE candidates (#5677); skip-listed dirs are not."""
         _populate(tmp_path)
         idx = FileIndex(str(tmp_path))
         await idx.start()
         try:
             names = {r["name"] for r in idx.search("widgets", _scorer, 50, "dirs")}
-            assert ".widgetshidden" not in names
-            assert "widgetsdep" not in names
-            assert "node_modules" not in names
+            assert ".widgetshidden" in names, "dot-prefixed dir must be offered as a candidate"
+            assert "widgetsdep" not in names, "a dir inside node_modules is never descended into"
+            assert "node_modules" not in names, "skip-listed dir must stay excluded from results"
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_dot_skip_dirs_are_not_offered(self, tmp_path):
+        """A dot-prefixed SKIP-listed dir (.git, .cache) is never a candidate.
+
+        Regression for #5677 review: candidacy no longer filters on a leading
+        dot, so the shared _SKIP_DIRS must name .git/.cache/.venv explicitly --
+        otherwise the indexed fast path would start offering them.
+        """
+        _populate(tmp_path)
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            for q in ("git", "cache"):
+                names = {r["name"] for r in idx.search(q, _scorer, 50, "dirs")}
+                assert f".{q}" not in names, f".{q} must never be offered as a candidate"
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_index_does_not_descend_into_dot_dirs(self, tmp_path):
+        """A dot-dir is offered, but its CONTENTS are never walked."""
+        hidden = tmp_path / ".secretcfg"
+        hidden.mkdir()
+        (hidden / "widgetsinside").mkdir()
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            names = {r["name"] for r in idx.search("widgets", _scorer, 50, "dirs")}
+            assert ".secretcfg" not in names, "does not match query, not expected here"
+            assert "widgetsinside" not in names, "must not descend into a dot-dir"
         finally:
             idx.stop()
 
@@ -228,15 +268,33 @@ class TestApiFileSearchDirs:
             assert kinds == {"dir", "file"}
 
     @pytest.mark.asyncio
-    async def test_walk_fallback_excludes_hidden_and_skip_dirs(self, tmp_path, mock_sel):
+    async def test_walk_fallback_offers_dot_dirs_but_not_skip_dirs(self, tmp_path, mock_sel):
+        """The walk fallback offers dot-dirs (#5677) but never skip-listed dirs."""
         _populate(tmp_path)
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(
                 f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
             )
             names = {r["name"] for r in (await resp.json())["results"]}
-            assert ".widgetshidden" not in names
-            assert "widgetsdep" not in names
+            assert ".widgetshidden" in names, "dot-prefixed dir must be offered as a candidate"
+            assert "widgetsdep" not in names, "a dir inside node_modules is never descended into"
+            assert "node_modules" not in names, "skip-listed dir must stay excluded from results"
+
+    @pytest.mark.asyncio
+    async def test_walk_fallback_dot_skip_dirs_are_not_offered(self, tmp_path, mock_sel):
+        """The walk fallback never offers a dot-prefixed skip-listed dir.
+
+        Same source of truth as the fast path (shared _SKIP_DIRS), so the two
+        paths of this endpoint agree on .git/.cache/.venv -- the #5677 review gap.
+        """
+        _populate(tmp_path)
+        async with TestClient(TestServer(_make_app())) as client:
+            for q in ("git", "cache"):
+                resp = await client.get(
+                    f"/api/file-search?q={q}&kinds=dirs&project={tmp_path}"
+                )
+                names = {r["name"] for r in (await resp.json())["results"]}
+                assert f".{q}" not in names, f".{q} must never be offered by the fallback"
 
     @pytest.mark.asyncio
     async def test_index_fast_path_forwards_kinds(self, tmp_path, mock_sel):

--- a/test/test_tcc_protected_dirs.py
+++ b/test/test_tcc_protected_dirs.py
@@ -203,6 +203,28 @@ class TestFileIndexPruning:
         assert "code" in walked, "non-TCC project dirs must still be indexed"
 
     @pytest.mark.asyncio
+    async def test_home_root_offers_dot_dir_but_not_tcc_dir(self, tmp_path):
+        """A dot-dir is an offered candidate (#5677); a TCC dir is not.
+
+        Regression: offering dot-dirs as candidates must not also start offering
+        (and os.stat-ing) the TCC-gated top-level folders from a $HOME root --
+        stat'ing one pops a consent modal. The candidate list must be TCC-pruned
+        too, while the dot-dir stays offered.
+        """
+        _make_home(tmp_path)
+        (tmp_path / ".config").mkdir()
+        with (
+            patch.object(platform_compat, "IS_MACOS", True),
+            patch.dict(os.environ, _home_env(tmp_path), clear=False),
+        ):
+            idx = FileIndex(str(tmp_path))
+            entries, _ = await __import__("asyncio").to_thread(idx._walk)
+        dir_names = {e[1] for e in entries if e[5] == "dir"}
+        assert ".config" in dir_names, "a dot-dir must be offered as a candidate"
+        for name in _TCC_DIRS:
+            assert name not in dir_names, f"{name} must not be offered as a candidate from $HOME"
+
+    @pytest.mark.asyncio
     async def test_scoped_tcc_dir_is_still_indexed(self, tmp_path):
         """Indexing ~/Downloads directly is deliberate — index it fully."""
         _make_home(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #5677. Typing `@` in the composer and searching for a dot-prefixed directory (`.github`, `.kiro`, `.claude`) never surfaced it in the picker, with or without the leading dot. The directory was never even a candidate.

## Root cause

Both search paths mutate the `os.walk` `dirnames` list in place, conflating two concerns:

1. telling `os.walk` not to DESCEND into a directory (correct for `.git`, `node_modules`, etc.), and
2. as an unintended side effect, never OFFERING the directory itself as a search candidate.

Because `dirnames` was pruned of dot-prefixed names before the directory-collection step ran, a dot-prefixed directory was never scored, so no query could find it. The two affected functions:

- `FileIndex._walk` in `src/kiro_crew/dashboard/file_index.py`
- `api_file_search`'s `_walk_file_search` in `src/kiro_crew/dashboard/handlers/files.py`

## Fix

Separate the descent list from the candidate list in both places:

- descent list: still prunes dot-prefixed names AND the skip-listed dirs (`.git`, `node_modules`, `__pycache__`, ...), so the walk never enters them;
- candidate list: drops only the skip-listed dirs, so dot-prefixed directories are offered as results.

Files keep their separate, deliberate `startswith(".")` exclusion (out of scope for this report).

## Tests

Extended `test/test_file_search_dirs.py`:

- flipped the two exclusion tests to assert a dot-prefixed dir IS now offered while skip-listed dirs (`.git`, `node_modules`) stay excluded, for both the FileIndex fast path and the walk fallback;
- added a test proving a dot-dir is offered but its CONTENTS are never walked.

All 52 tests across `test_file_search_dirs.py`, `test_file_index.py`, `test_file_search.py` pass locally.
