### PR TITLE
chore(release): rewrite the 0.4.0 changelog and re-stamp 0.4.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,315 +2,131 @@
 
 All notable changes to KiroCrew are documented in this file.
 
-## [0.4.0] — 2026-08-21
+## [0.4.0] — 2026-08-25
 
-The dashboard became a place to work on code rather than only talk about it: real
-side-by-side diffs, an editable file tree, a transcript you can scroll back
-forever, and a terminal and browser that dock where you want them. Underneath,
-Kiro Crew got measurably lighter and stopped guessing about MCP — servers are
-probed instead of assumed, and the panel tells you what is genuinely usable.
-Windows joins macOS and Linux as a first-class target, down to driving native
-desktop applications.
+Windows and Linux stop being second-class: both get signed, self-updating native
+installers, and Windows gains desktop automation and a real resource ceiling.
+Every messaging channel catches up to Slack, three new ones arrive, and secrets
+finally live in an encrypted vault instead of your config file. The dashboard
+turns into a place to edit code, not just discuss it.
 
-### Before you upgrade
+### Windows and Linux become first-class installs
 
-- **The automatic move from `~/.kirocrew` to `~/.kiro/crew` is gone.** An install
-  that never ran that migration must move its data home by hand before upgrading.
-- **Updates follow Stable by default.** An Insider install that never recorded a
-  channel preference moves to Stable; re-opt into Insider from About. This is what
-  keeps a promoted release from drifting its users onto the prerelease lane.
-- **The installer provisions Python with a pinned `uv`** instead of the
-  apt/dnf/yum/mise ladder. Hosts that relied on system packages get a user-owned
-  interpreter beside the data home; set `KIROCREW_PYTHON_DIR` to relocate it.
-- **A self-frozen build is no longer supported.** Use the bundled-interpreter
-  install or the wheel.
-- **The git update lane is gated on how you installed, not just where you are.** A
-  release install launched from inside a clone no longer updates by pulling that
-  clone; use an editable install if you want that path.
-- **The built-in browser is the default.** The browser tool drives the dashboard's
-  own panel; turn it off in Settings → Browser if you depend on `playwright-cli`.
-- **Board view is opt-in.** Enable it explicitly, or the layout shows as a list.
-- **Creating a crew requires choosing an agent template.** A crew without one no
-  longer creates.
-- **An MCP server that declares its own `env` is pooled by default.** Set the
-  env-forwarding option or an absolute command path to keep one unpooled.
-- **Numeric settings are bounds-enforced, and several are now actually read.** The
-  subagent memory floor and the per-kind session counts take effect where they were
-  silently ignored — including a `0` you set to disable the memory gate — fractional
-  container limits are refused, and out-of-range values are clamped. Re-check what
-  you configured.
-- **A path containing an unexpanded `$VAR` is denied, and an app token can no longer
-  flip global auto-approve or resolve an approval.** Adjust any workflow that passed
-  an unexpanded variable inside a path.
-- **The skip-permissions setting must be a real boolean.** A quoted string no longer
-  auto-approves every tool call, and no longer takes effect at all.
-- **Publishing an artifact to a public URL needs an explicit acknowledgement**, and
-  an operator can close the path entirely. If you had already narrowed the allowed
-  destinations, add the AWS web deploy target to keep deploying.
-- **"Run in terminal" sends the command to the terminal dock** instead of
-  transferring it into the chat.
-- **Private Slack channels need the app manifest re-imported.** Update or re-import
-  the manifest, reinstall the app to the workspace, and copy the new bot token.
-- **Explore is sourced from registries only.** Content that came from anywhere else
-  no longer appears there; add it through a registry.
-- **Nightly is no longer a one-click switch on the About page**, and **Apply &
-  Restart has left the overview page** — use the per-server restart or Reload
-  session instead.
-- **Duplicate skill keys are removed.** An edition holding a stored reference to one
-  of them must re-point it at the skill's canonical key.
+- **Signed Windows installer** — Windows ships a signed installer with in-app auto-updates, published on the stable channel alongside macOS and Linux.
+- **Linux deb and rpm packages** — The desktop app installs from `.deb` or `.rpm` with a fixed install path, a desktop entry, and per-format in-app updates. The Linux desktop app needs glibc 2.34 or newer; on an older host use the one-line CLI install.
+- **Computer use on Windows** — Kiro Crew can read and drive native Windows applications through UI Automation, so desktop work is no longer macOS-only.
+- **A resource ceiling for Windows agents** — The Windows agent tree now runs under a Job-object process and memory limit, mirroring the Linux cgroup control that previously had no Windows equivalent.
+- **Provider CLI trust on Windows** — Issue Radar and Code Review Sage now work on Windows, because `gh` and `glab` trust is established by reading ACLs.
+- **Managed Python for old distros** — The installer can provision a pinned interpreter into a user directory with `--managed-python`, which works on hosts whose system Python is too old, and stays on that interpreter across updates.
+- **Bring your existing setup** — First-run setup imports from Gemini CLI and Antigravity, including their MCP servers and workspaces.
+- **Switch Kiro accounts from the CLI** — `kirocrew cloud logout` ends the current sign-in so you can log back in as someone else.
 
-### Work on code in the dashboard
+### Every messaging channel catches up, and three new ones arrive
 
-- **Side-by-side diffs, inline editing, and a project file tree** — review and edit
-  a change where you are already talking about it, instead of leaving for an editor.
-- **The transcript scrolls back forever** — reaching the top loads older messages
-  instead of stopping at the window the session opened with.
-- **Reasoning streams as it happens** — the collapsed thinking row shows the model's
-  reasoning live, one block per burst rather than a whole turn flattened into one,
-  and the blocks survive a tab switch.
-- **Pinned messages get their own side-panel tab** instead of stacking up in the
-  conversation.
-- **Click an inline code span to copy it.**
-- **A command launcher** — an opt-in quick-search gesture opens a launcher whose
-  rows say what kind of thing each one is.
-- **Design Tweak** — click an element on a rendered page and edit it visually
-  instead of describing the change you want.
-- **A local Markdown link opens in the side panel** rather than failing.
+- **WhatsApp** — A new channel links a personal account by QR code, with tool approvals answered by typing a number.
+- **iMessage** — A new channel routes through your own Messages.app via a local bridge on macOS, deny-by-default with an explicit handle allowlist.
+- **Feishu** — A native Feishu (Lark / 飞书) channel joins the roster.
+- **Teams, Telegram, and Webex reach parity with Slack** — Each gains the same commands and capabilities, and Webex adds group spaces, file uploads, and Adaptive Cards. Shared fixes along the way mean `/yolo` and per-session Trust now actually take effect on Teams, Webex, WeCom, WeChat, and iMessage, where they were silently inert.
+- **Discord gets a command menu** — Nine slash commands, a model picker, runtime stats, ephemeral replies, and cron delivery, with rate limiting so bursts stop dropping. Images an agent produces upload as real attachments instead of appearing as a filesystem path.
+- **Tables survive the trip** — Markdown tables in a reply are re-rendered to fit each channel's formatting instead of arriving broken.
 
-### Sessions that keep up
+### Secrets leave your config file
 
-- **Reload a session in place** — relaunch its agent to pick up new MCP servers or
-  a config change without restarting the gateway or losing the conversation.
-- **Search across every connected instance** from one box, and **find a chat by its
-  PR, MR, or issue number**.
-- **Filter the session list by tag**, and give a session **any colour you like**
-  rather than one of seven.
-- **Search inside a folder tab recursively** — nested files are found, not just the
-  folder's top level.
-- **The model footer says when "auto" chose** — you can see which model actually
-  served the turn and that it was picked for you.
-- **Crew Mode is labelled experimental** in the create menu, so its stability is
-  clear before you pick it.
-- **The summary panel bounds its height** and keeps more history within raised
-  limits, and the session-pulse survey is back with consent and scope safeguards.
-- **The "+N" source-link chip expands**, so you can open every linked source.
+- **An encrypted vault** — Secrets are stored encrypted and can be withheld from agents on a denylist, managed from a new Settings → Secrets page where values stay masked and are never sent to the browser.
+- **Reference secrets from MCP servers** — An MCP server's environment can name a secret as `secret://NAME`, resolved from the vault at spawn time so the value never sits in on-disk config.
+- **Share pooled servers safely** — An operator can declare which environment keys carry per-session identity, which lets MCP servers that use per-session credentials be pooled instead of relaunched.
+- **Read what is blocked** — `kirocrew policy show` prints the built-in denied-command rules grouped by category, so the agent can read the list instead of discovering it by refusal.
 
-### Reach it from more places
+### The dashboard becomes a place to edit code
 
-- **Computer use on Windows** — drive native Windows desktop applications through
-  the accessibility layer, not only macOS.
-- **Windows publishes on the Stable channel** with its updater enabled, and a
-  spawned agent tree is bounded by a real resource ceiling there.
-- **Native `.deb` and `.rpm` packages**, each with its own update lane.
-- **Import from Gemini CLI and Antigravity** during first-run setup.
-- **Switch Kiro accounts from the CLI**, and **open the dashboard login from
-  Telegram** for signing in on a phone.
-- **The installer remembers your managed-Python choice**, and Doctor now warns when
-  a source checkout is stale or on the wrong branch.
-- **A managed deployment can supply its own update provider**, pointing self-update
-  at an internal source.
+- **Real diffs and inline editing** — Side-by-side diff rendering, per-file editing inside the transcript, and a project file tree in the side panel.
+- **Tool edits are visible by default** — A file edit made by a tool renders as an always-visible diff card instead of hiding inside collapsed tool details.
+- **Many more file types preview inline** — Video and audio play in place, XLSX spreadsheets render with sheet tabs, and notebook previews show embedded images, highlighted code, and Mermaid diagrams.
+- **Find and attach files faster** — Folder tabs gain recursive search, right-clicking any file or folder adds it to chat as an @-mention, and you can drop files anywhere on the chat pane.
+- **A command bar** — A launcher opens by keystroke and names each row's kind, replacing a full-corpus scan on every keypress. It ships on by default.
+- **Live reasoning** — The model's reasoning streams on the collapsed thinking row instead of showing a static label.
+- **A terminal dock for the whole app** — The terminal is an app-wide dock tab rather than living inside one chat, and its font comes from a searchable, previewed picker that detects your local fonts.
+- **The footer names who chose the model** — Left on auto, the turn footer says which model auto actually picked.
+- **Choose which browser the agent drives** — A Settings toggle picks the built-in panel, falling back to playwright-cli (desktop app only).
 
-### MCP and tools stop guessing
+### Sessions you can find, organize, and hand off
 
-- **Measure every MCP server's shareability on purpose** — one labelled action that
-  names how much is left and runs the whole fleet as a background pass, instead of
-  an icon that quietly did two at a time. The probe now compares tool lists as well
-  as capabilities, and records the version a server reported, so a
-  `@latest`-style launch that changes upstream is re-measured rather than trusted.
-- **A server that would degrade is no longer silently downgraded** — opted-in
-  servers stop falling back to an unpooled backend behind your back, and the warning
-  names the fix.
-- **The Online badge means the tools are usable**, and says when it was checked,
-  instead of presenting a stale reading as current.
-- **Apply & Restart actually mounts a newly installed server** — and says so
-  honestly when it could not, rather than skipping the change or reporting success.
-- **Two servers can expose the same tool name** — the collision resolves through
-  registry aliases instead of one of them losing.
-- **A server that declares its own PATH keeps the inherited one too**, and every
-  configuration surface expands it the same way, so a server can no longer work
-  under one consumer and fail under another.
-- **A guided five-whys mode** drives structured root-cause research step by step.
-- **Choose whether the browser tool drives the native panel** or falls back to
-  `playwright-cli`.
+- **Search every instance at once** — Session search spans all connected gateways and interleaves local and remote results.
+- **Search by PR or issue number** — A query like `4411`, `/pull/4411`, or `owner/repo#4411` all find the same session.
+- **Scroll back through history** — Reaching the top of a long transcript loads older turns instead of stopping.
+- **Organize how you like** — Filter by tag, assign any custom hex colour, pin crews as chips, and jump past the ninth session with keyboard letters shown on each row.
+- **Apps can file their own work** — An app can create, rename, and reparent chat folders it owns; deleting a folder stays yours alone.
+- **Reload without losing the thread** — A Reload action relaunches the agent process in place so newly added MCP servers and config take effect while the conversation survives.
+- **Hand work between sessions** — An opt-in dashboard MCP set lets one session message, stop, and read another to pass work along with its context, deny-by-default and gateway-key authorized.
+- **Drop a note without spending a turn** — A note appears in the transcript and reaches the agent on your next message, costing no model call.
+- **See every linked item** — The sidebar's "+N" source-link chip expands to list every linked pull request and issue.
+- **The summary panel stays bounded** — It caps its height and raises its storage rails, so a long summary no longer takes over the panel.
+- **Subagents share one ceiling** — Concurrent subagents count against a single memory and process ceiling, so many small spawns cannot exhaust the host between them.
+- **Task Runner shows its trust state** — The compose panel gains an auto-approve checkbox and a badge naming the trust state before you run.
 
-### Autonomy with a ceiling
+### Apps you can install, pin, and build on
 
-- **Concurrent subagents share one memory and process ceiling**, so many small
-  spawns can no longer add up past what the host has.
-- **A monitoring loop stops itself when it stops making progress** instead of
-  running to its cycle cap.
-- **Hooks match by regex or substring** and can inject a skill declaratively, and a
-  Stop hook that blocks now continues the turn with its feedback instead of halting.
-- **Toggle auto-approve for the task runner from its compose panel**, without
-  leaving the view.
-- **The crew editor shows what wakes each crew.**
+- **Install from the official catalog at a pinned commit** — A catalog app installs directly at its pinned revision, so an app can reach you without waiting for a release.
+- **Pin your organization's own registry** — A deployment can pin its own app registry and mark it owner-trusted, so its apps clone with credentials from a private forge.
+- **Design Tweak** — Point at a local web project, right-click an element in the preview, describe the change, and it lands in a per-project chat session.
+- **A Kanban task board** — A one-sentence intent becomes a runnable card that executes in a linked dashboard chat session, and columns can derive from live session state so cards move as the agent's state changes.
+- **Auto-Triage Pipeline** — A built-in app showing every crew work item's phase and how long it has been stuck.
+- **Issue Radar grows** — Azure DevOps repositories and work items join GitHub and GitLab, with dependency edges, an unblocked-dependency signal, and a Focus Tree graph. Investigations now lead with a plain explanation of the issue before the verdict, written in your dashboard language.
+- **External registries appear when the catalog is online** — The store lists apps from registries beyond the bundled catalog.
+- **Each app has its own icon** — Channels, Dev Fleet, and Workflows drop the generic placeholder.
+- **Crew Mode is labelled experimental** — The create menu says so rather than presenting it as settled.
 
-### Memory, knowledge, and secrets
+### MCP servers stop guessing
 
-- **An encrypted secrets vault** — store a credential where the agent is denied from
-  reading it.
-- **Scope a lesson to one repository**, so it applies only where it belongs.
-- **Filter the knowledge graph by source** to look at one origin at a time.
-- **A notebook can sync itself** on an interval you choose, in the background.
-- **Read the memory layer from the command line**, not only the dashboard.
-- **A lesson embedded by an older model is no longer deleted as a duplicate** or
-  offered to you as a false contradiction.
+- **Measure shareability on purpose** — A Measure action assesses whether a server can safely share a process, comparing tool sets rather than only capabilities, and remembers the verdict. MCP Management adds a read-only view of each server's evidence tier and current run mode.
+- **The Online badge means the tools are usable** — It says when it was last checked instead of presenting a stale reading as current.
+- **Apply & Restart actually mounts a newly installed server** — and says so honestly when it could not, rather than skipping the change or reporting success.
+- **Colliding tool names stay reachable** — Registry aliases keep tools from two servers that ship the same name, such as Linear and Vercel and GitHub, both usable.
 
-### Apps and the store
+### Memory, knowledge, and skills
 
-- **Install what the official catalog lists**, each app pinned to a vetted commit.
-- **A managed deployment can pin its own registry** and assign trust tiers to the
-  apps it serves.
-- **External registries appear in the store when the catalog is online** — a
-  configured registry's apps were previously visible only offline.
-- **Issue Radar** — edit an issue's assignees from the detail pane, and its
-  Investigate, Review, summary and label agents write in your dashboard language.
-- **Notes** — mermaid diagrams and images render in the preview, fenced code blocks
-  are syntax-coloured, and headings follow a clearer ramp.
-- **Channels, Dev Fleet, and Workflows each have their own icon.**
+- **Scope a lesson to one repository** — A lesson no longer has to apply to every session, and the scope option that previously did nothing now works.
+- **Tune how memories age** — Episodic memory decay is configurable per tag, so different kinds of memory fade at different speeds.
+- **Search one knowledge source** — Knowledge search takes a source filter with source discovery, and the graph view gains a source dropdown, physics layout, community clustering, and adjustable depth.
+- **Project-local skills** — Kiro Crew can load a project's own skills, gated behind per-directory consent.
+- **Hooks explain themselves** — Hooks gain regex and contains matcher modes plus declarative skill injection, and the UI shows why a hook last failed as a badge tooltip.
+- **A guided five-whys mode** — A built-in skill walks a dive-deep investigation one question at a time and folds the log into a report.
 
-### Voice, terminal, and files
+### Voice, themes, and accessibility
 
-- **Local speech-to-text with Parakeet**, alongside the existing engines.
-- **Choose the terminal's font** from a searchable list, and **stop voice read-back
-  with Escape** instead of waiting it out.
-- **A terminal dock for the whole app** receives "Run in terminal" output.
-- **Spreadsheets open inline** with sheet tabs and headers, and **video and audio
-  play inline** with seeking, instead of a download card or garbled binary.
-
-### Security and governance
-
-- **`kirocrew policy show` prints the 139 built-in denied-command rules**, grouped by
-  category, so the agent can read what is blocked instead of discovering it by
-  refusal.
-- **A managed deployment can close external access** — the skill and MCP registries
-  and cloud provisioning are no longer offered unconditionally.
-- **An operator policy can declare a fallback looser than deny-all**, instead of
-  being forced to block everything.
-- **The skill auto-approve grant is visible and controllable** from the review panel
-  and its notification.
-- **The agents configuration directory is write-protected**, so an agent cannot
-  plant an unsandboxed backend there.
+- **Faster local speech-to-text** — A Parakeet provider runs locally on Apple Silicon, faster than Whisper.
+- **Stop the read-back** — Escape stops the assistant speaking.
+- **OpenDyslexic** — Available as a built-in font family, with a matching monospace face for code and diffs.
 
 ### Faster and lighter
 
-- **CLI startup: 1.3s and 112 MB of imports down to 0.5s and 54 MB** — about 0.8s
-  and 58 MB saved for every MCP stdio server as well, which is per server, per
-  session.
-- **Computer use costs nothing when it is off** — no ~109 MB backend per chat when
-  it is disabled or unsupported. One Linux host was carrying 16 of them, 1.75 GB.
-- **The browser baseline installs Chromium only**, not every engine.
-- **Chat turns no longer queue behind subagent cost sampling**, which moved off the
-  main loop.
-- **Leaks closed**: an orphaned MCP gateway daemon self-exits instead of staying
-  resident at ~27 MB, removing a Dev Fleet worktree reclaims its ~0.6 GB pod home,
-  and the one-time config migration stops littering backup files — one host had
-  reached 72,327 of them.
+- **Boot uses ~875MB less memory** — The embedding model is no longer loaded at startup when there is no embedding work to do; it loads on first real use.
+- **The bytecode cache stops growing without bound** — It had been reaching tens of gigabytes; foreign Python processes no longer mirror their standard library under the Crew home, and the gateway prunes its own cache.
+- **The dashboard opens immediately** — Boot prints the URL and opens the browser without waiting on MCP probing, and probes each server once instead of twice.
+- **Sandboxed spawns are ~1.45s faster each** — A needless credential and hardlink scan on every sandboxed spawn is gone.
+- **Graphs and grids load instantly** — The Issue Radar dependency graph serves from cache and refreshes in the background instead of blocking its tab for about eleven seconds, and the multi-session grid loads a bounded slice of each pane instead of full history.
+- **Long chats stop leaking** — An abandoned streamed turn no longer holds its entire token stream for the life of the process.
+- **CLI commands start more than twice as fast** — `kirocrew` startup drops from 1.3s and 112 MB of imports to 0.5s and 54 MB.
 
 ### Notable fixes
 
-**Chat transcript correctness** — Sending several messages quickly no longer
-produces duplicate bubbles or strands a half-sent row, and switching sessions
-cancels an in-flight history load so an old conversation cannot land in the one you
-just opened. Steering mid-turn keeps reasoning above the answer, text that merely
-looks like a tag renders as the characters you typed, the rename box stays attached
-to the session you opened it on, and the composer reliably takes focus.
+**Reliability of the gateway itself.** A slow filesystem used to take the whole gateway down: the sidebar's pull-request status refresh resolved `gh` and `glab` on the event loop, and once those syscalls turned slow the loop stopped serving everything, heartbeat included, until the watchdog killed the process — one host took three such kills in fourteen hours, each ending every live chat session. That walk is now offloaded, as are vector-store initialization, per-agent tool filtering, audit-log reads, session teardown, and knowledge folder-watcher flushes, so a slow disk costs one widget its latency instead of the process.
 
-**Session list ordering and freshness** — The list ranks by when a conversation
-actually settled rather than reshuffling on every streamed line, so a session you
-are watching stays where you expect and a running turn stays near the top. Digit
-shortcuts jump in the order the sidebar shows and hold that order while the modifier
-is down, your open tabs no longer clutter the older-sessions list, and the
-capabilities roster stops blinking empty while it refreshes. History also stops
-serving a stale view after a rename, and duplicate saved messages and leftover
-streamed fragments are cleaned up rather than accumulating.
+**Chat and the transcript.** Transcript cards line up with the rows around them instead of sitting inset and narrower in one pane and flush to the edge in another. Lists keep their contents while refreshing rather than flashing empty on every live update. Composing in a non-Latin input method no longer submits mid-composition across the surfaces where Enter, Tab, and Escape are handled, and the folder-suggestion prompt names the folder it is asking about.
 
-**Staying up under stress** — A partial or malformed status update no longer takes
-the dashboard down with it. MCP servers start even when a worker is still booting, a
-backend that wedges on its first handshake is replaced instead of hanging forever,
-and flipping one server's switch no longer rebuilds the entire broker. A slow probe
-stops greying out the Continue button, a scheduled turn resumes after a transient
-hiccup rather than stalling silently, ineffective auto-compaction backs off instead
-of firing repeatedly, and orphaned agent processes are reaped even when their parent
-was re-parented.
+**Sessions, history, and search.** Reopening an unchanged history costs a stat instead of a full re-read, saving history updates the index in place, and an auto-compaction that frees no headroom stops immediately re-triggering and burning summaries. A session dropped onto its own pane keeps its own copy, and the header rename editor stays pinned to the session it opened on.
 
-**Scheduling and background jobs** — A recurring job's next run is scheduled the
-moment the previous one finishes instead of waiting for the next sweep, so it fires
-on time rather than up to half a minute late. A command job clears its last result on
-every exit path, one malformed stored entry no longer takes your other jobs down
-with it, and in the jobs table the message column keeps its width while the actions
-column stays pinned as you scroll.
+**Cron and tasks.** A job's timeout is charged to its execution rather than to time spent waiting in a queue, so a busy pool no longer kills jobs before they start and one-shots that never dispatched are not deleted. Deleting a single job is recorded in the audit log from the dashboard, MCP, and CLI alike, and the Schedule page shows which session owns a job so you can tell why its results are not arriving in chat.
 
-**Security and credential handling** — A credential path can no longer be respelled
-past the guard through a shell variable or a directory change, command boundaries
-respect quoted and escaped separators so a disguised second command is caught, and
-appending `--help` no longer runs a command without its approval prompt. A generated
-skill cannot slip code past the validator, a file read cannot climb out of the
-sandbox, and a busy temp directory or a stray thread no longer quietly turns
-isolation off. A corrupted Slack configuration fails closed instead of reopening the
-enterprise allowlist, changing one session's mode no longer revokes your
-workspace-wide auto-approve grant, per-host integration tokens are stored on a
-hardened path, the internal API credential is bound to the port it protects, and the
-security panel distinguishes an unusable profile from a deliberate lockdown. A batch
-of externally reported disclosure findings is closed.
+**Subagents and long-running loops.** Monitoring loops stop when they detect no progress instead of running to their cycle cap, and durable working state on disk keeps per-cycle cost from growing and survives compaction. Each spawned agent gets its own scratch directory, and completion cards name the model a run actually used so a downgrade from a requested pin is visible.
 
-**Windows, installs, and international input** — The desktop gateway recovers its
-ports after a restart and the launcher survives the install being moved. A failed app
-clone's partial checkout is actually removed, Windows absolute paths are accepted
-where they used to be rejected, renaming agent configuration retries through a
-file-sharing conflict, and uninstalling reclaims the update cache. The app refuses to
-launch from a half-extracted backend rather than starting broken, rebuilding an
-environment relinks its interpreter, an update shows an installing overlay and resets
-cleanly when aborted, and small macOS icons render instead of coming up blank.
-Pressing Enter to choose a candidate while composing Chinese, Japanese, or Korean no
-longer sends the message.
+**Approvals, security, and the sandbox.** Several approval-gate and validator bypasses are closed, including a forged flag that could create a git ref and a credential-directory read that auto-approved itself. Two long commands sharing a prefix no longer collapse into one trust label, and the full command is available on hover. Snapshot and restore are hardened against symlink and hardlink attacks, and a partial restore no longer reports success.
 
-**Messaging and connectors** — Markdown images survive into Slack instead of turning
-into broken links, replies route to the correct thread, automatic thread titling
-recovers instead of silently breaking, and Discord is told when a resumed session
-loses its binding. A server name containing a colon is accepted, the pre-resolve
-check no longer reports a false all-clear, content that should be shareable is not
-wrongly refused, tools can reach a gateway on a non-default port, and "auto" falls
-back to a model that works on GovCloud.
+**Windows and the desktop app.** Settings survive the package rename instead of silently resetting, a failed app clone actually removes its partial checkout, and starting a task no longer briefly freezes while the memory store initializes. Signing runs once per artifact rather than twice, shortening builds.
 
-**Interface polish and accessibility** — The keyboard focus ring is back and appears
-only when you are actually navigating by keyboard, the notification badge is no
-longer clipped, and notification text stays legible over a busy background. Meter
-numbers stay readable against their bar, project and activity lists hold a stable
-newest-first order when timestamps tie so rows stop shuffling, sidebar labels show
-the right relative day, and a long subagent digest stays inside its card. Animations
-that were silently dead now play, a destructive button shows its colour on a touch
-device and an armed Delete explains itself, the paste preview is reachable by
-keyboard and screen reader, and builtin app pages start their content at the same
-distance from a phone edge as the core pages do.
+**Updates and install.** `kirocrew update` refuses to discard local commits on a diverged checkout and tells you how to override it. `kirocrew doctor` gained a stored-defaults view, detection of agent specs pointing at removed virtualenvs or relocated tools with repair for managed ones, and a warning when an editable-install checkout is stale or on the wrong branch.
 
-**Clearer messages when something goes wrong** — A denied file send gives the real
-reason, a rejected connection names the setting to fix, and a session that stalls on
-startup names which servers reported, which failed and why, and which are waiting for
-authorization. A rejected credential is reported as an authentication failure rather
-than a backend outage, switching accounts mid-session offers a way out instead of a
-raw token error, a failed subagent keeps its error type and request id, background
-cleanup that fails surfaces a warning and a count, and a subagent result is reported
-with a path you can open. The Publish panel reports what actually happened, the top
-bar tells a warming-up credit balance apart from one that failed to load, and an
-over-long question refusal quotes a limit that is true for the script you are
-writing in.
-
-### Contributors
-
-59 people wrote the code in this release. Thank you:
-
-@adiarora06, @amadsalmon, @anant-kaushik, @andreyaurelien, @aniketshukla1,
-@atomsbaza, @bolichen97, @buluoray, @cabbey, @chenmingwei23, @chuqijiang2026,
-@cixuuz, @coozgan, @CrysisDeu, @DeryFerd, @dwu96, @dwzhangx, @el-pedrito,
-@gbrunoo, @greysonevins, @gspivey, @iamwhatever, @isotope14, @jeeshofone,
-@josej4m, @kaizawa97, @konippi, @krishdhasmana, @kyleseaman, @leeclarkuk,
-@leonlaiyc, @leozhad, @LeTeutz, @logesh4v, @LucaButBoring, @Luccas-carvalho,
-@mcryan77, @miamanav, @michellemxm, @NicholasRBowers, @patrigao, @pepmach,
-@pkot1980, @Premshay, @rnoack1, @RohanK6, @rubencu, @SebastianYuSun,
-@severity1, @ShotaroKataoka, @shrihan-vijay, @srinivasrk, @tjdwlsdlaek,
-@tlobinger, @unstablebrainiac, @veerjain-1, @Xianwen-Peng, @xuejinT, @zakil-02.
-
+**Localization.** Product names stay in English across every locale and are interpolated through a shared placeholder, so the application name renders consistently, and a CI gate now flags catalog entries left untranslated.
 
 ## [0.3.0] — 2026-08-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.5.0"
+version = "0.4.0-rc.9"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.5.0"
+__version__ = "0.4.0-rc.9"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.5.0",
+  "version": "0.4.0-rc.9",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
Rewrites the `[0.4.0]` changelog section from a full audit of the release range, and re-stamps the three version declaration files that the branch's move onto `main` reset.

## This edits a shipped section, deliberately

**Declared up front, because the gate asks for exactly that.** `scripts/check_changelog_history.py` treats any section present at the base ref as immutable — there is no unreleased exemption, and its own docstring records that an earlier "newest section at base" exemption was removed. So this change **will fail `Changelog History Gate`**, and that is understood rather than discovered: the gate is doing its job, and merging needs a human to accept the edit.

Context for that decision: **0.4.0 has not shipped.** The only tags are `v0.4.0-insider.1` through `.8`, and `src/kiro_crew/changelog.py` folds every prerelease onto its base version's single heading, so this is the release's own notes being finalized rather than a past release's record being altered.

**Earlier sections are untouched, and that is verified rather than asserted.** `[0.3.0]` onward and the file header are byte-identical to the previous branch tip — md5 of the extracted `[0.3.0]`-onward region matches on both sides — and every diff hunk falls inside the old `[0.4.0]` region. This file was destroyed once by a commit that replaced it instead of prepending, so the check is explicit.

## Correcting two claims from the first revision of this description

The first version of this PR body said the replaced section had been "assembled by appending a line per merged pull request" and "named none of the withdrawn capabilities." **Both were wrong**, and the First Principles lane was right to say so.

The base section already carries the documented shape — theme paragraph, grouped subsections, prose fixes tail — and it opened with 17 upgrade-warning bullets. The real problem is narrower and more defensible: **it is stale, not malformed.** It was written against roughly 453 commits; the range from 0.3.0 to this branch tip is now 918. Surfaces that landed since had no line at all — three new messaging channels, the secrets vault, Azure DevOps in Issue Radar, Windows desktop automation, the app-wide terminal dock.

The first revision also said no mechanical gate blocked this. That was wrong too: the gate exists and is wired into `ci.yml`. Both errors came from reasoning off a stale reading instead of checking, and both are corrected here.

## Method

Audited **every commit** in `merge-base(v0.3.0, main)..94bfee7a5` — 918 commits — reading bodies, and diffs where a body was insufficient. Each was classified as a new capability, a perceptible performance change, a user-visible fix, or internal. Coverage was reconciled against the commit list rather than trusted: 903 were accounted for by the audit passes and the remaining 15 classified by hand, so the range is fully covered with none double-counted.

The structural reason this needs reading rather than scanning, and it will recur: **this repository never self-declares a behaviour change.** Zero `feat!:`/`fix!:` markers and zero `BREAKING CHANGE:` trailers exist in the entire range, so a removal or a changed default is always disguised — usually as `refactor:` or `chore:`, sometimes as `fix:` — and only the body admits it.

Examples of what that surfaced:

- One `feat` removed `monaco-editor` from the dependency tree and re-platformed chat diffs, the file viewer, and the Papyrus editor onto Pierre.
- A routine-looking `fix(security)` closed seven coordinated-disclosure findings, breaking two credential-exfiltration chains.
- A commit reading as test hygiene also cut ~1.45s off *every* sandboxed spawn.
- A `fix` reading as a sidebar tweak is the gateway-wide reliability fix now leading the fixes section: resolving `gh`/`glab` on the event loop meant a slow filesystem took the whole process down, and one host was killed by the watchdog three times in fourteen hours.
- Conversely, a commit labelled `feat(messaging)` landed with **zero production callers**, so it is deliberately not credited as shipped.
- The ACP-over-KAS feature and its revert are **both** inside this range, so they net to nothing and are correctly absent rather than advertised or mourned.

## Coverage against the previous section

A first pass compressed too hard and dropped 18 real entries. Every bullet of the previous section was then checked one by one and the non-upgrade ones restored: CLI startup time (1.3s/112 MB → 0.5s/54 MB), the app-wide terminal dock and font picker, MCP shareability measurement, the Online badge, Apply & Restart, colliding tool-name aliases, the five-whys skill, the Gemini CLI / Antigravity import, `kirocrew cloud logout`, `kirocrew policy show`, the source-link chip, the summary-panel bounds, the shared subagent ceiling, the Task Runner trust badge, external registries, per-app icons, and the Crew Mode experimental label.

Net **+116 / −300**: 126 lines against the previous 310, while covering roughly twice the commit range.

## Two blocks deliberately not carried over

On the maintainer's instruction, the leading upgrade-warning list and the trailing contributor credits are **not** in the new section. That is a decision about what these notes are for, not an oversight, and it is the reason the five review lanes object — each of them names one or both. Three items in particular now have no reader-facing home and may be surfaced elsewhere (GitHub Release notes or docs): the removed `~/.kirocrew` home migration, `kirocrew update` refusing a diverged checkout, and channel-preference-less installs being moved once to Stable.

## Version re-stamp

Moving this branch onto `main` made it inherit `main`'s next-minor stamp, so all three declaration files read `0.5.0`. They are re-stamped to `0.4.0-rc.9`. The spelling is valid as both PEP 440 (normalizing to `0.4.0rc9`) and semver, so one string serves `src/kiro_crew/__init__.py`, `pyproject.toml`, and `website/electron/package.json`. A tag overrides this at build time; the stamp governs nightly and source installs.

Two things left alone on purpose: `website/electron/package-lock.json` carries root `version: 0.4.0` while `main`'s `package.json` says `0.5.0` — pre-existing drift that nothing pins. And existing 0.4.0 tags all use `-insider.N` while this stamp uses `-rc.N`; `release.md` prefers one spelling per base version, and no number collides today, though a future `v0.4.0-insider.9` and `v0.4.0-rc.9` would both map to wheel `0.4.0rc9`.

## Verification

- Earlier-section integrity — md5 match on `[0.3.0]`-onward and on the header; all hunks inside the old `[0.4.0]` region.
- The product's own parser reads 5 sections with `0.4.0 — 2026-08-25` first and no prerelease headings.
- Changelog tests 46 pass; version-contract tests 83 pass; brand-name gate and `docs-lint.sh` clean.
- `check_changelog_history.py --test` self-test passes (20 probes); the enforced run against the PR base fails by design, as described above.
