### PR TITLE
fix(mcp): strict identity for warm-pool sessions on unpooled servers

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -35,7 +35,7 @@
 1 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 2 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
 1 src/kiro_crew/cli.py
-6 src/kiro_crew/cli_doctor.py
+5 src/kiro_crew/cli_doctor.py
 1 src/kiro_crew/cli_perf.py
 2 src/kiro_crew/cli_setup.py
 1 src/kiro_crew/cloud/aws.py

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -919,6 +919,62 @@ def _doctor_trust_root() -> None:
     print("               restart the gateway if another process relocated it.")
 
 
+#: Builtin MCP servers that resolve STRICT session identity
+#: (``mcp_core._resolve_session_key_strict``) for state-mutating tools —
+#: session control, folders, the work ledger, monitor loops, cron origin,
+#: computer use. Kept in sync with the resolver's importers.
+_STRICT_IDENTITY_SERVERS = (
+    "kirocrew-core",
+    "kirocrew-dashboard",
+    "kirocrew-computer",
+    "kirocrew-cron",
+)
+
+
+def _doctor_strict_identity(cfg: KiroCrewConfig, issues: list[str]) -> None:
+    """Warn when strict session-identity tools have no working identity source.
+
+    On macOS/Windows every dashboard session is served by a warm-pool runtime
+    spawn, which by design carries neither ``KIROCREW_SESSION_KEY`` nor
+    ``KIROCREW_HOST_PID`` in the environment. A strict-identity server then
+    resolves the caller from exactly one of two places: gatewayd's per-call
+    caller injection (only for servers in ``mcp_gateway.stub_servers``) or
+    the signature-verified ancestor lookup (which needs a healthy signing
+    trust root). When a server is unpooled AND signing is broken, every
+    strict tool on it fails closed with "cannot verify which session is
+    calling" — silently, per call. This check turns that silence into one
+    doctor line.
+
+    Linux is skipped: the sandbox launcher exports ``KIROCREW_HOST_PID``
+    there, so the env source works regardless of pooling or signing.
+    """
+    if _plat.system() not in ("Darwin", "Windows"):
+        return
+    try:
+        pooled = set(cfg.mcp_gateway.stub_servers)
+    except Exception:
+        pooled = set()
+    unpooled = [s for s in _STRICT_IDENTITY_SERVERS if s not in pooled]
+    if not unpooled:
+        print("  strict identity: ✅ gateway caller injection (all identity servers routed)")
+        return
+    ok, _key_path = signing_health()
+    if ok:
+        print("  strict identity: ✅ signed-sidecar ancestor lookup covers unrouted servers")
+        return
+    names = ", ".join(unpooled)
+    print(f"  ⚠ strict identity: no working identity source for {names}.")
+    _print_wrapped(
+        "These servers are not in mcp_gateway.stub_servers (no gateway caller "
+        "injection) and the signing trust root is unhealthy (the verified "
+        "ancestor lookup fails closed), so session-control, folder, ledger, "
+        "monitor and cron tools will be refused with 'cannot verify which "
+        "session is calling'. Fix the trust root above, or route the servers "
+        "from MCP Management."
+    )
+    issues.append(f"strict identity: no identity source for {names}")
+
+
 _INDENT = "               "
 
 
@@ -2256,6 +2312,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     _doctor_data_home()
     _doctor_path_launcher()
     _doctor_trust_root()
+    _doctor_strict_identity(cfg, issues)
 
     # ── Agents dir janitor (orphaned atomic-write temps + stale backups) ──
     _doctor_agents_janitor(issues, cfg.agent.sweep_agents_backups)

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -616,11 +616,59 @@ def _resolve_session_key() -> str:
     return ""
 
 
-def _resolve_session_key_strict() -> str:
-    """Resolve the session key, refusing PID-walked and unsigned identities.
+# Maximum ancestor hops for the strict resolver's verified fallback
+# (:func:`_resolve_verified_ancestor_key`). The spawn topology places an MCP
+# server exactly two processes below the kiro-cli host pid the gateway keys
+# ``session_pid_<pid>.txt`` by (server -> kiro-cli worker -> kiro-cli host).
+# A parent slot's host always sits ABOVE the calling server's own host chain
+# — a subagent's MCP server has the subagent's own worker and host between
+# itself and anything of the parent's — so this bound, not the signature, is
+# what keeps a subagent from resolving its parent's identity: the parent's
+# sidecar is legitimately signed and would verify if the walk reached it.
+_STRICT_ANCESTOR_HOPS = 2
 
-    Like ``_resolve_session_key`` but drops the ``/proc`` ancestor walk.
-    Two identity sources are accepted:
+
+def _resolve_verified_ancestor_key() -> str:
+    """Bounded, signature-verified ancestor lookup (strict source 3).
+
+    Covers the topology none of the other strict sources reach: a warm-pool
+    runtime spawn (``acp/runtime.py`` injects neither ``KIROCREW_SESSION_KEY``
+    nor ``KIROCREW_HOST_PID`` — the pool pre-spawns before any session
+    exists) serving an UNPOOLED server (no gatewayd per-call caller). On
+    macOS/Windows that combination previously had no identity source at all,
+    so every strict tool failed closed even though the gateway had published
+    a valid signed mapping for the session's host pid at claim time
+    (``messaging/identity.py`` ``publish_turn_identity``).
+
+    Two rules distinguish this from the lenient resolver's open-ended walk:
+
+    * **Bounded to ``_STRICT_ANCESTOR_HOPS``** — the calling server's own
+      host is within the bound; a parent slot's host never is (see the
+      constant's comment for the topology argument).
+    * **Stops at the first pid that owns a mapping at all** — if the nearest
+      ``session_pid_<pid>.txt`` fails signature verification, fail closed
+      rather than skipping past it: hop-skipping would let a forged unsigned
+      file at the near hop redirect resolution toward a legitimately-signed
+      far hop that is not this process's host.
+    """
+    from kiro_crew.session_pid_sig import read_session_pid_txt, verify_session_pid
+
+    cfg = config_dir()
+    pid = os.getppid()
+    for _ in range(_STRICT_ANCESTOR_HOPS):
+        if pid <= 1:
+            return ""
+        if read_session_pid_txt(pid, cfg):
+            return verify_session_pid(str(pid))
+        pid = _get_ppid(pid)
+    return ""
+
+
+def _resolve_session_key_strict() -> str:
+    """Resolve the session key, refusing open-ended PID walks and unsigned identities.
+
+    Like ``_resolve_session_key`` but drops the open-ended ``/proc`` ancestor
+    walk. Two identity sources are accepted:
 
     1. The gateway-injected ``KIROCREW_SESSION_KEY`` env var.
     2. The direct ``KIROCREW_HOST_PID`` -> ``session_pid_<pid>.txt``
@@ -639,14 +687,24 @@ def _resolve_session_key_strict() -> str:
        in every sandboxed dashboard session even though the session is
        fully identified.
 
-    Returns ``""`` when only the ``/proc`` ancestor WALK would have
-    matched, or when the sidecar is missing/invalid. The walk stays
-    excluded: a subagent spawned via ``spawn_run`` lives under the
-    parent slot's process tree, so walking ancestors from its MCP-core
-    child silently resolves to the parent — which would let the
-    subagent mutate state on the wrong slot. Read-only callers (audit,
-    telemetry) keep the lenient resolver where misattribution is
-    harmless.
+    Returns ``""`` when only the OPEN-ENDED ``/proc`` ancestor WALK would
+    have matched, or when a sidecar is missing/invalid. The open-ended walk
+    stays excluded: a subagent spawned via ``spawn_run`` lives under the
+    parent slot's process tree, so walking ancestors without a bound from
+    its MCP-core child silently resolves to the parent — which would let
+    the subagent mutate state on the wrong slot. Read-only callers (audit,
+    telemetry) keep the lenient resolver where misattribution is harmless.
+
+    Source 3 (accepted LAST, only when the above are all absent): the
+    bounded, signature-verified ancestor lookup
+    (:func:`_resolve_verified_ancestor_key`). This is what gives the
+    warm-pool + unpooled-server topology (macOS/Windows, server not in
+    ``mcp_gateway.stub_servers``) an identity source at all — before it,
+    that combination failed closed on every strict tool despite the gateway
+    having published a valid signed mapping for the session. It is NOT the
+    excluded walk: it is hop-bounded so a parent slot's host is structurally
+    out of reach, and every accepted key must carry a verifying HMAC
+    sidecar.
 
     Source 0 (accepted BEFORE both of the above): the gateway-injected
     per-call caller context. In the pooled topology gatewayd strips any
@@ -671,6 +729,10 @@ def _resolve_session_key_strict() -> str:
             from kiro_crew.session_pid_sig import verify_session_pid
 
             return verify_session_pid(host_pid)
+    except Exception:
+        pass
+    try:
+        return _resolve_verified_ancestor_key()
     except Exception:
         pass
     return ""

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -302,6 +302,69 @@ class TestTrustRoot:
         assert "⚠" not in out
 
 
+class TestStrictIdentity:
+    """Doctor names the live strict-identity source, or the missing one.
+
+    The failure this surfaces is otherwise silent-per-call: a warm-pool
+    session (macOS/Windows) calling a strict tool on an unpooled server with
+    a broken trust root gets 'cannot verify which session is calling' with
+    no hint at the topology cause.
+    """
+
+    class _Cfg:
+        class _GW:
+            def __init__(self, stubs):
+                self.stub_servers = stubs
+
+        def __init__(self, stubs):
+            self.mcp_gateway = self._GW(stubs)
+
+    def test_skipped_on_linux(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Linux")
+        issues: list = []
+        cli_doctor._doctor_strict_identity(self._Cfg([]), issues)
+        assert capsys.readouterr().out == ""
+        assert issues == []
+
+    def test_all_identity_servers_routed_is_healthy(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Darwin")
+        issues: list = []
+        cli_doctor._doctor_strict_identity(
+            self._Cfg(list(cli_doctor._STRICT_IDENTITY_SERVERS)), issues
+        )
+        out = capsys.readouterr().out
+        assert "strict identity: ✅" in out and "caller injection" in out
+        assert issues == []
+
+    def test_unrouted_with_healthy_signing_is_covered_by_fallback(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Darwin")
+        monkeypatch.setattr(
+            cli_doctor, "signing_health", lambda: (True, tmp_path / "sel_hmac.key")
+        )
+        issues: list = []
+        cli_doctor._doctor_strict_identity(self._Cfg([]), issues)
+        out = capsys.readouterr().out
+        assert "strict identity: ✅" in out and "ancestor lookup" in out
+        assert issues == []
+
+    def test_unrouted_and_broken_signing_warns_and_names_servers(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Darwin")
+        monkeypatch.setattr(
+            cli_doctor, "signing_health", lambda: (False, tmp_path / "sel_hmac.key")
+        )
+        issues: list = []
+        cli_doctor._doctor_strict_identity(self._Cfg(["aws-mcp"]), issues)
+        out = capsys.readouterr().out
+        assert "⚠ strict identity" in out
+        assert "kirocrew-core" in out and "kirocrew-dashboard" in out
+        assert "cannot verify which session is calling" in out
+        assert len(issues) == 1
+
+
 class TestSwapTotalProbe:
     """``SwapTotal`` parsed from /proc/meminfo → KiB, or None when unreadable."""
 

--- a/test/test_mcp_core_set_project.py
+++ b/test/test_mcp_core_set_project.py
@@ -53,12 +53,15 @@ class TestResolveSessionKeyStrict:
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:slot-B")
         assert mcp_core._resolve_session_key_strict() == "dashboard:slot-B"
 
-    def test_returns_empty_when_only_pid_walk_would_match(self, monkeypatch):
-        """Lenient resolver would walk /proc and find a session_pid_*.txt;
-        strict returns "" so the caller can refuse."""
+    def test_returns_empty_when_only_pid_walk_would_match(self, monkeypatch, tmp_path):
+        """Lenient resolver would walk /proc open-endedly and find a
+        session_pid_*.txt; strict returns "" when no VERIFIED mapping exists
+        within the bounded ancestor hops (config dir isolated to an empty
+        tmp_path so the host machine's real mappings cannot leak in)."""
         monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
         monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
-        assert mcp_core._resolve_session_key_strict() == ""
+        with patch.object(mcp_core, "config_dir", return_value=tmp_path):
+            assert mcp_core._resolve_session_key_strict() == ""
 
     def test_env_var_wins_over_host_pid(self, monkeypatch, tmp_path):
         """When both identities are present the env var is authoritative."""
@@ -183,6 +186,83 @@ class TestResolveSessionKeyStrict:
             session_pid_sig, "verify_session_pid", side_effect=OSError("boom")
         ):
             assert mcp_core._resolve_session_key_strict() == ""
+
+
+# ─────────────────────── verified ancestor lookup (source 3) ────────────────
+
+
+class TestVerifiedAncestorLookup:
+    """Strict source 3: bounded, signature-verified ancestor lookup.
+
+    Covers the warm-pool + unpooled-server topology (macOS/Windows) where
+    neither env source exists and no gateway caller is injected. The contract
+    under test: a VERIFIED mapping within ``_STRICT_ANCESTOR_HOPS`` resolves;
+    anything else — beyond the bound, unsigned, or absent — fails closed.
+    """
+
+    def _publish(self, tmp_path, pid: int, session_key: str) -> None:
+        from kiro_crew import session_pid_sig
+
+        (tmp_path / "sel_hmac.key").write_bytes(b"k" * 32)
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ):
+            session_pid_sig.publish_session_pid(pid, session_key)
+
+    def _strict(self, tmp_path) -> str:
+        from kiro_crew import session_pid_sig
+
+        with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+             patch.object(
+                 session_pid_sig,
+                 "sel_hmac_key_path",
+                 return_value=tmp_path / "sel_hmac.key",
+             ), patch.object(mcp_core, "config_dir", return_value=tmp_path):
+            return mcp_core._resolve_session_key_strict()
+
+    def _chain(self, monkeypatch, *pids: int) -> None:
+        """Fake the process tree: getppid() -> pids[0] -> pids[1] -> ..."""
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+        monkeypatch.setattr(os, "getppid", lambda: pids[0])
+        links = {pids[i]: pids[i + 1] for i in range(len(pids) - 1)}
+        monkeypatch.setattr(mcp_core, "_get_ppid", lambda p: links.get(p, 0))
+
+    def test_verified_parent_mapping_accepted(self, monkeypatch, tmp_path):
+        """Hop 1: the direct parent owns a signed mapping — accepted."""
+        self._chain(monkeypatch, 7001, 7002)
+        self._publish(tmp_path, 7001, "dashboard:warm-slot")
+        assert self._strict(tmp_path) == "dashboard:warm-slot"
+
+    def test_verified_grandparent_mapping_accepted(self, monkeypatch, tmp_path):
+        """Hop 2 (the measured topology: server -> worker -> host) — accepted."""
+        self._chain(monkeypatch, 7001, 7002, 7003)
+        self._publish(tmp_path, 7002, "dashboard:warm-slot-2")
+        assert self._strict(tmp_path) == "dashboard:warm-slot-2"
+
+    def test_mapping_beyond_hop_bound_refused(self, monkeypatch, tmp_path):
+        """Hop 3 is where a parent slot's host could live — never reached."""
+        self._chain(monkeypatch, 7001, 7002, 7003, 7004)
+        self._publish(tmp_path, 7003, "dashboard:parent-slot")
+        assert self._strict(tmp_path) == ""
+
+    def test_unsigned_near_mapping_blocks_hop_skip(self, monkeypatch, tmp_path):
+        """A forged unsigned .txt at hop 1 must fail closed, NOT be skipped
+        in favour of a legitimately-signed mapping at hop 2 — hop-skipping
+        would let a same-uid forger steer resolution."""
+        self._chain(monkeypatch, 7001, 7002, 7003)
+        self._publish(tmp_path, 7002, "dashboard:legit-slot")
+        # Forge: bare .txt with no sidecar at the NEAR hop.
+        (tmp_path / "session_pid_7001.txt").write_text("dashboard:forged-slot")
+        assert self._strict(tmp_path) == ""
+
+    def test_no_mappings_anywhere_returns_empty(self, monkeypatch, tmp_path):
+        self._chain(monkeypatch, 7001, 7002, 7003)
+        (tmp_path / "sel_hmac.key").write_bytes(b"k" * 32)
+        assert self._strict(tmp_path) == ""
 
 
 # ───────────────────────────── set_project tool ─────────────────────────────


### PR DESCRIPTION
## Problem

On macOS/Windows, every dashboard session is served by a warm-pool runtime spawn (`acp/runtime.py`), which by design carries neither `KIROCREW_SESSION_KEY` nor `KIROCREW_HOST_PID` in the environment — the pool pre-spawns kiro-cli before any session exists, and env is fixed at process birth. For an MCP server that is **not** in `mcp_gateway.stub_servers` (the default: the list is empty), there is also no gatewayd per-call caller injection. That leaves `_resolve_session_key_strict()` with **zero identity sources**, so every strict tool — `session_create` / `session_stop` / `session_send`, `chat_folder_*`, `session_ledger_*`, `monitor_start` / `monitor_update` / `autonudge_stop`, `set_project`, cron origin resolution, computer use — fails closed with "cannot verify which session is calling", silently, per call.

The resolver's own docstring acknowledges the warm-pool env gap and points at source 0 (gateway caller injection) as the cover — but source 0 only exists for pooled servers, and pooling is a user-opted, per-server topology decision (`loader.py`: "Empty by default … an empty list means no broker runs at all"). The two mechanisms are each correct in isolation; their composition leaves the default install with no identity path.

## Why it matters

The strict resolver has 33 call sites across 10 modules (session control from #2435, the work ledger from #5198, monitor loops, folders, cron, computer use). On a default-config macOS/Windows install, **all of it is dead**. Diagnosed live: a freshly built session got four tool groups refused; the failure reproduced from a plain main-agent session on the same build, confirming it is topology-wide, not agent-specific.

## Fix

Symptoms → root cause → change:

- **Symptom**: strict tools return "cannot verify which session is calling" on warm-pool sessions whenever the serving MCP server is unpooled.
- **Root cause**: the strict resolver accepts three sources (gateway per-call caller / `KIROCREW_SESSION_KEY` env / `KIROCREW_HOST_PID` + HMAC sidecar) and the warm-pool + unpooled combination provides none of them — even though the gateway **has already published** a valid, HMAC-signed `session_pid_<host-pid>.txt` mapping at claim time (`messaging/identity.py::publish_turn_identity`, signed via `session_pid_sig.publish_session_pid`).
- **Change 1 — source 3, `_resolve_verified_ancestor_key()` (`mcp_core.py`)**: a **bounded, signature-verified** ancestor lookup, consulted only after sources 0–2 all miss. Two rules distinguish it from the open-ended `/proc` walk the strict resolver was created to exclude:
  - **Hop bound (`_STRICT_ANCESTOR_HOPS = 2`)**: the measured spawn topology places an MCP server exactly two processes below the host pid the gateway keys the sidecar by (server → kiro-cli worker → kiro-cli host). A parent slot's host always sits *above* the calling server's own worker+host chain, so it is structurally outside the bound. The bound — not the signature — is what preserves the original walk-exclusion guarantee (a subagent must not resolve its parent's identity: the parent's sidecar is legitimately signed and *would* verify if reached).
  - **Stop at the first pid owning a mapping**: if the nearest `session_pid_<pid>.txt` fails signature verification, fail closed rather than continue — hop-skipping would let a forged unsigned file at the near hop steer resolution toward a legitimately-signed far hop.

  Every accepted key must carry a verifying HMAC sidecar (`verify_session_pid`, keyed off the agent-unreadable SEL trust root with domain separation) — unsigned and forged mappings stay refused exactly as before.
- **Change 2 — doctor check (`cli_doctor.py::_doctor_strict_identity`)**: turns the residual silent-failure case into one visible line. On macOS/Windows it names the live identity source (gateway caller injection when all identity-hosting servers are routed; the verified ancestor lookup otherwise) and warns — naming the affected servers and the exact refusal string — when servers are unpooled **and** the signing trust root is unhealthy (the one combination that still has no source after this fix). Skipped on Linux, where the sandbox launcher exports `KIROCREW_HOST_PID` and the env source works regardless of pooling.

Not changed: the open-ended ancestor walk stays excluded from the strict resolver; the lenient resolver, sidecar publication, and pooling semantics are untouched; source precedence (0 → 1 → 2 → 3) means pooled topologies behave exactly as today.
- **Ratchet housekeeping**: `.github/subprocess-encoding-baseline.txt` entry for `cli_doctor.py` lowered 6 -> 5 — the diff-scoped `check_subprocess_encoding.py` gate fires only when a PR touches the file, and it mandates pruning a shrunk entry (`--update-baseline`, which only ever lowers). This change adds zero subprocess calls; the entry was stale from an earlier count reduction.


## Tests

- `test_mcp_core_set_project.py::TestVerifiedAncestorLookup` (new, 5 tests): verified mapping at hop 1 accepted; at hop 2 (the measured topology) accepted; at hop 3 (where a parent slot's host could live) refused; a forged unsigned `.txt` at the near hop fails closed and is **not** skipped in favour of a legitimately-signed far hop; no mappings → `""`. Process tree faked via `os.getppid` / `_get_ppid` monkeypatching; mappings published through the real `publish_session_pid` signer against an isolated config dir.
- `test_mcp_core_set_project.py::test_returns_empty_when_only_pid_walk_would_match` updated: now hermetic (config dir isolated to `tmp_path`) so the host machine's real sidecars cannot leak into the assertion, and re-scoped to the new contract (no *verified* mapping within the bound → `""`).
- `test_cli_doctor.py::TestStrictIdentity` (new, 4 tests): skipped on Linux; healthy line when all identity servers are routed; healthy line when unrouted but signing is healthy (fallback covers); warning naming servers + refusal string when unrouted and signing is broken.
- Full affected suites green: `test_mcp_core_set_project.py`, `test_cli_doctor.py`, `test_identity_topology.py`, `test_session_pid_sig.py`, `test_mcp_pool_identity_computer_dashboard.py`, `test_mcp_computer.py`, `test_session_ledger.py`, `test_autonudge_stop_auth.py`, `test_mcp_dashboard_folders.py` — 559 passed, 5 xfailed. isort/flake8 clean.

## Manual verification

Live end-to-end probe on a real macOS warm-pool install (default `stub_servers`, i.e. the broken topology): a probe process `exec`'d so its ancestor chain matches a real MCP server's (probe → kiro-cli worker → kiro-cli host), with both env identity vars stripped. Before this change `_resolve_session_key_strict()` returned `""`; with it, the bounded lookup walked 2 hops to the live host pid, verified the real gateway-published HMAC sidecar, and resolved the session's actual key (`dashboard:chat-238-…`). Topology measurement (`ps -eo pid,ppid`) confirmed the server → worker → host = 2 hops shape the bound encodes.

