### PR TITLE
fix(dashboard): serialize slot model/workspace switches under the slot lock

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1151,
+    "missing_code": 1150,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1563,
+  "_compliant": 1601,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -37,7 +37,7 @@
       "missing_code": 21
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 49
+      "missing_code": 48
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 7

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5623,8 +5623,10 @@ async def _try_live_model_switch(
     if provider.has_active_turn():
         # Same hazard api_chat_slot_reasoning_effort documents: awaiting a
         # response mid-turn races the streaming prompt loop on stdout for the
-        # non-multiplexed client. The UI disables the model button while a turn
-        # runs, so this is defensive — take the old reset path.
+        # non-multiplexed client. api_chat_slot_model answers 409 before
+        # reaching here (its check and this call share one no-await window),
+        # so this is defense in depth for any future caller — decline the
+        # live switch rather than race the stream.
         return False
     wire = _wire_model_id(provider, model_name)
     if not wire:
@@ -5680,8 +5682,9 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/model — set model for a chat slot.
 
     Prefers an in-place ``session/set_model`` on the running session and only
-    resets when that is impossible (no ACP provider, a turn in flight, an
-    unrepresentable target, or the live call failing).
+    resets when that is impossible (no ACP provider, an unrepresentable
+    target, or the live call failing). A turn in flight answers 409 instead:
+    the reset fallback would tear down the streaming turn mid-stream.
     """
     state: DashboardState = request.app["state"]
     name = request.match_info["slot"]
@@ -5705,14 +5708,53 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # below has nothing to act on: the session that would receive
         # ``session/set_model`` is on the other machine.
         return await _apply_remote_pick(request, state, slot, "model", {"model": model_name})
-    # One pick transaction at a time per slot (verifier finding on 84fc7961):
-    # two picks interleaving at the set_model await can roll back each other's
-    # state no matter how careful the rollback condition is — with two failed
-    # picks out of order, the later one restores the earlier one's already-
-    # refused model. Serialising the whole check → mutate → switch → rollback
-    # span makes each pick atomic; the CAS below stays as a backstop against
-    # any writer outside this lock.
-    async with slot._model_pick_lock:
+    # Two locks, always in this order (slot._lock outer, _model_pick_lock
+    # inner; the bulk handler nests them the same way and nothing takes them
+    # in the opposite order):
+    #
+    # slot._lock — same serialization as the agent, effort and workspace
+    # switch handlers: the awaits below yield the event loop, and an
+    # interleaved second switch could otherwise observe (or write)
+    # intermediate state — two racing switches would each commit and reset
+    # against the other's half-applied session. Holding it across the
+    # provider RPC mirrors the effort handler holding it across change_effort.
+    #
+    # slot._model_pick_lock — one pick transaction at a time against the
+    # model-fallback machinery (verifier finding on 84fc7961): the fallback
+    # swap and restore probe in chat_runner hold it across their own
+    # set_model awaits, and a pick landing inside that window could be
+    # overwritten by the swap (or roll back the swap's state). Serialising
+    # the whole check → mutate → switch → rollback span makes each pick
+    # atomic; the CAS rollback below stays as a backstop against any writer
+    # outside both locks.
+    #
+    # There is deliberately NO unlocked no-op fast path: a serialized switch
+    # holding the locks commits slot.model before its RPC and rolls it back
+    # on AcpModelUnavailable, so an unlocked equality read could match that
+    # transient value and report "already on X" for a model that is then
+    # rolled back.
+    async with slot._lock, slot._model_pick_lock:
+        # The session the switch will probe and, on the reset path, tear
+        # down. ``effective_session_key``, never ``_history_key_for`` (the
+        # reload handler's rule): a channel- or cron-born slot runs its turns
+        # under its linked key, and the dashboard-prefixed spelling names a
+        # session that never existed — the busy probe would see nothing and
+        # the reset would "succeed" against nothing while the live process
+        # kept the old model. Resolved INSIDE the lock, not before it: the
+        # binding can land while this request waits on the lock (a cron or
+        # workflow slot is linked when its first result is injected), and a
+        # key read before the wait would then name the wrong session.
+        session_key = effective_session_key(slot)
+        # App isolation on the SESSION, not just the slot (the cancel
+        # routes' policy): slot ownership does not imply ownership of a
+        # linked channel session, so an app caller may not switch the model
+        # a channel thread runs on. Denied as an indistinguishable 404.
+        denied = _app_cancel_denied(request, slot, "chat.slot_model", session_key)
+        if denied is not None:
+            return denied
+        # Checked INSIDE the locks only: a serialized predecessor targeting the
+        # same model may have committed while this request waited, and acting
+        # again would tear down the session that predecessor just set up.
         if slot.model == model_name and not slot._active_fallback_model:
             # Same-value pick: nothing to switch, but the user's EXPLICIT
             # affirmation of this model must still be recorded — the fallback
@@ -5732,8 +5774,29 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
             # still protects the choice from the restore probe.
             slot._model_pick_gen += 1
             return web.json_response({"ok": True, "model": model_name})
-        session_key = _history_key_for(name)
         provider = state.sessions.get_provider(session_key)
+        if slot.running or (isinstance(provider, LLMProvider) and provider.has_active_turn()):
+            # Never tear down an in-flight turn: _try_live_model_switch
+            # declines a mid-turn live switch, so falling through would take
+            # the reset fallback and kill the streaming turn for any
+            # programmatic caller (the UI disables the picker mid-turn, but
+            # the API has no such guard). Answer busy instead — same policy
+            # as the effort handler's defer-not-reset branch and the bulk
+            # handler's skip_running default. slot.running is checked FIRST
+            # because it is set at dispatch, BEFORE the multi-second
+            # provider.start() registers a session — a cold-starting first
+            # turn is invisible to get_provider but not to slot.running
+            # (api_chat's own busy gate uses the same signal). The refusal
+            # applies to EVERY provider class with an active turn, not only
+            # the ACP one that could have gone live: the reset fallback below
+            # tears down the in-flight turn regardless of provider type, and
+            # a 409 is retryable once the turn completes. isinstance, not a
+            # None check: the base class documents that caller-side guards
+            # defend against test doubles that are not LLMProvider instances,
+            # and the base default is False so no real provider is missed.
+            return web.json_response(
+                {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+            )
         prior_model = slot.model
         prior_pick_gen = slot._model_pick_gen
         slot.model = model_name
@@ -5741,45 +5804,222 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # restore probe never overrides this choice (automatic backfill does NOT
         # bump it).
         slot._model_pick_gen += 1
-        try:
-            went_live = await _try_live_model_switch(name, slot, provider, model_name)
-        except AcpModelUnavailable as exc:
-            # The live session refused the pick as unavailable to this account. Roll
-            # the slot back so the picker keeps showing what is actually running, and
-            # answer 4xx — deliberately NOT the reset fallback below, which would
-            # destroy the conversation and cold-start on a different model while
-            # reporting success. Only the session that owns the advertised list gets
-            # to make this call, so there is no pre-emptive gate here to go stale.
-            # The pick generation rolls back WITH the model: a refused pick changed
-            # nothing, and leaving the bump in place would make the fallback
-            # restore probe read it as an explicit choice and silently abandon
-            # restoring the primary — the session would stay on the fallback with
-            # no card and no probe.
-            #
-            # COMPARE-AND-SWAP, not unconditional (local review finding on
-            # eb3cf067): handlers interleave at the await above, so a NEWER pick
-            # may have landed while this one was in flight. An unconditional
-            # rollback would erase that later pick's model AND its generation,
-            # making the restore probe treat it as nonexistent. Only restore when
-            # the state is still exactly ours (our bump, our model); the check and
-            # both writes are synchronous, so they are atomic on the event loop.
-            # Interleavings compose: a later pick's own rollback restores what IT
-            # observed, unwinding in LIFO order to a consistent state.
+
+        def _rollback_pick() -> None:
+            """Undo this request's commit — model AND pick generation together.
+
+            A refused or declined pick changed nothing, and leaving the bump in
+            place would make the fallback restore probe read it as an explicit
+            choice and silently abandon restoring the primary — the session
+            would stay on the fallback with no card and no probe.
+
+            COMPARE-AND-SWAP, not unconditional (local review finding on
+            eb3cf067): both locks make an interleaved pick impossible, so this
+            is a backstop against any writer outside them. Only restore when
+            the state is still exactly ours (our bump, our model); the check
+            and both writes are synchronous, so they are atomic on the event
+            loop.
+            """
             if slot._model_pick_gen == prior_pick_gen + 1 and slot.model == model_name:
                 slot.model = prior_model
                 slot._model_pick_gen = prior_pick_gen
+
+        def _live_serves_target(candidate: object) -> bool:
+            """True when the live session's BACKEND-RESOLVED model already
+            equals the requested wire id — the truth-based success exception.
+
+            Not identity guessing: dispatch captures slot.model at its call
+            site and registers the session only after provider.start(), so
+            neither identity nor registration time proves anything; the
+            served model does. A True here means slot.model is consistent
+            with what actually runs — the partially-applied live switch
+            (set_model landed, then the effort reapply failed) — so rollback
+            would publish the OLD model over a live session running the NEW
+            one, and a teardown would kill it. Defined once and consumed by
+            BOTH the pre-reset busy re-check and the post-decline
+            disambiguation, so the two spellings cannot diverge.
+            """
+            if not isinstance(candidate, AcpProvider):
+                return False
+            wire = _wire_model_id(candidate, model_name)
+            if not wire:
+                return False
+            if candidate.served_model == wire:
+                return True
+            if wire == "auto":
+                # AcpProvider.served_model collapses the "auto" sentinel to ""
+                # on purpose (the fallback canary must never probe a model the
+                # backend did not resolve), so a landed switch TO Auto is
+                # invisible through it. The session client keeps the raw id —
+                # after set_model("auto") lands the handle prefers that
+                # explicit assignment — so read it unfiltered for this one
+                # value (the same literal _wire_model_id hands out for Auto).
+                # Any other non-match stays False (fail-closed).
+                raw = getattr(candidate.client, "served_model", "")
+                return str(raw or "").strip() == wire
+            return False
+
+        try:
+            went_live = await _try_live_model_switch(name, slot, provider, model_name)
+        except AcpModelUnavailable as exc:
+            # The live session refused the pick as unavailable to this account.
+            # Roll the slot back so the picker keeps showing what is actually
+            # running, and answer 4xx — deliberately NOT the reset fallback
+            # below, which would destroy the conversation and cold-start on a
+            # DIFFERENT model while reporting success. Only the session that
+            # owns the advertised list gets to make this call, so there is no
+            # pre-emptive gate here to go stale. The rollback runs under the
+            # locks, so no serialized successor can observe the transient value.
+            _rollback_pick()
             logger.warning("Slot %s model rejected: %s", name, exc)
             return web.json_response({"error": str(exc), "code": "model_unavailable"}, status=400)
+        if effective_session_key(slot) != session_key:
+            # The slot was bound to a different session while the live switch
+            # awaited its provider RPCs (a cron/workflow slot gets linked when
+            # its first result is injected). Whatever set_model did landed on
+            # a session the slot no longer runs on, and resetting the key this
+            # request resolved would tear down (or "succeed" against) the
+            # wrong session — either way committing would advertise the new
+            # model over a session this handler never touched. Roll back and
+            # answer 409; the retry resolves the current binding.
+            _rollback_pick()
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
         if went_live:
             _broadcast_context_reset(state, slot.key, provider)
         else:
+            # LAST-INSTANT busy re-check — the invariant all the review rounds
+            # on this handler converge on: no destructive step may run while a
+            # turn can be live, so idleness must be established within a
+            # NO-AWAIT window immediately before the teardown, and the atomic
+            # skip_if_busy decline covers only that microsecond residue. The
+            # pre-check above is separated from this point by
+            # _try_live_model_switch's provider RPCs (seconds on a slow
+            # backend), so a send may have started — and even posted an
+            # ask_question card — since it ran; _reset_slot_session clears
+            # pending waits BEFORE its atomic decline (its docstring's safety
+            # argument assumes a caller-side busy check microseconds old), so
+            # entering it busy would falsely reject that turn's cards even
+            # though the reset itself declines. Busy here → roll back and
+            # answer the same 409 the pre-check gives.
+            recheck = state.sessions.get_provider(session_key)
+            if slot.running or (isinstance(recheck, LLMProvider) and recheck.has_active_turn()):
+                if _live_serves_target(recheck):
+                    # The turn that slipped in runs on a session that already
+                    # serves the target (set_model landed before the effort
+                    # reapply failed): slot.model is truthful, so report
+                    # success without teardown — rolling back would publish
+                    # the old model while the live turn streams under the new
+                    # one.
+                    logger.warning(
+                        "Slot %s model switch: live session already serves the "
+                        "target; skipping the reset under its in-flight turn",
+                        name,
+                    )
+                    _broadcast_context_reset(state, slot.key, recheck)
+                    state.push_slots_update()
+                    return web.json_response({"ok": True, "model": model_name})
+                _rollback_pick()
+                return web.json_response(
+                    {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                )
+            # Children guard, shared with reload/continue: the reset tears
+            # down the runtime attached sub-agents run on, so a parent that is
+            # idle but still has children (running, queued, or with a
+            # completion event in flight) must refuse rather than discard
+            # their work. Same probe block as api_chat_slot_reload; only the
+            # rollback is added here because this handler committed first.
+            children_409 = _subagents_attached_response(state, slot, session_key, "slot_model")
+            if children_409 is not None:
+                _rollback_pick()
+                return children_409
             logger.info(
                 "Slot %s model switched to %r, resetting session", name, model_name or "auto"
             )
-            await _reset_slot_session(state, slot, session_key)
+            # skip_if_busy: the has_active_turn() 409 above is a best-effort
+            # fast path — message dispatch does not take slot._lock, so a turn
+            # can start between that check and this reset. SessionManager.reset
+            # evaluates busyness atomically with the session pop (the same
+            # authoritative-backstop split api_chat_slot_reload documents), so
+            # a turn that slipped into the window is declined here instead of
+            # torn down mid-stream.
+            reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+            if not reset_ok:
+                # Disambiguate the decline FAIL-CLOSED — with one truth-based
+                # exception checked first. Provider identity or registration
+                # time cannot prove which model a live session runs: dispatch
+                # captures slot.model at its call site but registers the
+                # session only after a multi-second provider.start(), so a
+                # session registered after the commit may still carry the old
+                # model. A false 409 is retryable and costs nothing; a false
+                # success strands a live session on the old model under the
+                # new slot.model.
+                busy_provider = state.sessions.get_provider(session_key)
+                live_serves_target = _live_serves_target(busy_provider)
+                if live_serves_target:
+                    # See _live_serves_target: slot.model is consistent with
+                    # what actually runs, so success without teardown is the
+                    # truthful answer; the un-pushed effort override is
+                    # already persisted on the slot and applies on the next
+                    # cold start (same degradation the effort handler's defer
+                    # branch accepts).
+                    logger.warning(
+                        "Slot %s model switch: live session already serves the "
+                        "target; declined reset left it in place (effort "
+                        "override, if any, applies on the next cold start)",
+                        name,
+                    )
+                if not live_serves_target and isinstance(busy_provider, LLMProvider):
+                    if busy_provider.has_active_turn():
+                        # A turn slipped in: roll back the commit and answer
+                        # the same 409 the fast path gives, leaving the turn
+                        # running whichever model it captured.
+                        _rollback_pick()
+                        return web.json_response(
+                            {"error": "a turn is in flight", "code": "turn_in_flight"},
+                            status=409,
+                        )
+                    # A live IDLE session declined the reset (its turn ended
+                    # before this re-read). Reporting success would leave that
+                    # process alive on whatever model it captured. Tearing
+                    # down an idle session is always safe — history lives on
+                    # the slot, not in the process — so retry once
+                    # (api_chat_slot_reload's template for this exact race); a
+                    # second decline means another turn is genuinely racing,
+                    # which is the turn-in-flight case again.
+                    reset_ok = await _reset_slot_session(
+                        state, slot, session_key, skip_if_busy=True
+                    )
+                    if not reset_ok:
+                        _rollback_pick()
+                        return web.json_response(
+                            {"error": "a turn is in flight", "code": "turn_in_flight"},
+                            status=409,
+                        )
+                # No live provider: there was no registered session to tear
+                # down — the next message cold-starts under the new model,
+                # which is exactly what the reset would have arranged.
+            if effective_session_key(slot) != session_key:
+                # Same check after the reset await(s) as after the live
+                # switch: the session this request tore down is no longer
+                # the slot's, so the commit would advertise the new model
+                # over a session that never saw the switch. The teardown
+                # itself was harmless (that session was idle and no longer
+                # bound); roll back the commit and let the retry resolve the
+                # current binding.
+                _rollback_pick()
+                return web.json_response(
+                    {
+                        "error": "slot session was rebound during the switch",
+                        "code": "session_rebound",
+                    },
+                    status=409,
+                )
             _broadcast_context_reset(state, slot.key, None)
-        state.push_slots_update()
-        return web.json_response({"ok": True, "model": model_name})
+    state.push_slots_update()
+    return web.json_response({"ok": True, "model": model_name})
 
 
 # Per-slot transaction locks for the autocompact endpoint. The write span
@@ -6050,11 +6290,13 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
 
     Body: {"model": "<name>" | "", "skip_running": bool (default True)}.
     "" selects the provider/auto default. Applies the model to every slot
-    whose model differs, resetting each affected slot's session — a model
-    switch always resets, same as ``api_chat_slot_model``. Slots mid-turn are
-    skipped when ``skip_running`` is true to avoid the model-switch-mid-stream
-    duplicate-content bug; pass ``skip_running: false`` to force
-    every slot. Returns the slot keys that were switched / skipped / unchanged /
+    whose model differs, resetting each affected slot's session. Mid-turn
+    policy deliberately differs from ``api_chat_slot_model``: the single-slot
+    handler prefers a live in-place switch and answers 409 for a slot
+    mid-turn, while this bulk endpoint always resets and skips mid-turn slots
+    when ``skip_running`` is true (the default) — passing ``skip_running:
+    false`` is an explicit opt-in that still tears down in-flight turns.
+    Returns the slot keys that were switched / skipped / unchanged /
     failed; a per-slot reset failure is isolated (that slot is reported in
     ``failed`` and keeps its old model) rather than aborting the whole switch.
     """
@@ -6094,33 +6336,125 @@ async def api_chat_slots_model(request: web.Request) -> web.Response:
         # user bypasses the ownership check.
         if not is_dashboard_user and slot._app != request_app:
             continue
-        # Same transaction lock as the single-slot pick (verifier finding on
-        # 9f182b0c): without it, a bulk select of a model that a single-slot
-        # pick is speculatively holding reads equality and reports the slot
-        # unchanged — then the single pick's failure rolls it back, leaving
-        # the bulk response claiming a model the slot does not have.
-        async with slot._model_pick_lock:
+        # Same two locks, same order, as the single-slot pick (slot._lock
+        # outer, _model_pick_lock inner). ALL classification happens inside
+        # them, equality FIRST: a serialized switch commits slot.model before
+        # its provider RPC and rolls it back on failure, so an unlocked
+        # equality read could match that transient value and report a slot
+        # "unchanged" for a model that is then rolled back (verifier finding
+        # on 9f182b0c) — and an unlocked running-check ahead of the equality
+        # check would classify a running slot that already uses the requested
+        # model as skipped_running instead of unchanged. Queuing on the locks
+        # is cheap: turns do not hold slot._lock, so a running slot's lock
+        # only contends with another switch handler.
+        async with slot._lock, slot._model_pick_lock:
+            # The session this slot's turns run on — effective_session_key,
+            # never _history_key_for (see api_chat_slot_model), resolved
+            # INSIDE the lock so a binding that lands while this iteration
+            # waits on it is what the reset addresses.
+            session_key = effective_session_key(slot)
+            if not is_dashboard_user and session_key != _history_key_for(name):
+                # Slot ownership does not imply ownership of a linked channel
+                # session (the cancel routes' second condition): an app caller
+                # does not get to switch the model a channel thread runs on.
+                # Skipped silently, like every other slot the app does not own.
+                continue
             if slot.model == model_name:
                 unchanged.append(name)
                 continue
             if skip_running and slot.running:
                 skipped_running.append(name)
                 continue
-            # Reset before flipping the model and isolate per-slot failures: if the
-            # reset raises, leave slot.model untouched so the slot is never left on
-            # the new model with stale history (the model/history inconsistency), and a
-            # single failure doesn't abort the whole bulk switch.
+            # Last-instant busy re-check on the EFFECTIVE session, same as the
+            # single-slot handler: slot.running only sees turns dispatched
+            # through this slot's task, and a channel-linked slot's turn runs
+            # under its linked key without setting it. _reset_slot_session
+            # clears pending waits BEFORE its atomic decline (its docstring's
+            # safety argument assumes a caller-side busy check microseconds
+            # old), so entering it against a live linked turn would reject
+            # that turn's cards even though the reset itself declines.
+            live_now = state.sessions.get_provider(session_key)
+            if skip_running and isinstance(live_now, LLMProvider) and live_now.has_active_turn():
+                skipped_running.append(name)
+                continue
+            # Children guard (api_chat_slot_reload's): the reset tears down the
+            # runtime attached sub-agents run on, so a parent with children
+            # running, queued, or mid-delivery is skipped rather than have
+            # their work discarded — regardless of skip_running, which speaks
+            # to the parent's own turn, not to its children.
+            if subagents_attached(state, slot, session_key, "slots_model"):
+                skipped_running.append(name)
+                continue
+            # Reset before flipping the model and isolate per-slot failures: if
+            # the reset raises, leave slot.model untouched so the slot is never
+            # left on the new model with stale history (the model/history
+            # inconsistency), and a single failure doesn't abort the whole bulk
+            # switch. skip_if_busy mirrors skip_running: when the caller asked
+            # to skip running slots, a turn that started AFTER the checks above
+            # (message dispatch does not take slot._lock) is declined at the
+            # authoritative point — SessionManager.reset evaluates busyness
+            # atomically with the session pop — instead of being torn down;
+            # skip_running=false keeps its documented force semantics.
             try:
-                await _reset_slot_session(state, slot, _history_key_for(name))
+                reset_ok = await _reset_slot_session(
+                    state, slot, session_key, skip_if_busy=skip_running
+                )
+                if skip_running and not reset_ok:
+                    if slot.running:
+                        # A first send slipped into the reset await and is still
+                        # inside its multi-second provider.start(): visible to
+                        # slot.running (set at dispatch) but not yet to
+                        # get_provider, so the provider ladder below would read
+                        # "no live provider" and commit over a session that
+                        # captured the OLD model (this handler commits AFTER the
+                        # reset). Classify it as the in-lock pre-check would have.
+                        skipped_running.append(name)
+                        continue
+                    busy_provider = state.sessions.get_provider(session_key)
+                    if isinstance(busy_provider, LLMProvider):
+                        if busy_provider.has_active_turn():
+                            # A turn slipped into the check window: classify it
+                            # the same as the pre-check would have, leaving the
+                            # turn (and the slot's model) untouched.
+                            skipped_running.append(name)
+                            continue
+                        # A live IDLE session declined the reset: the
+                        # slipped-in turn already finished before the re-read.
+                        # This handler commits AFTER the reset, so that session
+                        # is still on the old model — committing over it would
+                        # create the exact model/history inconsistency the
+                        # ordering exists to prevent. Retry once
+                        # (api_chat_slot_reload's template); a second decline
+                        # means another turn is genuinely racing. The retry
+                        # runs INSIDE this try so a teardown that raises keeps
+                        # the per-slot failure isolation: the slot lands in
+                        # failed with its model untouched instead of aborting
+                        # the whole bulk switch with a 500.
+                        reset_ok = await _reset_slot_session(
+                            state, slot, session_key, skip_if_busy=True
+                        )
+                        if not reset_ok:
+                            skipped_running.append(name)
+                            continue
+                    # No live provider: no session to tear down — the next
+                    # message cold-starts under the new model.
             except Exception:
                 logger.error("Bulk model switch: session reset failed for %s", name, exc_info=True)
                 failed.append(name)
                 continue
+            if effective_session_key(slot) != session_key:
+                # The slot was bound to a different session during the reset
+                # await: the session torn down is no longer the slot's, so
+                # committing would advertise the new model over one that
+                # never saw the switch. Nothing to roll back (bulk commits
+                # after the reset); report it as skipped so the caller retries.
+                skipped_running.append(name)
+                continue
             slot.model = model_name
             # Explicit pick (bulk): same generation bump as the single-slot pick.
             slot._model_pick_gen += 1
-        _broadcast_context_reset(state, slot.key, None)
-        switched.append(name)
+            _broadcast_context_reset(state, slot.key, None)
+            switched.append(name)
 
     if switched:
         logger.info(
@@ -6374,24 +6708,126 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
         return body_err
     assert body is not None  # read_bounded_json returns (dict, None) on success
     ws_name = body.get("workspace", "default")
-    # Block workspace change after conversation has started
-    if slot.total_messages > 0:
-        return web.json_response(
-            {
-                "error": "Cannot change workspace after messages have been sent. Open a new session instead."
-            },
-            status=409,
-        )
     if slot.is_remote:
+        # Same guard as the local path, then hand the pick to the peer.
         # ``slot.project`` is deliberately left alone: it is a path on THIS
         # machine (file search, @-mentions), and `default_project_dir` would
         # write a local directory that has nothing to do with the peer's
-        # workspace. The peer resolves its own project from the name.
+        # workspace. The peer resolves its own project from the name. No
+        # local session is reset, so this runs outside slot._lock (the
+        # effort handler's ordering).
+        if slot.total_messages > 0:
+            return web.json_response(
+                {
+                    "error": "Cannot change workspace after messages have been sent. Open a new session instead.",
+                    "code": "conversation_started",
+                },
+                status=409,
+            )
         return await _apply_remote_pick(request, state, slot, "workspace", {"workspace": ws_name})
-    slot.workspace = ws_name
-    slot.project = default_project_dir(ws_name)
-    logger.info("Slot %s workspace switched to %r, resetting session", name, ws_name)
-    await _reset_slot_session(state, slot, _history_key_for(name))
+    # Same serialization as the agent switch: the reset await yields the event
+    # loop, so the mutate-then-reset section runs under the slot's lock — an
+    # unlocked write here would interleave with the agent handler's locked
+    # compare-and-set on the same workspace/project fields, and two racing
+    # workspace switches could each reset against the other's half-applied
+    # state. Commit-before-reset ordering per the agent-handler template: a
+    # send landing while the reset await is in flight cold-starts a session
+    # from the slot's CURRENT bindings, so the new pair must already be
+    # visible.
+    async with slot._lock:
+        # The session the reset tears down — effective_session_key, never
+        # _history_key_for (see api_chat_slot_model), resolved INSIDE the lock
+        # so a binding that lands while this request waits on it is what the
+        # reset addresses — with the same session-level app isolation the
+        # model handler applies.
+        session_key = effective_session_key(slot)
+        denied = _app_cancel_denied(request, slot, "chat.slot_workspace", session_key)
+        if denied is not None:
+            return denied
+        # Block workspace change after conversation has started. Checked
+        # INSIDE the lock: the guard is a check-then-act across an await, so
+        # an unlocked read could pass while a serialized switch this request
+        # waited on was still resetting.
+        if slot.total_messages > 0:
+            return web.json_response(
+                {
+                    "error": "Cannot change workspace after messages have been sent. Open a new session instead.",
+                    "code": "conversation_started",
+                },
+                status=409,
+            )
+        prior_workspace = slot.workspace
+        prior_project = slot.project
+        slot.workspace = ws_name
+        slot.project = default_project_dir(ws_name)
+        logger.info("Slot %s workspace switched to %r, resetting session", name, ws_name)
+        # skip_if_busy: the total_messages guard above is checked before this
+        # await, and message dispatch does not take slot._lock — a first send
+        # can slip into that window. SessionManager.reset evaluates busyness
+        # atomically with the session pop (the authoritative backstop
+        # api_chat_slot_reload documents), so the slipped-in turn is declined
+        # here instead of torn down mid-stream.
+        reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+        if not reset_ok:
+            # Disambiguate FAIL-CLOSED, same as the model handler: dispatch
+            # captures the slot bindings at its call site but registers the
+            # session only after a multi-second provider.start(), so no
+            # identity or registration-time reasoning can prove which
+            # bindings a live session carries. A false 409 is retryable; a
+            # false success strands a live session on the old bindings.
+            busy_provider = state.sessions.get_provider(session_key)
+            live_serves_target = False
+            if isinstance(busy_provider, AcpProvider) and slot.project:
+                # Truth-based check, mirroring the model handler: when the
+                # live session's actual working directory already equals the
+                # COMMITTED project, the session cold-started on the new
+                # bindings (a first send captured them after the commit) —
+                # rolling back would advertise the old workspace while the
+                # live process runs the new one. Success without teardown is
+                # the truthful answer.
+                live_serves_target = busy_provider.cwd == slot.project
+                if live_serves_target:
+                    logger.info(
+                        "Slot %s workspace switch: live session already runs under %r; "
+                        "declined reset left it in place",
+                        name,
+                        slot.project,
+                    )
+            if not live_serves_target and isinstance(busy_provider, LLMProvider):
+                if busy_provider.has_active_turn():
+                    # Roll back the commit (commit-before-reset means the new
+                    # pair is already visible) and answer the same 409 the
+                    # guard gives.
+                    slot.workspace = prior_workspace
+                    slot.project = prior_project
+                    return web.json_response(
+                        {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                    )
+                # A live IDLE session declined the reset. Tearing down an idle
+                # session is always safe, so retry once
+                # (api_chat_slot_reload's template); a second decline means
+                # another turn is genuinely racing.
+                reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+                if not reset_ok:
+                    slot.workspace = prior_workspace
+                    slot.project = prior_project
+                    return web.json_response(
+                        {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                    )
+            # No live provider: no registered session to tear down — the next
+            # message cold-starts under the new bindings.
+        if effective_session_key(slot) != session_key:
+            # The slot was bound to a different session during the reset
+            # await(s): the session torn down is no longer the slot's, so the
+            # committed bindings would describe a session that never saw the
+            # switch. Roll back and answer 409; the retry resolves the
+            # current binding.
+            slot.workspace = prior_workspace
+            slot.project = prior_project
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
     state.push_slots_update()
     return web.json_response({"ok": True, "workspace": ws_name})
 
@@ -6446,35 +6882,46 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
                 {"error": conflict, "code": "workspace_overlaps_data_home"},
                 status=400,
             )
-    old_project = slot.project
-    slot.project = project
-    logger.info("Slot %s project set to %r", name, project)
-    sel().log_api_access(
-        caller=request.get("user", "dashboard"),
-        operation="chat_slot_project",
-        outcome="allowed",
-        resources=f"slot={name} project={project}",
-    )
-    # Track recent projects
-    if project:
-        try:
-            await asyncio.to_thread(_save_recent_project, project)
-        except Exception:
-            logger.warning("Failed to save recent project", exc_info=True)
-    # Reset the session so the next message cold-starts with the new CWD and
-    # picks up project-level .kiro/steering/**/*.md (mirrors api_chat_slot_agent).
-    # Only on an actual change — avoids a needless cold start on a no-op set.
-    #
-    # Deferred via a flag because this endpoint is reachable over loopback HTTP
-    # from inside the kiro-cli process group (the set_project MCP tool); an
-    # inline reset would killpg() the caller. Consumed in chat_runner.
-    if project != old_project:
-        slot._pending_reset_history_key = _history_key_for(name)
-        # Speculatively re-create the session rooted at the new project so the
-        # cwd change is paid during think-time. The eager task consumes the
-        # deferred reset itself, but only when no turn is running — the
-        # same killpg constraint that deferred the reset applies to it.
-        schedule_eager_spawn(state, slot)
+    # Same serialization as the agent/model/workspace switch handlers: this is
+    # the one remaining live HTTP mutator of slot.project (the MCP set_project
+    # directive in session_directive_apply also writes it, but from inside the
+    # slot's own running turn, where this lock is not an option), and unlocked
+    # it could interleave with a locked switch's mutate-then-reset section —
+    # the workspace handler's rollback would then erase a project pick that
+    # landed during its reset await. The lock only serializes the write; the
+    # reset stays DEFERRED via the flag (the killpg constraint below), so no
+    # reset is awaited while holding the lock beyond what the other switch
+    # handlers already hold.
+    async with slot._lock:
+        old_project = slot.project
+        slot.project = project
+        logger.info("Slot %s project set to %r", name, project)
+        sel().log_api_access(
+            caller=request.get("user", "dashboard"),
+            operation="chat_slot_project",
+            outcome="allowed",
+            resources=f"slot={name} project={project}",
+        )
+        # Track recent projects
+        if project:
+            try:
+                await asyncio.to_thread(_save_recent_project, project)
+            except Exception:
+                logger.warning("Failed to save recent project", exc_info=True)
+        # Reset the session so the next message cold-starts with the new CWD and
+        # picks up project-level .kiro/steering/**/*.md (mirrors api_chat_slot_agent).
+        # Only on an actual change — avoids a needless cold start on a no-op set.
+        #
+        # Deferred via a flag because this endpoint is reachable over loopback HTTP
+        # from inside the kiro-cli process group (the set_project MCP tool); an
+        # inline reset would killpg() the caller. Consumed in chat_runner.
+        if project != old_project:
+            slot._pending_reset_history_key = _history_key_for(name)
+            # Speculatively re-create the session rooted at the new project so the
+            # cwd change is paid during think-time. The eager task consumes the
+            # deferred reset itself, but only when no turn is running — the
+            # same killpg constraint that deferred the reset applies to it.
+            schedule_eager_spawn(state, slot)
     state.push_slots_update()
     return web.json_response({"ok": True, "project": project})
 

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -1,0 +1,1283 @@
+"""Concurrency tests for the slot model/workspace switch handlers.
+
+The agent and effort switch handlers serialize their mutate-then-reset
+sections under ``slot._lock``; the model and workspace handlers ran the same
+shape unlocked, so two racing switches could each commit and reset against
+the other's half-applied state, and a mid-turn model switch fell through to
+the reset fallback and tore down the in-flight turn for any programmatic
+caller. These tests pin the lock serialization, the in-lock re-checks, and
+the mid-turn 409 (clones of the concurrency template in
+``test_chat_slot_reasoning_effort.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.chat import (
+    api_chat_slot_model,
+    api_chat_slot_workspace,
+    api_chat_slots_model,
+)
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+# Valid registry aliases the model guard accepts (tests are exempt from the
+# hardcoded-model-literal gate; these mirror the ids the existing model-switch
+# tests use).
+_MODEL_A = "claude-opus-4.8"
+_MODEL_B = "gpt-5.6-sol"
+
+
+def _make_app(state: DashboardState) -> web.Application:
+    # Mirror production: token_auth middleware sets request["app"] on every
+    # authenticated path ("" = dashboard user); the bulk handler fails closed
+    # without it.
+    @web.middleware
+    async def dashboard_auth_marker(request, handler):
+        if "app" not in request:
+            request["app"] = ""
+        return await handler(request)
+
+    app = web.Application(middlewares=[dashboard_auth_marker])
+    app["state"] = state
+    app.router.add_post("/api/chat/slots/model", api_chat_slots_model)
+    app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
+    app.router.add_post("/api/chat/slots/{slot}/workspace", api_chat_slot_workspace)
+    return app
+
+
+def _mock_state(slot: _ChatSlot, provider: object = None) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._slots = {slot.key: slot}
+    state.push_slots_update = MagicMock()
+    state.broadcast_context_usage = MagicMock()
+    state.sessions = MagicMock()
+    state.sessions.reset = AsyncMock()
+    # No live AcpProvider by default → the model handler takes the reset path.
+    state.sessions.get_provider = MagicMock(return_value=provider)
+    return state
+
+
+class TestSlotModelSwitchAtomicity:
+    @pytest.mark.asyncio
+    async def test_mid_turn_switch_answers_409_without_reset(self):
+        # _try_live_model_switch declines a mid-turn live switch, and the old
+        # unlocked handler then fell through to the reset — tearing down the
+        # in-flight turn mid-stream. The handler must answer busy instead:
+        # no live switch, no reset, slot model untouched.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = True
+        provider.client = MagicMock()
+        provider.client.set_model = AsyncMock()
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            provider.client.set_model.assert_not_awaited()
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cold_start_turn_answers_409_via_slot_running(self):
+        # A first message can be INSIDE the multi-second provider.start() when
+        # the switch arrives: no session is registered yet, so the provider
+        # pre-check sees nothing — but slot.running is set at dispatch, so the
+        # handler still answers 409 instead of committing a model the
+        # cold-starting session did not capture.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        running_task = MagicMock()
+        running_task.done.return_value = False
+        slot.task = running_task
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_starting_during_live_switch_answers_409_before_reset(self):
+        # _try_live_model_switch's provider RPCs take seconds; a send can start
+        # (and post an ask_question card) in that window. _reset_slot_session
+        # clears pending waits BEFORE its atomic decline, so entering it busy
+        # would falsely reject that turn's cards even though the reset itself
+        # declines. The handler re-checks busyness in a no-await window
+        # immediately before the reset: busy → rollback + 409, reset NEVER
+        # entered.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = False
+        provider.has_active_turn.return_value = False
+        provider.client = MagicMock()
+
+        running_task = MagicMock()
+        running_task.done.return_value = False
+
+        async def _set_model_starts_a_send(*args, **kwargs):
+            # A send dispatches while the live switch's RPC is in flight.
+            slot.task = running_task
+            raise RuntimeError("wire hiccup")  # live switch fails -> reset path
+
+        provider.client.set_model = AsyncMock(side_effect=_set_model_starts_a_send)
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            # The invariant under test: the reset (and its pending-wait
+            # clearing) is never entered while the slot is busy.
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_target_model_during_live_switch_succeeds(self):
+        # The counterpart to the 409 above: set_model LANDED, then the effort
+        # reapply failed as a turn started. The pre-reset busy re-check sees
+        # the turn, but the live session already serves the target — rolling
+        # back would publish the old model while the turn streams under the
+        # new one. Success, no rollback, reset never entered.
+        from kiro_crew import model_registry
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.reasoning_effort = "high"
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = False
+        # Pre-check idle, _try_live_model_switch's own check idle (so
+        # set_model runs), then the pre-reset re-check sees the raced turn.
+        provider.has_active_turn.side_effect = [False, False, True]
+        provider.served_model = model_registry.to_acp_id(_MODEL_B)
+        provider.client = MagicMock()
+        provider.client.set_model = AsyncMock()
+        provider.supports_effort = MagicMock(return_value=True)
+        provider.change_effort = AsyncMock(side_effect=RuntimeError("turn raced the push"))
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert slot.model == _MODEL_B
+            provider.client.set_model.assert_awaited_once()
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_auto_during_live_switch_succeeds_via_raw_served_model(self):
+        # Same chain as above with Auto as the target. AcpProvider.served_model
+        # collapses the "auto" sentinel to "" (the fallback canary's
+        # invariant), so the filtered read can never equal the "auto" wire id
+        # — the handler must read the session client's raw served id instead,
+        # or a landed switch to Auto rolls back to the old model while the
+        # live session runs Auto.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.reasoning_effort = "high"
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = False
+        provider.available_models = MagicMock(return_value=[{"modelId": "auto"}])
+        provider.has_active_turn.side_effect = [False, False, True]
+        provider.served_model = ""  # filtered: "auto" -> ""
+        provider.client = MagicMock()
+        provider.client.served_model = "auto"  # raw, unfiltered
+        provider.client.set_model = AsyncMock()
+        provider.supports_effort = MagicMock(return_value=True)
+        provider.change_effort = AsyncMock(side_effect=RuntimeError("turn raced the push"))
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": ""})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert slot.model == ""
+            provider.client.set_model.assert_awaited_once_with("auto")
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_other_model_during_auto_switch_still_fails_closed(self):
+        # The raw read is scoped to the Auto wire id only: when the raw served
+        # id is something else, the switch to Auto did not land and the
+        # fail-closed rollback + 409 stands.
+        from kiro_crew import model_registry
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.reasoning_effort = "high"
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = False
+        provider.available_models = MagicMock(return_value=[{"modelId": "auto"}])
+        provider.has_active_turn.side_effect = [False, False, True]
+        provider.served_model = model_registry.to_acp_id(_MODEL_A)
+        provider.client = MagicMock()
+        provider.client.served_model = model_registry.to_acp_id(_MODEL_A)
+        provider.client.set_model = AsyncMock(side_effect=RuntimeError("set_model failed"))
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": ""})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_busy_rolls_back_and_answers_409(self):
+        # A turn can start even after the in-lock has_active_turn pre-check
+        # (message dispatch does not take slot._lock), so the reset fallback
+        # runs with skip_if_busy=True and its atomic decline is
+        # authoritative: when the pre-commit session (same provider object)
+        # declined and is mid-turn, the committed model is rolled back, the
+        # response is the same 409 the pre-check gives, and the in-flight
+        # turn survives.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-check AND the last-instant pre-reset re-check (so
+        # the handler proceeds into the reset), mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, False, True]
+        state.sessions.get_provider = MagicMock(return_value=busy)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_idle_old_session_retries_once(self):
+        # The slipped-in turn can FINISH before the post-decline re-read: the
+        # declined reset left a live idle session on the OLD model, and
+        # reporting success would leave that stale process alive under the
+        # new slot.model. The handler retries the reset once (the reload
+        # handler's template for this exact race) and succeeds.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        stale = MagicMock(spec=LLMProvider)
+        stale.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=stale)
+        state.sessions.reset = AsyncMock(side_effect=[False, True])
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_second_time_fails_closed_to_409(self):
+        # An idle live session declined the reset twice (another turn is
+        # genuinely racing the retry): the handler must fail closed — roll
+        # back the commit and answer 409 — never report success over a live
+        # session whose model it cannot prove.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        stale = MagicMock(spec=LLMProvider)
+        stale.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=stale)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_post_commit_session_fails_closed(self):
+        # No session existed at the pre-check; the decline came from a session
+        # registered AFTER the commit. Registration time proves nothing about
+        # which model the session captured (dispatch reads slot.model at its
+        # call site but registers only after a multi-second provider.start()),
+        # so the handler fails CLOSED: rollback + 409, never a silent success
+        # over a live session that may be running the old model.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        newborn = MagicMock(spec=LLMProvider)
+        newborn.has_active_turn.return_value = True
+        # Pre-check and the last-instant pre-reset re-check see no provider;
+        # the post-decline re-read sees the session a slipped-in send
+        # registered after the commit.
+        state.sessions.get_provider = MagicMock(side_effect=[None, None, newborn])
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_live_session_already_on_target_succeeds(self):
+        # The partially-applied live switch: set_model landed, the effort
+        # reapply failed, and the consistency reset declined because a new
+        # turn started. The live session's backend-resolved model already
+        # equals the requested wire id, so slot.model is TRUTHFUL — rolling
+        # back would report the old model while the turn runs the new one.
+        # Success, no rollback, no second reset.
+        from kiro_crew import model_registry
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        live = MagicMock(spec=AcpProvider)
+        live.is_claude_backend = False
+        live.served_model = model_registry.to_acp_id(_MODEL_B)
+        live.has_active_turn.return_value = False
+        live.client = MagicMock()
+        live.client.set_model = AsyncMock()
+        # set_model lands, then the effort reapply fails → went_live False →
+        # the handler takes the consistency-reset fallback, which declines.
+        slot.reasoning_effort = "high"
+        live.supports_effort = MagicMock(return_value=True)
+        live.change_effort = AsyncMock(side_effect=RuntimeError("effort push failed"))
+        state = _mock_state(slot, provider=live)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert slot.model == _MODEL_B
+            # set_model actually landed and the declined reset was accepted as
+            # final: exactly one reset attempt, no retry, no rollback.
+            live.client.set_model.assert_awaited_once()
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_no_live_provider_succeeds(self):
+        # A declined reset with NO live registered provider is the legitimate
+        # success case: nothing to tear down, the next message cold-starts
+        # under the new model. Exactly one reset attempt, no 409.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_attached_subagents_refuse_the_reset_and_roll_back(self):
+        # The reset tears down the runtime attached children run on, so an
+        # idle parent with children (running, queued, or mid-delivery) answers
+        # the reload handler's 409 instead of discarding their work — and the
+        # already-committed model rolls back with its pick generation.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        gen_before = slot._model_pick_gen
+        state = _mock_state(slot, provider=None)
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for.return_value = ["child-1"]
+        state.subagents._queued_depth.return_value = 0
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "slot_subagents_running"
+            assert slot.model == _MODEL_A
+            assert slot._model_pick_gen == gen_before
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_switch_waits_for_slot_lock(self):
+        # The mutate-then-reset section runs under slot._lock, same as the
+        # agent/effort handlers: while another actor holds the lock, a model
+        # switch must neither commit nor reset.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+                )
+                # Let the request reach (and block on) the slot lock.
+                await asyncio.sleep(0.05)
+                assert slot.model == _MODEL_A
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_racing_switches_serialize_instead_of_interleaving(self):
+        # Two racing switches to DIFFERENT targets: the second must not
+        # commit its model while the first's reset await is still in flight
+        # (unlocked, it did — each then reset against the other's
+        # half-applied session). Serialized, each reset observes exactly the
+        # model its own request committed.
+        slot = _ChatSlot("test")
+        slot.model = ""
+        state = _mock_state(slot)
+
+        seen_at_reset: list[str] = []
+        first_reset_started = asyncio.Event()
+        release_first_reset = asyncio.Event()
+
+        async def _reset(*args, **kwargs):
+            seen_at_reset.append(slot.model)
+            if len(seen_at_reset) == 1:
+                first_reset_started.set()
+                await release_first_reset.wait()
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            first = asyncio.create_task(
+                client.post("/api/chat/slots/test/model", json={"model": _MODEL_A})
+            )
+            await first_reset_started.wait()
+            second = asyncio.create_task(
+                client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            )
+            # Let the second request reach (and block on) the slot lock, then
+            # release the first request's reset.
+            await asyncio.sleep(0.05)
+            # The serialization under test: the second switch has NOT
+            # committed while the first's reset is still in flight.
+            assert slot.model == _MODEL_A
+            release_first_reset.set()
+            resp1 = await first
+            resp2 = await second
+            assert resp1.status == 200
+            assert resp2.status == 200
+            assert seen_at_reset == [_MODEL_A, _MODEL_B]
+            assert slot.model == _MODEL_B
+
+    @pytest.mark.asyncio
+    async def test_same_target_successor_noops_under_lock(self):
+        # Two clients pick the SAME target; the second is queued behind the
+        # first's in-flight reset. The no-op check is re-run INSIDE the lock,
+        # so the successor observes the predecessor's committed value and
+        # answers OK without tearing down the session the predecessor just
+        # set up — one reset total.
+        slot = _ChatSlot("test")
+        slot.model = ""
+        state = _mock_state(slot)
+
+        first_reset_started = asyncio.Event()
+        release_first_reset = asyncio.Event()
+        calls = {"n": 0}
+
+        async def _reset(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                first_reset_started.set()
+                await release_first_reset.wait()
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            first = asyncio.create_task(
+                client.post("/api/chat/slots/test/model", json={"model": _MODEL_A})
+            )
+            await first_reset_started.wait()
+            second = asyncio.create_task(
+                client.post("/api/chat/slots/test/model", json={"model": _MODEL_A})
+            )
+            await asyncio.sleep(0.05)
+            release_first_reset.set()
+            resp1 = await first
+            resp2 = await second
+            assert resp1.status == 200
+            assert resp2.status == 200
+            assert slot.model == _MODEL_A
+            assert calls["n"] == 1
+
+
+class TestSlotWorkspaceSwitchAtomicity:
+    @pytest.fixture(autouse=True)
+    def _stub_project_dir(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.default_project_dir",
+            lambda ws: f"/workspace/{ws}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_switch_waits_for_slot_lock(self):
+        # The workspace switch mutates the same workspace/project fields the
+        # agent handler compare-and-sets under slot._lock, so it must take
+        # the same lock: while another actor holds it, the switch neither
+        # mutates nor resets.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+                )
+                await asyncio.sleep(0.05)
+                assert slot.workspace == "old-ws"
+                assert slot.project == "/workspace/old-ws"
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            assert resp.status == 200
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_message_guard_is_checked_inside_the_lock(self):
+        # The total_messages guard is a check-then-act across the reset
+        # await: an unlocked read could pass while a serialized predecessor
+        # was still running, then mutate a slot whose conversation had
+        # started in the meantime. Checked inside the lock, a message that
+        # lands while the request waits makes it answer 409 and touch
+        # nothing.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+                )
+                # Let the request reach (and block on) the slot lock, then
+                # start the conversation before releasing it.
+                await asyncio.sleep(0.05)
+                slot.total_messages = 1
+            resp = await task
+            assert resp.status == 409
+            assert slot.workspace == "old-ws"
+            assert slot.project == "/workspace/old-ws"
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_busy_rolls_back_and_answers_409(self):
+        # A first send can slip in between the total_messages guard and the
+        # reset (message dispatch does not take slot._lock), so the reset runs
+        # with skip_if_busy=True: on an atomic decline the committed
+        # workspace/project pair is rolled back, the response is 409, and the
+        # slipped-in turn survives.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        busy = MagicMock(spec=LLMProvider)
+        busy.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=busy)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.workspace == "old-ws"
+            assert slot.project == "/workspace/old-ws"
+            assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_idle_session_retries_once(self):
+        # An idle live session declined the first reset (a slipped-in first
+        # send finished before the re-read): the handler retries once and
+        # succeeds, so the stale process never survives under the new
+        # bindings.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        idle = MagicMock(spec=LLMProvider)
+        idle.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=idle)
+        state.sessions.reset = AsyncMock(side_effect=[False, True])
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 200
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_live_session_on_new_bindings_succeeds(self):
+        # A first send slipped in AFTER the commit, captured the committed new
+        # project, and its session declined the reset. The live session's
+        # actual cwd equals the committed project, so slot state is TRUTHFUL —
+        # rolling back would advertise the old workspace while the live
+        # process runs the new one. Success, no rollback, no teardown.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        live = MagicMock(spec=AcpProvider)
+        live.cwd = "/workspace/new-ws"
+        live.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=live)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_post_commit_session_fails_closed(self):
+        # Pre-check era saw no session; the decline came from a session
+        # registered after the commit with a turn in flight. Fail closed:
+        # both fields rolled back, 409.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        newborn = MagicMock(spec=LLMProvider)
+        newborn.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=newborn)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.workspace == "old-ws"
+            assert slot.project == "/workspace/old-ws"
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_second_time_fails_closed_to_409(self):
+        # Two declined resets from an idle live session: exactly two
+        # attempts, both fields rolled back, 409 — never success over a live
+        # session whose bindings cannot be proven.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        idle = MagicMock(spec=LLMProvider)
+        idle.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=idle)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.workspace == "old-ws"
+            assert slot.project == "/workspace/old-ws"
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_no_live_provider_succeeds(self):
+        # A declined reset with NO live registered provider is the legitimate
+        # success case: nothing to tear down, the next message cold-starts
+        # under the new bindings. Exactly one reset attempt.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 200
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_new_bindings_visible_during_reset(self):
+        # Commit-before-reset ordering per the agent-handler template: a send
+        # landing while the reset await is in flight cold-starts a session
+        # from the slot's CURRENT bindings, so the new workspace/project pair
+        # must already be committed when the reset runs.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot)
+        seen_during_reset: list[tuple[str, str]] = []
+
+        async def _observe(*args, **kwargs):
+            seen_during_reset.append((slot.workspace, slot.project))
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_observe)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            assert resp.status == 200
+            assert seen_during_reset == [("new-ws", "/workspace/new-ws")]
+
+
+def _make_app_as(state: DashboardState, app_name: str) -> web.Application:
+    """Like _make_app but the caller is an App Kit token owning *app_name*."""
+
+    @web.middleware
+    async def app_marker(request, handler):
+        request["app"] = app_name
+        return await handler(request)
+
+    app = web.Application(middlewares=[app_marker])
+    app["state"] = state
+    app.router.add_post("/api/chat/slots/model", api_chat_slots_model)
+    app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
+    app.router.add_post("/api/chat/slots/{slot}/workspace", api_chat_slot_workspace)
+    return app
+
+
+class TestLinkedSlotSessionKey:
+    """A channel-/cron-born slot runs its turns under ``linked_session_key``.
+
+    The switch handlers must probe and reset THAT session (the reload
+    handler's rule), not the ``dashboard:<slot>`` spelling that names a
+    session which never existed — otherwise the busy probe sees nothing and
+    the reset "succeeds" against nothing while the live process keeps the old
+    model. And slot ownership does not imply ownership of the linked session,
+    so an app caller may not switch a channel thread's model.
+    """
+
+    @pytest.mark.asyncio
+    async def test_model_switch_probes_and_resets_the_linked_session(self):
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+            probed = {c.args[0] for c in state.sessions.get_provider.call_args_list}
+            assert probed == {"slack:123.456"}
+            state.sessions.reset.assert_awaited_once()
+            assert state.sessions.reset.await_args.args[0] == "slack:123.456"
+
+    @pytest.mark.asyncio
+    async def test_model_switch_sees_the_linked_sessions_active_turn(self):
+        # The busy probe now lands on the live linked session: an in-flight
+        # channel turn answers 409 instead of a silent success over it.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.linked_session_key = "slack:123.456"
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=None)
+        state.sessions.get_provider = MagicMock(
+            side_effect=lambda key: provider if key == "slack:123.456" else None
+        )
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_app_caller_cannot_switch_a_linked_sessions_model(self):
+        # Owning the slot is not owning the channel session it is bound to:
+        # denied as an indistinguishable 404, nothing mutated.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 404
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_app_caller_still_switches_its_own_unlinked_slot(self):
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot._app = "demo-app"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+
+    @pytest.mark.asyncio
+    async def test_bulk_switch_resets_the_linked_session_for_dashboard_users(self):
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == ["test"]
+            assert state.sessions.reset.await_args.args[0] == "slack:123.456"
+
+    @pytest.mark.asyncio
+    async def test_bulk_switch_skips_linked_slots_for_app_callers(self):
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == []
+            assert data["skipped_running"] == []
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_workspace_switch_resets_the_linked_session(self):
+        slot = _ChatSlot("test")
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "ws2"})
+            assert resp.status == 200
+            assert state.sessions.reset.await_args.args[0] == "slack:123.456"
+
+    @pytest.mark.asyncio
+    async def test_binding_that_lands_while_queued_on_the_lock_is_the_one_switched(self):
+        # The key is resolved INSIDE the lock: a slot that gets linked while
+        # the request waits on slot._lock has its LINKED session probed and
+        # reset, not the dashboard:<slot> key a pre-lock read would have named.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+                )
+                await asyncio.sleep(0.05)
+                slot.linked_session_key = "cron:job-1"
+            resp = await task
+            assert resp.status == 200
+            assert slot.model == _MODEL_B
+            probed = {c.args[0] for c in state.sessions.get_provider.call_args_list}
+            assert probed == {"cron:job-1"}
+            assert state.sessions.reset.await_args.args[0] == "cron:job-1"
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_live_switch_rolls_back_and_answers_409(self):
+        # A binding that lands DURING _try_live_model_switch's provider RPC
+        # (after the key was resolved) means whatever set_model did landed on
+        # a session the slot no longer runs on: commit nothing, reset nothing,
+        # 409 so the retry resolves the current binding.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        provider.is_claude_backend = False
+        provider.has_active_turn.return_value = False
+        provider.client = MagicMock()
+
+        async def _set_model_and_rebind(_wire):
+            slot.linked_session_key = "cron:job-1"
+
+        provider.client.set_model = AsyncMock(side_effect=_set_model_and_rebind)
+        provider.supports_effort = MagicMock(return_value=False)
+        state = _mock_state(slot, provider=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_reset_rolls_back_the_model_switch(self):
+        # The same check after the reset await: the session torn down is no
+        # longer the slot's, so the commit is rolled back and the caller
+        # retries against the current binding.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+
+        async def _reset_and_rebind(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            return False
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.model == _MODEL_A
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_reset_lands_bulk_slot_in_skipped_running(self):
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+
+        async def _reset_and_rebind(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_reset_rolls_back_the_workspace_switch(self):
+        slot = _ChatSlot("test")
+        prior_ws, prior_project = slot.workspace, slot.project
+        state = _mock_state(slot, provider=None)
+
+        async def _reset_and_rebind(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "ws2"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert (slot.workspace, slot.project) == (prior_ws, prior_project)
+
+
+class TestSlotProjectSwitchAtomicity:
+    @pytest.mark.asyncio
+    async def test_project_set_waits_for_slot_lock(self, tmp_path):
+        # api_chat_slot_project is the one remaining live mutator of
+        # slot.project outside the switch handlers: unlocked, its write could
+        # land during a locked workspace switch's reset await and then be
+        # erased by that switch's rollback. Serialized on the same lock, the
+        # write queues until the switch completes.
+        import os
+
+        from kiro_crew.dashboard.chat import api_chat_slot_project
+
+        slot = _ChatSlot("test")
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot)
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
+        # A real directory on every OS: the endpoint realpaths and isdir-checks
+        # the payload before the locked section this test pins.
+        new_dir = os.path.realpath(str(tmp_path))
+        async with TestClient(TestServer(app)) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/test/project", json={"project": new_dir})
+                )
+                # Let the request pass validation and block on the slot lock.
+                await asyncio.sleep(0.05)
+                assert slot.project == "/workspace/old-ws"
+            resp = await task
+            assert resp.status == 200
+            assert slot.project == new_dir
+
+
+class TestBulkModelSwitchAtomicity:
+    @pytest.mark.asyncio
+    async def test_bulk_switch_waits_for_slot_lock(self):
+        # The bulk handler acquires each slot's lock per-iteration, same lock
+        # as the single-slot switch handlers: while another actor holds slot
+        # A's lock, the bulk switch must neither commit nor reset A.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+                )
+                # Let the request reach (and block on) the slot lock.
+                await asyncio.sleep(0.05)
+                assert slot.model == _MODEL_A
+                state.sessions.reset.assert_not_awaited()
+            resp = await task
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == ["test"]
+            assert slot.model == _MODEL_B
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_slot_that_started_running_while_queued_is_skipped(self):
+        # The skip_running pre-check is re-run INSIDE the lock: a slot that
+        # became running while the bulk request waited on its lock must land
+        # in skipped_running — not be reset mid-turn (the defect this PR
+        # exists to prevent, on the bulk path).
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            async with slot._lock:
+                task = asyncio.create_task(
+                    client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+                )
+                # Let the request pass the unlocked pre-check and block on the
+                # lock, then start a turn before releasing it.
+                await asyncio.sleep(0.05)
+                running_task = MagicMock()
+                running_task.done.return_value = False
+                slot.task = running_task
+            resp = await task
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_running_slot_already_on_target_is_unchanged_not_skipped(self):
+        # Classification order inside the lock is equality FIRST: a running
+        # slot that already uses the requested model is "unchanged", not
+        # "skipped_running" — a running-check ahead of the equality check
+        # would misreport it and imply work was left undone.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_B
+        running_task = MagicMock()
+        running_task.done.return_value = False
+        slot.task = running_task
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["unchanged"] == ["test"]
+            assert data["skipped_running"] == []
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_exception_is_isolated_per_slot(self):
+        # The retry runs inside the per-slot failure-isolation try: a teardown
+        # that raises on the retry classifies THAT slot as failed (model
+        # untouched) and the remaining slots are still processed — never a
+        # 500 aborting the whole bulk switch.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot_a = _ChatSlot("a")
+        slot_a.model = _MODEL_A
+        slot_b = _ChatSlot("b")
+        slot_b.model = _MODEL_A
+        idle = MagicMock(spec=AcpProvider)
+        idle.has_active_turn.return_value = False
+        state = _mock_state(slot_a, provider=idle)
+        state._slots = {"a": slot_a, "b": slot_b}
+        # Slot a: first reset declines, retry raises. Slot b: reset succeeds.
+        state.sessions.reset = AsyncMock(side_effect=[False, RuntimeError("boom"), True])
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["failed"] == ["a"]
+            assert data["switched"] == ["b"]
+            assert slot_a.model == _MODEL_A
+            assert slot_b.model == _MODEL_B
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_no_live_provider_switches(self):
+        # A declined reset with NO live registered provider commits: nothing
+        # to tear down, the next message cold-starts under the new model.
+        # Exactly one reset attempt, slot lands in switched.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == ["test"]
+            assert slot.model == _MODEL_B
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_cold_start_lands_in_skipped_running(self):
+        # A first send can slip into the reset await and still be INSIDE its
+        # provider.start() when the decline is read: slot.running is set (at
+        # dispatch) but get_provider sees nothing yet. Bulk commits AFTER the
+        # reset, so that cold-starting session captured the OLD model —
+        # committing here would report success over it. The handler re-reads
+        # slot.running before the provider ladder and classifies the slot as
+        # skipped_running with its model untouched.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+
+        async def _decline_and_start_turn(*_a, **_k):
+            running_task = MagicMock()
+            running_task.done.return_value = False
+            slot.task = running_task
+            return False
+
+        state.sessions.reset = AsyncMock(side_effect=_decline_and_start_turn)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_idle_retry_switches(self):
+        # An idle live session declined the first reset (its slipped-in turn
+        # already finished). Bulk commits AFTER the reset, so that session is
+        # on the old model: the handler retries once, and on success the slot
+        # is switched — never left as a silent stale process.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=provider)
+        state.sessions.reset = AsyncMock(side_effect=[False, True])
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["switched"] == ["test"]
+            assert slot.model == _MODEL_B
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_twice_lands_in_skipped_running(self):
+        # A second decline means another turn is genuinely racing the retry:
+        # the slot lands in skipped_running with its model untouched.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=provider)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+            assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_declined_busy_lands_in_skipped_running(self):
+        # A turn can start even after the in-lock checks (message dispatch
+        # does not take slot._lock), so the reset runs with
+        # skip_if_busy=skip_running and its atomic decline is authoritative:
+        # the slot lands in skipped_running with its model untouched, and the
+        # in-flight turn survives.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        provider = MagicMock(spec=AcpProvider)
+        # Idle at the in-lock pre-check, busy by the time the decline is read.
+        provider.has_active_turn.side_effect = [False, True]
+        state = _mock_state(slot, provider=provider)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+            assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+
+    @pytest.mark.asyncio
+    async def test_live_turn_on_effective_session_is_skipped_before_the_reset(self):
+        # slot.running only sees turns dispatched through this slot's task; a
+        # channel-linked slot's turn runs under its linked key without setting
+        # it. The last-instant has_active_turn re-check on the effective
+        # session catches it BEFORE the reset, so _reset_slot_session's
+        # unblock half never runs against the live turn's pending cards.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        slot.linked_session_key = "slack:123.456"
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=None)
+        state.sessions.get_provider = MagicMock(
+            side_effect=lambda key: provider if key == "slack:123.456" else None
+        )
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slot_with_attached_subagents_is_skipped_even_when_forced(self):
+        # The reset tears down the runtime attached children run on, so a
+        # parent with children is skipped — even with skip_running=false,
+        # which speaks to the parent's own turn, not to its children.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for.return_value = ["child-1"]
+        state.subagents._queued_depth.return_value = 0
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/model", json={"model": _MODEL_B, "skip_running": False}
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["skipped_running"] == ["test"]
+            assert data["switched"] == []
+            assert slot.model == _MODEL_A
+            state.sessions.reset.assert_not_awaited()

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -18677,10 +18677,12 @@ class TestSlotModelLiveSwitch:
         state.sessions.reset.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_active_turn_falls_back_to_reset(self, tmp_path):
+    async def test_active_turn_answers_409_without_reset(self, tmp_path):
         # Awaiting a response mid-turn would race the streaming prompt loop on
         # stdout for the non-multiplexed client (same hazard the effort handler
-        # documents), so a turn in flight takes the old reset path.
+        # documents), and the old reset fallback tore down the in-flight turn
+        # mid-stream for any programmatic caller. A turn in flight now answers
+        # busy: no live switch, no reset, slot model untouched.
         state = _make_state(tmp_path)
         state.sessions.reset = AsyncMock()
         provider = self._provider(active_turn=True)
@@ -18690,10 +18692,13 @@ class TestSlotModelLiveSwitch:
 
         async with TestClient(TestServer(self._app(state))) as client:
             resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
+            data = await resp.json()
 
-        assert resp.status == 200
+        assert resp.status == 409
+        assert data["code"] == "turn_in_flight"
         provider.client.set_model.assert_not_awaited()
-        state.sessions.reset.assert_awaited_once()
+        state.sessions.reset.assert_not_awaited()
+        assert state._slots["a"].model == "claude-opus-4.8"
 
     @pytest.mark.asyncio
     async def test_live_switch_failure_falls_back_to_reset(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

Two slot-switch handlers in `src/kiro_crew/dashboard/chat_handlers.py` mutate slot state and reset the session WITHOUT the `slot._lock` serialization the agent and effort switch handlers already use:

1. `api_chat_slot_model` mutates `slot.model` and awaits `_try_live_model_switch` / `_reset_slot_session` unlocked. Worse, `_try_live_model_switch` returns False when `provider.has_active_turn()`, and the caller then fell through to `_reset_slot_session(...)` — tearing down an in-flight streaming turn for any programmatic caller (the UI disables the picker mid-turn, but the API had no guard).
2. `api_chat_slot_workspace` mutates `slot.workspace` / `slot.project` and resets unlocked, behind only the orthogonal `total_messages > 0` UX guard.

Two racing switches could each commit-and-reset against the other's half-applied session state across their awaits.

## Why it matters

Any programmatic caller (App Kit, scripts, a second dashboard tab) that switches a slot's model mid-turn silently kills the streaming response the user is watching. Racing switches can leave a slot's committed settings and its live session inconsistent — the model/history inconsistency class the in-tree handlers' locking exists to prevent.

## What changed (motivation → approach → change)

Copied the in-tree lock + ordering template from the agent and effort switch handlers rather than inventing a new mechanism. Rebased onto `main` after #5431 landed the per-slot `_model_pick_lock` + pick-generation machinery for the two model handlers: that lock is kept (nested inside `slot._lock`) rather than replaced, because it also serializes against the fallback swap/restore probe in `chat_runner`, which `slot._lock` does not cover.


- **`api_chat_slot_model`**: the section from the no-op check through the reset now runs under `async with slot._lock, slot._model_pick_lock` — `slot._lock` (outer) is the same lock the agent, effort and workspace switch handlers hold; `slot._model_pick_lock` (inner) is the model-fallback pick transaction lock #5431 landed on `main` while this PR was open (the fallback swap and restore probe in `chat_runner` hold it across their own `set_model` awaits, and nothing takes the two in the opposite order). The equality check is INSIDE the locks only (an unlocked read could match a serialized predecessor's transient pre-rollback value), and keeps #5431's `not slot._active_fallback_model` clause and pick-generation bump. A slot that is running, or a provider with an active turn, answers **409 `turn_in_flight`** instead of falling through to the reset — the same policy as the effort handler's defer-not-reset branch, the bulk handler's `skip_running` default, and the reload handler's 409. Every rollback (the `AcpModelUnavailable` refusal, the last-instant busy re-check, the declined-reset ladder) goes through one nested `_rollback_pick()` helper that unwinds the model AND the pick generation together with #5431's compare-and-swap, so no rollback path can leave a phantom pick generation behind. The session the handler probes and resets is `effective_session_key(slot)`, never `_history_key_for(name)` (the reload handler's rule): a channel- or cron-born slot runs its turns under its linked key, and the dashboard-prefixed spelling names a session that never existed — the busy probe would see nothing and the reset would "succeed" against nothing while the live process kept the old model. With that comes the cancel routes' session-level app isolation (`_app_cancel_denied`): owning a slot is not owning the channel session it is bound to, so an App Kit caller may not switch a linked thread's model (indistinguishable 404). The key is resolved INSIDE the lock (a cron/workflow slot is linked when its first result is injected, which can land while a request waits on the lock), and re-checked after every await (the live switch's provider RPCs and the reset): a binding that moved in that window means `set_model` landed on a session the slot no longer runs on, so the handler rolls back and answers **409 `session_rebound`** instead of committing over a session that never saw the switch (the workspace handler does the same; the bulk handler reports such a slot as `skipped_running`). Two more guards sit immediately before the reset, in the same no-await window as the busy re-check: the reload handler's children guard (`_subagents_attached_response` → **409 `slot_subagents_running`** with rollback — the reset tears down the runtime attached sub-agents run on), and on the bulk path a last-instant `has_active_turn` re-check on the EFFECTIVE session (`slot.running` does not see a channel-linked turn) plus the same children probe, both landing the slot in `skipped_running` (children regardless of `skip_running`, which speaks to the parent's own turn).
- **`api_chat_slot_workspace`**: body wrapped in the lock, `total_messages` guard re-checked inside it, commit-before-reset ordering per the agent-handler template; resets `effective_session_key(slot)` (resolved inside the lock) with the same session-level app isolation as the model handler.
- **`api_chat_slots_model`** (bulk): acquires each slot's two locks (same order as the single-slot handler) per-iteration with all classification in-lock, equality first (a running slot already on the target model stays `unchanged`), preserving reset-before-commit failure isolation and #5431's pick-generation bump on commit. The docstring now states the deliberate single-vs-bulk mid-turn policy divergence (`skip_running: false` remains an explicit opt-in that resets mid-turn slots). Each slot's reset addresses `effective_session_key(slot)` (resolved inside its locks); for an App Kit caller a slot bound to a linked channel session is skipped like any other slot the app does not own.
- **`api_chat_slot_project`**: the `slot.project` write is serialized under `slot._lock` too — it was the one remaining live HTTP mutator of `slot.project` outside the lock, and unlocked it could interleave with the workspace handler's locked mutate-then-reset section (whose rollback would then erase a project pick that landed during its reset await). Only the write is locked; the reset stays deferred via `_pending_reset_history_key` (the killpg constraint), so nothing is awaited under the lock beyond what the other switch handlers already hold. (The MCP `set_project` directive path in `session_directive_apply.py` writes `slot.project` without the lock and is out of scope here — see the First Principles disposition.)
- **Authoritative backstop**: message dispatch does not take `slot._lock`, so the `has_active_turn` checks are best-effort fast paths. The resets now pass `skip_if_busy=True` (`skip_if_busy=skip_running` on the bulk path) — `SessionManager.reset` evaluates busyness atomically with the session pop, the same fast-path/authoritative split `api_chat_slot_reload` documents. A declined reset is disambiguated **fail-closed**, with one truth-based exception checked first in the model handler: when the live ACP session's backend-resolved model already equals the requested wire id (`AcpProvider.served_model`; for a switch TO Auto, whose `"auto"` sentinel `served_model` deliberately collapses to `""` for the fallback canary, the session client's raw served id is read instead — scoped to that one wire value (the same `"auto"` literal `_wire_model_id` hands out; no new ACP-layer import), so every other non-match stays fail-closed) — the partially-applied live switch, where `set_model` landed, the effort reapply failed, and the consistency reset declined — the handler reports success without teardown or rollback, because rolling back would advertise the old model over a live session running the new one. Otherwise: live provider mid-turn → roll back the committed slot state and 409 (bulk: `skipped_running`); bulk with `slot.running` set after the decline — a first send that slipped into the reset await and is still inside its multi-second `provider.start()`, visible to `slot.running` but not yet to `get_provider` — → `skipped_running` (bulk commits AFTER the reset, so that session captured the old model); live idle provider → retry the reset once (the reload handler's template, run inside the bulk path's per-slot failure-isolation try), second decline fails closed the same way; no live provider → success (nothing registered to tear down). Identity/registration-time reasoning is deliberately not used: dispatch captures slot bindings at its call site but registers the session only after the multi-second `provider.start()`, so neither proves which bindings a live session carries.

The only behavior change (mid-turn model switch: reset → 409) fixes the reported defect and matches three in-tree precedents.

## Tests

New `test/test_chat_slot_switch_atomicity.py` (49 tests), cloning the concurrency template from `test_chat_slot_reasoning_effort.py:145-198`:

- Mid-turn model switch answers 409 with zero resets and untouched slot model
- Model/workspace/bulk switches block on a held `slot._lock` (neither commit nor reset until release)
- Racing switches serialize instead of interleaving; a same-target successor no-ops under the lock (one reset total)
- Workspace `total_messages` guard is checked inside the lock; commit-before-reset visibility pinned
- Fail-closed decline paths on all three handlers: busy decline → rollback + 409 / `skipped_running`; idle decline → exactly one retry; second decline → fail closed; post-commit-registered session → fail closed
- No-live-provider decline → legitimate success, pinned on all three handlers
- The truth-based exception: live session already serving the target wire model → success without rollback (`test_reset_declined_live_session_already_on_target_succeeds`, driving the exact set_model-lands / effort-reapply-fails / reset-declines chain)
- Bulk retry exception stays per-slot isolated (`test_retry_exception_is_isolated_per_slot`: retry raises → that slot `failed`, the rest still switch)
- Bulk: a running slot already on the target model is `unchanged`, not `skipped_running`
- Bulk: a declined reset with `slot.running` set and no registered provider (cold-start slipped into the reset await) lands in `skipped_running` with the model untouched (`test_reset_declined_cold_start_lands_in_skipped_running`)
- Auto as the live-switch target: landed `set_model("auto")` recognized through the raw client served id → 200 without rollback; a raw id that is NOT `auto` still fails closed to 409 (`test_turn_on_auto_during_live_switch_succeeds_via_raw_served_model`, `test_turn_on_other_model_during_auto_switch_still_fails_closed`)
- Linked slots (`TestLinkedSlotSessionKey`, 12 tests): model, bulk and workspace switches probe and reset `linked_session_key`, not `dashboard:<slot>`; an in-flight linked turn answers 409; an App Kit caller gets 404 on a linked slot's model switch and has linked slots skipped by the bulk switch, while still switching its own unlinked slot; a binding that lands while the request waits on the lock is the one switched; a binding that lands during the live switch's RPC rolls back to 409 `session_rebound` with no reset; a binding that lands during the reset rolls back the model/workspace commit (409) and lands the bulk slot in `skipped_running`
- Children guard: an idle parent with attached sub-agents answers 409 `slot_subagents_running` with model + pick generation rolled back; bulk skips it even with `skip_running: false`. Bulk last-instant busy re-check: a live turn on a linked session (invisible to `slot.running`) lands in `skipped_running` before the reset is entered (`test_attached_subagents_refuse_the_reset_and_roll_back`, `test_slot_with_attached_subagents_is_skipped_even_when_forced`, `test_live_turn_on_effective_session_is_skipped_before_the_reset`)

Updated `test_dashboard_chat.py::TestSlotModelLiveSwitch::test_active_turn_answers_409_without_reset` (was `test_active_turn_falls_back_to_reset`) for the intended behavior change.

## Manual verification

N/A — unit coverage sufficient: the affected paths are HTTP handlers fully exercised through aiohttp TestClient with the same request shapes the frontend sends.

## Related Issues

Closes #2363

## Pattern harvest

Rule candidate: review-prompt
Pattern: slot switch handler addresses the slot's session by `_history_key_for(name)` instead of `effective_session_key(slot)`, or resets/mutates slot state without `slot._lock` while sibling switch handlers hold it — the remaining siblings (agent, effort, project) are tracked in #8415.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — handler docstrings updated
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (Python HTTP handlers + tests); no frontend file touched, no rendered pixel changes.






