### PR TITLE
fix: harden gateway restart and local gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,6 +433,7 @@ Kiro Crew runs on macOS, Linux (x86_64 and ARM), and Windows (native). `fcntl`,
 | Process start time (PID-reuse guard) | `process_start_time(pid)` | `/proc/<pid>/stat` / `ps -o lstart=` (both answer `None` on Windows, so the guard silently never confirms) |
 | Signals | `platform_compat.SIGKILL` / `SIGTERM` | `signal.SIGKILL` (undefined on Windows) |
 | Spawn isolation | `start_new_session=IS_POSIX` + `creationflags=CREATE_NEW_PROCESS_GROUP` | bare `start_new_session=True` |
+| Re-exec the current Python module | `reexec_python_module(module, args)` | `os.execv(sys.executable, [sys.executable, ...])` (breaks when the Windows interpreter path contains spaces) |
 | Race-free Job object assignment | `creationflags \|= CREATE_SUSPENDED`, then `apply_job_limits`, then `resume_process_main_thread` | assigning a job to an already-running child (descendants it already spawned escape) |
 | Fork-bomb / memory ceiling on a spawned tree | `sandbox.apply_windows_resource_ceiling(pid)` after the spawn, alongside `cgroup_scope_argv` | `cgroup_scope_argv` alone (a no-op on Windows, so no ceiling at all) |
 | File mode | `chmod_safe(path, mode)` / `fchmod_safe(fd, mode)` | `os.chmod` / `os.fchmod` (no `os.fchmod` on Windows) |

--- a/scripts/local-gate.py
+++ b/scripts/local-gate.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import argparse
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -60,6 +61,7 @@ _SELECTOR = _REPO_ROOT / "scripts" / "ci-surface-tests.py"
 # pins this against the workflow file so drift fails a test instead of shipping.
 _FRONTEND_PREFIXES = ("website/",)
 _META_PREFIXES = (".github/", "scripts/")
+_NODE_LAUNCHERS = frozenset({"npm", "npx"})
 
 
 def classify(paths: list[str]) -> tuple[bool, bool, bool]:
@@ -159,6 +161,23 @@ def _frontend_full(plan: Plan) -> None:
     plan.add("frontend (full)", ["npm", "test"], _REPO_ROOT / "website")
 
 
+def _resolve_command(cmd: list[str]) -> list[str]:
+    """Resolve Node's platform launcher before passing argv to subprocess.
+
+    npm installs ``npm.cmd`` / ``npx.cmd`` on Windows.  ``subprocess.run`` with
+    ``shell=False`` does not apply the shell's PATHEXT lookup, so a bare
+    ``"npx"`` raises ``FileNotFoundError`` even though the same command works
+    at an interactive prompt.  ``shutil.which`` performs the portable lookup
+    and still preserves list argv / no-shell execution.
+    """
+    if not cmd or cmd[0] not in _NODE_LAUNCHERS:
+        return cmd
+    launcher = shutil.which(cmd[0])
+    if launcher is None:
+        raise FileNotFoundError(f"required launcher {cmd[0]!r} was not found on PATH")
+    return [launcher, *cmd[1:]]
+
+
 def build_plan(args: argparse.Namespace) -> Plan:
     if args.full:
         plan = Plan("--full requested")
@@ -250,7 +269,11 @@ def main(argv: list[str] | None = None) -> int:
 
     for label, cmd, cwd in plan.commands:
         print(f"local-gate: running [{label}]", file=sys.stderr)
-        proc = subprocess.run(cmd, cwd=cwd)
+        try:
+            proc = subprocess.run(_resolve_command(cmd), cwd=cwd)
+        except OSError as exc:
+            print(f"local-gate: [{label}] FAILED to start: {exc}", file=sys.stderr)
+            return 127
         if proc.returncode != 0:
             print(f"local-gate: [{label}] FAILED (rc={proc.returncode})", file=sys.stderr)
             return proc.returncode

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_discovery.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_discovery.py
@@ -257,6 +257,9 @@ class TestPinnedRepoReadIsGuarded(unittest.TestCase):
         anywhere the gateway can read, under the shape the sidebar trusts.
         """
         outside = self.root.parent / "elsewhere.json"
+        # Register first: on Windows the symlink attempt below commonly skips,
+        # and unittest does not resume at the final unlink after skipTest().
+        self.addCleanup(outside.unlink, missing_ok=True)
         outside.write_text(json.dumps({"repos": [
             {"owner": "evil", "repo": "payload"}]}), encoding="utf-8")
         path = discovery.repos_path(self.root)

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_store.py
@@ -14,6 +14,7 @@ import sqlite3
 import tempfile
 import threading
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
@@ -176,7 +177,9 @@ class TestVectorStaleness(PreferenceStoreTestCase):
         with _no_embedder():
             store.update(entry_id, text="budget under $400")
 
-        with sqlite3.connect(str(self.db)) as conn:
+        # sqlite's context manager commits/rolls back but does NOT close the
+        # handle.  Close explicitly so Windows can remove the WAL directory.
+        with closing(sqlite3.connect(str(self.db))) as conn:
             text, blob = conn.execute(
                 "SELECT text, embedding FROM preferences WHERE id = ?", (entry_id,)
             ).fetchone()
@@ -191,7 +194,7 @@ class TestVectorStaleness(PreferenceStoreTestCase):
         with _with_embedder(_FakeEmbedder({"prefers minimalist style": [0.0, 1.0]})):
             self.assertEqual(store.reembed_all(), 1)
 
-        with sqlite3.connect(str(self.db)) as conn:
+        with closing(sqlite3.connect(str(self.db))) as conn:
             (blob,) = conn.execute("SELECT embedding FROM preferences").fetchone()
         self.assertIsNotNone(blob)
 

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -64,6 +64,7 @@ from kiro_crew.platform.update_layout import detect_install_layout
 from kiro_crew.platform.update_layout import release_channel as _release_channel
 from kiro_crew.platform.update_layout import set_release_channel, wheel_update_command
 from kiro_crew.platform.update_provider import CommandProvider, resolve_provider
+from kiro_crew.platform_compat import reexec_python_module
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -1189,7 +1190,7 @@ async def _restart_gateway(state: DashboardState) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     await asyncio.sleep(0.5)
-    os.execv(exe, [exe, "-m", "kiro_crew"] + sys.argv[1:])
+    reexec_python_module("kiro_crew", sys.argv[1:])
 
 
 async def api_update_apply(request: web.Request) -> web.Response:

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Generator
 
+from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.paths import config_dir
 from kiro_crew.deploy import engine
 from kiro_crew.platform_compat import file_lock
@@ -129,7 +130,7 @@ def locked_registry() -> Generator[dict[str, Any], None, None]:
                 tmp_fd.flush()
                 os.fsync(tmp_fd.fileno())
                 tmp_fd.close()
-                os.replace(tmp_fd.name, str(_registry_path()))
+                replace_with_retry(tmp_fd.name, _registry_path())
             except BaseException:
                 tmp_fd.close()
                 try:
@@ -210,7 +211,7 @@ def save_registry(reg: dict[str, Any]) -> dict[str, Any]:
                 tmp_fd.flush()
                 os.fsync(tmp_fd.fileno())
                 tmp_fd.close()
-                os.replace(tmp_fd.name, str(_registry_path()))
+                replace_with_retry(tmp_fd.name, _registry_path())
             except BaseException:
                 tmp_fd.close()
                 try:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -15,6 +15,7 @@ import errno
 import functools
 import io
 import logging
+import ntpath
 import os
 import shutil
 import signal
@@ -38,6 +39,21 @@ IS_WINDOWS: bool = sys.platform == "win32"
 IS_POSIX: bool = not IS_WINDOWS
 IS_LINUX: bool = sys.platform == "linux"
 IS_MACOS: bool = sys.platform == "darwin"
+
+
+def reexec_python_module(module: str, args: Sequence[str]) -> None:
+    """Replace this process with ``sys.executable -m module``.
+
+    Windows reconstructs an ``execv`` command line from ``argv`` and reparses
+    it in the child.  A full ``argv[0]`` containing spaces is split before the
+    module flag, so Python treats the path suffix as a script name.  The
+    executable path passed separately to ``execv`` still selects the exact
+    interpreter; only its display name needs to be space-free.
+    """
+    executable = sys.executable
+    argv0 = ntpath.basename(executable) if IS_WINDOWS else executable
+    os.execv(executable, [argv0, "-m", module, *args])
+
 
 # Python's os.rename() replaces an existing empty directory on POSIX. Directory
 # publication sometimes needs the stronger create-if-absent contract, which the

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -56,14 +56,13 @@ from __future__ import annotations
 import os
 import plistlib
 import re
-import shlex
 import shutil
 import subprocess
 import time
 from pathlib import Path
 
 from kiro_crew.pod.config import PodConfig, environment_vars
-from kiro_crew.pod.unit import _kirocrew_bin
+from kiro_crew.pod.unit import _kirocrew_argv as _shared_kirocrew_argv
 
 # Reverse-DNS label namespace. One label per pod; the name has already been
 # through runtime.validate_name (single safe segment, no '/', no '..'), which is
@@ -166,13 +165,8 @@ def log_paths(cfg: PodConfig, name: str) -> tuple[Path, Path]:
 
 
 def _kirocrew_argv() -> list[str]:
-    """``ProgramArguments`` needs a real argv, not systemd's command string.
-
-    ``unit._kirocrew_bin()`` may return ``"<python> -m kiro_crew"`` (two words)
-    when no console script is installed, so it is split rather than used as a
-    single path.
-    """
-    return shlex.split(_kirocrew_bin())
+    """Return the shared entry-point prefix in launchd's list form."""
+    return list(_shared_kirocrew_argv())
 
 
 def render_plist(cfg: PodConfig, name: str) -> dict[str, object]:

--- a/src/kiro_crew/pod/unit.py
+++ b/src/kiro_crew/pod/unit.py
@@ -18,11 +18,13 @@ by a pod that went away without a ``down``.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import sys
 from pathlib import Path
 
 from kiro_crew.pod.config import PodConfig, environment_vars
+from kiro_crew.service.common import systemd_quote
 
 _UNIT_TEMPLATE = """\
 [Unit]
@@ -62,9 +64,8 @@ WantedBy=default.target
 """
 
 
-def _kirocrew_bin() -> str:
-    """Absolute path (or module invocation) to the kirocrew entry-point the unit
-    should boot.
+def _kirocrew_argv() -> tuple[str, ...]:
+    """Argv prefix that re-enters the kirocrew entry point the unit should boot.
 
     Resolution order:
       1. ``KIROCREW_POD_BIN`` — explicit override (used when installing a unit that
@@ -74,11 +75,11 @@ def _kirocrew_bin() -> str:
     """
     override = os.environ.get("KIROCREW_POD_BIN")
     if override:
-        return override
+        return (override,)
     found = shutil.which("kirocrew")
     if found:
-        return found
-    return f"{sys.executable} -m kiro_crew"
+        return (found,)
+    return (sys.executable, "-m", "kiro_crew")
 
 
 def _environment_block(cfg: PodConfig) -> str:
@@ -88,12 +89,15 @@ def _environment_block(cfg: PodConfig) -> str:
     launchd backend pins the identical plane; this function only serialises it in
     systemd's syntax. Returns "" when everything is at defaults.
     """
-    return "".join(f"Environment={key}={val}\n" for key, val in environment_vars(cfg).items())
+    return "".join(
+        f"Environment={systemd_quote(f'{key}={val}')}\n"
+        for key, val in environment_vars(cfg).items()
+    )
 
 
 def render_unit(cfg: PodConfig) -> str:
     return _UNIT_TEMPLATE.format(
-        kirocrew_bin=_kirocrew_bin(),
+        kirocrew_bin=" ".join(systemd_quote(arg) for arg in _kirocrew_argv()),
         unit_prefix=cfg.unit_prefix,
         environment=_environment_block(cfg),
     )
@@ -129,7 +133,15 @@ def unit_exec_ok(cfg: PodConfig) -> bool:
         return False
     for line in text.splitlines():
         if line.startswith("ExecStart="):
-            exe = line[len("ExecStart="):].split()[0]
+            try:
+                argv = shlex.split(line[len("ExecStart="):], posix=True)
+            except ValueError:
+                return False
+            if not argv:
+                return False
+            # ``systemd_quote`` doubles percent signs to suppress specifier
+            # expansion; recover the literal executable path before probing it.
+            exe = argv[0].replace("%%", "%")
             return os.access(exe, os.X_OK) if os.path.isabs(exe) else True
     return False
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -7011,6 +7011,12 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
     # the line prompts. The taint pass already denies that shape, so this widens
     # nothing in practice.
     seen_bases: list[str] = []
+    # Classifying a base resolves symlinks and sensitive-home roots. A chained
+    # parameter expansion revisits the same bases many times, so repeating that
+    # filesystem work made this synchronous gate exceed its latency ceiling
+    # under normal test load. The filesystem cannot change while this one
+    # command is being inspected; keep the classification only for this call.
+    base_sensitivity: dict[str, bool] = {}
     # The directories `cd -` goes back to.
     prev_bases: list[str] = []
     # Saved (base_dirs, prev_bases, assignments) per open subshell.
@@ -7221,7 +7227,7 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
             if not raw_targets:
                 # A bare `cd` goes to the home directory.
                 base_dirs = [os.path.expanduser("~")]
-                _remember_bases(seen_bases, base_dirs)
+                _remember_bases(seen_bases, base_dirs, base_sensitivity)
                 continue
             # A Windows home anchor becomes `~` BEFORE anything else looks at the
             # token: the hypothesis below reads `$env:USERPROFILE` as the variable
@@ -7267,7 +7273,7 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
             base_dirs = next_bases
             if len(base_dirs) > _MAX_TRACKED_BASES:
                 del base_dirs[: len(base_dirs) - _MAX_TRACKED_BASES]
-            _remember_bases(seen_bases, next_bases)
+            _remember_bases(seen_bases, next_bases, base_sensitivity)
             continue
 
         # No read-verb requirement: the operands of this segment are checked
@@ -7316,7 +7322,9 @@ def _check_sensitive_via_normalizer(command: str) -> str | None:
     return _check_sensitive_cd_taint(command)
 
 
-def _remember_bases(seen: list[str], bases: list[str]) -> None:
+def _remember_bases(
+    seen: list[str], bases: list[str], sensitivity: dict[str, bool]
+) -> None:
     """Add *bases* to the never-pruned *seen* list, keeping order and uniqueness.
 
     Bounded so a long chain of `cd`s cannot grow it without limit; the cap is far
@@ -7331,11 +7339,10 @@ def _remember_bases(seen: list[str], bases: list[str]) -> None:
         # Never evict sensitive bases -- an attacker could flood with dummy cd
         # targets to push a real sensitive base out of the tracked set.
         excess = len(seen) - _MAX_TRACKED_BASES
-        evictable = [
-            i
-            for i, b in enumerate(seen)
-            if not is_sensitive_path(b) and not _dir_holds_sensitive_leaf(b)
-        ]
+        for base in seen:
+            if base not in sensitivity:
+                sensitivity[base] = is_sensitive_path(base) or _dir_holds_sensitive_leaf(base)
+        evictable = [i for i, base in enumerate(seen) if not sensitivity[base]]
         to_remove = set(evictable[:excess])
         seen[:] = [b for i, b in enumerate(seen) if i not in to_remove]
 

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -24,6 +24,26 @@ LAUNCHD_LABEL = "dev.kirocrew.gateway"  # launchd Label
 _AUTH_ENV_VAR = "KIRO_API_KEY"
 
 
+def systemd_quote(value: str) -> str:
+    """Double-quote a value for a systemd unit token.
+
+    systemd splits unquoted ``ExecStart`` / ``Environment=`` tokens on
+    whitespace, so paths and environment values containing spaces must be
+    quoted.  Percent signs are doubled because systemd performs specifier
+    expansion even inside quotes, and backslashes / quotes use C-style escapes.
+
+    Control characters are rejected rather than escaped: a newline would end
+    the physical value and let the remainder be parsed as fresh unit directives.
+    """
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        raise ValueError(
+            "refusing to render a systemd unit value containing a control "
+            "character (possible unit-file injection): " + repr(value)
+        )
+    escaped = value.replace("%", "%%").replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def launchd_live_program() -> "os.PathLike[str]":
     """Stable path the launchd agent's ``ProgramArguments[0]`` points at.
 

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -34,6 +34,7 @@ from kiro_crew.service.common import (
     kirocrew_bin,
     service_environment,
 )
+from kiro_crew.service.common import systemd_quote as _sd_quote
 
 log = logging.getLogger(__name__)
 
@@ -65,46 +66,6 @@ _ENV_FILE_TEMPLATE = """\
 # default 5476, or when 5476 is already taken):
 #KIROCREW_PORT=5477
 """
-
-
-def _sd_quote(value: str) -> str:
-    """Double-quote a value for a systemd unit token.
-
-    systemd splits unquoted ``ExecStart`` / ``Environment=`` tokens on
-    whitespace, so any path or locale containing a space (a spaced
-    ``KIROCREW_SERVICE_BIN`` / ``KIROCREW_KIRO_BIN`` override, ``PATH`` entries
-    with spaces, etc.) must be wrapped in double quotes. Inside a double-quoted
-    token systemd honours C-style escapes, so ``\\`` and ``"`` are
-    backslash-escaped.
-
-    ``%`` is escaped to ``%%`` *first* (before quoting): systemd performs
-    specifier expansion on ``ExecStart`` / ``Environment=`` values regardless of
-    quoting — an unescaped ``%h`` / ``%i`` in a path (e.g. a directory literally
-    named ``100%``) would be replaced with the home dir / instance name and the
-    exec would target the wrong path. See systemd.unit(5) "Specifiers",
-    systemd.service(5) "Command lines", and systemd.exec(5) ``Environment=``.
-
-    A control character — most dangerously a newline — is rejected outright
-    (``ValueError``) rather than escaped. A double-quoted systemd token does not
-    span physical lines, so a newline in an operator override
-    (``KIROCREW_SERVICE_BIN`` / ``KIROCREW_KIRO_BIN``) would terminate the value
-    and let the remainder be parsed as fresh unit directives — e.g. injecting
-    ``User=root`` + a replacement ``ExecStart`` into the root-owned unit that
-    ``sudo … service install`` writes (a privilege-escalation vector). No
-    legitimate executable path or locale contains a C0/DEL control character, so
-    refusing them is strictly safer than trying to escape them.
-    """
-    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
-        raise ValueError(
-            "refusing to render a systemd unit value containing a control "
-            "character (possible unit-file injection): " + repr(value)
-        )
-    escaped = (
-        value.replace("%", "%%")
-        .replace("\\", "\\\\")
-        .replace('"', '\\"')
-    )
-    return f'"{escaped}"'
 
 
 def _current_user() -> str:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -8389,7 +8389,7 @@ class GatewayOrchestrator:
                 )
         if self.sessions:
             await self.sessions.close_all()
-        os.execv(sys.executable, [sys.executable, "-m", "kiro_crew"] + sys.argv[1:])
+        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
 
     async def _check_for_updates_legacy(self) -> None:
         """Legacy update check — the existing layout-aware logic."""
@@ -8876,7 +8876,7 @@ class GatewayOrchestrator:
             # Use -m kiro_crew rather than sys.argv[0] so the restart resolves
             # the freshly reinstalled entry point regardless of how the
             # original process was launched.
-            os.execv(sys.executable, [sys.executable, "-m", "kiro_crew"] + sys.argv[1:])
+            platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
         except Exception:
             logger.warning("Auto-update failed", exc_info=True)
             if self.dashboard_state:
@@ -9095,7 +9095,7 @@ class GatewayOrchestrator:
         if self.sessions:
             await self.sessions.close_all()
         # Restart into the freshly-installed version.
-        os.execv(sys.executable, [sys.executable, "-m", "kiro_crew"] + sys.argv[1:])
+        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
 
     # ------------------------------------------------------------------
     # Main run loop

--- a/src/kiro_crew/task_reporter.py
+++ b/src/kiro_crew/task_reporter.py
@@ -105,7 +105,12 @@ async def notify(
 
 
 def save_progress(run: Project) -> None:
-    """Write TASK_PROGRESS.md next to the spec file."""
+    """Write TASK_PROGRESS.md next to the spec file, when the run has one."""
+    if not run.spec_path:
+        # Ad-hoc plans have no spec directory.  Treating Path("").parent as a
+        # destination leaks TASK_PROGRESS.md into the gateway's current working
+        # directory (and into the repository during tests).
+        return
     spec_dir = Path(run.spec_path).parent
     progress_path = spec_dir / PROGRESS_FILE
     try:

--- a/test/test_deploy_profiles_cov80.py
+++ b/test/test_deploy_profiles_cov80.py
@@ -132,7 +132,7 @@ class TestAtomicWrites:
         def _boom(*_a, **_k):
             raise OSError("replace failed")
 
-        monkeypatch.setattr(profiles_mod.os, "replace", _boom)
+        monkeypatch.setattr(profiles_mod, "replace_with_retry", _boom)
         with pytest.raises(OSError, match="replace failed"):
             with profiles_mod.locked_registry() as reg:
                 reg["default"] = "doomed"
@@ -147,7 +147,7 @@ class TestAtomicWrites:
         def _unlink_boom(*_a, **_k):
             raise OSError("unlink failed")
 
-        monkeypatch.setattr(profiles_mod.os, "replace", _replace_boom)
+        monkeypatch.setattr(profiles_mod, "replace_with_retry", _replace_boom)
         monkeypatch.setattr(profiles_mod.os, "unlink", _unlink_boom)
         with pytest.raises(OSError, match="replace failed"):
             with profiles_mod.locked_registry() as reg:
@@ -159,7 +159,7 @@ class TestAtomicWrites:
         def _boom(*_a, **_k):
             raise OSError("replace failed")
 
-        monkeypatch.setattr(profiles_mod.os, "replace", _boom)
+        monkeypatch.setattr(profiles_mod, "replace_with_retry", _boom)
         with pytest.raises(OSError, match="replace failed"):
             profiles_mod.save_registry({"version": 2, "profiles": [], "default": ""})
         assert list(tmp_path.glob("*.json.tmp")) == []
@@ -173,7 +173,7 @@ class TestAtomicWrites:
         def _unlink_boom(*_a, **_k):
             raise OSError("unlink failed")
 
-        monkeypatch.setattr(profiles_mod.os, "replace", _replace_boom)
+        monkeypatch.setattr(profiles_mod, "replace_with_retry", _replace_boom)
         monkeypatch.setattr(profiles_mod.os, "unlink", _unlink_boom)
         with pytest.raises(OSError, match="replace failed"):
             profiles_mod.save_registry({"version": 2, "profiles": [], "default": ""})

--- a/test/test_local_gate.py
+++ b/test/test_local_gate.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -263,6 +264,45 @@ def test_backend_only_diff_with_no_guards_runs_backend_alone(gate, monkeypatch) 
     monkeypatch.setattr(gate, "selector_must_run", lambda surface: [])
     plan = gate.build_plan(_args())
     assert _plan_labels(plan) == ["backend (full)"]
+
+
+# ---------------------------------------------------------------------------
+# execution: Node's Windows launchers are .cmd shims
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", ["npm", "npx"])
+def test_node_command_resolves_platform_launcher(gate, monkeypatch, name: str) -> None:
+    launcher = rf"C:\Program Files\nodejs\{name}.CMD"
+    monkeypatch.setattr(gate.shutil, "which", lambda candidate: launcher)
+
+    assert gate._resolve_command([name, "vitest", "run"]) == [
+        launcher,
+        "vitest",
+        "run",
+    ]
+
+
+def test_non_node_command_is_unchanged(gate) -> None:
+    cmd = [gate.sys.executable, "-m", "pytest"]
+    assert gate._resolve_command(cmd) is cmd
+
+
+def test_missing_node_launcher_fails_cleanly(gate, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(gate, "build_plan", lambda _args: gate.Plan("test plan"))
+    plan = gate.build_plan(None)
+    plan.add("frontend", ["npx", "vitest", "run"], gate._REPO_ROOT / "website")
+    monkeypatch.setattr(gate, "build_plan", lambda _args: plan)
+    monkeypatch.setattr(gate.shutil, "which", lambda _candidate: None)
+    monkeypatch.setattr(
+        gate.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0),
+    )
+
+    assert gate.main([]) == 127
+    err = capsys.readouterr().err
+    assert "FAILED to start" in err
+    assert "not found on PATH" in err
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -60,6 +60,38 @@ class TestPlatformFlags:
         assert isinstance(pc.SIGTERM, int) and pc.SIGTERM > 0
 
 
+class TestReexecPythonModule:
+    def test_windows_uses_space_free_argv0(self, monkeypatch):
+        executable = (
+            r"C:\Users\alice\AppData\Local\Programs\KiroCrew Nightly"
+            r"\resources\backend-dist\kirocrew-backend\python.exe"
+        )
+        calls = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "executable", executable)
+        monkeypatch.setattr(pc.os, "execv", lambda path, argv: calls.append((path, argv)))
+
+        pc.reexec_python_module("kiro_crew", ["gateway", "--port", "5476"])
+
+        assert calls == [
+            (
+                executable,
+                ["python.exe", "-m", "kiro_crew", "gateway", "--port", "5476"],
+            )
+        ]
+
+    def test_posix_preserves_full_argv0(self, monkeypatch):
+        executable = "/opt/Kiro Crew/bin/python3"
+        calls = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc.sys, "executable", executable)
+        monkeypatch.setattr(pc.os, "execv", lambda path, argv: calls.append((path, argv)))
+
+        pc.reexec_python_module("kiro_crew", ["gateway"])
+
+        assert calls == [(executable, [executable, "-m", "kiro_crew", "gateway"])]
+
+
 class TestFileLock:
     def test_exclusive_lock_round_trips(self, tmp_path):
         # The lock must acquire + release cleanly and run the body, on whatever

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -304,8 +304,16 @@ class TestUnitRendering:
         monkeypatch.setenv("KIROCREW_POD_ROOT", "/tmp/hermetic-pods")
         monkeypatch.setenv("KIROCREW_POD_REPO", "/tmp/some-repo")
         txt = unit_mod.render_unit(PodConfig.load())
-        assert "Environment=KIROCREW_POD_ROOT=/tmp/hermetic-pods" in txt
-        assert "Environment=KIROCREW_POD_REPO=/tmp/some-repo" in txt
+        assert 'Environment="KIROCREW_POD_ROOT=/tmp/hermetic-pods"' in txt
+        assert 'Environment="KIROCREW_POD_REPO=/tmp/some-repo"' in txt
+
+    def test_env_block_quotes_spaces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", "/tmp/pod root")
+        cfg = PodConfig.load()
+        txt = unit_mod.render_unit(cfg)
+        root_line = next(line for line in txt.splitlines() if "KIROCREW_POD_ROOT=" in line)
+        assert root_line.startswith('Environment="')
+        assert "pod root" in root_line
 
     def test_unit_path_uses_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("KIROCREW_POD_UNIT_PREFIX", "kirocrew-podtest")
@@ -905,7 +913,7 @@ class TestLinuxTeardownOrdering:
         unit_file = tmp_path / "pod@.service"
         unit_file.write_text("[Service]\nExecStart=/x\nExecStopPost=/y pod _cleanup %i\n")
         monkeypatch.setattr(rt.unit_mod, "unit_path", lambda c: unit_file)
-        monkeypatch.setattr(rt.unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        monkeypatch.setattr(rt.unit_mod, "_kirocrew_argv", lambda: (sys.executable,))
         issued: list[str] = []
 
         def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
@@ -1127,7 +1135,7 @@ class TestTheUnitFileNeverOutlivesAFailedLoad:
     def _plane(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         unit_file = tmp_path / "pod@.service"
         monkeypatch.setattr(rt.unit_mod, "unit_path", lambda c: unit_file)
-        monkeypatch.setattr(rt.unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        monkeypatch.setattr(rt.unit_mod, "_kirocrew_argv", lambda: (sys.executable,))
         monkeypatch.setattr(rt, "require_backend", lambda: None)
         return unit_file
 
@@ -2483,7 +2491,7 @@ class TestUnitExecSelfHeal:
         cfg = self._cfg_with_unit(
             tmp_path,
             monkeypatch,
-            f"ExecStart={tmp_path}/gone/.venv/bin/kirocrew pod _run %i",
+            f"ExecStart={(tmp_path / 'gone/.venv/bin/kirocrew').as_posix()} pod _run %i",
         )
         assert unit_mod.unit_exec_ok(cfg) is False
 
@@ -2493,7 +2501,7 @@ class TestUnitExecSelfHeal:
         exe = tmp_path / "kirocrew"
         exe.write_text("#!/bin/sh\n")
         exe.chmod(0o755)
-        cfg = self._cfg_with_unit(tmp_path, monkeypatch, f"ExecStart={exe} pod _run %i")
+        cfg = self._cfg_with_unit(tmp_path, monkeypatch, f"ExecStart={exe.as_posix()} pod _run %i")
         assert unit_mod.unit_exec_ok(cfg) is True
 
     def test_missing_unit_file_detected(self, tmp_path, monkeypatch):
@@ -2513,7 +2521,7 @@ class TestUnitExecSelfHeal:
         exe = tmp_path / "kirocrew"
         exe.write_text("#!/bin/sh\n")
         exe.chmod(0o755)
-        cfg = self._cfg_with_unit(tmp_path, monkeypatch, f"ExecStart={exe} pod _run %i")
+        cfg = self._cfg_with_unit(tmp_path, monkeypatch, f"ExecStart={exe.as_posix()} pod _run %i")
         unit_path = tmp_path / "pod@.service"
         assert unit_mod.unit_is_current(cfg) is True  # what this build renders
         unit_path.write_text(unit_path.read_text() + f"ExecStopPost={exe} pod _cleanup %i\n")
@@ -2527,9 +2535,28 @@ class TestUnitExecSelfHeal:
         monkeypatch.setattr(unit_mod, "unit_path", lambda c: tmp_path / "pod@.service")
         # An executable that exists on every platform the suite runs on — a POSIX
         # path here made unit_exec_ok report "stale" on Windows.
-        monkeypatch.setattr(unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        monkeypatch.setattr(unit_mod, "_kirocrew_argv", lambda: (sys.executable,))
         unit_mod.install_unit(cfg)
         assert unit_mod.unit_is_current(cfg) is True
+
+    def test_spaced_executable_is_quoted_and_current(self, cfg, monkeypatch, tmp_path):
+        from kiro_crew.pod import unit as unit_mod
+
+        exe = tmp_path / "venv with spaces" / "kirocrew"
+        exe.parent.mkdir()
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(0o755)
+        monkeypatch.setattr(unit_mod, "unit_path", lambda c: tmp_path / "pod@.service")
+        monkeypatch.setattr(unit_mod, "_kirocrew_argv", lambda: (str(exe),))
+        rendered = unit_mod.install_unit(cfg).read_text()
+        assert 'ExecStart="' in rendered
+        assert unit_mod.unit_is_current(cfg) is True
+
+    def test_malformed_execstart_is_stale(self, tmp_path, monkeypatch):
+        from kiro_crew.pod import unit as unit_mod
+
+        cfg = self._cfg_with_unit(tmp_path, monkeypatch, 'ExecStart="unterminated')
+        assert unit_mod.unit_exec_ok(cfg) is False
 
     def test_start_pod_reinstalls_a_stale_unit_before_booting_it(self, cfg, monkeypatch):
         steps: list[str] = []

--- a/test/test_publish_providers.py
+++ b/test/test_publish_providers.py
@@ -284,7 +284,7 @@ async def test_core_deploy_provider_configured_when_profiles_exist(tmp_path, mon
 # --- concurrent registry write safety (item 5) --------------------------------
 
 def test_save_registry_concurrent_no_lost_updates(tmp_path, monkeypatch):
-    """Threaded concurrent save_registry calls must not lose updates."""
+    """Threaded registry mutations must not lose updates."""
     import threading
 
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
@@ -297,9 +297,8 @@ def test_save_registry_concurrent_no_lost_updates(tmp_path, monkeypatch):
     def writer(i: int) -> None:
         try:
             barrier.wait(timeout=5)
-            reg = profiles_mod.load_registry()
-            reg["profiles"].append(profiles_mod.make_entry(f"p{i}", "us-west-2"))
-            profiles_mod.save_registry(reg)
+            with profiles_mod.locked_registry() as reg:
+                reg["profiles"].append(profiles_mod.make_entry(f"p{i}", "us-west-2"))
         except Exception as e:
             errors.append(str(e))
 
@@ -310,16 +309,10 @@ def test_save_registry_concurrent_no_lost_updates(tmp_path, monkeypatch):
         t.join(timeout=10)
 
     assert not errors, f"threads raised: {errors}"
-    # With locking, final registry must have at least the last writer's entry
-    # (concurrent load-modify-write without locking could lose some). The lock
-    # guarantees NO lost updates — each write serializes, so the final file
-    # has exactly as many entries as the last writer saw + 1. But because each
-    # writer loads independently (not chaining), total entries may be <n_threads
-    # unless the test chains reads. What we CAN assert: the file is valid JSON
-    # and at least 1 profile exists (not corrupted/empty).
     final = profiles_mod.load_registry()
-    assert len(final["profiles"]) >= 1
-    # More importantly: no file corruption.
+    assert {entry["name"] for entry in final["profiles"]} == {
+        f"p{i}" for i in range(n_threads)
+    }
     raw = profiles_mod._registry_path().read_text(encoding="utf-8")
     parsed = json.loads(raw)
     assert "profiles" in parsed

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -930,6 +930,15 @@ class TestSaveProgress:
         assert "boom" in content
         assert "(attempts: 2)" in content
 
+    def test_save_progress_without_spec_does_not_write_to_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        runner = TaskRunner(sessions=_make_mock_sessions(), auto_test=False)
+        run = TaskRun(spec_path="", spec_content="ad-hoc", started_at=1000.0)
+        runner._save_progress(run)
+        assert not (tmp_path / PROGRESS_FILE).exists()
+
 
 # ── 12.1a: Checkpoint Resume ──
 

--- a/website/src/test/DiffBlock.test.tsx
+++ b/website/src/test/DiffBlock.test.tsx
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import DiffBlock, { extractFilePath } from '../components/DiffBlock'
+
+// These assertions exercise controls rendered by the lazy Pierre implementation,
+// not the Suspense fallback. Warm that chunk once so a saturated full-suite worker
+// cannot make Testing Library's default query timeout race module loading.
+beforeAll(() => import('../pierre/PierreImpl'))
 
 beforeEach(() => {
   globalThis.fetch = vi.fn(() => Promise.resolve({ ok: true })) as unknown as typeof fetch

--- a/website/src/test/safeArea.guard.test.ts
+++ b/website/src/test/safeArea.guard.test.ts
@@ -23,6 +23,10 @@ import { join, relative } from 'node:path'
 const WEBSITE_ROOT = join(__dirname, '..', '..')
 const SRC = join(WEBSITE_ROOT, 'src')
 
+/** Stable repository-relative path for allowlists and diagnostics. `relative()`
+ *  uses the host separator, while the checked-in allowlists use POSIX paths. */
+const repoRelative = (file: string) => relative(WEBSITE_ROOT, file).replaceAll('\\', '/')
+
 /** Physical edges plus the two axis shorthands, mapped to the safe utility
  *  that satisfies each. `inset-{x,y}-*` are included deliberately: they pin two
  *  edges at once and are just as capable of hugging a notch as `left-*`. */
@@ -166,7 +170,7 @@ describe('fixed surfaces inset themselves from the safe area', () => {
     const violations: string[] = []
 
     for (const file of walk(SRC)) {
-      const rel = relative(WEBSITE_ROOT, file)
+      const rel = repoRelative(file)
       for (const literal of stringLiterals(readFileSync(file, 'utf8'))) {
         if (!hasBareFixed(literal) || hasBlanketInset(literal)) continue
 
@@ -222,7 +226,7 @@ describe('fixed surfaces inset themselves from the safe area', () => {
     const violations: string[] = []
 
     for (const file of walk(SRC)) {
-      const rel = relative(WEBSITE_ROOT, file)
+      const rel = repoRelative(file)
       const src = readFileSync(file, 'utf8')
 
       for (const m of src.matchAll(STYLE_OBJ)) {
@@ -276,7 +280,7 @@ describe('fixed surfaces inset themselves from the safe area', () => {
     const violations: string[] = []
 
     for (const file of walk(SRC)) {
-      const rel = relative(WEBSITE_ROOT, file)
+      const rel = repoRelative(file)
       const src = readFileSync(file, 'utf8')
       for (const m of src.matchAll(/position\s*:\s*['"`]fixed['"`]/g)) {
         // The enclosing object literal: back to its opening brace, forward to


### PR DESCRIPTION
## Problem / Motivation

On Windows, restarting the Gateway from Overview after configuring Tailscale can fail when KiroCrew's embedded Python executable lives in a path containing spaces (for example, `KiroCrew Nightly`). Windows reparses the `execv` command line and splits the full executable path used as `argv[0]`, so Python tries to open the remainder as a script instead of restarting the module.

The local pre-PR gates also exposed unrelated correctness and portability defects in service-unit quoting, atomic deploy-profile writes, progress-file handling, Windows npm command resolution, temporary-resource cleanup, and two Windows-sensitive frontend tests.

## Why it matters

Affected Windows users cannot restart the Gateway from the dashboard after a normal install into a spaced path. The additional gate failures could produce invalid pod service definitions, lost concurrent profile updates, leaked progress files/resources, or false local-gate failures on Windows.

## What changed (motivation → approach → change)

- Added a shared Python module re-exec helper that preserves the exact executable path while using a basename-only Windows `argv[0]`; routed Overview and Slack Gateway restart paths through it.
- Centralized systemd argument quoting and made pod systemd/launchd commands token-based, including paths and environment values containing spaces or `%`.
- Made deploy-profile registry replacement use the existing retrying atomic replace helper and corrected the concurrency test to exercise locked read-modify-write behavior.
- Prevented empty spec paths from writing `TASK_PROGRESS.md`, cached command-base sensitivity checks, closed SQLite connections deterministically, and registered skipped symlink cleanup before the skip.
- Made the local gate resolve `npm`/`npx` to Windows `.cmd` shims without enabling a shell, with clean startup-error reporting.
- Normalized repository-relative paths in the safe-area guard on Windows and preloaded the lazy Pierre implementation before timing-sensitive DiffBlock assertions.

## Tests

- Added/updated unit coverage for spaced Windows interpreter paths, all Gateway restart call sites, pod quoting, task-progress suppression, deploy-profile replacement/concurrency, local-gate command resolution/startup errors, and resource cleanup.
- Backend full suite: 62,043 passed, 2,554 skipped, 6 xfailed.
- Changed-module suite: 691 passed, 60 skipped.
- Frontend targeted regression suite: 32 passed.
- Electron suite: 1,293 passed, 2 skipped.
- Passed Black, isort, flake8, mypy, build/typecheck/ESLint, i18n static/render, jscpd, bundle-size, vendor-manifest, lockdown, subprocess-encoding, documentation, scrub-lint, cfn-lint, and production-audit gates.
- The complete frontend matrix is delegated to this PR's CI, per request.

## Manual verification

Reproduced the broken command-line parsing with the installed Nightly embedded interpreter path, then verified the helper restarts the target module successfully with that same interpreter and spaced path. Tailscale configuration is not the cause; it only preceded the restart action that exposed the Windows re-exec bug.

## Related Issues

No linked issue: reported directly from the local Nightly installation log.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where applicable
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository template contains no CLA text to accept yet.
