### PR TITLE
fix(taskrunner): remove the inline spec a rejected start leaves behind

### DIFF
--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -153,6 +153,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         spec_path = str(resolved)
 
     # Handle inline spec content
+    created_spec: Path | None = None
     if spec_path.startswith("__inline__:"):
         content = spec_path[len("__inline__:"):]
         if not content.strip():
@@ -162,6 +163,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         fpath = Path(work_dir) / fname
         fpath.parent.mkdir(parents=True, exist_ok=True)
         fpath.write_text(content, encoding="utf-8")
+        created_spec = fpath
         spec_path = str(fpath)
 
     try:
@@ -180,6 +182,19 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
             auto_approve=auto_approve,
         )
     except Exception as exc:
+        # The handler owns the temp file ONLY when it created it: a rejected
+        # start must not strand TASK_*.md orphans in the work dir, and an
+        # external spec the caller passed by path must never be deleted.
+        # Cleanup is best-effort — its failure must not replace the startup
+        # error the client is about to receive.
+        if created_spec is not None:
+            try:
+                created_spec.unlink(missing_ok=True)
+            except OSError:
+                logger.warning(
+                    "failed to remove inline spec %s after a rejected start",
+                    created_spec, exc_info=True,
+                )
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response({"ok": True, "spec": spec_path, "task_id": task_id})
 

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -534,3 +535,86 @@ class TestAutoApproveProvenanceGating:
         # (async) SEL write failure reaches this fail-closed handler rather than
         # being swallowed by the background writer after the gate has returned.
         assert boom.log_tool_invocation.call_args.kwargs["critical"] is True
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Inline spec ownership: a rejected start must not leak its temp file
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestInlineSpecCleanup:
+    """POST /api/taskrunner writes inline specs to work/TASK_<id>.md before
+    calling start_background; when the start path raises, the handler owns
+    that file and must remove it — while a caller-supplied external path is
+    never the handler's to delete."""
+
+    async def _start(self, tmp_path: Path, body: dict, raising: bool):
+        runner = MagicMock()
+        runner._work_dir = str(tmp_path)
+        if raising:
+            runner.start_background = AsyncMock(side_effect=RuntimeError("boom: rejected"))
+        else:
+            runner.start_background = AsyncMock(return_value="tid")
+        app = web.Application()
+        app["state"] = SimpleNamespace(task_runner=runner)
+        req = make_mocked_request("POST", "/api/taskrunner", app=app)
+        req["app"] = ""
+        req.json = AsyncMock(return_value=body)
+        return await api_taskrunner_start(req), runner
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_inline_start_leaves_no_task_file_behind(self, tmp_path: Path) -> None:
+        resp, _ = await self._start(
+            tmp_path,
+            {"spec": "__inline__:# rejected plan", "source": "dashboard"},
+            raising=True,
+        )
+        assert resp.status == 400
+        assert list(tmp_path.glob("TASK_*.md")) == []
+
+    @pytest.mark.asyncio
+    async def test_the_original_error_survives_even_if_cleanup_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A best-effort unlink that itself fails must not replace the startup
+        # error the client is about to receive.
+        calls = {"n": 0}
+
+        def _flaky(self: Path, missing_ok: bool = False) -> None:
+            calls["n"] += 1
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(Path, "unlink", _flaky, raising=False)
+        resp, _ = await self._start(
+            tmp_path,
+            {"spec": "__inline__:# rejected plan", "source": "dashboard"},
+            raising=True,
+        )
+        assert calls["n"] >= 1  # the cleanup was attempted
+        assert resp.status == 400
+        assert json.loads(resp.text)["error"].startswith("boom: rejected")
+
+    @pytest.mark.asyncio
+    async def test_an_external_spec_is_never_deleted_on_a_rejected_start(
+        self, tmp_path: Path
+    ) -> None:
+        external = tmp_path / "caller-owned.md"
+        external.write_text("# caller's own spec")
+        resp, _ = await self._start(
+            tmp_path,
+            {"spec": str(external), "source": "dashboard"},
+            raising=True,
+        )
+        assert resp.status == 400
+        assert external.exists(), "the handler deleted a caller-owned spec file"
+
+    @pytest.mark.asyncio
+    async def test_a_successful_inline_start_keeps_its_spec_file(self, tmp_path: Path) -> None:
+        resp, _ = await self._start(
+            tmp_path,
+            {"spec": "__inline__:# good plan", "source": "dashboard"},
+            raising=False,
+        )
+        assert resp.status == 200
+        payload = json.loads(resp.text)
+        assert Path(payload["spec"]).is_file()


### PR DESCRIPTION
﻿## Problem / Motivation

`POST /api/taskrunner` writes every inline spec to `work/TASK_<id>.md` **before** it calls `start_background`. If the start path raises, the handler returns HTTP 400 but never removes the file it just created — so repeated failed submissions accumulate orphan `TASK_*.md` files containing whatever content was rejected, indefinitely (fixes #5626).

## Why it matters

The work directory is the runner's operational home: orphaned specs accumulate forever, are indistinguishable from live run inputs by name, and carry whatever content was rejected. The failure is silent — a 400 says nothing about the file it left behind.

## What changed (motivation → approach → change)

The handler now tracks whether **it** created the spec (`created_spec`), and the existing exception path unlinks exactly that file before returning:

- best-effort by contract: an unlink failure is logged and the ORIGINAL startup error still reaches the client unchanged;
- an external spec passed by path is never tracked and therefore never deleted — the boundary the issue calls out explicitly;
- successful inline starts are untouched: same file, same path in the response.

No task execution, cancellation, persistence, or success-path behaviour changes — the issue's stated scope line, kept verbatim.

## Tests

New `TestInlineSpecCleanup` in `test/test_auto_approve.py`, reusing that file's established MagicMock-runner + `make_mocked_request` harness:

- a rejected inline start returns 400 and leaves **zero** `TASK_*.md` files in the work dir;
- cleanup failing itself does not replace the original error (response body still carries `boom: rejected`);
- an external caller-owned spec survives a rejected start;
- a successful inline start keeps its spec file and names it in the response.

All 22 pre-existing tests in the file pass unchanged.

## Manual verification

Windows 11 / Python 3.12: targeted suite green above; flake8 / isort / mypy clean on both touched files.

## Related Issues

Fixes #5626

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: ownership contract documented at the code site
- [x] No secrets, credentials, or internal references in the diff
