### PR TITLE
fix(cron): fall back to config default_agent for LLM jobs with no agent_id

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -4026,6 +4026,26 @@ class GatewayOrchestrator:
                 await _alert_cron_failure(job, gate_reason, denied=True)
                 return None
 
+            # ── Default-agent fallback (LLM jobs) ──
+            # A job with no explicit agent_id must run the configured default
+            # agent (config.agent.default_agent), matching the chat transports'
+            # fallback (transport_dispatch: `self.agent or cfg.agent.default_agent`).
+            # Without this, `job.agent_id or None` flows to the provider factory,
+            # AcpProvider omits the kwarg, and AcpClient falls back to its
+            # hardcoded CLIENT_NAME ("kirocrew") — an agent that carries none of
+            # the default agent's MCP servers (observed: default-agent MCP servers absent from
+            # cron sessions). In-memory only: _merge_job_result never persists
+            # agent_id, so this cannot rewrite crons.json.
+            if not (job.agent_id or "").strip() and not job.agent_sequence:
+                _default_agent = ""
+                if hasattr(self, "_cfg"):
+                    try:
+                        _default_agent = (self._cfg.agent.default_agent or "").strip()
+                    except Exception:
+                        _default_agent = ""
+                if _default_agent:
+                    job.agent_id = _default_agent
+
             def _cron_extra_env() -> dict[str, str] | None:
                 """job.env plus KIROCREW_APPROVAL_MODE when the job runs auto.
 


### PR DESCRIPTION
## Summary
A cron LLM job with an empty `agent_id` runs the wrong agent: `agent=None` flows through `get_or_create` to the provider factory, `AcpProvider` omits the kwarg, and `AcpClient` falls back to its hardcoded `CLIENT_NAME` ("kirocrew") — an agent config that carries none of the configured default agent's MCP servers. The job still runs, but silently without the toolset the operator expects.

## Fix
Resolve the fallback at job execution, mirroring the chat transports (`agent or cfg.agent.default_agent`): if a job has no `agent_id` and no `agent_sequence`, set `job.agent_id` to `config.agent.default_agent` in memory. `_merge_job_result` never persists `agent_id`, so stored job definitions are unchanged.

## Observed
Two consecutive scheduled runs of a watcher cron executed without the default agent's MCP servers before this patch (2026-08-19); with it, the same job resolves the default agent and its full toolset.

## Testing
Running on our production deployment since 2026-08-19 across daily scheduled jobs. `python3 -m py_compile` clean; cherry-picks onto current `main` (8bd724f68) with no conflicts.
