### PR TITLE
test: await the cursor write instead of sleeping for it

### DIFF
--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -611,6 +611,30 @@ class TestReactionAllowList:
 # ---------------------------------------------------------------------------
 
 
+async def _drain_offset_writes(client: Any) -> None:
+    """Await the cursor writes ``_maybe_persist_offset`` fired.
+
+    That call is fire-and-forget: it creates a TRACKED task which hands the file
+    operation to a thread, so how long it takes belongs to the thread pool, not to
+    any duration a test can name. Waiting a fixed number of milliseconds for it is
+    the same bug in test form, and it surfaced on the Windows CI shards -- coarse
+    ~15.6ms timer granularity with four pytest shards competing on one runner -- as
+    the assertion's ``read_text`` landing BEFORE the write, i.e. FileNotFoundError
+    on the cursor file rather than a wrong value.
+
+    Draining the tracked set is exact and finishes the moment the write does. The
+    loop re-checks rather than gathering once because a task can be created from the
+    done-callback of the one being awaited; the ceiling is a backstop so a future
+    regression fails loudly instead of hanging the suite, never a timing assertion.
+    """
+
+    async def _drain() -> None:
+        while client._handler_tasks:
+            await asyncio.gather(*tuple(client._handler_tasks))
+
+    await asyncio.wait_for(_drain(), timeout=30)
+
+
 class TestOffsetDurability:
     """The persisted cursor is a LOW-water mark, not what the poll observed.
 
@@ -655,8 +679,7 @@ class TestOffsetDurability:
         client._offset = 10
         client._in_flight = {7, 9}
         client._resolve_updates((7,))
-        await asyncio.sleep(0)  # the write goes to a thread
-        await asyncio.sleep(0.05)
+        await _drain_offset_writes(client)
         assert (
             json.loads(path.read_text(encoding="utf-8"))["offset"] == 9
         ), "update 9 is still running, so a restart must resume AT it"
@@ -3280,7 +3303,10 @@ class TestCursorWriteOrdering:
             asyncio.to_thread(lambda: None),
             *[asyncio.create_task(_resolve_soon(client, uid)) for uid in (9, 7, 8)],
         )
-        await asyncio.sleep(0.1)
+        # The sleep inside `_resolve_soon` is what makes the writes overlap, which is
+        # this test's whole point; the WAIT for them to land is a completion signal,
+        # so it is drained rather than slept for.
+        await _drain_offset_writes(client)
         assert json.loads(path.read_text(encoding="utf-8"))["offset"] == 10
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`Backend Tests (Windows) (4)` fails intermittently on

```
FAILED test/test_telegram_parity.py::TestOffsetDurability::
  test_a_finished_turn_persists_and_a_crash_would_replay_the_rest
  - FileNotFoundError: [Errno 2] No such file or directory:
    'C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw1\
     test_a_finished_turn_persists_0\offset.json'
```

Observed on two unrelated PRs' current heads within the same hour — [#5651](https://github.com/kirodotdev/KiroCrew/pull/5651) (frontend-only, zero Python) and [#5661](https://github.com/kirodotdev/KiroCrew/pull/5661) (lifecycle hook timeouts) — while shards 1-3 stayed green on both and five other sampled PRs were fully green. So it is intermittent rather than a main break, and it belongs to neither diff.

The symptom is the tell: `FileNotFoundError`, not a wrong offset. The file was not there **yet**.

## Why it happens

`_maybe_persist_offset` is fire-and-forget — it creates a **tracked** task, and that task hands the file operation to a thread:

```python
self._track(asyncio.create_task(self._persist_offset()))
...
await asyncio.to_thread(self._save_offset, safe)
```

How long that takes is the thread pool's business, not a duration a test can name. Two tests waited a fixed amount for it anyway (`sleep(0) + sleep(0.05)`, and `sleep(0.1)`) and then read the file. The Windows shards are simply where a fixed budget runs out first: ~15.6 ms timer granularity, and four pytest shards competing for one runner's CPU and disk.

This is the "poll instead of sleeping" class in
`docs/system-specs/common/testing-conventions.md` § Determinism — and here the better form is available, because a completion signal already exists.

## Fix

Await the tracked tasks instead of a duration:

```python
async def _drain_offset_writes(client: Any) -> None:
    async def _drain() -> None:
        while client._handler_tasks:
            await asyncio.gather(*tuple(client._handler_tasks))

    await asyncio.wait_for(_drain(), timeout=30)
```

- Exact, and finishes the moment the write does — so it is also *faster* than the sleeps it replaces on a healthy runner.
- The loop re-checks rather than gathering once, because a task can be created from the done-callback of the one being awaited.
- The 30 s ceiling is a **backstop** so a future regression fails loudly instead of hanging the suite. It is not a timing assertion and nothing is asserted about it.

Applied at the two sites that read the cursor file after a write. The `sleep(0.05)` **inside** `_resolve_soon` is deliberately left alone: that one makes the two writes overlap, which is exactly what `test_two_advancing_writes_do_not_overlap` exercises — it is not a completion wait.

Production code is untouched.

## Tests

Falsification, three mutations, all caught:

| mutation | result |
|---|---|
| the new drain stubbed to a no-op | `test_a_finished_turn_persists_…` FAILS with the **exact CI symptom** — `FileNotFoundError` on the cursor file |
| production drops the monotonic `safe <= self._offset_saved` refusal | `test_a_lower_value_is_refused_rather_than_written` FAILS |
| production drops `async with self._offset_lock` | `test_the_lock_is_held_across_the_write` FAILS |

The first proves the change is load-bearing rather than inert, and reproduces the Windows failure locally. The second and third prove the tests still detect the real regressions they exist for — nothing was weakened, no assertion relaxed, no rerun added.

`test/test_telegram_parity.py`: **346 passed**. `isort`, `flake8`, `black --check` on the touched file and `mypy --platform linux src/kiro_crew` (1099 files) all clean.

**Disclosure:** I did not run the full 56 k-test backend suite locally — the change is one test file, and I ran that whole file plus the lint/type/format gates. CI's shards are the confirmation.

**Why no screenshot:** no user-visible surface changes — this is a single backend test file.
