### PR TITLE
refactor(messaging): give the [OPTIONS:] trailer parse one owner

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -46,7 +46,7 @@ Slack's transport path is gated behind the `messaging.use_transport` config flag
 | `messaging/__init__.py` | Package facade re-exporting the public contracts, approval-mode constants, and Layer-3 helpers |
 | `messaging/transport.py` | **Layer 1** — `MessagingTransport` ABC + the `TransportCapabilities`, `InboundMessage`, and `ConfiguredChannelTarget` value objects (stdlib-only) |
 | `messaging/driver.py` | **Layer 2** — `TurnDriver` (channel-neutral turn loop), approval-mode constants, `_redact` helper |
-| `messaging/renderer.py` | **Layer 2b** — `Renderer` ABC, `OutputEvent`, output-kind constants + `OUTPUT_KINDS`, `chunk_text` helper, `apply_options_cap`/`cap_choices`/`format_overflow` (`max_buttons` enforcement), and `render_options_as_text` — the whole-trailer path for a channel with no widget, which reaches the same cap with zero slots so every choice becomes a numbered line |
+| `messaging/renderer.py` | **Layer 2b** — `Renderer` ABC, `OutputEvent`, output-kind constants + `OUTPUT_KINDS`, `chunk_text` helper, `apply_options_cap`/`cap_choices`/`format_overflow` (`max_buttons` enforcement), `split_options_trailer` (the ONE `[OPTIONS:]` parse — see below), and `render_options_as_text` — the whole-trailer path for a channel with no widget, which reaches the same cap with zero slots so every choice becomes a numbered line |
 | `messaging/approval.py` | Two channel-neutral approval styles behind one INTERACTIVE `decider`, both deny-by-default on timeout and keyed `session_key`+`request_id`. **Typed reply** (`TEXT_APPROVAL_TIMEOUT_S`, the verdict vocabulary, `TextReplyApprovalDecider`) for a `max_buttons=0` channel, with Trust recorded as the session's own approval policy rather than a second trust store. **Widget awaiter** (`PendingApprovals` + `SessionApprovalDecider`) for a press whose correlation id and per-prompt nonce travel a round trip this module cannot see (a Webex Adaptive Card over the device websocket); a typed answer has no nonce, a press has no free text |
 | `messaging/driver.py` `deny_all_tools` | Rejects EVERY permission request ahead of every approve path. The approval ladder cannot express "this sender is not the operator" on its own: the PreToolUse hook may answer `auto_approve` and the Trust/YOLO predicates approve and short-circuit, both BEFORE the ladder is consulted, so setting the mode to `interactive` without a decider is not sufficient. Defaults False |
 | `messaging/display_safety.py` | `strip_ansi` / `canonicalize_display` / `redact_for_display` — credential redaction against the form a platform RENDERS, not the bytes sent. Hoisted out of `slack/format.py` when the shared overflow sink began writing choice text into the parsed body on every widget channel |
@@ -2412,6 +2412,41 @@ keeps its own `_render_options_as_text` rather than the shared
 `render_options_as_text` for one reason, and the contract test names it: WeCom
 STREAMS, so an unterminated `[OPTIONS…` tail there really may be a marker
 mid-flight and is hidden, where the buffer-and-send-once channels keep it as prose.
+That difference is now expressed as `split_options_trailer(..., hide_partial=True)`
+rather than as a second copy of the parse — only the folding into `format_overflow`
+stays local.
+
+### One parse of the `[OPTIONS:]` marker
+
+`split_options_trailer(text, *, hide_partial=False) -> (body, choices)` is the
+single parse. `render_options_as_text` returns only the body, so every
+widget-capable renderer used to carry its own copy — six of them, three (Discord,
+Telegram, Teams) identical down to the comment. A parse duplicated per channel
+drifts per channel and does it silently, because each copy reads correctly alone.
+
+`hide_partial` is the one thing the channels genuinely disagree about, so it is a
+parameter rather than a baked-in policy:
+
+- **`True` — a streaming surface** (Discord, Telegram, Teams, WeCom, and Webex's
+  status frame). Text is still arriving, so an unfinished `[OPTIONS` fragment may
+  be a marker mid-flight; hiding it keeps reserved protocol off the screen, and the
+  next frame re-renders from the full buffer, so nothing is lost.
+- **`False` — a buffered surface that sends once** (Webex's final answer and the
+  zero-widget path). Such a caller cannot tell a live fragment from prose, and
+  cutting prose is permanent: a reply ending `see the [OPTIONS section` keeps its
+  last four words.
+
+The default is `False` because the failure directions are asymmetric — a needless
+keep flashes markup for one frame, a needless cut deletes unrecoverable text — so a
+caller that forgets degrades toward the cosmetic failure, and every streaming caller
+states `True` explicitly, which also makes the destructive choice greppable.
+
+**`slack/format.py::extract_options` is deliberately NOT converged.** It parses the
+LINE grammar (`OPTIONS_RE_LINE` — `re.MULTILINE`, end-of-*line*), not the
+end-of-buffer `OPTIONS_RE_TRAILER` every other channel uses, so routing it through
+this helper would silently stop matching a marker that ends a line mid-message.
+Different grammar, not a duplicate. `test_options_cap_contract.py::TestOnlyOneTrailerParseExists`
+greps the tree for a re-derived parse and records both exemptions.
 
 **Proactive push works, per-target.** `aibot_send_msg` needs no token and has no
 expiry, but WeCom only delivers into a conversation the user has already written

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -56,7 +56,7 @@ import urllib.parse
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
+from kiro_crew.constants import split_trailing_protocol_suffix
 from kiro_crew.discord.client import (
     DISCORD_MAX_FILE_BYTES,
     DISCORD_MAX_FILES_PER_MESSAGE,
@@ -78,6 +78,7 @@ from kiro_crew.messaging.renderer import (
     apply_options_cap,
     chunk_text,
     new_approval_nonce,
+    split_options_trailer,
 )
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.status_reactions import (
@@ -170,14 +171,6 @@ _MAX_BUTTONS = _BUTTONS_PER_ROW * _MAX_ACTION_ROWS
 #: Component-spec ceiling on a button label.
 _BUTTON_LABEL_CHARS = 80
 
-# Trailing "[OPTIONS: a | b | c]" -- extracted for button-row rendering. Matched
-# only at the very END of the message, so use the DOTALL/trailer canonical
-# parser. Defined once in constants.py (shared with the Slack/dashboard/Telegram/
-# WeCom surfaces) so the ReDoS-hardened grammar can never drift; see
-# OPTIONS_RE_TRAILER for the full rationale. Per-choice whitespace is stripped by
-# the caller.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
 # kiro-cli's inline "[STEERING steer-<id>: …]" steer-ack marker (see the
 # Telegram renderer for the full rationale — Discord likewise has no parser).
 _STEER_MARKER_RE = re.compile(r"\[STEERING\b[^\]\r\n]*\]", re.IGNORECASE)
@@ -185,17 +178,13 @@ _STEER_SUMMARY_RE = re.compile(r"\[STEERING\s+steer-[0-9a-f]+\s*:\s*([^\]\r\n]*)
 
 
 def _extract_options(text: str) -> tuple[str, list[str]]:
-    """Split text into (body, options). Handles the streamed partial too."""
-    m = _OPTIONS_RE.search(text)
-    if m:
-        body = text[: m.start()].rstrip()
-        options = [o.strip() for o in m.group(1).split("|") if o.strip()]
-        return body, options
-    # Hold back an incomplete "[OPTIONS…" fragment mid-stream.
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip(), []
-    return text, []
+    """Split text into ``(body, options)``, holding back a streamed partial.
+
+    ``hide_partial=True`` because this renderer STREAMS: a still-arriving
+    ``[OPTIONS…`` fragment really may be a marker mid-flight, and the next frame
+    re-renders from the full buffer, so hiding it costs nothing permanent.
+    """
+    return split_options_trailer(text, hide_partial=True)
 
 
 def _strip_steering(text: str) -> str:

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -339,6 +339,61 @@ def apply_options_cap(
     return f"{body}{sep}{lines}", kept
 
 
+def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str, list[str]]:
+    """Split a trailing ``[OPTIONS:]`` marker off *text* into ``(body, choices)``.
+
+    The ONE parse of that marker. Widget-capable renderers need both halves and
+    :func:`render_options_as_text` returns only the body, so before this existed
+    every channel carried the same eight lines: search the shared trailer regex,
+    ``rstrip`` the body, split the group on ``|``, drop the blanks, and decide what
+    to do with an unfinished marker. Six copies of it, three of them (Discord,
+    Telegram, Teams) identical down to the comment -- and a parse duplicated per
+    channel is a parse that drifts per channel, silently, because each copy looks
+    right in isolation.
+
+    Only a COMPLETE, end-anchored marker yields choices, and both halves of that
+    matter:
+
+    * A quoted ``[OPTIONS:`` mid-answer cannot swallow the body between it and
+      some later ``]`` -- the end-of-buffer anchor is what prevents that.
+    * An unfinished ``[OPTIONS`` tail is not a marker yet, so what to do with it
+      is the CALLER's question, which is why it is a parameter rather than a
+      policy baked in here.
+
+    *hide_partial* is that question, and the channels genuinely answer it
+    differently:
+
+    * ``True`` -- a STREAMING surface (Discord, Telegram, Teams, WeCom, and Webex's
+      status frame). The text is still arriving, so a partial marker really may be
+      a marker mid-flight, and showing reserved protocol as raw text is the cost
+      being avoided. Safe there precisely because the frame is transient: the next
+      frame, or the sealed answer, re-renders from the full buffer.
+    * ``False`` -- a BUFFERED surface that sends once (Slack's extraction, Webex's
+      final answer, and this module's own zero-widget path). Such a caller cannot
+      tell a live fragment from the assistant's prose, and cutting prose is
+      PERMANENT data loss: a reply ending ``see the [OPTIONS section`` must keep
+      its last four words.
+
+    The default is ``False`` because the two failure directions are not
+    symmetric -- a needless keep flashes reserved markup for one frame, a needless
+    cut deletes text nobody can recover -- so a caller that forgets degrades
+    toward the cosmetic failure. Every streaming caller states ``True``
+    explicitly, which is also what makes the data-loss choice greppable.
+
+    Stripping a genuine steering frame is ``TurnDriver``'s job and happens before
+    a renderer sees the text.
+    """
+    match = OPTIONS_RE_TRAILER.search(text)
+    if match:
+        choices = [c.strip() for c in match.group(1).split("|") if c.strip()]
+        return text[: match.start()].rstrip(), choices
+    if hide_partial:
+        idx = text.rfind("[OPTIONS")
+        if idx != -1 and "]" not in text[idx:]:
+            return text[:idx].rstrip(), []
+    return text, []
+
+
 def render_options_as_text(text: str, capabilities: TransportCapabilities) -> str:
     """Rewrite a trailing ``[OPTIONS:]`` trailer in *text* as numbered text.
 
@@ -347,30 +402,21 @@ def render_options_as_text(text: str, capabilities: TransportCapabilities) -> st
     Returns the body only; the widget half of :func:`apply_options_cap` has
     nothing to keep at ``max_buttons == 0``.
 
-    Only a COMPLETE marker at the very end is recognised, via the shared
-    ``OPTIONS_RE_TRAILER``. Everything else is returned untouched, and both halves
-    of that matter:
+    Parsing is :func:`split_options_trailer`, at its buffered default: this path's
+    callers do not stream — they buffer a whole turn and send once — so an
+    unfinished ``[OPTIONS`` tail is the assistant's prose here and is kept. The one
+    zero-widget channel that DOES stream (WeCom) asks for ``hide_partial=True`` in
+    its own ``wecom.renderer._render_options_as_text``, where the cost is a
+    transient flash whose next frame replaces the bubble anyway.
 
-    * A quoted ``[OPTIONS:`` mid-answer cannot swallow the body between it and
-      some later ``]`` — the end-of-buffer anchor is what prevents that.
-    * An UNFINISHED ``[OPTIONS`` tail is left alone rather than stripped. It reads
-      like a marker still arriving, but this helper cannot tell a live frame from
-      a sealed answer, and its callers here do not stream at all — they buffer a
-      whole turn and send once — so for them such a tail is simply the assistant's
-      prose and cutting it is permanent data loss. A reply ending
-      ``see the [OPTIONS section`` keeps its last four words. The one zero-widget
-      channel that DOES stream (WeCom) trades the other way and hides the tail,
-      in its own ``wecom.renderer._render_options_as_text``: there the cost is a
-      transient cosmetic flash whose next frame replaces the bubble anyway.
-
-    Stripping a genuine steering frame is ``TurnDriver``'s job and happens before
-    a renderer sees the text.
+    ``apply_options_cap`` is reached unconditionally rather than behind an
+    ``if not choices`` guard, which would NOT be equivalent: a matched-but-EMPTY
+    trailer (``[OPTIONS: ]``) must still have the marker stripped. With no match
+    ``split_options_trailer`` hands back the text unchanged, and the cap is the
+    identity on an empty choice list, so one call covers all three cases.
     """
-    match = OPTIONS_RE_TRAILER.search(text)
-    if not match:
-        return text
-    choices = [c.strip() for c in match.group(1).split("|") if c.strip()]
-    return apply_options_cap(text[: match.start()].rstrip(), choices, capabilities)[0]
+    body, choices = split_options_trailer(text)
+    return apply_options_cap(body, choices, capabilities)[0]
 
 
 class Renderer(ABC):

--- a/src/kiro_crew/teams/renderer.py
+++ b/src/kiro_crew/teams/renderer.py
@@ -44,7 +44,6 @@ import os
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.outbound_files import (
     OutboundFile,
@@ -56,6 +55,7 @@ from kiro_crew.messaging.renderer import (
     _default_redactor,
     apply_options_cap,
     new_approval_nonce,
+    split_options_trailer,
 )
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.tables import TABLE_POLICY_CARDS
@@ -139,11 +139,6 @@ def _persisted_upload_root(session_key: str) -> str:
     return root if root and os.path.isabs(root) else ""
 
 
-# Trailing "[OPTIONS: a | b | c]" chip trailer. Defined once in constants.py
-# (shared across surfaces) so the ReDoS-hardened grammar can't drift.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
-
 def _display_safe(text: str) -> str:
     """Redact *text* against the form Teams will RENDER (blocking; offloaded).
 
@@ -160,17 +155,11 @@ def _extract_options(text: str) -> tuple[str, list[str]]:
     """Split text into ``(body, options)`` for a trailing ``[OPTIONS:]`` chip list.
 
     Teams renders the choices as Adaptive Card actions, so the trailer is parsed
-    rather than dropped. A partial ``[OPTIONS…`` fragment (no closing ``]``) is
-    held back so it never lands as raw text.
+    rather than dropped. ``hide_partial=True`` because this renderer STREAMS a
+    progress bubble: a partial ``[OPTIONS…`` fragment is held back so reserved
+    protocol never lands as raw text, and the next frame re-renders it anyway.
     """
-    m = _OPTIONS_RE.search(text)
-    if m:
-        body = text[: m.start()].rstrip()
-        return body, [o.strip() for o in m.group(1).split("|") if o.strip()]
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip(), []
-    return text, []
+    return split_options_trailer(text, hide_partial=True)
 
 
 def _strip_options(text: str) -> str:

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -37,7 +37,7 @@ import secrets
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
+from kiro_crew.constants import split_trailing_protocol_suffix
 from kiro_crew.messaging.approval import APPROVAL_TIMEOUT_S
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.outbound_files import (
@@ -53,6 +53,7 @@ from kiro_crew.messaging.renderer import (
     _default_redactor,
     apply_options_cap,
     new_approval_nonce,
+    split_options_trailer,
 )
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.transport import TransportCapabilities
@@ -156,14 +157,6 @@ _THINKING_SCAFFOLD = "<blockquote expandable>💭 </blockquote>"
 # that says retrying will not help.
 _GENERIC_ERROR_TEXT = "⚠️ Error — please try again"
 
-# Trailing "[OPTIONS: a | b | c]" -- extracted for inline-keyboard rendering.
-# Matched only at the very END of the message, so use the DOTALL/trailer
-# canonical parser. Defined once in constants.py (shared with the Slack/
-# dashboard/Discord/WeCom surfaces) so the ReDoS-hardened grammar can never
-# drift; see OPTIONS_RE_TRAILER for the full rationale. Per-choice whitespace is
-# stripped by the caller.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
 
 def _display_safe(text: str) -> str:
     """Redact against the form Telegram RENDERS, not the bytes we send.
@@ -216,17 +209,13 @@ def md_to_telegram_html_safe(text: str) -> str:
 
 
 def _extract_options(text: str) -> tuple[str, list[str]]:
-    """Split text into (body, options). Handles the streamed partial too."""
-    m = _OPTIONS_RE.search(text)
-    if m:
-        body = text[: m.start()].rstrip()
-        options = [o.strip() for o in m.group(1).split("|") if o.strip()]
-        return body, options
-    # Hold back an incomplete "[OPTIONS…" fragment mid-stream.
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip(), []
-    return text, []
+    """Split text into ``(body, options)``, holding back a streamed partial.
+
+    ``hide_partial=True`` because this renderer STREAMS: a still-arriving
+    ``[OPTIONS…`` fragment really may be a marker mid-flight, and the next frame
+    re-renders from the full buffer, so hiding it costs nothing permanent.
+    """
+    return split_options_trailer(text, hide_partial=True)
 
 
 # kiro-cli emits an inline "[STEERING steer-<id>: …]" ack marker when it folds a

--- a/src/kiro_crew/webex/renderer.py
+++ b/src/kiro_crew/webex/renderer.py
@@ -42,7 +42,6 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.outbound_files import (
     ExtractLimits,
@@ -50,7 +49,7 @@ from kiro_crew.messaging.outbound_files import (
     hide_local_refs,
     upload_filename,
 )
-from kiro_crew.messaging.renderer import Renderer, apply_options_cap
+from kiro_crew.messaging.renderer import Renderer, apply_options_cap, split_options_trailer
 from kiro_crew.messaging.tables import TABLE_POLICY_CARDS
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -171,43 +170,6 @@ _TOOL_LABEL_MAX = 120
 # remove text or create a target, and inside the body's code span an underscore
 # is literal.
 _MD_CONTROL_RE = re.compile(r"[*`\[\]()<>{}]")
-
-
-# Trailing "[OPTIONS: a | b | c]" chip trailer. The shared ReDoS-hardened,
-# end-anchored grammar from constants.py, aliased locally exactly as the other
-# widget channels do (teams, discord, telegram): a widget renderer needs BOTH
-# halves of the parse -- the body and the choices it will put on buttons -- and
-# ``messaging.renderer.render_options_as_text`` returns only the body, which is
-# what the zero-widget channels want.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
-
-def _split_trailer(text: str, *, hide_partial: bool = False) -> tuple[str, list[str]]:
-    """Split a COMPLETE trailing ``[OPTIONS:]`` marker off *text*.
-
-    Only a complete, end-anchored marker counts. An UNFINISHED ``[OPTIONS`` tail
-    is left in the body by default, matching ``render_options_as_text``: this
-    renderer buffers the whole turn and sends once, so by the time ``on_done``
-    reads the buffer such a tail is the assistant's own prose and cutting it is
-    permanent data loss -- a reply ending ``see the [OPTIONS section`` keeps its
-    last four words.
-
-    ``hide_partial=True`` is the STATUS-FRAME caller, and it is the one place the
-    other reading applies: a frame renders text that is still arriving, so a
-    partial marker there really may be a marker mid-flight, and showing reserved
-    protocol as raw text -- even for one frame -- is what this hides. The cost is
-    only cosmetic and only mid-turn, because the next frame and the final answer
-    both re-render from the buffer.
-    """
-    match = _OPTIONS_RE.search(text)
-    if match:
-        choices = [c.strip() for c in match.group(1).split("|") if c.strip()]
-        return text[: match.start()].rstrip(), choices
-    if hide_partial:
-        idx = text.rfind("[OPTIONS")
-        if idx != -1 and "]" not in text[idx:]:
-            return text[:idx].rstrip(), []
-    return text, []
 
 
 def _safe_tool_label(raw: str) -> str:
@@ -365,7 +327,12 @@ class WebexRenderer(Renderer):
             return
         self._finalized = True
         ok = stop_reason != "error"
-        body, choices = _split_trailer("".join(self._buf).strip())
+        # The BUFFERED default: this renderer sends the answer once, so an
+        # unfinished ``[OPTIONS`` tail here is the assistant's own prose and
+        # cutting it would be permanent -- a reply ending ``see the [OPTIONS
+        # section`` keeps its last four words. The status frame above trades the
+        # other way, because a frame is transient.
+        body, choices = split_options_trailer("".join(self._buf).strip())
         # Cap the choices for the widget and degrade the remainder to numbered
         # text through the SHARED helper, so the cap is enforced in one place and
         # a choice past it is still visible rather than silently dropped.
@@ -568,8 +535,13 @@ class WebexRenderer(Renderer):
         Used for the status frame's tail. The trailer is NOT rendered here:
         ``on_done`` decides between a card and numbered text, and a status frame
         showing choices the user cannot yet act on would be noise.
+
+        ``hide_partial=True``: a frame renders text still arriving, so a partial
+        marker really may be a marker mid-flight, and showing reserved protocol as
+        raw text -- even for one frame -- is what this hides. Safe here and not on
+        the answer path because the next frame re-renders from the same buffer.
         """
-        return _split_trailer("".join(self._buf).strip(), hide_partial=True)[0]
+        return split_options_trailer("".join(self._buf).strip(), hide_partial=True)[0]
 
     def authorize_upload_root(self, root: str) -> None:
         """Authorize the provider's resolved cwd as the upload root.

--- a/src/kiro_crew/wecom/renderer.py
+++ b/src/kiro_crew/wecom/renderer.py
@@ -28,8 +28,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.constants import OPTIONS_RE_TRAILER
-from kiro_crew.messaging.renderer import Renderer, format_overflow
+from kiro_crew.messaging.renderer import Renderer, format_overflow, split_options_trailer
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.transport import TransportCapabilities
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -72,14 +71,6 @@ _STREAM_MAX_AGE_S = 8 * 60.0
 # what is inside it as a collapsed reasoning block rather than as the answer.
 _THINKING = "<think>…</think>"
 
-# Trailing "[OPTIONS: a | b | c]" chip trailer (a dashboard convention WeCom
-# can't render as tappable chips). Matched only at the very END of the message,
-# so use the DOTALL/trailer canonical parser. Defined once in constants.py
-# (shared with the Slack/dashboard/Discord/Telegram surfaces) so the
-# ReDoS-hardened grammar can never drift; see OPTIONS_RE_TRAILER for the full
-# rationale. Per-choice whitespace is stripped by the caller.
-_OPTIONS_RE = OPTIONS_RE_TRAILER
-
 
 def _render_options_as_text(text: str) -> str:
     """Turn a trailing ``[OPTIONS: a | b | c]`` trailer into a numbered list.
@@ -98,18 +89,11 @@ def _render_options_as_text(text: str) -> str:
     A still-streaming partial ``[OPTIONS…`` fragment (no closing ``]``) is hidden
     rather than rendered, so protocol markup never flashes as raw text mid-stream.
     """
-    m = _OPTIONS_RE.search(text)
-    if m:
-        body = text[: m.start()].rstrip()
-        choices = [c.strip() for c in m.group(1).split("|") if c.strip()]
-        if not choices:
-            return body
-        listing = format_overflow(choices, start=0)
-        return f"{body}\n\n{listing}" if body else listing
-    idx = text.rfind("[OPTIONS")
-    if idx != -1 and "]" not in text[idx:]:
-        return text[:idx].rstrip()
-    return text
+    body, choices = split_options_trailer(text, hide_partial=True)
+    if not choices:
+        return body
+    listing = format_overflow(choices, start=0)
+    return f"{body}\n\n{listing}" if body else listing
 
 
 class WeComRenderer(Renderer):

--- a/test/test_options_cap_contract.py
+++ b/test/test_options_cap_contract.py
@@ -38,6 +38,7 @@ from kiro_crew.messaging.renderer import (
     apply_options_cap,
     cap_choices,
     render_options_as_text,
+    split_options_trailer,
 )
 from kiro_crew.messaging.transport import TransportCapabilities
 
@@ -289,6 +290,139 @@ class TestSharedHelper:
 
         out = format_overflow(["Rebase onto main", "Skip the `--force` flag"], start=2)
         assert out == "3. Rebase onto main\n4. Skip the `--force` flag"
+
+
+class TestSplitOptionsTrailer:
+    """The ONE parse of the ``[OPTIONS:]`` marker, both halves and both policies.
+
+    Six channels carried this parse before it was hoisted -- three of them
+    (Discord, Telegram, Teams) identical down to the comment. The reason to pin it
+    here rather than per channel is that a duplicated parse drifts silently: each
+    copy reads correctly in isolation, so nothing goes red when one of them stops
+    agreeing with the others.
+    """
+
+    def test_a_complete_trailer_yields_body_and_choices(self) -> None:
+        body, choices = split_options_trailer("Pick one.\n\n[OPTIONS: A | B | C]")
+        assert body == "Pick one."
+        assert choices == ["A", "B", "C"]
+
+    def test_choices_are_stripped_and_blanks_dropped(self) -> None:
+        _, choices = split_options_trailer("q\n\n[OPTIONS:  A  |  | B ]")
+        assert choices == ["A", "B"]
+
+    def test_no_marker_is_an_untouched_passthrough(self) -> None:
+        text = "Just an answer, no trailer."
+        assert split_options_trailer(text) == (text, [])
+
+    def test_a_matched_but_empty_trailer_still_strips_the_marker(self) -> None:
+        """Otherwise reserved protocol ships as visible text.
+
+        Distinct from the no-match case, which must NOT strip -- the two are only
+        distinguishable by comparing the body, which is why the zero-widget path
+        routes through ``apply_options_cap`` unconditionally rather than branching
+        on an empty choice list.
+        """
+        body, choices = split_options_trailer("Body here.\n\n[OPTIONS: ]")
+        assert body == "Body here."
+        assert choices == []
+
+    def test_a_quoted_marker_mid_answer_cannot_swallow_the_body(self) -> None:
+        """The end-of-buffer anchor is what prevents this."""
+        text = "See [OPTIONS: in the docs] for the list, then decide."
+        assert split_options_trailer(text) == (text, [])
+
+    def test_a_partial_marker_is_kept_by_default(self) -> None:
+        """The BUFFERED reading: cutting the assistant's prose is permanent.
+
+        A sealed reply ending ``see the [OPTIONS section`` must keep its last four
+        words, so the default cannot be the destructive one.
+        """
+        text = "Read the docs, see the [OPTIONS section"
+        assert split_options_trailer(text) == (text, [])
+
+    def test_a_partial_marker_is_hidden_when_asked(self) -> None:
+        """The STREAMING reading: the fragment may be a marker mid-flight."""
+        body, choices = split_options_trailer("Working on it. [OPTIONS: A | B", hide_partial=True)
+        assert body == "Working on it."
+        assert choices == []
+
+    def test_hide_partial_does_not_touch_a_closed_bracket_elsewhere(self) -> None:
+        """Only an UNCLOSED fragment is a fragment.
+
+        ``[OPTIONS: …]`` that failed the end anchor is prose, not a live marker, so
+        the streaming reading must not cut it either.
+        """
+        text = "See [OPTIONS: in the docs] for the list."
+        assert split_options_trailer(text, hide_partial=True) == (text, [])
+
+    def test_the_default_is_the_non_destructive_one(self) -> None:
+        """Pins the DIRECTION of the default, not just its value.
+
+        A caller that forgets to state a policy must degrade toward a cosmetic
+        failure (reserved markup visible for one frame), never toward deleting
+        text nobody can recover.
+        """
+        import inspect
+
+        param = inspect.signature(split_options_trailer).parameters["hide_partial"]
+        assert param.default is False
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
+
+class TestOnlyOneTrailerParseExists:
+    """Ratchet: no channel may re-derive the trailer parse.
+
+    Greps the tree rather than trusting review. The two allowed sites are the
+    shared helper itself and ``constants.split_trailing_protocol_suffix``, which
+    answers a different question (where does the protocol suffix begin, for a
+    length splitter). ``slack/format.py`` is deliberately NOT in scope: it parses
+    the LINE grammar (``OPTIONS_RE_LINE``, end-of-line, MULTILINE), not the
+    end-of-buffer TRAILER, so converging it would silently stop matching a marker
+    mid-message.
+    """
+
+    _ALLOWED_PARTIAL = {"messaging/renderer.py", "constants.py"}
+
+    def _hits(self, needle: str) -> set[str]:
+        from pathlib import Path
+
+        import kiro_crew as pkg
+
+        root = Path(pkg.__file__).parent
+        found = set()
+        for path in root.rglob("*.py"):
+            if "_vendor" in path.parts or "static" in path.parts:
+                continue
+            if needle in path.read_text(encoding="utf-8"):
+                # ``as_posix``, not ``str``: on Windows the latter yields
+                # ``messaging\renderer.py``, which matches no entry in the
+                # forward-slash allow-lists below -- so the exemptions silently
+                # stop applying and the ratchet reports its own allowed sites as
+                # offenders. A path used as a KEY has to have one spelling.
+                found.add(path.relative_to(root).as_posix())
+        return found
+
+    def test_no_channel_hand_rolls_the_partial_marker_scan(self) -> None:
+        offenders = self._hits('rfind("[OPTIONS")') - self._ALLOWED_PARTIAL
+        assert not offenders, (
+            "these re-derive the unfinished-marker scan instead of passing "
+            f"hide_partial= to messaging.renderer.split_options_trailer: {sorted(offenders)}"
+        )
+
+    def test_only_the_shared_helper_and_slack_split_the_choice_group(self) -> None:
+        # Slack keeps its own because its GRAMMAR differs (OPTIONS_RE_LINE).
+        allowed = {"messaging/renderer.py", "slack/format.py"}
+        offenders = self._hits('group(1).split("|")') - allowed
+        assert not offenders, (
+            "these re-derive the choice split instead of calling "
+            f"messaging.renderer.split_options_trailer: {sorted(offenders)}"
+        )
+
+    def test_the_ratchet_is_not_vacuous(self) -> None:
+        """A grep that matches nothing would make both checks pass forever."""
+        assert "messaging/renderer.py" in self._hits('rfind("[OPTIONS")')
+        assert "messaging/renderer.py" in self._hits('group(1).split("|")')
 
 
 class TestRenderOptionsAsText:


### PR DESCRIPTION
Follow-up to #5218, which is where I noticed this: six channels each carried the same `[OPTIONS:]` parse, and three of them were identical down to the comment.

## What was duplicated

Every widget-capable renderer had the same eight lines — search the shared trailer regex, `rstrip` the body, split the group on `|`, drop the blanks, then decide what to do with an unfinished marker:

| site | partial handling |
|---|---|
| `discord/renderer.py::_extract_options` | hide |
| `telegram/renderer.py::_extract_options` | hide — **byte-identical to Discord's, comment included** |
| `teams/renderer.py::_extract_options` | hide — **same again** |
| `wecom/renderer.py::_render_options_as_text` | hide, then folds into `format_overflow` |
| `webex/renderer.py::_split_trailer` | behind a flag |
| `messaging/renderer.py::render_options_as_text` | keep |

`render_options_as_text` could not serve any of the widget channels, which is *why* they each grew a copy: it returns only the body, and a widget renderer needs the choices too.

A parse duplicated per channel drifts per channel, and does it **silently** — every copy reads correctly in isolation, so nothing goes red when one of them stops agreeing with the others.

## The one thing they genuinely disagree about

`hide_partial` is a **parameter**, not a policy baked into the helper, because the channels are each right for their own surface:

- **`True` — a streaming surface.** Text is still arriving, so an unfinished `[OPTIONS` fragment really may be a marker mid-flight. Hiding it keeps reserved protocol off screen, and the next frame re-renders from the full buffer, so nothing is lost.
- **`False` — a buffered surface that sends once.** It cannot tell a live fragment from the assistant's prose, and cutting prose is permanent: a reply ending `see the [OPTIONS section` has to keep its last four words.

**The default is `False`** because the two failure directions are not symmetric — a needless keep flashes markup for one frame, a needless cut deletes text nobody can recover. So a caller that forgets degrades toward the cosmetic failure, and every streaming caller says `True` out loud, which also makes the destructive choice greppable.

Webex is the one channel that needs both answers, and it keeps them: `hide_partial=True` on the status frame, the default on the final answer.

## What I deliberately did NOT converge

**`slack/format.py::extract_options` stays as it is.** It looks like a seventh copy and isn't: it parses `OPTIONS_RE_LINE` (`re.MULTILINE`, end-of-**line**), not the end-of-buffer `OPTIONS_RE_TRAILER` every other channel uses. Routing it through this helper would silently stop matching a marker that ends a line mid-message. Different grammar, not a duplicate.

I caught this by migrating it first and then checking which regex it aliased — worth stating plainly, because on a skim it is the most obvious candidate in the set.

## One behaviour trap in the shared path

`render_options_as_text` reaches `apply_options_cap` unconditionally rather than behind an `if not choices` guard, and that is load-bearing: a matched-but-**empty** trailer (`[OPTIONS: ]`) must still have the marker stripped, while a **no-match** must not touch the text. Those two are indistinguishable from the choice list alone. With no match `split_options_trailer` returns the text unchanged and the cap is the identity on an empty list, so one call covers all three cases. My first attempt did add that guard and would have shipped `[OPTIONS: ]` as visible text; there is now a test for it.

## Tests

- `TestSplitOptionsTrailer` — both policies, the empty-vs-absent trailer distinction, the quoted-marker-mid-answer case the end anchor exists for, and a test pinning the **direction** of the default (not just its value) so a future edit cannot flip it to the destructive reading unnoticed.
- `TestOnlyOneTrailerParseExists` — a ratchet that greps the tree for a re-derived parse, records both allowed sites (the helper, and `constants.split_trailing_protocol_suffix`, which answers a different question) plus the Slack exemption and why, and asserts it is **not vacuous** so a grep that stops matching cannot make it pass forever.

Behaviour-preserving by construction: each call site keeps its own historical answer. **1,312 tests across the six affected channels pass unchanged**, and the full suite is **63,232 passed / 0 failed**. mypy (1101 files), flake8, isort, the black baseline, docs-lint, brand, harness-parity and scrub all clean.

Net **-143/+276** (the growth is tests and the rationale; production code shrinks by ~90 lines).

## Note for whoever merges second

#5708 touches the same `from kiro_crew.messaging.renderer import …` line in `webex/renderer.py` (it adds `new_approval_nonce`; this adds `split_options_trailer`). Trivial import-line conflict, no semantic overlap.
