### PR TITLE
feat(mobile): product logo for the nav button, panel glyph for the sessions toggle

### DIFF
--- a/website/capture/topbar-search-variants.tsx
+++ b/website/capture/topbar-search-variants.tsx
@@ -31,7 +31,7 @@
  */
 import { useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
-import { Home, Search, Bell, Lightbulb, Bug, Layers, Coins, AudioWaveform, ChevronDown, Menu } from 'lucide-react'
+import { Home, Search, Bell, Lightbulb, Bug, Layers, Coins, AudioWaveform, ChevronDown } from 'lucide-react'
 
 import { initI18n } from '../src/i18n/all'
 import '../src/index.css'
@@ -201,7 +201,13 @@ function TopBarMobile() {
   return (
     <header className="topbar topbar-glass relative pl-3 pr-3" data-topbar style={{ height: 42 }}>
       <div className="tb-left relative h-full px-2">
-        <button className="p-2 rounded-md bg-transparent border-none text-muted shrink-0" aria-label="nav"><Menu size={20} /></button>
+        {/* The nav button, verbatim from App.tsx. `/logo.png` is a GATEWAY route, so
+            the harness serves nothing for it and the shot shows an empty rounded box:
+            the layout under test is the 24px box the classes fix, which `object-contain`
+            cannot change, so the missing bitmap costs the rungs nothing. */}
+        <button className="group p-2 rounded-md bg-transparent border-none text-muted shrink-0" aria-label="nav">
+          <img src="/logo.png" alt="" aria-hidden="true" className="w-6 h-6 rounded-md shrink-0 object-contain transition-transform duration-300 group-hover:rotate-[-8deg]" />
+        </button>
         <div className="instance-tab-bar-inline flex items-center h-full gap-1 min-w-0">
           <div className="flex items-center gap-1 min-w-0">
             <button

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -41,7 +41,7 @@ import type { KiroCreditUsage, KiroUsagePayload } from './api/client'
 import { safeSetItem } from './utils/safeStorage'
 import { gcOrphanedStorage } from './utils/storageGc'
 import { isMetricNumber, metricNumber } from './utils/metrics'
-import { Rocket, Menu, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, LayoutGrid, Fullscreen, SquareTerminal, Bot, Search as SearchIcon } from 'lucide-react'
+import { Rocket, Bell, Code, RefreshCw, Package, Loader2, Download, Hammer, XCircle, Check, AlertTriangle, CheckCircle, X, AudioWaveform, ChevronUp, MoreHorizontal, Coins, ArrowLeftToLine, LayoutGrid, Fullscreen, SquareTerminal, Bot, Search as SearchIcon } from 'lucide-react'
 import { GithubIcon, DiscordIcon } from './components/BrandIcon'
 import { Toggle } from './components/ui'
 import OnboardingFlow from './components/OnboardingFlow'
@@ -2372,20 +2372,26 @@ export default function App() {
           {!isMobile && isWinElectron && <WindowsTitlebarMenu />}
 
           {isMobile && (
-            <button className="p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text shrink-0" onClick={toggleNav} aria-label={i18nT('app.open_menu')}>
-              {/* `Menu` is the one icon in this app whose artwork does NOT fill its
-                  box: lucide draws its three rules from x=4 in a 24-unit viewBox, and
-                  the round cap adds half a stroke, so 3 units of the box are empty on
-                  the left. At size 20 that is 3 * 20/24 = 2.5px, which put the visible
-                  glyph at 18.5px while the button's box sat correctly on the 16px
-                  gutter -- reading as indented against a card border directly below it.
-                  A transform, not a margin: the box, the hit target and the hover pill
-                  stay on the 8px grid, and no sibling in the cluster shifts. Sized off
-                  the icon's own geometry, which `narrowFirstBaseline.test.ts` re-derives
-                  from lucide so a version bump that recentres `Menu` fails loudly.
-                  Icons that DO fill their box need none of this: the chat session
-                  toggle's `MessageSquare` starts at x=2, i.e. 0.67px at size 16. */}
-              <Menu size={20} className="-translate-x-[2.5px]" />
+            <button className="group p-2 rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text shrink-0" onClick={toggleNav} aria-label={i18nT('app.open_menu')}>
+              {/* The product logo, not a generic menu glyph. A narrow layout has exactly
+                  one nav affordance, and it opens the same rail whose header carries this
+                  same `avatar` on a wide one -- so it is the same asset, the same
+                  `rounded-md object-contain` treatment and the same hover tilt, which is
+                  live here because this bar is what a NARROW WINDOW gets, not only a
+                  touch device. Reading `avatar` rather than importing a file is what
+                  keeps a theme-supplied or user-configured logo in step: the branding
+                  registry resolves it once for the whole shell.
+
+                  A full-colour raster mark is an <img>, which is exactly what the
+                  `use-lucide-icons` rule's brand-mark exception prescribes -- a CSS mask
+                  over `currentColor` would flatten the art to one colour.
+
+                  Square box, so no optical correction exists: the art is square and
+                  `object-contain` fills the box, putting the ink on the 16px page gutter
+                  (topbar pl-2 + this button's p-2) that the page title and every card's
+                  left edge below it sit on, with the button's own box at 24 + 16 = 40px
+                  for the tap target. `narrowFirstBaseline.test.ts` re-derives that sum. */}
+              <img src={avatar} alt="" aria-hidden="true" className="w-6 h-6 rounded-md shrink-0 object-contain transition-transform duration-300 group-hover:rotate-[-8deg]" />
             </button>
           )}
           <InstanceTabBar variant="inline" />

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -188,7 +188,7 @@ import { focusComposerAfter, revealComposer } from './chat/composerFocus'
 import { useHoverIntent } from '../hooks/useHoverIntent'
 import { useKnowledgeFetch, extractKnowledgeQuery, expandKnowledgeBlock } from './chat/useKnowledgeFetch'
 import { KnowledgePicker } from './chat/KnowledgePicker'
-import { BookOpen, EyeOff, Loader, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, MessageSquareDot, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, Paperclip, Folder, X } from 'lucide-react'
+import { BookOpen, EyeOff, Loader, Pen, ChevronDown, ChevronRight, Plug, ArrowDown, MessageSquare, Sparkles, VenetianMask, Clock, Undo2, Columns2, ExternalLink, Paperclip, Folder, X } from 'lucide-react'
 import { PanelLeftSolid, PanelLeftLight, PanelRightSolid } from '../components/icons/panels'
 
 import InfoTip from '../components/InfoTip'
@@ -6731,7 +6731,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         {isMobile && !embedded && !sidebarOpen && !inlineSidePanelShowing && !(activeSlot && (messages.length > 0 || slotRunning)) && (
           <div className="fixed top-safe-offset-[42px] left-safe ml-2 z-10">
             <button className="p-2 rounded-lg text-muted hover:text-text bg-bg-elevated border border-border shadow-sm cursor-pointer" onClick={() => setMobileSessions(true)} aria-label={i18nT('pages.chatPage.toggle_sessions')}>
-              {effectiveMode === 'orchestrator' ? <MessageSquareDot size={18} /> : <MessageSquare size={18} />}
+              {/* Same glyph as the desktop toggle: a control is named by the SURFACE
+                  it opens, and this opens the sessions panel. Solid rather than
+                  `PanelLeftLight` because this form only renders while that panel is
+                  closed. It carries no conversation-mode variant -- mode belongs to
+                  the conversation, not to the drawer, and the header's own mode
+                  control already shows it. */}
+              <PanelLeftSolid size={18} />
             </button>
           </div>
         )}
@@ -6776,7 +6782,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 )}
                 {embedMode !== 'chat' && isMobile && (
                   <button className="p-1 rounded-md text-muted hover:text-text cursor-pointer bg-transparent border-none pointer-events-auto" onClick={() => setMobileSessions(p => !p)} aria-label={i18nT('pages.chatPage.toggle_sessions')}>
-                    {effectiveMode === 'orchestrator' ? <MessageSquareDot size={16} /> : <MessageSquare size={16} />}
+                    {/* Mirrors the desktop toggle exactly, state included: solid
+                        while the panel is hidden, light while it is showing. */}
+                    {mobileSessions ? <PanelLeftLight size={16} /> : <PanelLeftSolid size={16} />}
                   </button>
                 )}
                 <div className="group/header flex min-w-0 items-stretch gap-0.5 pointer-events-auto">

--- a/website/src/test/narrowFirstBaseline.test.ts
+++ b/website/src/test/narrowFirstBaseline.test.ts
@@ -194,7 +194,7 @@ describe('narrow-first layout baseline', () => {
 
   it('leaves the top bar left cluster without a redundant mobile inset', async () => {
     // `.tb-left`'s icon buttons carry their own 8px inside the header's inset, so a
-    // mobile-only `px-2` on the cluster stacked to push the hamburger out past the
+    // mobile-only `px-2` on the cluster stacks to push the nav button out past the
     // page's own left edge, which is what made it read as indented on every page.
     // The RIGHT cluster keeps its own padding/negative-margin pair, which exists to
     // stop the notification badge's 4px overhang being clipped.
@@ -203,13 +203,13 @@ describe('narrow-first layout baseline', () => {
     expect(cluster, 'App.tsx should render the tb-left cluster').toBeTruthy()
     expect(
       cluster![0],
-      'a mobile-only inset here stacks on the header and pushes the hamburger out',
+      'a mobile-only inset here stacks on the header and pushes the nav button out',
     ).not.toMatch(/isMobile[^\n]*px-/)
   })
 
   it('keeps the chat transcript on the same gutter as a page', async () => {
     // The doc's claim is that one vertical line runs through the whole app: the
-    // hamburger glyph, a page title, a page row, a card's left edge and the agent's
+    // nav glyph, a page title, a page row, a card's left edge and the agent's
     // own text. Chat is the surface the rest was lined up WITH, so its gutter and
     // `PageHeader`'s are one number -- asserted across the two files rather than as
     // two literals, because a drift here is invisible to every other check: both
@@ -279,54 +279,51 @@ describe('narrow-first layout baseline', () => {
   })
 
   it('lands the top bar glyphs on the page gutter, derived not hand-typed', async () => {
-    // The hamburger, the page title and every card's left edge read as one vertical
-    // line. That line is arithmetic across three files, and what has to land on it is
-    // the glyph's INK, not the button's box: `Menu` is the one icon here whose artwork
-    // does not fill its viewBox, so a box sitting correctly on the gutter still draws
-    // 2.5px right of it. Asserted as a SUM rather than as literals, because every part
-    // of this failure is silent -- moving any one number just makes the chrome look
-    // indented, which no overflow or scroll assertion can see.
-    //
-    // The icon's own inset is re-derived from lucide's shipped path data rather than
-    // hand-typed, so upgrading lucide to a `Menu` drawn on different coordinates fails
-    // here instead of quietly making the correction wrong.
+    // The narrow-layout nav button, the page title and every card's left edge read as
+    // one vertical line. That line is arithmetic across three files, and what has to
+    // land on it is the mark's INK, not just the button's box. Asserted as a SUM rather
+    // than as literals, because every part of this failure is silent -- moving any one
+    // number just makes the chrome look indented, which no overflow or scroll assertion
+    // can see.
     const app = await readFile(join(SRC, 'App.tsx'), 'utf8')
     const header = app.match(/topbar topbar-glass relative pl-(\d+(?:\.\d+)?) /)
     expect(header, 'App.tsx should give the topbar an explicit left inset').toBeTruthy()
-    const btn = app.match(/className="p-(\d+(?:\.\d+)?) rounded-md bg-transparent[^\n]*aria-label=\{i18nT\('app\.open_menu'\)\}/)
+    const btn = app.match(/className="group p-(\d+(?:\.\d+)?) rounded-md bg-transparent[^\n]*aria-label=\{i18nT\('app\.open_menu'\)\}/)
       ?? app.match(/p-(\d+(?:\.\d+)?) rounded-md bg-transparent border-none cursor-pointer text-muted hover:text-text shrink-0/)
-    expect(btn, 'the hamburger should carry its own padding').toBeTruthy()
+    expect(btn, 'the nav button should carry its own padding').toBeTruthy()
 
-    const glyph = app.match(/<Menu size=\{(\d+)\} className="-translate-x-\[(\d+(?:\.\d+)?)px\]" \/>/)
+    // The mark is the product logo, a SQUARE raster served from /logo.png, laid out
+    // with `object-contain`. `contain` only ever letterboxes a box whose ratio differs
+    // from the art's, so a square box is what makes the ink fill it and start at the
+    // box's own left edge -- i.e. what makes the sum below the whole story. A `w-5 h-6`
+    // slip would centre the art inside the taller box and inset the ink silently, so
+    // the two edges are pinned EQUAL rather than pinned to a literal.
+    const mark = app.match(/<img src=\{avatar\}[^\n]*className="w-(\d+(?:\.\d+)?) h-(\d+(?:\.\d+)?) rounded-md/)
+    expect(mark, 'the nav button should render the branding avatar as the mark').toBeTruthy()
     expect(
-      glyph,
-      'the hamburger glyph should declare its size and its optical correction together',
-    ).toBeTruthy()
-    const [, sizePx, correction] = glyph!
-
-    const menuIcon = await readFile(
-      join(SRC, '..', 'node_modules', 'lucide-react', 'dist', 'esm', 'icons', 'menu.js'),
-      'utf8',
-    )
-    const startXs = [...menuIcon.matchAll(/d: "M(\d+(?:\.\d+)?)/g)].map((m) => Number(m[1]))
-    expect(startXs.length, "lucide's menu icon should expose its path data").toBeGreaterThan(0)
-    // lucide's default stroke is 2 units with a round cap, so the ink reaches half a
-    // stroke beyond the geometry; the viewBox is 24 units wide at any rendered size.
-    const inkInsetPx = (Math.min(...startXs) - 1) * (Number(sizePx) / 24)
+      mark![1],
+      `the mark's box is w-${mark![1]} h-${mark![2]}: a non-square box letterboxes the `
+        + `square logo and insets its ink from the gutter`,
+    ).toBe(mark![2])
 
     const ui = await readFile(join(SRC, 'components', 'ui.tsx'), 'utf8')
     const gutter = ui.match(/px-(\d+(?:\.\d+)?) md:px-\d+(?:\.\d+)? pt-2 pb-3/)
     expect(gutter, 'PageHeader should carry a narrow-first gutter').toBeTruthy()
 
     const px = (rem: string) => Number(rem) * 4
-    const boxLeft = px(header![1]) + px(btn![1])
-    const inkLeft = boxLeft - Number(correction) + inkInsetPx
+    const inkLeft = px(header![1]) + px(btn![1])
     expect(
       inkLeft,
-      `topbar pl-${header![1]} + hamburger p-${btn![1]} puts the button box at ${boxLeft}px; `
-        + `less the ${correction}px correction plus Menu's own ${inkInsetPx}px of empty box, `
-        + `the GLYPH lands at ${inkLeft}px, but the page gutter is px-${gutter![1]} `
-        + `(${px(gutter![1])}px) -- the chrome would read as indented from the title`,
+      `topbar pl-${header![1]} + nav button p-${btn![1]} puts the mark's ink at `
+        + `${inkLeft}px, but the page gutter is px-${gutter![1]} (${px(gutter![1])}px) `
+        + `-- the chrome would read as indented from the title`,
     ).toBe(px(gutter![1]))
+    // The tap target is the mark's box plus that padding on both sides. Pinned as a
+    // FLOOR, not an equality: growing the mark for legibility is fine, shrinking the
+    // target below the 36px the rest of the chrome's icon buttons hold is not.
+    expect(
+      px(mark![1]) + 2 * px(btn![1]),
+      'the nav button should keep at least a 36px tap target',
+    ).toBeGreaterThanOrEqual(36)
   })
 })


### PR DESCRIPTION
## What

Two narrow-layout chrome glyphs name the wrong thing. This changes both.

**1. Top-bar nav button: hamburger → the product logo.** A phone-width layout gives the app exactly one nav affordance, and it opens the same nav rail whose header already carries the product logo on a wide window. The button now draws that logo — the same `avatar` the branding registry resolves for the shell, so a theme-supplied or user-configured logo stays in step, with the rail's own `rounded-md object-contain` treatment and hover tilt. That tilt is live rather than decorative: `useIsMobile` is a viewport-width check, so this bar is what a NARROW WINDOW gets, not only a touch device. A full-colour raster mark is an `<img>`, which is what the `use-lucide-icons` rule's brand-mark exception prescribes — a CSS mask over `currentColor` would flatten the art to one colour.

**2. Chat sessions toggle: `MessageSquare` → `PanelLeft`.** The desktop toggle for that panel already draws `PanelLeftSolid` / `PanelLeftLight`; both mobile forms drew a message glyph, so the control that opens the sessions panel looked unrelated to the control that opens the same panel one breakpoint up. The in-header form mirrors the desktop state flip too (solid while hidden, light while showing).

## Geometry

The mark's box is square, matching the art, so `object-contain` fills it and the ink starts at the box's own left edge: the 16px page gutter that the page title and every card's left edge below it sit on (topbar `pl-2` + the button's `p-2`). No optical correction exists here — the outgoing `Menu` glyph needed a hand-typed `-translate-x-[2.5px]` only because lucide draws its rules from x=4 of a 24-unit viewBox.

At `w-6` (24px) the mark reads as three ghosts rather than a smudge, and the button's box is 40px — above the 36px the rest of the chrome's icon buttons hold.

## Subtraction

The orchestrator-mode variant (`MessageSquareDot`) is dropped from both mobile toggles. Mode is a property of the conversation, not of the drawer, the desktop toggle never carried it, and the header's own mode-bearing control still shows it.

## Guard

`narrowFirstBaseline.test.ts` previously derived the optical correction from lucide's shipped `menu.js`. It now asserts the property that makes the gutter sum the whole story — that the mark's box is **square**, since `object-contain` silently letterboxes and re-centres the art inside any other ratio (a `w-5 h-6` slip would inset the ink with nothing else failing) — then that the sum lands on the gutter, and that the tap target stays at or above 36px. All three files that own that arithmetic are read, so a drift in any one fails here rather than just looking indented.

`capture/topbar-search-variants.tsx` reproduces the shipped nav button, so it is updated in step. `/logo.png` is a gateway route the harness has no server for; the note there records that the layout under test is the box the classes fix, which the missing bitmap cannot change.

## Evidence

**1. Top-bar nav button** — rendered at 390px through the existing top-bar capture harness (`capture/topbar-search-variants.html?form=mobile`), dark theme, DPR 3, with `/logo.png` fulfilled from the shipped nightly bitmap.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-mobile-brand-glyphs/before-topbar.png) | ![after](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-mobile-brand-glyphs/after-topbar.png) |

**2. Sessions toggles** — both mobile forms in every state they can render, with the desktop toggle they are being aligned WITH on the same frame for comparison. Same 390px / dark / DPR 3, real components and real stylesheet, class strings verbatim from `ChatPage.tsx`.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-mobile-brand-glyphs/before-sessions.png) | ![after](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-mobile-brand-glyphs/after-sessions.png) |

The bottom row is the unchanged desktop toggle. Before, neither mobile form resembles it and both render the same glyph whether the panel is showing or hidden; after, both match it and the in-header form carries the open/closed state in the pane's weight.

Measured in the same render: mark `24×24` with its ink at x=28 (= the harness's own `pl-3 px-2` cluster inset + `p-2`), button `40×40`, logo decoded at its native 512px.

## Checks

`tsc -b` clean · `eslint` 0 errors (warnings unchanged from the main baseline) · `narrowFirstBaseline` 8/8 · `KiroGhostMark` green · brand, harness-parity, focus-cue and i18n gates pass.

---

no linked issue: reported directly by the maintainer as narrow-layout chrome polish; there is no tracking issue for it.
