### PR TITLE
fix(apps): list the catalog's pinned git apps

### DIFF
--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -24,11 +24,11 @@ instead of degrading silently:
 - **Display-only inventory.** ``list_catalog_rows`` maps the published list's
   DISPLAY fields (identity, name, summary, version, tags, author, asset refs)
   into storefront rows. It emits no clone coordinates and no ``origin``, because
-  the catalog is trusted only as far as TLS: install coordinates stay with the
-  seed and external registries, and a non-builtin row never mints the verified
-  badge. ``list_catalog_apps`` intersects the rendered set with the seed's
-  installable entries, so a catalog-only ``git`` name renders nothing until it is
-  installable.
+  the catalog is trusted only as far as TLS, and a non-builtin row never mints
+  the verified badge. Install coordinates come from ``inventory``, materialised
+  ONLY from a fresh fetch (``fetch_inventory_entries``) and never from the cache,
+  so ``list_catalog_apps`` keeps a ``git`` row that either the seed, an external
+  registry, or the catalog's own pins can install.
 """
 
 from __future__ import annotations
@@ -697,8 +697,8 @@ def list_catalog_rows() -> list[dict[str, Any]]:
         if isinstance(source, dict):
             # The source TYPE is a display marker (builtin vs git), not install
             # coordinates: url/ref stay out, so the catalog cannot name a clone
-            # target. ``registry.list_catalog_apps`` uses it to intersect git rows
-            # with the seed's installable set.
+            # target. ``registry.list_catalog_apps`` uses it to gate git rows on
+            # the installable set: the seed's names plus the catalog's own pins.
             stype = _curated_str(source.get("type"))
             if stype in ("builtin", "git"):
                 row["source"] = {"type": stype}

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2875,6 +2875,35 @@ async def list_registry() -> list[dict[str, Any]]:
     )
 
 
+def _catalog_installable_names() -> set[Any]:
+    """Names the catalog can install, from a FRESH fetch -- never the local cache.
+
+    ``list_catalog_rows`` reads the cache under the data home, which is
+    agent-writable. That is harmless while a cached row only re-dresses a row that
+    exists anyway -- the posture ``annotate`` already documents -- and NOT harmless
+    if a cached row could CREATE a listed row: a planted name would render with
+    official provenance and deduplicate the real same-named external row out of the
+    listing, so a consent prompt would describe an official app while the name grant
+    it produces installs the external one.
+
+    So the decision to LIST a catalog-only ``git`` name is authorised from the
+    fetched document and never from the cache. ``fetch_inventory_entries`` is the
+    only source allowed to materialise inventory, and it honours the module's
+    failure memory, so an outage costs a refusal rather than a fresh timeout on
+    every listing.
+
+    Returns an empty set on ANY failure, which degrades the storefront to the seed's
+    names -- the listing this path produced before the catalog could supply
+    coordinates. A store listing must never fail because the catalog is unreachable.
+    """
+    try:
+        entries = official_catalog.fetch_inventory_entries()
+        return {row.get("name") for row in official_catalog.inventory(entries)}
+    except Exception:  # noqa: BLE001 - degrade to the seed, never 500 the store
+        logger.warning("cannot confirm the catalog's install coordinates", exc_info=True)
+        return set()
+
+
 async def list_catalog_apps() -> list[dict[str, Any]]:
     """Store rows built from the published catalog, enriched and trust-stamped.
 
@@ -2883,13 +2912,16 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
     published document's list and display copy. An empty result means the catalog
     was unavailable, and the caller falls back to ``list_registry`` offline.
 
-    Install coordinates stay with the seed: the catalog is trusted only as far as
-    TLS, so a ``git`` row is kept only when the seed or an external registry also
-    names it, and it carries no clone URL of its own — install resolves the seed
-    entry by name. A catalog-only ``git`` name renders nothing until it is
-    installable. ``verified`` stays ``False`` for non-builtin rows until the
-    catalog signature is checked, so this path never mints the first-party badge
-    from a document trusted only as far as TLS.
+    Install coordinates are the CATALOG's when it pins them: a ``git`` row is kept
+    when the seed or an external registry names it, or when the catalog itself
+    supplies validated pinned coordinates for it -- the same resolution
+    ``inventory_for_install`` performs on the install path. Gating the listing on
+    the seed alone made the two disagree, so a published app stayed invisible in
+    the store until a release shipped a new seed -- the release-per-app cost
+    ``inventory`` exists to remove. The row still carries no clone URL of its own;
+    install resolves the coordinates by name. ``verified`` stays ``False`` for
+    non-builtin rows until the catalog signature is checked, so this path never
+    mints the first-party badge from a document trusted only as far as TLS.
 
     User-configured external registries (``config.registries``) are appended here
     too, through the same ``_append_external_registry_apps`` merge site
@@ -2913,6 +2945,21 @@ async def list_catalog_apps() -> list[dict[str, Any]]:
     # `git` row filtered out here for not being installable yet, whose name
     # install still resolves by.
     reserved_names: set[Any] = {row.get("name") for row in rows} | installable_names
+    # A `git` row the seed does not name is STILL installable when the catalog
+    # pins it -- that is exactly what `inventory_for_install` resolves on the
+    # install path. Asking only the seed made the two resolvers disagree: install
+    # accepted a catalog-only row while the storefront dropped it, so a published
+    # app was unlistable, and therefore undiscoverable, until a release shipped a
+    # new seed.
+    #
+    # Only paid when it can change the answer. With every `git` row already seeded
+    # the fetch cannot unlock anything, so the storefront's hot path keeps costing
+    # one cached read.
+    if any(
+        row.get("source", {}).get("type") == "git" and row.get("name") not in installable_names
+        for row in rows
+    ):
+        installable_names |= await asyncio.to_thread(_catalog_installable_names)
     rows = [
         row
         for row in rows

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -27,6 +27,7 @@ import json
 import os
 import stat
 import sys
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1407,6 +1408,26 @@ class TestApplyTrustFields:
 # external app was silently dropped from the store the moment the catalog came
 # online. list_catalog_apps now appends external-registry rows itself.
 # ---------------------------------------------------------------------------
+_PINNED_SHA = "a" * 40
+
+
+def _pinned_catalog_entry(name: str) -> dict[str, Any]:
+    """A catalog entry `official_catalog.inventory` accepts as installable.
+
+    The real `inventory` runs over this, so the coordinates have to satisfy its
+    validation (https clone URL, full-length lowercase-hex pin) rather than being
+    waved through by a stub.
+    """
+    return {
+        "name": name,
+        "source": {
+            "type": "git",
+            "url": f"https://github.com/org/{name}",
+            "ref": _PINNED_SHA,
+        },
+    }
+
+
 class TestCatalogAppsIncludesExternalRegistries:
     @pytest.mark.asyncio
     async def test_external_registry_app_appears_when_catalog_is_online(self, monkeypatch):
@@ -1515,6 +1536,11 @@ class TestCatalogAppsIncludesExternalRegistries:
         )
         monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
         monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+        # The catalog pins nothing either, so the row stays filtered -- and the
+        # listing never reaches for a real fetch.
+        monkeypatch.setattr(
+            registry.official_catalog, "fetch_inventory_entries", lambda: []
+        )
 
         async def _fake_external():
             # External registry tries to claim the filtered-out catalog name.
@@ -1532,6 +1558,165 @@ class TestCatalogAppsIncludesExternalRegistries:
         # EXTERNAL row pointing at the "evil" repo.
         assert rows.get("filtered-git", {}).get("provenance") != "external"
         assert "filtered-git" not in rows
+
+    # -----------------------------------------------------------------------
+    # Regression: the storefront intersected every catalog `git` row with the
+    # BUNDLED SEED, which ships only at release cadence. `inventory` was added so
+    # the catalog itself could supply validated pinned coordinates, and the install
+    # path honours them (`inventory_for_install`) -- but this listing was written a
+    # day earlier and still asked the seed. The two resolvers disagreed: install
+    # accepted a catalog-only app while the store hid it, so a freshly published
+    # app was undiscoverable until a release shipped a new seed.
+    # -----------------------------------------------------------------------
+    @pytest.mark.asyncio
+    async def test_a_catalog_pinned_git_row_is_listed_without_a_seed_entry(self, monkeypatch):
+        """A `git` row the catalog PINS is listed even though the seed omits it."""
+        catalog_rows = [
+            {"name": "keep-app", "displayName": "Keep App"},
+            {"name": "pinned-app", "source": {"type": "git"}},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        # The seed names NOTHING -- the catalog alone has to carry this row.
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "fetch_inventory_entries",
+            lambda: [_pinned_catalog_entry("pinned-app")],
+        )
+
+        async def _fake_external():
+            return []
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert "pinned-app" in rows, "a catalog-pinned git row must reach the store"
+        # It is an official row, and still unverified -- listing it does not mint
+        # the first-party badge from a document trusted only as far as TLS.
+        assert rows["pinned-app"]["provenance"] != "external"
+        assert rows["pinned-app"]["verified"] is False
+        assert "keep-app" in rows
+
+    @pytest.mark.asyncio
+    async def test_a_name_only_the_local_cache_claims_is_not_listed(self, monkeypatch):
+        """The unlock is authorised by the FRESH document, never by the cache.
+
+        `list_catalog_rows` reads the cache under the data home, which is
+        agent-writable. A planted row there must not BECOME a listed row: it would
+        render with official provenance and dedupe the real same-named external row
+        out of the listing, so a consent prompt would describe an official app while
+        the name grant it produces installs the external one.
+        """
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "list_catalog_rows",
+            lambda: [{"name": "planted-app", "source": {"type": "git"}}],
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+        # The fetched document pins a DIFFERENT app, so it never authorises
+        # "planted-app" -- only the cache claims that name.
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "fetch_inventory_entries",
+            lambda: [_pinned_catalog_entry("honest-app")],
+        )
+
+        async def _fake_external():
+            return []
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert "planted-app" not in rows
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_catalog_degrades_to_the_seed(self, monkeypatch):
+        """A listing must never fail because the catalog cannot be reached.
+
+        Without the fresh document there is nothing authorising the catalog-only
+        row, so it stays filtered -- the listing this path produced before the
+        catalog could supply coordinates -- and the rest of the store still renders.
+        """
+        catalog_rows = [
+            {"name": "keep-app", "displayName": "Keep App"},
+            {"name": "pinned-app", "source": {"type": "git"}},
+        ]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        def _unavailable():
+            raise registry.official_catalog.CatalogUnavailable("cdn is down")
+
+        monkeypatch.setattr(
+            registry.official_catalog, "fetch_inventory_entries", _unavailable
+        )
+
+        async def _fake_external():
+            return []
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert "pinned-app" not in rows
+        assert "keep-app" in rows, "the rest of the store still renders"
+
+    @pytest.mark.asyncio
+    async def test_no_fresh_fetch_when_the_seed_already_covers_every_git_row(
+        self, monkeypatch
+    ):
+        """The storefront is the hot path, so the fetch is paid only when it can
+        change the answer. With every `git` row already seeded there is nothing to
+        unlock, and the listing must stay at one cached read."""
+        catalog_rows = [{"name": "seeded-app", "source": {"type": "git"}}]
+        monkeypatch.setattr(
+            registry.official_catalog, "list_catalog_rows", lambda: catalog_rows
+        )
+        monkeypatch.setattr(
+            registry, "_load_registry_file", lambda: [{"name": "seeded-app"}]
+        )
+        monkeypatch.setattr(registry, "list_installed_apps", lambda: [])
+
+        calls: list[int] = []
+
+        def _counting():
+            calls.append(1)
+            return []
+
+        monkeypatch.setattr(
+            registry.official_catalog, "fetch_inventory_entries", _counting
+        )
+
+        async def _fake_external():
+            return []
+
+        async def _fake_resolve(entry):
+            return entry
+
+        monkeypatch.setattr(registry, "_load_external_registries", _fake_external)
+        monkeypatch.setattr(registry, "_resolve_manifest", _fake_resolve)
+
+        rows = {r["name"]: r for r in await registry.list_catalog_apps()}
+        assert calls == [], "the seed already answers, so no fetch may be paid"
+        assert "seeded-app" in rows
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

An app published to the official catalog does not appear in the App Store at all — it cannot be browsed, and searching for it by name returns nothing.

Observed with a freshly published app: the local catalog cache (`~/.kiro/crew/cache/official-catalog.json`, revision `2026-08-24T22:44:45Z-b161b30`) contained 23 well-formed entries including the new one, yet the store rendered 22. Running the installed backend's own code confirmed which row went missing and why:

```
catalog rows: 23
seed names: ['launchdarkly', 'todo-ledger', 'todo-txt']
kept: 22
DROPPED: ['crew-manager']
crew-manager source: {'type': 'git'}
```

`list_catalog_apps` intersects every catalog row whose `source.type == "git"` against the bundled wheel seed (`src/kiro_crew/apps/app-registry.json`). The published app is the only `git`-source row the seed does not name, so it is filtered out server-side and never reaches the frontend.

## Why it matters

Publishing to the catalog is supposed to be the whole point of the catalog — it decouples shipping an app from shipping a client release. Today it silently does not: a curator publishes, the document validates, the CDN serves it, the client caches it, and the app is still invisible until a KiroCrew release ships a new seed.

The filter also buys nothing. Install-by-name already accepts a catalog-only row: `_resolve_registry_row` resolves through `inventory_for_install`, and the catalog row wins outright over a same-repo seed row. So the gate blocks **discovery** while leaving **installation** open — the app is installable but unfindable, which is the worst of both.

## What changed (motivation → approach → change)

**Symptom** — a published `git`-source app is absent from the store listing.

**Root cause** — two resolvers disagree about who owns install coordinates, and the disagreement is a one-day-old leftover:

- `f0606d3d1` (2026-08-15) *"feat: render the app storefront from the published catalog (#3779)"* added `list_catalog_apps` and this filter. At that point the premise was true: `list_catalog_rows` deliberately strips `url`/`ref` and keeps only `{"type": ...}`, so a catalog row had no coordinates of its own and install had to resolve by name against the seed. Listing a name install could not resolve would have rendered an install control that fails. The docstring still stated the premise verbatim: *"Install coordinates stay with the seed."*
- `e8df22b56` (2026-08-16) *"feat: install apps the official catalog lists, at their pinned commit (#3659)"* added `inventory()`, `fetch_inventory_entries()` and `inventory_for_install()`, making the catalog a validated coordinate source, and wired it into `list_registry` and the install path — **but not into `list_catalog_apps`**.

The premise the filter guards became false the next day and the filter stayed. (The PR numbers land out of order — #3779 merged before #3659 — which is how the seam was missed: the storefront branch baked in an assumption the install branch then invalidated while only touching the paths it owned.) `list_registry` has the correct merge, but `handle_registry` only falls back to it when the catalog is *empty*, so a healthy catalog never takes that path.

**Change** — derive the installable set from the catalog's own pinned coordinates in addition to the seed, so the listing asks the same question install answers.

Two properties are deliberate:

- **The unlock is authorised by a FRESH fetch, never by the cache.** The names come from `fetch_inventory_entries()` — the path `inventory_for_install` uses — and not from `list_catalog_rows()`, which reads the agent-writable cache under the data home. That distinction is load-bearing: a cached row that could *create* a listed row would render with official provenance and deduplicate the real same-named external row out of the listing, so a consent prompt would describe an official app while the name grant it produces installs the external one. Authorising from the fetched document keeps the name→URL binding fetch-derived; the cache can then only re-dress a row the fresh catalog already names, which is the display-copy posture `annotate` already documents.
- **The fetch is paid only when it can change the answer.** With every `git` row already named by the seed there is nothing to unlock, so the guard short-circuits and the listing keeps costing one cached read. Any failure returns an empty set and degrades to the seed's names — the listing this path produced before the catalog could supply coordinates — because a store listing must never fail on an unreachable catalog.

`reserved_names` is still snapshotted before the filter, so external-registry name shadowing is unaffected. `verified` still stays `False` for non-builtin rows, so listing a catalog row does not mint the first-party badge from a document trusted only as far as TLS.

### One thing I would like a ruling on

In a deployment that has *any* catalog-only `git` app, the guard is true on every listing, so `/api/apps/registry` now pays one extra HTTPS fetch per store load. It is off the event loop (`asyncio.to_thread`), and `fetch_inventory_entries` honours the module's on-disk failure memory so an outage costs a refusal rather than a fresh timeout each time — but it is still a real per-request cost on the path the document cache exists to keep cheap.

I deliberately did **not** add an in-process memo for the resolved names in this PR: caching semantics in this module are what the security invariant above rests on, so a second cache layer deserves its own review rather than riding along on a correctness fix. Happy to add it here if you would rather it land together.

Related, and also deliberate: because the listed row itself still comes from the cached document, a newly published app appears once that document refreshes (≤ `CACHE_TTL`), not instantly. Synthesising rows from inventory would fix that and would also breach the invariant that inventory must never create a listed row, so it is out of scope.

## Tests

Four cases in `test/test_apps_registry.py`, all on `list_catalog_apps`:

- `test_a_catalog_pinned_git_row_is_listed_without_a_seed_entry` — the regression itself: a `git` row the catalog pins and the seed omits now reaches the store, as an official (non-external) row that is still `verified: False`. This is the assertion the old filter fails.
- `test_a_name_only_the_local_cache_claims_is_not_listed` — the security invariant: a name present only in the cache-derived rows, which the freshly fetched document does not pin, stays dropped. This is what stops the fix from turning the agent-writable cache into a way to create listed rows.
- `test_an_unreachable_catalog_degrades_to_the_seed` — `CatalogUnavailable` leaves the catalog-only row filtered and still renders the rest of the store, rather than failing the listing.
- `test_no_fresh_fetch_when_the_seed_already_covers_every_git_row` — counts calls to assert the hot path pays no fetch when the seed already answers.

The entry builder feeds the **real** `official_catalog.inventory`, so the fixtures have to satisfy its actual validation (https clone URL, 40-char lowercase-hex pin) instead of being waved through by a stub.

One existing test changed: `test_external_row_cannot_shadow_filtered_catalog_git_name` depends on a `git` row being filtered, which now makes the path consult the catalog — it is told the catalog pins nothing, both to keep the row filtered and to keep the test off the network.

## Manual verification

The diagnosis was produced by running the installed backend's own `list_catalog_rows` + the pre-fix filter against the live catalog, which is the `DROPPED: ['crew-manager']` output quoted above — that is what identified the filter as the cause rather than a publish or cache-staleness problem.

**I did not run the test suite locally** (no venv in this worktree, and per standing preference CI is the gate here), so the four new cases are unproven locally and CI is their first real execution. Verified locally without a venv: both changed files byte-compile, and no added line exceeds the repo's 100-column limit.

Local pre-push review ran as a **self-review against the two extracted CI contracts** (`codex-review.yml`, `claude-review.yml` + base-ref `AUTOSDE.yaml`), not via model-pinned subagents — the subagent facility was unavailable in this session, so local green is weaker than usual here. The `no-blocking-call-on-event-loop` blocking rule was checked specifically: the new blocking fetch is handed to a thread, which that rule lists as allowed.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to one registry listing function; no watched frontend path is touched and nothing renders differently. The user-visible effect is that an already-published app appears in the existing store list.

## Related Issues

no linked issue: found while diagnosing why a specific published app was unsearchable; no tracking issue existed and the fix is small enough that filing one first would only have duplicated this description.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — new tests added; **existing suite not run locally**, see Manual verification
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — the changed function's docstring is updated; no separate doc states the old rule
- [x] No secrets, credentials, or internal references in the diff
