### PR TITLE
fix(dashboard): offer dot-prefixed directories in the @-mention file picker

### DIFF
--- a/src/kiro_crew/dashboard/file_index.py
+++ b/src/kiro_crew/dashboard/file_index.py
@@ -12,11 +12,19 @@ from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
 
-# Dot-prefixed dirs (.kirocrew, .kiro, .aim, .git) are already excluded by
-# the ``not d.startswith(".")`` guard in _walk(), so only non-dot dirs here.
+# Directory names that are neither offered as @-mention candidates nor
+# descended into: build/dependency noise nobody references.
 _SKIP_DIRS = frozenset({
     "node_modules", "__pycache__", "venv",
     "dist", "build", "env", "out", "target",
+})
+
+# Dot-prefixed directories are OFFERED as candidates (e.g. .github, .kiro,
+# .claude) but never descended into. These specific dot-dirs are the exception:
+# they are pure tooling/VCS noise, so they are excluded from candidacy too.
+_SKIP_DOT_DIRS = frozenset({
+    ".git", ".hg", ".svn", ".cache", ".venv", ".tox", ".mypy_cache",
+    ".pytest_cache", ".ruff_cache",
 })
 
 _REFRESH_SECS = 30
@@ -120,12 +128,28 @@ class FileIndex:
         # a dismissed consent dialog would be re-triggered on every refresh --
         # which is how one prompt becomes a recurring stream of them.
         for dirpath, dirnames, filenames in os.walk(self.root):
+            # Directory candidates OFFERED to the picker: dot-prefixed dirs are
+            # included (a user references .github/.kiro/.claude), but build/VCS
+            # noise (_SKIP_DIRS, _SKIP_DOT_DIRS) is not. TCC-gated folders are
+            # pruned so scoring them never pops a consent dialog.
+            dir_candidates = platform_compat.tcc_prune_walk_dirs(
+                self.root,
+                dirpath,
+                [
+                    d for d in dirnames
+                    if d not in _SKIP_DIRS
+                    and not (d.startswith(".") and d in _SKIP_DOT_DIRS)
+                ],
+            )
+            # DESCENT is separate: never walk INTO a dot-dir (its contents are
+            # not offered) or a skip-dir. This must stay pruned independently of
+            # the candidate list above, or the two purposes collide (#5677).
             dirnames[:] = platform_compat.tcc_prune_walk_dirs(
                 self.root,
                 dirpath,
                 [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS],
             )
-            for dname in dirnames:
+            for dname in dir_candidates:
                 if len(entries) >= _MAX_ENTRIES:
                     truncated = True
                     break

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -2353,7 +2353,9 @@ async def api_file_search(request: web.Request) -> web.Response:
             return web.json_response({"results": trimmed, "root": safe_roots[0]})
 
     # Fallback: walk filesystem per request
-    # Dot-prefixed dirs (.kirocrew, .kiro, .aim) excluded by startswith(".") guard below.
+    # Dot-prefixed dirs are OFFERED as @-mention candidates (e.g. .github,
+    # .kiro) but never descended into. The dotted entries below (.git, .cache,
+    # .venv) are pure noise, so they stay excluded from candidacy too.
     skip_dirs = {
         ".git", "node_modules", "__pycache__", ".cache", ".venv", "venv",
         "dist", "build", "env", "out", "target",
@@ -2432,6 +2434,16 @@ async def api_file_search(request: web.Request) -> web.Response:
                 # Bounds the traversal; the per-kind counters stop advancing once
                 # their kind is done.
                 dirs_visited += 1
+                # Directory candidates OFFERED to the picker include dot-dirs
+                # (.github/.kiro); only build/VCS noise in skip_dirs is dropped.
+                dir_candidates = [d for d in dirnames if d not in skip_dirs]
+                if not scoped:
+                    dir_candidates = platform_compat.tcc_prune_walk_dirs(
+                        root_dir, dirpath, dir_candidates
+                    )
+                # DESCENT is separate: never walk INTO a dot-dir or skip-dir.
+                # Keeping this prune independent of dir_candidates is the #5677
+                # fix -- the same pruned list must not serve both purposes.
                 pruned = [
                     d for d in dirnames
                     if not d.startswith(".") and d not in skip_dirs
@@ -2442,7 +2454,7 @@ async def api_file_search(request: web.Request) -> web.Response:
                 # Files first: under a tight scan budget the file candidates are
                 # the ones that survive.
                 _collect("file", dirpath, filenames, root_dir)
-                _collect("dir", dirpath, dirnames, root_dir)
+                _collect("dir", dirpath, dir_candidates, root_dir)
                 if _full():
                     break
         return found["file"] + found["dir"]

--- a/test/test_file_index.py
+++ b/test/test_file_index.py
@@ -67,6 +67,52 @@ class TestFileIndex:
             idx.stop()
 
     @pytest.mark.asyncio
+    async def test_dot_prefixed_dirs_are_offered_as_candidates(self, tmp_path):
+        """A dot-prefixed directory (.github, .kiro) is a valid @-mention target.
+
+        The prune of ``dirnames`` stops ``os.walk`` descending into dot-dirs, but
+        it must not also stop the directory itself from being OFFERED as a search
+        candidate -- that was the bug in #5677 (the directory was never scored).
+        """
+        (tmp_path / ".github").mkdir()
+        (tmp_path / ".kiro").mkdir()
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            all_names = {e[1] for e in idx._entries}
+            assert ".github" in all_names
+            assert ".kiro" in all_names
+            # And they are reachable by the picker, dot typed or not.
+            assert any(r["name"] == ".github" for r in idx.search(".github", _scorer))
+            assert any(r["name"] == ".github" for r in idx.search("github", _scorer))
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
+    async def test_dot_dirs_offered_but_not_descended(self, tmp_path):
+        """Offering a dot-dir must not descend into it or offer noise dot-dirs.
+
+        ``.github`` is offered but its contents are not walked (dot-dirs are not
+        descended), while ``.git`` and other noise dirs stay excluded entirely.
+        """
+        gh = tmp_path / ".github"
+        gh.mkdir()
+        (gh / "hello_inner.py").write_text("x")  # inside a dot-dir: not descended
+        git = tmp_path / ".git"
+        git.mkdir()
+        (git / "hello_obj").write_text("g")
+        idx = FileIndex(str(tmp_path))
+        await idx.start()
+        try:
+            all_names = {e[1] for e in idx._entries}
+            assert ".github" in all_names  # the dir itself is a candidate
+            assert "hello_inner.py" not in all_names  # but we did not descend
+            assert ".git" not in all_names  # noise dot-dir stays excluded
+            assert "hello_obj" not in all_names
+        finally:
+            idx.stop()
+
+    @pytest.mark.asyncio
     async def test_search_returns_empty_for_no_match(self, tmp_path):
         _populate(tmp_path)
         idx = FileIndex(str(tmp_path))

--- a/test/test_file_search_dirs.py
+++ b/test/test_file_search_dirs.py
@@ -47,8 +47,10 @@ def _populate(tmp_path):
     (nested / "leaf.py").write_text("z")
     # An empty directory: proof dirs are walked, not derived from file paths.
     (tmp_path / "widgetsempty").mkdir()
-    # Excluded: dot-prefixed and skip-listed dirs
+    # A dot-prefixed dir is now OFFERED as a candidate (#5677), but its
+    # contents are still not descended into and skip-listed dirs stay excluded.
     (tmp_path / ".widgetshidden").mkdir()
+    (tmp_path / ".widgetshidden" / "widgetsburied.py").write_text("h")
     nm = tmp_path / "node_modules"
     nm.mkdir()
     (nm / "widgetsdep").mkdir()
@@ -112,13 +114,18 @@ class TestFileIndexDirs:
             idx.stop()
 
     @pytest.mark.asyncio
-    async def test_index_excludes_hidden_and_skip_dirs(self, tmp_path):
+    async def test_index_offers_dot_dirs_but_excludes_skip_dirs(self, tmp_path):
         _populate(tmp_path)
         idx = FileIndex(str(tmp_path))
         await idx.start()
         try:
             names = {r["name"] for r in idx.search("widgets", _scorer, 50, "dirs")}
-            assert ".widgetshidden" not in names
+            # #5677: a dot-prefixed dir is now a valid candidate...
+            assert ".widgetshidden" in names
+            # ...but its contents are still not descended into.
+            all_names = {e[1] for e in idx._entries}
+            assert "widgetsburied.py" not in all_names
+            # Skip-listed dirs and their contents stay excluded.
             assert "widgetsdep" not in names
             assert "node_modules" not in names
         finally:
@@ -228,14 +235,16 @@ class TestApiFileSearchDirs:
             assert kinds == {"dir", "file"}
 
     @pytest.mark.asyncio
-    async def test_walk_fallback_excludes_hidden_and_skip_dirs(self, tmp_path, mock_sel):
+    async def test_walk_fallback_offers_dot_dirs_but_excludes_skip_dirs(self, tmp_path, mock_sel):
         _populate(tmp_path)
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(
                 f"/api/file-search?q=widgets&kinds=dirs&project={tmp_path}"
             )
             names = {r["name"] for r in (await resp.json())["results"]}
-            assert ".widgetshidden" not in names
+            # #5677: dot-prefixed dir offered; skip-listed content excluded.
+            assert ".widgetshidden" in names
+            assert "widgetsburied.py" not in names  # dot-dir not descended
             assert "widgetsdep" not in names
 
     @pytest.mark.asyncio
@@ -380,3 +389,32 @@ class TestApiFileSearchDirs:
             f"walk descended {calls['n']} directories of {levels + 1} -- the "
             "dirs-visited ceiling did not stop the traversal"
         )
+
+    @pytest.mark.asyncio
+    async def test_dot_dirs_offered_via_walk_fallback(self, tmp_path, mock_sel):
+        """The filesystem-walk fallback offers dot-prefixed directories too.
+
+        #5677: the walk pruned ``dirnames`` for descent AND used the same pruned
+        list as the directory candidate set, so ``.github``/``.kiro`` were never
+        offered. They must now be reachable (dot typed or not) while ``.git`` and
+        other noise dirs stay excluded and dot-dir contents are not descended.
+        """
+        (tmp_path / ".github").mkdir()
+        gh_inner = tmp_path / ".github" / "widgets_inner.py"
+        gh_inner.write_text("x")  # inside a dot-dir: must not be descended
+        git = tmp_path / ".git"
+        git.mkdir()
+        (git / "widgets_obj").write_text("g")  # noise dot-dir: excluded
+
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"/api/file-search?q=.github&project={tmp_path}")
+            names_dotted = [r["name"] for r in (await resp.json())["results"]]
+            resp = await client.get(f"/api/file-search?q=github&project={tmp_path}")
+            names_plain = [r["name"] for r in (await resp.json())["results"]]
+
+        assert ".github" in names_dotted, "dot-dir not offered when the dot is typed"
+        assert ".github" in names_plain, "dot-dir not offered when the dot is omitted"
+        # .git stays excluded; dot-dir contents are not descended.
+        assert ".git" not in names_dotted and ".git" not in names_plain
+        assert "widgets_inner.py" not in names_dotted
+        assert "widgets_obj" not in names_dotted


### PR DESCRIPTION
## Summary

Dot-prefixed directories (`.github`, `.kiro`, `.claude`) never appeared in the `@`-mention file picker -- with the leading dot typed or omitted -- because both search paths pruned `dirnames` in place for two purposes at once:

1. telling `os.walk` not to *descend into* the directory (correct -- nobody wants a walk into `.git`/`node_modules`), and
2. as an unintended side effect of the same mutation, never *offering the directory itself* as a search candidate.

Because `dirnames` was pruned before the directory-collection loop ran, a dot-prefixed directory was never scored, so no query could ever find it.

## Fix

Decouple the two purposes. Build a separate directory-candidate list that keeps dot-prefixed dirs (minus build/VCS noise) while the in-place `dirnames` prune continues to control descent. Applied symmetrically to both search paths:

- `FileIndex._walk` (fast in-memory index path) in `file_index.py`
- `api_file_search`'s `_walk_file_search` (filesystem-walk fallback) in `handlers/files.py`

Noise dot-dirs (`.git`, `.venv`, `.cache`, `.hg`, `.tox`, ...) stay excluded from candidacy, dot-dir contents are still not descended into, and files keep their separate deliberate dot-exclusion.

## Tests

Red-before / green-after regressions on both paths asserting a dot-dir is offered (dot typed or omitted) while `.git`/skip-dirs and dot-dir contents stay excluded. Updated two existing tests that encoded the old dot-dir-excluded contract.

Fixes #5677
