### PR TITLE
feat: let a caller ask for a conversation reset that actually starts empty

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -341,6 +341,36 @@ about. The only reachable way to break the link was `DELETE /api/sessions/{key}`
 which destroys the record in order to reset the pointer — so "start over" and
 "erase this" were the same button.
 
+**`replay` is what the caller means by "fresh", and it has to be asked for.**
+Clearing the sid stops the provider resuming its own conversation — and "the
+provider has no history" is precisely the condition that makes the next cold
+start rebuild one from `conversation_log` as a `[CONVERSATION HISTORY]` block
+(`chat_runner`, injected OUTSIDE the capped session context). So the two
+mechanisms work against each other by construction: the caller discards the
+conversation and the next turn is handed a reconstruction of it. Measured on one
+app-owned session, that replay was 80,359 characters — 76% of the first turn's
+injected context, and most of what discarding the conversation was meant to
+reclaim. `discard_conversation(key, replay=False)` records a ONE-SHOT
+suppression, consumed at the replay gate inside the cold-start branch so a warm
+turn cannot spend it, and the route threads it from an optional `replay` field on
+the request body. The default is `True`, which keeps every existing caller and
+the dashboard's own copy ("Conversation history is preserved — your next message
+starts a fresh process") true. Only the RE-INJECTION is suppressed: the
+transcript is untouched, so the conversation stays readable in the dashboard and
+on disk.
+
+The flag cannot live on the session object the way `needs_context_reinjection`
+does, because `discard_conversation` POPS that session — the decision is made by
+the turn that tears the conversation down and acted on by the next turn, which
+builds a new one. It is therefore a manager-level set, process-scoped on purpose:
+a gateway restart also cold-starts the session, but there the replay is
+legitimate, since nobody asked for a fresh conversation and re-anchoring is what
+that surface has always done. Every teardown path that already clears the
+compaction cooldown clears it too (`reset`, `remove`,
+`retire_kiro_identity_sessions`, `remove_if_unclaimed`, `destroy`, and
+`close_all`), because slot keys ARE reused and a leaked flag would starve the
+NEXT holder of that key of its re-anchor.
+
 Three properties the route holds, each of which fails silently if broken:
 
 - The key comes from `effective_session_key(slot)`, never a derived

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3216,6 +3216,25 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     if denied is not None:
         return denied
 
+    # Read the body HERE — after authorization, before the busy guards. Reading it
+    # is an await the CLIENT controls the duration of, and every guard below
+    # protects work that can START during a suspension: a turn admitted after
+    # ``has_active_turn()`` answered False is torn down mid-write by the discard.
+    # Parsing after the guards would widen that window from one event-loop hop to
+    # however long a slow body takes to arrive. The guards must be the last thing
+    # that happens before the teardown.
+    #
+    # A malformed or absent body is not an error. This route took no body before,
+    # so refusing one would break every existing caller for a parameter they do
+    # not send.
+    replay = True
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if isinstance(body, dict) and "replay" in body:
+        replay = bool(body.get("replay"))
+
     # A turn in flight on the SESSION, which ``slot.running`` cannot see: that
     # flag tracks this slot's own task, while an inbound channel message runs a
     # turn on the linked session with no dashboard task at all. Tearing the
@@ -3253,14 +3272,14 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     if attached is not None:
         return attached
 
-    await state.sessions.discard_conversation(key)
+    await state.sessions.discard_conversation(key, replay=replay)
     sel().log_api_access(
         caller=request.get("app", "") or "dashboard",
         operation="slot_reset_conversation",
         outcome="completed",
-        resources=f"slot={name}",
+        resources=f"slot={name} replay={replay}",
     )
-    return web.json_response({"slot": name, "reset": True})
+    return web.json_response({"slot": name, "reset": True, "replay": replay})
 
 
 async def api_chat_slot_delete(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5648,33 +5648,43 @@ async def _run_chat(
                 if isinstance(client, AcpProvider) and client.client.resumed:
                     _provider_has_history = True
             if is_new and not _provider_has_history and state.context_builder.conversation_log:
-                from kiro_crew.context import (  # circular: context -> chat
-                    build_session_replay,
-                    window_for_provider_client,
-                )
+                # Consumed HERE rather than before the branch, so only a real cold
+                # start can spend the flag: a warm turn that never rebuilds history
+                # must not burn the one chance the reset asked for.
+                if state.sessions.consume_replay_suppression(session_key):
+                    logger.info(
+                        "Session replay suppressed by an explicit conversation reset: %s",
+                        session_key,
+                    )
+                    compressed = None
+                else:
+                    from kiro_crew.context import (  # circular: context -> chat
+                        build_session_replay,
+                        window_for_provider_client,
+                    )
 
-                # drop the just-flushed current-turn user message
-                # from replay. chat_handlers.py:146 (or queue dequeue at L1898)
-                # always appended exactly one message before _run_chat fires,
-                # and the periodic flush_loop may have already written it to
-                # disk during the kiro-cli cold spawn (~5s flush vs ≥15s spawn).
-                # Scale the replay budget to the model window (client is live here).
-                # Offloaded: resolving this chat's tab id globs and opens every
-                # session file sharing it to rebuild an index, then reads each
-                # chained file in full — unbounded file IO on the hottest path in
-                # the gateway, where it would block every other request.
-                compressed = await asyncio.to_thread(
-                    build_session_replay,
-                    state.context_builder.conversation_log,
-                    session_key,
-                    exclude_last_n=1,
-                    model_window=window_for_provider_client(client),
-                )
-                logger.info(
-                    "Session replay: key=%s result=%s",
-                    session_key,
-                    f"{len(compressed)} chars" if compressed else "None (no history)",
-                )
+                    # drop the just-flushed current-turn user message
+                    # from replay. chat_handlers.py:146 (or queue dequeue at L1898)
+                    # always appended exactly one message before _run_chat fires,
+                    # and the periodic flush_loop may have already written it to
+                    # disk during the kiro-cli cold spawn (~5s flush vs ≥15s spawn).
+                    # Scale the replay budget to the model window (client is live here).
+                    # Offloaded: resolving this chat's tab id globs and opens every
+                    # session file sharing it to rebuild an index, then reads each
+                    # chained file in full — unbounded file IO on the hottest path in
+                    # the gateway, where it would block every other request.
+                    compressed = await asyncio.to_thread(
+                        build_session_replay,
+                        state.context_builder.conversation_log,
+                        session_key,
+                        exclude_last_n=1,
+                        model_window=window_for_provider_client(client),
+                    )
+                    logger.info(
+                        "Session replay: key=%s result=%s",
+                        session_key,
+                        f"{len(compressed)} chars" if compressed else "None (no history)",
+                    )
             # After a soft-cancel, kiro-cli drops the cancelled turn from its
             # conversation log — but everything BEFORE the cancel is preserved.
             # Re-inject just the cancelled turn (user prompt + partial assistant)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -1030,6 +1030,19 @@ class SessionManager:
         # cold-start).
         self._recycling: dict[str, "_Session"] = {}
         self._compact_cooldown_until: dict[str, float] = {}
+        #: Session keys whose NEXT cold start must not replay prior history.
+        #:
+        #: Set by ``discard_conversation(replay=False)`` and consumed one-shot at
+        #: the replay gate. It cannot live on the session object the way
+        #: ``needs_context_reinjection`` does, because ``discard_conversation``
+        #: POPS that session — the decision is made by the turn that tears the
+        #: conversation down and acted on by the NEXT turn, which builds a new one.
+        #:
+        #: Process-scoped on purpose. A gateway restart also cold-starts the
+        #: session, but there the replay is legitimate: nobody asked for a fresh
+        #: conversation, the process simply went away, and re-anchoring is the
+        #: behaviour that surface has always had.
+        self._suppress_replay: set[str] = set()
         # Compactions whose effect could not be measured at completion time
         # (post-compaction stats reset to unknown, or telemetry not refreshed
         # yet): key -> the pct that triggered the attempt. Settled by the
@@ -3310,6 +3323,7 @@ class SessionManager:
             # The new process is a fresh start — drop any stale failure
             # cooldown so it isn't inherited.
             self._compact_cooldown_until.pop(key, None)
+            self._suppress_replay.discard(key)
             self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         if clear_conversation and session is not None:
@@ -3520,6 +3534,25 @@ class SessionManager:
             return False
         sess.needs_context_reinjection = False
         return True
+
+    def consume_replay_suppression(self, key: str) -> bool:
+        """Read *and clear* whether *key*'s next cold start must skip replay.
+
+        One-shot by construction, the same shape as
+        :meth:`consume_needs_reinjection`: the flag is cleared as it is read, so
+        exactly the FIRST cold start after ``discard_conversation(replay=False)``
+        starts empty. Leaving it set would make every later cold start on that
+        key — an idle-timeout expiry, a gateway restart — silently amnesiac,
+        which nobody asked for.
+        """
+        if key in self._suppress_replay:
+            self._suppress_replay.discard(key)
+            return True
+        folded = self._fold_key(key)
+        if folded in self._suppress_replay:
+            self._suppress_replay.discard(folded)
+            return True
+        return False
 
     def set_recycle_callback(self, cb: _RecycleCallback | None) -> None:
         """Register a callback fired when the watchdog recycles a session.
@@ -4129,6 +4162,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._suppress_replay.discard(key)
             self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         if session:
@@ -4241,6 +4275,7 @@ class SessionManager:
                             continue
                         del self._sessions[key]
                         self._compact_cooldown_until.pop(key, None)
+                        self._suppress_replay.discard(key)
                         self._origin_links.pop(key, None)
                         doomed.append((key, sess.provider))
             finally:
@@ -4453,6 +4488,7 @@ class SessionManager:
                 return False
             del self._sessions[key]
             self._compact_cooldown_until.pop(key, None)
+            self._suppress_replay.discard(key)
             self._compact_pending_verdict.pop(key, None)
             self._origin_links.pop(key, None)
         await asyncio.to_thread(_unlink_session_queue, session)
@@ -4471,6 +4507,7 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
+            self._suppress_replay.discard(key)
             self._compact_pending_verdict.pop(key, None)
         try:
             if session:
@@ -4482,7 +4519,7 @@ class SessionManager:
             self._session_map.delete(key, reason=UNBIND_REASON_SESSION_DESTROYED)
             logger.info("Destroyed session (map deleted): %s", key)
 
-    async def discard_conversation(self, key: str) -> None:
+    async def discard_conversation(self, key: str, *, replay: bool = True) -> None:
         """Tear down the live session and drop ONLY its native conversation.
 
         Like :meth:`destroy`, the provider is shut down and the resume sid is
@@ -4495,12 +4532,35 @@ class SessionManager:
         conversation. Used by the poisoned-conversation escalation in
         chat_runner, where the conversation is unusable but the session's
         channel identity must persist.
+
+        ``replay`` is what "fresh" MEANS to the caller, and the default keeps
+        every existing caller's behaviour. Clearing the sid stops the provider
+        resuming its own conversation — and "the provider has no history" is
+        precisely the condition that makes the next cold start rebuild one from
+        ``conversation_log`` as a ``[CONVERSATION HISTORY]`` block. So the two
+        mechanisms work against each other: the caller discards the
+        conversation and the next turn is handed a reconstruction of it.
+        Measured on one app-owned session, that replay was 80,359 characters —
+        76% of the first turn's injected context — which is most of what
+        discarding the conversation was meant to reclaim.
+
+        Pass ``replay=False`` when a fresh conversation is the point rather than
+        a side effect (an app rotating a long-running session at a clean
+        boundary). The transcript is untouched either way: this suppresses the
+        RE-INJECTION, it does not delete history, so the conversation stays
+        readable in the dashboard and on disk.
         """
         key = self._fold_key(key)
         async with self._lock:
             session = self._sessions.pop(key, None)
             self._compact_cooldown_until.pop(key, None)
             self._compact_pending_verdict.pop(key, None)
+            # Recorded under the same lock that pops the session, so the next
+            # turn cannot observe a torn-down session with the flag not yet set.
+            if replay:
+                self._suppress_replay.discard(key)
+            else:
+                self._suppress_replay.add(key)
         try:
             if session:
                 await asyncio.to_thread(_unlink_session_queue, session)
@@ -4739,6 +4799,7 @@ class SessionManager:
             sessions = dict(self._sessions)
             self._sessions.clear()
             self._compact_cooldown_until.clear()
+            self._suppress_replay.clear()
             self._compact_pending_verdict.clear()
 
         # Bound concurrent shutdowns: each provider.shutdown() -> _kill_process()

--- a/test/test_chat_slot_reset_conversation.py
+++ b/test/test_chat_slot_reset_conversation.py
@@ -106,6 +106,70 @@ async def _post(app: web.Application, slot: str):
         return resp.status, body
 
 
+class TestTheReplayParameter:
+    """``replay`` decides whether the next cold start re-injects the old
+    conversation as a ``[CONVERSATION HISTORY]`` block. Default True keeps the
+    route's existing behaviour and its own copy true."""
+
+    @pytest.mark.asyncio
+    async def test_replay_false_threads_through(self):
+        state = _state(_slot("chat-1-foo"))
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/chat-1-foo/reset-conversation",
+                json={"replay": False},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body["replay"] is False
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:chat-1-foo", replay=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_body_less_post_still_works(self):
+        """The route took no body before this parameter existed."""
+        state = _state(_slot("chat-1-foo"))
+
+        status, body = await _post(_make_app(state), "chat-1-foo")
+
+        assert status == 200
+        assert body["replay"] is True
+
+    def test_the_body_is_read_before_the_busy_guards(self):
+        """Source-order guard: reading the body must not widen the teardown race.
+
+        ``await request.json()`` is a suspension whose duration the CLIENT
+        controls. Every busy guard below it protects work that can START during a
+        suspension — a turn admitted after ``has_active_turn()`` answered False is
+        then torn down mid-write by the discard. Parsing the body after the guards
+        would stretch that window from one event-loop hop to however long a slow
+        body takes to arrive, so the guards must be the LAST thing before the
+        teardown.
+
+        Asserted on the source rather than on behaviour because the failure is an
+        interleaving: a test that posts a slow body and races a concurrent turn
+        would be exactly the timing-dependent flake the testing conventions
+        forbid, and it would pass on a fast machine with the bug present.
+        """
+        import inspect
+
+        from kiro_crew.dashboard import chat_handlers
+
+        src = inspect.getsource(chat_handlers.api_chat_slot_reset_conversation)
+        body_read = src.index("await request.json()")
+        first_guard = src.index("state.sessions.get_provider(key)")
+        discard = src.index("discard_conversation(key, replay=")
+
+        assert body_read < first_guard, (
+            "the body is parsed after the first busy guard, so a slow body widens "
+            "the window in which a concurrent turn can start and be torn down"
+        )
+        assert first_guard < discard, "the guards must sit between the body read and the teardown"
+
+
 class TestItClearsTheRightThing:
     @pytest.mark.asyncio
     async def test_it_clears_the_slot_s_own_session(self):
@@ -115,7 +179,9 @@ class TestItClearsTheRightThing:
 
         assert status == 200
         assert body["reset"] is True
-        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:chat-1-foo", replay=True
+        )
 
     @pytest.mark.asyncio
     async def test_a_channel_born_slot_clears_its_channel_session(self):
@@ -131,7 +197,7 @@ class TestItClearsTheRightThing:
         status, _ = await _post(_make_app(state), "slack_123.456")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("slack:123.456")
+        state.sessions.discard_conversation.assert_awaited_once_with("slack:123.456", replay=True)
 
     @pytest.mark.asyncio
     async def test_it_keeps_the_entry_rather_than_deleting_it(self):
@@ -196,7 +262,9 @@ class TestItRefusesWhenItCannotBeSafe:
         status, _ = await _post(_make_app(state), "chat-1-foo")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:chat-1-foo", replay=True
+        )
 
     @pytest.mark.asyncio
     async def test_a_plan_between_stages_blocks_the_reset(self):
@@ -236,7 +304,9 @@ class TestItRefusesWhenItCannotBeSafe:
         status, _ = await _post(_make_app(state), "chat-1-foo")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:chat-1-foo")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:chat-1-foo", replay=True
+        )
 
 
 class TestAppScope:
@@ -247,7 +317,9 @@ class TestAppScope:
         status, _ = await _post(_make_app(state, declared_app=OWNER), "acme-obj-1")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:acme-obj-1")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:acme-obj-1", replay=True
+        )
 
     @pytest.mark.asyncio
     async def test_an_app_cannot_reset_another_app_s_slot(self):
@@ -298,4 +370,6 @@ class TestAppScope:
         status, _ = await _post(_make_app(state, declared_app=""), "acme-obj-1")
 
         assert status == 200
-        state.sessions.discard_conversation.assert_awaited_once_with("dashboard:acme-obj-1")
+        state.sessions.discard_conversation.assert_awaited_once_with(
+            "dashboard:acme-obj-1", replay=True
+        )

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2174,6 +2174,71 @@ class TestDestroy:
         mock_delete.assert_called_once_with("k1", reason="session_destroyed")
 
 
+class TestReplaySuppression:
+    """``replay=False`` is what makes discarding a conversation actually stick.
+
+    Clearing the sid stops the provider resuming its own conversation — and "the
+    provider has no history" is exactly the condition that makes the next cold
+    start rebuild one from ``conversation_log``. So the two mechanisms work
+    against each other, and the caller who wanted a fresh conversation is handed
+    a reconstruction of the old one. Measured on one app-owned session, that
+    replay was 80,359 characters, 76% of the first turn's injected context.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_does_not_suppress(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.release("k1")
+        await mgr.discard_conversation("k1")
+        assert (
+            mgr.consume_replay_suppression("k1") is False
+        ), "the default must leave every existing caller's behaviour alone"
+
+    @pytest.mark.asyncio
+    async def test_replay_false_suppresses_exactly_once(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.release("k1")
+        await mgr.discard_conversation("k1", replay=False)
+
+        assert mgr.consume_replay_suppression("k1") is True
+        assert mgr.consume_replay_suppression("k1") is False, (
+            "one-shot: a later cold start (idle expiry, gateway restart) must "
+            "re-anchor rather than stay silently amnesiac"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_later_replay_true_reset_clears_a_pending_suppression(self, cfg):
+        """Two resets in a row must not leave the first one's intent standing."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.release("k1")
+        await mgr.discard_conversation("k1", replay=False)
+        await mgr.get_or_create("k1")
+        mgr.release("k1")
+        await mgr.discard_conversation("k1")
+
+        assert mgr.consume_replay_suppression("k1") is False
+
+    @pytest.mark.asyncio
+    async def test_teardown_does_not_leave_a_suppression_for_a_reused_key(self, cfg):
+        """A slot key outlives the slot that held it, and keys ARE reused.
+
+        A leaked flag would starve the NEXT holder of that key of its re-anchor —
+        so the teardown paths clear it alongside the compaction cooldown they
+        already clear, rather than leaving it to age out.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.get_or_create("k1")
+        mgr.release("k1")
+        await mgr.discard_conversation("k1", replay=False)
+
+        await mgr.remove("k1")
+
+        assert mgr.consume_replay_suppression("k1") is False
+
+
 class TestDiscardConversation:
     """Tests for discard_conversation() — the poisoned-conversation escape.
 


### PR DESCRIPTION
## Problem

Clearing a session's resume sid stops the provider resuming its own conversation — and **"the provider has no history" is precisely the condition that makes the next cold start rebuild one** from `conversation_log` as a `[CONVERSATION HISTORY]` block, injected *outside* the capped session context:

```python
# chat_runner
_provider_has_history = resumed
...
if is_new and not _provider_has_history and state.context_builder.conversation_log:
    compressed = await asyncio.to_thread(build_session_replay, ...)
```

So the two mechanisms work against each other by construction. `discard_conversation` clears the sid *so that* the provider cannot resume; that same fact is the replay trigger. The caller discards the conversation and the next turn is handed a reconstruction of it.

## Why it matters

Measured on one app-owned session that rotates its conversation deliberately:

| | |
|---|---|
| replay injected on the first turn after the reset | **80,359 chars** |
| share of that turn's whole injected context | **76%** |
| the session's own meter on that turn | 177,310 tokens |

The reset had cut the session from 394,903 tokens, so it worked — and then most of the reclaimed space was handed straight back. A "fresh conversation" that arrives pre-loaded with the old one is not the thing the caller asked for, and nothing in the API said so.

## Fix

`discard_conversation(key, replay=False)` records a one-shot suppression that the replay gate consumes. **The default is `True`**, so every existing caller is unchanged and the dashboard's own copy — *"Conversation history is preserved — your next message starts a fresh process"* — stays true.

Only the **re-injection** is suppressed. The transcript is untouched, so the conversation stays readable in the dashboard and on disk.

Three placement decisions carry the change:

- **The parameter is on the MANAGER method, not only on the route**, because the route is one caller and the app that motivated this calls the manager in-process. It is NOT wired into any in-repo caller, and that is deliberate: all four — the poisoned-conversation escalation in `chat_runner` and the Slack / Discord / Telegram `/compact` failure recovery — are RECOVERY paths, where the provider's conversation is unusable but KiroCrew's own transcript is not. The replay there is rebuilt from `conversation_log` rather than resumed from the provider, so it carries no poison, and `chat_runner:9154` documents the re-anchor as the property that preserves the dashboard session across the failure. So the default is not merely conservative — it is what every in-repo caller wants, and suppression is opt-in for a caller that rotates a HEALTHY conversation on purpose.
- **The flag cannot live on the session object** the way `needs_context_reinjection` does, because `discard_conversation` POPS that session: the decision is made by the turn that tears the conversation down and acted on by the next turn, which builds a new one. It is a manager-level set, **process-scoped on purpose** — a gateway restart also cold-starts the session, but there the replay is legitimate, since nobody asked for a fresh conversation and re-anchoring is what that surface has always done.
- **It is consumed INSIDE the cold-start branch**, not before it, so a warm turn that never rebuilds history cannot spend the one chance the reset asked for. Every teardown path that already clears the compaction cooldown clears the flag too (`reset`, `remove`, `retire_kiro_identity_sessions`, `remove_if_unclaimed`, `destroy`, `close_all`), because slot keys are reused and a leaked flag would starve the next holder of that key of its re-anchor.

`session.md` is updated in the same commit.

### Considered and not taken

**Archiving the transcript instead of suppressing the re-injection.** `_archive_lines(reason=...)` plus a metadata-only rewrite is an established pattern in `history.py` (it is what compaction and rotation already do), it needs no per-key state at all, and it would make "reset" mean what its name says. It was not taken because of what the two failure modes cost: a leaked suppression flag means one cold start without a re-anchor — a degradation, and one the opting-in caller wanted anyway — while a failure between the archive write and the transcript rewrite risks readable history. When the design is genuinely arguable, the reversible option wins. Worth revisiting if the flag's lifecycle proves harder to hold than this PR expects.

## Tests

4 new guards, 3 mutation-verified (the fourth is the default-behaviour assertion, which the existing suite already covers from the other direction).

| Guard | Falsified by |
|---|---|
| `test_replay_false_suppresses_exactly_once` | stop recording the intent (`replay=False` becomes a no-op) |
| same test, one-shot half | stop clearing on consumption |
| `test_teardown_does_not_leave_a_suppression_for_a_reused_key` | remove `remove()`'s cleanup |
| `test_default_does_not_suppress` / `test_a_later_replay_true_reset_clears_a_pending_suppression` | — |

**Two probe errors are worth recording, because both would have shipped a false green.** The teardown mutation is one line that appears identically in five teardown paths *and* inside `consume_replay_suppression` at the same indent. A plain string replace hit `reset()`; an ordinal count hit the consumer. Both times the test stayed green and the mutation had simply landed somewhere else. The probe now anchors on `remove()`'s own signature and takes the first cleanup after it, and the run prints the mutated function's hit count so a mis-aimed mutation cannot read as a passing test.

The six existing assertions pinning `discard_conversation`'s call shape were updated to the new signature rather than loosened.

`test_session.py` + `test_chat_slot_reset_conversation.py` + `test_dashboard_chat.py` + `test_channel_compact_failure_binding.py`: **936 passed**. black (via `scripts/check_black_formatting.py`), flake8, mypy `--platform linux`, isort, docs-lint all clean.

**Why no screenshot:** no frontend file is touched; the route gains an optional request field and no UI reads it yet.

