### PR TITLE
fix(snapshot): complete the rollback set before the first replace swap (#2844)

### DIFF
--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -1122,8 +1122,10 @@ def _lock_down_restored(path: Path, component: str) -> None:
 def _backup_tree_or_refuse(src: Path, dst: Path, *, allow_unpinned: bool = False) -> None:
     """Back a live tree up, and refuse the replace if the backup is not complete.
 
-    Replace mode's next step is ``rmtree`` on the live tree, so a file the backup pass
-    SKIPPED is a file the restore is about to delete with no copy anywhere. The staging
+    Replace mode later runs ``rmtree`` on the live tree, so a file the backup pass
+    SKIPPED is a file the restore is about to delete with no copy anywhere -- and the
+    call site is deliberately hoisted ahead of every live mutation, so a refusal
+    arrives while nothing has been swapped yet (#2844). The staging
     walk legitimately skips a hardlink alias, a symlink and a non-regular file -- which
     is right when producing an archive and catastrophic here, because the skip is
     followed by a delete rather than by an omission.
@@ -1151,6 +1153,25 @@ def _do_replace(
     backup.mkdir(exist_ok=True)
     print("🔄 Replace mode — backing up current state...")
 
+    # The ENTIRE rollback set is completed before the first live mutation. A tree
+    # backup can refuse (its fatal skip reporter raises on an entry it cannot
+    # copy, e.g. a hardlink alias or a symlink), and refusing is only safe
+    # while nothing has been swapped yet: the previous ordering ran the core-file
+    # swap loop first, so a tree-backup refusal aborted with the new databases
+    # live and the old trees live -- mixed state, with a rollback set missing the
+    # very trees the abort was protecting. Same
+    # complete-validation-before-first-mutation ordering the unsafe-root check
+    # already follows, applied to the rollback copy (issue #2844, failure mode 3).
+    if _want(components, "workspace"):
+        for dirname in ("workspace", "plan_memory"):
+            d = mc / dirname
+            if d.is_dir():
+                _backup_tree_or_refuse(d, backup / dirname, allow_unpinned=allow_unpinned)
+    if _want(components, "skills"):
+        sk = mc / "skills"
+        if sk.is_dir():
+            _backup_tree_or_refuse(sk, backup / "skills", allow_unpinned=allow_unpinned)
+
     for comp in ("memory", "crons", "config", "notifications", "security"):
         if _want(components, comp):
             _backup_and_copy(mc, backup, snap, comp, allow_unpinned=allow_unpinned)
@@ -1159,8 +1180,6 @@ def _do_replace(
     if _want(components, "workspace"):
         for dirname in ("workspace", "plan_memory"):
             d = mc / dirname
-            if d.is_dir():
-                _backup_tree_or_refuse(d, backup / dirname, allow_unpinned=allow_unpinned)
             sd = snap / dirname
             if sd.is_dir():
                 if d.is_dir():
@@ -1183,8 +1202,6 @@ def _do_replace(
 
     if _want(components, "skills"):
         sk = mc / "skills"
-        if sk.is_dir():
-            _backup_tree_or_refuse(sk, backup / "skills", allow_unpinned=allow_unpinned)
         snap_sk = snap / "skills"
         if snap_sk.is_dir():
             if sk.is_dir():

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.snapshot import restore_main, snapshot_main
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -279,6 +280,45 @@ class TestRestoreReplace:
         ]
         assert backups
         assert (backups[0] / "workspace/local_only.md").is_file()
+
+    @requires_symlinks
+    def test_replace_swaps_nothing_when_a_tree_backup_refuses(self, env, monkeypatch):
+        """Ordering ratchet for issue #2844, failure mode 3.
+
+        The ENTIRE rollback set must exist before the first core-file swap. A
+        tree backup can refuse through its fatal skip reporter (a symlink in
+        the live tree is the injectable case), and that refusal must arrive
+        with every live core file untouched -- the old ordering swapped the
+        databases first, so the abort left mixed state (new databases, old
+        trees) behind an incomplete rollback set.
+        """
+        _, _, tarball, tmp_path = env
+        existing = tmp_path / "existing2844"
+        _setup_fake_kirocrew(existing)
+        # Make the live core files byte-distinguishable from the snapshot's, so
+        # "unchanged" below cannot pass by the two sides being identical.
+        conn = sqlite3.connect(str(existing / "memory.db"))
+        conn.execute(
+            "INSERT INTO semantic_memory"
+            " (key, value_json, confidence, source, created_at, updated_at)"
+            " VALUES ('local.only', '\"survivor\"', 0.9, 'test', '2026-01-02', '2026-01-02')"
+        )
+        conn.commit()
+        conn.close()
+        (existing / "crons.json").write_text('{"version": 2, "jobs": []}')
+        # A symlink inside the live workspace is an entry the pinned backup walk
+        # skips, and the backup pass reports skips through fatal_skip_reporter,
+        # which refuses the whole replace.
+        os.symlink(str(existing / "workspace/doc.md"), str(existing / "workspace/alias.md"))
+        before_db = (existing / "memory.db").read_bytes()
+        before_crons = (existing / "crons.json").read_bytes()
+        monkeypatch.setenv("KIROCREW_HOME", str(existing))
+
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+
+        assert ret == 1
+        assert (existing / "memory.db").read_bytes() == before_db
+        assert (existing / "crons.json").read_bytes() == before_crons
 
 
 class TestRestoreMerge:


### PR DESCRIPTION
## Summary

Replace-mode restore ran the core-file/database swap loop (`memory`, `crons`, `config`, `notifications`, `security`) **before** copying the live `workspace`, `plan_memory`, and `skills` trees into the rollback dir. A tree backup can refuse through its fatal skip reporter (unpinnable entry such as a hardlink alias or symlink), and under the old ordering that refusal aborted with the new databases already live and the old trees still live: mixed state, behind a rollback set missing the very trees the abort was protecting.

This PR hoists the `_backup_tree_or_refuse` calls for `workspace`, `plan_memory`, and `skills` ahead of the component swap loop in `_do_replace`, so the **entire rollback set exists before the first live mutation** — the same complete-validation-before-first-mutation ordering `_refuse_unsafe_destination_roots` already follows. The `rmtree` + `_copytree_safe` replace steps stay where they were, and `_backup_and_copy` still runs its own `_staging_is_pinned` gate.

## Scope (narrowed by design)

Refs #2844 — this resolves **failure mode 3 only**. Modes 1 and 2 are already fixed on main (presence-driven `_backup_and_copy`; `sel_hmac.key` in `NEVER_SNAPSHOT_FILES`; staging pre-creates all three tree dirs). The remaining items in the issue — making `MANIFEST.json` the authoritative component set, and the "should selective archives exist at all" product question — were routed to a human by maintainer triage and are deliberately **not** implemented here, so the issue stays open.

no linked issue closure: part of #2844 is parked for a human decision per the maintainer triage comment, so this PR uses Refs, not Closes.

## Test

Ordering ratchet test `test_replace_swaps_nothing_when_a_tree_backup_refuses`: injects a tree-backup refusal (symlink in the live workspace), asserts the replace exits 1 with `memory.db` and `crons.json` byte-identical to their pre-restore state. The live core files are seeded byte-distinct from the snapshot's, so "unchanged" cannot pass by the two sides being identical. Mutation-verified: with the reorder reverted the test fails; with it, passes. Guarded with `requires_symlinks` for Windows runners without symlink privilege.

Local gates: isort / flake8 / mypy clean, `test/test_snapshot.py` 63 passed.

## Pre-push review

Two model-pinned read-only lanes over the commit diff:
- GPT (gpt-5.6-sol): PASS, 1 Medium adopted — `requires_symlinks` guard on the new test.
- Opus (claude-opus-5): PASS, 0 blocking, 2 advisories adopted — refreshed the `_backup_tree_or_refuse` docstring so the hoisted call-site placement is recorded as deliberate, and dropped an imprecise "full disk" example from the ordering comment (ENOSPC is an OSError, not a classified skip).
