### PR TITLE
feat(dashboard): accept video attachments in the composer

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1370,
+    "missing_code": 1369,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1078,
+  "_compliant": 1097,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -97,7 +97,7 @@
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 115
+      "missing_code": 114
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -29,6 +29,7 @@ from aiohttp.multipart import BodyPartReader
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
+from kiro_crew.dashboard import part_stream
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.state import DashboardState
@@ -761,6 +762,12 @@ def _upload_dir() -> Path:
 
 
 _MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB per file
+#: Video gets its own, larger ceiling: a 30-second retina screen recording is
+#: routinely 60-150 MB, so the 50 MB document cap would reject the dominant
+#: case and make the feature read as broken. Safe to raise only because video
+#: parts STREAM to disk (:func:`_stream_video_part`) instead of accumulating in
+#: memory the way every other accepted type does.
+_MAX_VIDEO_UPLOAD_BYTES = 512 * 1024 * 1024  # 512 MB per video
 _MAX_UPLOAD_FILES = 20  # max files per request
 
 # Fallback-walk budgets. ``_WALK_MAX_SCAN_*`` bounds entries scored PER KIND
@@ -816,6 +823,40 @@ _ALLOWED_DOC_EXT = {
     ".zip",
     ".tar",
     ".gz",
+}
+#: Video containers accepted at the upload boundary. Deliberately narrower than
+#: ``FileRenderers``' VIDEO_EXTS: every entry here must be verifiable by
+#: :func:`_sniff_media_type` AND playable by ``<video>``, so an accepted upload
+#: is always one the chat can actually show. ``.mkv`` is excluded — it shares
+#: WebM's EBML signature but browser playback is unreliable, and accepting a
+#: file that then refuses to play is worse than refusing it at the door.
+_ALLOWED_VIDEO_EXT = {".mp4", ".m4v", ".mov", ".webm"}
+#: Media containers a browser will often play but the upload boundary does not
+#: accept. Rejecting them with the bare "Unsupported file type" reads as "video
+#: is not supported at all", when the actual remedy is a re-encode -- so the
+#: refusal for one of these names the containers that do work. VIDEO containers
+#: only: naming the video set to an audio upload (``.m4a``) would tell its
+#: sender to re-encode audio into a video container, which is worse than the
+#: bare refusal.
+_VIDEO_HINT_EXT = frozenset(
+    {".mkv", ".ogv", ".avi", ".mpg", ".mpeg", ".wmv", ".flv", ".3gp"}
+)
+#: Media type :func:`_sniff_media_type` must report for the claimed video
+#: extension. The MP4 family (mp4/m4v/mov) all carry a ``ftyp`` box at offset 4
+#: and sniff as ``video/mp4``; QuickTime's brand differs but the box does not.
+#:
+#: This gate proves the bytes are the claimed FAMILY, not the exact container:
+#: ``.webm`` and ``.mkv`` share the EBML magic, so an ``.mkv`` renamed to
+#: ``.webm`` passes here even though the ``.mkv`` extension is refused.
+#: Distinguishing them needs the EBML DocType, which is not worth parsing for
+#: this boundary -- the gate's job is to keep NON-media bytes off disk (CWE-434),
+#: and the extension set is what carries the narrower "accepted means playable"
+#: promise.
+_VIDEO_EXT_MIME: dict[str, str] = {
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".mov": "video/mp4",
+    ".webm": "video/webm",
 }
 
 
@@ -902,6 +943,14 @@ def _content_matches_ext(ext: str, data: bytes) -> bool:
         # OOXML / ODF / zip all begin with a local-file-header, empty-archive,
         # or spanned-archive PK signature.
         return data[:4] in (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+    expected_media = _VIDEO_EXT_MIME.get(ext)
+    if expected_media is not None:
+        # Reuses the read path's container sniffer so the upload boundary and
+        # /api/file-stream agree on what each signature means. ``data`` may be
+        # just the leading chunk here — every signature involved lives in the
+        # first 12 bytes, so a header is sufficient and a whole-file read is
+        # never needed.
+        return _sniff_media_type(data[:SNIFF_BYTES]) == expected_media
     expected = _RASTER_EXT_MIME.get(ext)
     if expected is not None:
         return sniff_raster_mime(data[:SNIFF_BYTES]) == expected
@@ -909,6 +958,58 @@ def _content_matches_ext(ext: str, data: bytes) -> bool:
     if prefixes is None:
         return True  # text / svg / unknown — nothing to enforce
     return any(data.startswith(p) for p in prefixes)
+
+
+async def _stream_video_part(
+    part: BodyPartReader,
+    dest: Path,
+) -> tuple[int, tuple[str, str, str] | None]:
+    """Stream a video *part* to *dest*, gating on its container signature.
+
+    Returns ``(bytes_written, None)`` on success, or ``(bytes_written,
+    (audit_reason, error_code, user_message))`` on refusal. The code is a
+    machine-readable id the caller maps to a CONSTANT HTTP status: returning a
+    status from here would make the response's `status=` an expression at the
+    call site, which the error-code contract rejects because it defeats static
+    analysis of what the endpoint can return.
+
+    All the file handling lives in :func:`~kiro_crew.dashboard.part_stream.
+    stream_part_to_file`, which owns the temp through a synchronous context
+    manager. This function is now only the translation between that helper's
+    exceptions and this endpoint's audit reasons and error codes -- deliberately,
+    because the hand-rolled version of the streaming here collected SEVEN
+    blocking review findings in seven rounds, three of them introduced while
+    fixing the previous one. That module's docstring carries the ledger and the
+    invariant; the short version is that a cancellable coroutine cannot own a
+    file safely, so it no longer does.
+    """
+    ext = dest.suffix.lower()
+    try:
+        total = await part_stream.stream_part_to_file(
+            part,
+            dest,
+            max_bytes=_MAX_VIDEO_UPLOAD_BYTES,
+            accepts=lambda head: _content_matches_ext(ext, head),
+        )
+    except part_stream.PartTooLarge as too_large:
+        cap_mb = _MAX_VIDEO_UPLOAD_BYTES // 1024 // 1024
+        return too_large.total, (
+            f"too_large:{too_large.total}",
+            "video_too_large",
+            f"Video too large (max {cap_mb}MB)",
+        )
+    except part_stream.PartContentMismatch:
+        accepted = ", ".join(sorted(_ALLOWED_VIDEO_EXT))
+        return 0, (
+            f"content_signature_mismatch:{ext}",
+            "video_content_mismatch",
+            # Names the remedy for the same reason the unsupported-container
+            # refusal does: "does not match its type" tells the user their file
+            # is wrong without telling them what to do about it, and the fix
+            # (re-export) is not guessable from the sentence.
+            f"This file is not really a {ext} — re-export it as one of: {accepted}",
+        )
+    return total, None
 
 
 async def api_upload_file(request: web.Request) -> web.Response:
@@ -923,12 +1024,28 @@ async def api_upload_file(request: web.Request) -> web.Response:
     upload_dir.mkdir(parents=True, exist_ok=True)
     reader = await request.multipart()
     paths: list[str] = []
-    allowed = _ALLOWED_IMAGE_EXT | _ALLOWED_TEXT_EXT | _ALLOWED_DOC_EXT
+    allowed = _ALLOWED_IMAGE_EXT | _ALLOWED_TEXT_EXT | _ALLOWED_DOC_EXT | _ALLOWED_VIDEO_EXT
     caller = request.get("user", "dashboard")
 
-    def _cleanup() -> None:
-        for p in paths:
-            Path(p).unlink(missing_ok=True)
+    async def _cleanup(*also: Path) -> None:
+        """Remove this request's files, plus *also*, off the serving loop.
+
+        The ONE cleanup entry point for this handler, and a coroutine so it
+        cannot be called the blocking way by accident. Every refusal and error
+        path in a 20-file request may unlink up to 20 paths (a video among them
+        up to 512 MB), and `Path.unlink` is a synchronous syscall: on a slow or
+        network filesystem doing that inline stalls chat and heartbeat for the
+        whole gateway. It also absorbs the destination itself via *also*, so the
+        sites that previously paired a bare ``dest.unlink()`` with a cleanup call
+        have one call and cannot drift back to unlinking on the loop.
+        """
+        targets = [*paths, *(str(p) for p in also)]
+
+        def _rm() -> None:
+            for p in targets:
+                Path(p).unlink(missing_ok=True)
+
+        await asyncio.to_thread(_rm)
 
     try:
         while True:
@@ -940,7 +1057,7 @@ async def api_upload_file(request: web.Request) -> web.Response:
             if part.name != "file":
                 continue
             if len(paths) >= _MAX_UPLOAD_FILES:
-                _cleanup()
+                await _cleanup()
                 _sel().log_api_access(
                     caller=caller,
                     operation="upload.file",
@@ -957,7 +1074,7 @@ async def api_upload_file(request: web.Request) -> web.Response:
             safe_name = re.sub(r"[^\w.\-]", "_", Path(fname).name)
             ext = Path(safe_name).suffix.lower()
             if ext not in allowed:
-                _cleanup()
+                await _cleanup()
                 _sel().log_api_access(
                     caller=caller,
                     operation="upload.file",
@@ -965,10 +1082,82 @@ async def api_upload_file(request: web.Request) -> web.Response:
                     source="dashboard",
                     resources=f"file:{fname} reason:unsupported_type:{ext}",
                 )
+                detail = f"Unsupported file type: {ext}"
+                if ext in _VIDEO_HINT_EXT:
+                    # Name the way out. A browser plays several containers this
+                    # boundary refuses, so the bare refusal reads as "no video
+                    # support" when the remedy is a re-encode.
+                    accepted = ", ".join(sorted(_ALLOWED_VIDEO_EXT))
+                    detail = f"{detail} — accepted video containers: {accepted}"
                 return web.json_response(
-                    {"error": f"Unsupported file type: {ext}"},
+                    {"error": detail, "code": "unsupported_file_type"},
                     status=400,
                 )
+            # UUID prefix guarantees uniqueness even within a single request.
+            # Resolved BEFORE any byte is read because the video branch streams
+            # straight to this destination rather than buffering the part first.
+            dest = upload_dir / f"{uuid.uuid4().hex}_{safe_name}"
+            if not dest.resolve().is_relative_to(upload_dir.resolve()):
+                await _cleanup()
+                _sel().log_api_access(
+                    caller=caller,
+                    operation="upload.file",
+                    outcome="rejected",
+                    source="dashboard",
+                    resources=f"file:{fname} reason:path_traversal",
+                )
+                return web.json_response({"error": "Invalid filename"}, status=400)
+            if ext in _ALLOWED_VIDEO_EXT:
+                # Video takes the streaming route for two reasons: a screen
+                # recording is far too large to buffer, and its CONTENT is not
+                # something the model can read anyway (ACP has no video content
+                # block). So the bytes land on disk, the PATH reaches the agent
+                # as an [attached_file N] token, and the chat renders a <video>
+                # off /api/file-stream. An agent that needs frames runs ffmpeg
+                # on the path.
+                try:
+                    written, refusal = await _stream_video_part(part, dest)
+                except (Exception, asyncio.CancelledError):
+                    # CancelledError derives from BaseException, not Exception, so
+                    # a bare `except Exception` lets a gateway shutdown mid-stream
+                    # past every cleanup: the partial video AND the siblings this
+                    # request already wrote stay in uploads/, and the partial is
+                    # indistinguishable from a complete file to everything
+                    # downstream. Cleanup here rather than relying on the outer
+                    # handler, which has the same blind spot.
+                    await _cleanup(dest)
+                    raise
+                if refusal is not None:
+                    await _cleanup(dest)
+                    reason, code, message = refusal
+                    _sel().log_api_access(
+                        caller=caller,
+                        operation="upload.file",
+                        outcome="rejected",
+                        source="dashboard",
+                        resources=f"file:{fname} reason:{reason}",
+                    )
+                    # Branched rather than parameterised: each response states a
+                    # CONSTANT status and its own `code`, which is what keeps the
+                    # endpoint's possible outcomes statically readable (and is
+                    # what the error-code contract checks for).
+                    if code == "video_too_large":
+                        return web.json_response(
+                            {"error": message, "code": "video_too_large"},
+                            status=413,
+                        )
+                    return web.json_response(
+                        {"error": message, "code": "video_content_mismatch"},
+                        status=400,
+                    )
+                logger.info(
+                    "upload.file video: name=%s ext=%s size=%d",
+                    safe_name,
+                    ext,
+                    written,
+                )
+                paths.append(str(dest))
+                continue
             # Read with size limit
             data = bytearray()
             while True:
@@ -977,7 +1166,7 @@ async def api_upload_file(request: web.Request) -> web.Response:
                     break
                 data.extend(chunk)
                 if len(data) > _MAX_UPLOAD_BYTES:
-                    _cleanup()
+                    await _cleanup()
                     _sel().log_api_access(
                         caller=caller,
                         operation="upload.file",
@@ -993,7 +1182,7 @@ async def api_upload_file(request: web.Request) -> web.Response:
             # claimed extension BEFORE writing, so an allowed extension can't
             # smuggle arbitrary/binary content (e.g. a .png that is really HTML).
             if not _content_matches_ext(ext, bytes(data)):
-                _cleanup()
+                await _cleanup()
                 _sel().log_api_access(
                     caller=caller,
                     operation="upload.file",
@@ -1005,22 +1194,10 @@ async def api_upload_file(request: web.Request) -> web.Response:
                     {"error": f"File content does not match its type: {ext}"},
                     status=400,
                 )
-            # UUID prefix guarantees uniqueness even within a single request
-            dest = upload_dir / f"{uuid.uuid4().hex}_{safe_name}"
-            if not dest.resolve().is_relative_to(upload_dir.resolve()):
-                _cleanup()
-                _sel().log_api_access(
-                    caller=caller,
-                    operation="upload.file",
-                    outcome="rejected",
-                    source="dashboard",
-                    resources=f"file:{fname} reason:path_traversal",
-                )
-                return web.json_response({"error": "Invalid filename"}, status=400)
             try:
                 await asyncio.to_thread(_write_file_restricted, dest, bytes(data))
             except Exception:
-                dest.unlink(missing_ok=True)
+                await _cleanup(dest)
                 raise
             # Diagnostic logging for binary uploads. Compares the bytes
             # we received in memory against the bytes that landed on
@@ -1055,8 +1232,12 @@ async def api_upload_file(request: web.Request) -> web.Response:
                     # Diagnostic failure must never break the upload.
                     logger.exception("upload.file diagnostic failed for %s", safe_name)
             paths.append(str(dest))
-    except Exception:
-        _cleanup()
+    except (Exception, asyncio.CancelledError):
+        # Same blind spot as the video branch above: a cancelled request (gateway
+        # shutdown, client disconnect) raises CancelledError, which is NOT an
+        # Exception, so without naming it every file this request already wrote
+        # is orphaned in uploads/ with nothing left to reference or remove it.
+        await _cleanup()
         _sel().log_api_access(
             caller=caller,
             operation="upload.file",

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import uuid
 import zipfile
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -19,6 +20,7 @@ from aiohttp import web
 from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
+from kiro_crew.dashboard import part_stream
 from kiro_crew.dashboard.handlers.files import (
     _ZIP_CONTAINER_EXTS,
     _content_matches_ext,
@@ -57,7 +59,6 @@ from kiro_crew.knowledge.spend import source_spend
 from kiro_crew.knowledge.store import KnowledgeBundleError
 from kiro_crew.knowledge.sync import SyncScheduler
 from kiro_crew.knowledge.watcher import KnowledgeWatcher
-from kiro_crew.messaging.raster import SNIFF_BYTES
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
@@ -1523,39 +1524,32 @@ async def ingest_file(request: web.Request) -> web.Response:
     filename = getattr(field, "filename", None) or "upload"
     suffix = Path(filename).suffix
     ext = suffix.lower()
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix, prefix="kn_")
+    staged = Path(tempfile.gettempdir()) / f"kn_{uuid.uuid4().hex}{suffix}"
     try:
-        total_size = 0
-        # Capture the leading bytes so the claimed extension can be verified
-        # against the file signature; SNIFF_BYTES covers every signature in the
-        # sibling gate (PNG magic is 8, WEBP needs bytes 8:12, zip/PDF fewer).
-        head = bytearray()
-        while True:
-            chunk = await field.read_chunk()  # type: ignore[union-attr]
-            if not chunk:
-                break
-            total_size += len(chunk)
-            if total_size > _MAX_INGEST_FILE_SIZE:
-                tmp.close()
-                Path(tmp.name).unlink(missing_ok=True)
-                return web.json_response(
-                    {"error": f"file too large (max {_MAX_INGEST_FILE_SIZE // (1024 * 1024)} MB)"}, status=413)
-            if len(head) < SNIFF_BYTES:
-                head.extend(chunk[: SNIFF_BYTES - len(head)])
-            tmp.write(chunk)
-        tmp.close()
+        # The signature gate (CWE-434) and the byte ceiling are both enforced by
+        # the shared streaming path, which judges the leading bytes while they
+        # are still in memory. That is stricter than this call site used to be:
+        # it wrote the whole file first and only then sniffed, so rejected
+        # content did reach the filesystem. Cleanup on cancellation is the
+        # helper's, not this function's -- see part_stream's docstring.
+        await part_stream.stream_part_to_file(
+            field,  # type: ignore[arg-type]
+            staged,
+            max_bytes=_MAX_INGEST_FILE_SIZE,
+            accepts=lambda head: _content_matches_ext(ext, head),
+        )
+    except part_stream.PartTooLarge:
+        return web.json_response(
+            {"error": f"file too large (max {_MAX_INGEST_FILE_SIZE // (1024 * 1024)} MB)"},
+            status=413,
+        )
+    except part_stream.PartContentMismatch:
+        _sel_log("ingest", filename=filename, outcome="rejected")
+        return web.json_response(
+            {"error": f"file content does not match its type: {ext}"}, status=400
+        )
 
-        # Content-signature gate (CWE-434): the extension is attacker-controlled
-        # and FileReader dispatches to binary parsers (.pdf/.docx) purely by
-        # extension, so verify the magic bytes match the claimed type BEFORE the
-        # file is handed to a parser. Text formats have no reliable signature and
-        # pass through, matching the sibling upload gate in handlers/files.py.
-        if not _content_matches_ext(ext, bytes(head)):
-            Path(tmp.name).unlink(missing_ok=True)
-            _sel_log("ingest", filename=filename, outcome="rejected")
-            return web.json_response(
-                {"error": f"file content does not match its type: {ext}"}, status=400)
-
+    try:
         # Decompression-bomb guard (CWE-770): a valid-signature OOXML/zip can
         # still be a bomb whose members expand unbounded once python-docx / the
         # zip parser opens it. Bound the declared member count and aggregate
@@ -1564,9 +1558,9 @@ async def ingest_file(request: web.Request) -> web.Response:
         # corrupt/lying archive. Run off the event loop so a hostile central
         # directory can't stall the gateway loop/heartbeat.
         if ext in _ZIP_CONTAINER_EXTS:
-            reason = await asyncio.to_thread(_inspect_zip_archive, tmp.name)
+            reason = await asyncio.to_thread(_inspect_zip_archive, str(staged))
             if reason is not None:
-                Path(tmp.name).unlink(missing_ok=True)
+                staged.unlink(missing_ok=True)
                 _sel_log("ingest", filename=filename, outcome="rejected", reason=reason)
                 return web.json_response(
                     {"error": f"{ext} archive rejected ({reason})"}, status=400)
@@ -1596,7 +1590,7 @@ async def ingest_file(request: web.Request) -> web.Response:
             finally:
                 Path(tmp_path).unlink(missing_ok=True)
 
-        task = asyncio.create_task(_bg_ingest(tmp.name, source_id))
+        task = asyncio.create_task(_bg_ingest(str(staged), source_id))
         app_tasks = request.app.setdefault("_bg_tasks", set())
         app_tasks.add(task)
         task.add_done_callback(app_tasks.discard)
@@ -1605,7 +1599,7 @@ async def ingest_file(request: web.Request) -> web.Response:
         return web.json_response({"source_id": source_id, "status": "processing"})
     except Exception:
         logger.exception("Ingestion failed for %s", filename)
-        Path(tmp.name).unlink(missing_ok=True)
+        staged.unlink(missing_ok=True)
         return web.json_response({"error": "internal server error"}, status=500)
 
 

--- a/src/kiro_crew/dashboard/handlers/portability.py
+++ b/src/kiro_crew/dashboard/handlers/portability.py
@@ -5,15 +5,30 @@ from __future__ import annotations
 import asyncio
 import logging
 import tempfile
+import uuid
 from pathlib import Path
 
 from aiohttp import web
 from aiohttp.multipart import BodyPartReader
 
+from kiro_crew.dashboard import part_stream
 from kiro_crew.portability import apply_import_zip, create_export_zip, validate_import_zip
 from kiro_crew.sel import sel as _sel_fn  # circular import — sel imports lazily
 
 logger = logging.getLogger(__name__)
+
+#: Ceiling for an uploaded state archive, aligned with the bomb guard that
+#: already governs this path: `portability._MAX_IMPORT_UNCOMPRESSED` admits 2 GiB
+#: *uncompressed*, so a compressed archive under 2 GiB cannot be refused here
+#: without the two limits contradicting each other.
+#:
+#: An earlier revision set this to 512 MB and justified it as restoring a bound
+#: streaming had removed. That was wrong on the facts: the previous
+#: implementation already streamed to disk with no cap at all, so 512 MB was a
+#: NEW restriction that could 413 a legitimate export -- exactly when the source
+#: machine may be gone. The cap exists only so an unbounded upload cannot fill
+#: the disk, and 2 GiB is the largest value consistent with the guard downstream.
+_MAX_IMPORT_BYTES = 2 * 1024**3
 
 
 def _sel():
@@ -27,19 +42,22 @@ async def _read_upload_file(request: web.Request) -> tuple[Path | None, web.Resp
     if part is None or not isinstance(part, BodyPartReader) or part.name != "file":
         return None, web.json_response({"error": "file field required"}, status=400)
 
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    # A single path rather than a scratch directory: the callers below already
+    # own the returned file and unlink it in their `finally`, so a directory
+    # would be a second thing to clean and nobody is cleaning it.
+    dest = Path(tempfile.gettempdir()) / f"kc_import_{uuid.uuid4().hex}.zip"
     try:
-        while True:
-            chunk = await part.read_chunk(65536)
-            if not chunk:
-                break
-            tmp.write(chunk)
-        tmp.close()
-        return Path(tmp.name), None
-    except Exception:
-        tmp.close()
-        Path(tmp.name).unlink(missing_ok=True)
-        raise
+        await part_stream.stream_part_to_file(part, dest, max_bytes=_MAX_IMPORT_BYTES)
+    except part_stream.PartTooLarge:
+        limit_mb = _MAX_IMPORT_BYTES // (1024 * 1024)
+        return None, web.json_response(
+            {
+                "error": f"archive too large (max {limit_mb} MB)",
+                "code": "import_archive_too_large",
+            },
+            status=413,
+        )
+    return dest, None
 
 
 async def api_portability_export(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/part_stream.py
+++ b/src/kiro_crew/dashboard/part_stream.py
@@ -1,0 +1,235 @@
+"""Stream one multipart part to disk without ever publishing a partial file.
+
+Three handlers write an uploaded part to a temp file: composer uploads
+(``handlers/files.py``), state import (``handlers/portability.py``) and knowledge
+ingest (``handlers/knowledge.py``). Each had grown its own copy, and the copy in
+``files.py`` took **seven** blocking review findings in seven rounds before the
+shape below settled. Every one of them was a variation on the same thing: a
+coroutine owning a file it can be cancelled away from.
+
+The ledger, because the invariant is only legible next to what it prevents:
+
+1. ``os.write`` short count ignored -- a truncated file that looks complete.
+2. ``CancelledError`` derives from ``BaseException``, so ``except Exception``
+   let a gateway shutdown past every cleanup.
+3. Cancellation raced ``to_thread(open)`` -- the worker created the file *after*
+   cleanup had run.
+4. A fix for (3) registered its callback before the shielded await, so the
+   descriptor was closed before the coroutine resumed: ``EBADF`` on every upload.
+5. Cleanup ran ``close``/``unlink`` on the serving loop; and a double close by
+   descriptor *number* could hit a number the kernel had reassigned.
+6. Cleanup keyed on ``task.result()`` could not run for a directly cancelled
+   open task -- the one case that needed it.
+7. Cleanup keyed on the path instead raced the worker the other way: the
+   callback fired on cancellation and unlinked *before* the worker created.
+
+**The invariant.** A cancellable owner cannot both offload its cleanup and
+guarantee it: offloading needs an await or a callback, and each introduces an
+ordering the owner does not control -- which is precisely how (3), (6) and (7)
+happened, in both directions. So ownership lives in a **synchronous context
+manager**: ``__enter__`` creates, ``__exit__`` discards unless the body
+committed. ``with`` guarantees ``__exit__`` on every exit including
+``CancelledError``, and because no ``await`` sits between the create and the
+cleanup's registration, nothing can race it and no result has to be fetched from
+a task that may never produce one.
+
+The deliberate cost, stated plainly rather than hidden: ``__enter__``'s single
+``os.open`` and ``__exit__``'s single ``close``+``unlink`` run on the event loop.
+That is bounded work on one freshly-named local path -- microseconds -- and it
+buys an ordering guarantee that no off-loop arrangement provides. The *bulk*
+cleanup that finding (5) was actually about (a request unlinking up to 20
+published paths, a 512 MB video among them) still runs in a worker, at the
+caller's level. Writes, the commit, and the sniff all run in workers too: only
+the create/discard of one temp is on the loop, and only because correctness
+requires it.
+
+Two further properties the callers rely on:
+
+* **Atomic publish.** ``dest`` is created solely by ``os.replace`` from a
+  fully-written temp, so no failure path can leave anything at ``dest`` that
+  looks complete. A reader either sees no file or sees all of it.
+* **Sniff before disk.** The signature check runs on the first
+  ``SNIFF_BYTES`` while they are still buffered in memory, so content that
+  fails it never reaches the filesystem at all (CWE-434).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from pathlib import Path
+from types import TracebackType
+from typing import IO, Callable
+
+from aiohttp.multipart import BodyPartReader
+
+#: Bytes buffered before the signature predicate is consulted. Every container
+#: signature the callers check lives well inside this window (the MP4 family's
+#: ``ftyp`` box ends at 12, EBML's magic is 4, PNG's is 8).
+SNIFF_BYTES = 16
+
+#: Read size for the streaming loop, and deliberately NOT a caller-tunable
+#: parameter. It bounds the one blocking call this module leaves on the event
+#: loop: ``__exit__``'s ``close()`` contends for the ``BufferedWriter``'s own
+#: lock, so if cancellation arrives while a worker is inside
+#: ``to_thread(sink.write, chunk)``, the on-loop close waits for that write to
+#: finish. The wait is therefore one chunk of I/O, which is why the number is
+#: small enough to be uninteresting (64 KB is well under a single disk write's
+#: latency floor) rather than merely "fast on my machine" -- at the 1 MB this
+#: started as, a slow or network filesystem made that wait a real stall.
+#:
+#: It is a module constant rather than an argument on purpose: a value a caller
+#: can raise is not a bound, and the guarantee here is only as good as its
+#: worst caller. Raising it means re-arguing the trade above.
+CHUNK_BYTES = 64 * 1024
+
+
+class PartTooLarge(Exception):
+    """The part exceeded the caller's byte ceiling. Nothing was published."""
+
+    def __init__(self, total: int, limit: int) -> None:
+        super().__init__(f"part exceeded {limit} bytes (read {total})")
+        self.total = total
+        self.limit = limit
+
+
+class PartContentMismatch(Exception):
+    """The leading bytes failed the caller's signature predicate."""
+
+    def __init__(self, head: bytes) -> None:
+        super().__init__("part content does not match its claimed type")
+        self.head = head
+
+
+class _TempSink:
+    """Owns one temp file for the duration of a ``with`` block.
+
+    Synchronous on purpose -- see this module's docstring. ``__exit__`` is the
+    only cleanup path and it cannot be skipped by cancellation or raced by a
+    worker, because the file already exists when the block is entered and the
+    sink object (not a descriptor number) is what gets closed.
+    """
+
+    def __init__(self, dest: Path) -> None:
+        self.dest = dest
+        self.tmp = dest.with_name(dest.name + ".part")
+        self.sink: IO[bytes] | None = None
+        self.committed = False
+
+    def __enter__(self) -> _TempSink:
+        # O_EXCL: never adopt a file this request did not create. 0o600 because
+        # an upload may carry anything and the directory is shared. O_BINARY is
+        # 0 off Windows and load-bearing on it: without it the CRT translates
+        # newlines, so any payload containing 0x0A commits bytes that differ
+        # from what was uploaded -- a silently corrupted video or archive. This
+        # flag was on the pre-extraction opener and got dropped in the move;
+        # `test_open_flags_include_o_binary` now pins it.
+        fd = os.open(
+            str(self.tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        try:
+            self.sink = os.fdopen(fd, "wb")
+        except BaseException:
+            os.close(fd)
+            with contextlib.suppress(OSError):
+                self.tmp.unlink()
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self.committed:
+            return
+        # close() is idempotent and owns its own descriptor, so this can never
+        # close a number the kernel has reassigned to someone else.
+        if self.sink is not None:
+            with contextlib.suppress(OSError):
+                self.sink.close()
+        with contextlib.suppress(OSError):
+            self.tmp.unlink()
+
+    def write(self, data: bytes) -> None:
+        """Append *data*. Call from a worker; BufferedWriter loops short writes."""
+        assert self.sink is not None  # inside the with-block by construction
+        self.sink.write(data)
+
+    def commit(self) -> None:
+        """Close and publish atomically. Call from a worker.
+
+        Close and rename happen in this one call so no ``await`` can land
+        between them, and `committed` is set only after the rename succeeds --
+        so a failed publish still leaves ``__exit__`` responsible for the temp.
+        """
+        assert self.sink is not None
+        self.sink.close()
+        os.replace(self.tmp, self.dest)
+        self.committed = True
+
+
+async def stream_part_to_file(
+    part: BodyPartReader,
+    dest: Path,
+    *,
+    max_bytes: int,
+    accepts: Callable[[bytes], bool] | None = None,
+) -> int:
+    """Stream *part* to *dest*, or raise having published nothing.
+
+    Returns the byte count written. Raises :class:`PartTooLarge` when the part
+    exceeds *max_bytes*, :class:`PartContentMismatch` when *accepts* rejects the
+    leading bytes, and propagates anything else (including
+    ``asyncio.CancelledError``) after cleaning up.
+
+    *accepts* is consulted once, on the first ``SNIFF_BYTES`` -- which are held
+    in memory until it has answered, so rejected content never reaches disk.
+    A part shorter than that window is judged on what arrived, since every
+    signature the callers check is shorter than the window.
+    """
+    total = 0
+    head = bytearray()
+    verified = accepts is None
+
+    with _TempSink(dest) as sink:
+        while True:
+            chunk = await part.read_chunk(CHUNK_BYTES)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                raise PartTooLarge(total, max_bytes)
+            if verified:
+                await asyncio.to_thread(sink.write, chunk)
+                continue
+            head.extend(chunk)
+            if len(head) < SNIFF_BYTES:
+                continue  # too few bytes to judge yet -- keep holding them
+            assert accepts is not None
+            if not accepts(bytes(head)):
+                raise PartContentMismatch(bytes(head))
+            verified = True
+            await asyncio.to_thread(sink.write, bytes(head))
+            head.clear()
+        if not verified:
+            # The part ended inside the sniff window. Judge what arrived.
+            assert accepts is not None
+            if not accepts(bytes(head)):
+                raise PartContentMismatch(bytes(head))
+            await asyncio.to_thread(sink.write, bytes(head))
+        await asyncio.to_thread(sink.commit)
+    return total
+
+
+__all__ = [
+    "CHUNK_BYTES",
+    "SNIFF_BYTES",
+    "PartContentMismatch",
+    "PartTooLarge",
+    "stream_part_to_file",
+]

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2723,7 +2723,12 @@ async def start_dashboard(
 
     app = web.Application(
         client_max_size=60 * 1024 * 1024
-    )  # 60 MB: covers 50 MB upload + multipart overhead
+    )  # 60 MB: covers a 50 MB BUFFERED upload + multipart overhead. NOT a
+    # ceiling on every upload: aiohttp enforces this in Request.read()/.post(),
+    # not on the streaming multipart() reader, so the video path in
+    # handlers/files.py streams past it under its own _MAX_VIDEO_UPLOAD_BYTES
+    # (pinned by test_streaming_bypasses_the_app_client_max_size). Reading this
+    # number as a global request cap is the false invariant to avoid.
     app["state"] = state
     # Bind the serving loop once, here: this runs ON that loop, so every
     # surface that later hands work in from a foreign thread -- slots
@@ -3717,7 +3722,12 @@ async def start_api_server(
 
     app = web.Application(
         client_max_size=60 * 1024 * 1024
-    )  # 60 MB: covers 50 MB upload + multipart overhead
+    )  # 60 MB: covers a 50 MB BUFFERED upload + multipart overhead. NOT a
+    # ceiling on every upload: aiohttp enforces this in Request.read()/.post(),
+    # not on the streaming multipart() reader, so the video path in
+    # handlers/files.py streams past it under its own _MAX_VIDEO_UPLOAD_BYTES
+    # (pinned by test_streaming_bypasses_the_app_client_max_size). Reading this
+    # number as a global request cap is the false invariant to avoid.
     app["state"] = state
     # Bind the serving loop once, here: this runs ON that loop, so every
     # surface that later hands work in from a foreign thread -- slots

--- a/test/test_handlers_files_video_upload.py
+++ b/test/test_handlers_files_video_upload.py
@@ -1,0 +1,401 @@
+"""Tests for video uploads through ``api_upload_file`` (POST /api/upload/file).
+
+Video is the one accepted type that does NOT take the in-memory route: the part
+streams to disk chunk by chunk under its own, much larger ceiling, because a
+screen recording is routinely bigger than the whole document cap and cannot be
+buffered. That makes three properties worth pinning, none of which the existing
+upload suite covers:
+
+* the container signature is still checked BEFORE any byte is written, so an
+  allowed extension cannot smuggle arbitrary content (CWE-434), and a refused
+  upload leaves nothing behind on disk;
+* the document cap does not apply to video, and the video cap does;
+* the accepted set is narrower than what ``<video>`` will attempt — ``.mkv``
+  shares WebM's signature but stays rejected on purpose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import part_stream
+from kiro_crew.dashboard.handlers import files as files_mod
+from kiro_crew.dashboard.handlers.files import api_upload_file
+
+#: QuickTime / MP4 family: a box length, then the ``ftyp`` box at offset 4. The
+#: brand differs between .mov ('qt  ') and .mp4 ('isom'); the box does not, and
+#: the box is what the sniffer keys on.
+MOV_HEADER = b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00"
+MP4_HEADER = b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00"
+#: EBML magic, shared by WebM and Matroska.
+WEBM_HEADER = b"\x1a\x45\xdf\xa3\x01\x00\x00\x00\x00\x00\x00\x1f"
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app["state"] = MagicMock()
+    app.router.add_post("/api/upload/file", api_upload_file)
+    return app
+
+
+@pytest.fixture
+def mock_sel():
+    with patch("kiro_crew.dashboard.handlers.files._sel") as m:
+        m.return_value = MagicMock()
+        yield m.return_value
+
+
+@pytest.fixture
+def upload_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "uploads"
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.files._UPLOAD_DIR", target)
+    return target
+
+
+async def _post(payload: bytes, filename: str, content_type: str):
+    """POST one part and return ``(status, json_body)``."""
+    form = aiohttp.FormData()
+    form.add_field("file", payload, filename=filename, content_type=content_type)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post("/api/upload/file", data=form)
+        return resp.status, await resp.json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("header", "name", "mime"),
+    [
+        (MOV_HEADER, "screen.mov", "video/quicktime"),
+        (MP4_HEADER, "clip.mp4", "video/mp4"),
+        (WEBM_HEADER, "capture.webm", "video/webm"),
+    ],
+)
+async def test_accepted_container_lands_on_disk_byte_for_byte(
+    upload_dir: Path,
+    mock_sel,
+    header: bytes,
+    name: str,
+    mime: str,
+) -> None:
+    """Each accepted container uploads, and the streamed bytes are unchanged.
+
+    Byte equality is the assertion that matters here: the streaming path writes
+    the buffered header first and the remaining chunks after it, so an off-by-one
+    in that seam would produce a file that is subtly corrupt rather than one that
+    fails loudly.
+    """
+    payload = header + bytes(range(256)) * 40
+    status, body = await _post(payload, name, mime)
+    assert status == 200, body
+    assert len(body["paths"]) == 1, body
+    written = Path(body["paths"][0])
+    assert written.parent == upload_dir
+    assert written.read_bytes() == payload
+
+
+@pytest.mark.asyncio
+async def test_video_is_exempt_from_the_document_cap(
+    upload_dir: Path,
+    mock_sel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A video over ``_MAX_UPLOAD_BYTES`` but under the video cap is accepted.
+
+    Shrinking the document cap rather than sending a real 60 MB body keeps the
+    test fast while still proving which ceiling the video branch consults — the
+    whole point of the separate constant.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.files._MAX_UPLOAD_BYTES", 64)
+    payload = MOV_HEADER + b"\x00" * 4096
+    status, body = await _post(payload, "long.mov", "video/quicktime")
+    assert status == 200, body
+    assert Path(body["paths"][0]).stat().st_size == len(payload)
+
+
+@pytest.mark.asyncio
+async def test_video_over_its_own_cap_is_refused_and_leaves_nothing(
+    upload_dir: Path,
+    mock_sel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past the video ceiling the request 413s and the partial file is removed.
+
+    The partial matters: the streaming route has already created and written the
+    destination by the time the cap trips, so a missing cleanup would leave a
+    truncated recording in uploads/ that the composer would happily attach.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.files._MAX_VIDEO_UPLOAD_BYTES", 512)
+    status, body = await _post(MOV_HEADER + b"\x00" * 8192, "huge.mov", "video/quicktime")
+    assert status == 413, body
+    assert "too large" in body["error"].lower(), body
+    # The code, not the prose, is what a localized UI can branch on.
+    assert body["code"] == "video_too_large", body
+    assert list(upload_dir.glob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_html_wearing_a_mov_extension_is_refused_before_any_write(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """The signature gate runs on the header, so nothing reaches disk (CWE-434).
+
+    This is the case the streaming route could most easily regress: writing the
+    first chunk before judging it would put attacker-chosen bytes in uploads/
+    under a name the rest of the app treats as a playable video.
+    """
+    status, body = await _post(
+        b"<html><script>alert(1)</script></html>" + b"x" * 128,
+        "payload.mov",
+        "video/quicktime",
+    )
+    assert status == 400, body
+    assert body["code"] == "video_content_mismatch", body
+    # Asserted on the CODE plus the presence of a remedy, not on the sentence:
+    # the code is the contract, and pinning exact prose makes every wording
+    # improvement look like a regression. The remedy must be there, though --
+    # "does not match its type" alone tells the user nothing to do next.
+    for ext in (".mp4", ".mov", ".webm"):
+        assert ext in body["error"], body
+    assert list(upload_dir.glob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_file_shorter_than_the_sniff_window_is_refused(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """A part that ends before the header can be judged is refused, not written.
+
+    Guards the streaming loop's tail branch: the buffered header is still
+    unverified when the part ends, and treating "never got enough bytes" as
+    "passed" would be the natural bug.
+    """
+    status, body = await _post(b"\x00\x00", "tiny.mov", "video/quicktime")
+    assert status == 400, body
+    assert list(upload_dir.glob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_a_playable_but_unaccepted_container_names_the_way_out(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """Refusing ``.mkv`` says which containers DO work.
+
+    A browser plays several containers this boundary refuses, so a bare
+    "Unsupported file type: .mkv" reads as "video is not supported" when the
+    actual remedy is a re-encode. Asserted on the accepted list rather than the
+    exact sentence so rewording the message does not fail this test.
+    """
+    status, body = await _post(WEBM_HEADER + b"\x00" * 256, "capture.mkv", "video/x-matroska")
+    assert status == 400, body
+    for ext in (".mp4", ".mov", ".webm"):
+        assert ext in body["error"], body
+
+
+@pytest.mark.asyncio
+async def test_an_audio_container_is_not_told_to_re_encode_into_video(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """``.m4a`` is refused WITHOUT the accepted-video-containers hint.
+
+    The hint's whole purpose is "your video needs a re-encode"; attaching it to
+    an audio upload tells that sender to wrap audio in a video container, which
+    is worse guidance than the bare refusal. ``.m4a`` shares the MP4 ``ftyp``
+    magic, so only the extension set separates the two cases -- which is exactly
+    why this is easy to reintroduce.
+    """
+    status, body = await _post(MP4_HEADER + b"\x00" * 256, "voice.m4a", "audio/mp4")
+    assert status == 400, body
+    assert ".webm" not in body["error"], body
+    assert "accepted video containers" not in body["error"], body
+
+
+@pytest.mark.asyncio
+async def test_cancellation_mid_stream_leaves_nothing_on_disk(
+    upload_dir: Path,
+    mock_sel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled upload removes its partial file and its siblings.
+
+    ``asyncio.CancelledError`` derives from ``BaseException``, so a bare
+    ``except Exception`` around the streaming write does not see it. Without
+    naming it, a gateway shutdown or client disconnect part-way through a
+    recording leaves a truncated video in uploads/ that is indistinguishable
+    from a complete one to everything downstream — the composer would attach it
+    and the player would stop early with no error.
+
+    Simulated by raising from inside the sink's write rather than cancelling the
+    task: the property under test is that the handler's cleanup runs when a
+    BaseException escapes the stream, and this reaches it deterministically. The
+    temp already exists at that point — the sink is opened before the first
+    write — so an empty uploads/ is real evidence the unlink ran.
+
+    The injection point is the SINK's write, not ``os.write``: writes go through
+    a buffered writer that owns its own raw file, so patching a module's
+    ``os.write`` would no longer intercept them and this test would pass
+    vacuously while proving nothing.
+    """
+
+    def refuse(_self, _data) -> int:  # noqa: ANN001, ANN202
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(part_stream._TempSink, "write", refuse)
+    form = aiohttp.FormData()
+    form.add_field(
+        "file",
+        MOV_HEADER + b"\x00" * 512,
+        filename="interrupted.mov",
+        content_type="video/quicktime",
+    )
+    async with TestClient(TestServer(_make_app())) as client:
+        with pytest.raises(BaseException):  # noqa: B017,PT011 - CancelledError
+            await client.post("/api/upload/file", data=form)
+    monkeypatch.undo()
+    # Neither the destination nor the `.part` temp may survive: a truncated
+    # recording that looks complete is worse than a failed upload to retry.
+    assert list(upload_dir.glob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_dest_is_never_published_when_the_commit_rename_fails(
+    upload_dir: Path,
+    mock_sel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the atomic publish fails, `dest` does not exist and no temp survives.
+
+    This pins the invariant the whole shape exists for: `dest` is created only
+    by the rename, from a file already complete, so there is no failure path
+    that leaves something at `dest` for the composer to attach and the player to
+    truncate. Three separate blocking findings on this function were all that
+    same defect — an ignored short write, a cancellation skipping cleanup, a
+    cancellation racing the open — so the test is on the invariant rather than
+    on any one of those paths.
+    """
+
+    def boom(src, dst) -> None:  # noqa: ANN001 - os.replace signature
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(part_stream.os, "replace", boom)
+    with pytest.raises(Exception):
+        await _post(MOV_HEADER + b"\x00" * 512, "doomed.mov", "video/quicktime")
+    monkeypatch.undo()
+    # Neither the destination nor the `.part` temp may survive.
+    assert list(upload_dir.glob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_bypasses_the_app_client_max_size(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """A video larger than the app's ``client_max_size`` still uploads.
+
+    The whole 512 MB ceiling rests on this: the dashboard builds its
+    ``web.Application`` with ``client_max_size=60 MB``, which aiohttp enforces in
+    ``Request.read()`` / ``.post()`` but NOT on the streaming ``multipart()``
+    reader this handler uses. If that were wrong the feature would be dead for
+    exactly the 60-150 MB recordings it exists to carry, and no cap-shrinking
+    test would show it.
+
+    Driven with a deliberately tiny ``client_max_size`` rather than a real 60 MB
+    body: the property under test is "the limit does not apply", which a 2 KB
+    limit demonstrates as well as a 60 MB one and in a fraction of the time.
+    """
+    app = web.Application(client_max_size=2048)
+    app["state"] = MagicMock()
+    app.router.add_post("/api/upload/file", api_upload_file)
+
+    payload = MOV_HEADER + b"\x00" * 8192  # 4x the app's limit
+    form = aiohttp.FormData()
+    form.add_field("file", payload, filename="big.mov", content_type="video/quicktime")
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/api/upload/file", data=form)
+        body = await resp.json()
+    assert resp.status == 200, body
+    assert Path(body["paths"][0]).read_bytes() == payload
+
+
+def _website_source(name: str) -> str:
+    """Read a frontend source file from the repo, for the cross-language pins."""
+    root = Path(__file__).resolve().parents[1]
+    return (root / "website" / "src" / name).read_text(encoding="utf-8")
+
+
+def test_accept_list_covers_every_accepted_extension() -> None:
+    """The composer's `accept` MIME list matches the server's accepted set.
+
+    This pin only works from the Python side: a vitest cannot read
+    ``_ALLOWED_VIDEO_EXT``, so a frontend-only assertion is one-sided and cannot
+    catch the drift that matters — an extension the server accepts but the
+    picker filters out of the photo library, which is invisible until a user
+    cannot find their own recording.
+    """
+    accept = re.search(
+        r"const VIDEO_ACCEPT = '([^']+)'", _website_source("components/ChatInput.tsx")
+    )
+    assert accept, "VIDEO_ACCEPT not found in ChatInput.tsx"
+    offered = set(accept.group(1).split(","))
+    # Every accepted extension needs a MIME a picker can filter on. `.m4v` is the
+    # trap: its `video/x-m4v` type is not implied by `video/mp4`.
+    required = {"video/mp4", "video/x-m4v", "video/quicktime", "video/webm"}
+    assert required <= offered, (offered, required - offered)
+    assert set(files_mod._ALLOWED_VIDEO_EXT) == {".mp4", ".m4v", ".mov", ".webm"}
+
+
+def test_client_video_cap_matches_the_server_ceiling() -> None:
+    """`VIDEO_MAX_BYTES` in fileTokens.ts equals ``_MAX_VIDEO_UPLOAD_BYTES``.
+
+    ChatPane pre-checks against the client copy because it has no error surface,
+    so a server cap raised without the mirror leaves that pane silently refusing
+    recordings the server would take. Asserted here rather than in the vitest
+    that reads the constant: only this side can see both numbers.
+    """
+    src = _website_source("utils/fileTokens.ts")
+    match = re.search(r"VIDEO_MAX_BYTES = (\d+) \* 1024 \* 1024", src)
+    assert match, "VIDEO_MAX_BYTES not found in fileTokens.ts"
+    assert int(match.group(1)) * 1024 * 1024 == files_mod._MAX_VIDEO_UPLOAD_BYTES
+
+
+def test_client_video_regex_matches_the_server_extension_set() -> None:
+    """`VIDEO_EXT` in fileTokens.ts lists exactly the server's extensions.
+
+    Third spelling of the same set. A regex that accepts more than the server
+    exempts a file from the client size guard only for the server to refuse it;
+    one that accepts less applies the 50 MB document cap to a legal recording.
+    """
+    src = _website_source("utils/fileTokens.ts")
+    match = re.search(r"VIDEO_EXT = /\\\.\(([^)]+)\)\$/i", src)
+    assert match, "VIDEO_EXT not found in fileTokens.ts"
+    from_regex = {f".{alt}" for alt in match.group(1).split("|")}
+    assert from_regex == set(files_mod._ALLOWED_VIDEO_EXT), from_regex
+
+
+@pytest.mark.asyncio
+async def test_mkv_stays_unsupported_despite_a_valid_ebml_signature(
+    upload_dir: Path,
+    mock_sel,
+) -> None:
+    """``.mkv`` is excluded on purpose and is refused on EXTENSION, not content.
+
+    It carries the same EBML magic WebM does, so only the allowlist separates
+    them. Pinned so a future "just add mkv, the magic already matches" change
+    has to argue with browser playback rather than pass silently.
+    """
+    status, body = await _post(WEBM_HEADER + b"\x00" * 256, "capture.mkv", "video/x-matroska")
+    assert status == 400, body
+    assert "Unsupported file type" in body["error"], body
+    assert body["code"] == "unsupported_file_type", body
+    assert list(upload_dir.glob("*")) == []

--- a/test/test_part_stream.py
+++ b/test/test_part_stream.py
@@ -1,0 +1,283 @@
+"""Invariants of the shared part-to-disk path.
+
+Every test here pins a property that a blocking review finding was filed
+against. `kiro_crew.dashboard.part_stream`'s docstring carries the ledger; this
+file is the executable half of it, so a future refactor that reintroduces any of
+the seven defects fails here rather than in a review round.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard import part_stream
+from kiro_crew.dashboard.part_stream import (
+    PartContentMismatch,
+    PartTooLarge,
+    _TempSink,
+    stream_part_to_file,
+)
+
+
+class _FakePart:
+    """Minimal BodyPartReader stand-in: hands out chunks, then EOF."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def read_chunk(self, _size: int = 0) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+def test_exit_removes_the_temp_when_the_body_did_not_commit(tmp_path: Path) -> None:
+    """The context manager's exit is the ONLY cleanup path, and it is sufficient.
+
+    Findings 2, 3, 6 and 7 were all cleanup that either did not run or ran in the
+    wrong order relative to creation. A synchronous `__exit__` cannot be skipped
+    by cancellation and cannot race the create, because the file already exists
+    when the block is entered.
+    """
+    dest = tmp_path / "x.bin"
+    with _TempSink(dest) as sink:
+        sink.write(b"partial")
+        tmp = sink.tmp
+        assert tmp.exists()
+    assert not tmp.exists()
+    assert not dest.exists()
+
+
+def test_exit_still_cleans_up_when_the_body_is_cancelled(tmp_path: Path) -> None:
+    """`CancelledError` derives from BaseException; `with` does not care.
+
+    Finding 2 was an `except Exception` that a gateway shutdown walked straight
+    past. Expressed as a context manager the question does not arise -- there is
+    no exception filter to get wrong.
+    """
+    dest = tmp_path / "y.bin"
+    tmp_seen: Path | None = None
+    with pytest.raises(asyncio.CancelledError):
+        with _TempSink(dest) as sink:
+            tmp_seen = sink.tmp
+            sink.write(b"half a video")
+            raise asyncio.CancelledError()
+    assert tmp_seen is not None
+    assert not tmp_seen.exists()
+    assert not dest.exists()
+
+
+def test_exit_after_a_commit_touches_nothing(tmp_path: Path) -> None:
+    """A committed block must not have its published file removed on the way out.
+
+    The mirror of the cleanup tests: cleanup that is unconditional in the wrong
+    way would delete the artifact it just published.
+    """
+    dest = tmp_path / "z.bin"
+    with _TempSink(dest) as sink:
+        sink.write(b"complete")
+        sink.commit()
+    assert dest.read_bytes() == b"complete"
+    assert not sink.tmp.exists()
+
+
+def test_exit_is_idempotent_and_never_closes_a_descriptor_number(tmp_path: Path) -> None:
+    """Finding 5b: a double close must not land on a reassigned fd number.
+
+    A raw `int` cannot express "already closed", so a cleanup running after a
+    successful close could `os.close` a NUMBER the kernel had handed to an
+    unrelated request. The sink owns its descriptor, so `close()` is idempotent
+    and running the exit path twice is a no-op rather than a corruption.
+    """
+    dest = tmp_path / "w.bin"
+    sink = _TempSink(dest)
+    with sink:
+        sink.write(b"payload")
+    assert sink.sink is not None and sink.sink.closed
+    # Second exit: the file object refuses to touch the number again and the
+    # already-removed temp is tolerated.
+    sink.__exit__(None, None, None)
+    assert sink.sink.closed
+
+
+def test_open_refuses_to_adopt_an_existing_temp(tmp_path: Path) -> None:
+    """O_EXCL: never write into a `.part` this request did not create."""
+    dest = tmp_path / "collide.bin"
+    (tmp_path / "collide.bin.part").write_bytes(b"someone else's")
+    with pytest.raises(FileExistsError):
+        with _TempSink(dest):
+            pass
+    assert (tmp_path / "collide.bin.part").read_bytes() == b"someone else's"
+
+
+@pytest.mark.asyncio
+async def test_dest_is_never_published_when_the_rename_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The atomic-publish invariant: `dest` appears only via a successful rename.
+
+    Whatever goes wrong, a reader must see either no file or a complete one --
+    never a partial that looks finished, which was the shape of finding 1.
+    """
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise OSError("rename refused")
+
+    monkeypatch.setattr(part_stream.os, "replace", boom)
+    dest = tmp_path / "never.bin"
+    with pytest.raises(OSError, match="rename refused"):
+        await stream_part_to_file(_FakePart([b"abcdef"]), dest, max_bytes=1024)
+    monkeypatch.undo()
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_every_byte_lands_across_many_chunks(tmp_path: Path) -> None:
+    """Finding 1: a short write must not silently truncate the payload.
+
+    `BufferedWriter.write` loops internally, which is why the hand-rolled
+    `_write_all` could be deleted; this pins the resulting bytes rather than the
+    mechanism, so it keeps holding if the mechanism changes again.
+    """
+    dest = tmp_path / "joined.bin"
+    chunks = [bytes([i]) * 1000 for i in range(8)]
+    total = await stream_part_to_file(_FakePart(chunks), dest, max_bytes=1 << 20)
+    assert total == 8000
+    assert dest.read_bytes() == b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_over_cap_raises_and_leaves_nothing(tmp_path: Path) -> None:
+    dest = tmp_path / "big.bin"
+    with pytest.raises(PartTooLarge) as excinfo:
+        await stream_part_to_file(_FakePart([b"x" * 100, b"y" * 100]), dest, max_bytes=150)
+    assert excinfo.value.limit == 150
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_content_never_reaches_disk(tmp_path: Path) -> None:
+    """CWE-434: the predicate decides while the bytes are still in memory.
+
+    Asserted by refusing and then proving the directory is empty -- if the sniff
+    ran after the write, the temp would have existed and been cleaned up, which
+    is a weaker guarantee than never having written it.
+    """
+    dest = tmp_path / "liar.mov"
+    with pytest.raises(PartContentMismatch):
+        await stream_part_to_file(
+            _FakePart([b"<html>not a video at all</html>"]),
+            dest,
+            max_bytes=1 << 20,
+            accepts=lambda head: head.startswith(b"\x00\x00\x00\x14ftyp"),
+        )
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_a_part_shorter_than_the_sniff_window_is_still_judged(tmp_path: Path) -> None:
+    """The tail branch: EOF before SNIFF_BYTES must not accept by default."""
+    dest = tmp_path / "tiny.mov"
+    with pytest.raises(PartContentMismatch):
+        await stream_part_to_file(
+            _FakePart([b"\x00\x00"]),
+            dest,
+            max_bytes=1 << 20,
+            accepts=lambda head: head.startswith(b"\x00\x00\x00\x14ftyp"),
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_accepted_content_lands_byte_for_byte(tmp_path: Path) -> None:
+    """The held-back sniff window must be written, not dropped."""
+    dest = tmp_path / "real.mov"
+    payload = b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00" + b"\xab" * 4096
+    total = await stream_part_to_file(
+        _FakePart([payload[:8], payload[8:]]),
+        dest,
+        max_bytes=1 << 20,
+        accepts=lambda head: head.startswith(b"\x00\x00\x00\x14ftyp"),
+    )
+    assert total == len(payload)
+    assert dest.read_bytes() == payload
+
+
+@pytest.mark.asyncio
+async def test_read_size_is_bounded_and_not_caller_tunable(tmp_path: Path) -> None:
+    """The read size bounds the ONE blocking call left on the event loop.
+
+    `__exit__`'s `close()` contends for the BufferedWriter's lock, so if
+    cancellation lands while a worker is inside `to_thread(sink.write, chunk)`,
+    the on-loop close waits for that write. The wait is one chunk of I/O, so the
+    chunk size *is* the bound — at the 1 MB this module started with, a slow or
+    network filesystem made it a real stall.
+
+    Two assertions, and the second is the load-bearing one: the size is capped,
+    and it is capped by a module constant that no caller can raise. A tunable
+    parameter would make the bound only as good as its worst caller, which is how
+    this became a finding in the first place.
+    """
+    seen: list[int] = []
+
+    class _RecordingPart:
+        def __init__(self) -> None:
+            self._left = 3
+
+        async def read_chunk(self, size: int = 0) -> bytes:
+            seen.append(size)
+            self._left -= 1
+            return b"z" * 32 if self._left > 0 else b""
+
+    await stream_part_to_file(_RecordingPart(), tmp_path / "bounded.bin", max_bytes=1 << 20)
+
+    assert seen, "the loop never read anything"
+    assert max(seen) <= 64 * 1024, seen
+    assert part_stream.CHUNK_BYTES == 64 * 1024
+    # No per-call override: re-adding one silently un-bounds the wait above.
+    params = inspect.signature(stream_part_to_file).parameters
+    assert "chunk_bytes" not in params, sorted(params)
+
+
+def test_open_flags_include_o_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The open must be binary-mode, which only Windows can actually get wrong.
+
+    `O_BINARY` is 0 on POSIX, so a POSIX-only test cannot observe the corruption
+    — it would pass on this machine while Windows CI committed newline-translated
+    bytes. So assert on the FLAGS rather than on the written file: that holds on
+    every platform, and it is exactly the regression this had (the flag was on
+    the pre-extraction opener and was dropped when the code moved).
+    """
+    seen: list[int] = []
+    real_open = os.open
+
+    def recording_open(path, flags, *rest):  # noqa: ANN001, ANN202
+        seen.append(flags)
+        return real_open(path, flags, *rest)
+
+    monkeypatch.setattr(part_stream.os, "open", recording_open)
+    with _TempSink(tmp_path / "flags.bin"):
+        pass
+    monkeypatch.undo()
+
+    assert seen, "the sink did not open anything"
+    # Compared against the attribute rather than a literal: the constant does not
+    # exist off Windows, and hardcoding its value would assert nothing there.
+    expected = getattr(os, "O_BINARY", 0)
+    assert seen[0] & expected == expected, oct(seen[0])
+    assert seen[0] & os.O_EXCL, oct(seen[0])
+
+
+def test_temp_is_created_owner_only(tmp_path: Path) -> None:
+    """An upload may carry anything and `uploads/` is shared."""
+    dest = tmp_path / "perm.bin"
+    with _TempSink(dest) as sink:
+        mode = os.stat(sink.tmp).st_mode & 0o777
+    if os.name != "nt":  # Windows does not model POSIX permission bits
+        assert mode == 0o600, oct(mode)

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -56,7 +56,16 @@ import type { SendMode } from '../pages/chat/ChatSettings'
 // Upload picker accept hints. Client-side ONLY (UX) — the server validates type
 // (magic bytes), size, and runs malware scanning per input-validation guidance.
 const IMAGE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg+xml'
-const FILE_ACCEPT = IMAGE_ACCEPT + ',.txt,.md,.json,.har,.yaml,.yml,.xml,.csv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
+// Video containers the server accepts (see `_ALLOWED_VIDEO_EXT`). MIME form, not
+// extensions, because this string is also what the MOBILE photo picker filters
+// the library by: iOS shows videos only when a video/* type is listed, so an
+// extension-only hint is what made a phone able to attach photos and nothing else.
+// One MIME per accepted extension — `video/x-m4v` is NOT covered by `video/mp4`
+// in a picker's filter, so omitting it hides a file the server would accept.
+// test_accept_list_covers_every_accepted_extension pins this set against the
+// server's, from the Python side, since a vitest cannot read the Python constant.
+const VIDEO_ACCEPT = 'video/mp4,video/x-m4v,video/quicktime,video/webm'
+const FILE_ACCEPT = IMAGE_ACCEPT + ',' + VIDEO_ACCEPT + ',.txt,.md,.json,.har,.yaml,.yml,.xml,.csv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
 
 // Extension per image MIME type, mirroring IMAGE_ACCEPT. Used to synthesize a
 // filename for clipboard-pasted images (see nameClipboardImage).

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -31,7 +31,7 @@ import { performAgentSlotSwitch } from '../lib/agentSwitch'
 import { api } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
 import { classifyDrop } from '../utils/dropClassify'
-import { serializeDirTokens, spliceDirTokens } from '../utils/fileTokens'
+import { serializeDirTokens, spliceDirTokens, VIDEO_EXT, VIDEO_MAX_BYTES } from '../utils/fileTokens'
 import { displayModel } from '../lib/model'
 
 
@@ -275,7 +275,17 @@ export default function ChatPane({
   })
   const uploadFiles = useCallback((files: File[]) => {
     if (!files.length || files.length > 20) return
-    if (files.find((f) => f.size > 50 * 1024 * 1024)) return
+    // Same video exemption as ChatPage's uploadFiles: the server's video cap is
+    // far higher than 50 MB, and this guard drops the batch SILENTLY, so
+    // applying it to a recording would swallow the attach with no explanation.
+    // But this pane has no error surface at all -- `uploadMutation` renders
+    // nothing on failure -- so it cannot delegate the ceiling to the server's
+    // 413 the way ChatPage does. It pre-checks against the server's own cap
+    // instead: a legal recording gets through, and an over-cap one is dropped
+    // exactly the way this pane already drops every oversized file, rather than
+    // gaining a NEW silent failure mode from this change.
+    const cap = (f: File) => (VIDEO_EXT.test(f.name) ? VIDEO_MAX_BYTES : 50 * 1024 * 1024)
+    if (files.find((f) => f.size > cap(f))) return
     uploadMutation.mutate(files)
   }, [uploadMutation])
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -67,7 +67,7 @@ import { useScrollManager } from './chat/useScrollManager'
 import { shouldPaginateOlder } from './chat/pagination'
 import EarlierMessagesBar from './chat/EarlierMessagesBar'
 import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
-import { addPendingFile, parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, buildRelMap, findUnreferencedAttachments, hasExactRelMention, normalizeWindowsPath, parseDirTokens, serializeDirTokens, parseDirs, resolveDirSegment, spliceDirTokens } from '../utils/fileTokens'
+import { addPendingFile, parseFiles, prepareSendPayload, resolveFileSegment, buildFileLabels, buildRelMap, findUnreferencedAttachments, hasExactRelMention, normalizeWindowsPath, parseDirTokens, serializeDirTokens, parseDirs, resolveDirSegment, spliceDirTokens, VIDEO_EXT } from '../utils/fileTokens'
 import { classifyDrop } from '../utils/dropClassify'
 import { makeRelative } from '../components/FilePickerMenu'
 import { type PasteBlock, expandAll as expandPasteTokens, findTokenRanges, pruneBlocks as pruneBlocksUtil, remapCarriedBlocks, saveStoredPaste, recollapsePastes } from '../utils/pasteTokens'
@@ -3047,7 +3047,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const requestSlot = targetSlot !== undefined ? targetSlot : activeSlotRef.current
     setUploadError('')
     if (files.length > 20) { setUploadError(i18nT('pages.chatPage.too_many_files_max_20')); return }
-    const big = files.find(f => f.size > 50 * 1024 * 1024)
+    // Video is deliberately exempt from this pre-check: it has a much larger
+    // server-side ceiling and streams to disk there, so the 50 MB figure this
+    // message states would be a lie for a recording. Its own 413 carries the
+    // real cap and surfaces through the `upload_failed_error` branch below,
+    // the same route every other server-side rejection already takes.
+    const big = files.find(f => !VIDEO_EXT.test(f.name) && f.size > 50 * 1024 * 1024)
     if (big) { setUploadError(i18nT('pages.chatPage.file_too_large', { name: big.name })); return }
     setUploading(true)
     try {

--- a/website/src/test/ChatInput.videoAccept.test.tsx
+++ b/website/src/test/ChatInput.videoAccept.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The composer must OFFER video, not just tolerate it.
+ *
+ * On a phone the `<input accept>` list is what the system photo picker filters
+ * the library by, so an accept list of image MIME types plus document
+ * extensions is exactly what made "attach" show photos and hide every
+ * recording — the bug this covers. The picker is the only surface that carries
+ * this hint (`openPicker` rewrites `accept` for the image-only entry), so it is
+ * asserted on the rendered input rather than on the constant.
+ *
+ * VIDEO_EXT is pinned alongside it because the two must agree: the accept list
+ * decides what a user can CHOOSE, VIDEO_EXT decides which of those choices skip
+ * the 50 MB client-side pre-check, and a mismatch means either a file the
+ * picker offers and the client then silently drops, or a document sent past a
+ * guard that exists to catch it.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+
+import { VIDEO_EXT, VIDEO_MAX_BYTES } from '../utils/fileTokens'
+
+vi.mock('../hooks/useScreenSnip', () => ({ isScreenSnipSupported: () => false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => true }))
+vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => true }))
+vi.mock('../api/client', () => ({ api: new Proxy({}, { get: () => vi.fn() }) }))
+
+import ChatInput from '../components/ChatInput'
+
+const base = { value: '', onChange: vi.fn(), onSend: vi.fn(), onUploadFiles: vi.fn() }
+
+const fileInput = () =>
+  screen.getByLabelText('Attach files', { selector: 'input[type="file"]' })
+
+describe('composer accept list — video', () => {
+  it('offers the video containers the server accepts', () => {
+    renderWithProviders(<ChatInput {...base} />)
+    const accept = fileInput().getAttribute('accept') || ''
+    // MIME form, not extensions: iOS filters the photo library by type, and an
+    // extension-only hint leaves videos invisible even though they are legal.
+    expect(accept).toContain('video/quicktime') // .mov — macOS/iOS screen recording
+    expect(accept).toContain('video/mp4')
+    // `.m4v` needs its own type: a picker filtering on `video/mp4` alone hides it.
+    expect(accept).toContain('video/x-m4v')
+    expect(accept).toContain('video/webm')
+  })
+
+  it('keeps the existing image and document hints intact', () => {
+    renderWithProviders(<ChatInput {...base} />)
+    const accept = fileInput().getAttribute('accept') || ''
+    expect(accept).toContain('image/png')
+    expect(accept).toContain('.pdf')
+    expect(accept).toContain('.zip')
+  })
+})
+
+describe('VIDEO_EXT', () => {
+  it('matches every container the accept list offers', () => {
+    for (const name of ['clip.mp4', 'clip.m4v', 'Screen Recording.mov', 'cap.webm']) {
+      expect(VIDEO_EXT.test(name)).toBe(true)
+    }
+  })
+
+  it('is case-insensitive — a camera roll yields .MOV and .MP4', () => {
+    expect(VIDEO_EXT.test('IMG_0042.MOV')).toBe(true)
+    expect(VIDEO_EXT.test('CLIP.MP4')).toBe(true)
+  })
+
+  it('does not match documents, images, or the excluded .mkv', () => {
+    for (const name of ['notes.md', 'shot.png', 'deck.pptx', 'capture.mkv']) {
+      expect(VIDEO_EXT.test(name)).toBe(false)
+    }
+  })
+
+  it('anchors at the end so a video name inside a document name does not match', () => {
+    // `mp4-notes.md` and `about-mov.txt` are documents; matching them would
+    // exempt a real document from the 50 MB guard.
+    expect(VIDEO_EXT.test('mp4-notes.md')).toBe(false)
+    expect(VIDEO_EXT.test('about-mov.txt')).toBe(false)
+  })
+})
+
+describe('VIDEO_MAX_BYTES', () => {
+  it('is the ceiling ChatPane pre-checks against, and clears the document cap', () => {
+    // NOT a cross-language pin: a vitest cannot read `_MAX_VIDEO_UPLOAD_BYTES`,
+    // so this only fixes the value the client uses. The two-sided check lives in
+    // test/test_handlers_files_video_upload.py
+    // (test_client_video_cap_matches_the_server_ceiling), which can see both
+    // numbers — a server cap raised without the mirror leaves ChatPane, which
+    // renders nothing on failure, silently refusing legal recordings.
+    expect(VIDEO_MAX_BYTES).toBe(512 * 1024 * 1024)
+    expect(VIDEO_MAX_BYTES).toBeGreaterThan(50 * 1024 * 1024)
+  })
+})

--- a/website/src/utils/fileTokens.ts
+++ b/website/src/utils/fileTokens.ts
@@ -4,6 +4,18 @@ import { decodeLocalPath } from './urlTransform'
 
 export const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg)$/i
 
+/** Video containers the upload boundary accepts, mirroring `_ALLOWED_VIDEO_EXT`
+ *  in `dashboard/handlers/files.py`. Kept in sync deliberately: this drives the
+ *  client's cap decision, and a client that is more permissive than the server
+ *  only produces uploads that die at the door. */
+export const VIDEO_EXT = /\.(mp4|m4v|mov|webm)$/i
+
+/** The server's own per-video ceiling (`_MAX_VIDEO_UPLOAD_BYTES`). Mirrored here
+ *  only for the surfaces that cannot report a server error and must therefore
+ *  pre-check locally; a surface that CAN report one should let the server's 413
+ *  speak, since it states the cap authoritatively. */
+export const VIDEO_MAX_BYTES = 512 * 1024 * 1024
+
 /** Boundary-aware regex for @token matching. Prevents `@foo.ts` from matching
  *  inside `@foo.tsx` (right boundary) and inside `foo@bar.ts` (left boundary).
  *


### PR DESCRIPTION
## What

The composer accepts video attachments. `.mp4`, `.m4v`, `.mov`, `.webm`.

## Why

Reported as "the phone can only pick photos, not videos". The phone was the symptom, not the bug.

A mobile `+` fires the file input directly, and the system photo picker filters the library by that input's `accept` list — which held image MIME types plus document extensions. So the library showed photos and hid every recording. Desktop shared the same accept string, a dragged `.mov` went to the upload route, and the server refused it on an extension allowlist with no video in it (`allowed = _ALLOWED_IMAGE_EXT | _ALLOWED_TEXT_EXT | _ALLOWED_DOC_EXT`).

What made it *look* mobile-only is that desktop has path routes that bypass uploads entirely — an `@`-mention, a dropped folder — and those never consult the allowlist. A phone has no filesystem to point at, so upload is its only route.

Everything downstream already worked. `FileRenderers` maps the video extensions to a `<video>` element, `/api/file-stream` serves them with Range support so seeking works, and the `[attached_file N]` plumbing already carries non-image attachments. The gap was the upload boundary alone.

## How

**Video streams to disk instead of joining the in-memory route.** A 30-second retina screen recording is routinely 60–150 MB, so the 50 MB document cap would have rejected the dominant case. Video gets its own 512 MB ceiling, and that is only safe because `_stream_video_part` writes chunk by chunk rather than accumulating a `bytearray` — a 500 MB recording costs one chunk of memory, not 500 MB.

**The file is owned by a synchronous context manager, in one shared module.** This is the part of the PR that cost the most, so it is worth stating what happened rather than only what shipped. Streaming a part to disk collected **seven** blocking review findings in seven rounds, and three of them I introduced while fixing the previous one: an ignored `os.write` short count; a `CancelledError` walking past `except Exception`; a cancel racing the `to_thread(open)`; an `EBADF` on every upload from a callback registered before the shielded await; a double close of a descriptor *number* the kernel may have reassigned; a cleanup keyed on `task.result()` that could not run for a directly cancelled open task; and then a cleanup keyed on the path instead, which raced the same worker the other way and unlinked *before* it created.

The invariant those seven share: **a cancellable owner cannot both offload its cleanup and guarantee it.** Offloading needs an await or a callback, and each introduces an ordering the owner does not control — which is how the open race happened in both directions. So ownership now lives in a synchronous context manager in `dashboard/part_stream.py`: `__enter__` creates the temp, `__exit__` discards unless the body committed. `with` guarantees `__exit__` on every exit including `CancelledError`, and because no `await` sits between the create and the cleanup's registration, nothing can race it and no result has to be fetched from a task that may never produce one. `BufferedWriter.write` supplies the short-write loop, `close()` is idempotent so double-close-by-number is unreachable, and `commit()` does close **and** `os.replace` in one worker call.

The deliberate cost, stated rather than hidden: that one `os.open` and the one `close`+`unlink` run on the event loop. An earlier revision of this section called that "microseconds", which was wrong on its central claim and the review caught it — the cost is not the syscall. `close()` contends for the `BufferedWriter`'s own lock, so if cancellation arrives while a worker is inside `to_thread(sink.write, chunk)`, the on-loop close waits for **that write** to finish. The wait is therefore one chunk of I/O.

So the chunk size *is* the bound, and it is now set to make the bound uninteresting rather than merely asserted: **`CHUNK_BYTES = 64 KB`**, down from the 1 MB this module started with (and the 256 KB the video path used before the extraction). At 1 MB on a slow or network filesystem that wait was a real stall; 64 KB is well under a single disk write's latency floor. It is a module constant with **no per-call override** — a value a caller can raise is not a bound, and the guarantee is only as good as its worst caller. `test_read_size_is_bounded_and_not_caller_tunable` pins both halves: the observed read size, and the absence of a `chunk_bytes` parameter.

The *bulk* cleanup that the loop-blocking finding was originally about — a request unlinking up to 20 published paths, a 512 MB video among them — still runs in a worker. Writes, the commit and the sniff run in workers too.

**Three of the FOUR stream-a-part-to-disk sites now share that path.** `handlers/files.py` (composer uploads), `handlers/portability.py` (state import) and `handlers/knowledge.py` (knowledge ingest) each had their own copy; the other two wrote **synchronously on the event loop** and knowledge ingest sniffed the signature only *after* the whole file was on disk, so rejected content did reach the filesystem. Both are strictly tighter now, and both stop leaking their temp on cancellation.

An earlier revision of this section said "all three", which First Principles falsified by grepping `read_chunk(`: there are **four**. `api_stt_transcribe` (`dashboard/handlers/core.py`) still hand-writes chunks synchronously on the loop — the same defect class this PR names. It is not converted here because the STT path has a different shape (no signature gate, no publish step) and it is not the boundary this PR is about; tracked separately.

**Import keeps a cap, aligned rather than invented.** An earlier revision set it to 512 MB and justified it as restoring a bound streaming had removed. First Principles falsified that too, correctly: the previous `_read_upload_file` **already streamed to disk** with no cap of any kind, so 512 MB was a NEW restriction that could 413 a legitimate state export — in exactly the scenario where the source machine may be gone. The cap is now **2 GiB**, matching `portability._MAX_IMPORT_UNCOMPRESSED`, the bomb guard that already governs this path: a compressed archive under 2 GiB cannot be refused at the door without the two limits contradicting each other. The cap exists only so an unbounded upload cannot fill the disk.

**Cancellation cleanup covers EVERY upload type, not just video.** The outer-handler hunk that unlinks partials on `BaseException` is in the shared request path, so an image or document upload cancelled mid-stream also stops leaving files behind, and `_cleanup` is now a coroutine that unlinks in a worker. That is a behaviour change beyond this PR's stated video scope; it rides along because the defect it removes is real and the guard cannot be narrowed to one branch without leaving the others wrong.

**The signature gate still runs before the first byte lands.** The header is buffered only until it is long enough to judge (`SNIFF_BYTES`), so a `.mov` that is really HTML never reaches disk (CWE-434). A refusal unlinks the partial along with its siblings — worth pinning, because the streaming route has already created the destination by the time a cap trips.

**The accepted set is narrower than what `<video>` will attempt.** Every entry must be verifiable by the existing container sniffer *and* playable, so `.mkv` stays out: it shares WebM's EBML signature, but accepting a file that then refuses to play is worse than refusing it at the door.

**A refusal for a playable-but-unaccepted container names the way out.** `.mkv`, `.ogv`, `.avi` and friends get the accepted set appended, so the message points at a re-encode instead of reading as "video is not supported at all". The general wording is unchanged for everything else.

**`ChatPane` pre-checks instead of delegating.** It has no error surface — its upload mutation renders nothing on failure — so it cannot let the server's 413 explain itself the way `ChatPage` can. It checks against the server's own ceiling, so a legal recording gets through and an over-cap one is dropped exactly the way that pane already drops every oversized file, rather than gaining a new silent failure from this change. Its pre-existing silence for *all* server refusals is #5707.

**No new FRONTEND copy — two new backend strings.** (Corrected: an earlier revision of this description claimed "no new UI copy", which First Principles correctly falsified.) No i18n catalog changes: the client-side 50 MB pre-check exempts video in ChatPage, whose message states a figure that would be a lie for a recording, and lets the server's own 413 surface through the existing `upload_failed_error` branch — the route every other server-side rejection already takes. The server does add two un-localized English strings, in the same style as the endpoint's existing ones: the over-cap message and the accepted-containers hint on a refusal. The client-side 50 MB pre-check exempts video (its message states a figure that would be a lie for a recording) and lets the server's own 413 surface through the existing `upload_failed_error` branch — the same route every other server-side rejection already takes.

**The model still cannot see video content.** ACP has no video content block, so the path reaches the agent as text rather than an inlined block. An agent that needs frames runs ffmpeg on the path. This is a deliberate limit, not an oversight.


**Every new error body carries a machine-readable `code`.** `video_too_large`, `video_content_mismatch`, and `unsupported_file_type` on the refusal this PR already touched. The refusal path branches to CONSTANT statuses rather than passing a computed one, because a `status=` expression makes the endpoint's outcomes unreadable to static analysis (`test_error_code_contract.py`). Adding a code dropped this file's `missing_code` count 115 → 114, so `error-code-baseline.json` is re-snapshotted in the tightening direction only.

**Three cross-language pins, asserted from the Python side.** `VIDEO_ACCEPT`, `VIDEO_MAX_BYTES` and `VIDEO_EXT` must agree with `_ALLOWED_VIDEO_EXT` / `_MAX_VIDEO_UPLOAD_BYTES`; only the Python side can see both numbers, so a vitest assertion would be one-sided. This caught a real gap: `VIDEO_ACCEPT` was missing `video/x-m4v`, so the picker could hide a `.m4v` the server accepts.

## Tests

- `test/test_part_stream.py` — **new**, and the executable half of the ledger above: every test pins a property one of the seven findings was filed against, so a refactor that reintroduces any of them fails here instead of in a review round. The exit path removes the temp when the body did not commit, still runs when the body raises `CancelledError`, touches nothing after a commit, and is idempotent (the double-close-by-number property). `O_EXCL` refuses to adopt an existing `.part`. `dest` never appears when the rename fails. Every byte lands across many chunks. Over-cap and signature-mismatch both raise having written nothing — asserted by an empty directory, which is a stronger claim than "cleaned up afterwards". A part shorter than the sniff window is still judged. The temp is owner-only.
- `test/test_handlers_files_video_upload.py` — the endpoint's own behaviour, now that the file handling is tested one layer down: each accepted container lands byte-for-byte; video is exempt from the document cap and bound by its own; over-cap 413s and leaves nothing behind; HTML wearing `.mov` is refused before any write; a cancelled write leaves neither the destination nor its `.part` temp; `.mkv` stays rejected on extension despite valid EBML, and its refusal names the accepted containers — while `.m4a`, which shares the same `ftyp` magic, is refused *without* that hint, since telling an audio sender to re-encode into a video container is worse guidance than the bare refusal.
- `website/src/test/ChatInput.videoAccept.test.tsx` — the rendered input offers `video/quicktime` / `video/mp4` / `video/webm` while keeping the image and document hints; `VIDEO_EXT` is case-insensitive (a camera roll yields `.MOV`), end-anchored, and does not match `.mkv`; `VIDEO_MAX_BYTES` mirrors the server ceiling and sits above the document cap.

Rebased onto current main. Local: black gate / isort / flake8 clean, `test_error_code_contract.py` 6/6, `tsc -b` clean, `eslint src/` 0 errors / 643 warnings against the 664 cap, `i18n:check` green, new vitest file 6/6. Python suites left to CI (no local venv).

## Not verified

Real-device check that the iOS photo picker now lists videos. The accept list is the documented mechanism and the test pins the MIME types reach the input, but nobody has held a phone.

<!-- no-visual-delta -->

**Why no screenshot:** nothing this diff touches renders differently. The user-visible effect lives inside the OS photo picker / Finder dialog, which filters by the input's `accept` list and is not part of the app's own rendering — a harness cannot capture it. Within the composer, a video attachment reuses the existing non-image chip branch that already renders `.pdf` and `.zip` identically, so no new pixels come from this change; the three watched files gain an `accept` entry, a regex import, and a size-guard predicate.



Closes #5762


