### PR TITLE
fix: stop a context block absorbing its neighbours' bytes

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -580,8 +580,36 @@ both emitted spellings, with and without the colon — and the `[System: …]`
 regenerate line): a marker absent from `_MARKERS` does NOT surface as its own
 bucket, it
 folds into the PRECEDING recognised block and mislabels those bytes, so the set
-must stay complete. Only leading bytes before the first marker fall outside every
-block and surface as `unclassified`. The returned sizes sum EXACTLY to `len(prompt)` (closure); the user's
+must stay complete.
+A block owns the span from its opener up to **the earlier of** the next opener and
+its OWN closer (`_CLOSERS`, keyed by the same labels — only the closers the
+assembly actually emits are listed, so extending it is a data change rather than a
+scanner edit). The closer taken is the LAST match before the next opener, not the
+first: a block's content can quote its own closer — a custom agent prompt that
+documents the envelope it is injected into embeds `[END AGENT SYSTEM PROMPT]`
+verbatim — and first-match would end the block at that quotation and book the rest
+of its real body as `unclassified`. Last-match is right by construction, because
+nothing of the block follows its real closer, so any earlier occurrence in range is
+content. The closer search is bounded by the next opener, which is what
+keeps a WRAPPER correct: `[SESSION CONTEXT` closes long after the memory family
+opens inside it, never finds its own closer in range, and ends where it always did
+— unbounded, it would swallow every block nested within. The blank line a block
+emits right after its closer stays with that block, so a closed block does not
+leave a two-character crumb behind it. Escaping matters in one place worth naming:
+`[End of skill]` is a PREFIX of `[End of skills]`, so an unanchored closer would
+let one loaded skill claim the whole skills index that follows it.
+Characters that fall between a block's closer and the next opener therefore
+surface as `unclassified`, as do leading bytes before the first marker. This is
+the honest reading and it replaces a silent one: without closer awareness a span
+ran all the way to the next opener, which turned *unattributed* bytes into
+*MIS-attributed* ones with no way for a reader to tell a genuinely large block from
+a small one that had absorbed its neighbours. The trigger is ordinary rather than
+exotic — the blocks between two openers are conditional (workspace identity and the
+docs pointer are skipped for a custom agent, the memory family for a session sealed
+from the user's memory), so their absence is exactly what lets an earlier block
+absorb everything downstream of it. Measured on one real session, a ~470-character
+`[USER PROFILE]` block was reported as 8,116.
+The returned sizes sum EXACTLY to `len(prompt)` (closure); the user's
 own text is carved into the `your_message` label using the exact `(start, end)`
 span that `build_message` reports through its `user_span_out` out-parameter. That
 span is authoritative because `build_message` is the only code that sees every

--- a/src/kiro_crew/context_blocks.py
+++ b/src/kiro_crew/context_blocks.py
@@ -67,6 +67,56 @@ _MARKERS: Final[tuple[tuple[str, str], ...]] = (
 
 _COMPILED: Final = tuple((label, re.compile(pat)) for label, pat in _MARKERS)
 
+# Closing markers, by label. A block that has one owns only up to its OWN
+# closer; the characters between that closer and the next opening marker belong
+# to no block anybody named and are reported as ``unclassified``.
+#
+# Without this, a block's span ran all the way to the next marker it could find,
+# which silently turned "unattributed" into "MIS-attributed" — and the panel has
+# no way to tell a genuinely large block from a small one that swallowed its
+# neighbours. It is not a rare edge either: whichever blocks are conditional
+# (workspace identity and the docs pointer are skipped for a custom agent, the
+# memory family for a session sealed from the user's memory) are exactly the
+# ones whose absence lets an earlier block absorb everything downstream of it.
+# Measured on one real session: a ~470-char profile block was reported as 8,116.
+#
+# Only closers that the assembly actually emits are listed, so adding one is a
+# data change here rather than an edit to the scanner. A single-line block
+# (``[CURRENT DATE]``, ``[RUNTIME]``, …) has no closer and keeps the old
+# next-marker behaviour, which is correct for it: there is nothing in between.
+#
+# Nesting needs no special case. ``[SESSION CONTEXT`` wraps the memory family and
+# closes long after it, but the search below is bounded by the next opening
+# marker, so a wrapper whose nested blocks start first simply never finds its own
+# closer in range and ends where it always did.
+_CLOSERS: Final[dict[str, re.Pattern[str]]] = {
+    label: re.compile(pat)
+    for label, pat in (
+        ("critical_rules", r"\[END CRITICAL RULES\]"),
+        ("agent_instructions", r"\[END AGENT SYSTEM PROMPT\]"),
+        ("session_wrapper", r"\[END OF SESSION CONTEXT\]"),
+        ("workspace_identity", r"\[End of workspace identity\]"),
+        ("docs_pointer", r"\[END DOCUMENTATION\]"),
+        ("memory", r"\[End of memory\]"),
+        ("semantic_memory", r"\[End of semantic memory\]"),
+        ("skill_index", r"\[End of skills\]"),
+        ("lessons", r"\[End of learned corrections\]"),
+        ("episodic_memory", r"\[End of episodic memory\]"),
+        # Escaped `]` matters: `[End of skill]` is a prefix of `[End of skills]`,
+        # and an unanchored pattern would let one loaded skill claim the whole
+        # skills index that follows it.
+        ("loaded_skill", r"\[End of skill\]"),
+        ("skill_hint", r"\[End of relevant skills\]"),
+        ("channel_context", r"\[END SLACK THREAD CONTEXT\]"),
+        ("conversation_replay", r"\[END CONVERSATION HISTORY\]"),
+        ("hook_context", r"\[End of hook context\]"),
+        ("theme_persona", r"\[END THEME PERSONA\]"),
+        ("user_profile", r"\[End of user profile\]"),
+        ("ui_language", r"\[End of UI language\]"),
+        ("cancelled_turn", r"\[END PREVIOUS TURN\]"),
+    )
+}
+
 # The reply-format / tool-contract paragraphs the assembly appends after the
 # user's text. They open with a parenthesis at the start of a line and are the
 # only trailing blocks, so one anchored pattern covers all of them.
@@ -211,7 +261,33 @@ def split_blocks(
     # unrelated header bytes instead.
     user_taken = 0
     for index, (start, label) in enumerate(hits):
-        end = hits[index + 1][0] if index + 1 < len(hits) else len(prompt)
+        next_start = hits[index + 1][0] if index + 1 < len(hits) else len(prompt)
+        # A block owns up to its own closer when it has one IN RANGE, otherwise up
+        # to the next block. Bounding the search by ``next_start`` is what keeps a
+        # wrapper (whose nested blocks open before it closes) behaving as before.
+        end = next_start
+        closer = _CLOSERS.get(label)
+        if closer is not None:
+            # The LAST match before the next opener, not the first. A block's
+            # content can quote its own closer — a custom agent prompt that
+            # documents the envelope it is injected into embeds
+            # `[END AGENT SYSTEM PROMPT]` verbatim — and first-match would end the
+            # block at that quotation, booking the rest of its real body as
+            # `unclassified`. Last-match is right by construction: nothing of the
+            # block follows its real closer, so any earlier occurrence in range is
+            # content. Bounded by `next_start`, so this still cannot reach past the
+            # next block.
+            closed = None
+            for match in closer.finditer(prompt, start, next_start):
+                closed = match
+            if closed is not None:
+                end = closed.end()
+                # The blank line a block emits right after its own closer is that
+                # block's separator, not unattributed text. Keeping it here is what
+                # makes the remainder a real gap instead of a two-character crumb
+                # of `unclassified` after every single closed block.
+                while end < next_start and prompt[end] in " \t\r\n":
+                    end += 1
         seg = end - start
         if user_start >= 0:
             overlap = max(0, min(end, user_end) - max(start, user_start))
@@ -219,6 +295,18 @@ def split_blocks(
             user_taken += overlap
         if seg > 0:
             out[label] = out.get(label, 0) + seg
+        # The characters after this block's closer and before the next block
+        # started. Naming them ``unclassified`` is the whole point: they used to be
+        # billed to whichever block happened to precede them, which reads as a
+        # confident measurement of something nobody measured.
+        if end < next_start:
+            gap = next_start - end
+            if user_start >= 0:
+                overlap = max(0, min(next_start, user_end) - max(end, user_start))
+                gap -= overlap
+                user_taken += overlap
+            if gap > 0:
+                out[UNCLASSIFIED_LABEL] = out.get(UNCLASSIFIED_LABEL, 0) + gap
 
     if user_taken > 0:
         out[USER_LABEL] = out.get(USER_LABEL, 0) + user_taken

--- a/test/metrics/test_context_blocks.py
+++ b/test/metrics/test_context_blocks.py
@@ -506,3 +506,107 @@ class TestPrependedContextOffset:
         # No crash, closure holds, nothing negative.
         assert sum(out.values()) == len(prompt)
         assert all(v > 0 for v in out.values())
+
+
+class TestABlockEndsAtItsOwnCloser:
+    """A block owns up to its closer, not up to whatever marker comes next.
+
+    Before this, a span ran to the next OPENING marker, which silently turned
+    unattributed characters into MIS-attributed ones — and the panel cannot tell a
+    genuinely large block from a small one that swallowed its neighbours. The
+    trigger is ordinary: the blocks between two markers are conditional (workspace
+    identity and the docs pointer are skipped for a custom agent, the memory family
+    for a session sealed from the user's memory), so their absence is exactly what
+    lets an earlier block absorb everything downstream. Measured on one real
+    session, a ~470-char profile block was reported as 8,116.
+    """
+
+    def test_unmarked_text_after_a_closer_is_unclassified_not_the_block(self):
+        profile = "[USER PROFILE]\nrole: dev.\n[End of user profile]\n\n"
+        orphan = "some assembly text nobody gave a marker\n\n"
+        replay = "[CONVERSATION HISTORY — replay]\nu: hi\n[END CONVERSATION HISTORY]\n\n"
+        prompt = profile + orphan + replay
+        out = split_blocks(prompt)
+        assert out["user_profile"] == len(profile), "the block is its own span, no more"
+        assert out[UNCLASSIFIED_LABEL] == len(orphan), "the orphan is named as unknown"
+        assert out["conversation_replay"] == len(replay)
+        assert sum(out.values()) == len(prompt)
+
+    def test_the_separator_after_a_closer_stays_with_its_block(self):
+        """The blank line a block emits after closing is its own, so it must not
+        become a two-character crumb of `unclassified` after every closed block."""
+        profile = "[USER PROFILE]\nrole: dev.\n[End of user profile]\n\n"
+        prompt = profile + "[CURRENT DATE] today\n"
+        out = split_blocks(prompt)
+        assert out["user_profile"] == len(profile)
+        assert UNCLASSIFIED_LABEL not in out
+
+    def test_a_wrapper_whose_nested_blocks_open_first_is_unchanged(self):
+        """`[SESSION CONTEXT` closes long after the memory family opens inside it.
+
+        The closer search is bounded by the next opening marker, so the wrapper
+        never finds its own closer in range and ends where it always did. Without
+        that bound the wrapper would swallow every block nested inside it.
+        """
+        head = "[SESSION CONTEXT — background]\n"
+        mem = "[Memory — profile]\nlikes tea\n[End of memory]\n\n"
+        tail = "[END OF SESSION CONTEXT]\n\n"
+        prompt = head + mem + tail
+        out = split_blocks(prompt)
+        assert out["session_wrapper"] == len(head), "the wrapper stops at the nested block"
+        assert out["memory"] == len(mem), "the nested block keeps its own span"
+        # The wrapper's own closer trails the last nested block, which has already
+        # closed, so it is unattributed rather than silently booked to memory.
+        assert out[UNCLASSIFIED_LABEL] == len(tail)
+        assert sum(out.values()) == len(prompt)
+
+    def test_one_loaded_skill_does_not_claim_the_skills_index(self):
+        """`[End of skill]` is a PREFIX of `[End of skills]`.
+
+        An unanchored closer would match inside the index's own closer and let a
+        single loaded skill book the entire index that follows it.
+        """
+        skill = "[Skill: widgets]\nuse mcwidget.\n[End of skill]\n\n"
+        index = "[Skills:]\n- widgets\n- artifacts\n[End of skills]\n\n"
+        prompt = skill + index
+        out = split_blocks(prompt)
+        assert out["loaded_skill"] == len(skill)
+        assert out["skill_index"] == len(index)
+        assert sum(out.values()) == len(prompt)
+
+    def test_a_block_quoting_its_own_closer_still_ends_at_the_real_one(self):
+        """A block's content can contain its own closer verbatim.
+
+        A custom agent prompt that documents the envelope it is injected into
+        embeds `[END AGENT SYSTEM PROMPT]` as text. Ending the block at that
+        quotation would book the rest of its real body as `unclassified` — a new
+        mis-measurement introduced by closer awareness itself. The LAST match
+        before the next opener is right by construction: nothing of the block
+        follows its real closer, so an earlier occurrence in range is content.
+        """
+        body = (
+            "[AGENT SYSTEM PROMPT]\n"
+            "Your turn is wrapped like this:\n"
+            "[END AGENT SYSTEM PROMPT]\n"  # quoted by the prompt, not the real end
+            "and that wrapper is not yours to emit.\n"
+            "[END AGENT SYSTEM PROMPT]\n\n"
+        )
+        orphan = "assembly text with no marker\n\n"
+        prompt = body + orphan + "[CURRENT DATE] today\n"
+        out = split_blocks(prompt)
+        assert out["agent_instructions"] == len(body), (
+            "the block must run to its REAL closer, not to the one it quotes"
+        )
+        assert out[UNCLASSIFIED_LABEL] == len(orphan)
+        assert sum(out.values()) == len(prompt)
+
+    def test_a_block_with_no_closer_still_runs_to_the_next_marker(self):
+        """Single-line blocks emit no closer, and running to the next marker is
+        correct for them — there is nothing in between to mis-attribute."""
+        date = "[CURRENT DATE] Monday\n"
+        runtime = "[RUNTIME] dashboard\n"
+        prompt = date + runtime
+        out = split_blocks(prompt)
+        assert out["date"] == len(date)
+        assert out["surface"] == len(runtime)
+        assert UNCLASSIFIED_LABEL not in out


### PR DESCRIPTION
## Problem

`split_blocks` gave every block the span from its opener to the *next* opener. Characters sitting between one block's closer and the next block's start were therefore not merely unattributed — they were billed to whichever block happened to precede them.

Measured on one real session, a **~470-character `[USER PROFILE]` block was reported as 8,116**.

## Why it matters

A reader cannot distinguish a genuinely large block from a small one that swallowed everything after it, and the panel exists precisely to answer "what is eating my context".

The trigger is ordinary rather than exotic: the blocks in between are *conditional* — workspace identity and the docs pointer are skipped for a custom agent, the memory family for a session sealed from the user's memory — so their absence is exactly what lets an earlier block absorb the rest.

## Fix

A block now owns up to the **earlier of** the next opener and its own closer (`_CLOSERS`, keyed by the same labels; only closers the assembly actually emits are listed, so extending it is a data change, not a scanner edit). The remainder surfaces as `unclassified` — the bucket that already existed for exactly this. Closure (`sum == len(prompt)`) is preserved.

Four details are load-bearing:

- **The closer search is bounded by the next opener.** That is what keeps a wrapper correct: `[SESSION CONTEXT` closes long after the memory family opens inside it, so it never finds its own closer in range and ends where it always did. Unbounded, it would swallow every nested block.
- **The closer taken is the LAST match in range, not the first.** A block's content can quote its own closer — a custom agent prompt documenting the envelope it is injected into embeds `[END AGENT SYSTEM PROMPT]` verbatim. Nothing of a block follows its real closer, so an earlier occurrence in range is content.
- **The blank line after a closer stays with its block**, so a closed block does not leave a two-character crumb of `unclassified` behind it.
- **`[End of skill]` is a prefix of `[End of skills]`.** An unanchored closer would let one loaded skill claim the whole skills index that follows.

`metrics.md` is updated in the same commit.

## Scope was reduced — see the note below

This PR previously also carried a second, unrelated half: recording the context-meter snapshot for non-persistent slots. **That half has been removed** and will be redone differently. The rationale is in a comment on this PR; the short version is that its premise was wrong — the reading was already available from the resident provider, and routing it through the key-indexed snapshot sidecar created a family of key-reuse and entry-lifecycle hazards that produced five separate blocking findings. The earlier review comments about `_SNAPSHOT_BORN_KEY`, `_snapshot_may_be_written` and the dirty-flag/prune rules describe code that is no longer in this PR.

What remains is independent of that half, has had no findings since the last-match closer fix, and touches three files.

## Tests

5 new guards, every one mutation-verified — the mutation is named with what it breaks.

| Guard | Falsified by |
|---|---|
| `test_unmarked_text_after_a_closer_is_unclassified_not_the_block` | drop the closer truncation |
| `test_the_separator_after_a_closer_stays_with_its_block` | drop the trailing-whitespace extension |
| `test_a_wrapper_whose_nested_blocks_open_first_is_unchanged` | unbound the closer search |
| `test_a_block_quoting_its_own_closer_still_ends_at_the_real_one` | revert last-match to first-match |
| `test_one_loaded_skill_does_not_claim_the_skills_index` | unanchor the closer (`r"\[End of skill"`) |

`test/metrics/` + the context-meter suites: **495 passed**. black (via `scripts/check_black_formatting.py`), flake8, mypy `--platform linux`, isort, docs-lint all clean.

**Why no screenshot:** no frontend file is touched. The change alters the *numbers* the existing Context Breakdown panel receives, not its markup, and the honest before/after is the character counts quoted above rather than a frame.
