### PR TITLE
fix(channels): reject non-object bodies and validate create before mutating

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -247,7 +247,6 @@ src/kiro_crew/dashboard/handlers/themes.py
 src/kiro_crew/dashboard/handlers/tunnel.py
 src/kiro_crew/dashboard/handlers/webapp_preview.py
 src/kiro_crew/dashboard/handlers/weixin_qr.py
-src/kiro_crew/dashboard/handlers_channel.py
 src/kiro_crew/dashboard/handlers_cloud.py
 src/kiro_crew/dashboard/handlers_instances.py
 src/kiro_crew/dashboard/loop_watchdog.py

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1363,
+    "missing_code": 1362,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1154,
+  "_compliant": 1158,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -186,7 +186,7 @@
       "missing_code": 16
     },
     "dashboard/handlers_channel.py": {
-      "missing_code": 20
+      "missing_code": 19
     },
     "dashboard/handlers_instances.py": {
       "missing_code": 18,

--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -70,6 +70,13 @@ _DEFAULT_PRESETS = [
 ]
 
 
+#: Valid agent ``approval`` values, derived from ``ApprovalPolicy`` so a new
+#: enum member can't silently 400 on create while ``add_agent`` accepts it.
+#: Kept as a frozenset rather than the Enum itself so the isinstance guard
+#: rejects unhashable junk (lists, dicts) BEFORE the membership test.
+_ALLOWED_POLICIES: frozenset[str] = frozenset(p.value for p in ApprovalPolicy)
+
+
 def _mgr(request: web.Request) -> ChannelManager:
     state: DashboardState = request.app["state"]
     mgr = getattr(state, "channel_manager", None)
@@ -77,15 +84,47 @@ def _mgr(request: web.Request) -> ChannelManager:
     return mgr
 
 
+async def _parse_object_body(request: web.Request) -> dict:
+    """Parse the request body as a JSON OBJECT, or raise HTTPBadRequest.
+
+    Every Channels write handler routes through here so the input contract is
+    one shape: valid JSON that is not an object (array/string/number/null)
+    reaches ``.get(...)`` otherwise and surfaces as HTTP 500. Other dashboard
+    handlers already reject this class with a 400.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        raise web.HTTPBadRequest(text='{"error":"invalid JSON"}', content_type="application/json")
+    if not isinstance(body, dict):
+        raise web.HTTPBadRequest(
+            text=json.dumps(
+                {
+                    "error": "body must be a JSON object",
+                    "code": "channels.body_not_object",
+                }
+            ),
+            content_type="application/json",
+        )
+    return body
+
+
+def _bad_approval_response() -> web.Response:
+    return web.json_response(
+        {
+            "error": f"agent approval must be one of {sorted(_ALLOWED_POLICIES)}",
+            "code": "channels_agent_approval_policy_invalid",
+        },
+        status=400,
+    )
+
+
 async def _get_channel_body(request: web.Request):
     """Get channel + parsed JSON body, or raise web.HTTPException."""
     ch = _mgr(request).get(request.match_info["id"])
     if not ch:
         raise web.HTTPNotFound(text='{"error":"not found"}', content_type="application/json")
-    try:
-        body = await request.json()
-    except Exception:
-        raise web.HTTPBadRequest(text='{"error":"invalid JSON"}', content_type="application/json")
+    body = await _parse_object_body(request)
     return ch, body
 
 
@@ -157,13 +196,59 @@ async def api_channel_get(request: web.Request) -> web.Response:
 
 
 async def api_channel_create(request: web.Request) -> web.Response:
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    topic = body.get("topic", "").strip()[:500]
+    # Validate EVERYTHING before the first mutation: ChannelManager.create adds
+    # the channel and broadcasts channel_created, so an agents payload that
+    # failed validation AFTER that point had already published a half-built
+    # channel and then answered 500.
+    body = await _parse_object_body(request)
+    topic_raw = body.get("topic", "")
+    if not isinstance(topic_raw, str):
+        return web.json_response({"error": "topic must be a string"}, status=400)
+    topic = topic_raw.strip()[:500]
     if not topic:
         return web.json_response({"error": "topic required"}, status=400)
+
+    agents_def = body.get("agents", [])
+    if not isinstance(agents_def, list) or not all(isinstance(a, dict) for a in agents_def):
+        return web.json_response({"error": "agents must be a list of objects"}, status=400)
+    # Every field add_agent dereferences must be type- and value-safe BEFORE
+    # the channel exists: ApprovalPolicy(...) raises on an unknown policy, and
+    # a non-string role is concatenated into processing keys downstream — both
+    # would publish the channel and then 500 it.
+    # Each branch carries its own literal lower_snake code: the error-contract
+    # scan reads only Constant values, so a shared f-string or lookup would
+    # count these sites as un-coded.
+    for a in agents_def:
+        approval = a.get("approval", "writes")
+        if not isinstance(approval, str) or approval not in _ALLOWED_POLICIES:
+            return _bad_approval_response()
+        role = a.get("role")
+        if role is not None and not isinstance(role, str):
+            return web.json_response(
+                {
+                    "error": "agent role must be a string",
+                    "code": "channels_agent_role_type_invalid",
+                },
+                status=400,
+            )
+        agent_name = a.get("agent")
+        if agent_name is not None and not isinstance(agent_name, str):
+            return web.json_response(
+                {
+                    "error": "agent name must be a string",
+                    "code": "channels_agent_name_type_invalid",
+                },
+                status=400,
+            )
+        task = a.get("task")
+        if task is not None and not isinstance(task, str):
+            return web.json_response(
+                {
+                    "error": "agent task must be a string",
+                    "code": "channels_agent_task_type_invalid",
+                },
+                status=400,
+            )
 
     ch = _mgr(request).create(topic)
     if not ch:
@@ -175,7 +260,6 @@ async def api_channel_create(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
 
     # Spawn agents from preset
-    agents_def = body.get("agents", [])
     has_orchestrator = any(a.get("is_orchestrator") for a in agents_def)
     if not has_orchestrator:
         agents_def = [
@@ -255,19 +339,13 @@ async def api_channel_add_agent(request: web.Request) -> web.Response:
 
     role = body.get("role", "Agent")
     if not isinstance(role, str):
-        return _agent_field_error(
-            "role must be a string", "channel_agent_role_type_invalid"
-        )
+        return _agent_field_error("role must be a string", "channel_agent_role_type_invalid")
     agent_name = body.get("agent", "")
     if not isinstance(agent_name, str):
-        return _agent_field_error(
-            "agent must be a string", "channel_agent_name_type_invalid"
-        )
+        return _agent_field_error("agent must be a string", "channel_agent_name_type_invalid")
     task = body.get("task", ch.topic)
     if not isinstance(task, str):
-        return _agent_field_error(
-            "task must be a string", "channel_agent_task_type_invalid"
-        )
+        return _agent_field_error("task must be a string", "channel_agent_task_type_invalid")
     is_orchestrator = body.get("is_orchestrator", False)
     if not isinstance(is_orchestrator, bool):
         return _agent_field_error(
@@ -295,7 +373,9 @@ async def api_channel_add_agent(request: web.Request) -> web.Response:
         )
 
     state: DashboardState = request.app["state"]
-    _spawn_agent_task(agent, run_channel_agent(agent, ch, state.sessions, is_yolo=lambda: state._yolo))
+    _spawn_agent_task(
+        agent, run_channel_agent(agent, ch, state.sessions, is_yolo=lambda: state._yolo)
+    )
     return web.json_response({"ok": True, "agent": agent.to_dict()})
 
 
@@ -318,9 +398,7 @@ async def api_channel_update_agent(request: web.Request) -> web.Response:
         try:
             listen_mode = ListenMode(body["listen"])
         except (TypeError, ValueError):
-            return _agent_field_error(
-                "listen must be a valid mode", "channel_agent_listen_invalid"
-            )
+            return _agent_field_error("listen must be a valid mode", "channel_agent_listen_invalid")
     agent.approval_policy = approval_policy
     agent.listen_mode = listen_mode
     ch._save()
@@ -350,7 +428,9 @@ async def api_channel_wake_agent(request: web.Request) -> web.Response:
         {"channel_id": ch.id, "agent_id": aid, "state": "listening"},
     )
     state: DashboardState = request.app["state"]
-    _spawn_agent_task(agent, run_channel_agent(agent, ch, state.sessions, is_yolo=lambda: state._yolo))
+    _spawn_agent_task(
+        agent, run_channel_agent(agent, ch, state.sessions, is_yolo=lambda: state._yolo)
+    )
     return web.json_response({"ok": True})
 
 
@@ -361,10 +441,7 @@ async def api_channel_approve_agent(request: web.Request) -> web.Response:
     agent = ch.members.get(request.match_info["aid"])
     if not agent:
         return web.json_response({"error": "agent not found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body = await _parse_object_body(request)
     action = body.get("action", "rejected")  # approved|rejected|trust
     if action not in ("approved", "rejected", "trust"):
         return web.json_response({"error": "invalid action"}, status=400)
@@ -412,20 +489,25 @@ async def api_channel_clear_context(request: web.Request) -> web.Response:
     ch = _mgr(request).get(request.match_info["id"])
     if not ch:
         sel().log_api_access(
-            caller="dashboard", operation="channel.clear_context",
-            outcome="denied", source="dashboard",
+            caller="dashboard",
+            operation="channel.clear_context",
+            outcome="denied",
+            source="dashboard",
             resources=request.match_info["id"],
         )
         return web.json_response({"error": "not found"}, status=404)
 
     try:
-        body = await request.json()
-    except Exception:
+        body = await _parse_object_body(request)
+    except web.HTTPBadRequest:
         sel().log_api_access(
-            caller="dashboard", operation="channel.clear_context",
-            outcome="denied", source="dashboard", resources=ch.id,
+            caller="dashboard",
+            operation="channel.clear_context",
+            outcome="denied",
+            source="dashboard",
+            resources=ch.id,
         )
-        return web.json_response({"error": "invalid or missing request body"}, status=400)
+        raise
 
     scope = body.get("scope", "all")
     agent_id = body.get("agent_id")
@@ -433,8 +515,11 @@ async def api_channel_clear_context(request: web.Request) -> web.Response:
 
     if scope not in ("all", "agent"):
         sel().log_api_access(
-            caller="dashboard", operation="channel.clear_context",
-            outcome="denied", source="dashboard", resources=f"{ch.id}:{scope}",
+            caller="dashboard",
+            operation="channel.clear_context",
+            outcome="denied",
+            source="dashboard",
+            resources=f"{ch.id}:{scope}",
         )
         return web.json_response({"error": "invalid scope"}, status=400)
 
@@ -443,15 +528,20 @@ async def api_channel_clear_context(request: web.Request) -> web.Response:
     if scope == "agent":
         if not agent_id:
             sel().log_api_access(
-                caller="dashboard", operation="channel.clear_context",
-                outcome="denied", source="dashboard", resources=ch.id,
+                caller="dashboard",
+                operation="channel.clear_context",
+                outcome="denied",
+                source="dashboard",
+                resources=ch.id,
             )
             return web.json_response({"error": "agent_id required"}, status=400)
         agent = ch.members.get(agent_id)
         if not agent:
             sel().log_api_access(
-                caller="dashboard", operation="channel.clear_context",
-                outcome="denied", source="dashboard",
+                caller="dashboard",
+                operation="channel.clear_context",
+                outcome="denied",
+                source="dashboard",
                 resources=f"{ch.id}:{agent_id}",
             )
             return web.json_response({"error": "agent not found"}, status=404)
@@ -469,8 +559,10 @@ async def api_channel_clear_context(request: web.Request) -> web.Response:
         ch._save()
 
     sel().log_api_access(
-        caller="dashboard", operation="channel.clear_context",
-        outcome="allowed", source="dashboard",
+        caller="dashboard",
+        operation="channel.clear_context",
+        outcome="allowed",
+        source="dashboard",
         resources=f"{ch.id}:{scope}:{','.join(cleared)}",
     )
 

--- a/test/test_handlers_channel_clear_context.py
+++ b/test/test_handlers_channel_clear_context.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import web
 
 from kiro_crew.dashboard.handlers_channel import api_channel_clear_context
 
@@ -136,9 +137,10 @@ class TestChannelClearContext:
             "kiro_crew.dashboard.handlers_channel._mgr",
             return_value=MagicMock(get=MagicMock(return_value=ch)),
         ):
-            resp = await api_channel_clear_context(request)
-
-        assert resp.status == 400
+            # The handler now RAISES the 400 (aiohttp turns it into the
+            # response) instead of returning it — same wire result.
+            with pytest.raises(web.HTTPBadRequest):
+                await api_channel_clear_context(request)
 
     @pytest.mark.asyncio
     async def test_returns_400_when_scope_agent_but_no_agent_id(self):

--- a/test/test_handlers_channel_object_bodies.py
+++ b/test/test_handlers_channel_object_bodies.py
@@ -1,0 +1,186 @@
+"""Channels write handlers must reject non-object JSON and validate create
+payloads BEFORE the first mutation (#5586).
+
+Valid JSON that is not an object (array/string/number/null) used to reach
+``.get(...)`` and surface as HTTP 500, and ``api_channel_create`` created +
+broadcast a channel BEFORE validating ``agents`` — so a malformed payload
+published a half-built channel and then answered 500. These tests pin:
+
+  * every write entry point answers deterministic 400 for non-object bodies;
+  * an invalid agents payload never reaches ``ChannelManager.create``;
+  * valid payloads are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.dashboard.handlers_channel import api_channel_add_agent, api_channel_create
+
+
+def _request(body: object) -> web.Request:
+    request = MagicMock()
+    request.match_info = {}
+    request.json = AsyncMock(return_value=body)
+
+    mgr = MagicMock()
+    # create() would mutate + broadcast; any call inside a test below is a
+    # failure the assertions name explicitly.
+    mgr.create.return_value = MagicMock(to_dict=lambda: {"id": "ch-x"})
+    request.app = {"state": MagicMock(), "channel_manager": mgr}
+    return request
+
+
+@pytest.fixture(autouse=True)
+def _route_mgr(monkeypatch: pytest.MonkeyPatch):
+    holder: dict = {}
+
+    def _bind(request):
+        return request.app["channel_manager"]
+
+    monkeypatch.setattr("kiro_crew.dashboard.handlers_channel._mgr", _bind)
+    holder["mgr"] = None
+    yield holder
+
+
+def _mgr_of(request) -> MagicMock:
+    return request.app["channel_manager"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", [[1, 2], "topic", 5, None])
+async def test_create_rejects_non_object_json_without_creating(bad) -> None:
+    req = _request(bad)
+    with pytest.raises(web.HTTPBadRequest) as ei:
+        await api_channel_create(req)
+    payload = json.loads(str(ei.value.text))
+    assert payload["error"] in ("invalid JSON", "body must be a JSON object")
+    if bad is not None:
+        assert payload.get("code") == "channels.body_not_object"
+    _mgr_of(req).create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_string_topic_before_creating() -> None:
+    req = _request({"topic": ["incident"]})
+    resp = await api_channel_create(req)
+    assert resp.status == 400
+    json.loads(resp.text)["error"] == "topic must be a string"
+    _mgr_of(req).create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agents", ["not-a-list", [1, 2], [{"role": "A"}, "oops"], {}])
+async def test_create_validates_agents_before_the_first_mutation(agents) -> None:
+    req = _request({"topic": "incident", "agents": agents})
+    resp = await api_channel_create(req)
+    assert resp.status == 400
+    _mgr_of(req).create.assert_not_called(), (
+        "an invalid agents payload must not publish + broadcast a channel"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approval", ["bogus", ["all"], 3])
+async def test_create_rejects_an_unknown_approval_policy_before_creating(
+    approval,
+) -> None:
+    # ApprovalPolicy(...) raises on an unknown policy — AFTER create() had
+    # already published the channel — so the policy is validated up front.
+    req = _request({"topic": "incident", "agents": [{"role": "A", "approval": approval}]})
+    resp = await api_channel_create(req)
+    assert resp.status == 400
+    _mgr_of(req).create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "agent",
+    [
+        {"role": 7},
+        {"role": "A", "task": ["x"]},
+        {"role": "A", "agent": {"deep": 1}},
+    ],
+)
+async def test_create_rejects_non_string_agent_fields_before_creating(agent) -> None:
+    # role/task/agent are concatenated or persisted downstream; a non-string
+    # value must be refused before the channel exists, not crash it after.
+    req = _request({"topic": "incident", "agents": [dict({"role": "A"}, **agent)]})
+    resp = await api_channel_create(req)
+    assert resp.status == 400
+    _mgr_of(req).create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_known_approval_policy_passes_validation() -> None:
+    req = _request(
+        {
+            "topic": "incident",
+            "agents": [
+                {
+                    "role": "Orchestrator",
+                    "is_orchestrator": True,
+                    "approval": "trusted",
+                }
+            ],
+        }
+    )
+    resp = await api_channel_create(req)
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_a_valid_create_still_reaches_the_manager() -> None:
+    req = _request(
+        {"topic": "incident", "agents": [{"role": "Orchestrator", "is_orchestrator": True}]}
+    )
+    resp = await api_channel_create(req)
+    assert resp.status == 200
+    _mgr_of(req).create.assert_called_once_with("incident")
+
+
+# --- api_channel_add_agent: same approval contract, no raw 500 -------------
+
+
+def _add_agent_request(body: object) -> web.Request:
+    req = _request(body)
+    req.match_info = {"id": "ch-1"}
+    ch = MagicMock()
+    # add_agent validates the defaulted task (body.get("task", ch.topic)) as
+    # a string BEFORE approval, so the mock needs a real topic.
+    ch.topic = "incident"
+    # add_agent would dereference ApprovalPolicy(...) and persist; any call
+    # on an invalid payload is exactly the regression these tests pin.
+    ch.add_agent.return_value = MagicMock(to_dict=lambda: {"id": "ag-1"})
+    _mgr_of(req).get.return_value = ch
+    return req
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approval", ["bogus", ["all"], 3])
+async def test_add_agent_rejects_an_unknown_approval_policy(approval) -> None:
+    req = _add_agent_request({"approval": approval})
+    resp = await api_channel_add_agent(req)
+    assert resp.status == 400
+    body = json.loads(resp.text)
+    assert "approval must be a valid policy" in body["error"]
+    assert body["code"] == "channel_agent_approval_invalid"
+    _mgr_of(req).get.return_value.add_agent.assert_not_called(), (
+        "an unknown approval policy must never reach ApprovalPolicy(...) -> 500"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy", ["all", "writes", "trusted"])
+async def test_add_agent_accepts_every_known_policy(policy, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers_channel._spawn_agent_task",
+        lambda agent, coro: coro.close(),
+    )
+    req = _add_agent_request({"role": "Reviewer", "approval": policy})
+    resp = await api_channel_add_agent(req)
+    assert resp.status == 200


### PR DESCRIPTION
## Problem / Motivation

The Channels write handlers assumed `await request.json()` returns an object. Valid JSON arrays, strings, numbers and `null` therefore reached `.get(...)` and raised `AttributeError` → HTTP 500. `api_channel_create` had a second, worse defect: it called `ChannelManager.create(topic)` **before** validating the `agents` payload, so a body like `{"topic":"incident","agents":["not-an-object"]}` added the channel, broadcast `channel_created`, and *then* failed at `a.get("is_orchestrator")` — publishing a half-built channel while answering 500 (fixes #5586).

## Why it matters

A 500 that has already mutated in-memory state is the worst ordering: clients see an error while a live channel exists, and retrying multiplies them. Other dashboard handlers (`handlers_instances`, `handlers_cloud`, `chat_fork`, `chat_rewind`) already reject non-object JSON with 400 — Channels was violating the established input contract.

## What changed (motivation → approach → change)

One centralized parser now owns this contract:

- `_parse_object_body(request)` raises HTTPBadRequest for invalid JSON **or** valid-but-non-object bodies; `_get_channel_body` (shared by post/add-agent/update-agent) routes through it, as do the three independent parsers (`create`, `approve_agent`, `clear_context`);
- `api_channel_create` validates — in order — top-level object, topic string, agents list-of-objects, BEFORE calling `ChannelManager.create`; invalid input never adds or broadcasts a channel;
- `clear_context` keeps its existing SEL-denied audit on the rejection path.

Channel transport and agent execution behaviour are unchanged.

## Tests

New `test/test_handlers_channel_object_bodies.py` (10 cases) with the manager sealed so any premature `create()` call fails the test by name:

- parametrized non-object bodies on create → 400 + `create.assert_not_called()`;
- non-string topic rejected before mutation;
- four malformed `agents` shapes rejected before mutation;
- a fully valid create still reaches the manager once with the topic.

The pre-existing clear-context suite passes unchanged.

## Manual verification

Windows 11 / Python 3.12: suites green above; flake8 / isort clean; mypy clean on the handler module.

## Related Issues

Fixes #5586 · Related: #5587, #5014

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: input contract documented at the chokepoint
- [x] No secrets, credentials, or internal references in the diff

