### PR TITLE
ci: raise the all-chunk budget to cover catalog growth on main

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -41,7 +41,7 @@ export const CHUNK_BUDGETS = {
   // `src/i18n/all.ts` — Rolldown names the chunk after that entry. Grows a
   // little with every translated string, which is expected and fine; what this
   // ceiling catches is a NEW library or surface landing in the catalog chunk.
-  all: 9100 * KB, // measured 8666 KB
+  all: 9200 * KB, // measured 9103 KB
 
   // The i18n RUNTIME — the i18next singleton, `initI18n`, the English catalog —
   // named after `src/i18n/t.ts`. Held separately from `all` above because


### PR DESCRIPTION
## Summary

Raises the `all` chunk budget from 9100 KB to 9200 KB (measured 9103 KB on current main).

The `all` chunk is the eager i18n catalog bundle, and its own budget comment says growth "with every translated string ... is expected and fine". Main has grown it from the recorded 8666 KB to 9103 KB across ordinary feature PRs, each adding catalog strings while individually under the line. The chunk is now 3,004 bytes over budget on a clean build of main, so the next `Bundle Size Gate` run on ANY branch rebased onto current main fails without that branch touching `website/src/i18n/` at all (first observed on #5703, whose i18n tree is byte-identical to main's).

100 KB headroom follows the existing convention of budget = measured + margin; no new library or surface entered the chunk — `git log` over `website/src/i18n/locales/` since the last measurement shows only catalog string additions.

## Testing

- `node website/scripts/check-bundle-size.mjs` against a fresh `npm run build` report: all chunks within budget, `all` at 9103 KB < 9200 KB.

## Screenshots

None — CI budget table only, no user-facing change.
