### PR TITLE
fix(dashboard): keep a link navigable when its label is a code span

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -441,6 +441,22 @@ function slugify(children: React.ReactNode): string | undefined {
   return raw || undefined
 }
 
+/**
+ * True for the markdown subtree rendered INSIDE an anchor's own text.
+ *
+ * `InlineCode` consults it so a code span used as a link label —
+ * ``[`https://example.com/x`](https://example.com/x)`` — stays inert instead of
+ * becoming a click-to-copy chip. The chip's handler calls `preventDefault`, and
+ * that cancels the anchor's default action from anywhere in propagation, so
+ * without this the label copied and the link silently stopped navigating (a
+ * regression from #4433, which gave non-path spans a primary-click copy).
+ *
+ * Provided only where `MdAnchor` places `children` inside an `<a>`. The Jira and
+ * forge chips render a parsed label instead of `children`, and a `LinkOverride`
+ * owns its element outright, so neither needs it.
+ */
+const InsideLinkCtx = createContext(false)
+
 /** Default markdown anchor, unless a `LinkOverrideCtx` provider claims the href.
  *
  * Extracted from the inline `MD_COMPONENTS.a` so it can read context (it is a
@@ -552,7 +568,13 @@ function MdAnchor({ node, href, children }: React.AnchorHTMLAttributes<HTMLAncho
       </span>
     )
   }
-  if (target && meta) return <LinkChip meta={meta} href={target}>{children}</LinkChip>
+  if (target && meta) {
+    return (
+      <LinkChip meta={meta} href={target}>
+        <InsideLinkCtx.Provider value={true}>{children}</InsideLinkCtx.Provider>
+      </LinkChip>
+    )
+  }
   let ext = false
   try { ext = !!href && ALLOWED_PROTOCOLS.has(new URL(href, 'http://x').protocol) } catch { /* not a URL */ }
   return (
@@ -563,7 +585,7 @@ function MdAnchor({ node, href, children }: React.AnchorHTMLAttributes<HTMLAncho
       {...(ext ? {} : { target: '_blank', rel: 'noopener noreferrer' })}
       className="text-accent underline underline-offset-2 decoration-accent/40 hover:decoration-accent"
     >
-      {children}
+      <InsideLinkCtx.Provider value={true}>{children}</InsideLinkCtx.Provider>
     </a>
   )
 }
@@ -742,6 +764,7 @@ function InlineCode({ children, ...props }: { children?: React.ReactNode } & Rec
   const codeStr = String(children).replace(/\n$/, '')
   const probeEnabled = useContext(PathProbeCtx)
   const actions = useContext(PathActionCtx)
+  const insideLink = useContext(InsideLinkCtx)
   const gatewayPlatform = useGatewayPlatform()
   const raw = codeStr.trim()
   const pathResolution = usePathResolution(raw, probeEnabled)
@@ -757,6 +780,10 @@ function InlineCode({ children, ...props }: { children?: React.ReactNode } & Rec
 
   if (pathResolution.probePending
     || (pathResolution.kind !== 'file' && pathResolution.kind !== 'dir')) {
+    // Inside an anchor the link owns the click, so stay the inert span this was
+    // before #4433 rather than cancelling the navigation to copy. Nothing is
+    // lost: the browser's own "Copy link address" still reaches the URL.
+    if (insideLink) return <code className={CHIP_BASE} {...safeProps}>{children}</code>
     return <CopyableCode className={CHIP_BASE} safeProps={safeProps} text={codeStr}>{children}</CopyableCode>
   }
   const isDir = pathResolution.kind === 'dir'

--- a/website/src/test/MarkdownRenderer.inlineCodeInLink.test.tsx
+++ b/website/src/test/MarkdownRenderer.inlineCodeInLink.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import { copyToClipboard } from '../utils/clipboard'
+
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn(async () => undefined) }))
+
+beforeEach(() => { vi.mocked(copyToClipboard).mockClear() })
+
+/** Dispatch a real cancelable click and report whether the default action
+ *  survived. `preventDefault` from ANY listener in propagation cancels an
+ *  anchor's navigation, so this is the mechanism under test — not a spy on
+ *  window.location, which jsdom does not implement. */
+function clickAndReadDefault(el: Element): boolean {
+  const ev = new MouseEvent('click', { bubbles: true, cancelable: true })
+  el.dispatchEvent(ev)
+  return ev.defaultPrevented
+}
+
+describe('inline code used as a link label', () => {
+  it('keeps the anchor navigable instead of copying', async () => {
+    render(<MarkdownRenderer content={'See [`https://example.com/x`](https://example.com/x) now.'} />)
+    const code = await screen.findByText('https://example.com/x')
+
+    expect(code.tagName).toBe('CODE')
+    expect(code.closest('a')).toHaveAttribute('href', 'https://example.com/x')
+
+    // The defect: the span's copy handler called preventDefault, which cancels
+    // the enclosing anchor's navigation from anywhere in propagation.
+    expect(clickAndReadDefault(code)).toBe(false)
+    expect(copyToClipboard).not.toHaveBeenCalled()
+
+    // Not a control either: the anchor owns the click, so the span must not
+    // advertise itself as a button or take the keyboard.
+    expect(code).not.toHaveAttribute('role', 'button')
+    expect(code).not.toHaveAttribute('tabindex')
+  })
+
+  it('still copies a backticked span that is NOT inside a link', async () => {
+    render(<MarkdownRenderer content={'Open `https://example.com/x` now.'} />)
+    const code = await screen.findByText('https://example.com/x')
+
+    expect(code).toHaveAttribute('role', 'button')
+    fireEvent.click(code)
+    expect(copyToClipboard).toHaveBeenCalledWith('https://example.com/x')
+  })
+
+  it('still copies a backticked command in prose', async () => {
+    render(<MarkdownRenderer content={'Run `npm test` please.'} />)
+    const code = await screen.findByText('npm test')
+    fireEvent.click(code)
+    expect(copyToClipboard).toHaveBeenCalledWith('npm test')
+  })
+
+  it('leaves a plain-text link label navigable', async () => {
+    render(<MarkdownRenderer content={'See [the docs](https://example.com/y) now.'} />)
+    const anchor = await screen.findByText('the docs')
+    expect(anchor.tagName).toBe('A')
+    expect(clickAndReadDefault(anchor)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

A markdown link whose label is a **code span** stopped navigating in dashboard
chat. Clicking it copies the label text instead:

```markdown
See [`https://example.com/x`](https://example.com/x) now.
```

`2302c5944` ("feat(dashboard): add click-to-copy for inline code spans", #4433,
2026-08-18) gave every non-path code span a primary-click copy. Before it, the
fall-through element was an inert `<code>`, so the click bubbled to the enclosing
`<a>` and navigated.

Two things this is **not** about, because they look identical in a transcript and
only one of the three forms regressed:

- a backticked URL with **no link** around it copying — that is the intended
  #4364 behaviour, and it is unchanged here;
- a plain-text link label — always navigated, still does.

## Why it matters

Agent output backticks anything that looks like a reference and frequently wraps
it in a link, so this exact form is common in practice. The failure is silent:
the user asked for a navigation and got a clipboard write, with nothing on screen
to say so. It is also an a11y defect — the label renders as
`button` **inside** `link`, an interactive control nested in another one.

## What changed (motivation → approach → change)

**Symptom → cause.** `InlineCode` falls through to `CopyableCode` for any span
the path probe does not confirm as a `file` or `dir`. `CopyableCode`'s handler
calls `e.preventDefault(); e.stopPropagation()` before copying, and
`preventDefault` from *anywhere* in propagation cancels the anchor's default
action. `CopyableCode` has no notion of an ancestor anchor, so nothing guarded
the nested case. This reads as an oversight rather than a decision: #4364
enumerated two constraints (path chips keep their primary click; the chip stays a
breakable inline box) and did not consider a code span used as a link label.

**Approach.** Let the anchor win, and decide it through context rather than the
DOM. `MarkdownRenderer.tsx` already routes every cross-cutting decision this way
(`LinkOverrideCtx`, `LinkUnfurlCtx`, `PathProbeCtx`, `JiraHostsCtx`), so a new
`InsideLinkCtx` follows the existing grain. The alternative — probing with
`closest('a')` — needs a ref and a second render pass to settle, which would make
the first paint of every code span wrong.

**Change.** `InsideLinkCtx` is provided at the two places `MdAnchor` puts
`children` inside an `<a>` (the default anchor and the `LinkChip` unfurl branch),
and `InlineCode` consumes it to restore the pre-#4433 inert `<code>` for exactly
that case. Two branches deliberately get **no** provider: the Jira and forge
chips render a parsed label instead of `children`, and a `LinkOverride` owns its
element outright.

Nothing is lost by going inert inside a link — the browser's own "Copy link
address" still reaches the URL — and the copy chip is untouched everywhere it is
not cannibalising a link.

## Tests

`website/src/test/MarkdownRenderer.inlineCodeInLink.test.tsx` — four tests. They
dispatch a real cancelable `click` and read `event.defaultPrevented`, which is
the actual mechanism, rather than spying on `window.location` (jsdom does not
implement navigation).

| Test | Locks in |
|---|---|
| keeps the anchor navigable instead of copying | the regression: no `preventDefault`, no clipboard write, and the label carries neither `role=button` nor a tabindex |
| still copies a backticked span that is NOT inside a link | the #4364 feature for a bare URL |
| still copies a backticked command in prose | the #4364 feature for ordinary inline code |
| leaves a plain-text link label navigable | that the new context did not break normal anchors |

The first fails on `main` with `expected true to be false`. The other three pass
before the fix — that is what makes them guards rather than decoration.

## Manual verification

Verified in a real browser (Playwright), because jsdom cannot show a tab opening.
The component was mounted on a scratch page (not committed) with all three forms,
and the same click run against both revisions:

| | accessibility tree for form 1 | click on the label |
|---|---|---|
| `main` | `link` → `button "https://example.com/x"` | no new tab; nothing opens |
| this branch | `link` → `code "https://example.com/x"` | new tab opens and loads `https://example.com/x` |

Form 3 (backticked, no link) stayed a `button` in both, confirming the copy chip
survived.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** nothing rendered changes — the label keeps the same tag,
classes, text and inline-box behaviour, and the anchor around it already showed a
pointer cursor; what changes is the element's ARIA role and which handler wins
the click, neither of which a still frame can show. The observable difference is
the before/after tab-open comparison in **Manual verification** above:
`link → button` and no navigation on `main`, versus `link → code` and a real tab
opening on this branch.

## Related Issues

Closes #5730

Not a duplicate of #5729 ("long URLs not clickable") as far as I can tell — same
area, but that one points at the streaming-cut / GFM autolink-tail handling
rather than at `CopyableCode`.

## Out of scope

``[`/path/to/file.ts`](https://github.com/…)`` also swallows its anchor, but that
predates #4433 — the path chip's own handler has always called `preventDefault`
— and is arguably intended, since the primary click opens the local file. Folding
it in would turn a regression fix into a behaviour change, so it is left for a
separate issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe
      this behaviour; the reasoning is captured in a doc comment on
      `InsideLinkCtx`
- [x] No secrets, credentials, or internal references in the diff

Rebased onto `main` at `963cc160c`; one commit, touching two files. The
Bundle Size Gate breach this PR originally tripped was pre-existing catalog drift
on `main` — #5721 has since raised the `all` ceiling to 9200 KB against the same
9103 KB measurement I took, so nothing is needed here and the gate passes on the
rebased branch.

Local gates on this branch: `npx tsc -b` clean; `npx vitest run` green across the
MarkdownRenderer suites (341 tests over 23 files; 988 over all 52
MarkdownRenderer-adjacent files before the rebase);
`node scripts/check-bundle-size.mjs` green after an analyze build (669 chunks
within budget); `eslint` reports one
`jsx-a11y/no-noninteractive-element-to-interactive-role` warning that is
pre-existing (same single warning on a pristine `main` copy of the file, at line
790 before the new doc comment shifted it to 817). Backend gates were not run
locally — the diff touches no Python.

CI has since confirmed both of those local claims on the runners: all four Backend
Tests shards (3.10, 3.12, Windows, namespace sandbox) are green, so the 64 backend
failures I saw locally were indeed this host's symlinked `/home` breaking a
`realpath` assertion; and the Bundle Size Gate is green on #5721's ceiling.
