### PR TITLE
test(approval): assert TOOL_DENY never yields an approvable card

### DIFF
--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -393,6 +393,68 @@ class TestApprovalModes:
         ), perm_activity
 
     @pytest.mark.asyncio
+    async def test_hook_deny_never_registers_approval_future(self, tmp_path):
+        """Non-bypass guard for the Tool-Approval Layer (Req 6.1-6.3).
+
+        The single-authority boundary rests on the runner's BRANCH ORDER: a
+        TOOL_DENY hits ``reject_tool`` + SEL audit and returns BEFORE the
+        interactive path that stores ``slot._approval_futures[request_id]`` and
+        renders an approvable card. If that order regressed so a denied call
+        reached the approval-future registration, the frontend could surface —
+        and a human/batch could resume — a call the gate denied.
+
+        Checking ``request_id not in slot._approval_futures`` AFTER the turn is
+        not enough: the runner's ``finally`` (``chat_runner.py`` ~7396) pops
+        every future at end-of-turn, so the interactive path also leaves it
+        absent — the residue is identical for allow and deny. So this test
+        instead OBSERVES THE REGISTRATION ITSELF by recording every key ever
+        assigned to ``_approval_futures`` during the turn. On a deny that key
+        must never appear; if the branch order regressed to register it, the
+        recorded-keys assertion fails fast and by name (not via a 120s parked-
+        future timeout).
+        """
+        request_id = "req-deny-guard"
+        cb = _context_builder(ToolHookResult.deny("blocked by policy"))
+        state, client = _make_state(tmp_path, context_builder=cb)
+        slot = _make_slot()
+
+        # Record every request id the runner ever REGISTERS as an approval
+        # future — observed at assignment time, so a deny that (wrongly) reached
+        # the interactive registration is caught even though the end-of-turn
+        # finally would later pop it.
+        registered_ids: list[str] = []
+
+        class _RecordingFutures(dict):  # type: ignore[type-arg]
+            def __setitem__(self, key, value):  # type: ignore[no-untyped-def]
+                registered_ids.append(key)
+                super().__setitem__(key, value)
+
+        slot._approval_futures = _RecordingFutures()  # type: ignore[assignment]
+
+        deny_event = LLMEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            title="fs_write",
+            tool_kind="edit",
+            request_id=request_id,
+        )
+        _set_stream(client, [deny_event, _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        # The bypass this guards: a denied call must NEVER be registered as a
+        # pending approval. If the runner registered a future for it, an
+        # operator (or a batch resume) could execute what the gate denied.
+        assert request_id not in registered_ids, (
+            "TOOL_DENY registered an approval future — a denied call became "
+            "approvable, defeating the single-authority boundary (Req 6.1). "
+            f"registered ids: {registered_ids!r}"
+        )
+        # And the deny took the terminal reject path, not the interactive one.
+        client.reject_tool.assert_called_once()
+        client.approve_tool.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_hook_auto_approve_skips_prompt(self, tmp_path):
         """Hook auto-approve must approve without interactive prompt."""
         cb = _context_builder(ToolHookResult.auto_approve())


### PR DESCRIPTION
## Problem
The Human-in-the-Loop Tool-Approval Layer adds render + resume + batch on top of the existing `HookManager.on_tool_call` enforcement gate. Its single most important safety invariant — a `TOOL_DENY` verdict is terminal and can never surface as an approvable card — is not pinned by any test. The invariant lives in the runner's branch order (`chat_runner.py`: the `TOOL_DENY` branch rejects + audits and returns BEFORE the interactive path that registers `slot._approval_futures[request_id]`). A refactor of that order could let a denied call reach the approval registration and become executable via a human/batch resume — a silent parallel-policy bypass (Req 6.1–6.3).

## Why it matters
`on_tool_call` is the sole policy authority. If a denied call could be registered as a pending approval, the frontend could execute what the backend denied. A test locks the invariant so the bypass can't be reintroduced unnoticed.

## Fix (symptoms → root cause → change)
- **Symptom:** no regression guard that a deny stays terminal at the runner.
- **Root cause:** the invariant is implicit in the runner's branch order and untested.
- **Change:** add one runner-level test, `test_hook_deny_never_registers_approval_future`, to `test/test_dashboard_approval.py` (where the `_run_chat` harness lives, alongside the existing `test_hook_deny_rejects`). It drives a `TOOL_DENY` permission event through `_run_chat` and **observes approval-future registration directly** — `slot._approval_futures` is swapped for a `dict` subclass that records every key assigned during the turn — then asserts the denied `request_id` was **never registered**, plus `reject_tool` fired and `approve_tool` did not.

Observing the registration (not the post-turn residue) is deliberate: the runner's end-of-turn `finally` pops every future, so `request_id not in slot._approval_futures` after the turn holds on the interactive path too — a residue check would be vacuous and a regression would surface only as a slow parked-future timeout. The recording dict makes a regressed deny fail fast, by name.

## Tests
`test/test_dashboard_approval.py::TestApprovalModes::test_hook_deny_never_registers_approval_future`. Verified locally: pytest green (6 `hook_deny` tests incl. the new one), flake8 + isort clean. (The file carries pre-existing mypy `method-assign` notes on unrelated lines, unchanged by this diff.)

## Manual verification
N/A — the test exercises the real runner path via `_run_chat`; unit coverage is the verification.
