### PR TITLE
fix(mcp): name the cause when strict session identity is unavailable

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -35,7 +35,7 @@
 1 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 2 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
 1 src/kiro_crew/cli.py
-6 src/kiro_crew/cli_doctor.py
+5 src/kiro_crew/cli_doctor.py
 1 src/kiro_crew/cli_perf.py
 2 src/kiro_crew/cli_setup.py
 1 src/kiro_crew/cloud/aws.py

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -919,6 +919,64 @@ def _doctor_trust_root() -> None:
     print("               restart the gateway if another process relocated it.")
 
 
+#: MCP servers that host strict-identity tools — the reflexive verbs
+#: (``monitor_start``, ``session_ledger_*``, ``set_project``, ``ask_question``)
+#: and the authorization-subject ones (session control, ``chat_folder_*``).
+#: Mirrors ``mcp_core._STRICT_IDENTITY_SERVERS``; ``kirocrew-dashboard`` is
+#: opt-in per agent, so it is reported only when an agent actually references it.
+_STRICT_IDENTITY_SERVERS = ("kirocrew-core", "kirocrew-dashboard")
+
+
+def _doctor_strict_identity(cfg: KiroCrewConfig) -> None:
+    """Report whether strict-identity tools have a working identity channel.
+
+    On the kiro backend a session's process is an ``AcpRuntime``, which is
+    session-UNBOUND by design (one process multiplexes N sessions, so it cannot
+    carry one session's key in its environment — ``acp/runtime.py`` injects
+    none). The gateway's per-call caller injection is therefore the ONLY
+    identity channel for that backend, and it exists only for servers listed in
+    ``mcp_gateway.stub_servers``. An unrouted server means every strict tool on
+    it is refused — silently, once per call, with no hint that the cause is
+    topology rather than the calling session.
+
+    Reports only, and deliberately appends NO entry to doctor's ``issues``:
+    ``mcp_gateway.stub_servers`` is empty by default because routing starts a
+    broker plus a stub per server, so a hard issue here would make
+    ``kirocrew doctor`` exit 1 on every stock install — the same failure the
+    speech-to-text section is written to avoid. Parity with
+    :func:`_doctor_trust_root`, which also only prints.
+
+    Skipped where the env sources exist by construction: on Linux the sandbox
+    launcher exports ``KIROCREW_HOST_PID``, so routing is not what decides
+    whether strict identity resolves.
+    """
+    if _plat.system() not in ("Darwin", "Windows"):
+        return
+    try:
+        routed = set(cfg.mcp_gateway.stub_servers)
+    except Exception:
+        routed = set()
+    unrouted = [s for s in _STRICT_IDENTITY_SERVERS if s not in routed]
+    if not unrouted:
+        print("  strict identity: ✅ routed — the gateway injects a per-call caller")
+        return
+    names = ", ".join(unrouted)
+    print(f"  strict identity: ⏹ no identity channel for {names}")
+    _print_wrapped(
+        "Tools that must know which session is calling (monitor_start, "
+        "session_ledger_*, set_project, ask_question, session control, "
+        "chat_folder_*) are refused while a server is unrouted: on the kiro "
+        "backend the session's AcpRuntime carries no session key in its "
+        "environment by design, so the gateway's per-call caller injection is "
+        "the only channel, and it covers routed servers only. Route them from "
+        "MCP Management (or add them to mcp_gateway.stub_servers and restart) "
+        "if you use those tools. Leaving them unrouted is a valid choice — "
+        "routing starts a broker and one stub process per server — so this is "
+        "a note, not a problem to fix; the tools' own refusal now names the "
+        "same cause."
+    )
+
+
 _INDENT = "               "
 
 
@@ -2246,6 +2304,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     _doctor_data_home()
     _doctor_path_launcher()
     _doctor_trust_root()
+    _doctor_strict_identity(cfg)
 
     # ── Agents dir janitor (orphaned atomic-write temps + stale backups) ──
     _doctor_agents_janitor(issues, cfg.agent.sweep_agents_backups)

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -676,6 +676,47 @@ def _resolve_session_key_strict() -> str:
     return ""
 
 
+def strict_identity_diagnosis(server: str = "kirocrew-core") -> str:
+    """Return the machine-specific reason strict identity is unavailable, or "".
+
+    Every strict refusal already says *what* was refused; none of them says why
+    THIS install cannot answer "which session is calling", so the reader has no
+    next step. This inspects the same three sources
+    :func:`_resolve_session_key_strict` accepts and names the missing channel.
+
+    The distinction that matters to an operator: on the kiro backend a session's
+    kiro-cli process is an ``AcpRuntime``, which is deliberately
+    session-UNBOUND (one process multiplexes N sessions, so it cannot carry a
+    single session's key in its environment — ``acp/runtime.py`` injects none).
+    The gateway's per-call caller injection is therefore the ONLY identity
+    channel for that backend, and it exists only for servers listed in
+    ``mcp_gateway.stub_servers``. An unrouted server on kiro has no channel at
+    all, which is a topology gap an operator can close in one line — not a bug
+    in the calling session.
+
+    Returns "" when identity IS resolvable (the caller should not be refusing),
+    so a caller can append this unconditionally.
+    """
+    if _resolve_session_key_strict():
+        return ""
+    if os.environ.get("KIROCREW_HOST_PID", "").isdigit():
+        # The sandbox launcher declared a host pid, so the channel exists and
+        # the sidecar is what failed — a signing/trust-root problem, not routing.
+        return (
+            f" No identity channel: the signed pid mapping for this session did not "
+            f"verify. Check `kirocrew doctor` (trust root) — {server} does not need "
+            f"routing when this channel works."
+        )
+    return (
+        f" No identity channel on this install: {server} is not in "
+        f"mcp_gateway.stub_servers, so the gateway injects no per-call caller, and "
+        f"the kiro backend's AcpRuntime is session-unbound (it carries no session "
+        f"key in its environment by design). Route {server} from MCP Management "
+        f"(or add it to mcp_gateway.stub_servers and restart) to give this session "
+        f"a verifiable identity. `kirocrew doctor` reports the same check."
+    )
+
+
 def _deny_channel_agent_messaging(caller_session: str, tool_name: str) -> str | None:
     """Return an ``Error:`` denial when a channel agent calls a messaging tool.
 

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -38,7 +38,11 @@ from kiro_crew.cron import (
 from kiro_crew.cron_script import resolve_script_path
 from kiro_crew.cron_trigger import _JOB_ID_RE, trigger_cron_job
 from kiro_crew.mcp_caller import current_caller
-from kiro_crew.mcp_core import _resolve_session_key, _resolve_session_key_strict
+from kiro_crew.mcp_core import (
+    _resolve_session_key,
+    _resolve_session_key_strict,
+    strict_identity_diagnosis,
+)
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
@@ -1561,7 +1565,7 @@ def _unidentified_caller_refusal(tool_name: str) -> str:
     return (
         "Error: cannot determine which session is calling, so this write is "
         "refused. Manage jobs from the CLI (`kirocrew cron ...`), which carries "
-        "admin authority."
+        "admin authority." + strict_identity_diagnosis("kirocrew-cron")
     )
 
 

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -77,6 +77,7 @@ from kiro_crew.mcp_core import (
     _post,
     _resolve_session_key,
     _resolve_session_key_strict,
+    strict_identity_diagnosis,
 )
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.platform import redact_via_context as redact
@@ -716,6 +717,7 @@ def _visible_chat_slots() -> tuple[list[dict], str | None]:
         return [], (
             "cannot verify which session is calling, so the session list is "
             "withheld — these tools scope what they show to the caller"
+            + strict_identity_diagnosis(SERVER_NAME)
         )
     scope = _caller_app_scope(caller_key, rows)
     if scope is None:
@@ -760,6 +762,7 @@ def _refuse_tree_shaping_if_unverifiable(verb: str) -> tuple[str, str | None]:
             f"Error: cannot verify which session is calling, so {verb} is "
             "refused — reshaping the shared folder tree requires a caller "
             "identity the gateway can vouch for."
+            + strict_identity_diagnosis(SERVER_NAME)
         )
     rows, err = _get_rows("/api/chat/slots")
     if err:
@@ -817,6 +820,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 "Error: this session cannot be identified well enough to control another "
                 "session. Session control authorizes on the calling session's identity, and "
                 "only a gateway-issued key counts — a spawned subagent has none of its own."
+                + strict_identity_diagnosis(SERVER_NAME)
             )
 
     if name == "session_create":
@@ -1087,7 +1091,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return (
                 "Error: cannot verify which session is calling, so this move is "
                 "refused — filing another session requires a caller identity the "
-                "gateway can vouch for."
+                "gateway can vouch for." + strict_identity_diagnosis(SERVER_NAME)
             )
         # The verified key is passed through unchanged: re-resolving inside the
         # helper would let the write carry a different session's authority than

--- a/src/kiro_crew/mcp_tools/apps.py
+++ b/src/kiro_crew/mcp_tools/apps.py
@@ -328,7 +328,7 @@ def _crew_session_key() -> tuple[str, str]:
             "Error: this tool needs a directly-identified dashboard session. "
             "A subagent resolves to its parent's session, which would read and "
             "write the parent crew's ledger. Run this from the crew's own "
-            "session."
+            "session." + mcp_core.strict_identity_diagnosis()
         )
     return _crew_sk, ""
 

--- a/src/kiro_crew/mcp_tools/ledger.py
+++ b/src/kiro_crew/mcp_tools/ledger.py
@@ -139,7 +139,7 @@ def _strict_session_key() -> tuple[str, str]:
             "Error: this session's identity could not be verified strictly, "
             "so the ledger is not reachable from here. Subagents inherit no "
             "session identity of their own — record ledger updates from the "
-            "parent session instead."
+            "parent session instead." + mcp_core.strict_identity_diagnosis()
         )
     return sk, ""
 

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -408,6 +408,7 @@ def send_message(name: str, args: dict[str, Any]) -> str:
                 "Error: cannot verify caller identity for a channel_type send "
                 "(no gateway-injected session key or HMAC-verified pid). "
                 "Refusing to post into a conversation that cannot be attributed."
+                + mcp_core.strict_identity_diagnosis()
             )
     # ``gov_session`` is the identity every gate below is keyed on. It is the
     # STRICT key whenever one was required, so the identity that is checked is
@@ -551,6 +552,7 @@ def send_notification(name: str, args: dict[str, Any]) -> str:
             "Error: cannot verify caller identity for send_notification "
             "(no gateway-injected session key or HMAC-verified pid). "
             "Refusing to publish without a trusted governance identity."
+            + mcp_core.strict_identity_diagnosis()
         )
     # Channel-agent containment: same boundary
     # as send_message — an auto-approved call emits no permission event,

--- a/test/test_strict_identity_diagnostics.py
+++ b/test/test_strict_identity_diagnostics.py
@@ -1,0 +1,207 @@
+"""Strict-identity diagnostics: the refusal names its cause, and doctor reports it.
+
+Two surfaces are under test, and they exist for two different readers:
+
+1. :func:`kiro_crew.mcp_core.strict_identity_diagnosis` — the reader who just
+   had a tool refused. Every strict refusal already said WHAT was refused; none
+   said why THIS install cannot answer "which session is calling", so there was
+   no next step. The diagnosis is appended to the refusal text.
+2. ``cli_doctor._doctor_strict_identity`` — the reader doing a checkup before
+   hitting the wall.
+
+Both are REPORTS. ``mcp_gateway.stub_servers`` is empty by default on purpose
+(routing starts a broker plus a stub per server), so neither surface repairs
+anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from kiro_crew import cli_doctor, mcp_core
+
+
+class TestStrictIdentityDiagnosis:
+    """The machine-specific reason strict identity is unavailable."""
+
+    def test_empty_when_identity_resolves(self, monkeypatch) -> None:
+        """A caller appends this unconditionally, so a resolvable identity must
+        produce nothing rather than a misleading explanation."""
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:chat-7")
+        assert mcp_core.strict_identity_diagnosis() == ""
+
+    def test_names_the_routing_gap_and_the_fix(self, monkeypatch) -> None:
+        """The no-channel case: no env identity and no gateway caller. The text
+        must name the server, the config key, and why the backend cannot supply
+        an env identity — that last part is what stops a reader concluding their
+        session is broken."""
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+        with patch.object(mcp_core, "current_caller", return_value=None):
+            out = mcp_core.strict_identity_diagnosis("kirocrew-dashboard")
+        assert "kirocrew-dashboard" in out
+        assert "mcp_gateway.stub_servers" in out
+        assert "session-unbound" in out
+        assert "doctor" in out
+
+    def test_a_declared_host_pid_points_at_signing_not_routing(self, monkeypatch) -> None:
+        """When the launcher DID declare a host pid the channel exists and the
+        sidecar is what failed, so advising the operator to route the server
+        would send them to the wrong place."""
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.setenv("KIROCREW_HOST_PID", "4242")
+        with (
+            patch.object(mcp_core, "current_caller", return_value=None),
+            patch.object(mcp_core, "_resolve_session_key_strict", return_value=""),
+        ):
+            out = mcp_core.strict_identity_diagnosis()
+        assert "did not verify" in out
+        assert "trust root" in out
+        assert "mcp_gateway.stub_servers" not in out
+
+
+class TestRefusalsCarryTheDiagnosis:
+    """The tool-layer refusals that own strict-identity text append it.
+
+    Asserted per call site rather than by grep: a refusal that silently loses
+    the diagnosis is the regression this pins.
+    """
+
+    _MARKER = " [why: no identity channel]"
+
+    def test_ledger_refusal_carries_it(self, monkeypatch) -> None:
+        from kiro_crew.mcp_tools import ledger
+
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        monkeypatch.setattr(mcp_core, "strict_identity_diagnosis", lambda *a: self._MARKER)
+        _sk, err = ledger._strict_session_key()
+        assert err.startswith("Error:") and self._MARKER in err
+
+    def test_crew_ledger_refusal_carries_it(self, monkeypatch) -> None:
+        from kiro_crew.mcp_tools import apps
+
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        monkeypatch.setattr(mcp_core, "strict_identity_diagnosis", lambda *a: self._MARKER)
+        _sk, err = apps._crew_session_key()
+        assert err.startswith("Error:") and self._MARKER in err
+
+    def test_every_strict_refusal_string_carries_it(self) -> None:
+        """Source-level completeness check across the modules that own strict
+        refusal text. A sibling refusal added later without the diagnosis is the
+        exact regression that made this change necessary in the first place —
+        five sites had it, four did not, and the four were invisible.
+        """
+        import re
+
+        roots = {
+            "mcp_tools/ledger.py": "mcp_core.strict_identity_diagnosis",
+            "mcp_tools/apps.py": "mcp_core.strict_identity_diagnosis",
+            "mcp_tools/messaging.py": "mcp_core.strict_identity_diagnosis",
+            "mcp_dashboard.py": "strict_identity_diagnosis(",
+            "mcp_cron.py": "strict_identity_diagnosis(",
+        }
+        src_root = Path(mcp_core.__file__).parent
+        # Refusal text that means "I could not tell which session is calling".
+        pattern = re.compile(
+            r"cannot verify (which session|caller identity)"
+            r"|could not be verified strictly"
+            r"|cannot determine which session"
+            r"|cannot be identified well enough"
+            r"|needs a directly-identified dashboard session"
+        )
+        for rel, marker in roots.items():
+            text = (src_root / rel).read_text(encoding="utf-8")
+            refusals = len(pattern.findall(text))
+            wired = text.count(marker)
+            assert refusals > 0, f"{rel}: expected strict refusal text"
+            assert wired >= refusals, (
+                f"{rel}: {refusals} strict refusal(s) but only {wired} carry the "
+                f"diagnosis — a refusal without it leaves the reader no next step"
+            )
+
+
+class TestDoctorStrictIdentity:
+    """``kirocrew doctor`` answers the question without waiting for a refusal."""
+
+    class _Cfg:
+        class _GW:
+            def __init__(self, routed):
+                self.stub_servers = routed
+
+        def __init__(self, routed):
+            self.mcp_gateway = self._GW(routed)
+
+    def _darwin(self, monkeypatch) -> None:
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Darwin")
+
+    def test_all_routed_reads_healthy(self, monkeypatch, capsys) -> None:
+        self._darwin(monkeypatch)
+        cli_doctor._doctor_strict_identity(self._Cfg(list(cli_doctor._STRICT_IDENTITY_SERVERS)))
+        out = capsys.readouterr().out
+        assert "strict identity: ✅" in out and "per-call caller" in out
+
+    def test_unrouted_names_the_servers_and_the_affected_tools(self, monkeypatch, capsys) -> None:
+        self._darwin(monkeypatch)
+        cli_doctor._doctor_strict_identity(self._Cfg(["aws-mcp"]))
+        out = capsys.readouterr().out
+        assert "no identity channel" in out
+        assert "kirocrew-core" in out and "kirocrew-dashboard" in out
+        assert "monitor_start" in out and "session_ledger" in out
+
+    def test_it_never_makes_doctor_exit_nonzero(self, monkeypatch, capsys) -> None:
+        """The line is a NOTE, not a problem. ``stub_servers`` is empty by
+        default, so appending to doctor's ``issues`` would make a stock install
+        exit 1 and break ``kirocrew doctor && kirocrew gateway`` — the failure
+        the speech-to-text section is written to avoid. Signature-enforced: the
+        function takes no ``issues`` list at all, so it structurally cannot.
+        """
+        import inspect
+
+        params = inspect.signature(cli_doctor._doctor_strict_identity).parameters
+        assert list(params) == ["cfg"], "no issues list may be threaded in"
+        self._darwin(monkeypatch)
+        cli_doctor._doctor_strict_identity(self._Cfg([]))
+        out = capsys.readouterr().out
+        # Neutral marker, not a warning glyph: doctor's ⚠ lines read as work to do.
+        assert "⚠" not in out
+
+    def test_it_reports_rather_than_prescribes(self, monkeypatch, capsys) -> None:
+        """Routing is an opt-in topology change (a broker plus a stub per
+        server), so the note must say that leaving it unrouted is valid —
+        otherwise doctor reads as demanding a change the design made optional."""
+        self._darwin(monkeypatch)
+        cli_doctor._doctor_strict_identity(self._Cfg([]))
+        out = capsys.readouterr().out
+        assert "valid choice" in out
+        assert "broker" in out
+
+    def test_skipped_where_the_env_channel_exists(self, monkeypatch, capsys) -> None:
+        """On Linux the sandbox launcher exports ``KIROCREW_HOST_PID``, so
+        routing is not what decides whether strict identity resolves — warning
+        there would be false."""
+        monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Linux")
+        cli_doctor._doctor_strict_identity(self._Cfg([]))
+        assert capsys.readouterr().out == ""
+
+    def test_a_malformed_config_does_not_raise(self, monkeypatch, capsys) -> None:
+        """Doctor never fails on the object it was handed."""
+
+        class _Broken:
+            @property
+            def mcp_gateway(self):  # pragma: no cover - raising getter is the point
+                raise RuntimeError("no gateway block")
+
+        self._darwin(monkeypatch)
+        cli_doctor._doctor_strict_identity(_Broken())
+        assert "no identity channel" in capsys.readouterr().out
+
+
+def test_no_new_dependency_on_a_running_gateway() -> None:
+    """The diagnosis is pure inspection of this process's own state: it must not
+    reach the gateway, because it runs on the failure path of a tool that could
+    not even identify its session."""
+    src = Path(mcp_core.__file__).read_text(encoding="utf-8")
+    body = src.split("def strict_identity_diagnosis(")[1].split("\ndef ")[0]
+    for forbidden in ("_api_urlopen", "_get(", "_post(", "urlopen", "requests."):
+        assert forbidden not in body, f"diagnosis must not call {forbidden}"


### PR DESCRIPTION
## Problem / Motivation

Every tool that must know which session is calling — `monitor_start`, `monitor_update`, `autonudge_stop`, `ask_question`, `wait`, `session_ledger_*`, `issue_radar_crew_*`, session control, `chat_folder_*`, `send_message`(channel), `send_notification`, the cron ownership verbs — fails closed with a message that says only *what* was refused:

> Error: cannot verify which session is calling …
> Error: this session's identity could not be verified strictly …

None of them says why **this install** cannot answer the question, so the reader has no next step. Diagnosing it took a multi-hour investigation across `mcp_core`, `session_pid_sig`, `acp/runtime.py`, `mcp_gateway/claim.py` and the live process tree; the answer turned out to be a single missing config entry.

The cause, and why it is invisible: on the kiro backend a session's kiro-cli process is an `AcpRuntime`, which is **deliberately session-unbound** — one process multiplexes N sessions (`acp/runtime.py`, single-reader demux keyed by `sessionId`), so it cannot carry one session's key in its environment, and it injects none. `KIROCREW_HOST_PID` exists only where the sandbox launcher declares it (Linux). That leaves the gateway's per-call caller injection as the **only** identity channel for that backend — and it exists only for servers listed in `mcp_gateway.stub_servers`, which is empty by default. An unrouted `kirocrew-core` therefore has no identity channel at all, and the failure surfaces as a per-call refusal that reads like a defect in the calling session.

## Why it matters

The strict resolver has ~33 call sites across 10 modules. On a default-config install of the kiro backend, every one of them is refused with no actionable message. Two readers are affected and neither is served today: the person who just had a tool refused (the refusal explains nothing they can act on), and the person doing a checkup before they hit the wall (`kirocrew doctor` never mentioned this).

This is a diagnosis gap, not a behaviour gap — see "What did NOT change" below.

## What changed (motivation → approach → change)

**Motivation → approach.** The refusals are correct; what is missing is the *cause*. Rather than change any gate, add one pure-inspection helper that names the missing channel, append it to the refusals that own strict-identity text, and report the same check proactively in `doctor`.

**Change 1 — `mcp_core.strict_identity_diagnosis(server)`.** Inspects the same three sources `_resolve_session_key_strict` accepts and returns the machine-specific reason, or `""` when identity *is* resolvable (so a caller can append it unconditionally). It distinguishes the two causes, because they have different fixes:

- **No channel at all** → names the server, `mcp_gateway.stub_servers`, *and* why the backend cannot supply an env identity. That last clause is what stops a reader concluding their session is broken.
- **`KIROCREW_HOST_PID` declared but the sidecar did not verify** → a signing/trust-root problem; points at `doctor`'s trust-root line and deliberately does **not** mention routing, which would send the operator to the wrong place.

Appended at all nine refusal sites that own strict-identity text: `mcp_tools/ledger.py`, `mcp_tools/apps.py`, `mcp_tools/messaging.py` (channel `send_message`, `send_notification`), `mcp_cron.py` (job-ownership writes), and `mcp_dashboard.py`'s slot-listing, folder-shaping, session-control and move-session gates. A source-level test walks those five modules and asserts every strict-refusal string is matched by a diagnosis call, so a sibling added later cannot silently go without one.

**Change 2 — `cli_doctor._doctor_strict_identity`.** Prints one line: routed → healthy (names the channel); unrouted → a neutral note (`⏹`, not `⚠`) that names the servers, the affected tools, the one-line fix, **and that leaving them unrouted is a valid choice** — routing starts a broker plus a stub per server, an opt-in topology change (`config/loader.py`: "an empty list means no broker runs at all").

It **cannot** make doctor exit non-zero: the function takes no `issues` list at all, so a stock install (`stub_servers` empty) still exits 0 and `kirocrew doctor && kirocrew gateway` keeps working — the same constraint the speech-to-text section is written to. Parity with `_doctor_trust_root`, which also only prints. The check returns early on Linux, where the sandbox launcher exports `KIROCREW_HOST_PID` and routing is therefore not what decides whether identity resolves.

**What did NOT change, and why — the load-bearing finding.** An earlier attempt at this problem tried to *add* an identity source (a hop-bounded, HMAC-verified ancestor lookup). That was wrong and is not revived here. Investigation established:

- **Subagent isolation is structural, and the strict tools are already contained.** `kirocrew-dashboard` (all session control + `chat_folder_*`) is `opt_in=True`, ships no `autoApprove`, sits in `cli_doctor._NO_BLANKET_ALLOW_MCPS`, and a ratchet pins that the default agent is never granted it — **so a subagent cannot see those verbs at all**. The `kirocrew-core` verbs a subagent *can* see each resolve strictly with the ancestor walk excluded, with the rationale stated per call site ("a subagent under the parent's process tree must NOT be able to PID-walk into the parent's identity and mint a loop"). `session_directive.py` states the principle: *"Subagent isolation is therefore STRUCTURAL, not cryptographic … There is no walk to get wrong."*
- **The two directions are not in conflict.** `mcp_gateway/claim.py` deliberately makes a subagent's calls carry the *parent's* session so `spawn_run` can record a non-empty `parent_session` (an RFC calls it the "Parent delivery **address**"). That is the gateway attributing **downward**, and it is intended. A subagent resolving **upward** into the parent's identity for state mutation is what the strict resolver refuses. Same key value, opposite provenance — adding an ancestor source would have granted the second under cover of the first.
- **The gap is not warm-pool-specific.** Every kiro session runs on `AcpRuntime` (`providers/acp.py` replaces the bootstrap `AcpClient` with `AcpSessionProvider`); pooling only pre-spawns it. `agent.session_sharing` (default on) is what co-tenants subagents onto one PID. `claude` is immune (`AcpClient`, one process per session). So no pid-keyed scheme — env, sidecar, ancestor walk, or tenancy lease — can be correct, and none is added.

Therefore: fail-closed is the intended behaviour here, and the only thing worth fixing is that it was silent about a topology the operator can change in one line.

**Ratchet housekeeping.** `.github/subprocess-encoding-baseline.txt`'s entry for `cli_doctor.py` is lowered 6 -> 5. The diff-scoped gate fires only when a PR touches the file and mandates pruning a shrunk entry; this change adds zero subprocess calls, so the entry was already stale on main. Same class as the `black` baseline: the local gate is baseline-aware and passed, while CI evaluates the merge ref and refuses the stale entry.

## Tests

`test/test_strict_identity_diagnostics.py` (new, 11 tests):

- **Diagnosis** — empty when identity resolves (a caller appends it unconditionally, so a false explanation is the failure mode); the no-channel text names server + config key + `session-unbound` + `doctor`; a declared `KIROCREW_HOST_PID` routes the reader to the trust root and asserts the routing advice is **absent**.
- **Refusal wiring** — asserted per call site (ledger, crew ledger) rather than by grep, so a refusal that silently loses the diagnosis is caught.
- **Doctor** — healthy line when routed; warning names servers *and* affected tool names; the warning says routing is optional and mentions the broker cost (otherwise doctor reads as demanding a change the design made opt-in); a config object whose `mcp_gateway` getter raises still produces the warning instead of crashing doctor; the server tuple matches `mcp_core`'s so the two audiences cannot drift.
- **Purity guard** — parses the helper's own body to assert it makes no gateway/HTTP call: it runs on the failure path of a tool that could not identify its session, so it must not depend on a reachable gateway.

Adjacent suites green: `test_mcp_dashboard_folders`, `test_mcp_dashboard_registration`, `test_cli_doctor`, `test_session_ledger`, `test_mcp_pool_identity_computer_dashboard`, `test_identity_topology` — 291 passed, 5 xfailed. isort / flake8 / black-check / mypy clean.

## Manual verification

Ran the helper against this machine's real state — an install that reproduces the failure (`stub_servers: ["aws-mcp"]`, so both builtin servers unrouted; macOS, no env identity). `_resolve_session_key_strict()` returned `''` and the diagnosis printed the correct cause and fix verbatim:

```
No identity channel on this install: kirocrew-core is not in mcp_gateway.stub_servers,
so the gateway injects no per-call caller, and the kiro backend's AcpRuntime is
session-unbound (it carries no session key in its environment by design). Route
kirocrew-core from MCP Management (or add it to mcp_gateway.stub_servers and
restart) to give this session a verifiable identity. `kirocrew doctor` reports the
same check.
```

Following that advice on the same machine restores the refused tools, which is the check that the message points somewhere real.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — an MCP tool-refusal string and a `kirocrew doctor` CLI line; no dashboard surface is touched.

## Related Issues

no linked issue: found while diagnosing a live failure, not filed first. Three follow-ups are worth separate issues and deliberately not in this diff — `monitor_start`'s refusal is emitted consumer-side (route layer), not in the tool, so its message is unchanged here; `browser` is a self-referential tool that uses the *lenient* resolver, inconsistent with its peers; and a per-call session id in the MCP frame's `_meta` (a kiro-cli change) is the only thing that could remove the multi-tenant window rather than fail closed on it.


