### PR TITLE
fix(apps): harden backend health probes

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -263,7 +263,7 @@ show the real product UI; the detail page renders both when both are declared.
 |-------|------|---------|-------------|
 | `backend.entryPoint` | string | | Script to run (relative to app root), or a dotted Python module path launched via `python -m` (used by built-in apps like `file-explorer`, e.g. `kiro_crew.apps.builtins.file_explorer.server`) |
 | `backend.port` | string | `"auto"` | Port number or `"auto"` for auto-assignment |
-| `backend.healthCheck` | string | `"/health"` | Health check endpoint path. Polled until it answers at startup, then re-polled for the life of the backend — keep the handler cheap and dependency-free. A backend that stops answering it is dropped from the reverse proxy and its MCP servers are deregistered until it answers again. |
+| `backend.healthCheck` | string | `"/health"` | Absolute health-check path beginning with `/`; unsafe or ambiguous paths are refused. Polled until it answers at startup, then re-polled for the life of the backend — keep the handler cheap and dependency-free. A backend that stops answering it is dropped from the reverse proxy and its MCP servers are deregistered until it answers again. |
 | `backend.routes` | string | | Base route path for the backend |
 | `backend.type` | string | `""` | Backend runtime: `"python"`, `"asgi"`, `"node"`, `"exec"` (execute the entry point file as-is), or `""` (auto-detect from `entryPoint` — a `.sh` file or an extensionless executable with a non-Python shebang is treated as a shell launcher) |
 

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -1128,6 +1128,14 @@ state that is no longer on disk, so nothing retries. **The scrub also re-materia
   survives an unexpected fault in any single sweep, because the failure MODE is the bug
   itself: a dead watch thread freezes `healthy` at its last value and silently restores
   the write-once behaviour, with the proxy still routing to a port nothing serves.
+- **Every health verdict uses the same loopback-only probe boundary.** Adoption,
+  startup polling, and the standing watch pass the manifest's app-authored
+  `healthCheck` through `_health_probe_url`: the port must be valid and the value must
+  be an absolute path whose restricted character set cannot move the URL authority or
+  be silently normalized by the parser. Rejected paths fail closed as unhealthy and
+  warn once per distinct value. The shared `_health_probe` opens accepted URLs through
+  `loopback_urlopen`, which ignores HTTP proxy environment variables and rejects
+  redirects, so a probe cannot be redirected or proxied away from `127.0.0.1`.
 - **Every writer of an app's MCP and agent state shares one serialization.** Two
   independent families write it: the lifecycle paths in `apps/bridges.py` (enable,
   update, boot reconcile) and the backend's health watch. Unserialized they interleave

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -10,6 +10,7 @@ import http.client
 import json
 import logging
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -34,6 +35,7 @@ from kiro_crew.apps.manager import app_dir, get_app_manifest, list_apps
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     RLIMIT_PROFILE_TOOL,
@@ -52,6 +54,12 @@ _MAX_PORT = 9200
 _HEALTH_CHECK_TIMEOUT = 5
 _HEALTH_CHECK_RETRIES = 15
 _HEALTH_CHECK_INTERVAL = 2.0
+# ``healthCheck`` is app-authored text. A leading slash terminates the URL authority;
+# the remaining class is the ordinary RFC 3986 path/query set with characters that
+# can be parsed inconsistently (userinfo, fragments, backslashes, brackets) excluded.
+_HEALTH_PATH_RE = re.compile(r"\A/[A-Za-z0-9._~!$&'()*+,;=:/?%-]*\Z")
+_warned_health_paths: set[str] = set()
+_health_warn_lock = threading.Lock()
 
 # Post-startup liveness watch (see _watch_backend_health). The startup poll above only
 # establishes that a backend CAME UP; without a standing watch `healthy` would be a
@@ -207,18 +215,9 @@ def _listening_pids(port: int) -> list[int]:
 
 
 def _probe_adoption_health(port: int, health_path: str) -> bool:
-    """Whether ``127.0.0.1:port`` answers the manifest's health check (< 400)."""
+    """Whether an already-running backend answers its health check."""
 
-    try:
-        req = urllib.request.Request(
-            f"http://127.0.0.1:{port}{health_path}",
-            method="GET",
-        )
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            return bool(resp.status < 400)
-    # HTTPException is not an OSError — see _health_probe for why that matters.
-    except (urllib.error.URLError, OSError, http.client.HTTPException):
-        return False
+    return _health_probe(port, health_path, timeout=3)
 
 
 def _capture_adopted_owners(
@@ -1693,8 +1692,38 @@ def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> bool:
         return False
 
 
-def _health_probe(url: str) -> bool:
-    """Whether the health endpoint answers below 400. Never raises.
+def _warn_bad_health_path(health_path: str) -> None:
+    """Log a rejected manifest health path once per distinct value."""
+
+    with _health_warn_lock:
+        if health_path in _warned_health_paths:
+            return
+        _warned_health_paths.add(health_path)
+    logger.warning(
+        "App backend health path %r is unsafe; healthCheck must be an absolute "
+        "loopback path such as /health",
+        health_path,
+    )
+
+
+def _health_probe_url(port: int, health_path: str) -> str | None:
+    """Build a loopback health URL without letting app text change its authority."""
+
+    if not 0 < port < 65536:
+        return None
+    if not _HEALTH_PATH_RE.fullmatch(health_path or ""):
+        _warn_bad_health_path(health_path)
+        return None
+    return f"http://127.0.0.1:{port}{health_path}"
+
+
+def _health_probe(
+    port: int,
+    health_path: str,
+    *,
+    timeout: float = _HEALTH_CHECK_TIMEOUT,
+) -> bool:
+    """Whether the validated loopback health endpoint answers below 400. Never raises.
 
     `http.client.HTTPException` is caught alongside the socket errors because it is NOT
     an `OSError` or `URLError` subclass (only `RemoteDisconnected` is, via
@@ -1705,9 +1734,12 @@ def _health_probe(url: str) -> bool:
     and freeze `healthy` at its last value: silently reinstating the write-once bug this
     module's watch exists to prevent.
     """
+    url = _health_probe_url(port, health_path)
+    if url is None:
+        return False
     try:
         req = urllib.request.Request(url, method="GET")
-        with urllib.request.urlopen(req, timeout=_HEALTH_CHECK_TIMEOUT) as resp:
+        with loopback_urlopen(req, timeout=timeout) as resp:
             return bool(resp.status < 400)
     except (urllib.error.URLError, OSError, http.client.HTTPException):
         return False
@@ -1728,13 +1760,12 @@ def _health_check_loop(ap: AppProcess, health_path: str) -> AppProcess | None:
     """
     app_name = ap.app_name
     port = ap.port
-    url = f"http://127.0.0.1:{port}{health_path}"
     for attempt in range(_HEALTH_CHECK_RETRIES):
         time.sleep(_HEALTH_CHECK_INTERVAL)
         with _lock:
             if _processes.get(app_name) is not ap:
                 return None  # replaced or stopped — this poll is a retired generation
-        if _health_probe(url):
+        if _health_probe(port, health_path):
             # Health-gated MCP registration: only now that the
             # backend has passed /health do we write its HTTP MCP url (live port) to
             # global mcp.json. Registering before this could leave a dead-but-enabled
@@ -1845,7 +1876,6 @@ def _watch_backend_health_sweeps(ap: AppProcess, health_path: str) -> None:
     pops it and a restart replaces it, so this needs no separate teardown — the same
     "no longer tracked" guard the startup poll already uses.
     """
-    url = f"http://127.0.0.1:{ap.port}{health_path}"
     consecutive_failures = 0
     while True:
         time.sleep(_HEALTH_WATCH_INTERVAL)
@@ -1887,7 +1917,7 @@ def _watch_backend_health_sweeps(ap: AppProcess, health_path: str) -> None:
                 return
             continue
 
-        if _health_probe(url):
+        if _health_probe(ap.port, health_path):
             consecutive_failures = 0
             healthy = True
         else:

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -1471,7 +1471,7 @@ class TestHealthGatedMcpRegistration:
         monkeypatch.setattr(bmod, "_gate_mcp_registration",
                             lambda name, port, *, healthy: calls.append((name, port, healthy)))
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp())
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *a, **k: _FakeHealthResp())
 
         with bmod._lock:
             bmod._processes["hg-app"] = AppProcess(app_name="hg-app", port=9150, healthy=False)
@@ -1498,7 +1498,7 @@ class TestHealthGatedMcpRegistration:
                             lambda name, port, *, healthy: calls.append((name, port, healthy)))
 
         # urlopen "succeeds" but the app is NOT in _processes (stopped mid-check).
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp())
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *a, **k: _FakeHealthResp())
         with bmod._lock:
             bmod._processes.clear()  # ensure absent
 
@@ -1519,7 +1519,7 @@ class TestHealthGatedMcpRegistration:
 
         def _boom(*a, **k):
             raise OSError("connection refused")
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", _boom)
+        monkeypatch.setattr(bmod, "loopback_urlopen", _boom)
 
         with bmod._lock:
             bmod._processes["sick-app"] = AppProcess(app_name="sick-app", port=9152, healthy=False)
@@ -1810,7 +1810,7 @@ class TestBackendLivenessWatch:
 
         probes: list[bool] = []
 
-        def _scripted(_url):
+        def _scripted(_port, _path):
             if not probes:
                 # Script exhausted: untrack so the watch exits at its top-of-loop guard.
                 with bmod._lock:
@@ -2094,7 +2094,7 @@ class TestMcpReconcileHonoursRecordIdentity:
         monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
         monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 2)
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp())
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *a, **k: _FakeHealthResp())
         held: list[bool] = []
         monkeypatch.setattr(
             bmod, "_gate_mcp_registration",
@@ -2139,7 +2139,7 @@ class TestStartupProbeCannotPromoteAReplacement:
         original = AppProcess(app_name="app", port=9190, healthy=False)
         successor = AppProcess(app_name="app", port=9191, healthy=False)
 
-        def _probe_then_swap(_url):
+        def _probe_then_swap(_port, _path):
             # The stop/start lands while the probe is in flight.
             with bmod._lock:
                 bmod._processes["app"] = successor
@@ -2186,7 +2186,7 @@ class TestFailedMcpReconcileIsRetried:
             bmod._processes["w"] = ap
         probes: list[bool] = []
 
-        def _scripted(_url):
+        def _scripted(_port, _path):
             if not probes:
                 with bmod._lock:
                     bmod._processes.pop("w", None)
@@ -2297,7 +2297,7 @@ class TestStartupPollBelongsToOneGeneration:
 
         swapped = {"done": False}
 
-        def _never_answers(_url):
+        def _never_answers(_port, _path):
             if not swapped["done"]:  # the restart lands between attempts
                 swapped["done"] = True
                 with bmod._lock:
@@ -2319,7 +2319,7 @@ class TestStartupPollBelongsToOneGeneration:
 
         state = {"n": 0}
 
-        def _probe(_url):
+        def _probe(_port, _path):
             state["n"] += 1
             if state["n"] == 1:
                 with bmod._lock:
@@ -2356,7 +2356,7 @@ class TestTerminalScrubIsRetriedUntilItLands:
         with bmod._lock:
             bmod._processes.clear()
             bmod._processes["x"] = ap
-        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+        monkeypatch.setattr(bmod, "_health_probe", lambda *_a: False)
         try:
             yield bmod, ap
         finally:
@@ -2495,7 +2495,7 @@ class TestAdoptedRecoveryRebindsOwnership:
             bmod._processes["ad"] = ap
         probes: list[bool] = []
 
-        def _scripted(_url):
+        def _scripted(_port, _path):
             if not probes:
                 with bmod._lock:
                     bmod._processes.pop("ad", None)
@@ -2578,7 +2578,7 @@ class TestUnknownMcpStateStillGetsScrubbed:
             attempts.append(healthy)
             return len(attempts) >= 3  # the first two scrubs fail
         monkeypatch.setattr(bmod, "_gate_mcp_registration", _gate)
-        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+        monkeypatch.setattr(bmod, "_health_probe", lambda *_a: False)
 
         # The state a failed startup reconcile leaves: promoted, never confirmed written.
         ap = AppProcess(app_name="u", port=9250, pid=5,
@@ -2607,7 +2607,7 @@ class TestUnknownMcpStateStillGetsScrubbed:
             bmod, "_gate_mcp_registration",
             lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
         )
-        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+        monkeypatch.setattr(bmod, "_health_probe", lambda *_a: False)
 
         ap = AppProcess(app_name="u", port=9251, pid=5,
                         proc=_FakeProc(returncode=0), healthy=False, mcp_healthy=False)
@@ -2620,6 +2620,138 @@ class TestUnknownMcpStateStillGetsScrubbed:
         finally:
             with bmod._lock:
                 bmod._processes.clear()
+
+
+class TestHealthProbeSecurity:
+    """App-authored health paths cannot redirect a loopback liveness probe."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/healthz?verbose=1", "/a/b_c-d.e~f", "/", "//example.com/x"],
+    )
+    def test_ordinary_paths_preserve_the_loopback_authority(self, path):
+        import urllib.parse
+
+        import kiro_crew.apps.backend as bmod
+
+        url = bmod._health_probe_url(9101, path)
+        assert url == f"http://127.0.0.1:9101{path}"
+        assert urllib.parse.urlsplit(url).hostname == "127.0.0.1"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "@example.com/", "health", "", "/a@b", "/x\ny", "/x\ty",
+            "/x\ry", "/x y", "http://example.com/", "/#frag", "/a\\b", "/[::1]",
+        ],
+    )
+    def test_authority_smuggling_and_ambiguous_paths_are_refused(self, path):
+        import kiro_crew.apps.backend as bmod
+
+        assert bmod._health_probe_url(9101, path) is None
+
+    @pytest.mark.parametrize("port", [0, -1, 65536, 99999])
+    def test_impossible_ports_are_refused(self, port):
+        import kiro_crew.apps.backend as bmod
+
+        assert bmod._health_probe_url(port, "/health") is None
+
+    def test_the_userinfo_payload_would_otherwise_leave_loopback(self):
+        import urllib.parse
+
+        import kiro_crew.apps.backend as bmod
+
+        naive = "http://127.0.0.1:9101@example.com/"
+        assert urllib.parse.urlsplit(naive).hostname == "example.com"
+        assert bmod._health_probe_url(9101, "@example.com/") is None
+
+    def test_an_invalid_path_never_reaches_http_and_warns_only_once(
+        self, monkeypatch, caplog
+    ):
+        import logging
+
+        import kiro_crew.apps.backend as bmod
+
+        monkeypatch.setattr(bmod, "_warned_health_paths", set())
+        monkeypatch.setattr(
+            bmod,
+            "loopback_urlopen",
+            lambda *_a, **_k: pytest.fail("unsafe health path reached HTTP client"),
+        )
+        with caplog.at_level(logging.WARNING, logger=bmod.logger.name):
+            for _ in range(3):
+                assert bmod._health_probe(9101, "@example.com/") is False
+
+        warnings = [r.message for r in caplog.records if "health path" in r.message]
+        assert len(warnings) == 1
+        assert "@example.com/" in warnings[0]
+
+    def test_a_valid_path_uses_the_hardened_opener_with_the_exact_url(
+        self, monkeypatch
+    ):
+        import kiro_crew.apps.backend as bmod
+
+        seen = {}
+
+        def _open(req, *, timeout):
+            seen.update(url=req.full_url, timeout=timeout)
+            return _FakeHealthResp()
+
+        monkeypatch.setattr(bmod, "loopback_urlopen", _open)
+        monkeypatch.setattr(
+            bmod.urllib.request,
+            "urlopen",
+            lambda *_a, **_k: pytest.fail("bare urlopen bypassed loopback policy"),
+        )
+
+        assert bmod._health_probe(9101, "/health?q=1", timeout=1.5) is True
+        assert seen == {"url": "http://127.0.0.1:9101/health?q=1", "timeout": 1.5}
+
+    def test_adoption_startup_and_watch_share_the_same_probe_contract(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        calls = []
+
+        def _probe(port, path, **kwargs):
+            calls.append((port, path, kwargs))
+            return False
+
+        monkeypatch.setattr(bmod, "_health_probe", _probe)
+        assert bmod._probe_adoption_health(9101, "/adopt") is False
+
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 1)
+        monkeypatch.setattr(bmod, "_set_backend_health", lambda *_a, **_k: True)
+        startup = AppProcess(app_name="startup-contract", port=9102)
+        with bmod._lock:
+            bmod._processes[startup.app_name] = startup
+        try:
+            assert bmod._health_check_loop(startup, "/startup") is None
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        watch = AppProcess(
+            app_name="watch-contract", port=9103, healthy=True, mcp_healthy=True
+        )
+
+        def _watch_probe(port, path, **kwargs):
+            calls.append((port, path, kwargs))
+            with bmod._lock:
+                bmod._processes.pop(watch.app_name, None)
+            return True
+
+        monkeypatch.setattr(bmod, "_health_probe", _watch_probe)
+        with bmod._lock:
+            bmod._processes[watch.app_name] = watch
+        bmod._watch_backend_health_sweeps(watch, "/watch")
+
+        assert calls == [
+            (9101, "/adopt", {"timeout": 3}),
+            (9102, "/startup", {}),
+            (9103, "/watch", {}),
+        ]
 
 
 class TestProbeSurvivesAMalformedHttpResponse:
@@ -2662,7 +2794,7 @@ class TestProbeSurvivesAMalformedHttpResponse:
         import kiro_crew.apps.backend as bmod
         port = self._serve_garbage(b"NOT-HTTP garbage\r\n\r\n")
 
-        assert bmod._health_probe(f"http://127.0.0.1:{port}/health") is False
+        assert bmod._health_probe(port, "/health") is False
 
     def test_the_adoption_probe_survives_it_too(self):
         # Same class of bug in the sibling probe — fixed together so one does not sit
@@ -2695,7 +2827,7 @@ class TestWatchSurvivesAnUnexpectedSweepFault:
 
         calls = {"n": 0}
 
-        def _probe(_url):
+        def _probe(_port, _path):
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("something nobody anticipated")
@@ -2726,7 +2858,7 @@ class TestWatchSurvivesAnUnexpectedSweepFault:
 
         calls = {"n": 0}
 
-        def _probe(_url):
+        def _probe(_port, _path):
             calls["n"] += 1
             with bmod._lock:
                 bmod._processes.pop("w", None)
@@ -2871,7 +3003,7 @@ class TestSupervisorIsBoundAtSpawn:
             bmod, "_gate_mcp_registration",
             lambda name, port, *, healthy: (gate.append((name, port, healthy)), True)[1],
         )
-        monkeypatch.setattr(bmod, "_health_probe", lambda _u: True)
+        monkeypatch.setattr(bmod, "_health_probe", lambda *_a: True)
 
         original = AppProcess(app_name="s", port=9291, healthy=False)
         successor = AppProcess(app_name="s", port=9292, healthy=False)

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -15,7 +15,7 @@ branches those files leave untouched:
 Everything here is hermetic and order-independent: no real process is spawned,
 no socket is bound, no network request is made, and no wall-clock duration is
 asserted. ``subprocess.Popen`` / ``subprocess.run``, the ``socket`` module,
-and ``urllib.request.urlopen`` are stubbed, and the spawn body is frozen at the
+and ``loopback_urlopen`` are stubbed, and the spawn body is frozen at the
 ``Popen`` seam with a sentinel exception.
 """
 from __future__ import annotations
@@ -668,7 +668,7 @@ class TestAdoptExistingInstance:
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         port = bmod._MIN_PORT + 6
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         _stub_listeners(
             monkeypatch,
             [
@@ -700,7 +700,7 @@ class TestAdoptExistingInstance:
         to signal.
         """
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         _stub_listeners(
             monkeypatch,
@@ -720,7 +720,7 @@ class TestAdoptExistingInstance:
         v4 owner from an unrelated IPV6_V6ONLY listener sharing its port, and
         the latter never saw the 127.0.0.1 health probe."""
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         _stub_listeners(
             monkeypatch,
@@ -742,7 +742,7 @@ class TestAdoptExistingInstance:
             raise RuntimeError("sel unavailable")
 
         monkeypatch.setattr(bmod, "sel", _boom)
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(333, "127.0.0.1", "4")])
         ap = self._run(bmod._MIN_PORT + 7)
@@ -754,7 +754,7 @@ class TestAdoptExistingInstance:
     ) -> None:
         """Adopting without PIDs would leave a backend we can never stop."""
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         _stub_listeners(monkeypatch, [])
         with caplog.at_level(logging.WARNING):
             assert self._run(bmod._MIN_PORT + 8) is None
@@ -768,7 +768,7 @@ class TestAdoptExistingInstance:
         attributed — adopting the other-address listener would be adopting a
         process that never answered the health check."""
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(999, "192.168.1.5", "4")])
         assert self._run(bmod._MIN_PORT + 9) is None
         assert "adoptee" not in bmod._processes
@@ -780,7 +780,7 @@ class TestAdoptExistingInstance:
         later: stop and uninstall would skip it, leaving a third-party backend
         running after its trust was revoked. Refuse the adoption instead."""
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: None)
         _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")])
         with caplog.at_level(logging.WARNING):
@@ -796,7 +796,7 @@ class TestAdoptExistingInstance:
         bystander (e.g. a coexisting v6-only wildcard) — the re-read owner set
         differs, so adoption is refused instead of recording the bystander."""
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(200))
         monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         seqs = [
             [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")],
@@ -826,7 +826,7 @@ class TestAdoptExistingInstance:
                 return _FakeResp(200)
             raise urllib.error.URLError("gone mid-capture")
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        monkeypatch.setattr(bmod, "loopback_urlopen", _urlopen)
         monkeypatch.setattr(bmod, "_proc_start_time", lambda pid: f"st-{pid}")
         _stub_listeners(monkeypatch, [bmod.platform_compat.PortListener(111, "127.0.0.1", "4")])
         with caplog.at_level(logging.WARNING):
@@ -840,7 +840,7 @@ class TestAdoptExistingInstance:
         def _refused(*_a: Any, **_k: Any) -> Any:
             raise urllib.error.URLError("connection refused")
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", _refused)
+        monkeypatch.setattr(bmod, "loopback_urlopen", _refused)
         with caplog.at_level(logging.WARNING):
             assert self._run(bmod._MIN_PORT + 10) is None
         assert any("occupied by unhealthy process" in r.message for r in caplog.records)
@@ -848,7 +848,7 @@ class TestAdoptExistingInstance:
     def test_an_error_status_counts_as_unhealthy(
         self, occupied: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(503))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(503))
         assert self._run(bmod._MIN_PORT + 11) is None
 
 
@@ -1591,7 +1591,7 @@ class TestHealthCheckLoop:
             attempts["n"] += 1
             return _FakeResp(500)
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        monkeypatch.setattr(bmod, "loopback_urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["sick"] = AppProcess(app_name="sick", port=9134)
         bmod._health_check_loop(bmod._processes.get("sick") or bmod.AppProcess(app_name="sick", port=9134), "/health")
@@ -1616,7 +1616,7 @@ class TestHealthCheckLoop:
                 bmod._processes.pop("racy", None)
             return _FakeResp(200)
 
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        monkeypatch.setattr(bmod, "loopback_urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["racy"] = AppProcess(app_name="racy", port=9135)
         bmod._health_check_loop(bmod._processes.get("racy") or bmod.AppProcess(app_name="racy", port=9135), "/health")
@@ -1887,7 +1887,7 @@ class TestDefensiveBranches:
             raise RuntimeError("sel unavailable")
 
         monkeypatch.setattr(bmod, "sel", _no_sel)
-        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(500))
+        monkeypatch.setattr(bmod, "loopback_urlopen", lambda *_a, **_k: _FakeResp(500))
         monkeypatch.setattr(
             bmod, "popen_limited", lambda *_a, **_k: pytest.fail("spawned onto a taken port")
         )


### PR DESCRIPTION
## Problem / Motivation

#5929 already merged the backend liveness, generation-fencing, locking, retry, and tri-state reconciliation work that this older PR originally carried. One security residual remains absent from `main`: the app-authored `backend.healthCheck` is concatenated into a URL without validation, and the probe uses the ordinary opener.

## Why it matters

A value such as `@example.com/` can move the assembled URL authority away from loopback. The default opener also inherits proxy environment variables and follows redirects. A health check intended only for `127.0.0.1` therefore lacks a firm loopback-only boundary.

## What changed

- Validate `backend.healthCheck` before building a URL, requiring a valid port and an absolute restricted path that cannot move the authority or be silently normalized.
- Route adoption, startup polling, and the standing watch through the same validated `_health_probe` contract.
- Use `loopback_urlopen`, which bypasses proxy environment variables and refuses redirects.
- Fail closed for invalid paths and warn once per distinct value.
- Document the absolute-path and loopback-only contract in the manifest reference and App Kit system specification.

## Scope

This PR does not replay the supervisor or reconciliation state machine from the old branch. The generation, lock, retry, ownership, and tri-state behavior merged in #5929 remains unchanged.

## Tests

- `test/test_app_backend.py` + `test/test_apps_backend_coverage.py`: 272 passed, 9 skipped
- focused health security, adoption/startup/watch, malformed-response, and real proxy/redirect coverage: 50 passed
- isort, flake8, scoped mypy, docs-lint, and `git diff --check`: passed

## Related

The liveness portion of the original change is covered by #5929. This PR is limited to the remaining path-validation and no-proxy/no-redirect security boundary.

## Contribution License Agreement

I agree to the terms of the Contribution License Agreement for this repository.