### PR TITLE
feat(meetings): import a recording into a meeting

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -117,8 +117,6 @@ src/kiro_crew/apps/builtins/meetings/backend/domain/dictionary.py
 src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
 src/kiro_crew/apps/builtins/meetings/backend/providers/calendar.py
 src/kiro_crew/apps/builtins/meetings/backend/providers/tasks.py
-src/kiro_crew/apps/builtins/meetings/backend/routes/__init__.py
-src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
 src/kiro_crew/apps/builtins/meetings/backend/routes/calendar.py
 src/kiro_crew/apps/builtins/meetings/backend/routes/tasks.py
 src/kiro_crew/apps/builtins/mochi/backend/routes.py
@@ -859,7 +857,6 @@ test/test_md_notebook.py
 test/test_meetings_agent_names.py
 test/test_meetings_dictionary.py
 test/test_meetings_providers.py
-test/test_meetings_routes.py
 test/test_meetings_session.py
 test/test_memory_benchmark_workflow.py
 test/test_memory_selfheal.py

--- a/docs/system-specs/modules/meetings.md
+++ b/docs/system-specs/modules/meetings.md
@@ -18,11 +18,12 @@ action items.
 | `.../backend/domain/dictionary.py` | speech-correction dictionary (TOML) |
 | `.../backend/domain/session.py` | batching dispatcher + meeting state machine |
 | `.../backend/domain/translate.py` | live per-line translation queue + its prompt |
+| `.../backend/domain/audio.py` | splitting an imported transcript into lines |
 | `.../backend/providers/tasks.py` | **task-provider seam** + the local ledger |
 | `.../backend/providers/calendar.py` | **calendar-provider seam** + the `.ics` reader |
 | `.../backend/calendar_sync.py` | one calendar sync (provider fetch → cache), shared by the route and the poller |
 | `.../backend/calendar_poller.py` | background calendar poll: keeps the cache fresh, pre-creates the meeting about to start |
-| `.../backend/routes/` | `_common` (gate + validation), `meeting_lifecycle`, `agents`, `tasks`, `calendar`, `settings` |
+| `.../backend/routes/` | `_common` (gate + validation + the dispatch transaction), `meeting_lifecycle`, `agents`, `audio_import`, `tasks`, `calendar`, `settings` |
 | `.../agents/*.json` | the three shipped agent specs |
 | `src/kiro_crew/builtin_skills/meetings/SKILL.md` | the bundled skill (data layout, lifecycle, provider config) |
 | `website/src/apps/meetings/` | `MeetingsPage` (list) → `MeetingView` → `TaskReviewView`, `SettingsView` |
@@ -68,6 +69,7 @@ POST   /meetings/{id}/attachments   {action: add|remove, attachments[]|index}
 POST   /meetings/{id}/agents        {agent_id, enable} — toggle mid-meeting
 POST   /meetings/{id}/mute          {agent_id, muted}
 POST   /meetings/{id}/dispatch      {text, chat?} — persist then fan out one line
+POST   /meetings/{id}/import        {audio_path} — transcribe a file into the meeting
 POST   /meetings/{id}/message       {agent_id, text} — one agent, flushed at once
 POST   /meetings/{id}/reset         reset tripped circuit breakers
 GET    /meetings/{id}/tasks         extracted action items
@@ -79,7 +81,22 @@ POST   /meetings/{id}/tasks/review  {id, review_status} — pending | archived
 ```
 
 Every handler is wrapped by `_common.route`, which applies the enable gate and
-turns validation failures into 4xx.
+turns validation failures into 4xx. `_common.error_response` maps an exception's
+status to a LITERAL `web.json_response(..., status=NNN)` per branch — repetitive on
+purpose, because the error-code contract scanner reads `status=exc.status` as
+`dynamic_status` and cannot prove the contract is met. **A status with no branch
+falls through to 400**, which was a live bug before the import route needed 403:
+`store.contain` raises `MeetingsPathError(status=403)` for a path escaping the data
+root, and that was reported as "bad request". A containment violation reported as
+400 reads like a typo the caller can fix by retrying.
+
+The two transcript PRODUCERS — `…/dispatch` and `…/import` — share
+`_common.dispatch_line`: the live-session check, the transcript append, and the
+synchronous queue fan-out as ONE transaction under the dispatch-admission lock,
+plus the expiry branch's SIDE EFFECTS (close admission, drain the queues, mark the
+meeting ended on disk). Shared rather than copied because a second copy of that
+transaction is a second thing that has to stay correct — and because a producer
+that skipped it would reopen the stop-versus-append race the lock closes.
 
 ## Data
 
@@ -296,6 +313,53 @@ line number**, because a `queryFn` that runs twice for one cursor (React Strict 
 in dev) would otherwise duplicate every line. Stored `n` stays monotonic when the
 file is trimmed. A failed line is persisted with `text: ""` on purpose, so the panel
 marks it rather than leaving a gap indistinguishable from nobody speaking.
+## Importing a recording
+
+`POST …/{id}/import` (`backend/routes/audio_import.py`) takes a host path,
+transcribes it with the gateway's batch speech-to-text (`kiro_crew.transcribe`),
+and feeds the result into the meeting **as if it had been spoken**: every line goes
+through `_common.dispatch_line`, so it is appended to `transcript.jsonl` and only
+then fanned out — the same persist-before-fan-out boundary live speech crosses —
+and gets the same pipeline: domain-dictionary correction, the noise gate,
+per-agent batching, and the muted list, with nothing re-implemented and nothing
+that can drift. The consequence, the honest way round: **an import needs a LIVE
+meeting** — the agents are what turn transcript into minutes, and they only exist
+while one is running. The session is resolved FIRST so an hour of audio is not
+decoded on the way to an error that could be given immediately, and each line is
+re-admitted individually, so a meeting stopped or expired mid-import fails the
+loop with the same 409/410 a spoken line would get instead of writing into a
+torn-down meeting. The 16 MiB transcript ceiling applies per line exactly as it
+does to speech: 413, with everything already dispatched staying dispatched.
+
+`domain/audio.split_transcript` turns the one returned blob into lines in three
+tiers: the transcriber's own segments when it gave any (a whisper segment is the
+closest thing to one utterance), sentence boundaries when it returned a single
+paragraph (AWS Transcribe does), and a hard wrap at `MAX_TRANSCRIPT_CHARS` —
+wrapped rather than truncated, because truncating drops the tail of a long
+sentence. `MAX_IMPORT_LINES` (2000) caps the fan-out — an overflow refuses the
+entire import with a 413 rather than importing a truncated head, because a 200
+that silently dropped the recording's tail is data loss. A recording file above
+`MAX_IMPORT_AUDIO_BYTES` (512 MiB) is refused with a 413 before the decoder
+runs — decoding materializes PCM for the whole file, so the size gate is the
+only ceiling that fires while the memory cost is still zero. One import runs
+per meeting at a time; a second concurrent request answers 409
+(`import_in_progress`), because both would dispatch line-by-line into the same
+transcript and interleave.
+
+The path goes through `hooks.validate_file_path`, the shared dashboard file gate,
+which canonicalizes (following symlinks) and enforces `is_sensitive_path`. The
+predicate is never called directly, so this route's answer is identical to every
+other file read in the product, and the extension check runs on the CANONICAL
+path — a symlink named `.mp3` cannot smuggle in its target. `transcribe_audio`
+re-checks the path itself, so a refusal is enforced twice by two owners. The
+extension allowlist is a "did you mean this file" filter, not a content check.
+
+`lines` and `dispatched` are reported separately: the gap is what the noise gate
+dropped, and a recording that yields 400 lines of which 0 were dispatched (an
+empty room, filler) is a real outcome the user must be able to see.
+
+There is **no UI for this yet** — it is an API surface. A host-path picker in the
+meeting view is a separate UI decision.
 
 ## The two provider seams
 
@@ -552,9 +616,15 @@ toast, and the user can still type into the broadcast bar to feed the agents.
   `website/src/test/sketchSrcdoc.test.ts` — nothing executable survives, **and** a
   Mermaid diagram plus an inline-styled HTML table still render (the guards
   against over-stripping the panel into a blank).
+* **A client-supplied FILE path exists in exactly one place** — the audio import —
+  and it goes through `hooks.validate_file_path` rather than a local check, so it
+  gets the same canonicalization and `is_sensitive_path` verdict as every other
+  file read in the product. The format check runs on the canonical path, so a
+  symlink cannot use its own name to pass it.
 * **No blocking call on the loop.** The calendar fetch is aiohttp; transcript
   reads/appends, DNS validation, the local `.ics` read, the data-dir seed, the
-  enable check, the task-provider `create`, and every store read and the init
+  enable check, the task-provider `create`, the import's path vetting and
+  speech-to-text availability probe, and every store read and the init
   transaction inside a calendar-poller tick all run on an executor.
 
 ## What the port changed
@@ -577,9 +647,13 @@ validation, redaction, the enable gate), `test_meetings_calendar_poller.py` (the
 due-event rule, a tick against a real `.ics`, pre-creation as init-not-start, the
 loop surviving a bad tick, the settings round trip), `test_meetings_minutes.py` (the
 editable minutes: sidecar ownership, the read overlay, staleness, the widget
-gate, redaction asymmetry, body caps), and `test_meetings_translation.py` (the
-injection guard, the bounded queue, off-by-default), with the shared fixtures and
-fake session manager; no test spawns a process or opens a socket.
+gate, redaction asymmetry, body caps), `test_meetings_translation.py` (the
+injection guard, the bounded queue, off-by-default), and
+`test_meetings_audio_import.py` (the split's boundary rules, the refusals in
+ORDER, and the shared dispatch transaction), with the shared fixtures and the
+fake session manager in `test/meetings_helpers.py`. Every dispatch goes through
+that fake session manager; no test spawns a process, opens a socket, calls a
+model, or decodes audio.
 
 These live in the repo-level `test/` tree, not an in-package `tests/`:
 `setup.cfg` sets `testpaths = test transfer`, so a test under

--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -532,23 +532,75 @@ def is_available() -> bool:
     return availability().ok
 
 
-async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
+class TranscriptionRefusedError(RuntimeError):
+    """Base for pre-conversion refusals ``transcribe()`` surfaces as errors."""
+
+
+class RecordingTooLongError(TranscriptionRefusedError):
+    """The input exceeds the transcription ceiling; refusing beats truncating."""
+
+
+class DurationUnverifiedError(TranscriptionRefusedError):
+    """The duration probe could not answer; refusing beats risking truncation.
+
+    A ``None`` probe is not proof the input is under the ceiling: a TRANSIENT
+    cause — a load spike that times the probe out but clears before the
+    remux — would let the ``-t``-bounded conversion succeed on the truncated
+    prefix of an over-cap recording (GPT review r27). Only a persistent cause
+    is covered by the aligned-budget argument, so ``None`` must refuse loudly
+    and retryably, exactly as the meetings import gate does (r14).
+    """
+
+
+async def _to_native_audio(
+    audio_path: str, probe_timeout_secs: int = DEFAULT_TIMEOUT_SECS
+) -> tuple[str, bool]:
     """Return a path ``AVAudioFile`` can open, plus whether it is a temp file.
 
     Transcodes to 16 kHz mono WAV with ffmpeg when the input container is not one
     the framework reads. Falls back to the original path when ffmpeg is missing, so
     the caller still gets the framework's own error rather than a silent refusal.
-    """
-    if Path(audio_path).suffix.lower() in _NATIVE_AUDIO_SUFFIXES:
-        return audio_path, False
 
+    Raises :class:`RecordingTooLongError` for an input the duration probe shows
+    is over the transcription ceiling, and :class:`DurationUnverifiedError`
+    when the probe cannot answer at all — both BEFORE the conversion, because
+    the remux below is ``-t``-bounded (a temp-disk guard) and converting only
+    the first hour of a longer-or-unknown recording would return a silently
+    truncated transcript, the exact data loss the meetings import gate refuses
+    (GPT reviews r26/r27). The no-ffmpeg degrade path is exempt: with no
+    decoder there is no remux and therefore no truncation to guard against.
+    """
     from kiro_crew.transcribe import (
+        _MAX_AUDIO_SECS,
         _close_ffmpeg_for_execution,
         _create_ffmpeg_subprocess,
         _describe_ffmpeg_exit,
+        _dev_fd_number,
+        _forced_demuxer_args,
+        _input_suffix,
         _resolve_ffmpeg_for_execution,
+        audio_exceeds_secs,
         ensure_ffmpeg_in_path,
     )
+
+    # The native fast path hands *audio_path* to the Swift helper BY VALUE, and
+    # a descriptor path (``/dev/fd/N``) names a descriptor of THIS process —
+    # useless to the helper, whose own fd table does not hold N (GPT review
+    # r23: a native-suffix import would fail with a 502). The remux below is
+    # the materializing path: its FFmpeg child inherits the descriptor via the
+    # spawn seam and writes a NAMED temp file the helper can open.
+    if _dev_fd_number(audio_path) is None and _input_suffix(audio_path) in _NATIVE_AUDIO_SUFFIXES:
+        return audio_path, False
+
+    try:
+        # Same demuxer pin as every other FFmpeg input (transcribe r20/r21):
+        # resolved BEFORE the decoder handle so a refusal cannot leak it. The
+        # loud-failure convention below applies: the helper then reports the
+        # undecodable input rather than this remux sniffing its content.
+        demux_args = _forced_demuxer_args(audio_path)
+    except OSError:
+        logger.warning("apple_speech: cannot resolve a demuxer for %s", audio_path)
+        return audio_path, False
 
     await asyncio.to_thread(ensure_ffmpeg_in_path)
     # A bundled decoder is 49-88 MB and is SHA-256 authenticated on every
@@ -560,6 +612,34 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
             Path(audio_path).suffix or "<no suffix>",
         )
         return audio_path, False
+
+    # Duration gate, AFTER the decoder resolve on purpose: with no ffmpeg there
+    # is no remux and therefore no truncation to guard against (the degrade
+    # return above hands the original file over and the framework fails
+    # loudly), while WITH a decoder the ``-t``-bounded conversion below must
+    # never run on an input whose duration is over — or UNKNOWN. ``None``
+    # refuses too (GPT review r27): a transient probe cause (a load spike that
+    # clears before the remux) is not covered by the aligned-budget argument,
+    # and proceeding would transcribe a silently truncated prefix.
+    try:
+        exceeds = await audio_exceeds_secs(
+            audio_path, _MAX_AUDIO_SECS, timeout_secs=probe_timeout_secs
+        )
+    except BaseException:
+        await _close_ffmpeg_for_execution(ffmpeg, preserve_active_exception=True)
+        raise
+    if exceeds:
+        await _close_ffmpeg_for_execution(ffmpeg)
+        raise RecordingTooLongError(
+            f"recording exceeds the {_MAX_AUDIO_SECS // 60}-minute transcription "
+            "ceiling; trim it rather than transcribing a truncated prefix"
+        )
+    if exceeds is None:
+        await _close_ffmpeg_for_execution(ffmpeg)
+        raise DurationUnverifiedError(
+            "could not verify the recording's duration just now; retry, or trim "
+            f"it to under {_MAX_AUDIO_SECS // 60} minutes"
+        )
 
     # Both syscalls in ONE thread hop. `os.close` alone is trivial, but
     # `tempfile.mkstemp` is the heavier half — it creates a file — and leaving it
@@ -582,12 +662,21 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
             proc = await _create_ffmpeg_subprocess(
                 ffmpeg,
                 "-y",
+                *demux_args,
                 "-i",
                 audio_path,
                 "-ar",
                 "16000",
                 "-ac",
                 "1",
+                # Bounds the temp file as well as the conversion itself: a large
+                # low-bitrate input could otherwise expand into a multi-gigabyte
+                # WAV and exhaust the temp volume (GPT review r23). This is the
+                # ceiling ``batch_duration_cap_secs`` reports for the Apple lane,
+                # so the meetings import refuses over-cap recordings loudly
+                # BEFORE this truncation could ever bite.
+                "-t",
+                str(_MAX_AUDIO_SECS),
                 out,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
@@ -676,7 +765,13 @@ async def transcribe(
     if not helper:
         return None, {"error": "speech helper could not be built"}
 
-    native_path, is_temp = await _to_native_audio(audio_path)
+    try:
+        native_path, is_temp = await _to_native_audio(audio_path, probe_timeout_secs=timeout_secs)
+    except TranscriptionRefusedError as exc:
+        # Loud, user-actionable refusal — never a transcript that silently
+        # omits everything past the ceiling (GPT review r26/r27): over-cap
+        # AND duration-unverified inputs both stop here, before conversion.
+        return None, {"error": str(exc)}
     # When `is_temp` is true this invocation owns the transcode temp from here
     # on, so every exit — the sandbox rejection included — must route through
     # the cleanup `finally` below. An original input (`is_temp` false) is the

--- a/src/kiro_crew/apps/builtins/meetings/ATTRIBUTION.md
+++ b/src/kiro_crew/apps/builtins/meetings/ATTRIBUTION.md
@@ -22,3 +22,17 @@ the task-review flow, the multi-agent panel UI) is a faithful port.
 | Two speech-to-text providers, one of which was a separate locally built daemon from an internal source repository | KiroCrew's own streaming speech-to-text (`/api/ws/stt`). The daemon and its setup script are removed. |
 | A standalone `aiohttp` server on its own port, called back into by the gateway over authenticated loopback HTTP | In-gateway routes under `/api/apps/meetings/*`, and in-process agent dispatch through the shared session manager. |
 | Two crons: a data-directory self-heal written as a shell blob in the cron message, and an update check that pulled from an internal git host | The self-heal is Python that runs at app startup. The update check is removed — a builtin app versions with the KiroCrew package, so there is nothing to check. |
+
+## Added after the port
+
+This section records what has been added since that port, so the line between the two
+stays legible to anyone reading the app cold.
+
+The design comes from **MeetNote**, Kai Mitsuzawa's native macOS meeting app — a
+SwiftUI application that records a meeting, transcribes it on the machine, and
+generates summaries and minutes from it. The design ports; the implementation does
+not, because MeetNote rests on macOS frameworks a browser has no equivalent for.
+
+| MeetNote (native macOS) | Here |
+|---|---|
+| Importing an existing recording as a new meeting record | Imported into a LIVE meeting instead: transcribed with the gateway's own batch speech-to-text and dispatched through the same admission transaction live speech uses, so every line is persisted to the meeting's transcript and reaches the agents exactly as if it had been spoken. |

--- a/src/kiro_crew/apps/builtins/meetings/backend/constants.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/constants.py
@@ -303,3 +303,42 @@ MAX_MINUTES_CHARS = 200_000
 #: below the gateway's own 60 MiB ``client_max_size``. Raised for this ONE route
 #: rather than for all of them: every other body here is a short field.
 MAX_MINUTES_BODY_BYTES = 3 * 1024 * 1024
+# ── importing an existing recording ─────────────────────────────────────────
+
+#: Extensions the import route accepts. An allowlist, so an unrecognised suffix is
+#: refused rather than handed to the transcriber.
+#:
+#: Extension-only, and it is worth being clear that this is NOT a content check: it
+#: is a cheap "did the user mean to pick this file" filter. The suffix it validates
+#: is LOAD-BEARING downstream, though — ``transcribe._forced_demuxer_args`` maps each
+#: entry here to a forced FFmpeg demuxer (``-f``), so an imported file is always
+#: decoded as the format its validated name promises, never by content sniffing.
+#: The barrier that matters for an import is
+#: :func:`kiro_crew.hooks.validate_file_path` (which enforces ``is_sensitive_path``),
+#: and ``transcribe_audio`` re-checks the path itself — sniffing container magic here
+#: would add a third opinion about audio formats without adding a guarantee.
+IMPORT_AUDIO_EXTENSIONS = frozenset(
+    {".wav", ".mp3", ".m4a", ".ogg", ".flac", ".webm", ".opus", ".aac", ".wma"}
+)
+
+#: Cap on the path an import request may carry. Generous — this is a host path the
+#: user chose, and PATH_MAX is 4096 on Linux.
+MAX_AUDIO_PATH_CHARS = 4096
+
+#: Size ceiling for an imported recording, enforced BEFORE the decoder runs.
+#:
+#: The decoder materializes decoded PCM for the whole file, so an unbounded
+#: multichannel WAV can cost several gigabytes of gateway memory before the
+#: transcript-length ceiling — which only runs AFTER decoding — can refuse
+#: anything. 512 MiB comfortably covers the product's own 4-hour meeting ceiling
+#: in every ordinary recording format (a 4-hour 16 kHz mono WAV is ~440 MiB;
+#: compressed formats are far smaller) while refusing the studio-grade
+#: multichannel files that are the memory hazard — re-encode those first.
+MAX_IMPORT_AUDIO_BYTES = 512 * 1024 * 1024
+
+#: Lines one import may feed into a meeting.
+#:
+#: An hour of speech is roughly 500–900 sentences, so this covers a long recording
+#: with room to spare while keeping a pathological file (a transcript of silence
+#: split into thousands of fragments) from filling every agent queue.
+MAX_IMPORT_LINES = 2000

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/audio.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/audio.py
@@ -1,0 +1,108 @@
+"""Meetings — turning a whole-file transcript into dispatchable lines.
+
+An imported recording comes back from ``transcribe_audio`` as ONE string, but every
+consumer downstream of the dispatch transaction is built around a line: the
+transcript stores one record per utterance, the domain dictionary corrects per line,
+the noise gate judges per line, and the agent batcher coalesces lines over a window.
+Handing that pipeline a single hour-long blob would defeat all four — one giant
+transcript row, one prompt too large to be useful, one noise verdict for the whole
+meeting, and nothing to batch.
+
+So this module holds the split, as a pure function with no IO, because the interesting
+part is the boundary rules rather than the plumbing.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Sentence-final punctuation, Latin and CJK. Used only when the transcriber gave us
+#: no line structure of its own.
+#:
+#: The lookahead requires whitespace or end-of-string AFTER the mark, which is what
+#: keeps "3.5" from becoming a boundary — a decimal point has a digit after it, not
+#: a space. An abbreviation followed by a space ("e.g. this") DOES split; transcribed
+#: speech essentially never contains written abbreviations, so an abbreviation-aware
+#: splitter would be complexity spent on input the transcribers do not produce. CJK
+#: marks are followed by neither in practice, hence the separate alternative that
+#: needs no trailing space.
+_SENTENCE_END = re.compile(r"(?<=[.!?])(?=\s)|(?<=[。！？])")
+
+
+class TranscriptTooLong(ValueError):
+    """The split would exceed *max_lines* — the recording is too long to import.
+
+    Raised INSTEAD of silently slicing the tail off: an import that drops the end
+    of a recording while returning success is data loss the user cannot see, and
+    there is no line a splitter could reasonably choose to discard. The route maps
+    this to a 413 the same way an over-full transcript is refused, BEFORE anything
+    is dispatched, so a too-long recording is a clean rejection rather than a
+    partial import.
+    """
+
+
+def split_transcript(text: str, *, max_chars: int, max_lines: int) -> list[str]:
+    """Break *text* into lines suitable for :meth:`MeetingSession.broadcast`.
+
+    Three tiers, in order of how much the transcriber told us:
+
+    1. **Its own line breaks**, when there are any. Tier 1 preserves whatever
+       line structure the CALLER supplied: adapters that receive per-segment
+       output may join segments with newlines before calling this, and a break
+       chosen by the transcriber (or that adapter) is the closest thing
+       available to "one thing somebody said" — better than anything
+       punctuation can reconstruct.
+    2. **Sentence boundaries**, when the whole transcript arrived as one line (AWS
+       Transcribe returns a single paragraph).
+    3. **A hard wrap at *max_chars***, applied to whatever tier 1 or 2 produced, so
+       one runaway sentence cannot exceed what ``broadcast`` would truncate anyway.
+       Truncating instead would DROP the tail of a long sentence; wrapping keeps it.
+
+    Empty and whitespace-only pieces are dropped. A split that would exceed
+    *max_lines* raises :class:`TranscriptTooLong` rather than discarding the tail —
+    a capped result is indistinguishable from a complete one to the caller, and an
+    import that silently omits the end of the recording is data loss (the check
+    bails as soon as the budget is exceeded, so an hour of over-long audio is not
+    split to completion just to be refused).
+    """
+    if not text or not text.strip():
+        return []
+
+    pieces = [line.strip() for line in text.splitlines()]
+    pieces = [line for line in pieces if line]
+    if len(pieces) <= 1:
+        # Tier 2. Split the single line the transcriber gave us.
+        single = pieces[0] if pieces else ""
+        pieces = [part.strip() for part in _SENTENCE_END.split(single)]
+        pieces = [part for part in pieces if part]
+
+    wrapped: list[str] = []
+    for piece in pieces:
+        if len(piece) <= max_chars:
+            wrapped.append(piece)
+        else:
+            # Tier 3. Wrap on whitespace where possible so a word is not cut in
+            # half, and fall back to a hard slice for text with no spaces (CJK).
+            wrapped.extend(_wrap(piece, max_chars))
+        if len(wrapped) > max_lines:
+            raise TranscriptTooLong(f"recording splits into more than {max_lines} lines")
+
+    return wrapped
+
+
+def _wrap(piece: str, max_chars: int) -> list[str]:
+    """Break one over-long piece at whitespace, or hard-slice when there is none."""
+    out: list[str] = []
+    remaining = piece
+    while len(remaining) > max_chars:
+        window = remaining[:max_chars]
+        cut = window.rfind(" ")
+        # A space too close to the start would make almost no progress, so only
+        # honour one in the last third of the window; otherwise slice.
+        if cut < max_chars // 3:
+            cut = max_chars
+        out.append(remaining[:cut].strip())
+        remaining = remaining[cut:].strip()
+    if remaining:
+        out.append(remaining)
+    return [line for line in out if line]

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/__init__.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/__init__.py
@@ -28,6 +28,7 @@ from kiro_crew.apps.builtins.meetings.backend import constants as k
 from kiro_crew.apps.builtins.meetings.backend import store
 from kiro_crew.apps.builtins.meetings.backend.domain import session as sess
 from kiro_crew.apps.builtins.meetings.backend.routes import agents as agents_routes
+from kiro_crew.apps.builtins.meetings.backend.routes import audio_import as import_routes
 from kiro_crew.apps.builtins.meetings.backend.routes import calendar as calendar_routes
 from kiro_crew.apps.builtins.meetings.backend.routes import meeting_lifecycle as lifecycle_routes
 from kiro_crew.apps.builtins.meetings.backend.routes import settings as settings_routes
@@ -167,16 +168,12 @@ def register_routes(app: web.Application) -> None:
     router.add_post(
         f"{BASE}/dictionary/remove", route(settings_routes.handle_remove_dictionary_term)
     )
-    router.add_post(
-        f"{BASE}/dictionary/reload", route(settings_routes.handle_reload_dictionary)
-    )
+    router.add_post(f"{BASE}/dictionary/reload", route(settings_routes.handle_reload_dictionary))
 
     # Calendar
     router.add_get(f"{BASE}/calendar", route(calendar_routes.handle_get_calendar))
     router.add_post(f"{BASE}/calendar/sync", route(calendar_routes.handle_calendar_sync))
-    router.add_get(
-        f"{BASE}/calendar/providers", route(calendar_routes.handle_calendar_providers)
-    )
+    router.add_get(f"{BASE}/calendar/providers", route(calendar_routes.handle_calendar_providers))
 
     # Agents + dispatcher
     router.add_get(f"{BASE}/agents", route(agents_routes.handle_get_agents))
@@ -185,9 +182,7 @@ def register_routes(app: web.Application) -> None:
 
     # Meetings
     router.add_get(f"{BASE}/meetings", route(lifecycle_routes.handle_list_meetings))
-    router.add_get(
-        BASE + "/meetings/{meeting_id}", route(lifecycle_routes.handle_get_meeting)
-    )
+    router.add_get(BASE + "/meetings/{meeting_id}", route(lifecycle_routes.handle_get_meeting))
     router.add_delete(
         BASE + "/meetings/{meeting_id}", route(lifecycle_routes.handle_delete_meeting)
     )
@@ -232,28 +227,26 @@ def register_routes(app: web.Application) -> None:
     router.add_post(
         BASE + "/meetings/{meeting_id}/agents", route(agents_routes.handle_toggle_agent)
     )
-    router.add_post(
-        BASE + "/meetings/{meeting_id}/mute", route(agents_routes.handle_mute_agent)
-    )
+    router.add_post(BASE + "/meetings/{meeting_id}/mute", route(agents_routes.handle_mute_agent))
     router.add_post(
         BASE + "/meetings/{meeting_id}/dispatch", route(agents_routes.handle_dispatch_text)
     )
     router.add_post(
         BASE + "/meetings/{meeting_id}/message", route(agents_routes.handle_agent_message)
     )
+    router.add_post(BASE + "/meetings/{meeting_id}/reset", route(agents_routes.handle_reset_agents))
+
+    # Import an existing recording. A transcript PRODUCER, like /dispatch — it needs a
+    # live meeting for the same reason, and shares `_common.dispatch_line`.
     router.add_post(
-        BASE + "/meetings/{meeting_id}/reset", route(agents_routes.handle_reset_agents)
+        BASE + "/meetings/{meeting_id}/import", route(import_routes.handle_import_audio)
     )
 
     # Tasks
     router.add_get(BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_get_tasks))
     router.add_post(BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_add_task))
-    router.add_patch(
-        BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_update_task)
-    )
-    router.add_delete(
-        BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_delete_task)
-    )
+    router.add_patch(BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_update_task))
+    router.add_delete(BASE + "/meetings/{meeting_id}/tasks", route(tasks_routes.handle_delete_task))
     router.add_post(
         BASE + "/meetings/{meeting_id}/tasks/file", route(tasks_routes.handle_file_task)
     )

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
@@ -16,18 +16,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, Awaitable, Callable
+from typing import Any, AsyncIterator, Awaitable, Callable, NamedTuple
 
 from aiohttp import web
 
 from kiro_crew.apps.builtins.meetings.backend import constants as k
 from kiro_crew.apps.builtins.meetings.backend import store
-from kiro_crew.apps.builtins.meetings.backend.domain.session import MeetingSession
+from kiro_crew.apps.builtins.meetings.backend.domain.session import (
+    MeetingSession,
+    end_meeting_meta,
+)
 from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.hooks import get_global_hook_store  # noqa: F401  (re-export for handlers)
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.security import redact
 from kiro_crew.sel import sel
 
 logger = logging.getLogger("kirocrew.app.meetings")
@@ -254,7 +259,9 @@ def require_enabled(handler: Handler) -> Handler:
     async def _wrapped(request: web.Request) -> web.StreamResponse:
         if not await asyncio.to_thread(is_app_enabled, k.APP_NAME):
             audit("meetings.request", request.path, outcome="denied")
-            return web.json_response({"error": f"{k.APP_NAME} is disabled", "code": "app_disabled"}, status=403)
+            return web.json_response(
+                {"error": f"{k.APP_NAME} is disabled", "code": "app_disabled"}, status=403
+            )
         return await handler(request)
 
     return _wrapped
@@ -404,6 +411,13 @@ def error_response(exc: Exception) -> web.Response:
     # (it cannot statically tell the response is even an error) and a hoisted `body`
     # variable as `opaque_body` (it cannot see the `code` inside). Only the literal
     # form proves the contract is met, so the repetition buys a checkable guarantee.
+    # FORBIDDEN was MISSING until the audio-import route needed it, and its absence
+    # was a live bug rather than a gap: `store.contain` raises
+    # `MeetingsPathError(..., status=403)` for a path that escapes the data root, and
+    # without this branch that answered **400**. A containment violation reported as
+    # "bad request" reads like a typo the caller can fix by retrying.
+    if exc.status == HTTPStatus.FORBIDDEN:
+        return web.json_response({"error": str(exc), "code": exc.code}, status=403)
     if exc.status == HTTPStatus.NOT_FOUND:
         return web.json_response({"error": str(exc), "code": exc.code}, status=404)
     if exc.status == HTTPStatus.CONFLICT:
@@ -412,6 +426,17 @@ def error_response(exc: Exception) -> web.Response:
         return web.json_response({"error": str(exc), "code": exc.code}, status=410)
     if exc.status == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
         return web.json_response({"error": str(exc), "code": exc.code}, status=413)
+    # 502/503 both mean "your request was fine, the thing behind it was not", which is
+    # a distinction the client acts on: retry later, versus fix the configuration.
+    if exc.status == HTTPStatus.BAD_GATEWAY:
+        return web.json_response({"error": str(exc), "code": exc.code}, status=502)
+    if exc.status == HTTPStatus.SERVICE_UNAVAILABLE:
+        return web.json_response({"error": str(exc), "code": exc.code}, status=503)
+    # 501: the request is well-formed and the CAPABILITY is what this platform
+    # lacks (the audio-import route refuses hosts without kernel pinned
+    # traversal). Not 503 — no configuration change or retry will make it work.
+    if exc.status == HTTPStatus.NOT_IMPLEMENTED:
+        return web.json_response({"error": str(exc), "code": exc.code}, status=501)
     return web.json_response({"error": str(exc), "code": exc.code}, status=400)
 
 
@@ -431,6 +456,189 @@ def guarded(handler: Handler) -> Handler:
 def route(handler: Handler) -> Handler:
     """The standard decorator stack for every Meetings handler."""
     return require_enabled(guarded(handler))
+
+
+# ── dispatch admission, for every transcript producer ───────────────────────
+#
+# Two producers feed lines into a meeting — the browser's speech stream and
+# broadcast bar (``agents.handle_dispatch_text``) and an imported recording
+# (``audio_import.handle_import_audio``) — and both must obey the same two rules:
+#
+# * The live-session check, the transcript append, and the synchronous queue
+#   fan-out are ONE transaction under ``DISPATCH_LOCK``, so a concurrent stop
+#   followed by deletion cannot remove the meeting while a producer is awaiting
+#   disk IO and then have the append recreate an orphan directory.
+# * The expiry branch has SIDE EFFECTS — close admission, drain the queues, mark
+#   the meeting ended on disk — and a second copy of those is a second thing that
+#   has to stay correct.
+#
+# Extracted here rather than copied into each producer for exactly those reasons.
+
+
+class Admission(NamedTuple):
+    """The verdict :func:`dispatch_admission` yields while ``DISPATCH_LOCK`` is held.
+
+    ``holding`` says which kind of admission this is: False is a live session whose
+    ingress is open (fan out normally); True is a session still INITIALIZING its
+    agents, admitted only because the producer opted into the hold — the line is
+    wanted, so it is appended to the transcript and buffered for the drain instead
+    of refused (issue #4610).
+    """
+
+    session: MeetingSession
+    holding: bool
+
+
+@asynccontextmanager
+async def dispatch_admission(
+    request: web.Request,
+    meeting_id: str,
+    *,
+    require_session: MeetingSession | None = None,
+    hold_during_init: bool = False,
+) -> AsyncIterator[Admission]:
+    """Admit one transcript line: yield the live session, holding ``DISPATCH_LOCK``.
+
+    The caller's body IS the admission transaction — it runs while the lock is
+    held, so its append and fan-out cannot race a lifecycle transition. No live
+    session raises 409; an expired one closes admission promptly (so a later
+    request fails fast instead of waiting behind agent IO), then drains and marks
+    the meeting ended under ``START_LOCK`` — which still serializes the actual
+    teardown with start/stop/delete — and raises 410. ``guarded`` turns both into
+    the standard error bodies.
+
+    ``hold_during_init`` opts the producer into the initialization hold: when
+    ingress is closed because the meeting is STARTING (not stopping/reviewing/
+    expired), the starting session is yielded with ``holding=True`` instead of
+    raising 409, and the caller buffers the line for the drain. Off by default so
+    a producer added later refuses rather than silently buffering; it is also
+    mutually exclusive with ``require_session`` — a hold admits into a session
+    whose agents never saw the producer's earlier lines, which is exactly the
+    identity confusion ``require_session`` exists to refuse.
+
+    ``require_session`` pins admission to a SPECIFIC session object. A meeting id
+    is a name, not an identity: a meeting stopped and recreated with the same id
+    mid-operation installs a NEW session under the OLD name, and a producer that
+    was admitted against the old one must not write into its replacement (an
+    imported recording landing in a meeting it was never part of). Compared with
+    ``is`` — sessions are dataclasses and two for the same meeting id can compare
+    equal; identity is the question being asked. The check runs BEFORE the expiry
+    branch on purpose: the expiry branch has lifecycle side effects (it ends the
+    live meeting on disk), and a producer holding a stale identity has no business
+    tearing down a session it was never admitted to.
+    """
+    expired: MeetingSession | None = None
+    async with DISPATCH_LOCK:
+        session = ACTIVE.get_for_dispatch(meeting_id)
+        if session is None:
+            # The identity question FIRST, even while nothing is dispatchable: a
+            # meeting stopped and recreated under the same id installs a NEW
+            # session that spends its first moments initializing, and during that
+            # window ``get_for_dispatch`` answers None. Answering 409
+            # ``no_active_meeting`` there tells a ``require_session`` producer to
+            # retry into the replacement — the exact write ``require_session``
+            # exists to refuse. ``ACTIVE.get`` sees the initializing session too,
+            # so the honest 410 is available before the 409 fallback.
+            if require_session is not None:
+                current = ACTIVE.get(meeting_id)
+                if current is not None and current is not require_session:
+                    raise BadRequest(
+                        "the meeting session changed during the import",
+                        status=410,
+                        code="meeting_session_replaced",
+                    )
+            starting = (
+                ACTIVE.get_for_buffering(meeting_id)
+                if hold_during_init and require_session is None
+                else None
+            )
+            if starting is None:
+                raise BadRequest("no active meeting", status=409, code="no_active_meeting")
+            yield Admission(starting, True)
+            return
+        if require_session is not None and session is not require_session:
+            raise BadRequest(
+                "the meeting session changed during the import",
+                status=410,
+                code="meeting_session_replaced",
+            )
+        if session.expired:
+            ACTIVE.suspend_dispatches(session)
+            expired = session
+        else:
+            yield Admission(session, False)
+    if expired is None:
+        return
+    async with START_LOCK:
+        if ACTIVE.get(meeting_id) is expired:
+            # Drain, not cancel: a long meeting whose next line arrives after the
+            # session lapsed still has whatever was queued when it went quiet, and
+            # that transcript is exactly what the final notes would otherwise omit.
+            await ACTIVE.drain_and_clear()
+            # Then mark it ended on disk, for the same reason gateway shutdown does
+            # (`routes/__init__._on_cleanup`): the live session is gone, so leaving
+            # the metadata saying `active` makes the dashboard show Live and keep
+            # recording into 409s. `ended` is both honest and recoverable — it is
+            # the one status the user can Restart from.
+            await asyncio.to_thread(end_meeting_meta, meeting_id, data_root(request))
+    raise BadRequest("meeting session expired", status=410, code="meeting_session_expired")
+
+
+async def dispatch_line(
+    request: web.Request,
+    meeting_id: str,
+    text: str,
+    source: str,
+    *,
+    chat: bool = False,
+    require_session: MeetingSession | None = None,
+    hold_during_init: bool = False,
+) -> tuple[dict[str, Any], int, str]:
+    """Persist one line, then fan it out — the whole producer transaction.
+
+    Persist-before-fan-out is the data-integrity boundary: an accepted agent line
+    cannot be absent from the transcript, whether it was spoken, typed, or
+    imported. Redaction happens here, at the single entry point, so everything in
+    ``transcript.jsonl`` has been scrubbed exactly once. Returns
+    ``(segment, queues_accepted, line_as_dispatched)``; a full transcript raises
+    413 rather than truncating an accepted row. ``require_session`` and
+    ``hold_during_init`` are forwarded to :func:`dispatch_admission` — a
+    multi-line producer passes the session it was admitted against so a same-id
+    replacement cannot receive its lines, and only the live/typed producer opts
+    into the initialization hold. A held line is appended AT ARRIVAL exactly like
+    a live one, so the durable record stays in spoken order and complete even
+    when the hold later overflows — the overflow then costs the agents some
+    context, never the user their transcript. It reports ``queues_accepted`` of
+    0, the same answer as a live dispatch that reached nobody: the line is in the
+    durable transcript either way, so ``dispatched: 0`` is already the whole
+    answer to "did this land with an agent yet".
+    """
+    async with dispatch_admission(
+        request, meeting_id, require_session=require_session, hold_during_init=hold_during_init
+    ) as admitted:
+        transcript_text = redact(text)
+        # The append creates its parent directory when needed — which is why it must
+        # stay inside the admission transaction (see `dispatch_admission`).
+        segment = await asyncio.to_thread(
+            store.append_transcript, meeting_id, transcript_text, source, data_root(request)
+        )
+        if segment is None:
+            raise BadRequest(
+                "meeting transcript is too large", status=413, code="transcript_too_large"
+            )
+        line = f"{k.CHAT_PREFIX} {transcript_text}" if chat else transcript_text
+        if admitted.holding:
+            if not admitted.session.buffer_during_init(line):
+                logger.warning(
+                    "meetings: init hold for %r is full at %d line(s); "
+                    "dropped the oldest and will mark the gap on drain",
+                    meeting_id,
+                    k.MAX_INIT_BUFFER_LINES,
+                )
+            accepted = 0
+        else:
+            accepted = admitted.session.broadcast(line)
+    return segment, accepted, line
 
 
 # ── gateway wiring ──────────────────────────────────────────────────────────

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
@@ -26,6 +26,7 @@ from kiro_crew.apps.builtins.meetings.backend.routes._common import (
     BadRequest,
     audit,
     data_root,
+    dispatch_line,
     field_bool,
     field_str,
     json_body,
@@ -291,7 +292,8 @@ async def handle_mute_agent(request: web.Request) -> web.Response:
     #
     # The lock belongs HERE, on the one unlocked writer, rather than on the reader:
     # both the live fan-out and the initialization hold read this set after their
-    # own `_record_line` await, so guarding a single dispatch branch would close one
+    # own transcript-append await inside `_common.dispatch_line`, so guarding a
+    # single dispatch branch would close one
     # window and leave its twin open. Every other writer already holds this lock
     # (`handle_toggle_agent` takes it, and `add_agent` runs inside it).
     #
@@ -309,35 +311,6 @@ async def handle_mute_agent(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "muted_agents": meta["muted_agents"]})
 
 
-async def _record_line(
-    meeting_id: str, text: str, is_chat: bool, root: Any
-) -> tuple[str, dict[str, str]]:
-    """Redact one inbound line, append it to the transcript, build the agent line.
-
-    Shared by the live fan-out and the initialization hold so the two cannot
-    drift. The transcript append happens at ARRIVAL for both, which is what keeps
-    the durable record in spoken order and complete even when the hold later
-    overflows — the overflow then costs the agents some context, never the user
-    their transcript.
-
-    Raises :class:`BadRequest` (413) when the transcript ceiling is reached, so a
-    held line is size-checked on exactly the same terms as a live one.
-    """
-    transcript_text = redact(text)
-    source = k.TRANSCRIPT_SOURCE_TYPED if is_chat else k.TRANSCRIPT_SOURCE_SPEECH
-    segment = await asyncio.to_thread(
-        store.append_transcript, meeting_id, transcript_text, source, root
-    )
-    if segment is None:
-        raise BadRequest(
-            "meeting transcript is too large",
-            status=413,
-            code="transcript_too_large",
-        )
-    line = f"{k.CHAT_PREFIX} {transcript_text}" if is_chat else transcript_text
-    return line, segment
-
-
 async def handle_dispatch_text(request: web.Request) -> web.Response:
     """Broadcast one line to every unmuted agent.
 
@@ -352,62 +325,16 @@ async def handle_dispatch_text(request: web.Request) -> web.Response:
     text = field_str(body, "text", required=True, max_len=k.MAX_TRANSCRIPT_CHARS)
     is_chat = field_bool(body, "chat", default=False)
 
-    # The transcript append creates its parent directory when needed. Keep the
-    # live-session check, append, and fan-out in the lifecycle transaction so a
-    # concurrent stop followed by deletion cannot remove the meeting while this
-    # request is awaiting disk IO and then have the append recreate an orphan.
-    expired_session: sess.MeetingSession | None = None
-    async with DISPATCH_LOCK:
-        session = ACTIVE.get_for_dispatch(meeting_id)
-        if session is None:
-            # Direct fan-out is shut. Agent INITIALIZATION is the one reason to hold
-            # the line rather than refuse it (issue #4610) — a stopping, reviewing or
-            # expired meeting has nowhere to put it and still answers 409, which is
-            # the gate issue #1981 added and this must not widen.
-            starting = ACTIVE.get_for_buffering(meeting_id)
-            if starting is None:
-                return web.json_response(
-                    {"error": "no active meeting", "code": "no_active_meeting"}, status=409
-                )
-            line, segment = await _record_line(meeting_id, text, is_chat, data_root(request))
-            if not starting.buffer_during_init(line):
-                logger.warning(
-                    "meetings: init hold for %r is full at %d line(s); "
-                    "dropped the oldest and will mark the gap on drain",
-                    meeting_id,
-                    k.MAX_INIT_BUFFER_LINES,
-                )
-            # Same shape as a live dispatch that reached nobody. The hold needs no
-            # flag of its own: no client reads one, and the line is in the durable
-            # transcript either way, so `dispatched: 0` is already the whole answer
-            # to "did this land with an agent yet".
-            return web.json_response(
-                {"ok": True, "dispatched": 0, "text": line, "segment": segment}
-            )
-        if session.expired:
-            # Close admission before the slow drain. A later request can then fail
-            # promptly instead of waiting behind agent IO, while the lifecycle lock
-            # below still serializes the actual teardown with start/stop/delete.
-            ACTIVE.suspend_dispatches(session)
-            expired_session = session
-        else:
-            line, segment = await _record_line(meeting_id, text, is_chat, data_root(request))
-            accepted = session.broadcast(line)
-
-    if expired_session is not None:
-        async with START_LOCK:
-            if ACTIVE.get(meeting_id) is expired_session:
-                # Drain, not cancel: a long meeting whose next line arrives after the
-                # session lapsed still has whatever was queued when it went quiet.
-                await ACTIVE.drain_and_clear()
-                await asyncio.to_thread(sess.end_meeting_meta, meeting_id, data_root(request))
-        return web.json_response(
-            {
-                "error": "meeting session expired",
-                "code": "meeting_session_expired",
-            },
-            status=410,
-        )
+    # The admission transaction (live-session check, transcript append, fan-out,
+    # and the expiry side effects) is shared with the audio-import producer — see
+    # `_common.dispatch_line`. Only THIS producer opts into the initialization
+    # hold: a line of live speech arriving while the agents are still starting is
+    # wanted and is buffered (issue #4610), whereas a file import has no business
+    # trickling into a hold buffer — it is refused whole and retried.
+    source = k.TRANSCRIPT_SOURCE_TYPED if is_chat else k.TRANSCRIPT_SOURCE_SPEECH
+    segment, accepted, line = await dispatch_line(
+        request, meeting_id, text, source, chat=is_chat, hold_during_init=True
+    )
     return web.json_response({"ok": True, "dispatched": accepted, "text": line, "segment": segment})
 
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/audio_import.py
@@ -1,0 +1,709 @@
+"""Meetings — import an existing recording into a live meeting.
+
+``POST …/{id}/import`` takes a host path to an audio file, transcribes it with the
+gateway's own batch speech-to-text, and feeds the result into the meeting exactly as
+if it had been spoken.
+
+**Why "as if it had been spoken" rather than a separate record.** Every line goes
+through :func:`_common.dispatch_line`, the same admission transaction live speech and
+the broadcast bar use. So an imported line is persisted to ``transcript.jsonl``
+before it is fanned out — the app-wide data-integrity boundary: an accepted agent
+line cannot be absent from the transcript — and then gets the SAME pipeline a
+microphone gets: domain-dictionary correction, the noise gate, per-agent batching,
+and the muted-agent list. There is no second code path to keep in step, and the
+imported recording is readable back from the transcript panel like anything spoken.
+
+The consequence, and it is the honest way round: an import needs a LIVE meeting. That
+is not a limitation to work around — the agents are what turn transcript into minutes,
+and they only exist while a meeting is running. The session is checked FIRST, before
+the expensive steps, and each line is re-admitted individually, so a meeting stopped
+while an hour of audio was being transcribed fails the dispatch loop promptly instead
+of writing into a torn-down meeting.
+
+Security posture:
+
+* Only the dashboard OWNER may import: the handler refuses any other caller via
+  :func:`~kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request`
+  before the body is read, with the shared denial shape — the same gate the
+  aws-control routes and the app job routes apply, because the capability is the
+  same class: reading an arbitrary host file by path on the caller's say-so.
+* The client-supplied path goes through :func:`kiro_crew.hooks.validate_file_path`,
+  the shared dashboard file gate, which canonicalizes (following symlinks) and
+  enforces ``is_sensitive_path``. The predicate is never called directly here — using
+  the gate is what keeps this route's answer identical to every other file read in the
+  product. The transcriber never sees the client-supplied name: it consumes the
+  request-private snapshot produced by :func:`_snapshot_recording`, staged beneath
+  the agent-denied voice-runtime root (:func:`_new_snapshot_dir`) so a same-uid
+  agent cannot rewrite the pinned bytes in place.
+* Rejections are SEL-audited.
+* **This module calls no redactor of its own**, deliberately: ``transcribe_audio``
+  scrubs and hallucination-filters what it returns, and ``_common.dispatch_line``
+  redacts at the transcript boundary exactly as it does for live speech — a third
+  pass here would add no coverage. (That absence is also why this module is neither
+  a registered redaction sink nor an allowlisted non-egress module in
+  ``security_posture`` — there is no call site to classify.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import store
+from kiro_crew.apps.builtins.meetings.backend.domain import audio
+from kiro_crew.apps.builtins.meetings.backend.routes._common import (
+    BadRequest,
+    audit,
+    dispatch_admission,
+    dispatch_line,
+    field_str,
+    json_body,
+)
+from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
+from kiro_crew.hooks import validate_file_path
+from kiro_crew.pinned_fs import (
+    PinnedPathRefusal,
+    copy_file_pinned,
+    is_reparse_point,
+    pin_parent,
+    supports_pinned_walk,
+)
+from kiro_crew.sandbox import prime_voice_runtime_sandbox_paths
+
+logger = logging.getLogger("kirocrew.app.meetings")
+
+#: Meetings with an import currently running. One import per meeting at a time:
+#: two concurrent imports dispatch line-by-line into the same transcript, so their
+#: recordings would interleave — a garbled record neither upload asked for. Only
+#: touched from the event loop with no await between test and add, so the
+#: check-and-set needs no lock.
+_imports_in_flight: set[str] = set()
+
+
+def _meeting_id(request: web.Request) -> str:
+    return store.safe_meeting_id(request.match_info.get("meeting_id", ""))
+
+
+def _vet_audio_file(raw_path: str) -> "tuple[str, tuple[int, int] | None, str]":
+    """Return ``(canonical, (st_dev, st_ino), "")`` or ``("", None, reason)``. BLOCKING.
+
+    One helper for the whole check because all three steps touch the filesystem and
+    they belong in the same thread hop: the gate canonicalizes (a ``realpath``), and
+    the existence and suffix tests must apply to the CANONICAL path rather than to
+    what the client sent — otherwise a symlink with an ``.mp3`` name could point at
+    something else entirely.
+
+    The returned identity is the inode THIS vet judged. The snapshot copy
+    refuses a source descriptor that does not fstat to exactly it
+    (``copy_file_pinned(expected_src_ident=...)``), so a file swapped in at the
+    name after this check — a hardlink to something the sensitivity gate never
+    saw included — is never copied (GPT review r29).
+    """
+    try:
+        canonical = validate_file_path(raw_path)
+    except (ValueError, OSError):
+        # A path the OS itself refuses to work with — an embedded NUL byte
+        # (``realpath`` raises ValueError), an over-long name — is denied like
+        # any other unreadable path rather than crashing the request with a 500.
+        return "", None, "denied"
+    if canonical is None:
+        return "", None, "denied"
+    path = Path(canonical)
+    if not path.is_file():
+        return "", None, "not_a_file"
+    if path.suffix.lower() not in k.IMPORT_AUDIO_EXTENSIONS:
+        return "", None, "unsupported_format"
+    try:
+        st = path.stat()
+    except OSError:
+        # Raced away between the is_file() above and here — same answer as if it
+        # had never existed.
+        return "", None, "not_a_file"
+    if st.st_size > k.MAX_IMPORT_AUDIO_BYTES:
+        # BEFORE the decoder ever sees the file: decoding materializes PCM for
+        # the whole recording, so the size gate is the only ceiling that runs
+        # while the cost is still zero.
+        return "", None, "file_too_large"
+    return canonical, (st.st_dev, st.st_ino), ""
+
+
+def _transcription_ready(stt_config: Any) -> bool:
+    """Whether batch speech-to-text is usable at all. BLOCKING.
+
+    Answered against the caller's ONE config snapshot, never a fresh read — the
+    readiness answer, the duration-cap answer, and the transcription itself must
+    describe the same provider (see ``handle_import_audio``).
+    """
+    # Deliberately function-local (`top-level-imports` deviation, recorded): the STT
+    # stack pulls optional heavy dependencies (faster-whisper is not a declared
+    # extra), and a gateway that registers this app must not import a decoder at
+    # startup. Pinned by TestWiring.test_transcribe_is_imported_lazily.
+    from kiro_crew.transcribe import is_available
+
+    try:
+        return bool(is_available(stt_config))
+    except Exception:  # pragma: no cover — a broken config must not 500 the route
+        logger.warning("meetings: could not determine STT availability", exc_info=True)
+        return False
+
+
+def _new_snapshot_dir() -> str:
+    """Create this request's private snapshot directory under the agent-denied root.
+
+    A ``mkdtemp`` under the system temp directory is ``0700``, but ``/tmp`` itself
+    is world-listable and this module already treats a same-uid agent as a live
+    racing adversary: the identity pin (``_open_snapshot_pinned``) verifies the
+    INODE, so an actor who can reach the file can rewrite its bytes in place and
+    still pass the pin (GPT review r28). The one place a same-uid agent cannot
+    reach is the voice-runtime root — every agent sandbox mode denies read, write
+    and hardlink access to that fixed path, which is exactly why the transcriber
+    stages its decoder images there (``transcribe._ffmpeg_snapshot_root``). The
+    same validation is applied here: the root must be a real directory (not a
+    link) and is re-tightened to ``0700`` before the request's own directory is
+    created beneath it.
+    """
+    root = prime_voice_runtime_sandbox_paths()
+    root_stat = os.lstat(root)
+    if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+        raise OSError("voice runtime root is not a real directory")
+    os.chmod(root, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 intentionally keeps the snapshot staging root gateway-only while retaining directory traversal; Semgrep's suggested 0o644 would grant world-read and remove traversal.  # noqa: E501  # fmt: skip
+    return tempfile.mkdtemp("-import", "kc-meetings-", root)
+
+
+def _snapshot_recording(
+    canonical: str, snapshot_dir: str, expected_src_ident: "tuple[int, int]"
+) -> "tuple[str, tuple[int, int]] | None":
+    """Copy the vetted recording into *snapshot_dir* from a pinned descriptor.
+
+    ``expected_src_ident`` is the ``(st_dev, st_ino)`` that ``_vet_audio_file``
+    judged. The copy runs with ``copy_file_pinned(expected_src_ident=...)``, so
+    a source descriptor that fstats to any OTHER inode — a hardlink to a
+    sensitive file swapped in at the name after the vet — is refused rather
+    than copied: the descriptor pin alone proves the copied inode is the opened
+    inode, not that it is the inode the vet saw (GPT review r29).
+
+    Returns ``(snapshot_path, (st_dev, st_ino))`` — the path AND the copy-time
+    identity of the inode the copy published (``copy_file_pinned``'s
+    ``on_created`` witness) — or ``None`` when the source is refused. The
+    identity is what lets ``_open_snapshot_pinned`` prove its reopen reached
+    THIS copy rather than a replacement swapped in at the same name after the
+    copy finished (GPT review r24).
+
+    The path was validated by :func:`_vet_audio_file`, but a path is a NAME, and
+    between that check and the transcriber's own open anything running as this
+    user can swap the final component for a link to something else — the
+    validated path and the transcribed inode would then not be the same thing.
+    :func:`kiro_crew.pinned_fs.copy_file_pinned` is the repo's one mechanism for
+    exactly this: it opens with ``O_NOFOLLOW`` where the platform has it, judges
+    the DESCRIPTOR with ``fstat``, and copies those bytes, so the inode that was
+    validated is the inode the transcriber reads and no check-to-use window
+    remains. Everything downstream (the duration probe, the decode) consumes the
+    snapshot in our own fresh ``0700`` directory, never the user-writable name.
+
+    The snapshot keeps the original suffix — the transcriber's WAV fast path and
+    the AWS remux both look at it. Size is re-checked on the SNAPSHOT: the vet
+    step's ceiling judged the original name, and a swap could have replaced it
+    with something the memory ceiling exists to refuse. Returns the snapshot
+    path, or None when the source was refused (swapped for a link, ancestor
+    directory swapped for a link, no longer a regular file, vanished before the
+    copy) or grew past the ceiling. BLOCKING.
+    """
+    # Windows first: ``O_NOFOLLOW`` does not exist there, so the pinned open
+    # below would follow a link. ``is_reparse_point`` is the module's own answer
+    # for that platform (it also catches junctions, which ``islink`` misses). On
+    # POSIX this is a cheap redundant pre-check; the descriptor judgment below
+    # remains the race-free guard.
+    if is_reparse_point(canonical):
+        logger.warning("meetings: import source %r is a link/junction; refused", canonical)
+        return None
+
+    # The DESTINATION stays by-name: ``snapshot_dir`` is this request's own fresh
+    # ``0700`` ``mkdtemp``, which is exactly the "path this process just created"
+    # case ``copy_file_pinned`` documents as the appropriate by-name form.
+    dst = os.path.join(snapshot_dir, "recording" + Path(canonical).suffix.lower())
+    refused: list[str] = []
+    #: The publish-time ``fstat`` of the copy's destination descriptor — the
+    #: identity witness the reopen below is verified against.
+    created: list[os.stat_result] = []
+
+    def _report(reason: str, path: str) -> None:
+        refused.append(reason)
+
+    try:
+        if supports_pinned_walk():
+            # The SOURCE is a user-writable name, so ``O_NOFOLLOW`` on its final
+            # component is not enough: an ANCESTOR directory swapped for a link
+            # after validation redirects the whole traversal and the final open
+            # never sees a link. ``pin_parent`` is the repo's one mechanism for
+            # that — one ``openat`` per component, each ``O_NOFOLLOW`` — and
+            # ``canonical`` is already resolved once by the shared file gate,
+            # which is the resolution ``pin_parent`` requires its caller to have
+            # done. Same shape as the app-art reader in ``apps/routes.py``.
+            try:
+                dir_fd = pin_parent(os.path.dirname(canonical), what="import recording parent")
+            except PinnedPathRefusal as exc:
+                logger.warning("meetings: import source %r refused: %s", canonical, exc)
+                return None
+            try:
+                copied = copy_file_pinned(
+                    canonical,
+                    dst,
+                    dir_fd=dir_fd,
+                    name=os.path.basename(canonical),
+                    force_mode=0o600,
+                    max_bytes=k.MAX_IMPORT_AUDIO_BYTES,
+                    expected_src_ident=expected_src_ident,
+                    on_skip=_report,
+                    on_created=created.append,
+                )
+            finally:
+                os.close(dir_fd)
+        else:
+            # No pinned traversal (``dir_fd`` + ``O_NOFOLLOW`` — Windows): REFUSE.
+            # Three successive narrowings of this branch (name sweep r9, fd
+            # witness r18, vet identity r29) each conceded a residual window,
+            # because every variant still performed a by-name ``os.open`` of a
+            # user-influenced path — and on Windows that open FOLLOWS an
+            # ancestor junction planted after any check, reaching a UNC target
+            # and firing outbound SMB authentication as a side effect of the
+            # open itself (GPT review r31, adjudicator-upheld). No after-open
+            # check can undo that. ``snapshot.py``'s notification copy records
+            # the repo ruling for this exact shape: on a platform without the
+            # race-free primitive, decline the hand-rolled ctypes walk and
+            # refuse loudly. The route already answers 501 before any
+            # filesystem step (``handle_import_audio``); this branch is the
+            # backstop for any future caller that skips that gate.
+            logger.error(
+                "meetings: import snapshot refused: this platform has no pinned "
+                "traversal (dir_fd + O_NOFOLLOW), so a user-supplied path cannot "
+                "be opened race-free; source %r was NOT read",
+                canonical,
+            )
+            return None
+    except OSError as exc:
+        # ``copy_file_pinned`` propagates ``FileNotFoundError`` BY CONTRACT so a
+        # source that vanished between validation and the copy can be tolerated,
+        # and every other ``OSError`` here is the same story with a different
+        # errno: a source this request cannot read (``EACCES``/``EPERM``), a
+        # component swapped mid-walk (``ELOOP``/``ENOTDIR``), or bytes that
+        # stopped being readable. The honest answer for all of them is the same
+        # refusal as any other unreadable path — the route maps None to 403
+        # ``audio_path_denied`` — not a 500.
+        logger.warning("meetings: import source %r cannot be snapshotted: %s", canonical, exc)
+        return None
+    if not copied:
+        logger.warning(
+            "meetings: import source %r refused at snapshot (%s)",
+            canonical,
+            ", ".join(refused) or "not copied",
+        )
+        return None
+    # No after-the-fact size check: ``MAX_IMPORT_AUDIO_BYTES`` is enforced INSIDE
+    # ``copy_file_pinned`` (fstat pre-check + abort after the first excess byte),
+    # so a swapped-in oversize source is refused before it can fill the temp
+    # volume rather than after the copy already materialized it.
+    if not created:
+        # copied=True guarantees the witness fired; this is pure fail-closed
+        # paranoia so an identity-less snapshot can never be pinned.
+        return None
+    return dst, (created[-1].st_dev, created[-1].st_ino)
+
+
+def _open_snapshot_pinned(snapshot: str, expected_ident: "tuple[int, int]") -> int | None:
+    """Open the finished snapshot ONCE; every consumer reads this descriptor.
+
+    The copy pins the SOURCE, but the snapshot itself was still consumed by
+    name — opened once by the duration probe and again by the transcoder. The
+    snapshot dir is 0700, yet this module's threat model already treats a
+    same-uid agent as a live racing adversary, and such a racer could swap the
+    file between those two opens: the probe passes the cap on the real
+    recording, the transcoder decodes the replacement, and a silently wrong
+    transcript returns 200 (GPT review r21). Opening once and handing BOTH
+    consumers this descriptor makes that window unreachable.
+
+    *expected_ident* closes the remaining pre-pin window (GPT review r24): a
+    swap landing between the copy's completion and THIS open would otherwise
+    be pinned and consistently transcribed. The open is accepted only when
+    the descriptor's ``(st_dev, st_ino)`` equals the identity the copy
+    published (``_snapshot_recording``'s witness), so the pinned inode is
+    provably the one the pinned-source copy created — no name-trusting step
+    remains anywhere between validation and consumption.
+
+    Returns the descriptor — ownership stays with the caller — or ``None``
+    when the entry is not the regular, link-free file this request's copy
+    created.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(snapshot, flags)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+    except OSError:
+        os.close(fd)
+        return None
+    if not stat.S_ISREG(st.st_mode) or st.st_nlink != 1 or (st.st_dev, st.st_ino) != expected_ident:
+        os.close(fd)
+        return None
+    return fd
+
+
+def _pinned_consumer_path(snapshot: str, snap_fd: int) -> str:
+    """The input path the probe and the transcriber consume.
+
+    POSIX: a ``/dev/fd`` path, so every open — in-process readers and FFmpeg
+    children alike (the spawn seam inherits the descriptor) — resolves the
+    pinned inode, never the mutable name. Windows has no ``/dev/fd``; there
+    the NAME stays safe to reuse because *snap_fd* is held open without
+    delete sharing, which blocks the rename/delete a swap needs until the
+    descriptor is closed.
+    """
+    if platform_compat.IS_WINDOWS:
+        return snapshot
+    return f"/dev/fd/{snap_fd}"
+
+
+def _close_then_rmtree(snap_fd: "int | None", snapshot_dir: str) -> None:
+    """Close the pinned descriptor, THEN remove the snapshot dir. One worker.
+
+    Both are filesystem calls, so both stay off the event loop (the AUTOSDE
+    no-blocking-call-on-event-loop rule names ``os.close`` explicitly — GPT
+    review r22), and the ordering inside the single thread hop is what keeps
+    Windows correct: the held handle blocks the directory removal until it is
+    closed.
+    """
+    if snap_fd is not None:
+        with contextlib.suppress(OSError):
+            os.close(snap_fd)
+    shutil.rmtree(snapshot_dir, ignore_errors=True)
+
+
+async def _remove_snapshot_dir(
+    copy_task: "asyncio.Future[Any] | None", snapshot_dir: str, snap_fd: "int | None" = None
+) -> None:
+    """Join the snapshot copy, THEN close the pin and remove its directory.
+
+    The order is the point (GPT review r12): ``asyncio.to_thread`` workers are
+    not cancellable, so a request cancelled mid-copy leaves the worker thread
+    holding an open destination handle inside ``snapshot_dir``. Removing the
+    directory concurrently loses that race on Windows -- ``rmtree`` cannot
+    delete a file with an open handle, ``ignore_errors`` swallows the failure,
+    and the stale recording accumulates until the temp volume fills. Awaiting
+    the copy future first means the thread has exited and closed its handles
+    before the first unlink; a copy that failed re-raises on that await, which
+    is suppressed here because the removal must happen either way.
+
+    ``snap_fd`` is the route's pinned snapshot descriptor (see
+    ``_open_snapshot_pinned``); it rides this task so its close inherits the
+    same run-as-own-task + shield protection as the removal, and happens in
+    the same worker BEFORE ``rmtree`` (the held handle would otherwise block
+    the directory removal on Windows).
+
+    Run as its own task (``ensure_future``) so a REPEAT cancellation of the
+    request abandons only the caller's wait -- this coroutine keeps running on
+    the loop and still closes the pin and removes the directory after the join.
+    """
+    if copy_task is not None:
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(copy_task)
+    await asyncio.to_thread(_close_then_rmtree, snap_fd, snapshot_dir)
+
+
+async def handle_import_audio(request: web.Request) -> web.Response:
+    """Transcribe a recording from disk and dispatch it into the live meeting."""
+    meeting_id = _meeting_id(request)
+
+    # Owner gate FIRST, before the body is even read. This route's capability is
+    # "read an arbitrary host file by path and surface its contents through the
+    # transcript" — the same host-file class aws-control's ``_guarded`` and the
+    # app job routes gate on ``is_owner_dashboard_request``. An authenticated
+    # non-owner caller gets the shared denial shape, and the permission DECISION
+    # reaches the audit trail: a refused import is exactly what an incident
+    # review asks about.
+    if not is_owner_dashboard_request(request):
+        audit(
+            "meetings.import_audio",
+            f"{meeting_id} reason:non-owner",
+            outcome="denied",
+        )
+        # Imported here, not at module top: ``_shared`` pulls in the dashboard
+        # handler surface, and this branch is the only consumer (job_routes
+        # resolves it the same way for the same reason).
+        from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+
+        return _owner_denial_response(
+            request, "dashboard owner required", "dashboard_owner_required"
+        )
+
+    # An ALLOW is a permission decision too (the app job routes' own rule):
+    # auditing only denials leaves an incident review able to see who was
+    # refused and not who got through — and without this record an owner
+    # request that then fails JSON parsing (400) would leave no trace that the
+    # owner path was entered at all.
+    audit("meetings.import_audio", f"{meeting_id} owner-check", outcome="allowed")
+
+    body = await json_body(request)
+    raw_path = field_str(body, "audio_path", required=True, max_len=k.MAX_AUDIO_PATH_CHARS)
+
+    def _reject(reason: str) -> None:
+        audit("meetings.import_audio", f"{meeting_id} reason:{reason}", outcome="rejected")
+
+    # The live session FIRST, before the expensive steps. Transcribing an hour of
+    # audio and only then discovering there is nothing to dispatch into would waste
+    # minutes of the user's time to reach an error we can give immediately. The
+    # ADMITTED SESSION OBJECT is captured here and required per dispatched line
+    # below: a meeting id is a name, not an identity, and a meeting stopped and
+    # recreated with the same id while the audio was transcribing must not be
+    # contaminated with the old recording's lines.
+    async with dispatch_admission(request, meeting_id) as admitted:
+        admitted_session = admitted.session
+
+    # After admission (the liveness answer outranks the busy answer), before any
+    # expensive step. Held for the whole import — vetting through dispatch — and
+    # released in the ``finally`` below on every exit path.
+    if meeting_id in _imports_in_flight:
+        _reject("import_in_progress")
+        raise BadRequest(
+            "an import is already running for this meeting",
+            status=409,
+            code="import_in_progress",
+        )
+    _imports_in_flight.add(meeting_id)
+    try:
+        # Platform gate BEFORE any filesystem step. Without kernel-level pinned
+        # traversal (``dir_fd`` + ``O_NOFOLLOW``) there is no sequence of by-name
+        # checks that opens a USER-SUPPLIED path race-free: a same-uid actor can
+        # swap an ancestor for a junction between any sweep and the open, and on
+        # Windows a junction to a UNC path makes ``os.open`` itself fire outbound
+        # SMB authentication before any descriptor check can reject it (GPT
+        # review r31). ``snapshot.py``'s notification copy records the repo-wide
+        # ruling for exactly this shape: decline the hand-rolled ctypes walk and
+        # refuse loudly rather than narrow the window. 501, because the request
+        # is well-formed and the capability is what this platform lacks.
+        if not await asyncio.to_thread(supports_pinned_walk):
+            _reject("platform_unsupported")
+            raise BadRequest(
+                "importing a recording is not supported on this platform",
+                status=501,
+                code="import_unsupported_on_platform",
+            )
+        canonical, vetted_ident, reason = await asyncio.to_thread(_vet_audio_file, raw_path)
+        if reason == "denied":
+            _reject(reason)
+            raise BadRequest("that path cannot be read", status=403, code="audio_path_denied")
+        if reason == "not_a_file":
+            _reject(reason)
+            raise BadRequest("no such audio file", status=404, code="audio_file_not_found")
+        if reason == "file_too_large":
+            # 413 like the transcript ceiling: the request is well-formed, the payload
+            # is what cannot be accepted — and it is refused before the decoder can
+            # spend gigabytes of memory finding that out.
+            _reject(reason)
+            raise BadRequest(
+                "recording file is too large to import",
+                status=413,
+                code="audio_file_too_large",
+            )
+        if reason:
+            _reject(reason)
+            raise BadRequest(
+                "unsupported audio format", status=400, code="audio_format_unsupported"
+            )
+        if vetted_ident is None:
+            # Cannot happen when reason is empty (the vet returns the identity on
+            # every success path) — but the identity is the thing the snapshot
+            # copy verifies against, so its absence fails closed like a denial
+            # rather than being asserted away.
+            _reject("denied")
+            raise BadRequest("that path cannot be read", status=403, code="audio_path_denied")
+
+        # Function-local for the recorded lazy-import reason (`_transcription_ready`):
+        # the heavy optional STT stack must not be imported at gateway startup.
+        from kiro_crew.transcribe import (
+            audio_exceeds_secs,
+            batch_duration_cap_secs,
+            load_stt_config,
+            transcribe_audio,
+        )
+
+        # ONE configuration snapshot for the whole request. The readiness check, the
+        # duration-cap answer, and the transcription each accept a config and re-read
+        # it when handed None — three separate reads can straddle the operator
+        # switching providers in Settings, letting the cap be judged under a provider
+        # without a ceiling while the decode runs under the local one that silently
+        # truncates. The snapshot makes the three answers describe one provider.
+        stt_config = await asyncio.to_thread(load_stt_config)
+
+        if not await asyncio.to_thread(_transcription_ready, stt_config):
+            # 503, not 400: the request is fine and will work once speech-to-text is
+            # configured, which is a Settings action rather than a different request.
+            raise BadRequest(
+                "speech-to-text is not available",
+                status=503,
+                code="transcription_unavailable",
+            )
+
+        # Snapshot BEFORE the probe and the decode, so both consume bytes pinned at
+        # validation time (see `_snapshot_recording`) rather than re-opening the
+        # user-writable name. The snapshot directory is this request's own 0700 dir
+        # beneath the agent-denied voice-runtime root (see `_new_snapshot_dir` — a
+        # system-tmp dir would leave the bytes rewritable in place by a same-uid
+        # agent, defeating the inode pin), deleted on every exit path below.
+        snapshot_dir = await asyncio.to_thread(_new_snapshot_dir)
+        copy_task: "asyncio.Future[tuple[str, tuple[int, int]] | None] | None" = None
+        snap_fd: int | None = None
+        try:
+            # The copy runs as its OWN future, shielded: a ``to_thread`` worker
+            # cannot be cancelled anyway, so shielding just makes the bookkeeping
+            # honest -- the future stays alive for the cleanup below to JOIN, and
+            # a cancelled request abandons the wait rather than orphaning a
+            # thread that still holds handles inside ``snapshot_dir``.
+            copy_task = asyncio.ensure_future(
+                asyncio.to_thread(_snapshot_recording, canonical, snapshot_dir, vetted_ident)
+            )
+            snapped = await asyncio.shield(copy_task)
+            if snapped is None:
+                # The file changed identity between validation and the copy — the
+                # same answer as any other unreadable path, for the same reason.
+                _reject("denied")
+                raise BadRequest("that path cannot be read", status=403, code="audio_path_denied")
+            snapshot, snap_ident = snapped
+
+            # ONE open for everything below (see ``_open_snapshot_pinned``): the
+            # probe and the transcoder consume this descriptor, never the name —
+            # and the open is accepted only if it reaches the exact inode the
+            # copy published, so nothing swapped in at the name (before OR after
+            # this open) can ever be transcribed. Closed in the finally.
+            snap_fd = await asyncio.to_thread(_open_snapshot_pinned, snapshot, snap_ident)
+            if snap_fd is None:
+                _reject("denied")
+                raise BadRequest("that path cannot be read", status=403, code="audio_path_denied")
+            pinned = _pinned_consumer_path(snapshot, snap_fd)
+
+            # BEFORE transcription, because the local recogniser's decode paths stop
+            # reading at their ceiling WITHOUT saying so: a recording over the cap
+            # would transcribe its first hour, dispatch it, and return 200 — silent
+            # data loss, the exact failure the TranscriptTooLong branch below refuses.
+            # Provider-aware: the local decoder and the Apple lane (whose
+            # to-native remux is ``-t``-bounded the same way) share the
+            # ceiling, while AWS refuses an oversized payload loudly and so is
+            # not wrongly refused here.
+            # A probe that cannot answer (None) is REFUSED, loudly and retryably
+            # (GPT review r14): the aligned budget (``stt_config.timeout_secs``)
+            # guarantees a PERSISTENT cause also defeats the transcode, but a
+            # TRANSIENT one — a load spike that clears between probe and
+            # transcode — would let the decoder truncate an over-cap recording
+            # and answer 200. The error names the retry and the cap, so the
+            # refusal is actionable rather than a dead end.
+            cap_secs = await asyncio.to_thread(batch_duration_cap_secs, stt_config)
+            if cap_secs is not None:
+                exceeds = await audio_exceeds_secs(
+                    pinned, cap_secs, timeout_secs=stt_config.timeout_secs
+                )
+                if exceeds is None:
+                    _reject("duration_unverified")
+                    raise BadRequest(
+                        "could not verify the recording's duration just now; "
+                        "retry the import, or trim the recording to under "
+                        f"{cap_secs // 60} minutes",
+                        status=503,
+                        code="duration_unverified",
+                    )
+                if exceeds:
+                    _reject("recording_too_long")
+                    raise BadRequest(
+                        "recording is too long to import", status=413, code="recording_too_long"
+                    )
+
+            transcript = await transcribe_audio(pinned, stt_config)
+        finally:
+            # Join-then-close-then-remove, as its own task (see
+            # ``_remove_snapshot_dir``): scheduled before it is awaited so a
+            # repeat cancellation abandons only the wait, never the join, the
+            # descriptor close, or the removal. The pinned descriptor rides
+            # the task rather than being closed here — ``os.close`` is a
+            # blocking filesystem call and must stay off the event loop.
+            rm = asyncio.ensure_future(_remove_snapshot_dir(copy_task, snapshot_dir, snap_fd))
+            await asyncio.shield(rm)
+        # None covers three different endings — provider failure, a disabled provider,
+        # and a transcript the hallucination filter emptied — and the client's move is
+        # the same for all of them, so they share one code.
+        if not transcript:
+            audit("meetings.import_audio", f"{meeting_id} path:{canonical}", outcome="failed")
+            raise BadRequest(
+                "could not transcribe that recording", status=502, code="transcription_failed"
+            )
+
+        try:
+            lines = audio.split_transcript(
+                transcript, max_chars=k.MAX_TRANSCRIPT_CHARS, max_lines=k.MAX_IMPORT_LINES
+            )
+        except audio.TranscriptTooLong:
+            # Refused WHOLE, before anything is dispatched: a partial import that
+            # returns 200 while the recording's tail is missing is silent data loss.
+            # 413 like the transcript ceiling — the request was well-formed, the
+            # payload is what cannot be accepted.
+            _reject("too_many_lines")
+            raise BadRequest(
+                "recording is too long to import", status=413, code="recording_too_long"
+            )
+
+        # One admission transaction PER LINE, exactly as if each had been spoken: the
+        # line is persisted to the transcript and then enqueued for the per-agent
+        # batchers, which work through it on their own timers. Agent work is never
+        # awaited here; the request holds only for the appends. Per line rather than one
+        # long lock hold, so a live microphone's dispatches interleave with the import
+        # instead of queueing behind all of it — and a meeting stopped mid-import raises
+        # the same 409/410 a spoken line would get, rather than writing into a
+        # torn-down meeting. Every line requires the SESSION ADMITTED ABOVE — not merely
+        # a live session under the same meeting id — so a meeting stopped, deleted, and
+        # recreated with the same id mid-import gets a 410 instead of the old
+        # recording's lines. A recording that fills the transcript's ceiling raises the
+        # same 413 live speech gets; what was already dispatched stays dispatched, like
+        # a meeting that hit the cap while people were talking.
+        dispatched = 0
+        for line in lines:
+            _segment, accepted, _line = await dispatch_line(
+                request,
+                meeting_id,
+                line,
+                k.TRANSCRIPT_SOURCE_SPEECH,
+                require_session=admitted_session,
+            )
+            if accepted:
+                dispatched += 1
+
+        audit("meetings.import_audio", f"{meeting_id} lines:{len(lines)}", outcome="ok")
+        return _response(canonical, lines, dispatched)
+    finally:
+        _imports_in_flight.discard(meeting_id)
+
+
+def _response(canonical: str, lines: list[str], dispatched: int) -> web.Response:
+    """The success body.
+
+    ``lines`` and ``dispatched`` are reported separately on purpose: the gap between
+    them is the lines that reached no agent — noise-gate-filtered, or dropped
+    because every agent was muted — and a recording that yields 400 lines of
+    which 0 were dispatched is a real outcome the user needs to be able to see (an
+    empty room, a filtered hallucination) rather than a silent success.
+    """
+    payload: dict[str, Any] = {
+        "ok": True,
+        "path": canonical,
+        "lines": len(lines),
+        "dispatched": dispatched,
+    }
+    return web.json_response(payload)

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -102,6 +102,8 @@ class PinnedPathRefusal(Exception):
 SKIP_SYMLINK = "symlink"
 SKIP_VANISHED = "vanished"
 SKIP_NOT_REGULAR = "not_regular"
+SKIP_TOO_LARGE = "too_large"
+SKIP_IDENTITY_CHANGED = "identity_changed"
 
 #: ``(reason_code, by_name_path)``. The path is for the message only -- it is never
 #: re-opened, because re-opening it is the bug this module exists to prevent.
@@ -441,15 +443,44 @@ def copy_file_pinned(
     *,
     dir_fd: int | None = None,
     name: str | None = None,
+    src_fd: int | None = None,
     dst_dir_fd: int | None = None,
     dst_name: str | None = None,
     skip_existing: bool = False,
     force_mode: int | None = None,
+    max_bytes: int | None = None,
+    expected_src_ident: "tuple[int, int] | None" = None,
     on_skip: SkipReporter = _noop_skip,
+    on_created: "Callable[[os.stat_result], None] | None" = None,
 ) -> bool:
     """Copy one file's bytes from a descriptor pinned to a validated inode.
 
     Returns True when bytes were copied, False when the source was skipped.
+
+    ``expected_src_ident`` (when given) is the ``(st_dev, st_ino)`` a caller's
+    own validation observed: the copy proceeds only when the pinned source
+    descriptor fstats to exactly that inode, and reports
+    ``SKIP_IDENTITY_CHANGED`` otherwise. This closes the validate->copy window
+    the descriptor pin alone cannot: the pin proves the copied inode is the
+    OPENED inode, not that it is the inode the caller judged — a hardlink
+    swapped in at the name between validation and this open would be a regular
+    single-link file the other gates accept.
+
+    ``on_created`` (when given) receives the DESTINATION descriptor's ``fstat``
+    at publish time — the identity witness for a caller that must re-open the
+    copy by name later: matching ``(st_dev, st_ino)`` on that reopen proves it
+    reached the inode this copy created, not a replacement swapped in at the
+    same name between the copy and the reopen.
+
+    ``max_bytes`` is a size ceiling enforced INSIDE the copy, not after it: the
+    ``fstat`` size is checked before the destination is even created (a sparse
+    file's logical size is what ``fstat`` reports, so a swapped-in sparse giant
+    is refused before a byte lands), and the write loop aborts after the first
+    excess byte for a source that grows between the ``fstat`` and the read.
+    Both refusals report ``SKIP_TOO_LARGE`` and truncate whatever was written
+    through the destination descriptor -- a ceiling checked only after the copy
+    would let the copy itself exhaust the destination volume on the way to the
+    rejection.
 
     ``shutil.copy2`` cannot be used on a user-writable tree: it dereferences a
     hardlink into innocent-looking regular bytes, and a later tar-level hardlink
@@ -464,7 +495,12 @@ def copy_file_pinned(
     BOTH ends can be pinned, and on a destination the caller does not own they MUST
     be. Pass *dir_fd* + *name* for a pinned source and *dst_dir_fd* + *dst_name* for
     a pinned destination; each side falls back to the by-name form when its pair is
-    absent, which is only appropriate for a path this process just created. A
+    absent, which is only appropriate for a path this process just created. A caller
+    that already holds a validated source descriptor (an ``os.open`` followed by a
+    ``fd_real_path`` witness check) passes it as *src_fd* instead — ownership
+    transfers to this function, which closes it on every path — so the source is
+    never re-opened by name; on Windows, which has no ``dir_fd`` support, that is
+    the only pinned source form available. A
     destination reached by name is an ancestor swap away from landing the bytes
     somewhere else entirely -- that was a real gap in the first version of this
     module, caught in review, and it is why the by-name destination is now the
@@ -490,22 +526,47 @@ def copy_file_pinned(
     # exactly how an operator would experience it. The fstat below still rejects the FIFO;
     # this only guarantees we reach that check. On a regular file the flag has no effect.
     src_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-    try:
-        if dir_fd is not None and name is not None:
-            fd = os.open(name, src_flags, dir_fd=dir_fd)
-        else:
-            fd = os.open(by_name, src_flags)
-    except OSError as exc:
-        if exc.errno == errno.ELOOP:
-            # A symlink final component that appeared after the listing-time link
-            # screen -- refuse it the same way the screen would have.
-            on_skip(SKIP_SYMLINK, by_name)
-            return False
-        raise
+    if src_fd is not None:
+        # Caller-opened source: ownership TRANSFERS here — the descriptor is
+        # closed on every path by the ``finally`` below, exactly like one this
+        # function opened itself. This is the form for a caller that has
+        # already validated its descriptor (``fd_real_path`` witness after an
+        # ``os.open``): the by-name and ``dir_fd`` forms RE-OPEN the source,
+        # which re-introduces the check-to-open window that validation closed —
+        # and on Windows, which has no ``dir_fd`` support, this is the only
+        # pinned source form available at all. The fstat gates below still run
+        # against this descriptor, so a caller cannot use it to skip them.
+        fd = src_fd
+    else:
+        try:
+            if dir_fd is not None and name is not None:
+                fd = os.open(name, src_flags, dir_fd=dir_fd)
+            else:
+                fd = os.open(by_name, src_flags)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                # A symlink final component that appeared after the listing-time link
+                # screen -- refuse it the same way the screen would have.
+                on_skip(SKIP_SYMLINK, by_name)
+                return False
+            raise
     try:
         st = os.fstat(fd)
         if not _stat.S_ISREG(st.st_mode) or st.st_nlink != 1:
             on_skip(SKIP_NOT_REGULAR, by_name)
+            return False
+        if expected_src_ident is not None and (st.st_dev, st.st_ino) != expected_src_ident:
+            # The descriptor is pinned, but it is not the inode the caller's
+            # validation judged — something was swapped in at the name between
+            # the two. Refuse rather than copy bytes nobody vetted.
+            on_skip(SKIP_IDENTITY_CHANGED, by_name)
+            return False
+        if max_bytes is not None and st.st_size > max_bytes:
+            # BEFORE the destination is created: ``fstat`` reports a sparse
+            # file's LOGICAL size, so the swapped-in sparse giant is refused
+            # here with zero bytes written. The in-loop bound below covers the
+            # one case this cannot -- a source that grows after this fstat.
+            on_skip(SKIP_TOO_LARGE, by_name)
             return False
         # The bytes are written to the FINAL name, opened O_CREAT|O_EXCL, and no name is
         # resolved again afterwards. Three designs have now been tried on these lines and
@@ -558,13 +619,43 @@ def copy_file_pinned(
         # earlier form unlinked first and left the fragment exactly where cleanup was meant
         # to remove it, which my own Windows shard caught.
         try:
+            exceeded = False
             with os.fdopen(fd, "rb") as fsrc:
                 fd = -1  # ownership passed to the file object
                 # fdopen takes ownership and closes what it is given, so it gets a
                 # duplicate: dst_fd itself has to outlive the write for the two
                 # descriptor-based metadata calls below.
                 with os.fdopen(os.dup(dst_fd), "wb") as fdst:
-                    shutil.copyfileobj(fsrc, fdst)
+                    if max_bytes is None:
+                        shutil.copyfileobj(fsrc, fdst)
+                    else:
+                        # Enforced WHILE copying: the fstat pre-check above cannot
+                        # see a source that grows after it, and only aborting on
+                        # the first excess byte keeps the copy itself from
+                        # exhausting the destination volume on the way to a
+                        # rejection.
+                        remaining = max_bytes
+                        while True:
+                            chunk = fsrc.read(min(1024 * 1024, remaining + 1))
+                            if not chunk:
+                                break
+                            if len(chunk) > remaining:
+                                exceeded = True
+                                break
+                            fdst.write(chunk)
+                            remaining -= len(chunk)
+            if exceeded:
+                # AFTER the dup'd writer has closed (its buffer flushes on close,
+                # so truncating first would let the flush write stale bytes
+                # back). Same rule as the failure path below: the partial
+                # content is emptied through the descriptor we hold (O_EXCL
+                # proves the entry is ours), never by name.
+                try:
+                    os.ftruncate(dst_fd, 0)
+                except OSError:
+                    pass
+                on_skip(SKIP_TOO_LARGE, by_name)
+                return False
             _apply_metadata(
                 dst_fd,
                 st,
@@ -573,6 +664,10 @@ def copy_file_pinned(
                 dst_name=dst_name,
                 mode=force_mode,
             )
+            if on_created is not None:
+                # Through the descriptor we still hold, so the witness is the
+                # published inode itself — never a name re-resolution.
+                on_created(os.fstat(dst_fd))
             published = True
         except BaseException:
             # No name is unlinked here. `O_EXCL` above proves this entry is ours, so the

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1674,6 +1674,11 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "apps/builtins/meetings/backend/domain/translate.py",
         "apps/builtins/meetings/backend/providers/calendar.py",
         "apps/builtins/meetings/backend/providers/tasks.py",
+        # `_common.dispatch_line` is the transcript-ingress boundary every producer
+        # (speech, the broadcast bar, an audio import) redacts through — inbound
+        # scrubbing before the line reaches disk and the agents, same
+        # classification as its siblings below.
+        "apps/builtins/meetings/backend/routes/_common.py",
         "apps/builtins/meetings/backend/routes/agents.py",
         "apps/builtins/meetings/backend/routes/meeting_lifecycle.py",
         "apps/builtins/meetings/backend/routes/tasks.py",

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -47,7 +47,7 @@ import wave
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator
 
-from kiro_crew import aws_consent, platform_compat, stt
+from kiro_crew import aws_consent, pinned_fs, platform_compat, stt
 
 # The pinned-artifact table and the digest-verified decoder store live here. It
 # imports no numpy and no recogniser binding, so this stays cheap on the gateway
@@ -1011,16 +1011,132 @@ async def _create_ffmpeg_subprocess(
     close and must run it once the child has exited. A failed spawn never
     produced a child, so nothing depends on the path surviving and the handle
     is closed here before the error propagates.
+
+    Every invocation is pinned to LOCAL protocols: FFmpeg's protocol allowlist
+    flag is prepended ahead of the caller's args (set to ``file,pipe``) so it
+    precedes every ``-i``. The import suffix allowlist upstream is a "did the
+    user mean this" filter, not a content check, so a file whose bytes are an
+    HLS/ffconcat playlist reaches the demuxer — without the protocol pin the
+    demuxer would then FETCH the playlist's segment URLs (SSRF from a crafted
+    recording, GPT review r19). Every caller in this module reads one
+    validated local file and writes a local temp file, a null sink, or a pipe,
+    so nothing legitimate needs a network protocol; the pin applies to nested
+    opens (playlist segments) as well as the top-level input.
     """
+    guarded = ("-protocol_whitelist", "file,pipe", *args)  # wokeignore:rule=whitelist
+    if not platform_compat.IS_WINDOWS:
+        # A descriptor-path input (``/dev/fd/N``) is only readable by the child
+        # if N survives the exec: collect every one in the argv and inherit it.
+        # ``pass_fds`` keeps the same numbers open in the child, so the argv
+        # needs no rewriting. Windows never receives descriptor paths (the
+        # import route refuses platforms without pinned traversal), so this is
+        # POSIX-only by construction.
+        dev_fds = tuple(
+            fd for fd in (_dev_fd_number(a) for a in args if isinstance(a, str)) if fd is not None
+        )
+        if dev_fds:
+            kwargs["pass_fds"] = tuple(kwargs.get("pass_fds", ())) + dev_fds
     if isinstance(executable, str):
-        return await asyncio.create_subprocess_exec(executable, *args, **kwargs)
+        return await asyncio.create_subprocess_exec(executable, *guarded, **kwargs)
     try:
         if not platform_compat.IS_WINDOWS:
-            kwargs["pass_fds"] = (executable.descriptor,)
-        return await asyncio.create_subprocess_exec(executable.execution_path, *args, **kwargs)
+            kwargs["pass_fds"] = tuple(kwargs.get("pass_fds", ())) + (executable.descriptor,)
+        return await asyncio.create_subprocess_exec(executable.execution_path, *guarded, **kwargs)
     except BaseException:
         await _close_ffmpeg_for_execution(executable, preserve_active_exception=True)
         raise
+
+
+#: The FFmpeg demuxer each supported audio suffix promises to be. Forcing the
+#: demuxer (``-f <name>`` before ``-i``) is the second half of the r19 protocol
+#: pin: the protocol allowlist stops NETWORK fetches, but a crafted
+#: allowed-suffix HLS/ffconcat playlist could still make an auto-probed demuxer
+#: open OTHER LOCAL FILES its text names — reads that never went through
+#: ``validate_file_path`` (GPT review r20). With the suffix's own demuxer
+#: forced, playlist text is a decode error rather than a set of paths to open.
+#: A mislabeled-but-genuine recording is refused the same way, which matches
+#: the import vet gate's "did the user mean this" contract.
+_DEMUXER_BY_SUFFIX = {
+    ".wav": "wav",
+    ".mp3": "mp3",
+    ".m4a": "mov,mp4,m4a,3gp,3g2,mj2",
+    ".mp4": "mov,mp4,m4a,3gp,3g2,mj2",
+    ".ogg": "ogg",
+    ".oga": "ogg",
+    ".opus": "ogg",
+    ".flac": "flac",
+    ".webm": "matroska,webm",
+    ".mkv": "matroska,webm",
+    ".aac": "aac",
+    ".wma": "asf",
+}
+
+
+#: Descriptor-path inputs (``/dev/fd/N``, and Linux's ``/proc/self/fd/N``): an
+#: import hands its consumers one of these instead of the snapshot's mutable
+#: name, so every open — ours and FFmpeg's — pins the inode the route opened
+#: (GPT review r21: a same-uid racer could otherwise swap the snapshot between
+#: the duration probe and the transcode, defeating the truncation guard).
+_DEV_FD_RE = re.compile(r"^(?:/dev/fd|/proc/self/fd)/(\d+)$")
+
+
+def _dev_fd_number(audio_path: str) -> int | None:
+    """The descriptor a ``/dev/fd``-style input names, or None for a plain path."""
+    match = _DEV_FD_RE.match(audio_path)
+    return int(match.group(1)) if match else None
+
+
+def _input_suffix(audio_path: str) -> str | None:
+    """The validated suffix behind *audio_path*, resolving descriptor paths.
+
+    Format decisions (demuxer pin, WAV fast paths, remux branches) must follow
+    the suffix the caller VALIDATED. For a descriptor path that suffix is read
+    through the kernel's own name for the open descriptor
+    (:func:`kiro_crew.pinned_fs.fd_real_path`) — never by trusting the mutable
+    original name. ``None`` means the suffix cannot be known (an unresolvable
+    descriptor path): callers take no fast path, and the demuxer pin refuses
+    rather than falling back to content sniffing.
+    """
+    fd = _dev_fd_number(audio_path)
+    if fd is None:
+        return os.path.splitext(audio_path)[1].lower()
+    real = pinned_fs.fd_real_path(fd)
+    if real is None:
+        return None
+    return os.path.splitext(real)[1].lower()
+
+
+def _forced_demuxer_args(audio_path: str) -> tuple[str, ...]:
+    """``("-f", <demuxer>)`` for a recognized audio suffix, else ``()``.
+
+    Every import-admissible suffix (``k.IMPORT_AUDIO_EXTENSIONS``) is covered,
+    so an attacker-influenced import input is ALWAYS decoded by the demuxer its
+    validated name promises — never by content sniffing. The empty fallback is
+    reachable only for the gateway's own internal temp files, whose names this
+    process chose itself.
+    """
+    suffix = _input_suffix(audio_path)
+    if suffix is None:
+        # A descriptor-pinned input whose real suffix cannot be read: refuse.
+        # Falling back to content sniffing here is exactly the playlist hole
+        # the demuxer pin closes. OSError, so every spawn site's existing
+        # failure arm turns it into that caller's normal "could not decode"
+        # answer (a retryable refusal for the import route).
+        raise OSError(f"cannot resolve the suffix behind {audio_path}")
+    demuxer = _DEMUXER_BY_SUFFIX.get(suffix)
+    if demuxer is None:
+        if _dev_fd_number(audio_path) is not None:
+            # Descriptor inputs are the attacker-influenced imports, and their
+            # VALIDATED suffix always maps (the coverage test pins every
+            # IMPORT_AUDIO_EXTENSIONS entry). The resolution follows the
+            # descriptor's CURRENT name, so an unmapped answer here means the
+            # snapshot was renamed after pinning — a same-uid racer stripping
+            # the suffix to re-enable content sniffing (GPT review r25).
+            # Refuse: a rename may only ever cause a loud refusal, never a
+            # sniffed playlist.
+            raise OSError(f"descriptor input {audio_path} resolved to unmapped suffix {suffix!r}")
+        return ()
+    return ("-f", demuxer)
 
 
 def ensure_ffmpeg_in_path() -> None:
@@ -1258,11 +1374,67 @@ def _load_stt_config() -> Any:
     return KiroCrewConfig.load().stt
 
 
+def load_stt_config() -> Any:
+    """One STT configuration snapshot, for callers that must not re-read it.
+
+    Every function here that takes an ``stt_config`` parameter re-loads the
+    configuration when handed None. That is right for a single call, and wrong
+    for a SEQUENCE whose answers must agree: a readiness check, a duration-cap
+    answer, and the transcription itself each re-reading the file can straddle an
+    operator changing the provider in Settings, so the gate evaluates one
+    provider's rules and the decode runs under another's. A caller doing several
+    of those calls loads ONE snapshot here and passes it to each. BLOCKING
+    (reads config); call off the event loop.
+    """
+    return _load_stt_config()
+
+
+def _under_voice_runtime_root(real: str) -> bool:
+    """Whether *real* lies under the gateway's own voice-runtime staging root.
+
+    The crew ``run/`` directory is a read+write-sensitive leaf (it holds spawn
+    trust roots), so ``is_sensitive_path`` refuses everything beneath it —
+    including the import snapshots this gateway itself stages under
+    ``run/voice-runtime`` precisely BECAUSE agents cannot reach that root
+    (GPT review r29 relocation). Judged against the kernel-resolved name of an
+    already-pinned descriptor, membership here means "a file this process
+    staged", not "a caller-supplied path": the route's own vet gate has
+    already refused sensitive ORIGINAL paths before any snapshot exists.
+    """
+    from kiro_crew.sandbox import prime_voice_runtime_sandbox_paths
+
+    root = os.path.realpath(prime_voice_runtime_sandbox_paths())
+    try:
+        return os.path.commonpath((os.path.realpath(real), root)) == root
+    except ValueError:  # different drives on Windows
+        return False
+
+
 def _is_sensitive_audio_path(audio_path: str) -> bool:
-    """Run the filesystem-resolving sensitive-path guard off the event loop."""
+    """Run the filesystem-resolving sensitive-path guard off the event loop.
+
+    A descriptor path is judged by the kernel's name for the open descriptor,
+    and an unresolvable one is refused outright — the guard must never answer
+    "not sensitive" for a file it cannot identify. The one exemption is the
+    gateway's own voice-runtime snapshot staging (see
+    :func:`_under_voice_runtime_root`), on BOTH branches: POSIX consumers hold
+    a ``/dev/fd`` path, while Windows consumers hold the snapshot NAME (the
+    open handle blocks rename/delete there). The membership test resolves the
+    real path first, so a link planted under the root resolves outside it and
+    is judged as whatever it points at.
+    """
     from kiro_crew.security import is_sensitive_path
 
-    return is_sensitive_path(audio_path)
+    fd = _dev_fd_number(audio_path)
+    if fd is not None:
+        real = pinned_fs.fd_real_path(fd)
+        if real is None:
+            return True
+    else:
+        real = audio_path
+    if _under_voice_runtime_root(real):
+        return False
+    return is_sensitive_path(real)
 
 
 def _redact_transcript(transcript: str) -> str:
@@ -1389,7 +1561,7 @@ def _read_audio_bytes(audio_path: str) -> bytes:
 
 async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]
     """Transcribe using AWS Transcribe Streaming API (ogg-opus)."""
-    ext = os.path.splitext(audio_path)[1].lower()
+    ext = _input_suffix(audio_path)
     if ext not in (".ogg", ".webm"):
         logger.error("Unsupported format '%s' for Transcribe (expected .ogg or .webm)", ext)
         return None
@@ -1423,6 +1595,13 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
     tmp_ogg = None
     actual_path = audio_path
     if ext in (".webm",):
+        try:
+            # BEFORE the decoder handle is resolved: a refusal here must not
+            # leak the authenticated FFmpeg descriptor the seam would own.
+            demux_args = _forced_demuxer_args(audio_path)
+        except OSError:
+            logger.exception("Could not resolve a demuxer to remux %s", audio_path)
+            return None
         ffmpeg_bin = await _resolve_ffmpeg_for_execution()
         if not ffmpeg_bin:
             logger.error("ffmpeg required to remux webm to ogg for Transcribe")
@@ -1438,6 +1617,7 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
                 proc = await _create_ffmpeg_subprocess(
                     ffmpeg_bin,
                     "-y",
+                    *demux_args,
                     "-i",
                     audio_path,
                     "-c:a",
@@ -1620,6 +1800,145 @@ _WAV_SUFFIXES = (".wav", ".wave")
 _MAX_AUDIO_SECS = 3600
 
 
+def batch_duration_cap_secs(stt_config=None) -> int | None:  # type: ignore[no-untyped-def]
+    """The longest recording the ACTIVE provider transcribes whole, or None.
+
+    The local recogniser truncates: both of its decode paths stop at
+    ``_MAX_AUDIO_SECS`` (the WAV reader caps ``readframes``, the ffmpeg transcode
+    passes ``-t``), and neither reports that it did. The Apple lane's
+    to-native conversion is bounded the same way (``-t`` on the remux — an
+    unbounded conversion of a large low-bitrate input could exhaust the temp
+    volume, GPT review r23), so it shares the ceiling. AWS Transcribe refuses
+    an oversized payload outright (a loud ``None``), so for it there is no
+    silent ceiling to guard. Callers that must not dispatch a truncated
+    transcript — the meetings import route — ask here which ceiling applies
+    and refuse longer input BEFORE transcribing. BLOCKING when *stt_config*
+    is None (reads config).
+    """
+    if stt_config is None:
+        stt_config = _load_stt_config()
+    if stt_config.provider == "transcribe":
+        return None
+    return _MAX_AUDIO_SECS
+
+
+def _wav_duration_secs(audio_path: str) -> float | None:
+    """Exact duration from a WAV header, or None when it is not a readable WAV.
+
+    Header math only — no sample data is read — so this works for any rate or
+    width, including files :func:`_pcm_from_wav` would hand to ffmpeg. BLOCKING.
+    """
+    try:
+        with wave.open(audio_path, "rb") as wav:
+            rate = wav.getframerate()
+            if rate <= 0:
+                return None
+            return wav.getnframes() / rate
+    except (OSError, EOFError, wave.Error):
+        return None
+
+
+_PROGRESS_OUT_TIME_RE = re.compile(rb"^out_time_us=(\d+)", re.MULTILINE)
+
+
+async def audio_exceeds_secs(
+    audio_path: str, max_secs: int, *, timeout_secs: int = 300
+) -> bool | None:
+    """Whether the recording at *audio_path* is longer than *max_secs*.
+
+    True/False when the answer is known, None when it cannot be determined.
+
+    WAV files are answered exactly from the header. Everything else is answered
+    by the same decoder that will transcribe it: a null decode bounded at
+    ``max_secs`` plus one second (``-t``), reading the decoded timestamp from
+    ffmpeg's ``-progress`` stream. Decoding — not metadata — is deliberate: the
+    dashboard's own recordings are MediaRecorder webm, whose header carries no
+    duration at all, so a metadata probe would answer None for exactly the files
+    users are most likely to import. The ``-t`` bound keeps the probe's cost
+    proportional to the cap, not to the file.
+
+    A None is honest, not fail-open in disguise, ONLY while the caller gives the
+    probe at least the timeout the transcode itself will get (callers with an
+    ``stt_config`` in hand pass ``stt_config.timeout_secs``; the default matches
+    the config default). The probe decodes at most ``max_secs + 1`` seconds — a
+    strict subset of the transcode's work — so under an aligned budget every
+    None cause leads to a loud downstream failure: an undecodable file fails the
+    transcode the same way, and a host slow enough to time the probe out times
+    the strictly-larger transcode out too. A SHORTER probe budget would reopen
+    the gap where the probe gives up but the transcode "succeeds" truncated —
+    silent data loss on exactly the over-cap files this guard exists to catch.
+    """
+    duration = await asyncio.to_thread(_wav_duration_secs, audio_path)
+    if duration is not None:
+        return duration > max_secs
+    try:
+        # BEFORE the decoder handle is resolved: a refusal here must not leak
+        # the authenticated FFmpeg descriptor the seam would otherwise own.
+        demux_args = _forced_demuxer_args(audio_path)
+    except OSError:
+        logger.exception("Could not resolve a demuxer to probe %s", audio_path)
+        return None
+    ffmpeg_bin = await _resolve_ffmpeg_for_execution()
+    if not ffmpeg_bin:
+        return None
+    try:
+        try:
+            proc = await _create_ffmpeg_subprocess(
+                ffmpeg_bin,
+                "-v",
+                "error",
+                "-nostdin",
+                "-progress",
+                "pipe:1",
+                *demux_args,
+                "-i",
+                audio_path,
+                "-vn",
+                # One second PAST the cap: the probe only needs to know whether the
+                # recording crosses it, so decoding further would be pure waste.
+                "-t",
+                str(max_secs + 1),
+                "-f",
+                "null",
+                "-",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError:
+            logger.exception("Could not run ffmpeg (%s) to probe %s", ffmpeg_bin, audio_path)
+            return None
+        try:
+            stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
+        except asyncio.TimeoutError:
+            await _kill_and_reap(proc)
+            logger.error(
+                "ffmpeg duration probe of %s timed out after %ds", audio_path, timeout_secs
+            )
+            return None
+        except BaseException:
+            # CancelledError is a BaseException; stop AND reap the child so an
+            # abandoned request does not leak a decoder process.
+            await _kill_and_reap(proc)
+            raise
+        if proc.returncode != 0:
+            return None
+        matches = _PROGRESS_OUT_TIME_RE.findall(stdout or b"")
+        if not matches:
+            return None
+        return int(matches[-1]) / 1_000_000 > max_secs
+    finally:
+        # The authenticated handle must outlive the spawn (#8918): every path
+        # reaching this ``finally`` has already reaped the child (``communicate``
+        # on success and nonzero exit, kill-and-reap on timeout and
+        # cancellation) or never spawned one, so the staged image can be
+        # released now — off the loop, like every sibling spawn site, instead
+        # of by ``__del__`` running the blocking close on the gateway loop.
+        await _close_ffmpeg_for_execution(
+            ffmpeg_bin,
+            preserve_active_exception=sys.exc_info()[1] is not None,
+        )
+
+
 def _whisper_language(language_code: str) -> str:
     """Reduce a BCP-47 tag to the bare language whisper wants (``en-US`` -> ``en``).
 
@@ -1656,21 +1975,52 @@ def _pcm_from_wav(audio_path: str) -> np.ndarray | None:
             channels = wav.getnchannels()
             if wav.getframerate() != stt.SAMPLE_RATE_HZ or wav.getsampwidth() != 2 or channels < 1:
                 return None
-            raw = wav.readframes(min(wav.getnframes(), _MAX_AUDIO_SECS * stt.SAMPLE_RATE_HZ))
+            frames_total = min(wav.getnframes(), _MAX_AUDIO_SECS * stt.SAMPLE_RATE_HZ)
+            if channels == 1:
+                return stt.pcm_from_int16(wav.readframes(frames_total))
+            # Fold to mono in BYTE-bounded slices. A whole-file read would hold
+            # the interleaved int16 buffer AND its float32 conversion at once —
+            # around 1.5 GiB for a four-channel hour, enough to OOM the
+            # gateway on an input the 512 MiB import cap admits (GPT review
+            # r23). And the bound must be BYTES, not seconds: a frame is
+            # ``channels * 2`` bytes, so a fixed frame count lets the channel
+            # count scale the transient without limit — a valid 256-channel
+            # minute under the same cap would make a "60-second" slice
+            # allocate ~0.5 GiB raw plus its float32 conversion (GPT review
+            # r34). 8 MiB of raw int16 per slice keeps the transient under a
+            # few tens of MiB for ANY channel count, while the result stays
+            # the same: the per-frame mean is local to each frame, and
+            # ``readframes`` counts whole frames, so no frame is ever split
+            # across slices.
+            chunk_frames = max(1, (8 * 1024 * 1024) // (channels * 2))
+            folded = []
+            remaining = frames_total
+            while remaining > 0:
+                take = min(chunk_frames, remaining)
+                raw = wav.readframes(take)
+                if not raw:
+                    break
+                remaining -= take
+                pcm = stt.pcm_from_int16(raw)
+                # Drop a final frame the file cut in half before folding
+                # channels, so the reshape cannot fail on a truncated
+                # recording.
+                usable = pcm.size - (pcm.size % channels)
+                if usable <= 0:
+                    continue
+                folded.append(pcm[:usable].reshape(-1, channels).mean(axis=1, dtype=pcm.dtype))
     except (OSError, EOFError, wave.Error):
         # Not a readable PCM WAV (a compressed payload, a truncated header, a
         # mislabelled suffix). ffmpeg reads far more than the stdlib does, so this
         # is a "try the other route", not a failure.
         return None
-    pcm = stt.pcm_from_int16(raw)
-    if channels == 1:
-        return pcm
-    # Drop a final frame the file cut in half before folding channels, so the
-    # reshape cannot fail on a truncated recording.
-    usable = pcm.size - (pcm.size % channels)
-    if usable <= 0:
+    if not folded:
         return None
-    return pcm[:usable].reshape(-1, channels).mean(axis=1, dtype=pcm.dtype)
+    if len(folded) == 1:
+        return folded[0]
+    import numpy as np  # runtime import: module-level numpy is typing-only here
+
+    return np.concatenate(folded)
 
 
 async def _kill_and_reap(proc: Any) -> None:
@@ -1703,6 +2053,13 @@ async def _pcm_via_ffmpeg(audio_path: str, timeout_secs: int) -> np.ndarray | No
     accepts exactly one format, so the transcode targets it directly rather than
     leaving a rate conversion for later.
     """
+    try:
+        # BEFORE the decoder handle is resolved: a refusal here must not leak
+        # the authenticated FFmpeg descriptor the seam would otherwise own.
+        demux_args = _forced_demuxer_args(audio_path)
+    except OSError:
+        logger.exception("Could not resolve a demuxer to decode %s", audio_path)
+        return None
     ffmpeg_bin = await _resolve_ffmpeg_for_execution()
     if not ffmpeg_bin:
         logger.error(
@@ -1721,6 +2078,7 @@ async def _pcm_via_ffmpeg(audio_path: str, timeout_secs: int) -> np.ndarray | No
             proc = await _create_ffmpeg_subprocess(
                 ffmpeg_bin,
                 "-y",
+                *demux_args,
                 "-i",
                 audio_path,
                 "-ar",
@@ -1802,7 +2160,7 @@ async def _transcribe_local(audio_path: str, stt_config) -> str | None:  # type:
         return None
 
     pcm: np.ndarray | None = None
-    if os.path.splitext(audio_path)[1].lower() in _WAV_SUFFIXES:
+    if _input_suffix(audio_path) in _WAV_SUFFIXES:
         pcm = await asyncio.to_thread(_pcm_from_wav, audio_path)
     if pcm is None:
         pcm = await _pcm_via_ffmpeg(audio_path, stt_config.timeout_secs)

--- a/test/meetings_helpers.py
+++ b/test/meetings_helpers.py
@@ -35,7 +35,9 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.apps.builtins.meetings.backend import store
 from kiro_crew.apps.builtins.meetings.backend.domain import session as sess
-from kiro_crew.apps.builtins.meetings.backend.routes import _common, register_routes
+from kiro_crew.apps.builtins.meetings.backend.routes import _common
+from kiro_crew.apps.builtins.meetings.backend.routes import audio_import as _audio_import
+from kiro_crew.apps.builtins.meetings.backend.routes import register_routes
 
 
 @pytest.fixture(name="root")
@@ -51,9 +53,11 @@ def reset_module_state_fixture():
     """No test may leak the active meeting or the dictionary into the next one."""
     _common.ACTIVE.clear()
     sess.shared_dictionary().load_terms([])
+    _audio_import._imports_in_flight.clear()
     yield
     _common.ACTIVE.clear()
     sess.shared_dictionary().load_terms([])
+    _audio_import._imports_in_flight.clear()
 
 
 @pytest.fixture(name="enabled")

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from kiro_crew import apple_speech, platform_compat
+from kiro_crew import transcribe as _tr_mod
 from kiro_crew.config.loader import (
     _VALID_STT_PROVIDERS,
     STT_PROVIDER_LOCAL,
@@ -94,6 +95,20 @@ def _fake_native_audio(path):
         return path, False
 
     return _inner
+
+
+def _stub_probe_under_cap(monkeypatch):
+    """Answer the r26/r27 pre-remux duration gate with 'under the cap'.
+
+    Remux-driving tests fake the FFmpeg spawn, which would otherwise make the
+    probe unanswerable and trip the None-refuses gate before the code under
+    test runs.
+    """
+
+    async def _under_cap(path, max_secs, **kw):
+        return False
+
+    monkeypatch.setattr(_tr_mod, "audio_exceeds_secs", _under_cap)
 
 
 class TestHelperBuild:
@@ -430,6 +445,115 @@ class TestTranscribePlumbing:
         assert (path, is_temp) == ("/tmp/voice.wav", False)
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="descriptor paths are the POSIX branch")
+    async def test_a_descriptor_path_never_takes_the_native_fast_path(self, tmp_path):
+        """``/dev/fd/N`` names a descriptor of THIS process — meaningless to
+        the Swift helper (GPT review r23: a native-suffix import would 502).
+        The remux is the materializing path, so a descriptor input must reach
+        it even when its real suffix is native."""
+        real = tmp_path / "voice.wav"
+        real.write_bytes(b"x")
+        fd = os.open(str(real), os.O_RDONLY)
+        called = []
+        try:
+            with (
+                patch("kiro_crew.transcribe._open_ffmpeg_for_execution", return_value=None),
+                patch(
+                    "kiro_crew.transcribe.ensure_ffmpeg_in_path",
+                    side_effect=lambda: called.append(True),
+                ),
+            ):
+                await apple_speech._to_native_audio(f"/dev/fd/{fd}")
+        finally:
+            os.close(fd)
+        assert called, "the fast path must be skipped: the remux branch was never reached"
+
+    @pytest.mark.asyncio
+    async def test_an_over_cap_input_is_refused_before_the_remux(self, monkeypatch):
+        """The ``-t`` bound is a temp-disk guard, not a licence to truncate:
+        a recording the probe shows is over the ceiling must be REFUSED before
+        conversion (GPT review r26) — transcribing only its first hour would
+        be silent data loss for every non-import caller."""
+        from kiro_crew import transcribe as tr
+
+        async def _too_long(path, max_secs, **kw):
+            return True
+
+        monkeypatch.setattr(tr, "audio_exceeds_secs", _too_long)
+        with (
+            patch("kiro_crew.transcribe._resolve_ffmpeg_for_execution", return_value="ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+        ):
+            with pytest.raises(apple_speech.RecordingTooLongError, match="trim"):
+                await apple_speech._to_native_audio("/tmp/voice.webm")
+
+    @pytest.mark.asyncio
+    async def test_an_unverifiable_duration_is_refused_before_the_remux(self, monkeypatch):
+        """A ``None`` probe must refuse too (GPT review r27): a TRANSIENT
+        cause — a load spike that times the probe out but clears before the
+        remux — would let the ``-t``-bounded conversion succeed on the
+        truncated prefix of an over-cap recording. Only a persistent cause is
+        covered by the aligned-budget argument, so unknown duration is a loud,
+        retryable refusal — the same rule the meetings import gate applies."""
+        from kiro_crew import transcribe as tr
+
+        async def _unanswerable(path, max_secs, **kw):
+            return None
+
+        monkeypatch.setattr(tr, "audio_exceeds_secs", _unanswerable)
+        with (
+            patch("kiro_crew.transcribe._resolve_ffmpeg_for_execution", return_value="ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+        ):
+            with pytest.raises(apple_speech.DurationUnverifiedError, match="retry"):
+                await apple_speech._to_native_audio("/tmp/voice.webm")
+
+    @pytest.mark.asyncio
+    async def test_the_over_cap_refusal_surfaces_as_a_transcribe_error(self, monkeypatch):
+        from kiro_crew import transcribe as tr
+
+        async def _too_long(path, max_secs, **kw):
+            return True
+
+        monkeypatch.setattr(tr, "audio_exceeds_secs", _too_long)
+        monkeypatch.setattr(apple_speech, "availability", lambda: apple_speech.Availability(True))
+        monkeypatch.setattr(apple_speech, "helper_path", lambda: "/fake/helper")
+        with (
+            patch("kiro_crew.transcribe._resolve_ffmpeg_for_execution", return_value="ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+        ):
+            text, metrics = await apple_speech.transcribe("/tmp/voice.webm")
+        assert text is None
+        assert "ceiling" in metrics["error"]
+
+    @pytest.mark.asyncio
+    async def test_the_remux_is_bounded_by_the_decoder_ceiling(self, tmp_path, monkeypatch):
+        """An unbounded conversion of a large low-bitrate input could expand
+        into a multi-gigabyte WAV and exhaust the temp volume (GPT review
+        r23): the remux must carry ``-t _MAX_AUDIO_SECS``, the same ceiling
+        ``batch_duration_cap_secs`` reports for this lane."""
+        from kiro_crew import transcribe as tr
+
+        _stub_probe_under_cap(monkeypatch)
+        captured: dict = {}
+
+        async def fake_spawn(executable, *args, **kwargs):
+            captured["args"] = args
+            raise OSError("stop here — argv captured")
+
+        with (
+            patch("kiro_crew.transcribe._resolve_ffmpeg_for_execution", return_value="ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("kiro_crew.transcribe._create_ffmpeg_subprocess", side_effect=fake_spawn),
+        ):
+            with pytest.raises(OSError, match="argv captured"):
+                await apple_speech._to_native_audio("/tmp/voice.webm")
+
+        args = captured["args"]
+        assert "-t" in args
+        assert args[args.index("-t") + 1] == str(tr._MAX_AUDIO_SECS)
+
+    @pytest.mark.asyncio
     async def test_webm_without_ffmpeg_degrades_instead_of_refusing(self):
         """The dashboard records .webm, which the framework cannot read. With no
         ffmpeg we still hand the original path over so the caller surfaces the
@@ -545,6 +669,7 @@ class TestTranscodeTempOwnership:
     async def test_spawn_failure_removes_the_owned_temp(self, tmp_path, monkeypatch):
         """An ffmpeg that fails to spawn never ran, so nothing else will ever
         remove the mkstemp output — the invocation must."""
+        _stub_probe_under_cap(monkeypatch)
         owned = self._owned_temp(tmp_path, monkeypatch)
         src = tmp_path / "voice.webm"
         src.write_bytes(b"data")
@@ -572,6 +697,7 @@ class TestTranscodeTempOwnership:
         itself rather than by ``__del__`` on the gateway event loop."""
         from kiro_crew import transcribe as tr
 
+        _stub_probe_under_cap(monkeypatch)
         owned = self._owned_temp(tmp_path, monkeypatch)
         src = tmp_path / "voice.webm"
         src.write_bytes(b"data")
@@ -625,6 +751,7 @@ class TestTranscodeTempOwnership:
         only suspension point between the child exiting and the success return
         transferring the temp to the caller -- must not propagate with the
         invocation-owned ``.wav`` still on disk (#8918 round 2)."""
+        _stub_probe_under_cap(monkeypatch)
         owned = self._owned_temp(tmp_path, monkeypatch)
         src = tmp_path / "voice.webm"
         src.write_bytes(b"data")
@@ -657,6 +784,7 @@ class TestTranscodeTempOwnership:
     async def test_temp_creation_failure_closes_authenticated_decoder_off_loop(
         self, tmp_path, monkeypatch
     ):
+        _stub_probe_under_cap(monkeypatch)
         from kiro_crew import transcribe as tr
 
         binary = tmp_path / "ffmpeg"
@@ -721,6 +849,13 @@ class TestTranscodeTempOwnership:
             return real_unlink(path, *args, **kwargs)
 
         monkeypatch.setattr(apple_speech.os, "unlink", tracked_unlink)
+
+        async def _under_cap(path, max_secs, **kw):
+            return False
+
+        # The r26 pre-remux duration probe would otherwise consume the fake
+        # process; this test is about cancellation INSIDE the remux.
+        monkeypatch.setattr(_tr_mod, "audio_exceeds_secs", _under_cap)
         with (
             patch(
                 "kiro_crew.transcribe._open_ffmpeg_for_execution",
@@ -741,6 +876,7 @@ class TestTranscodeTempOwnership:
     ):
         """The cleanup must not eat the success path: the caller's existing
         cleanup relies on receiving the temp path with ownership."""
+        _stub_probe_under_cap(monkeypatch)
         owned = self._owned_temp(tmp_path, monkeypatch)
         src = tmp_path / "voice.webm"
         src.write_bytes(b"data")
@@ -769,7 +905,7 @@ class TestTranscodeTempOwnership:
         owned = tmp_path / "native.wav"
         owned.write_bytes(b"x")
 
-        async def fake_native(_path):
+        async def fake_native(*_a, **_k):
             return str(owned), True
 
         def boom(argv):

--- a/test/test_meetings_audio_import.py
+++ b/test/test_meetings_audio_import.py
@@ -1,0 +1,1366 @@
+"""Importing an existing recording into a live meeting.
+
+Two halves, tested separately because they fail differently:
+
+* :mod:`...domain.audio` — the pure split from one transcript blob into the lines
+  the dispatch transaction expects. Every downstream consumer (transcript append,
+  dictionary, noise gate, agent batcher) is per-line, so the boundary rules are the
+  feature.
+* the route — a file path arriving from a client, which means the interesting tests
+  are the refusals and their ORDER, not the happy path.
+
+No model and no audio decoder is ever reached: ``transcribe_audio`` and the
+availability probe are patched in every route test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from meetings_helpers import (  # noqa: F401 — fixtures are used by name
+    app_fixture,
+    client_for,
+    enabled_fixture,
+    fake_sessions_fixture,
+    reset_module_state_fixture,
+    root_fixture,
+)
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend.domain import audio
+from kiro_crew.apps.builtins.meetings.backend.routes import _common
+from kiro_crew.apps.builtins.meetings.backend.routes import audio_import as ai
+from kiro_crew.pinned_fs import supports_pinned_walk
+
+BASE = k.API_BASE
+
+
+async def _start(client, meeting_id: str = "standup") -> None:
+    await client.post(f"{BASE}/meetings/{meeting_id}/init", json={"title": "Standup"})
+    resp = await client.post(f"{BASE}/meetings/{meeting_id}/start", json={})
+    assert resp.status == 200, await resp.text()
+
+
+@pytest.fixture(autouse=True)
+def _owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every route test calls as the dashboard owner unless it says otherwise.
+
+    Mirrors ``_patch``'s philosophy: the owner gate stays ACTIVE but passing, so
+    the normal-path tests exercise the handler THROUGH the gate rather than
+    bypassing it. The helper itself reads dashboard auth state this bare test
+    app does not carry, so it is patched at this module's import site — the
+    denial test overrides it back to False.
+    """
+    monkeypatch.setattr(ai, "is_owner_dashboard_request", lambda _request: True)
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, **over: Any) -> dict[str, list]:
+    """Patch the route's external dependencies. Returns a call log.
+
+    ``transcribe_audio`` (and the config/duration helpers beside it) is patched on
+    :mod:`kiro_crew.transcribe`, not on this module, because the route imports
+    them INSIDE the handler (so a heavy optional dependency is not imported at
+    gateway startup). Defaults keep the gate ACTIVE but passing — a cap exists
+    and the recording is under it — so every normal-path test exercises the gate
+    rather than bypassing it. The snapshot copy is stubbed to write a REAL file
+    into the route's snapshot dir (named like the real helper's output): the
+    route pins that file with one descriptor and hands both consumers a
+    ``/dev/fd`` path, so the stub must produce something openable. The probe
+    and transcribe stubs log the CALL-TIME realpath of what they were handed —
+    the descriptor is closed before the response returns, so a later resolve
+    would fail. The real copy helper has its own tests below.
+    """
+    import kiro_crew.transcribe as transcribe_mod
+
+    stt_config = over.get("stt_config", SimpleNamespace(timeout_secs=300))
+    log: dict[str, list] = {
+        "vetted": [],
+        "transcribed": [],
+        "probed": [],
+        "probe_timeouts": [],
+        "config_loads": [],
+        "snapshots": [],
+        "snapshot_files": [],
+        "ready_config": [],
+        "cap_config": [],
+    }
+
+    def _vet(raw: str) -> "tuple[str, tuple[int, int] | None, str]":
+        log["vetted"].append(raw)
+        return over.get("vet", (raw, (0, 0), ""))
+
+    def _load_config() -> Any:
+        log["config_loads"].append(stt_config)
+        return stt_config
+
+    def _ready(cfg: Any) -> bool:
+        log["ready_config"].append(cfg)
+        return over.get("ready", True)
+
+    def _snapshot(
+        canonical: str, snapshot_dir: str, expected_src_ident: "tuple[int, int]"
+    ) -> "tuple[str, tuple[int, int]] | None":
+        log["snapshots"].append(canonical)
+        if over.get("snapshot_refused"):
+            return None
+        dst = os.path.join(snapshot_dir, "recording" + Path(canonical).suffix.lower())
+        with open(dst, "wb") as fh:
+            fh.write(over.get("snapshot_bytes", b"fake recording bytes"))
+        log["snapshot_files"].append(dst)
+        st = os.stat(dst)
+        return dst, (st.st_dev, st.st_ino)
+
+    async def _transcribe(path: str, *a: Any, **kw: Any) -> str | None:
+        log["transcribed"].append((os.path.realpath(path), a[0] if a else kw.get("stt_config")))
+        return over.get("transcript", "we decided to ship on Friday")
+
+    def _cap(cfg: Any = None) -> int | None:
+        log["cap_config"].append(cfg)
+        return over.get("cap", 3600)
+
+    async def _exceeds(path: str, max_secs: int, **kw: Any) -> bool | None:
+        log["probed"].append((os.path.realpath(path), max_secs))
+        log["probe_timeouts"].append(kw.get("timeout_secs"))
+        return over.get("exceeds", False)
+
+    monkeypatch.setattr(ai, "_vet_audio_file", _vet)
+    monkeypatch.setattr(ai, "_transcription_ready", _ready)
+    monkeypatch.setattr(ai, "_snapshot_recording", _snapshot)
+    # Route tests exercise HANDLER logic with the snapshot stubbed, so the
+    # platform gate must read as capable everywhere — on real Windows the
+    # gate would otherwise answer 501 for every test in this file. The 501
+    # test overrides this back to False explicitly.
+    monkeypatch.setattr(ai, "supports_pinned_walk", lambda: True)
+    monkeypatch.setattr(transcribe_mod, "load_stt_config", _load_config)
+    monkeypatch.setattr(transcribe_mod, "transcribe_audio", _transcribe)
+    monkeypatch.setattr(transcribe_mod, "batch_duration_cap_secs", _cap)
+    monkeypatch.setattr(transcribe_mod, "audio_exceeds_secs", _exceeds)
+    return log
+
+
+# ---------------------------------------------------------------------------
+# The split
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTranscript:
+    def _split(self, text: str, *, max_chars: int = 4000, max_lines: int = 2000) -> list[str]:
+        return audio.split_transcript(text, max_chars=max_chars, max_lines=max_lines)
+
+    def test_nothing_in_nothing_out(self):
+        assert self._split("") == []
+        assert self._split("   \n\n\t ") == []
+
+    def test_prefers_the_transcribers_own_segments(self):
+        """Tier 1. A whisper segment is the closest thing to "one utterance"."""
+        assert self._split("first line\nsecond line\n\nthird line") == [
+            "first line",
+            "second line",
+            "third line",
+        ]
+
+    def test_does_not_resplit_segments_on_punctuation(self):
+        """A segment containing two sentences stays ONE line.
+
+        Tier 1 wins outright: the transcriber's own boundary is better information
+        than anything punctuation can reconstruct, so sentence splitting must not
+        also run over it.
+        """
+        assert self._split("Yes. No.\nMaybe.") == ["Yes. No.", "Maybe."]
+
+    def test_falls_back_to_sentences_for_a_single_paragraph(self):
+        """Tier 2. AWS Transcribe returns one line for the whole recording."""
+        assert self._split("We shipped it. Bob owns the rollback! Does that work?") == [
+            "We shipped it.",
+            "Bob owns the rollback!",
+            "Does that work?",
+        ]
+
+    def test_a_decimal_point_is_not_a_sentence_boundary(self):
+        # The lookahead requires whitespace after the mark, which is what keeps
+        # "3.5" and "v1.2" intact.
+        assert self._split("We picked version 1.2 and 3.5 GB of RAM.") == [
+            "We picked version 1.2 and 3.5 GB of RAM.",
+        ]
+
+    def test_splits_cjk_sentence_marks(self):
+        assert self._split("出荷を決めた。ロールバックは田中さんが担当。") == [
+            "出荷を決めた。",
+            "ロールバックは田中さんが担当。",
+        ]
+
+    def test_an_over_long_line_is_wrapped_not_truncated(self):
+        """Tier 3. Truncating would silently DROP the tail of a long sentence."""
+        long_line = " ".join(["word"] * 100)  # ~499 chars
+        out = self._split(long_line, max_chars=50)
+        assert len(out) > 1
+        assert all(len(line) <= 50 for line in out)
+        # Every word survives, and in order.
+        assert " ".join(out).split() == long_line.split()
+
+    def test_text_with_no_spaces_is_hard_sliced(self):
+        # CJK has no word spaces, so the whitespace-preferring wrap must not loop
+        # forever or give up.
+        out = self._split("あ" * 120, max_chars=50)
+        assert [len(line) for line in out] == [50, 50, 20]
+
+    def test_a_line_count_overflow_is_rejected_not_sliced(self):
+        """GPT review: a capped result is indistinguishable from a complete one.
+
+        Silently discarding the tail past ``max_lines`` while the route returns
+        200 is data loss the user cannot see — the split refuses the whole
+        recording instead.
+        """
+        with pytest.raises(audio.TranscriptTooLong):
+            self._split("\n".join(f"line {i}" for i in range(50)), max_lines=10)
+
+    def test_a_recording_exactly_at_the_line_budget_is_accepted(self):
+        out = self._split("\n".join(f"line {i}" for i in range(10)), max_lines=10)
+        assert len(out) == 10
+        assert out[0] == "line 0"
+        assert out[-1] == "line 9"
+
+    def test_every_line_is_stripped_and_non_empty(self):
+        out = self._split("  padded  \n\n\n   \n  also padded  ")
+        assert out == ["padded", "also padded"]
+
+
+# ---------------------------------------------------------------------------
+# Refusals, and their order
+# ---------------------------------------------------------------------------
+
+
+class TestRefusals:
+    @pytest.mark.asyncio
+    async def test_a_non_owner_caller_is_refused_before_anything_runs(self, app, monkeypatch):
+        """The owner gate comes before everything — body parsing included.
+
+        The route's capability is "read an arbitrary host file by path", the
+        class aws-control and the app job routes reserve for the dashboard
+        owner. A non-owner gets the shared denial shape, and none of the
+        machinery below the gate (vetting, transcription) ever runs — proven by
+        the call log staying empty even though the request body names a path.
+        """
+        log = _patch(monkeypatch)
+        monkeypatch.setattr(ai, "is_owner_dashboard_request", lambda _request: False)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "dashboard_owner_required"
+        assert log["vetted"] == []
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_both_owner_decisions_reach_the_audit_trail(self, app, monkeypatch):
+        """GPT review r13: an ALLOW is a permission decision too. Without the
+        allowed record, an owner request that then fails JSON parsing would
+        leave no trace the owner path was entered; auditing only denials shows
+        who was refused but never who got through."""
+        _patch(monkeypatch, transcript="hello")
+        records: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            ai,
+            "audit",
+            lambda op, res, *, outcome, error="": records.append((op, res, outcome)),
+        )
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 200
+        assert any(o == "allowed" and "owner-check" in r for _op, r, o in records)
+
+        monkeypatch.setattr(ai, "is_owner_dashboard_request", lambda _request: False)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 403
+        assert any(o == "denied" and "non-owner" in r for _op, r, o in records)
+
+    @pytest.mark.asyncio
+    async def test_no_live_meeting_is_409(self, app, monkeypatch):
+        log = _patch(monkeypatch)
+        async with client_for(app) as client:
+            await client.post(f"{BASE}/meetings/standup/init", json={})
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "no_active_meeting"
+        # And nothing was transcribed: the session check comes FIRST so an hour of
+        # audio is not decoded on the way to an error we could give immediately.
+        assert log["transcribed"] == []
+        assert log["vetted"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_expired_session_is_410_and_ends_the_meeting(
+        self, app, fake_sessions, monkeypatch, root: Path
+    ):
+        """Shared with /dispatch through `_common.dispatch_admission`, side effects included."""
+        _patch(monkeypatch)
+        async with client_for(app) as client:
+            await _start(client)
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            session.started_at -= k.MAX_SESSION_DURATION + 1
+
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 410
+            assert (await resp.json())["code"] == "meeting_session_expired"
+
+            body = await (await client.get(f"{BASE}/meetings/standup")).json()
+        # The expiry branch's side effect: the session is gone AND the meeting says so.
+        assert _common.ACTIVE.get("standup") is None
+        assert body["meta"]["status"] == k.STATUS_ENDED
+
+    @pytest.mark.asyncio
+    async def test_a_recreated_meeting_does_not_receive_the_old_recording(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """A meeting stopped and recreated with the SAME id mid-import is not contaminated.
+
+        The id is a name, not an identity: transcription takes minutes, and a user
+        who stops the meeting and starts a new one under the same id during that
+        window must not find someone else's recording in the new meeting's
+        transcript. The import pins the session OBJECT admitted at its start and
+        every dispatched line requires that same object, so the replacement gets a
+        410 instead of the old lines.
+        """
+        import kiro_crew.transcribe as transcribe_mod
+
+        _patch(monkeypatch)
+        async with client_for(app) as client:
+            await _start(client)
+            old = _common.ACTIVE.get("standup")
+            assert old is not None
+
+            async def _transcribe_while_recreated(path: str, *_a: Any, **_kw: Any) -> str:
+                # Mid-transcription: the meeting is stopped and a NEW one is
+                # started under the same id — the reviewer's exact scenario.
+                resp = await client.post(f"{BASE}/meetings/standup/stop", json={})
+                assert resp.status == 200, await resp.text()
+                await _start(client)
+                return "a line from the old recording"
+
+            monkeypatch.setattr(transcribe_mod, "transcribe_audio", _transcribe_while_recreated)
+
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 410
+            assert (await resp.json())["code"] == "meeting_session_replaced"
+
+            new = _common.ACTIVE.get("standup")
+            assert new is not None and new is not old
+            # Nothing from the old recording reached the replacement session...
+            assert all(len(q.queue) == 0 for q in new.agents.values())
+            # ...or the recreated meeting's transcript.
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+        assert all("old recording" not in seg["text"] for seg in body["segments"]), body["segments"]
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_still_initializing_answers_410_not_409(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review r7: the replacement's INITIALIZATION window.
+
+        A recreated session spends its first moments with ingress closed, where
+        ``get_for_dispatch`` answers None. A 409 ``no_active_meeting`` there would
+        tell the import to retry — into a session it was never admitted to. The
+        identity check must see the initializing session (``ACTIVE.get``) and
+        answer the permanent 410, same as the fully-started replacement above.
+        """
+        import kiro_crew.transcribe as transcribe_mod
+
+        _patch(monkeypatch)
+        async with client_for(app) as client:
+            await _start(client)
+            old = _common.ACTIVE.get("standup")
+            assert old is not None
+
+            async def _transcribe_while_replacement_initializes(
+                path: str, *_a: Any, **_kw: Any
+            ) -> str:
+                # Stop, start the replacement, then close its ingress the same way
+                # the start handler does mid-initialization: session installed,
+                # dispatches held, exactly the window the 409 used to leak from.
+                resp = await client.post(f"{BASE}/meetings/standup/stop", json={})
+                assert resp.status == 200, await resp.text()
+                await _start(client)
+                _common.ACTIVE.suspend_dispatches(_common.ACTIVE.get("standup"), buffer_speech=True)
+                return "a line from the old recording"
+
+            monkeypatch.setattr(
+                transcribe_mod, "transcribe_audio", _transcribe_while_replacement_initializes
+            )
+
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 410, await resp.text()
+            assert (await resp.json())["code"] == "meeting_session_replaced"
+
+            # Nothing was buffered into the initializing replacement's hold.
+            new = _common.ACTIVE.get("standup")
+            assert new is not None and new is not old
+            assert all(len(q.queue) == 0 for q in new.agents.values())
+
+    @pytest.mark.asyncio
+    async def test_a_denied_path_is_403(self, app, fake_sessions, monkeypatch):
+        log = _patch(monkeypatch, vet=("", None, "denied"))
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import",
+                json={"audio_path": "/home/someone/.aws/credentials"},
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "audio_path_denied"
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_missing_file_is_404(self, app, fake_sessions, monkeypatch):
+        _patch(monkeypatch, vet=("", None, "not_a_file"))
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/gone.wav"}
+            )
+            assert resp.status == 404
+            assert (await resp.json())["code"] == "audio_file_not_found"
+
+    @pytest.mark.asyncio
+    async def test_a_platform_without_pinned_walk_is_501(self, app, fake_sessions, monkeypatch):
+        """GPT review r31: without kernel pinned traversal a user-supplied path
+        cannot be opened race-free (a Windows ancestor->UNC junction swap makes
+        the open itself fire outbound SMB auth). The route refuses BEFORE any
+        filesystem step — the vet must never run."""
+        log = _patch(monkeypatch)
+        monkeypatch.setattr(ai, "supports_pinned_walk", lambda: False)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/talk.wav"}
+            )
+            assert resp.status == 501
+            assert (await resp.json())["code"] == "import_unsupported_on_platform"
+        assert log["vetted"] == [], "the platform gate must fire before the vet"
+        assert log["snapshots"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_unsupported_format_is_400(self, app, fake_sessions, monkeypatch):
+        _patch(monkeypatch, vet=("", None, "unsupported_format"))
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/notes.pdf"}
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "audio_format_unsupported"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_speech_to_text_is_503(self, app, fake_sessions, monkeypatch):
+        """503, not 400: the request is fine and works once Settings is fixed."""
+        log = _patch(monkeypatch, ready=False)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "transcription_unavailable"
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_transcription_is_502(self, app, fake_sessions, monkeypatch):
+        _patch(monkeypatch, transcript=None)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 502
+            assert (await resp.json())["code"] == "transcription_failed"
+
+    @pytest.mark.asyncio
+    async def test_an_emptied_transcript_is_also_502(self, app, fake_sessions, monkeypatch):
+        """The hallucination filter returns "" for a transcript that was all boilerplate.
+
+        Reporting success with zero lines would put "Thanks for watching!" — or
+        nothing at all — in front of the user as a completed import.
+        """
+        _patch(monkeypatch, transcript="")
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 502
+
+    @pytest.mark.asyncio
+    async def test_an_over_long_recording_is_413_and_nothing_is_dispatched(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """The whole recording is refused — never a silent partial import."""
+        _patch(monkeypatch, transcript="\n".join(f"line {i}" for i in range(10)))
+        monkeypatch.setattr(k, "MAX_IMPORT_LINES", 5)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 413
+            assert (await resp.json())["code"] == "recording_too_long"
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert all(len(q.queue) == 0 for q in session.agents.values())
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+        assert body["segments"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_missing_path_is_400(self, app, fake_sessions, monkeypatch):
+        _patch(monkeypatch)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(f"{BASE}/meetings/standup/import", json={})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_file_is_413_and_never_reaches_the_decoder(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review: the size ceiling refuses BEFORE transcription, so an
+        oversized upload costs nothing — no decode, no dispatch."""
+        log = _patch(monkeypatch, vet=("", None, "file_too_large"))
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/huge.wav"}
+            )
+            assert resp.status == 413
+            assert (await resp.json())["code"] == "audio_file_too_large"
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_recording_over_the_decoder_cap_is_413_not_a_truncated_200(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review: the local decoder stops reading at its ceiling WITHOUT
+        saying so, so a recording over the cap must be refused whole before
+        transcription — never transcribed-truncated and dispatched as a 200."""
+        log = _patch(monkeypatch, exceeds=True)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/marathon.webm"}
+            )
+            assert resp.status == 413
+            assert (await resp.json())["code"] == "recording_too_long"
+        # The probe consumed the PINNED snapshot (call-time realpath), not the
+        # user-writable original name.
+        assert log["probed"] == [(os.path.realpath(log["snapshot_files"][0]), 3600)]
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_the_probe_gets_the_transcodes_own_time_budget(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review r8: the probe decodes a strict subset of the transcode's
+        work, so giving it a SHORTER budget than ``stt_config.timeout_secs``
+        opens a band where the probe times out (None → proceed) but the
+        transcode "succeeds" truncated — silent data loss on exactly the
+        over-cap files the guard exists to catch. The route must hand the probe
+        the same budget the transcode will get."""
+        log = _patch(monkeypatch, stt_config=SimpleNamespace(timeout_secs=222))
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/long.webm"}
+            )
+            assert resp.status == 200
+        assert log["probe_timeouts"] == [222]
+
+    @pytest.mark.asyncio
+    async def test_an_indeterminate_duration_probe_is_refused_retryably(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review r14: the aligned probe budget covers PERSISTENT None
+        causes (they defeat the transcode too), but a TRANSIENT one — a load
+        spike that clears between probe and transcode — would let the local
+        decoder truncate an over-cap recording and answer 200. An indeterminate
+        probe is refused with a retryable 503 whose message names the retry and
+        the cap, so the refusal is actionable, never silent data loss."""
+        log = _patch(monkeypatch, exceeds=None)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/glitch.webm"}
+            )
+            assert resp.status == 503
+            body = await resp.json()
+            assert body["code"] == "duration_unverified"
+            # Actionable: the message tells the user what to do next.
+            assert "retry" in body["error"] and "minutes" in body["error"]
+        assert log["transcribed"] == [], "nothing may be transcribed on an unverified duration"
+
+    @pytest.mark.asyncio
+    async def test_a_provider_without_a_ceiling_skips_the_duration_probe(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """AWS/Apple providers fail loudly instead of truncating, so an import
+        under them is not probed and not wrongly refused."""
+        log = _patch(monkeypatch, cap=None, exceeds=True)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/long.ogg"}
+            )
+            assert resp.status == 200
+        assert log["probed"] == []
+        assert [p for p, _cfg in log["transcribed"]] == [os.path.realpath(log["snapshot_files"][0])]
+
+    @pytest.mark.asyncio
+    async def test_one_config_snapshot_feeds_readiness_cap_and_transcription(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review: the readiness check, the duration gate, and the
+        transcription must all describe the SAME provider. The handler loads one
+        config snapshot and passes that identical object to all three — three
+        separate loads could straddle a provider switch, re-opening the
+        silent-truncation hole the duration gate exists to close."""
+        marker = SimpleNamespace(timeout_secs=222)
+        log = _patch(monkeypatch, stt_config=marker)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 200
+        assert log["config_loads"] == [marker], "exactly one config read per request"
+        assert log["ready_config"] == [marker]
+        assert log["cap_config"] == [marker]
+        assert [cfg for _p, cfg in log["transcribed"]] == [marker]
+
+    @pytest.mark.asyncio
+    async def test_a_snapshot_refusal_is_403_and_nothing_is_transcribed(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """GPT review: the vetted path can be swapped before it is opened. The
+        pinned snapshot copy is what closes that window, so a source it refuses
+        (no longer the validated inode) is denied like any unreadable path —
+        never probed, never transcribed."""
+        log = _patch(monkeypatch, snapshot_refused=True)
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/swapped.mp3"}
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "audio_path_denied"
+        assert log["snapshots"] == ["/tmp/swapped.mp3"]
+        assert log["probed"] == []
+        assert log["transcribed"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_concurrent_import_into_the_same_meeting_is_409(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """One import per meeting at a time: a second request answers 409 while
+        the first is running, and the guard is released when the first ends."""
+        import kiro_crew.transcribe as transcribe_mod
+
+        _patch(monkeypatch)
+        gate = asyncio.Event()
+        started = asyncio.Event()
+
+        async def _slow_transcribe(path: str, *_a: object, **_kw: object) -> str:
+            started.set()
+            await gate.wait()
+            return "we decided to ship on Friday"
+
+        monkeypatch.setattr(transcribe_mod, "transcribe_audio", _slow_transcribe)
+        async with client_for(app) as client:
+            await _start(client)
+            first = asyncio.create_task(
+                client.post(f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"})
+            )
+            try:
+                await asyncio.wait_for(started.wait(), timeout=5.0)
+                second = await client.post(
+                    f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/b.wav"}
+                )
+                assert second.status == 409
+                assert (await second.json())["code"] == "import_in_progress"
+            finally:
+                # no-test-side-effects: open the gate and join the first request
+                # even when an assertion above fails, so the blocked coroutine
+                # never outlives this test. ``return_exceptions`` keeps a join
+                # error from masking the original assertion failure.
+                gate.set()
+                first_result = (await asyncio.gather(first, return_exceptions=True))[0]
+            assert not isinstance(first_result, BaseException), first_result
+            assert first_result.status == 200
+            # The guard is released on completion — a follow-up import is admitted.
+            assert ai._imports_in_flight == set()
+
+
+# ---------------------------------------------------------------------------
+# The happy path
+# ---------------------------------------------------------------------------
+
+
+class TestImport:
+    @pytest.mark.asyncio
+    async def test_the_transcript_reaches_every_unmuted_agent(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """The point of routing through the dispatch transaction: the whole pipeline."""
+        _patch(monkeypatch, transcript="we shipped it\nBob owns the rollback")
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 200
+            body = await resp.json()
+
+            assert body["lines"] == 2
+            assert body["dispatched"] == 2
+            # Read INSIDE the client block: the app's `on_cleanup` hook drains and
+            # clears the active session, so the queues are gone once it exits.
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            for queue in session.agents.values():
+                assert "we shipped it" in queue.queue
+                assert "Bob owns the rollback" in queue.queue
+
+    @pytest.mark.asyncio
+    async def test_imported_lines_are_persisted_before_fan_out(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """An accepted agent line cannot be absent from the transcript — imports too.
+
+        The app-wide data-integrity boundary (`_common.dispatch_line` persists, then
+        fans out) applies to an imported recording exactly as it does to speech, so
+        the transcript panel can read the import back like anything spoken.
+        """
+        _patch(monkeypatch, transcript="we shipped it\nBob owns the rollback")
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 200
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+        assert [seg["text"] for seg in body["segments"]] == [
+            "we shipped it",
+            "Bob owns the rollback",
+        ]
+        # Imported audio is finalized speech that went through STT, so it carries the
+        # same source live STT segments do — the panel needs no third rendering rule.
+        assert all(seg["source"] == k.TRANSCRIPT_SOURCE_SPEECH for seg in body["segments"])
+
+    @pytest.mark.asyncio
+    async def test_the_domain_dictionary_corrects_an_imported_line(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """Imported text goes through the SAME pipeline as speech, corrections included.
+
+        This is the whole argument for dispatching rather than storing: nothing had
+        to be re-implemented for import, and nothing can drift.
+        """
+        from kiro_crew.apps.builtins.meetings.backend.domain import session as sess
+
+        _patch(monkeypatch, transcript="we deployed it to cooper netties today")
+        async with client_for(app) as client:
+            await _start(client)
+            # Loaded AFTER the server is up: the app's `on_startup` hook reloads the
+            # dictionary from disk, which would replace terms loaded any earlier.
+            sess.shared_dictionary().load_terms(
+                [{"correct": "Kubernetes", "aliases": ["cooper netties"]}]
+            )
+            await client.post(f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"})
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            queued = next(iter(session.agents.values())).queue
+            assert any("Kubernetes" in line for line in queued)
+
+    @pytest.mark.asyncio
+    async def test_a_muted_agent_is_skipped(self, app, fake_sessions, monkeypatch):
+        _patch(monkeypatch, transcript="one line")
+        async with client_for(app) as client:
+            await _start(client)
+            await client.post(
+                f"{BASE}/meetings/standup/mute",
+                json={"agent_id": "note-taker", "muted": True},
+            )
+            await client.post(f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"})
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert session.agents["note-taker"].queue == []
+            assert session.agents["sketch-artist"].queue == ["one line"]
+
+    @pytest.mark.asyncio
+    async def test_lines_and_dispatched_are_reported_separately(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """The gap between them is what the noise gate dropped.
+
+        A recording that yields lines of which NONE were dispatched is a real
+        outcome — an empty room, filler — and must be visible rather than reported
+        as a clean success.
+        """
+        _patch(monkeypatch, transcript="uh\num\nuh")
+        async with client_for(app) as client:
+            await _start(client)
+            body = await (
+                await client.post(
+                    f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+                )
+            ).json()
+        assert body["lines"] == 3
+        assert body["dispatched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_canonical_path_is_reported_not_the_clients(
+        self, app, fake_sessions, monkeypatch
+    ):
+        _patch(monkeypatch, vet=("/canonical/a.wav", (0, 0), ""))
+        async with client_for(app) as client:
+            await _start(client)
+            body = await (
+                await client.post(
+                    f"{BASE}/meetings/standup/import",
+                    json={"audio_path": "~/link-to-a.wav"},
+                )
+            ).json()
+        assert body["path"] == "/canonical/a.wav"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot descriptor pinning (GPT review r21)
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPinning:
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="descriptor paths are the POSIX branch")
+    async def test_a_swap_between_probe_and_transcribe_never_reaches_the_transcriber(
+        self, app, fake_sessions, monkeypatch
+    ):
+        """The r21 attack, replayed: a same-uid racer replaces the snapshot at
+        its NAME after the duration probe passes. Both consumers were handed
+        the same descriptor-pinned path, so the transcriber still reads the
+        bytes the probe capped — the replacement is unreachable."""
+        import kiro_crew.transcribe as transcribe_mod
+
+        log = _patch(monkeypatch, snapshot_bytes=b"ORIGINAL RECORDING")
+        seen: dict[str, Any] = {}
+
+        async def _exceeds(path: str, max_secs: int, **kw: Any) -> bool | None:
+            seen["probe_path"] = path
+            # The racer's swap, in the exact probe-to-transcode window the
+            # finding names: replace the snapshot AT ITS NAME.
+            snap = log["snapshot_files"][0]
+            replacement = snap + ".swap"
+            with open(replacement, "wb") as fh:
+                fh.write(b"ATTACKER REPLACEMENT")
+            os.replace(replacement, snap)
+            return False
+
+        async def _transcribe(path: str, *a: Any, **kw: Any) -> str | None:
+            seen["transcribe_path"] = path
+            with open(path, "rb") as fh:
+                seen["transcribe_bytes"] = fh.read()
+            return "pinned"
+
+        monkeypatch.setattr(transcribe_mod, "audio_exceeds_secs", _exceeds)
+        monkeypatch.setattr(transcribe_mod, "transcribe_audio", _transcribe)
+
+        async with client_for(app) as client:
+            await _start(client)
+            resp = await client.post(
+                f"{BASE}/meetings/standup/import", json={"audio_path": "/tmp/a.wav"}
+            )
+            assert resp.status == 200
+
+        assert seen["probe_path"].startswith("/dev/fd/")
+        assert (
+            seen["transcribe_path"] == seen["probe_path"]
+        ), "both consumers must share the one pinned descriptor"
+        assert (
+            seen["transcribe_bytes"] == b"ORIGINAL RECORDING"
+        ), "the swap landed at the name but must never reach the pinned inode"
+
+    def test_windows_consumers_reuse_the_name_under_the_held_handle(self, monkeypatch):
+        """On Windows there is no ``/dev/fd``: consumers reopen the NAME, and
+        that is safe only because the route holds the snapshot's handle open
+        (no delete sharing) for the whole window — so the branch must return
+        the name unchanged rather than a descriptor path."""
+        monkeypatch.setattr(ai.platform_compat, "IS_WINDOWS", True)
+        assert ai._pinned_consumer_path("C:/snap/recording.wav", 7) == "C:/snap/recording.wav"
+
+    def test_open_snapshot_pinned_refuses_a_vanished_or_irregular_entry(self, tmp_path):
+        assert ai._open_snapshot_pinned(str(tmp_path / "gone.wav"), (0, 0)) is None
+        d = tmp_path / "adir"
+        d.mkdir()
+        assert ai._open_snapshot_pinned(str(d), (0, 0)) is None
+        real = tmp_path / "recording.wav"
+        real.write_bytes(b"x")
+        st = os.stat(str(real))
+        fd = ai._open_snapshot_pinned(str(real), (st.st_dev, st.st_ino))
+        assert fd is not None
+        os.close(fd)
+
+    def test_a_replacement_swapped_in_before_the_pin_is_refused(self, tmp_path):
+        """The r24 attack: the racer replaces the snapshot at its name AFTER
+        the copy finishes but BEFORE the route's single open. The open reaches
+        an inode whose identity differs from the copy's published witness, so
+        it must be refused — never pinned and consistently transcribed."""
+        snap = tmp_path / "recording.wav"
+        snap.write_bytes(b"ORIGINAL")
+        st = os.stat(str(snap))
+        witness = (st.st_dev, st.st_ino)
+        replacement = tmp_path / "attacker.wav"
+        replacement.write_bytes(b"REPLACEMENT")
+        os.replace(replacement, snap)  # new inode at the same name
+        assert ai._open_snapshot_pinned(str(snap), witness) is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_task_closes_the_pin_before_removing_the_directory(self, tmp_path):
+        """The descriptor rides the shielded cleanup task and is closed in the
+        same worker thread BEFORE ``rmtree`` — never on the event loop (the
+        AUTOSDE no-blocking-call rule names ``os.close``, GPT review r22), and
+        before the removal because the held handle would block it on Windows."""
+        snap_dir = tmp_path / "snapdir"
+        snap_dir.mkdir()
+        snap = snap_dir / "recording.wav"
+        snap.write_bytes(b"x")
+        fd = os.open(str(snap), os.O_RDONLY)
+
+        await ai._remove_snapshot_dir(None, str(snap_dir), fd)
+
+        assert not snap_dir.exists()
+        with pytest.raises(OSError):
+            os.fstat(fd)  # closed by the cleanup worker, not leaked
+
+
+# ---------------------------------------------------------------------------
+# The path barrier
+# ---------------------------------------------------------------------------
+
+
+class TestPathBarrier:
+    def test_the_shared_gate_is_used_and_the_predicate_is_not(self):
+        """``validate_file_path``, never ``is_sensitive_path`` directly.
+
+        Using the gate is what makes this route's answer identical to every other
+        file read in the product; calling the predicate here would be a second
+        opinion that can drift from it.
+        """
+        import inspect
+
+        src = inspect.getsource(ai)
+        assert "validate_file_path(" in src
+        # The CALL, not the word — the module docstring names the predicate when it
+        # explains what the gate enforces, and that prose is the point.
+        assert "is_sensitive_path(" not in src
+
+    def test_the_extension_is_checked_on_the_canonical_path(self, tmp_path: Path):
+        """A symlink named ``.mp3`` must not smuggle in its target.
+
+        ``validate_file_path`` resolves symlinks, and the suffix test runs on the
+        RESULT — so the name the client chose is never what is checked.
+        """
+        target = tmp_path / "secret.pdf"
+        target.write_bytes(b"%PDF-1.4")
+        link = tmp_path / "innocent.mp3"
+        link.symlink_to(target)
+
+        canonical, _ident, reason = ai._vet_audio_file(str(link))
+        assert canonical == ""
+        assert reason == "unsupported_format"
+
+    def test_a_nul_byte_path_is_denied_not_a_crash(self):
+        """GPT review: `realpath` raises ValueError on an embedded NUL byte.
+
+        A malformed path the OS refuses to work with must come back as a
+        refusal — never propagate and 500 the request. The exact reason is
+        platform-dependent: POSIX `realpath` raises (caught -> "denied"),
+        while Windows' non-strict `realpath` swallows the error and the
+        existence check then reports "not_a_file". Both are non-crash
+        refusals the route maps to a 4xx, which is the pinned invariant.
+        """
+        canonical, _ident, reason = ai._vet_audio_file("/tmp/a\x00b.wav")
+        assert canonical == ""
+        assert reason in ("denied", "not_a_file")
+
+    def test_a_real_audio_file_passes(self, tmp_path: Path):
+        wav = tmp_path / "meeting.wav"
+        wav.write_bytes(b"RIFF....WAVE")
+        canonical, ident, reason = ai._vet_audio_file(str(wav))
+        assert reason == ""
+        assert canonical == str(wav.resolve())
+        st = os.stat(canonical)
+        assert ident == (st.st_dev, st.st_ino), "the vet must capture the inode it judged"
+
+    def test_an_oversized_file_is_refused_before_decoding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """GPT review: the decoder materializes PCM for the whole file, so the
+        size ceiling must fire in the vet step — while the memory cost is zero."""
+        wav = tmp_path / "huge.wav"
+        wav.write_bytes(b"RIFF" + b"\x00" * 60 + b"WAVE")
+        monkeypatch.setattr(k, "MAX_IMPORT_AUDIO_BYTES", 8)
+        canonical, _ident, reason = ai._vet_audio_file(str(wav))
+        assert canonical == ""
+        assert reason == "file_too_large"
+
+    def test_a_file_exactly_at_the_size_ceiling_is_accepted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        wav = tmp_path / "fits.wav"
+        payload = b"RIFF....WAVE"
+        wav.write_bytes(payload)
+        monkeypatch.setattr(k, "MAX_IMPORT_AUDIO_BYTES", len(payload))
+        canonical, _ident, reason = ai._vet_audio_file(str(wav))
+        assert reason == ""
+        assert canonical == str(wav.resolve())
+
+    def test_a_directory_is_not_a_file(self, tmp_path: Path):
+        d = tmp_path / "recordings.wav"
+        d.mkdir()
+        assert ai._vet_audio_file(str(d)) == ("", None, "not_a_file")
+
+    def test_every_accepted_extension_is_lowercase_and_dotted(self):
+        # The check lowercases the suffix, so an uppercase entry here would be dead.
+        for ext in k.IMPORT_AUDIO_EXTENSIONS:
+            assert ext == ext.lower()
+            assert ext.startswith(".")
+
+    def test_an_uppercase_suffix_is_still_accepted(self, tmp_path: Path):
+        wav = tmp_path / "MEETING.WAV"
+        wav.write_bytes(b"RIFF....WAVE")
+        assert ai._vet_audio_file(str(wav))[2] == ""
+
+
+def _ident_of(path: str) -> "tuple[int, int]":
+    """The (st_dev, st_ino) identity the vet step would have captured."""
+    st = os.stat(path)
+    return (st.st_dev, st.st_ino)
+
+
+class TestSnapshotStagingRoot:
+    """The snapshot dir must live under the agent-denied voice-runtime root.
+
+    A dir in the system temp directory is 0700, but /tmp is world-listable and
+    the inode pin only proves identity — a same-uid agent that can reach the
+    file can rewrite its bytes in place and still pass the pin (GPT review
+    r28). The voice-runtime root is the one path every agent sandbox mode
+    denies.
+    """
+
+    def test_the_snapshot_dir_is_created_beneath_the_runtime_root(
+        self, tmp_path: Path, monkeypatch
+    ):
+        root = tmp_path / "voice-root"
+        root.mkdir()
+        monkeypatch.setattr(ai, "prime_voice_runtime_sandbox_paths", lambda: str(root))
+        made = ai._new_snapshot_dir()
+        try:
+            assert Path(made).parent == root, "snapshot dirs must stage under the denied root"
+            assert Path(made).name.startswith("kc-meetings-") and made.endswith("-import")
+            mode = os.stat(root).st_mode & 0o777
+            if os.name == "posix":
+                assert mode == 0o700, "the root must be re-tightened to owner-only"
+        finally:
+            os.rmdir(made)
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform has no symlinks")
+    def test_a_symlinked_runtime_root_is_refused(self, tmp_path: Path, monkeypatch):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        monkeypatch.setattr(ai, "prime_voice_runtime_sandbox_paths", lambda: str(link))
+        with pytest.raises(OSError):
+            ai._new_snapshot_dir()
+
+
+@pytest.mark.skipif(
+    not supports_pinned_walk(),
+    reason="the pinned copy refuses platforms without dir_fd+O_NOFOLLOW by design (r31)",
+)
+class TestSnapshotRecording:
+    """The pinned snapshot copy — the real helper against a real filesystem."""
+
+    def test_a_regular_file_is_copied_with_its_suffix(self, tmp_path: Path):
+        src = tmp_path / "talk.MP3"
+        src.write_bytes(b"audio bytes")
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        snapped = ai._snapshot_recording(str(src), str(snap_dir), _ident_of(str(src)))
+        assert snapped is not None
+        dst, ident = snapped
+        assert dst.endswith(".mp3")
+        assert Path(dst).read_bytes() == b"audio bytes"
+        st = os.stat(dst)
+        assert ident == (st.st_dev, st.st_ino), "the witness must be the published inode"
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform has no symlinks")
+    def test_a_path_swapped_for_a_symlink_is_refused(self, tmp_path: Path):
+        """GPT review: the swap attack — the validated NAME now points at a link
+        to something else. The pinned open (O_NOFOLLOW + fstat on the
+        descriptor) refuses it instead of copying the link's target."""
+        secret = tmp_path / "credentials"
+        secret.write_bytes(b"AKIA...")
+        swapped = tmp_path / "talk.wav"
+        try:
+            os.symlink(secret, swapped)
+        except OSError:
+            pytest.skip("symlinks not permitted here")
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(str(swapped), str(snap_dir), (0, 0)) is None
+        assert list(snap_dir.iterdir()) == [], "nothing may be copied from a swapped path"
+
+    def test_a_source_grown_past_the_ceiling_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The vet step's size ceiling judged the original name; the snapshot
+        re-judges the bytes actually copied, so a swap to a huge file cannot
+        ride the earlier answer into the decoder. GPT review r12: enforced
+        INSIDE the copy, so the refusal materializes (at most) an emptied
+        destination entry, never the oversize bytes."""
+        monkeypatch.setattr(ai.k, "MAX_IMPORT_AUDIO_BYTES", 4)
+        src = tmp_path / "talk.wav"
+        src.write_bytes(b"more than four bytes")
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(str(src), str(snap_dir), _ident_of(str(src))) is None
+        assert sum(p.stat().st_size for p in snap_dir.iterdir()) == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_joins_the_copy_before_removing_the_directory(self, tmp_path: Path):
+        """GPT review r12: a ``to_thread`` copy cannot be cancelled, so removing
+        the snapshot directory while the worker still holds a handle inside it
+        loses the race on Windows (``rmtree`` cannot delete an open file,
+        ``ignore_errors`` hides it, the stale recording leaks). The cleanup
+        helper must JOIN the copy first -- proven here by a copy that holds the
+        directory open until released: the removal must not happen while the
+        worker is still inside."""
+        import threading
+
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        (snap_dir / "recording.wav").write_bytes(b"bytes")
+        release = threading.Event()
+        entered = threading.Event()
+
+        def _slow_copy() -> None:
+            with open(snap_dir / "recording.wav", "rb"):
+                entered.set()
+                release.wait(timeout=10)
+
+        copy_task = asyncio.ensure_future(asyncio.to_thread(_slow_copy))
+        cleanup = None
+        try:
+            await asyncio.to_thread(entered.wait, 10)
+
+            cleanup = asyncio.ensure_future(ai._remove_snapshot_dir(copy_task, str(snap_dir)))
+            await asyncio.sleep(0.1)
+            assert snap_dir.exists(), "removal must wait for the copy worker to exit"
+        finally:
+            # no-test-side-effects: release the worker and join both tasks even
+            # when the assertion above fails, so the pool thread and its open
+            # handle never outlive this test. ``return_exceptions`` keeps a join
+            # error from masking the original assertion failure.
+            release.set()
+            pending = [copy_task] + ([cleanup] if cleanup is not None else [])
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        assert cleanup is not None
+        await cleanup
+        assert not snap_dir.exists()
+
+    def test_a_vanished_source_is_refused_not_raised(self, tmp_path: Path):
+        """GPT review r7: ``copy_file_pinned`` propagates ``FileNotFoundError`` BY
+        CONTRACT so the caller can tolerate a vanished source — the helper maps it
+        to the same None as every other refusal, so the route answers 403, not 500."""
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(str(tmp_path / "gone.wav"), str(snap_dir), (0, 0)) is None
+        assert list(snap_dir.iterdir()) == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_an_unreadable_source_is_refused_not_raised(self, tmp_path: Path):
+        """GPT review r8: a vanished source was tolerated but a PERMISSION-DENIED
+        one escaped as an unhandled ``PermissionError`` → 500. Every ``OSError``
+        out of the pinned copy is the same story — a source this request cannot
+        read — so the helper maps them all to None and the route answers the
+        same 403 as any other unreadable path."""
+        if os.geteuid() == 0:  # pragma: no cover — root ignores permission bits
+            pytest.skip("running as root; chmod 000 does not deny reads")
+        src = tmp_path / "private.wav"
+        src.write_bytes(b"not yours")
+        src.chmod(0)
+        try:
+            snap_dir = tmp_path / "snap"
+            snap_dir.mkdir()
+            assert ai._snapshot_recording(str(src), str(snap_dir), _ident_of(str(src))) is None
+            assert list(snap_dir.iterdir()) == []
+        finally:
+            src.chmod(0o600)
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform has no symlinks")
+    def test_an_ancestor_swapped_for_a_symlink_is_refused(self, tmp_path: Path):
+        """GPT review r7: ``O_NOFOLLOW`` on the final component never fires when an
+        ANCESTOR directory is the link — the traversal is redirected before the
+        final open. ``pin_parent`` walks the chain with one O_NOFOLLOW ``openat``
+        per component and refuses the swapped ancestor."""
+        from kiro_crew.pinned_fs import supports_pinned_walk
+
+        if not supports_pinned_walk():
+            pytest.skip("platform cannot pin a directory walk")
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "talk.wav").write_bytes(b"innocent")
+        evil_dir = tmp_path / "evil"
+        evil_dir.mkdir()
+        (evil_dir / "talk.wav").write_bytes(b"AKIA...")
+        # The path the vet step validated…
+        canonical = str(real_dir / "talk.wav")
+        # …whose ancestor is now a link to somewhere else entirely.
+        try:
+            os.rename(real_dir, tmp_path / "moved")
+            os.symlink(evil_dir, real_dir)
+        except OSError:
+            pytest.skip("symlinks not permitted here")
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(canonical, str(snap_dir), (0, 0)) is None
+        assert list(snap_dir.iterdir()) == [], "nothing may be copied through a swapped ancestor"
+
+    def test_a_source_swapped_after_the_vet_is_refused_by_identity(self, tmp_path: Path):
+        """GPT review r29: the descriptor pin proves the copied inode is the
+        OPENED inode, not that it is the inode the vet judged — a regular
+        single-link file swapped in at the name (e.g. a hardlink to something
+        the sensitivity gate never saw) passes every other gate. The copy must
+        compare the pinned descriptor against the vet-time identity and refuse."""
+        src = tmp_path / "talk.wav"
+        src.write_bytes(b"vetted bytes")
+        vetted = _ident_of(str(src))
+        # The swap: a DIFFERENT inode replaces the name after the vet. The
+        # replacement is created while the original still exists, so the
+        # filesystem cannot hand the new file the old inode number — a plain
+        # unlink+recreate CAN (and on CI did), making the identity check pass
+        # for the attacker's file and the test flaky.
+        attacker = tmp_path / "attacker.wav"
+        attacker.write_bytes(b"attacker bytes")
+        assert _ident_of(str(attacker)) != vetted
+        os.replace(attacker, src)
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(str(src), str(snap_dir), vetted) is None
+        assert list(snap_dir.iterdir()) == [], "an unvetted inode must never be copied"
+
+
+class TestNoPinnedWalkBackstop:
+    """Runs on EVERY platform — this is the branch platforms without pinned
+    traversal actually take, so it must not sit inside the skipped class."""
+
+    def test_no_pinned_walk_refuses_outright_even_for_an_honest_file(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """GPT review r31 (6th hit, adjudicator-upheld): every by-name variant
+        of the no-``dir_fd`` fallback conceded a residual window — on Windows
+        the ``os.open`` itself follows an ancestor junction planted after any
+        check, and a UNC target fires outbound SMB authentication as a side
+        effect of the open, which no after-open check can undo. Per the repo
+        ruling recorded in ``snapshot.py``'s notification copy, the branch now
+        refuses outright: nothing is opened, nothing is copied, even for an
+        honest file. The route answers 501 before this is ever reached; this
+        pins the backstop."""
+
+        monkeypatch.setattr(ai, "supports_pinned_walk", lambda: False)
+        src = tmp_path / "talk.wav"
+        src.write_bytes(b"real recording bytes")
+        snap_dir = tmp_path / "snap"
+        snap_dir.mkdir()
+        assert ai._snapshot_recording(str(src), str(snap_dir), _ident_of(str(src))) is None
+        assert list(snap_dir.iterdir()) == [], "no byte may be read or copied without a pinned walk"
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWiring:
+    def test_the_route_is_registered(self):
+        from aiohttp import web
+
+        from kiro_crew.apps.builtins.meetings.backend.routes import register_routes
+
+        app = web.Application()
+        register_routes(app)
+        assert any(
+            route.method == "POST"
+            and route.resource is not None
+            and route.resource.canonical == f"{BASE}/meetings/{{meeting_id}}/import"
+            for route in app.router.routes()
+        )
+
+    def test_both_producers_share_the_dispatch_transaction(self):
+        """One copy of the admission transaction and the expiry side effects, not two.
+
+        A producer that skipped `dispatch_line` would either skip the transcript
+        append (breaking persist-before-fan-out) or re-implement the admission
+        lock (reopening the stop-versus-append race), so both handlers are pinned
+        to it.
+        """
+        import inspect
+
+        from kiro_crew.apps.builtins.meetings.backend.routes import agents as ag
+
+        assert "dispatch_line(" in inspect.getsource(ag.handle_dispatch_text)
+        assert "dispatch_line(" in inspect.getsource(ai.handle_import_audio)
+        # And the transaction owns the append, the fan-out, and the expiry side
+        # effects in exactly one place.
+        assert "append_transcript" in inspect.getsource(_common.dispatch_line)
+        admission = inspect.getsource(_common.dispatch_admission.__wrapped__)
+        assert "drain_and_clear" in admission
+        assert "end_meeting_meta" in admission
+
+    def test_the_handler_does_no_blocking_io_inline(self):
+        import inspect
+
+        src = inspect.getsource(ai.handle_import_audio)
+        assert "asyncio.to_thread" in src
+        # The blocking work lives in the helpers the thread runs.
+        assert "validate_file_path(" not in src
+        assert "is_available(" not in src
+
+    def test_transcribe_is_imported_lazily(self):
+        """Not at module import: the STT stack pulls optional heavy dependencies.
+
+        A gateway that registers this app must not pay for a decoder nobody asked
+        for, and `faster-whisper` is deliberately not a declared extra.
+        """
+        import inspect
+
+        header = inspect.getsource(ai).split("logger = ")[0]
+        assert "from kiro_crew.transcribe import" not in header

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -188,9 +188,7 @@ class TestConfigRoutes:
     @pytest.mark.asyncio
     async def test_put_config_drops_default_preset_that_does_not_exist(self, app):
         async with client_for(app) as client:
-            resp = await client.put(
-                f"{BASE}/config", json={"config": {"default_preset": "ghost"}}
-            )
+            resp = await client.put(f"{BASE}/config", json={"config": {"default_preset": "ghost"}})
             assert (await resp.json())["config"]["default_preset"] == ""
 
     @pytest.mark.asyncio
@@ -240,9 +238,7 @@ class TestDictionaryRoutes:
 
     @pytest.mark.asyncio
     async def test_reload_reports_count(self, app, root: Path):
-        store.dictionary_path(root).write_text(
-            '[[term]]\ncorrect = "X"\naliases = ["ex"]\n'
-        )
+        store.dictionary_path(root).write_text('[[term]]\ncorrect = "X"\naliases = ["ex"]\n')
         async with client_for(app) as client:
             resp = await client.post(f"{BASE}/dictionary/reload")
             assert (await resp.json())["count"] == 1
@@ -252,9 +248,7 @@ class TestMeetingLifecycleRoutes:
     @pytest.mark.asyncio
     async def test_init_creates_the_folder_and_files(self, app, root: Path):
         async with client_for(app) as client:
-            resp = await client.post(
-                f"{BASE}/meetings/standup/init", json={"title": "My Standup"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/init", json={"title": "My Standup"})
             assert resp.status == 200
         mdir = store.meeting_dir("standup", root)
         assert (mdir / k.SESSION_META_FILE).is_file()
@@ -272,9 +266,53 @@ class TestMeetingLifecycleRoutes:
 
     @pytest.mark.asyncio
     async def test_init_rejects_a_traversal_id(self, app):
+        """400, and it is worth saying WHICH of the two barriers answers.
+
+        ``safe_meeting_id`` refuses this before ``contain`` ever sees it — the id is
+        not ``[A-Za-z0-9._-]``, so it never becomes a path segment at all. That makes
+        400 the right status here: the request is malformed, not forbidden.
+
+        This assertion used to read ``in (400, 403, 404)``, and that looseness is how
+        a real bug survived: ``contain``'s own violation carries 403 and was being
+        reported as 400, and no HTTP-level test could tell. The pair is now split —
+        this one pins 400, and ``TestContainmentIsReportedAsForbidden`` pins 403.
+        """
         async with client_for(app) as client:
             resp = await client.post(f"{BASE}/meetings/..%2F..%2Fetc/init", json={})
-            assert resp.status in (400, 403, 404)
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_path"
+
+    @pytest.mark.asyncio
+    async def test_a_symlinked_meeting_dir_is_403_not_400(self, app, root: Path, tmp_path: Path):
+        """The regression test for the bug the loose assertion above was hiding.
+
+        ``contain`` is the SECOND barrier, and the one that fires here: the id
+        ``standup`` is perfectly legal, so ``safe_meeting_id`` passes it, and the
+        violation only appears once ``resolve()`` follows a symlink planted inside the
+        data dir and lands outside the root. That is the realistic reachable case —
+        traversal in the id itself never gets this far.
+
+        It carries 403 (``MeetingsPathError(status=403)``), but ``error_response`` had
+        no ``FORBIDDEN`` branch, so every containment violation answered **400** for as
+        long as this app has existed. A containment violation reported as "bad request"
+        reads like a typo the caller can fix by retrying, when in fact the server just
+        refused to leave its own data directory.
+
+        Asserted at the HTTP boundary on purpose: ``test_meetings_store.py``'s
+        ``test_outside_root_raises_403`` already proves the exception carries 403, and
+        that test passed throughout — the status was lost in the route layer, which is
+        the only place this can be caught.
+        """
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        planted = store.meetings_root(root) / "standup"
+        planted.parent.mkdir(parents=True, exist_ok=True)
+        planted.symlink_to(outside, target_is_directory=True)
+
+        async with client_for(app) as client:
+            resp = await client.get(f"{BASE}/meetings/standup")
+            assert resp.status == 403, "a containment violation must not read as 400"
+            assert (await resp.json())["code"] == "invalid_path"
 
     @pytest.mark.asyncio
     async def test_init_accepts_a_colon_id(self, app, root: Path):
@@ -326,24 +364,22 @@ class TestMeetingLifecycleRoutes:
         async with client_for(app) as client:
             await _start(client)
             fake_sessions.calls.clear()
-            resp = await client.post(
-                f"{BASE}/meetings/standup/start", json={"restart": True}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/start", json={"restart": True})
             assert resp.status == 200
         messages = [msg for _k, _a, msg in fake_sessions.calls]
         assert messages, "a restart dispatched nothing at all"
         # Every agent is told where to write...
-        assert any("OUTPUT_FILE:" in msg for msg in messages), (
-            "a restarted meeting's agents were never given their OUTPUT_FILE"
-        )
+        assert any(
+            "OUTPUT_FILE:" in msg for msg in messages
+        ), "a restarted meeting's agents were never given their OUTPUT_FILE"
         # ...and the notice still goes out, AFTER the instructions it qualifies.
         assert any(k.SYSTEM_MEETING_RESTARTED in msg for msg in messages)
         first_notice = next(
             i for i, msg in enumerate(messages) if k.SYSTEM_MEETING_RESTARTED in msg
         )
-        assert any("OUTPUT_FILE:" in msg for msg in messages[:first_notice]), (
-            "the restart notice must follow the init messages it refers to"
-        )
+        assert any(
+            "OUTPUT_FILE:" in msg for msg in messages[:first_notice]
+        ), "the restart notice must follow the init messages it refers to"
 
     @pytest.mark.asyncio
     async def test_start_redacts_the_title(self, app, root: Path, fake_sessions):
@@ -362,9 +398,7 @@ class TestMeetingLifecycleRoutes:
         async with client_for(app) as client:
             await _start(client)
             for state in (k.STATUS_PAUSED, k.STATUS_ACTIVE, k.STATUS_REVIEWING):
-                resp = await client.post(
-                    f"{BASE}/meetings/standup/status", json={"status": state}
-                )
+                resp = await client.post(f"{BASE}/meetings/standup/status", json={"status": state})
                 assert resp.status == 200
                 assert (await resp.json())["status"] == state
 
@@ -372,9 +406,7 @@ class TestMeetingLifecycleRoutes:
     async def test_status_rejects_an_unknown_state(self, app, fake_sessions):
         async with client_for(app) as client:
             await _start(client)
-            resp = await client.post(
-                f"{BASE}/meetings/standup/status", json={"status": "banana"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/status", json={"status": "banana"})
             assert resp.status == 400
 
     @pytest.mark.asyncio
@@ -466,9 +498,7 @@ class TestMeetingLifecycleRoutes:
             assert (await resp.json())["code"] == "meeting_not_found"
 
     @pytest.mark.asyncio
-    async def test_delete_waits_for_in_flight_initialization(
-        self, app, root: Path, monkeypatch
-    ):
+    async def test_delete_waits_for_in_flight_initialization(self, app, root: Path, monkeypatch):
         from kiro_crew.apps.builtins.meetings.backend.routes import meeting_lifecycle
 
         class ObservedLock:
@@ -514,9 +544,7 @@ class TestMeetingLifecycleRoutes:
         assert not store.meeting_dir("standup", root).exists()
 
     @pytest.mark.asyncio
-    async def test_delete_waits_for_in_flight_agent_toggle(
-        self, app, root: Path, monkeypatch
-    ):
+    async def test_delete_waits_for_in_flight_agent_toggle(self, app, root: Path, monkeypatch):
         from kiro_crew.apps.builtins.meetings.backend.routes import agents, meeting_lifecycle
 
         class ObservedLock:
@@ -673,13 +701,15 @@ class TestMeetingLifecycleRoutes:
         marker = "AKIAIOSFODNN7EXAMPLE"
         store.write_tasks(
             "standup",
-            [{
-                "id": f"t-{marker}",
-                "description": f"rotate {marker}",
-                "assignee": marker,
-                "context": marker,
-                "labels": [marker],
-            }],
+            [
+                {
+                    "id": f"t-{marker}",
+                    "description": f"rotate {marker}",
+                    "assignee": marker,
+                    "context": marker,
+                    "labels": [marker],
+                }
+            ],
             root,
         )
         async with client_for(app) as client:
@@ -696,9 +726,9 @@ class TestMeetingLifecycleRoutes:
     @pytest.mark.parametrize(
         ("labels", "expected"),
         [
-            (1, []),                    # not iterable -> used to raise TypeError
-            ("urgent", []),             # iterable, but per-CHARACTER -> junk labels
-            ({"a": 1}, []),             # iterable over keys
+            (1, []),  # not iterable -> used to raise TypeError
+            ("urgent", []),  # iterable, but per-CHARACTER -> junk labels
+            ({"a": 1}, []),  # iterable over keys
             (None, []),
             (["a", 2, "b"], ["a", "b"]),  # a real list still keeps its strings
         ],
@@ -790,9 +820,7 @@ class TestAttachmentRoutes:
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
             assert (
-                await client.post(
-                    f"{BASE}/meetings/standup/attachments", json={"action": "nuke"}
-                )
+                await client.post(f"{BASE}/meetings/standup/attachments", json={"action": "nuke"})
             ).status == 400
             assert (
                 await client.post(
@@ -838,18 +866,14 @@ class TestAgentRoutes:
             remaining = (await resp.json())["agents_enabled"]
         # The one we turned off is gone; the other default survives.
         assert "sketch-artist" not in remaining
-        assert "note-taker" in remaining, (
-            "disabling one default agent must not disable the rest"
-        )
+        assert "note-taker" in remaining, "disabling one default agent must not disable the rest"
 
     @pytest.mark.asyncio
     async def test_an_explicit_empty_roster_is_preserved(self, app):
         """Turning everything off is a real state, not a value to re-seed."""
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
-            await client.post(
-                f"{BASE}/meetings/standup/start", json={"agents_enabled": []}
-            )
+            await client.post(f"{BASE}/meetings/standup/start", json={"agents_enabled": []})
             resp = await client.post(
                 f"{BASE}/meetings/standup/agents",
                 json={"agent_id": "note-taker", "enable": True},
@@ -861,9 +885,7 @@ class TestAgentRoutes:
     def _default_output_names(self, root: Path) -> set[str]:
         """Output filenames the default roster would seed."""
         config = store.read_config(root)
-        return {
-            store.agent_output_filename(a) for a in sess.get_enabled_agents(config, None)
-        }
+        return {store.agent_output_filename(a) for a in sess.get_enabled_agents(config, None)}
 
     @pytest.mark.asyncio
     async def test_init_preserves_an_explicit_empty_roster(self, app, root):
@@ -879,15 +901,13 @@ class TestAgentRoutes:
         assert expected_defaults, "fixture config must define at least one default agent"
 
         async with client_for(app) as client:
-            resp = await client.post(
-                f"{BASE}/meetings/standup/init", json={"agents_enabled": []}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/init", json={"agents_enabled": []})
             assert resp.status == 200
 
         seeded = {p.name for p in store.meeting_dir("standup", root).iterdir() if p.is_file()}
-        assert not (seeded & expected_defaults), (
-            "an explicitly empty roster must seed no agent output files"
-        )
+        assert not (
+            seeded & expected_defaults
+        ), "an explicitly empty roster must seed no agent output files"
 
     @pytest.mark.asyncio
     async def test_init_without_a_roster_still_seeds_the_defaults(self, app, root):
@@ -914,9 +934,7 @@ class TestAgentRoutes:
         """
         async with client_for(app) as client:
             await _start(client)
-            resp = await client.post(
-                f"{BASE}/meetings/standup/status", json={"status": "idle"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/status", json={"status": "idle"})
             assert resp.status == 409
             body = await resp.json()
             assert body["code"] == "invalid_transition"
@@ -928,9 +946,7 @@ class TestAgentRoutes:
     async def test_a_legal_transition_still_works(self, app, fake_sessions):
         async with client_for(app) as client:
             await _start(client)
-            resp = await client.post(
-                f"{BASE}/meetings/standup/status", json={"status": "paused"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/status", json={"status": "paused"})
             assert resp.status == 200
 
     @pytest.mark.asyncio
@@ -938,9 +954,7 @@ class TestAgentRoutes:
         """An idempotent retry of a request whose response was lost must not fail."""
         async with client_for(app) as client:
             await _start(client)
-            resp = await client.post(
-                f"{BASE}/meetings/standup/status", json={"status": "active"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/status", json={"status": "active"})
             assert resp.status == 200
 
     def test_the_server_and_client_transition_tables_agree(self):
@@ -953,9 +967,7 @@ class TestAgentRoutes:
         """
         import re
 
-        source = (
-            _REPO_ROOT / "website/src/apps/meetings/hooks/useMeetingSession.ts"
-        ).read_text()
+        source = (_REPO_ROOT / "website/src/apps/meetings/hooks/useMeetingSession.ts").read_text()
         block = re.search(
             r"ALLOWED_TRANSITIONS: Record<MeetingStatus, MeetingStatus\[\]> = \{(.*?)\n\}",
             source,
@@ -1020,9 +1032,7 @@ class TestAgentRoutes:
                 params={"cursor": transcript_body["next_cursor"]},
             )
             page_body = await page.json()
-            assert [segment["text"] for segment in page_body["segments"]] == [
-                "second line"
-            ]
+            assert [segment["text"] for segment in page_body["segments"]] == ["second line"]
             assert page_body["next_cursor"] > transcript_body["next_cursor"]
 
     @pytest.mark.asyncio
@@ -1105,6 +1115,10 @@ class TestAgentRoutes:
                 assert release_append.wait(timeout=5)
                 return real_append(*args, **kwargs)
 
+            # The dispatch transaction lives in `_common.dispatch_admission`, which
+            # reads its own module global; the lifecycle handlers read their
+            # from-imported binding. Patch both so contention is observable.
+            monkeypatch.setattr(_common, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(agents, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(meeting_lifecycle, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(store, "append_transcript", blocked_append)
@@ -1114,9 +1128,7 @@ class TestAgentRoutes:
             )
             assert await asyncio.to_thread(append_entered.wait, 5)
 
-            stop_request = asyncio.create_task(
-                client.post(f"{BASE}/meetings/standup/stop")
-            )
+            stop_request = asyncio.create_task(client.post(f"{BASE}/meetings/standup/stop"))
             await asyncio.wait_for(observed_lock.waiter.wait(), timeout=5)
             release_append.set()
 
@@ -1163,6 +1175,10 @@ class TestAgentRoutes:
                 assert release_append.wait(timeout=5)
                 return real_append(*args, **kwargs)
 
+            # The dispatch transaction lives in `_common.dispatch_admission`, which
+            # reads its own module global; the lifecycle handlers read their
+            # from-imported binding. Patch both so contention is observable.
+            monkeypatch.setattr(_common, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(agents, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(meeting_lifecycle, "DISPATCH_LOCK", observed_lock)
             monkeypatch.setattr(store, "append_transcript", blocked_append)
@@ -1200,9 +1216,7 @@ class TestAgentRoutes:
                 await release_flush.wait()
 
             monkeypatch.setattr(session, "flush_all", slow_flush)
-            stop_request = asyncio.create_task(
-                client.post(f"{BASE}/meetings/standup/stop")
-            )
+            stop_request = asyncio.create_task(client.post(f"{BASE}/meetings/standup/stop"))
             await asyncio.wait_for(flush_entered.wait(), timeout=5)
 
             dispatch = await asyncio.wait_for(
@@ -1241,18 +1255,14 @@ class TestAgentRoutes:
     @pytest.mark.asyncio
     async def test_dispatch_without_an_active_meeting_is_409(self, app):
         async with client_for(app) as client:
-            resp = await client.post(
-                f"{BASE}/meetings/standup/dispatch", json={"text": "hello"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": "hello"})
             assert resp.status == 409
 
     @pytest.mark.asyncio
     async def test_dispatch_requires_text(self, app, fake_sessions):
         async with client_for(app) as client:
             await _start(client)
-            assert (
-                await client.post(f"{BASE}/meetings/standup/dispatch", json={})
-            ).status == 400
+            assert (await client.post(f"{BASE}/meetings/standup/dispatch", json={})).status == 400
 
     @pytest.mark.asyncio
     async def test_dispatch_on_an_expired_session_is_410(self, app, fake_sessions):
@@ -1349,9 +1359,7 @@ class TestAgentRoutes:
     async def test_toggle_unknown_agent_is_404(self, app, fake_sessions):
         async with client_for(app) as client:
             await _start(client)
-            resp = await client.post(
-                f"{BASE}/meetings/standup/agents", json={"agent_id": "ghost"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/agents", json={"agent_id": "ghost"})
             assert resp.status == 404
 
     @pytest.mark.asyncio
@@ -1416,18 +1424,14 @@ class TestTaskRoutes:
             updated = (await resp.json())["task"]
             assert updated["assignee"] == "Bob" and updated["priority"] == "low"
 
-            resp = await client.delete(
-                f"{BASE}/meetings/standup/tasks", json={"id": task_id}
-            )
+            resp = await client.delete(f"{BASE}/meetings/standup/tasks", json={"id": task_id})
             assert (await resp.json())["tasks"] == []
 
     @pytest.mark.asyncio
     async def test_add_requires_a_description(self, app):
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
-            assert (
-                await client.post(f"{BASE}/meetings/standup/tasks", json={})
-            ).status == 400
+            assert (await client.post(f"{BASE}/meetings/standup/tasks", json={})).status == 400
 
     @pytest.mark.asyncio
     async def test_add_normalizes_an_invalid_priority(self, app):
@@ -1516,9 +1520,7 @@ class TestTaskRoutes:
         task could be marked filed without a provider ever being called."""
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
-            resp = await client.post(
-                f"{BASE}/meetings/standup/tasks", json={"description": "d"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/tasks", json={"description": "d"})
             task_id = (await resp.json())["task"]["id"]
             resp = await client.post(
                 f"{BASE}/meetings/standup/tasks/review",
@@ -1535,9 +1537,7 @@ class TestTaskRoutes:
                 json={"description": "ship the seam", "assignee": "Alice"},
             )
             task_id = (await resp.json())["task"]["id"]
-            resp = await client.post(
-                f"{BASE}/meetings/standup/tasks/file", json={"id": task_id}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/tasks/file", json={"id": task_id})
             assert resp.status == 200
             body = await resp.json()
             assert body["ref"]["provider"] == k.TASK_PROVIDER_LOCAL
@@ -1550,9 +1550,7 @@ class TestTaskRoutes:
     async def test_file_unknown_task_is_404(self, app):
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
-            resp = await client.post(
-                f"{BASE}/meetings/standup/tasks/file", json={"id": "ghost"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/tasks/file", json={"id": "ghost"})
             assert resp.status == 404
 
     @pytest.mark.asyncio
@@ -1572,25 +1570,18 @@ class TestTaskRoutes:
                 raise RuntimeError("tracker down")
 
         monkeypatch.setattr(
-            "kiro_crew.apps.builtins.meetings.backend.routes.tasks."
-            "taskprov.get_task_provider",
+            "kiro_crew.apps.builtins.meetings.backend.routes.tasks." "taskprov.get_task_provider",
             lambda *_a, **_kw: Failing(),
         )
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={})
-            resp = await client.post(
-                f"{BASE}/meetings/standup/tasks", json={"description": "d"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/tasks", json={"description": "d"})
             task_id = (await resp.json())["task"]["id"]
-            resp = await client.post(
-                f"{BASE}/meetings/standup/tasks/file", json={"id": task_id}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/tasks/file", json={"id": task_id})
             assert resp.status == 502
             assert (await resp.json())["ok"] is False
         # The task must NOT be marked pushed when nothing was filed.
-        assert store.read_tasks("standup", root)["tasks"][0]["review_status"] == (
-            k.REVIEW_PENDING
-        )
+        assert store.read_tasks("standup", root)["tasks"][0]["review_status"] == (k.REVIEW_PENDING)
 
     @pytest.mark.asyncio
     async def test_task_providers_endpoint(self, app):
@@ -1835,15 +1826,15 @@ class TestAgentAndPresetSanitizers:
     @pytest.mark.parametrize(
         "ref",
         [
-            "../escape",          # traversal
-            "/absolute/agent",    # absolute
-            ".hidden",            # leading dot
-            "has space",          # illegal char
+            "../escape",  # traversal
+            "/absolute/agent",  # absolute
+            ".hidden",  # leading dot
+            "has space",  # illegal char
             "semi;colon",
-            "x" * 300,            # over the length cap
+            "x" * 300,  # over the length cap
             "",
             None,
-            123,                  # not a string at all
+            123,  # not a string at all
         ],
     )
     def test_an_unsafe_agent_ref_is_dropped(self, ref):
@@ -2042,6 +2033,7 @@ class TestNoStoreCallRunsOnTheEventLoop:
         from kiro_crew.apps.builtins.meetings.backend import calendar_poller, calendar_sync
         from kiro_crew.apps.builtins.meetings.backend.routes import (
             agents,
+            audio_import,
             calendar,
             meeting_lifecycle,
             settings,
@@ -2050,7 +2042,16 @@ class TestNoStoreCallRunsOnTheEventLoop:
 
         # The poller is not a route, but a periodic task is exactly as
         # loop-reachable as a handler, so it is held to the same rule.
-        return [agents, calendar, meeting_lifecycle, settings, tasks, calendar_sync, calendar_poller]
+        return [
+            agents,
+            audio_import,
+            calendar,
+            meeting_lifecycle,
+            settings,
+            tasks,
+            calendar_sync,
+            calendar_poller,
+        ]
 
     def _inline_blocking_calls(self, module) -> list[str]:
         """`file:line handler -> callee()` for every blocking call in an `async def`.
@@ -2079,9 +2080,9 @@ class TestNoStoreCallRunsOnTheEventLoop:
                 owner = callee.value
                 if not isinstance(owner, ast.Name):
                     continue
-                blocking = (
-                    owner.id == "store" and callee.attr in self._BLOCKING_STORE_FNS
-                ) or (owner.id == "sess" and callee.attr in self._BLOCKING_DOMAIN_FNS)
+                blocking = (owner.id == "store" and callee.attr in self._BLOCKING_STORE_FNS) or (
+                    owner.id == "sess" and callee.attr in self._BLOCKING_DOMAIN_FNS
+                )
                 if blocking:
                     offenders.append(
                         f"{module.__name__}:{node.lineno} "
@@ -2201,9 +2202,7 @@ class TestTaskWritesAreSerialized:
 
         def archive(index: int) -> None:
             barrier.wait()  # maximize overlap on the read-modify-write
-            task_routes._set_review_state(
-                meeting_id, f"t{index}", k.REVIEW_ARCHIVED, root
-            )
+            task_routes._set_review_state(meeting_id, f"t{index}", k.REVIEW_ARCHIVED, root)
 
         with futures.ThreadPoolExecutor(max_workers=count) as pool:
             list(pool.map(archive, range(count)))
@@ -2309,12 +2308,12 @@ class TestTaskWritesAreSerialized:
         for module in sorted(backend.rglob("*.py")):
             tree = ast.parse(module.read_text(encoding="utf-8"))
             functions = [
-                n for n in ast.walk(tree)
-                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
             ]
             for fn in functions:
                 writes = [
-                    n for n in ast.walk(fn)
+                    n
+                    for n in ast.walk(fn)
                     if isinstance(n, ast.Call)
                     and isinstance(n.func, ast.Attribute)
                     and n.func.attr == "write_meeting_meta"
@@ -2336,13 +2335,10 @@ class TestTaskWritesAreSerialized:
                 if not holds and not fn.name.endswith("_locked"):
                     offenders.append(f"{module.relative_to(backend)}::{fn.name}")
 
-        assert checked >= 6, (
-            f"only {checked} metadata writers found — the scan is probably broken"
-        )
+        assert checked >= 6, f"only {checked} metadata writers found — the scan is probably broken"
         assert not offenders, (
             "these write meeting metadata without holding store.meta_transaction(), "
-            "so a concurrent request can silently discard their update: "
-            + ", ".join(offenders)
+            "so a concurrent request can silently discard their update: " + ", ".join(offenders)
         )
 
     def test_concurrent_metadata_updates_all_survive(self, root: Path) -> None:
@@ -2376,9 +2372,12 @@ class TestTaskWritesAreSerialized:
             else:
                 lifecycle._apply_attachments(
                     meeting_id,
-                    {"action": "add", "attachments": [
-                        {"type": "url", "url": f"https://example.test/{index}"},
-                    ]},
+                    {
+                        "action": "add",
+                        "attachments": [
+                            {"type": "url", "url": f"https://example.test/{index}"},
+                        ],
+                    },
                     root,
                 )
 
@@ -2389,9 +2388,7 @@ class TestTaskWritesAreSerialized:
         muted = set(meta.get("muted_agents") or [])
         urls = {a.get("url") for a in (meta.get("attachments") or [])}
         assert muted == {f"agent-{i}" for i in range(count) if i % 2}
-        assert urls == {
-            f"https://example.test/{i}" for i in range(count) if i % 2 == 0
-        }
+        assert urls == {f"https://example.test/{i}" for i in range(count) if i % 2 == 0}
 
     def test_concurrent_agent_toggles_all_survive(self, root: Path) -> None:
         """Recomputing the roster inside the lock, not writing a stale list.
@@ -2416,17 +2413,13 @@ class TestTaskWritesAreSerialized:
 
         def toggle(index: int) -> None:
             barrier.wait()
-            agent_routes._commit_toggle(
-                meeting_id, f"agent-{index}", True, "", [], root
-            )
+            agent_routes._commit_toggle(meeting_id, f"agent-{index}", True, "", [], root)
 
         with futures.ThreadPoolExecutor(max_workers=count) as pool:
             list(pool.map(toggle, range(count)))
 
         meta = meetings_store.read_meeting_meta(meeting_id, root) or {}
-        assert set(meta.get("agents_enabled") or []) == {
-            f"agent-{i}" for i in range(count)
-        }
+        assert set(meta.get("agents_enabled") or []) == {f"agent-{i}" for i in range(count)}
 
     def test_concurrent_dictionary_edits_all_survive(self, root: Path) -> None:
         """One thread HOP is not one critical section.
@@ -2606,9 +2599,7 @@ class TestTeardownDrainsBeforeClearing:
 
         # `from ... import __init__` binds the dunder attribute, not the package —
         # import the package itself so `inspect.getsource` gets a module.
-        routes_init = importlib.import_module(
-            "kiro_crew.apps.builtins.meetings.backend.routes"
-        )
+        routes_init = importlib.import_module("kiro_crew.apps.builtins.meetings.backend.routes")
 
         offenders: list[str] = []
         for module in (routes_init, agents, meeting_lifecycle):
@@ -2886,9 +2877,9 @@ class TestTeardownLeavesNoMeetingFalselyActive:
         await routes_pkg._on_startup(app)
 
         for meeting_id in ("was-active", "was-paused", "was-reviewing"):
-            assert store.read_meeting_meta(meeting_id, root)["status"] == k.STATUS_ENDED, (
-                f"{meeting_id} was left orphaned at boot"
-            )
+            assert (
+                store.read_meeting_meta(meeting_id, root)["status"] == k.STATUS_ENDED
+            ), f"{meeting_id} was left orphaned at boot"
 
     @pytest.mark.asyncio
     async def test_startup_leaves_an_idle_meeting_alone(self, root: Path) -> None:
@@ -2946,9 +2937,7 @@ class TestFiledTasksStayFiled:
         assert after.get("filed_ref"), "the filing reference was lost"
 
     @pytest.mark.asyncio
-    async def test_an_unfiled_task_still_archives(
-        self, app: web.Application, root: Path
-    ) -> None:
+    async def test_an_unfiled_task_still_archives(self, app: web.Application, root: Path) -> None:
         """The guard must be scoped to `pushed` — ordinary archiving still works."""
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/m2/init", json={"title": "M2"})
@@ -3030,9 +3019,7 @@ class TestStartAndStopAreSerialized:
 
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/racer/init", json={"title": "Racer"})
-            start = asyncio.create_task(
-                client.post(f"{BASE}/meetings/racer/start", json={})
-            )
+            start = asyncio.create_task(client.post(f"{BASE}/meetings/racer/start", json={}))
             # Let the start reach its first await, then race a stop against it.
             await asyncio.sleep(0)
             stop = asyncio.create_task(client.post(f"{BASE}/meetings/racer/stop", json={}))
@@ -3344,9 +3331,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
 
         monkeypatch.setattr(sess, "init_agents", blocking_init)
         await client.post(f"{BASE}/meetings/{meeting_id}/init", json={"title": "Standup"})
-        start = asyncio.create_task(
-            client.post(f"{BASE}/meetings/{meeting_id}/start", json={})
-        )
+        start = asyncio.create_task(client.post(f"{BASE}/meetings/{meeting_id}/start", json={}))
         await asyncio.wait_for(entered.wait(), timeout=5)
         return start, release
 
@@ -3363,9 +3348,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
             start, release = await self._start_paused_in_init(client, monkeypatch)
 
             for line in ("first the agenda", "then the blockers", "and the owners"):
-                resp = await client.post(
-                    f"{BASE}/meetings/standup/dispatch", json={"text": line}
-                )
+                resp = await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": line})
                 assert resp.status == 200, await resp.text()
                 body = await resp.json()
                 # Held, not fanned out — and already durable either way. The hold is
@@ -3401,9 +3384,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
         """The durable record is written at ARRIVAL, so a reader loses nothing."""
         async with client_for(app) as client:
             start, release = await self._start_paused_in_init(client, monkeypatch)
-            await client.post(
-                f"{BASE}/meetings/standup/dispatch", json={"text": "opening remarks"}
-            )
+            await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": "opening remarks"})
             # Readable BEFORE initialization finishes — the user sees their own words.
             body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
             assert [s["text"] for s in body["segments"]] == ["opening remarks"]
@@ -3518,9 +3499,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
             # keeps: `read_transcript_page` drops unrecognized sources, so a marker
             # written outside `VALID_TRANSCRIPT_SOURCES` would vanish on read.
             body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
-            markers = [
-                s for s in body["segments"] if s["source"] == k.TRANSCRIPT_SOURCE_SYSTEM
-            ]
+            markers = [s for s in body["segments"] if s["source"] == k.TRANSCRIPT_SOURCE_SYSTEM]
             assert len(markers) == 1
             assert markers[0]["text"] == expected_marker
             # Every spoken line is still in the transcript — only the AGENTS lost two.
@@ -3572,9 +3551,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
             assert live["buffering_dispatches"] is False
 
     @pytest.mark.asyncio
-    async def test_a_reviewing_meeting_still_refuses_instead_of_buffering(
-        self, app, fake_sessions
-    ):
+    async def test_a_reviewing_meeting_still_refuses_instead_of_buffering(self, app, fake_sessions):
         """The #1981 gate is untouched: only INITIALIZATION holds a line.
 
         A reviewing meeting has nowhere to put the line — its agents were told to
@@ -3588,9 +3565,7 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
             )
             assert status.status == 200
 
-            resp = await client.post(
-                f"{BASE}/meetings/standup/dispatch", json={"text": "too late"}
-            )
+            resp = await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": "too late"})
             assert resp.status == 409
             assert (await resp.json())["code"] == "no_active_meeting"
 
@@ -3611,13 +3586,9 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
             await _start(client, "the-old-one")
             outgoing = _common.ACTIVE.get("the-old-one")
             assert outgoing is not None
-            monkeypatch.setattr(
-                type(outgoing), "expired", property(lambda _self: True)
-            )
+            monkeypatch.setattr(type(outgoing), "expired", property(lambda _self: True))
 
-            start, release = await self._start_paused_in_init(
-                client, monkeypatch, "the-new-one"
-            )
+            start, release = await self._start_paused_in_init(client, monkeypatch, "the-new-one")
             # The replaced meeting refuses; only the starting one holds.
             stale = await client.post(
                 f"{BASE}/meetings/the-old-one/dispatch", json={"text": "orphan line"}
@@ -3649,13 +3620,9 @@ class TestSpeechDuringAgentInitIsHeldNotRefused:
         async with client_for(app) as client:
             start, release = await self._start_paused_in_init(client, monkeypatch)
 
-            await client.post(
-                f"{BASE}/meetings/standup/dispatch", json={"text": "the real agenda"}
-            )
+            await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": "the real agenda"})
             for filler in ("uh", "um", "ok so uh", "hmm"):
-                resp = await client.post(
-                    f"{BASE}/meetings/standup/dispatch", json={"text": filler}
-                )
+                resp = await client.post(f"{BASE}/meetings/standup/dispatch", json={"text": filler})
                 assert resp.status == 200
 
             session = _common.ACTIVE.get("standup")
@@ -3725,10 +3692,8 @@ class TestMuteCannotLandInsideADispatch:
         self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
     ):
         async with client_for(app) as client:
-            start, release = await (
-                TestSpeechDuringAgentInitIsHeldNotRefused._start_paused_in_init(
-                    client, monkeypatch
-                )
+            start, release = await TestSpeechDuringAgentInitIsHeldNotRefused._start_paused_in_init(
+                client, monkeypatch
             )
             session = _common.ACTIVE.get("standup")
             assert session is not None

--- a/test/test_pinned_staging.py
+++ b/test/test_pinned_staging.py
@@ -223,6 +223,122 @@ def test_a_single_link_regular_file_still_copies_with_mode_and_mtime(tmp_path: P
     assert dst.stat().st_mtime_ns == src.stat().st_mtime_ns
 
 
+def test_an_oversize_source_is_refused_before_the_destination_exists(tmp_path: Path) -> None:
+    """GPT review r12: a ceiling checked only AFTER a copy lets the copy itself
+    exhaust the destination volume. The fstat pre-check refuses first -- and
+    fstat reports a sparse file's LOGICAL size, so a swapped-in sparse giant is
+    refused with zero bytes written and no destination entry at all."""
+    src = tmp_path / "huge.bin"
+    src.write_bytes(b"x" * 64)
+    dst = tmp_path / "copied.bin"
+    reasons: list[tuple[str, str]] = []
+
+    copied = pinned_fs.copy_file_pinned(
+        str(src), str(dst), max_bytes=16, on_skip=lambda r, p: reasons.append((r, p))
+    )
+
+    assert copied is False
+    assert reasons and reasons[0][0] == pinned_fs.SKIP_TOO_LARGE
+    assert not dst.exists(), "the pre-check must fire before the destination is created"
+
+
+def test_a_source_that_is_not_the_vetted_inode_is_refused(tmp_path: Path) -> None:
+    """GPT review r29 (meetings import): the descriptor pin proves the copied
+    inode is the OPENED inode, not that it is the inode the caller's validation
+    judged. ``expected_src_ident`` closes that validate->copy window: a regular
+    single-link file swapped in at the name fstats to a different identity and
+    is refused with zero bytes written."""
+    src = tmp_path / "vetted.bin"
+    src.write_bytes(b"vetted")
+    st = os.stat(src)
+    vetted = (st.st_dev, st.st_ino)
+    # Allocate the replacement while the original still exists: unlink+recreate
+    # lets the filesystem hand the new file the SAME inode number (observed on
+    # CI), which would make this test flaky rather than a swap replay.
+    swapped = tmp_path / "swapped.bin"
+    swapped.write_bytes(b"swapped-in")
+    assert (os.stat(swapped).st_dev, os.stat(swapped).st_ino) != vetted
+    os.replace(swapped, src)
+    dst = tmp_path / "copied.bin"
+    reasons: list[tuple[str, str]] = []
+
+    copied = pinned_fs.copy_file_pinned(
+        str(src), str(dst), expected_src_ident=vetted, on_skip=lambda r, p: reasons.append((r, p))
+    )
+
+    assert copied is False
+    assert reasons and reasons[0][0] == pinned_fs.SKIP_IDENTITY_CHANGED
+    assert not dst.exists(), "no byte of an unvetted inode may land"
+
+
+def test_a_source_matching_the_vetted_inode_is_copied(tmp_path: Path) -> None:
+    src = tmp_path / "vetted.bin"
+    src.write_bytes(b"vetted")
+    st = os.stat(src)
+    dst = tmp_path / "copied.bin"
+
+    assert (
+        pinned_fs.copy_file_pinned(str(src), str(dst), expected_src_ident=(st.st_dev, st.st_ino))
+        is True
+    )
+    assert dst.read_bytes() == b"vetted"
+
+
+def test_a_source_grown_after_fstat_aborts_at_the_first_excess_byte(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one case the fstat pre-check cannot see: bytes appended between the
+    fstat and the read. The copy loop is bounded, so the excess aborts the copy
+    and empties what was written through the descriptor."""
+    src = tmp_path / "growing.bin"
+    src.write_bytes(b"x" * 64)
+    dst = tmp_path / "copied.bin"
+    reasons: list[tuple[str, str]] = []
+
+    real_fstat = os.fstat
+
+    def lying_fstat(fd: int) -> os.stat_result:
+        st = real_fstat(fd)
+        if st.st_size == 64:  # only our source; every other caller sees the truth
+            return os.stat_result(
+                (
+                    st.st_mode,
+                    st.st_ino,
+                    st.st_dev,
+                    st.st_nlink,
+                    st.st_uid,
+                    st.st_gid,
+                    8,
+                    st.st_atime,
+                    st.st_mtime,
+                    st.st_ctime,
+                )
+            )
+        return st
+
+    monkeypatch.setattr(os, "fstat", lying_fstat)
+    copied = pinned_fs.copy_file_pinned(
+        str(src), str(dst), max_bytes=16, on_skip=lambda r, p: reasons.append((r, p))
+    )
+    monkeypatch.undo()
+
+    assert copied is False
+    assert reasons and reasons[0][0] == pinned_fs.SKIP_TOO_LARGE
+    # The destination entry exists (created before the loop) but holds no bytes:
+    # the partial content was emptied through the descriptor.
+    assert dst.stat().st_size == 0
+
+
+def test_the_ceiling_does_not_refuse_a_source_at_exactly_the_limit(tmp_path: Path) -> None:
+    """Boundary: max_bytes is a ceiling, not an exclusive bound."""
+    src = tmp_path / "exact.bin"
+    src.write_bytes(b"x" * 16)
+    dst = tmp_path / "copied.bin"
+
+    assert pinned_fs.copy_file_pinned(str(src), str(dst), max_bytes=16) is True
+    assert dst.read_bytes() == b"x" * 16
+
+
 # ── The restore side ─────────────────────────────────────────────────────────
 
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1268,7 +1268,21 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # sandboxed_spawn_argv: codesign must read the system trust store and
         # evaluate the Apple certificate chain, which the OS sandbox denies.
         "transcribe.py::_macos_developer_id_authentic",
+        # `_pcm_via_ffmpeg` decodes a container the stdlib cannot read (a Slack
+        # voice memo's ogg/Opus, an uploaded m4a) down to the 16 kHz mono PCM the
+        # recogniser takes. Fixed argv, ffmpeg only; the sole variable part is a
+        # positional audio path that `_is_sensitive_audio_path` has already
+        # cleared, so a hostile value can only name a bad file, not a command.
+        # (`audio_exceeds_secs`, the meetings import route's duration probe, is
+        # the same ffmpeg on the same class of path and routes through
+        # `_create_ffmpeg_subprocess` above — `_SPAWN_NAMES` propagates the audit
+        # to each caller, so it is classified here like the other three: a null
+        # decode with fixed flags, `-t` bounded at the duration cap, no output
+        # file at all (`-f null -`), and the only variable argv element a
+        # positional path that `_vet_audio_file` validated and the route then
+        # snapshot-copied via `pinned_fs` into its own 0700 directory.)
         "transcribe.py::_pcm_via_ffmpeg",
+        "transcribe.py::audio_exceeds_secs",
         "transcribe.py::_transcribe_aws",
         # The build probe executes the same authenticated image with the single
         # fixed `-version` argument; it accepts no external input at all. Both

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -887,6 +887,50 @@ class TestPcmFromWav:
         assert pcm.size == frames
         np.testing.assert_allclose(pcm, np.full(frames, 2_000 / 32768.0, dtype=np.float32))
 
+    def test_multichannel_folding_is_sliced_and_exact_across_the_slice_boundary(self, tmp_path):
+        """A whole-file multichannel read holds the interleaved int16 buffer
+        AND its float32 conversion at once — ~1.5 GiB for a four-channel hour,
+        an OOM on an input the import byte cap admits (GPT review r23). The
+        fold therefore runs in byte-bounded slices (8 MiB of raw int16 per
+        slice — GPT review r34: bounding by SECONDS let the channel count
+        scale the transient without limit); this file spans the slice boundary
+        and must fold to exactly the same per-frame mean as a whole-file fold."""
+        channels = 4
+        # One slice is (8 MiB // (channels * 2)) frames; cross it by a second.
+        frames = (8 * 1024 * 1024) // (channels * 2) + transcribe.stt.SAMPLE_RATE_HZ
+        rng = np.random.default_rng(23)
+        interleaved = rng.integers(-30_000, 30_000, frames * channels, dtype=np.int16)
+        audio = tmp_path / "quad.wav"
+        _write_wav(audio, interleaved, channels=channels)
+
+        pcm = transcribe._pcm_from_wav(str(audio))
+
+        assert pcm is not None and pcm.size == frames
+        expected = (interleaved.astype(np.float32) / 32768.0).reshape(-1, channels).mean(axis=1)
+        np.testing.assert_allclose(pcm, expected, rtol=0, atol=1e-7)
+
+    def test_slice_byte_budget_is_channel_count_independent(self, tmp_path):
+        """GPT review r34: a valid 256-channel WAV under the import size cap
+        must not make one slice allocate hundreds of MiB. The slice frame
+        count shrinks with the channel count, so the raw bytes read per
+        ``readframes`` call stay bounded — pinned here by folding a
+        256-channel file whose whole-file read would be ~50 MiB while each
+        slice stays at 8 MiB, and checking exactness end to end."""
+        channels = 256
+        # One slice for 256 channels is (8 MiB // 512) = 16384 frames; span
+        # three slices so the loop and the boundary are both exercised.
+        frames = 16384 * 2 + 1000
+        rng = np.random.default_rng(34)
+        interleaved = rng.integers(-30_000, 30_000, frames * channels, dtype=np.int16)
+        audio = tmp_path / "many.wav"
+        _write_wav(audio, interleaved, channels=channels)
+
+        pcm = transcribe._pcm_from_wav(str(audio))
+
+        assert pcm is not None and pcm.size == frames
+        expected = (interleaved.astype(np.float32) / 32768.0).reshape(-1, channels).mean(axis=1)
+        np.testing.assert_allclose(pcm, expected, rtol=0, atol=1e-7)
+
     @pytest.mark.parametrize("rate", [8_000, 44_100, 48_000])
     def test_other_sample_rates_defer_to_ffmpeg(self, tmp_path, rate):
         audio = tmp_path / "rate.wav"
@@ -1198,6 +1242,39 @@ class TestSensitivePathGuard:
         with patch("kiro_crew.security.is_sensitive_path", return_value=True):
             result = await transcribe_audio(str(audio), cfg)
         assert result is None
+
+    def test_the_gateways_own_voice_runtime_snapshot_is_not_refused(self, tmp_path, monkeypatch):
+        """GPT review r30: the crew ``run/`` dir is a sensitive leaf, and the
+        import snapshots are staged under ``run/voice-runtime`` precisely
+        because agents cannot reach it — so without the exemption every import
+        would be refused by the gateway's own guard and the feature would
+        always fail."""
+        root = tmp_path / "voice-root"
+        root.mkdir()
+        snap = root / "kc-meetings-x-import" / "recording.wav"
+        snap.parent.mkdir()
+        snap.write_bytes(b"bytes")
+        monkeypatch.setattr(
+            "kiro_crew.sandbox.prime_voice_runtime_sandbox_paths", lambda: str(root)
+        )
+        with patch("kiro_crew.security.is_sensitive_path", return_value=True):
+            assert transcribe._is_sensitive_audio_path(str(snap)) is False
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform has no symlinks")
+    def test_a_link_planted_under_the_runtime_root_is_still_judged(self, tmp_path, monkeypatch):
+        """The exemption is by REAL path: a link under the root resolves to its
+        target outside it and is judged as whatever it points at."""
+        root = tmp_path / "voice-root"
+        root.mkdir()
+        outside = tmp_path / "outside.wav"
+        outside.write_bytes(b"bytes")
+        link = root / "recording.wav"
+        link.symlink_to(outside)
+        monkeypatch.setattr(
+            "kiro_crew.sandbox.prime_voice_runtime_sandbox_paths", lambda: str(root)
+        )
+        with patch("kiro_crew.security.is_sensitive_path", return_value=True):
+            assert transcribe._is_sensitive_audio_path(str(link)) is True
 
 
 class TestTranscriptRedaction:
@@ -1940,6 +2017,107 @@ class TestBundledFfmpeg:
         await transcribe._close_ffmpeg_for_execution(opened)
         with pytest.raises(OSError):
             os.fstat(descriptor)
+
+    @pytest.mark.asyncio
+    async def test_every_spawn_is_pinned_to_local_protocols(self, monkeypatch):
+        """GPT review r19: the import suffix allowlist is not a content check,
+        so an allowed-suffix file whose bytes are an HLS/ffconcat playlist
+        reaches the demuxer — which would then FETCH the playlist's segment
+        URLs (SSRF). Every spawn must therefore carry FFmpeg's protocol
+        allowlist flag (pinned to ``file,pipe``) AHEAD of the caller's args,
+        so it precedes every ``-i`` and applies to nested (playlist-segment)
+        opens too."""
+        captured: list[tuple[str, ...]] = []
+        sentinel = object()
+
+        async def fake_spawn(execution_path, *args, **kwargs):
+            captured.append(args)
+            return sentinel
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
+        result = await transcribe._create_ffmpeg_subprocess(
+            "ffmpeg", "-y", "-i", "/tmp/a.wav", "out.ogg"
+        )
+        assert result is sentinel
+        flag = "-protocol_whitelist"  # wokeignore:rule=whitelist
+        assert captured[0][:2] == (flag, "file,pipe")
+        assert captured[0].index(flag) < captured[0].index("-i")
+
+    def test_every_import_suffix_has_a_forced_demuxer(self):
+        """GPT review r20: the protocol pin stops NETWORK fetches, but an
+        auto-probed playlist demuxer could still open other LOCAL files its
+        text names — reads that never went through ``validate_file_path``.
+        Forcing the validated suffix's own demuxer turns playlist text into a
+        decode error. Every import-admissible suffix must therefore map to a
+        demuxer, so no attacker-influenced input ever falls back to content
+        sniffing."""
+        from kiro_crew.apps.builtins.meetings.backend import constants as k
+
+        for suffix in k.IMPORT_AUDIO_EXTENSIONS:
+            forced = transcribe._forced_demuxer_args(f"/tmp/talk{suffix}")
+            assert forced and forced[0] == "-f", f"no forced demuxer for {suffix}"
+        # Internal temp files with unrecognized names keep the old behaviour.
+        assert transcribe._forced_demuxer_args("/tmp/unknown.xyz") == ()
+
+    @pytest.mark.skipif(os.name == "nt", reason="descriptor paths are the POSIX branch")
+    def test_a_descriptor_path_resolves_the_pinned_files_real_suffix(self, tmp_path):
+        """An import hands consumers ``/dev/fd/N`` (GPT review r21). Format
+        decisions must follow the suffix of the file the descriptor REALLY
+        holds — resolved through the kernel, never the mutable name."""
+        real = tmp_path / "talk.webm"
+        real.write_bytes(b"x")
+        fd = os.open(str(real), os.O_RDONLY)
+        try:
+            dev_path = f"/dev/fd/{fd}"
+            assert transcribe._input_suffix(dev_path) == ".webm"
+            assert transcribe._forced_demuxer_args(dev_path) == ("-f", "matroska,webm")
+        finally:
+            os.close(fd)
+        # Closed descriptor: the suffix is unknowable, and the demuxer pin
+        # refuses rather than letting FFmpeg sniff the content.
+        assert transcribe._input_suffix(dev_path) is None
+        with pytest.raises(OSError):
+            transcribe._forced_demuxer_args(dev_path)
+
+    @pytest.mark.skipif(os.name == "nt", reason="descriptor paths are the POSIX branch")
+    def test_a_descriptor_input_renamed_to_an_unmapped_suffix_is_refused(self, tmp_path):
+        """The r25 attack: the suffix behind ``/dev/fd/N`` follows the
+        descriptor's CURRENT name, so a same-uid rename that strips the suffix
+        after pinning would drop the forced demuxer and re-enable content
+        sniffing. A descriptor input must REFUSE on an unmapped suffix — the
+        sniffing fallback belongs only to plain-path internal temps."""
+        real = tmp_path / "talk.webm"
+        real.write_bytes(b"x")
+        fd = os.open(str(real), os.O_RDONLY)
+        try:
+            os.rename(real, tmp_path / "talk")  # the racer strips the suffix
+            with pytest.raises(OSError, match="unmapped suffix"):
+                transcribe._forced_demuxer_args(f"/dev/fd/{fd}")
+        finally:
+            os.close(fd)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="descriptor paths are the POSIX branch")
+    async def test_descriptor_inputs_are_inherited_by_the_ffmpeg_child(self, tmp_path, monkeypatch):
+        """A ``/dev/fd/N`` argv entry is useless to the child unless N survives
+        the exec: the spawn seam must put it in ``pass_fds``."""
+        real = tmp_path / "talk.wav"
+        real.write_bytes(b"x")
+        fd = os.open(str(real), os.O_RDONLY)
+        captured: dict = {}
+
+        async def fake_spawn(program, *args, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
+        try:
+            await transcribe._create_ffmpeg_subprocess(
+                "ffmpeg", "-y", "-i", f"/dev/fd/{fd}", "out.ogg"
+            )
+            assert fd in captured["kwargs"].get("pass_fds", ())
+        finally:
+            os.close(fd)
 
     @pytest.mark.asyncio
     async def test_failed_spawn_closes_handle_off_event_loop(self, monkeypatch, tmp_path):
@@ -2904,3 +3082,229 @@ class TestFfmpegIsNotResolvedFromPath:
                 assert os.path.basename(d.rstrip(os.sep)) in (
                     "bin",
                 ), f"{d} is not a package-manager bin directory"
+
+
+class TestBatchDurationCap:
+    """The provider-aware ceiling the meetings import route gates on."""
+
+    def _cfg(self, provider: str) -> SimpleNamespace:
+        return SimpleNamespace(provider=provider)
+
+    def test_the_local_provider_has_the_decoder_ceiling(self):
+        assert transcribe.batch_duration_cap_secs(self._cfg("local")) == transcribe._MAX_AUDIO_SECS
+
+    def test_the_apple_provider_shares_the_ceiling(self):
+        """The Apple lane's to-native remux is bounded with ``-t`` (an
+        unbounded conversion could exhaust the temp volume, GPT review r23),
+        so the import gate must refuse over-cap recordings for it too."""
+        assert transcribe.batch_duration_cap_secs(self._cfg("apple")) == transcribe._MAX_AUDIO_SECS
+
+    def test_providers_that_fail_loudly_have_no_ceiling(self):
+        """AWS refuses an oversized payload outright, so it needs — and may
+        impose — no local ceiling."""
+        assert transcribe.batch_duration_cap_secs(self._cfg("transcribe")) is None
+
+    def test_an_unrecognised_provider_gets_the_local_ceiling(self):
+        """The dispatch in transcribe_audio lands unknown providers on the local
+        engine, so the cap answer must travel with them."""
+        assert (
+            transcribe.batch_duration_cap_secs(self._cfg("something-new"))
+            == transcribe._MAX_AUDIO_SECS
+        )
+
+
+class TestAudioExceedsSecs:
+    """Duration verdicts: exact for WAV headers, honest None when unanswerable."""
+
+    def _write_wav(self, path, seconds: int, rate: int = 100) -> None:
+        with wave.open(str(path), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(rate)
+            wav.writeframes(b"\x00\x00" * (seconds * rate))
+
+    @pytest.mark.asyncio
+    async def test_a_short_wav_is_under_the_cap(self, tmp_path):
+        p = tmp_path / "short.wav"
+        self._write_wav(p, seconds=5)
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is False
+
+    @pytest.mark.asyncio
+    async def test_a_wav_over_the_cap_is_detected_from_the_header_alone(self, tmp_path):
+        """No decode and no sample read: the verdict is header math, which is
+        how a multi-hour meeting WAV can be refused instantly."""
+        p = tmp_path / "marathon.wav"
+        self._write_wav(p, seconds=11)
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is True
+
+    @pytest.mark.asyncio
+    async def test_a_wav_exactly_at_the_cap_is_not_over_it(self, tmp_path):
+        p = tmp_path / "exact.wav"
+        self._write_wav(p, seconds=10)
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is False
+
+    @pytest.mark.asyncio
+    async def test_a_nonwav_with_no_ffmpeg_is_unanswerable_not_wrong(self, tmp_path, monkeypatch):
+        """None, not False: without the decoder there is no answer — and the
+        transcode that would truncate needs the same missing binary, so nothing
+        is silently lost by proceeding."""
+        p = tmp_path / "memo.opus"
+        p.write_bytes(b"not really audio")
+
+        async def _no_decoder():
+            return None
+
+        monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _no_decoder)
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is None
+
+    def test_the_progress_parser_reads_the_last_out_time(self):
+        """ffmpeg emits a progress block per interval; only the final decoded
+        timestamp is the file's (bounded) duration."""
+        stdout = b"out_time_us=1000000\nprogress=continue\nout_time_us=3601000000\nprogress=end\n"
+        matches = transcribe._PROGRESS_OUT_TIME_RE.findall(stdout)
+        assert int(matches[-1]) / 1_000_000 == 3601.0
+
+    def test_wav_duration_math_ignores_sample_rate_mismatches(self, tmp_path):
+        """_pcm_from_wav would reject a 44.1 kHz file (ffmpeg's job), but the
+        duration answer is pure header math and stays exact for any rate."""
+        p = tmp_path / "hifi.wav"
+        self._write_wav(p, seconds=7, rate=200)
+        assert transcribe._wav_duration_secs(str(p)) == 7.0
+
+    def test_an_unreadable_file_has_no_wav_duration(self, tmp_path):
+        p = tmp_path / "not.wav"
+        p.write_bytes(b"RIFF but not really")
+        assert transcribe._wav_duration_secs(str(p)) is None
+
+
+class _FakeFfmpegProc:
+    """Stand-in for the ffmpeg probe child: scripted stdout/returncode, and a
+    hang mode that blocks until kill() so the timeout arm and _kill_and_reap
+    can both be exercised without a real process (or a real platform)."""
+
+    def __init__(self, stdout: bytes = b"", returncode: int = 0, hang: bool = False) -> None:
+        self._stdout = stdout
+        self.returncode = returncode
+        self._hang = hang
+        self._released = asyncio.Event()
+        self.killed = False
+
+    async def communicate(self):
+        if self._hang and not self.killed:
+            await self._released.wait()
+        return self._stdout, b""
+
+    def kill(self) -> None:
+        self.killed = True
+        self._released.set()
+
+
+class TestAudioExceedsSecsProbe:
+    """The ffmpeg null-decode branch, driven through a scripted child process."""
+
+    def _arm(self, monkeypatch, proc):
+        async def _resolve():
+            return "/opt/fake/ffmpeg"
+
+        async def _spawn(_executable, *_argv, **_kw):
+            if isinstance(proc, BaseException):
+                raise proc
+            return proc
+
+        monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _resolve)
+        monkeypatch.setattr(transcribe, "_create_ffmpeg_subprocess", _spawn)
+
+    @pytest.mark.asyncio
+    async def test_a_decode_past_the_cap_answers_true(self, tmp_path, monkeypatch):
+        p = tmp_path / "long.webm"
+        p.write_bytes(b"x")
+        stdout = b"out_time_us=5000000\nprogress=continue\nout_time_us=11000000\nprogress=end\n"
+        self._arm(monkeypatch, _FakeFfmpegProc(stdout=stdout))
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("returncode", [0, 1])
+    async def test_the_probe_closes_the_authenticated_handle_off_loop(
+        self, tmp_path, monkeypatch, returncode
+    ):
+        """GPT+Opus review r33: after #8918 moved close ownership to callers,
+        the probe resolved an authenticated handle and never closed it, so the
+        blocking ``os.close`` ran on the gateway event loop via ``__del__``.
+        Every exit — success and failure alike — must release the handle
+        through ``_close_ffmpeg_for_execution``, off the loop thread, like the
+        module's sibling spawn sites."""
+        import threading
+
+        p = tmp_path / "talk.webm"
+        p.write_bytes(b"x")
+        loop_thread = threading.get_ident()
+        close_threads: list[int] = []
+
+        handle = transcribe._AuthenticatedFfmpeg("src", -1, "/opt/fake/ffmpeg")
+        original_close = transcribe._AuthenticatedFfmpeg.close
+
+        def recording_close(self):
+            close_threads.append(threading.get_ident())
+            original_close(self)
+
+        monkeypatch.setattr(transcribe._AuthenticatedFfmpeg, "close", recording_close)
+
+        async def _resolve():
+            return handle
+
+        stdout = b"out_time_us=2000000\nprogress=end\n" if returncode == 0 else b""
+        proc = _FakeFfmpegProc(stdout=stdout, returncode=returncode)
+
+        async def _spawn(_executable, *_argv, **_kw):
+            return proc
+
+        monkeypatch.setattr(transcribe, "_resolve_ffmpeg_for_execution", _resolve)
+        monkeypatch.setattr(transcribe, "_create_ffmpeg_subprocess", _spawn)
+        await transcribe.audio_exceeds_secs(str(p), 10)
+        assert len(close_threads) == 1, "the handle must be closed exactly once"
+        assert close_threads[0] != loop_thread, "the close must run off the event loop"
+
+    @pytest.mark.asyncio
+    async def test_a_decode_under_the_cap_answers_false(self, tmp_path, monkeypatch):
+        p = tmp_path / "short.webm"
+        p.write_bytes(b"x")
+        self._arm(monkeypatch, _FakeFfmpegProc(stdout=b"out_time_us=2000000\nprogress=end\n"))
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is False
+
+    @pytest.mark.asyncio
+    async def test_a_failed_decode_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "corrupt.webm"
+        p.write_bytes(b"x")
+        self._arm(monkeypatch, _FakeFfmpegProc(returncode=1))
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is None
+
+    @pytest.mark.asyncio
+    async def test_a_decode_with_no_progress_output_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "odd.webm"
+        p.write_bytes(b"x")
+        self._arm(monkeypatch, _FakeFfmpegProc(stdout=b""))
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is None
+
+    @pytest.mark.asyncio
+    async def test_a_hung_probe_times_out_reaps_the_child_and_answers_none(
+        self, tmp_path, monkeypatch
+    ):
+        p = tmp_path / "hang.webm"
+        p.write_bytes(b"x")
+        proc = _FakeFfmpegProc(hang=True)
+        self._arm(monkeypatch, proc)
+        assert await transcribe.audio_exceeds_secs(str(p), 10, timeout_secs=0) is None
+        assert proc.killed, "the timed-out child must be killed, not leaked"
+
+    @pytest.mark.asyncio
+    async def test_an_unspawnable_ffmpeg_is_unanswerable(self, tmp_path, monkeypatch):
+        p = tmp_path / "noexec.webm"
+        p.write_bytes(b"x")
+        self._arm(monkeypatch, OSError("exec format error"))
+        assert await transcribe.audio_exceeds_secs(str(p), 10) is None
+
+    def test_the_capless_answer_loads_config_when_none_is_given(self, monkeypatch):
+        monkeypatch.setattr(
+            transcribe, "_load_stt_config", lambda: SimpleNamespace(provider="transcribe")
+        )
+        assert transcribe.batch_duration_cap_secs() is None


### PR DESCRIPTION
## Problem / Motivation

A meeting that happened outside the app — a phone recording, a call recorded by another tool — cannot reach the Meetings app at all. Its audio has no way into the transcript, so the note-taking crew, task extraction, and the domain dictionary never see it.

## Why it matters

The first meeting a user wants notes for is usually one that already happened. Without an import path, the app only works for meetings the user remembered to run it in.

## What changed (motivation → approach → change)

Goal: import an existing recording into a live meeting **as if it had been spoken** — one pipeline, nothing re-implemented, nothing that can drift.

- **`POST /meetings/{id}/import` `{audio_path}`** transcribes a host audio file with the gateway's own batch speech-to-text and dispatches the result line by line.
- **Every line goes through `_common.dispatch_line`**, the same admission transaction live speech and the broadcast bar use — extracted here so both producers share it rather than copy it. So an imported line is persisted to `transcript.jsonl` BEFORE fan-out (the app-wide invariant: an accepted agent line cannot be absent from the transcript) and then gets the same dictionary correction, noise gate, per-agent batching and mute list a microphone gets. Admission is re-checked per line, so a meeting stopped mid-import fails promptly with the same 409/410 as live speech; a recording that fills the transcript ceiling gets the same 413.
- **Every dispatched line requires the SESSION OBJECT admitted at import start** (`require_session`, compared by identity): a meeting id is a name, not an identity, and a meeting stopped, deleted, and recreated under the same id while the audio was transcribing must not be contaminated with the old recording's lines — it gets a 410 `meeting_session_replaced` instead. The identity check runs before the expiry branch so a producer holding a stale session cannot trigger another session's teardown.
- **Size ceiling enforced INSIDE the snapshot copy** (`copy_file_pinned` gained `max_bytes`): the fstat pre-check refuses a swapped-in oversize (or sparse) source before the destination exists, and the bounded write loop aborts after the first excess byte for a source that grows mid-copy — a ceiling checked only after the copy could exhaust the temp volume on the way to the rejection. Snapshot cleanup now JOINS the copy worker before `rmtree` (`_remove_snapshot_dir`), closing the Windows cancellation race where an open handle made the removal silently fail and stale recordings accumulate.
- **Owner-only:** the handler refuses any caller that is not the dashboard owner (`is_owner_dashboard_request`, checked before the body is read) with the shared denial shape and an audit entry — the same gate aws-control and the app job routes apply, because the capability is the same class: reading an arbitrary host file by path on the caller's say-so.
- **The client-supplied path goes through `hooks.validate_file_path`** (the shared dashboard file gate: canonicalization + `is_sensitive_path`), never a local check — and the extension check runs on the CANONICAL path, so a symlink named `.mp3` cannot smuggle in its target. `transcribe_audio` re-checks the path itself; rejections are SEL-audited.
- **`error_response` fix folded in (needed by this route):** statuses with no literal branch fell through to 400, so `store.contain`'s 403 for a path escaping the data root was reported as "bad request". Added the FORBIDDEN branch (plus 502/503 for the transcription outcomes) with regression tests pinning 403-not-400.
- `domain/audio.split_transcript` turns the returned blob into lines in three tiers: transcriber segments when given, sentence boundaries for single-paragraph providers, hard wrap at the char limit (wrapped, not truncated). A recording that would split into more than `MAX_IMPORT_LINES` lines is **refused whole with 413 `recording_too_long`** — never silently truncated, because a capped result is indistinguishable from a complete one and the tail would be lost without any signal. `lines` vs `dispatched` are reported separately — the gap is what the noise gate dropped, and "400 lines, 0 dispatched" is an outcome the user must be able to see.
- **No UI yet** — this is an API surface; a host-path picker is a separate UI decision. The App Store highlight advertising the feature is deliberately **deferred to the picker PR** (maintainer ruling: nothing is advertised before a user can find it in the UI), so the manifest and all locale catalogs are untouched; spec updated in the same commit (Importing a recording section, producer-sharing paragraph, error_response paragraph, security bullets).
- **Resource ceilings and concurrency** — a recording file above `MAX_IMPORT_AUDIO_BYTES` (512 MiB) is refused 413 `audio_file_too_large` in the vet step, BEFORE the decoder can materialize gigabytes of PCM (GPT round 4); a recording **longer than the local decoder's 3600 s ceiling is refused whole with 413 `recording_too_long` BEFORE transcription** (GPT round 5) — the local decode paths stop reading at that ceiling without saying so, so without this gate a multi-hour recording would import its first hour and return 200 (silent data loss). The gate is provider-aware (`transcribe.batch_duration_cap_secs`): AWS Transcribe refuses oversized payloads loudly and Apple reads whole files, so neither is wrongly capped. Duration comes from `transcribe.audio_exceeds_secs` — exact WAV-header math, else a null decode by the same ffmpeg bounded at cap+1 s (metadata probes cannot answer for MediaRecorder webm, which carries no duration header). And one import runs per meeting at a time — a second concurrent request answers 409 `import_in_progress`, because both would dispatch line-by-line into the same transcript and interleave.
- **Pinned snapshot + one config snapshot (GPT round 6):** the vetted path is a NAME, and anything running as this user could swap it between validation and the transcriber's open. The import now copies the file via the repo's central `kiro_crew.pinned_fs.copy_file_pinned` (`O_NOFOLLOW` open, verdict on the descriptor's `fstat`, exclusive-create destination) into a request-private `0700` temp dir — the duration probe and the transcription consume the snapshot, the size ceiling is re-checked on the copied bytes, a refused source answers 403, and the dir is deleted on every exit path. Round 7 completes the adoption of the central helpers: the source's ANCESTOR chain is pinned too (`pinned_fs.pin_parent`, one `O_NOFOLLOW` `openat` per component, the same shape as the app-art reader in `apps/routes.py`) with the pinned `dir_fd`+`name` pair handed to `copy_file_pinned`, and a source that vanishes between validation and the copy is tolerated per that helper's documented `FileNotFoundError` contract — it answers the same 403 as any other unreadable path instead of a 500. A replacement session still initializing now answers the permanent 410 `meeting_session_replaced` rather than the retryable 409 (`dispatch_line` compares `ACTIVE.get(meeting_id)` with `require_session` before the no-active-meeting fallback). The handler also loads ONE speech-to-text config snapshot (`transcribe.load_stt_config()`) and threads it through readiness, the duration ceiling, and the transcription, so a mid-request provider switch cannot skip the gate. The duration probe now spawns ffmpeg through main's authenticated `_create_ffmpeg_subprocess` helper rather than directly. Round 8 closes the guard’s last fail-open seam and hardens the snapshot’s error mapping: the duration probe now runs under the SAME time budget as the transcode (`stt_config.timeout_secs` is passed through; the probe decodes a strict subset of the transcode’s work, so an aligned budget means whatever defeats the probe defeats the transcode too and transcription fails loudly instead of truncating silently), and `_snapshot_recording` maps every `OSError` out of the pinned copy — permission denied, a component swapped mid-walk, a vanished file — to the same 403 `audio_path_denied` instead of letting non-ENOENT errnos escape as a 500.
- **Riders, declared:** `routes/__init__.py` and `_common.py` become black-clean and are therefore pruned from `.github/black-baseline.txt` (the ratchet fails on graduated files left in the baseline, so the prune cannot ship separately); `ATTRIBUTION.md` gains an "Added after the port" section covering the new module. Rebased onto current main after the live-translation feature merged: the shared dispatch transaction (`_common.dispatch_line`) now carries main's agent-initialization hold (issue #4610) as an explicit opt-in — the live/typed producer holds opening speech, while a file import still refuses whole and retries, preserving the never-partial invariant.
- **Platform support: importing requires kernel pinned traversal (`dir_fd` + `O_NOFOLLOW`), so Windows answers 501 `import_unsupported_on_platform` before any filesystem step.** Every by-name variant of the no-`dir_fd` fallback (name sweep, post-open `fd_real_path` witness, vet-identity check) conceded a residual window: on Windows the `os.open` itself follows an ancestor junction planted after any check, and a UNC target fires outbound SMB authentication as a side effect of the open, which no after-open check can undo. Per the repo ruling recorded in `snapshot.py`'s notification copy (decline the hand-rolled ctypes walk; refuse loudly), the fallback branch is now a loud fail-closed backstop and the route refuses up front with a user-actionable code. Live-microphone meetings on Windows are unaffected — only the file-import route is gated.

## Tests

- `test/test_meetings_audio_import.py` (59 tests) — the refusals in order (non-owner 403 / path denied 403 / not a file 404 / oversized file 413 / over-long recording 413 / bad format 400 / concurrent import 409 / STT unavailable 503 / transcription failed 502 / over-long transcript 413), `test_a_recreated_meeting_does_not_receive_the_old_recording` (red-before-green: a meeting stopped and recreated under the same id mid-import gets 410 `meeting_session_replaced` and its transcript/queues receive nothing from the old recording), `test_an_oversized_file_is_413_and_never_reaches_the_decoder` + `test_an_oversized_file_is_refused_before_decoding` (the size ceiling fires in the vet step while the decode cost is still zero), `test_a_concurrent_import_into_the_same_meeting_is_409` (second concurrent request refused; guard released when the first completes), `test_a_line_count_overflow_is_rejected_not_sliced` + `test_an_over_long_recording_is_413_and_nothing_is_dispatched` (a recording past the line budget is refused whole, never silently truncated), the split's boundary rules, `test_imported_lines_are_persisted_before_fan_out` (asserts the transcript contains exactly the imported lines with `source == "speech"`), and `test_both_producers_share_the_dispatch_transaction` (source-pins that both handlers go through `dispatch_line` and the expiry side effects live in `dispatch_admission`).
- `test/test_meetings_routes.py` — 403-vs-400 containment regression tests; the audio_import module added to the no-blocking-on-loop AST scan.
- Duration gate: `test_a_recording_over_the_decoder_cap_is_413_not_a_truncated_200` (red-before-green: the unfixed route returned a truncated 200), `test_a_provider_without_a_ceiling_skips_the_duration_probe`, and `test_an_unanswerable_duration_probe_proceeds_to_transcription` (route); `test/test_transcribe.py` gains `TestBatchDurationCap` + `TestAudioExceedsSecs` (provider-aware cap answers, exact WAV-header math incl. rate mismatches and the exactly-at-cap boundary, honest None without ffmpeg, ffmpeg `-progress` parsing). Round-6 coverage: `test_one_config_snapshot_feeds_readiness_cap_and_transcription` (one config read; the identical object reaches all three calls), `test_a_snapshot_refusal_is_403_and_nothing_is_transcribed` (route), and `TestSnapshotRecording` (real filesystem: copy works, a symlink-swapped path is refused, a symlink-swapped ANCESTOR directory is refused, a source grown past the ceiling is refused, a vanished source is refused with 403 rather than raising); `test_a_replacement_still_initializing_answers_410_not_409` (the recreated session's initialization window answers the permanent 410, and nothing is buffered into its hold). Round-8 coverage: `test_the_probe_gets_the_transcodes_own_time_budget` (the route hands the probe `stt_config.timeout_secs`, pinning the aligned-budget invariant) and `test_an_unreadable_source_is_refused_not_raised` (a chmod-0 source answers the same refusal as any unreadable path — 403, not an unhandled 500). `test/test_spawn_audit.py` allowlists `transcribe.py::audio_exceeds_secs` beside its sibling `_pcm_via_ffmpeg` — same fixed-argv ffmpeg, same already-vetted positional path, no output file (`-f null -`).

Local runs (rebased onto current `main`): backend `isort`/`flake8`/`mypy` (1284 files) and the black ratchet green; 308 meetings-suite + 379 transcribe/contract/manifest/spawn-audit tests green; website `tsc -b` and the full vitest suite (1635 test files) green.

## Manual verification

Not yet performed against a real audio file + configured STT provider (no test decodes audio or calls a model, by design). One end-to-end import against a real recording is still required before merge sign-off.

## Related Issues

Part of the meetings feature stack split from the `feat/meetnote` branch. Independent of the other PRs in the stack.

no linked issue: feature work from the meetings stack; no tracked issue exists for it.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** API-only; locale strings are the manifest-sync mirror — no rendered pixel changes.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff







