### PR TITLE
fix(security): lock remaining secret writers down before publish

### DIFF
--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -114,6 +114,7 @@ WRITE_DESTINATION_ARG = {
     "replace": 1,  # os.replace(tmp, final)
     "rename": 1,  # os.rename(tmp, final)
     "move": 1,  # shutil.move(tmp, final)
+    "link": 1,  # os.link(tmp, final) — create-only publish; still a content landing
 }
 
 #: The same destinations by KEYWORD name. Reading positionally alone let the
@@ -128,6 +129,7 @@ WRITE_DESTINATION_KWARG = {
     "replace": "dst",
     "rename": "dst",
     "move": "dst",
+    "link": "dst",
 }
 
 #: Keyword name of a publish call's SOURCE (the temp being renamed away).
@@ -150,7 +152,7 @@ WRITE_METHODS = frozenset({"write_text", "write_bytes"})
 #: ``move`` to the final path recorded no publication (so a lockdown after it was
 #: not flagged) AND the source got no temp exemption (so locking a temp and then
 #: moving it -- correct code -- was flagged).
-PUBLISH_CALLS = frozenset({"replace", "rename", "move"})
+PUBLISH_CALLS = frozenset({"replace", "rename", "move", "link"})
 
 #: The subset with a pathlib METHOD spelling where the receiver is the temp:
 #: ``<tmp>.rename(final)`` / ``<tmp>.replace(final)``. ``shutil.move`` is a
@@ -180,21 +182,10 @@ SUPPRESS_RE = re.compile(r"#\s*lockdown-ok\s*:\s*(?P<reason>\S.*)$")
 #: added to an allowlisted function would be suppressed along with the tracked
 #: one, so an allowlist entry would quietly widen into a whole-function waiver.
 KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
-    # Classified by #5346 -- the sites #5307's third acceptance criterion left
-    # untriaged. The remaining snapshot one is a shutil.copy2 into a final
-    # destination, so it needs copy-to-temp + restrict + replace rather than a
-    # one-line atomic_write swap.
-    #
-    # #5285's six sites were here until main converted them mid-review; the
-    # shrink-only rule below is what forced this list to follow.
-    "src/kiro_crew/snapshot.py::_do_merge": ("#5346", "d"),
-    "src/kiro_crew/sel.py::_append_lines_locked": ("#5346", "self._path"),
-    # Surfaced once _mode_of learned the symbolic spelling: writes a config that
-    # "can carry provider tokens / API keys" (its own docstring), then chmods.
-    # Path expressions are recorded after alias resolution, so this entry names
-    # `home_dir / "config.json"` rather than the local `dst_cfg` the line spells.
-    # That is the more durable key: renaming the local no longer stales the entry.
-    "src/kiro_crew/pod/runtime.py::write_pod_config": ("#5346", 'home_dir / "config.json"'),
+    # Empty: #5493 converted denied_commands; this PR converts write_pod_config
+    # and snapshot._do_merge, and annotates sel._append_lines_locked lockdown-ok
+    # (same event-loop / icacls reason as #5228). Shrink-only: do not re-add a
+    # converted site.
 }
 
 
@@ -650,6 +641,7 @@ def _temp_sources(node: ast.Call, source: str) -> list[str]:
     """Paths this call publishes UNDER ANOTHER NAME, in either spelling.
 
     ``os.replace(tmp, final)``   -- the temp is the first argument.
+    ``os.link(tmp, final)``      -- create-only publish; the temp is still arg 0.
     ``tmp.rename(final)``        -- the temp is the receiver.
     ``tmp.replace(target=final)`` -- likewise, and missing this spelling made the
     exemption fail OPEN in the other direction: a CORRECT writer that locked its

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -18,8 +18,9 @@ so the caller reads remediation instead of a raw regex. It is metadata only: it
 never participates in matching. Create-only, mirroring ``pattern`` — neither has
 an edit endpoint; you delete the rule and re-add it.
 
-Mutations run under the shared config lock, write atomically (0600), and emit a
-SEL audit entry (``ok`` on success, ``denied`` on reject). Governance
+Mutations run under the shared config lock, write atomically (owner-only
+before the payload is published), and emit a SEL audit entry (``ok`` on
+success, ``denied`` on reject). Governance
 ``commands``-scope pins force a built-in rule enabled even when the user disabled
 it or set disable-all (tightest-wins): a pinned rule cannot be turned off (409)
 and always counts as enabled in the snapshot.
@@ -353,7 +354,7 @@ async def _write_denied_state(mutate) -> dict:
 
     ``mutate(denied: dict) -> None`` edits the opt-out object (the file root) in
     place. Runs under the shared config lock. Returns the updated object so the
-    caller can hot-reload the live HookManager. The file is locked down to the
+    caller can hot-reload the live HookManager.     The file is locked down to the
     owner only on every write: 0600 on POSIX and an owner-only DACL on Windows.
     The lockdown is applied to the temp file before any content reaches it, so
     the keystone never exists in a world-readable file.
@@ -363,12 +364,15 @@ async def _write_denied_state(mutate) -> dict:
     loop; the async config lock still serializes concurrent mutations.
     """
     from kiro_crew.atomic_write import atomic_write
+
     path: Path = denied_commands_path()
 
     def _read_modify_write() -> dict:
         denied = _read_denied_strict()
         mutate(denied)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        # atomic_write(..., restrict_to_owner=True) refuses a linked parent
+        # before it mkdir's, then locks the temp. A mkdir here would walk
+        # through a planted link and create dirs under its target first.
         atomic_write(
             path,
             json.dumps(denied, indent=2) + "\n",

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -1143,8 +1143,16 @@ def write_pod_config(home_dir: Path, seed: str) -> None:
         return
     sanitized = sanitized_seed_config(Path(seed)) if seed else None
     cfg_data = sanitized if sanitized is not None else {"tunnel": {"enabled": False}}
-    dst_cfg.write_text(json.dumps(cfg_data, indent=2))
-    os.chmod(dst_cfg, stat.S_IRUSR | stat.S_IWUSR)  # 0o600 owner read/write only
+    # Create-only (the exists() guard above): lock the temp down before any
+    # token-bearing payload reaches the published name. write_text then chmod
+    # left the file at its inherited DACL until the chmod returned, and the
+    # chmod itself was a no-op on Windows. atomic_write encodes UTF-8; the
+    # previous write_text call did not pass encoding=.
+    atomic_write(
+        dst_cfg,
+        json.dumps(cfg_data, indent=2),
+        restrict_to_owner=True,
+    )
 
 
 def cleanup_home(cfg: PodConfig, name: str) -> int:

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -731,7 +731,7 @@ class SecurityEventLog:
         # the fallback taken when the writer thread cannot start (see
         # ``_may_rotate``) — where a blocking call freezes every gateway task.
         try:
-            os.chmod(self._path, 0o600)
+            os.chmod(self._path, 0o600)  # lockdown-ok: #5228 -- icacls would block the event loop
         except OSError:
             logger.warning("Failed to enforce 0o600 permissions on SEL audit log %s", self._path, exc_info=True)
         self._live_seen = (written.st_dev, written.st_ino, written.st_size)

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -33,6 +33,11 @@ VALID_COMPONENTS = ("memory", "crons", "config", "skills", "workspace", "notific
 # Files that must always have 0o600 permissions in snapshots and on restore.
 SECURITY_SENSITIVE_FILES: frozenset = frozenset({"sel_hmac.key", "telemetry_salt"})
 
+# Must match ``handlers_system._get_telemetry_salt`` (``secrets.token_bytes(32)``).
+# ``_copy_locked`` loads telemetry_salt into memory, so a planted giant in an
+# untrusted snapshot would OOM restore after earlier merge steps.
+_TELEMETRY_SALT_BYTES = 32
+
 # Files that must NEVER ride a snapshot: sel_hmac.key is regenerated on restore
 # so audit-log HMACs stay bound to the host that wrote them.
 #
@@ -1099,6 +1104,58 @@ def _backup_and_copy(
         os.close(src_fd)
 
 
+def _copy_locked(src: Path, dst: Path) -> bool:
+    """Copy *src* onto a missing *dst*, owner-only before the name is published.
+
+    Merge restore only copies when *dst* is absent. Publish with ``os.link``
+    (the create-only shape ``_get_telemetry_salt`` uses) so a dest that
+    appears in the window — ``--force`` restore racing a live gateway
+    creating ``telemetry_salt`` — raises ``FileExistsError`` and the live
+    file is left alone. ``os.replace`` / ``atomic_write`` would clobber it.
+    The temp is locked down before any payload is written. Failures to
+    publish (unsupported hard links, a restrict error, a size mismatch)
+    skip this file without raising, because merge restore has already
+    applied earlier components and ``_get_telemetry_salt`` regenerates a
+    missing salt. Return True only when this call published *dst*.
+    """
+    if dst.exists():
+        return False
+    if src.name == "telemetry_salt" or dst.name == "telemetry_salt":
+        size = src.stat().st_size
+        if size != _TELEMETRY_SALT_BYTES:
+            return False
+    payload = src.read_bytes()
+    if dst.exists():
+        return False
+    fd, tmp = tempfile.mkstemp(prefix=f".{dst.name}.", suffix=".tmp", dir=str(dst.parent))
+    tmp_path = Path(tmp)
+    try:
+        platform_compat.restrict_to_owner(str(tmp_path))
+        view = memoryview(payload)
+        while view:
+            written = os.write(fd, view)
+            if written == 0:
+                raise OSError(f"short write restoring {src.name}")
+            view = view[written:]
+        os.close(fd)
+        fd = -1
+        os.link(str(tmp_path), str(dst))
+        return True
+    except OSError:
+        # FileExistsError: live dest won. EXDEV / EPERM / no-hardlink /
+        # restrict / short write: dest stays missing and `_get_telemetry_salt`
+        # regenerates. Raising here aborts merge after earlier components
+        # were already applied.
+        return False
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def _lock_down_restored(path: Path, component: str) -> None:
     """Apply the owner-only lockdown a restored security file needs.
 
@@ -1278,19 +1335,8 @@ def _do_merge(
         for f in CORE_FILES["security"]:
             s, d = snap / f, mc / f
             if s.is_file() and not d.is_file():
-                shutil.copy2(str(s), str(d))
-                # restrict_to_owner (fail-loud), NOT chmod_safe — security
-                # files include sel_hmac.key; mirror the create path. Windows
-                # applies an owner-only DACL via icacls. Unlink the freshly
-                # copied file on
-                # failure so an icacls error doesn't leave a restored secret
-                # under the destination-inherited DACL.
-                try:
-                    platform_compat.restrict_to_owner(str(d))
-                except OSError:
-                    d.unlink(missing_ok=True)
-                    raise
-                print(f"  {f}: restored (was missing)")
+                if _copy_locked(s, d):
+                    print(f"  {f}: restored (was missing)")
         print("  ✅ security")
 
     if _want(components, "workspace"):

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -1137,19 +1137,29 @@ def _copy_locked(src: Path, dst: Path) -> bool:
             if written == 0:
                 raise OSError(f"short write restoring {src.name}")
             view = view[written:]
-        os.close(fd)
+        # Drop the fd from finally before close: a close-time writeback
+        # error must not be retried on an already-released descriptor,
+        # because a second OSError in finally would replace the skip and
+        # abort merge after earlier components were applied.
+        pending = fd
         fd = -1
+        os.close(pending)
         os.link(str(tmp_path), str(dst))
         return True
     except OSError:
         # FileExistsError: live dest won. EXDEV / EPERM / no-hardlink /
-        # restrict / short write: dest stays missing and `_get_telemetry_salt`
-        # regenerates. Raising here aborts merge after earlier components
-        # were already applied.
+        # restrict / short write / close: dest stays missing and
+        # `_get_telemetry_salt` regenerates. Raising here aborts merge
+        # after earlier components were already applied.
         return False
     finally:
         if fd >= 0:
-            os.close(fd)
+            pending = fd
+            fd = -1
+            try:
+                os.close(pending)
+            except OSError:
+                pass
         try:
             tmp_path.unlink(missing_ok=True)
         except OSError:

--- a/test/test_denied_commands_api.py
+++ b/test/test_denied_commands_api.py
@@ -968,3 +968,20 @@ def test_write_denied_state_does_not_fall_back_to_chmod_safe(
     assert captured.get("called"), (
         "_write_denied_state must route the keystone write through atomic_write"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_lockdown_publishes_no_denied_commands(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """restrict_to_owner runs on the temp; a failure must not leave the keystone file."""
+    monkeypatch.setattr(
+        "kiro_crew.atomic_write.platform_compat.restrict_to_owner",
+        lambda path: (_ for _ in ()).throw(OSError("icacls: transient failure")),
+    )
+    from kiro_crew.dashboard.handlers.security import _write_denied_state
+
+    with pytest.raises(OSError, match="icacls"):
+        await _write_denied_state(lambda d: d.update({"disable_all": True}))
+    assert not (home / "denied_commands.json").exists()
+    assert not list(home.glob("*.tmp"))

--- a/test/test_lockdown_before_publish.py
+++ b/test/test_lockdown_before_publish.py
@@ -129,6 +129,12 @@ def save(tmp, final, secret):
     shutil.move(tmp, final)
     os.chmod(final, 0o600)
 """,
+    "os.link into place, then restrict the published path": """
+def save(tmp, final, secret):
+    tmp.write_bytes(secret)
+    os.link(tmp, final)
+    platform_compat.restrict_to_owner(final)
+""",
     "fchmod_safe on the descriptor AFTER content": """
 def save(final, secret):
     fd = os.open(final, os.O_WRONLY | os.O_CREAT, 0o600)

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -752,6 +752,18 @@ class TestPodConfigWrite:
         assert data["tunnel"]["enabled"] is False  # sanitized
         assert stat.S_IMODE((home / "config.json").stat().st_mode) == 0o600
 
+    def test_a_failed_lockdown_publishes_no_config(self, tmp_path: Path, monkeypatch) -> None:
+        """restrict_to_owner runs on the temp; a failure must not leave config.json."""
+        monkeypatch.setattr(
+            "kiro_crew.atomic_write.platform_compat.restrict_to_owner",
+            lambda path: (_ for _ in ()).throw(OSError("icacls: transient failure")),
+        )
+        home = tmp_path / "pod-home"
+        with pytest.raises(OSError, match="icacls"):
+            rt.write_pod_config(home, seed="")
+        assert not (home / "config.json").exists()
+        assert not list(home.glob("*.tmp"))
+
 
 class TestCleanupHome:
     def test_removes_pod_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -1189,3 +1189,25 @@ class TestMergeRestoreLocksBeforePublish:
         monkeypatch.setattr(snapshot_mod.os, "link", _link)
         snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
         assert not (home / "telemetry_salt").exists()
+
+    def test_a_failed_close_does_not_abort_merge(self, tmp_path, monkeypatch):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "telemetry_salt").write_bytes(self._SALT)
+
+        real_close = os.close
+        fired = False
+
+        def _close(fdnum):
+            nonlocal fired
+            real_close(fdnum)
+            if fired:
+                return
+            fired = True
+            raise OSError("close: delayed writeback")
+
+        monkeypatch.setattr(snapshot_mod.os, "close", _close)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        assert not (home / "telemetry_salt").exists()

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from conftest import requires_symlinks
+from kiro_crew import snapshot as snapshot_mod
 from kiro_crew.snapshot import restore_main, snapshot_main
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -93,7 +94,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
     (d / "session_map.json").write_text("{}")
     (d / "hooks.json").write_text("{}")
     (d / "sel_hmac.key").write_bytes(b"\x00\x01\x02\x03")
-    (d / "telemetry_salt").write_bytes(b"\x04\x05\x06\x07")
+    (d / "telemetry_salt").write_bytes(b"\x04" * snapshot_mod._TELEMETRY_SALT_BYTES)
     (d / "notifications.jsonl").write_text('{"ts":"2026-01-01","msg":"test"}\n')
     (d / "project_dir").write_text("/home/user/project")
     (d / "workspace_dir").write_text("/home/user/.kirocrew/workspace")
@@ -1083,3 +1084,108 @@ class TestTheArchiveIsLockedDownBeforeItIsPublished:
         assert tarball.is_file()
         if os.name == "posix":
             assert tarball.stat().st_mode & 0o777 == 0o600, oct(tarball.stat().st_mode)
+
+
+class TestMergeRestoreLocksBeforePublish:
+    """#5346: merge restore of a missing security file must lock the temp first.
+
+    Merge only copies when the destination is absent, so a restrict failure
+    must leave that name uncreated rather than unlinking a published secret.
+    """
+
+    _SALT = b"s" * 32
+
+    def test_restrict_runs_on_the_temp_not_the_published_path(self, tmp_path, monkeypatch):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "telemetry_salt").write_bytes(self._SALT)
+
+        locked: list[Path] = []
+        dest = home / "telemetry_salt"
+        real = snapshot_mod.platform_compat.restrict_to_owner
+
+        def _recording(path):
+            locked.append(Path(path))
+            assert not dest.exists(), "payload was published before the temp was locked"
+            return real(path)
+
+        monkeypatch.setattr(snapshot_mod.platform_compat, "restrict_to_owner", _recording)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+
+        assert dest.is_file()
+        assert dest.read_bytes() == self._SALT
+        assert locked, "restrict_to_owner was never called"
+        assert dest not in locked
+        if os.name == "posix":
+            assert dest.stat().st_mode & 0o777 == 0o600
+
+    def test_a_failed_lockdown_leaves_the_destination_uncreated(self, tmp_path, monkeypatch):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "telemetry_salt").write_bytes(self._SALT)
+
+        monkeypatch.setattr(
+            snapshot_mod.platform_compat,
+            "restrict_to_owner",
+            lambda path: (_ for _ in ()).throw(OSError("icacls: transient failure")),
+        )
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+
+        assert not (home / "telemetry_salt").exists()
+        assert not list(home.glob("*.tmp"))
+
+    def test_an_existing_dest_is_not_overwritten(self, tmp_path):
+        src = tmp_path / "from-archive"
+        dst = tmp_path / "telemetry_salt"
+        src.write_bytes(self._SALT)
+        dst.write_bytes(b"live")
+        snapshot_mod._copy_locked(src, dst)
+        assert dst.read_bytes() == b"live"
+
+    def test_an_oversized_source_is_refused_before_publish(self, tmp_path):
+        src = tmp_path / "from-archive"
+        dst = tmp_path / "telemetry_salt"
+        src.write_bytes(b"x" * 33)
+        assert snapshot_mod._copy_locked(src, dst) is False
+        assert not dst.exists()
+
+    def test_an_oversized_salt_does_not_abort_merge(self, tmp_path):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "telemetry_salt").write_bytes(b"x" * 33)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        assert not (home / "telemetry_salt").exists()
+
+    def test_a_dest_created_before_link_is_not_clobbered(self, tmp_path, monkeypatch):
+        src = tmp_path / "from-archive"
+        dst = tmp_path / "telemetry_salt"
+        src.write_bytes(self._SALT)
+        real_link = os.link
+
+        def _link(source, dest):
+            Path(dest).write_bytes(b"live")
+            return real_link(source, dest)
+
+        monkeypatch.setattr(snapshot_mod.os, "link", _link)
+        snapshot_mod._copy_locked(src, dst)
+        assert dst.read_bytes() == b"live"
+
+    def test_a_hardlink_failure_does_not_abort_merge(self, tmp_path, monkeypatch):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "telemetry_salt").write_bytes(self._SALT)
+
+        def _link(_source, _dest):
+            raise OSError("Invalid cross-device link")
+
+        monkeypatch.setattr(snapshot_mod.os, "link", _link)
+        snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=True)
+        assert not (home / "telemetry_salt").exists()


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The remaining `#5346` writers still published a secret-bearing file and then
locked it down. On Windows `chmod` / `chmod_safe` is a no-op, so the payload
landed under the inherited parent DACL. On POSIX the file existed at the
published name with a wider mode until the chmod returned. After
[#5493](https://github.com/kirodotdev/KiroCrew/pull/5493) converted the
denied-commands keystone, three sites were still on that shape:

- `write_pod_config` (`write_text` then `os.chmod 0o600`)
- snapshot merge restore of missing security files (`shutil.copy2` then
  `restrict_to_owner` on the dest)
- SEL `_append_lines_locked` (`os.chmod` after append — same event-loop /
  icacls reason as `#5228`)

The denied-commands writer on this branch still drops a pre-write `mkdir`
that would follow a planted parent link, and adds a failed-lockdown test
`#5493` did not.

## Why it matters

These files carry provider tokens (pod config) and security-restore secrets
(`telemetry_salt`). A co-tenant who can read the inherited DACL can read a
restored secret. The lockdown-before-publish gate (`#5348`) was tracking the
debt in `KNOWN_UNCONVERTED`; leaving it there keeps the window.

## What changed (motivation → approach → change)

Symptom was write-then-restrict at the published path. The established fix
in this tree is lock the *temp* down first, then publish.

- **Pod config** — create-only path now uses
  `atomic_write(..., restrict_to_owner=True)`. That helper encodes UTF-8;
  the previous `write_text` call did not pass `encoding=`.
- **Snapshot merge restore** — `_copy_locked` locks the temp, writes the
  payload, then publishes with `os.link` (the create-only shape
  `_get_telemetry_salt` uses). `os.replace` / `atomic_write` would clobber a
  dest created in the window (`--force` restore racing a live gateway
  creating `telemetry_salt`). Any publish `OSError` (live dest, no hard
  links, restrict failure, short write) skips that file without aborting
  merge after earlier components were applied; dest stays missing and
  `_get_telemetry_salt` regenerates. Size is checked only when the source
  or dest is named `telemetry_salt` (32 bytes); a planted giant is skipped
  the same way. `_copy_locked` returns whether it published, so a lost
  `os.link` race does not print "restored".
- **Denied commands** — drop the `mkdir` that ran before
  `atomic_write(..., restrict_to_owner=True)`. The helper already refuses a
  linked parent then mkdirs; a mkdir here would walk a planted link first.
  `#5493` already routed the write through `atomic_write`.
- **SEL append** — not converted: `restrict_to_owner` shells out to icacls
  and this path can run on the asyncio loop. POSIX `os.open(..., 0o600)`
  already creates owner-only. Annotated
  `# lockdown-ok: #5228 -- icacls would block the event loop`.
- **Gate** — `KNOWN_UNCONVERTED` is empty (shrink-only). `os.link` is now a
  recognized publish call, so a lockdown after `os.link(tmp, dest)` is the
  same defect as a lockdown after `os.replace`.

## Tests

- `test/test_lockdown_before_publish.py` — real-tree scan asserts no
  unclassified write-then-restrict and that `KNOWN_UNCONVERTED` is empty;
  a fixture asserts `os.link` then restrict-dest is reported, and
  lock-temp-then-link is not.
- `test/test_pod.py::TestPodConfigWrite.test_a_failed_lockdown_publishes_no_config`
  — a refused restrict leaves no published `config.json`.
- `test/test_denied_commands_api.py::test_a_failed_lockdown_publishes_no_denied_commands`
  — a refused restrict leaves no published `denied_commands.json`.
- `test/test_snapshot.py::TestMergeRestoreLocksBeforePublish` — merge restore
  of `telemetry_salt` locks the temp, not the dest; a failed restrict leaves
  the dest uncreated; an existing dest is not overwritten; a dest created
  before `os.link` is not clobbered; an oversized source is skipped; a
  hard-link `OSError` skips that file and does not abort merge of other
  components; a close-time writeback error does not retry the released
  fd and abort merge. The fake-home helper writes a 32-byte salt so
  merge restore of a normal snapshot still succeeds.

Local: `python3 scripts/check_lockdown_before_publish.py` passed; targeted
lockdown, pod, denied-commands, and snapshot restore-merge tests passed
after rebase onto `origin/main`.

## Manual verification

N/A — unit coverage sufficient. The behaviour is the file-lockdown layer:
POSIX mode `0o600` is asserted in the tests; Windows DACL is the same
`restrict_to_owner` contract already exercised by other keystone writers.
Create-only publish is asserted by the `os.link` race test.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend file-lockdown only; no rendered UI change.

## Related Issues

Fixes #5346

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
