### PR TITLE
fix(apps): backfill default-on builtins onto installs that predate the flag

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -475,6 +475,49 @@ persisted at first registration and never routes through `enable_app`, so the
 governance `apps` activation allowlist is re-applied at that write: a
 governance-denied app registers disabled.
 
+`defaultEnabled` is read on FIRST registration only — every later start preserves
+the user's own state — so ADDING a name to the exemption reaches new installs
+alone. An install that registered the app while it was still default-off keeps
+`enabled: false` through every restart, update and version bump, because the
+record lives in the user's data home and a code update does not touch it. For a
+builtin that replaces a host surface that is terminal rather than inconvenient:
+it has no page, so it is absent from the launcher's own app list, and it is
+absent from Discover unless the published catalog carries a row, which leaves a
+disabled row in Library as the only trace of an app the user never heard of.
+
+`manager.backfill_default_on_builtins()` closes that gap, invoked from
+`agent.run_first_run_setup()`. It reads a SECOND set, `_DEFAULT_ON_BACKFILL`, and
+the separation is load-bearing rather than bookkeeping: `_DEFAULT_ON_BUILTINS`
+answers "what does a fresh install enable", while this one answers "which
+promotion has not yet reached installs that predate it". Reading the first for the
+second question reverses deliberate opt-outs — `projects` has shipped
+`defaultEnabled: true` since it was aligned with the other builtins, long before
+the allowlist existed, so it has been enabled and visible in the sidebar on every
+existing install and a disabled record for it is a user who found it and turned it
+off. A name qualifies only when a fresh install enables it AND existing installs
+were never in a position to choose; a ratchet test pins both halves.
+
+The backfill is ONE-SHOT, and the record of that is
+`InstalledApp.defaultOnBackfilled`, written in the SAME atomic record write that
+flips `enabled`. One document deliberately: a separate marker file has no correct
+ordering, because whichever of the two writes goes first leaves a window the other
+one owns — marker-last loses the record of an enable that happened, so every later
+start re-applies the promotion and reverses the user's own disable forever;
+marker-first can outlive a flip that failed, so the app is skipped forever and the
+promotion is never delivered. Both are real failures; neither is reachable when the
+flag and the state it guards land or fail together. A record created under the
+promoted default is born `True`, because a first registration with `defaultEnabled`
+IS the promotion being received — without that, "install, disable the app in the
+same session, restart" would re-enable it, and no write ordering can fix that since
+on a fresh install the record may not exist yet when first-run setup runs.
+Disabling the app must survive, since it is the only thing that gives a replaced
+host surface back. Both the `_builtin_owns_install` boundary (a user's own install
+under the same name is never touched) and the governance activation gate are
+re-applied, and a governance-denied app is deliberately left unflagged so the
+promotion is still delivered if policy later permits. The activation is recorded in
+the SEL, because it moves an app from inactive to active with no user request
+behind it.
+
 `hidden: true` on a builtin manifest removes it from the Discover catalog while
 leaving its code and routes fully intact. It stays installable and enablable by
 name from the CLI, and remains visible in the Library once enabled. **Channels**
@@ -497,7 +540,8 @@ deterministic order (hero art, then verified publishers, then name), so the
 surface is never empty and never arbitrary.
 
 Writers: `apps/manager.py` (`_BUILTIN_APPS`, `_DEFAULT_ON_BUILTINS`,
-`register_builtin_apps`), `apps/discovery.py::discover_builtin_apps`,
+`_DEFAULT_ON_BACKFILL`, `register_builtin_apps`, `backfill_default_on_builtins`),
+`agent.py::run_first_run_setup`, `apps/discovery.py::discover_builtin_apps`,
 `apps/registry.py::_apply_trust_fields`;
 consumers: `website/src/pages/AppsPage.tsx` (`pickFeatured`),
 `website/src/components/appstore/types.ts` (`isVerified`, `sourceLabel`).

--- a/docs/system-specs/modules/command-bar.md
+++ b/docs/system-specs/modules/command-bar.md
@@ -16,6 +16,13 @@ flag alone would fail the opt-in policy tests. Disabling the app hands the gestu
 legacy command palette, which is left in place precisely so that is a real choice rather than a
 downgrade; nothing about that path changes while the app is off.
 
+The flag reaches FRESH installs only. An install that registered `command-bar` while it was still
+default-off keeps `enabled: false` forever, and because this app has no page it appears in neither
+the launcher's own app list nor Discover — so those users have no way to learn it exists.
+`manager.backfill_default_on_builtins()`, which reads `manager._DEFAULT_ON_BACKFILL` and records
+delivery on the app's own record (`InstalledApp.defaultOnBackfilled`, written in the same atomic
+write that flips `enabled`), is what delivers the launcher to them; see app-kit-platform section 12.
+
 What makes the app worth existing is a single invariant: **the first page issues no network
 request.** The palette it replaces ran an unindexed scan over the sessions corpus on every
 keystroke, so fast typing could stall unrelated streaming. Command Bar's root carries only

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1002,7 +1002,7 @@ def run_first_run_setup() -> None:
     """Deliver the install-time steps the desktop app needs without a terminal.
 
     The Electron app only runs ``kirocrew gateway`` — never ``kirocrew
-    setup`` — yet two concerns aren't covered by the gateway's agent-config
+    setup`` — yet several concerns aren't covered by the gateway's agent-config
     rebuild. This is invoked from gateway startup to close that gap:
 
     * **PATH shim** — ``ensure_kirocrew_on_path()`` is idempotent and only
@@ -1010,6 +1010,10 @@ def run_first_run_setup() -> None:
       WITHOUT ``claim_existing`` for exactly that reason: running unattended on
       every start, it must fill an empty or broken slot only, never take the
       command away from another install that still works.
+    * **Default-on builtin backfill** — ``defaultEnabled`` is applied only on an
+      app's FIRST registration, so a builtin promoted to default-on later never
+      reaches installs that already registered it. Runs ONCE, guarded by its own
+      marker file, because re-running it would override a user's own disable.
     * **Stale predecessor MCP purge** — ``clean_stale_managed_mcp()`` mutates
       the user's *global* ``~/.kiro/settings/mcp.json``, so it runs ONCE,
       guarded by a marker file, to honor the "KiroCrew owns only the agent
@@ -1037,7 +1041,25 @@ def run_first_run_setup() -> None:
     except Exception:
         logger.warning("First-run: admission policy seed failed", exc_info=True)
 
-    # 3. Stale managed-MCP purge — one-time, marker-guarded.
+    # 3. Default-on builtin backfill — one-shot per app, self-recorded on the
+    #    app's own installed.json (no marker file: the flag and the state it
+    #    guards must land in one atomic write). Placed BEFORE the stale-MCP early
+    #    return for the same reason step 2 is, and here the reason is the whole
+    #    point: an EXISTING install already holds the stale-MCP marker, and an
+    #    existing install is the ONLY kind this step has anything to do (a fresh
+    #    one registers these apps enabled and already flagged).
+    try:
+        from kiro_crew.apps.manager import (  # noqa: PLC0415
+            backfill_default_on_builtins,
+        )
+
+        flipped = backfill_default_on_builtins()
+        if flipped:
+            logger.info("First-run: enabled default-on builtin(s): %s", flipped)
+    except Exception:
+        logger.warning("First-run: default-on builtin backfill failed", exc_info=True)
+
+    # 4. Stale managed-MCP purge — one-time, marker-guarded.
     stale_marker = _stale_mcp_purge_marker()
     if stale_marker.exists():
         return

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -115,6 +115,17 @@ class InstalledApp:
         ""  # noqa: N815  — target standalone app: "registry:{name}" or "standalone:{name}"
     )
     dev: bool = False  # dev mode: no-store UI serving + file-watch live reload
+    # Whether this record has already received a default-on PROMOTION (see
+    # ``_DEFAULT_ON_BACKFILL``).  Lives on the record rather than in a marker file
+    # so it is written by the SAME atomic write that flips ``enabled``: two
+    # separate writes have no correct ordering, since whichever goes first leaves
+    # a window the other owns (a lost flag re-applies the promotion forever and
+    # reverses the user's own disable; a flag that outlives a failed flip skips
+    # the app forever and never delivers it).  A record created under the promoted
+    # default is born ``True``: a first registration with ``defaultEnabled`` is
+    # the promotion being received, so nothing is owed.  Meaningless-but-inert
+    # (``False``) for every app that is not a promotion target.
+    defaultOnBackfilled: bool = False  # noqa: N815
     # Structured install provenance, recorded for registry installs (see
     # ``set_app_provenance``).  ``source`` alone is a bare ``registry:<name>``
     # marker that re-resolves by name, so a same-named entry from a different
@@ -158,6 +169,7 @@ class InstalledApp:
             schemaVersion=int(data.get("schemaVersion", 1)),
             migratedTo=str(data.get("migratedTo", "")),
             dev=bool(data.get("dev", False)),
+            defaultOnBackfilled=bool(data.get("defaultOnBackfilled", False)),
             sourceUrl=str(data.get("sourceUrl", "")),
             sourceRegistry=str(data.get("sourceRegistry", "")),
             sourceCommit=str(data.get("sourceCommit", "")),
@@ -1634,6 +1646,134 @@ _DEFAULT_ON_BUILTINS: frozenset[str] = frozenset(
     }
 )
 
+# Promotions still owed to installs that PREDATE them — a different question from
+# the set above, and the distinction is load-bearing.
+#
+# ``_DEFAULT_ON_BUILTINS`` answers "what does a FRESH install enable". This set
+# answers "which promotion has not yet reached installs that registered the app
+# while it was still default-off". Reading the first set for the second question
+# reverses deliberate opt-outs: ``projects`` (Task Runner) has shipped
+# ``defaultEnabled: true`` since it was aligned with the other builtins, long
+# before this allowlist existed, so it has been enabled and visible in the
+# sidebar on every existing install. A record showing ``enabled: false`` for it
+# is therefore a user who FOUND it and turned it off — the opposite of the
+# population a backfill exists to serve.
+#
+# So a name belongs here only when both hold: a fresh install enables it (it is
+# in the set above), and existing installs were never in a position to choose.
+# ``command-bar`` qualifies because it was default-OFF at first registration for
+# those installs AND, replacing the quick-search surface rather than adding a
+# sidebar entry, it appears on no store or launcher surface they could have found
+# it on. An app already default-on when they installed it never qualifies.
+#
+# Entries are permanent, not cleaned up after a release: the marker is per
+# install, so a user restoring an old data home still gets the promotion once.
+_DEFAULT_ON_BACKFILL: frozenset[str] = frozenset({"command-bar"})
+
+
+def backfill_default_on_builtins() -> list[str]:
+    """Deliver a default-on PROMOTION to installs that predate it. One-shot per app.
+
+    ``register_builtin_apps()`` applies ``defaultEnabled`` only on FIRST
+    registration and preserves user state on every later start, so adding a name
+    to ``_DEFAULT_ON_BUILTINS`` reaches NEW installs only. An install that
+    registered the app while it was still default-off keeps ``enabled: false``
+    through every subsequent restart, update and version bump — the record lives
+    in the user's data home, which a code update does not touch.
+
+    That is survivable for a builtin that adds a sidebar entry, because the App
+    Store can still offer it. It is not survivable for one that replaces a host
+    surface: it has no page, so it is absent from the launcher's own app list,
+    and it is absent from Discover unless the published catalog carries a row for
+    it, which leaves a disabled row in Library as the only trace. Those users
+    cannot enable what they have no way to learn exists.
+
+    Reads ``_DEFAULT_ON_BACKFILL``, NOT ``_DEFAULT_ON_BUILTINS`` — see that set's
+    comment for why conflating the two silently reverses deliberate opt-outs.
+
+    ONE-SHOT, and the record of that is ``InstalledApp.defaultOnBackfilled``,
+    written in the SAME atomic record write that flips ``enabled``. One document
+    deliberately: a separate marker file has no correct ordering, because
+    whichever of the two writes goes first leaves a window the other one owns.
+    Marker-last loses the record of an enable that happened, so every later start
+    re-applies the promotion and reverses the user's own disable forever;
+    marker-first can outlive a flip that failed, so the app is skipped forever and
+    the promotion is never delivered. Both are real; neither is reachable when the
+    flag and the state it guards land or fail together.
+
+    Surviving a user's disable is the point: disabling the app is the ONLY thing
+    that gives a replaced host surface back. Per app rather than per install, so a
+    promotion added in a later release is still delivered.
+
+    Returns the names actually flipped, so the caller can log them.
+    """
+    flipped: list[str] = []
+    for name in sorted(_DEFAULT_ON_BACKFILL):
+        existing = _read_installed(name)
+        if existing is None:
+            # Not registered on this install (an older wheel does not ship the
+            # app). A record created LATER is born already flagged, because a
+            # first registration under the promoted default IS the promotion
+            # being received — see register_builtin_apps().
+            continue
+        if not _builtin_owns_install(existing):
+            # A USER installed an app under this name. Same boundary
+            # register_builtin_apps() keeps: never touch their entry.
+            continue
+        if existing.defaultOnBackfilled:
+            continue
+        turning_on = not existing.enabled
+        if turning_on:
+            denied = _app_activation_denied(name)
+            if denied:
+                # Mirror the gate register_builtin_apps() applies to a default-on
+                # builtin: a deny-by-default host policy is not bypassed by
+                # arriving through the backfill. Deliberately NOT flagged — if the
+                # policy later permits the app, the promotion is still owed.
+                logger.info("Default-on backfill skipped %s: %s", name, denied)
+                continue
+            existing.enabled = True
+        existing.defaultOnBackfilled = True
+        existing.updatedAt = _now_iso()
+        # atomic_write, so a failure here persists NEITHER the flag nor the enable
+        # and the promotion is simply retried on the next start. The failure
+        # propagates out of this function (the caller logs it and continues
+        # startup), so no partially-delivered state and no half-truthful return
+        # value is observable. `flipped` is appended after the write to keep that
+        # reading obvious, not because anything could observe the other order.
+        _write_installed(name, existing)
+        if turning_on:
+            flipped.append(name)
+            _audit_default_on_backfill(name)
+    return flipped
+
+
+def _audit_default_on_backfill(name: str) -> None:
+    """Record that *name* was activated with no user request behind it.
+
+    The dashboard and CLI enable paths are reachable only by someone asking; this
+    one runs at startup, and activation is the chokepoint where an app starts
+    contributing agents, skills, crons and routes. An operator reconstructing
+    "when did this app become active, and who asked for it" would otherwise find
+    nothing at all. Same shape as the trust-grant withdrawal above: emitted AFTER
+    the write so it attests something that actually happened, and never allowed to
+    fail the operation — losing the audit line is bad, refusing to deliver a
+    promotion because the audit sink is unavailable is worse.
+    """
+    try:
+        from kiro_crew.sel import sel
+
+        sel().log_api_access(
+            caller="gateway",
+            operation="app_default_on_backfill",
+            outcome="allowed",
+            source="startup",
+            resources=f"{name}=enabled_by_promotion_backfill",
+        )
+    except Exception:  # noqa: BLE001 - the activation already happened
+        logger.warning("could not audit the default-on backfill for %r", name, exc_info=True)
+
+
 # EMPTY, and that is a finished migration rather than an oversight. Every builtin now
 # ships as a file-based manifest under ``builtins/<dir>/app.json`` and is picked up by
 # ``discover_builtin_apps()``. ``agent-worlds`` and ``channels`` were the last two
@@ -2191,6 +2331,20 @@ def register_builtin_apps() -> int:
                 resources="gateway",
                 lifecycle="locked",
                 migratedTo=_effective_migrated_to(app_data),
+                # A first registration under the promoted default IS the promotion
+                # being received, so nothing is owed and the backfill must never
+                # touch this record. Without this the sequence "install, disable
+                # the app in that same session, restart" would re-enable it: the
+                # backfill would find a disabled record it had never flagged and
+                # read the user's own choice as a promotion still owed.
+                #
+                # Gated on the POST-governance ``default_enabled``, matching the
+                # rule the backfill itself applies: a governance-denied app
+                # registers DISABLED, so it did NOT receive the promotion and is
+                # still owed one. Flagging it here would strand it -- relaxing the
+                # policy later could never deliver the launcher, because the
+                # record would claim it already had.
+                defaultOnBackfilled=default_enabled and name in _DEFAULT_ON_BACKFILL,
             )
             _write_installed(name, meta)
 

--- a/test/test_builtin_app_optional_enable.py
+++ b/test/test_builtin_app_optional_enable.py
@@ -865,3 +865,420 @@ class TestProperty7APIReturnsCompleteManifest:
         assert manifest["tags"] == ["hidden"]
         assert manifest["permissions"]["api"] == ["/api/test"]
         assert manifest["ui"]["pages"][0]["label"] == "Hidden"
+
+
+# ---------------------------------------------------------------------------
+# Default-on backfill: reaching installs that registered before the exemption
+# ---------------------------------------------------------------------------
+
+
+def _register_builtin_disabled(monkeypatch, tmp_path, name, *, backfilled: bool):
+    """Register *name* as a builtin and leave its record DISABLED.
+
+    Reproduces the state this backfill exists for: an install that registered the
+    app while it was still default-off. Written through the real registration
+    path first so ``source``/``origin`` carry genuine builtin provenance, then
+    flipped off — a hand-built record would not exercise
+    ``_builtin_owns_install``.
+    """
+    import kiro_crew.apps.manager as mgr
+
+    _ship_builtin(monkeypatch, tmp_path, name)
+    monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+        "name": name,
+        "version": "1.0.0",
+        "displayName": name,
+        "description": "Registered before the default-on exemption existed",
+        "author": "kirocrew",
+        "defaultEnabled": False,
+    }])
+    monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+    monkeypatch.setattr(mgr, "_DEFAULT_ON_BUILTINS", frozenset({name}))
+    # Registered while the promotion did NOT yet exist, which is the whole premise:
+    # release N ships the app default-off, release N+1 adds it to the promotion set.
+    # Setting the set before registering would make the record born flagged (see
+    # test_a_fresh_registration_is_born_flagged) and there would be nothing owed.
+    monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset())
+    register_builtin_apps()
+    meta = _read_installed(name)
+    assert meta is not None and meta.enabled is False
+    assert meta.defaultOnBackfilled is False
+    if backfilled:
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({name}))
+    return meta
+
+
+class TestDefaultOnBackfill:
+    """``backfill_default_on_builtins()`` — the one-shot that reaches existing installs."""
+
+    def test_flips_a_disabled_promoted_builtin(self, app_home, monkeypatch, tmp_path):
+        """The case the backfill exists for: promotion owed, record still disabled."""
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "late-default-on", backfilled=True)
+
+        assert backfill_default_on_builtins() == ["late-default-on"]
+        meta = _read_installed("late-default-on")
+        assert meta is not None
+        assert meta.enabled is True
+
+    def test_does_not_read_the_fresh_install_allowlist(self, app_home, monkeypatch, tmp_path):
+        """A default-on builtin NOT owed a promotion is left alone.
+
+        ``_DEFAULT_ON_BUILTINS`` answers what a fresh install enables;
+        ``_DEFAULT_ON_BACKFILL`` answers which promotion has not reached older
+        installs. Reading the first for the second question re-enables apps that
+        users deliberately turned off — the concrete case is ``projects``, which
+        has been default-on far longer than the allowlist has existed, so every
+        disabled record for it is an opt-out.
+        """
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "long-default-on", backfilled=False)
+
+        assert backfill_default_on_builtins() == []
+        meta = _read_installed("long-default-on")
+        assert meta is not None
+        assert meta.enabled is False
+
+    def test_projects_is_not_backfilled(self):
+        """Ratchet on the real sets, not a fixture.
+
+        ``projects`` (Task Runner) shipped default-on long before the exemption
+        allowlist existed, so it has been enabled and visible in the sidebar on
+        every existing install; a disabled record is a user who found it and
+        turned it off. Adding it here would silently reverse that.
+        """
+        import kiro_crew.apps.manager as mgr
+
+        assert "projects" not in mgr._DEFAULT_ON_BACKFILL
+
+    def test_backfill_targets_are_all_default_on(self):
+        """A backfilled app must also be one a FRESH install enables.
+
+        Otherwise the backfill would enable something the shipped policy says
+        should be off, which is a promotion nobody declared.
+        """
+        import kiro_crew.apps.manager as mgr
+
+        stray = set(mgr._DEFAULT_ON_BACKFILL) - set(mgr._DEFAULT_ON_BUILTINS)
+        assert not stray, f"backfilled but not default-on: {sorted(stray)}"
+
+    def test_does_not_touch_a_user_owned_entry(self, app_home, monkeypatch, tmp_path):
+        """A user install under the same name keeps its own state.
+
+        Same boundary ``register_builtin_apps()`` keeps via
+        ``_builtin_owns_install``: the backfill must not enable something the
+        user installed and disabled themselves.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"user-owned"}))
+        _write_installed("user-owned", InstalledApp(
+            name="user-owned",
+            version="1.0.0",
+            displayName="User owned",
+            enabled=False,
+            source="/home/someone/apps/user-owned",
+            origin="local",
+        ))
+
+        assert backfill_default_on_builtins() == []
+        meta = _read_installed("user-owned")
+        assert meta is not None
+        assert meta.enabled is False
+
+    def test_reports_nothing_when_already_enabled(self, app_home, monkeypatch, tmp_path):
+        """An already-enabled app is not reported as flipped.
+
+        The return value is what the caller logs, so a no-op start must not
+        claim it enabled something.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _ship_builtin(monkeypatch, tmp_path, "already-on")
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "already-on",
+            "version": "1.0.0",
+            "displayName": "Already on",
+            "description": "Default-on and already enabled",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BUILTINS", frozenset({"already-on"}))
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"already-on"}))
+        register_builtin_apps()
+        assert _read_installed("already-on").enabled is True  # precondition
+
+        assert backfill_default_on_builtins() == []
+        assert _read_installed("already-on").enabled is True
+
+    def test_honors_governance_deny(self, app_home, monkeypatch, tmp_path):
+        """A deny-by-default host policy is not bypassed by this path.
+
+        ``register_builtin_apps()`` re-applies ``_app_activation_denied`` to a
+        default-on builtin; arriving through the backfill instead must not be a
+        way around it.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "gov-denied", backfilled=True)
+        monkeypatch.setattr(mgr, "_app_activation_denied", lambda name: "denied by policy")
+
+        assert backfill_default_on_builtins() == []
+        meta = _read_installed("gov-denied")
+        assert meta is not None
+        assert meta.enabled is False
+
+    def test_ignores_an_app_this_install_never_registered(self, app_home, monkeypatch):
+        """An allowlist name with no record on disk is skipped, not created.
+
+        An older wheel may not ship the app at all; the backfill reads existing
+        state and must never conjure an install.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"never-shipped"}))
+
+        assert backfill_default_on_builtins() == []
+        assert _read_installed("never-shipped") is None
+
+    def test_runs_once_per_app_then_respects_a_disable(self, app_home, monkeypatch, tmp_path):
+        """The load-bearing property: a second run must not override a disable.
+
+        Disabling the app is the only way to get a replaced host surface back, so
+        a backfill that re-ran would make the promotion impossible to opt out of.
+        """
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "once-only", backfilled=True)
+
+        assert backfill_default_on_builtins() == ["once-only"]
+        # The user turns it back off.
+        meta = _read_installed("once-only")
+        meta.enabled = False
+        _write_installed("once-only", meta)
+
+        assert backfill_default_on_builtins() == []
+        assert _read_installed("once-only").enabled is False
+
+    def test_audits_the_activation(self, app_home, monkeypatch, tmp_path):
+        """Activating an app with no user request behind it is recorded in SEL.
+
+        The dashboard and CLI enable paths are reachable only by someone asking;
+        this one runs at startup, so without an event an operator cannot tell when
+        the app became active or why.
+        """
+        import kiro_crew.sel as sel_mod
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "audited-app", backfilled=True)
+        events: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                events.append(kw)
+
+        monkeypatch.setattr(sel_mod, "sel", lambda: _Sel())
+
+        assert backfill_default_on_builtins() == ["audited-app"]
+
+        assert len(events) == 1, "activation was not audited"
+        assert events[0]["operation"] == "app_default_on_backfill"
+        assert events[0]["outcome"] == "allowed"
+        assert "audited-app" in events[0]["resources"]
+
+    def test_a_failing_audit_sink_does_not_lose_the_promotion(
+        self, app_home, monkeypatch, tmp_path
+    ):
+        """Losing the audit line must not refuse the activation.
+
+        Same trade the trust-grant withdrawal above makes: the record is emitted
+        after the fact and never allowed to fail the operation.
+        """
+        import kiro_crew.sel as sel_mod
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "audit-down", backfilled=True)
+
+        def _boom():
+            raise RuntimeError("sel sink unavailable")
+
+        monkeypatch.setattr(sel_mod, "sel", _boom)
+
+        assert backfill_default_on_builtins() == ["audit-down"]
+        assert _read_installed("audit-down").enabled is True
+
+    def test_a_failed_write_delivers_nothing_and_is_retried(
+        self, app_home, monkeypatch, tmp_path
+    ):
+        """A failed record write leaves NOTHING half-done, and the next start retries.
+
+        This is what one document buys. With a separate marker file there is no
+        correct ordering: marker-last loses the record of an enable that happened
+        (re-applied forever, reversing the user's disable), and marker-first can
+        outlive a failed flip (skipped forever, never delivered). Here the flag and
+        `enabled` land or fail together, so a failure is simply not-yet-done.
+
+        Pins the persisted outcome, not the order of the in-memory append: the
+        write raising propagates out of the call, so no caller ever sees a return
+        value to be misled by.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _register_builtin_disabled(monkeypatch, tmp_path, "write-fails", backfilled=True)
+
+        boom = {"on": True}
+        real_write = mgr._write_installed
+
+        def _maybe_fail(name, meta):
+            if boom["on"] and name == "write-fails":
+                raise OSError("no space left on device")
+            return real_write(name, meta)
+
+        monkeypatch.setattr(mgr, "_write_installed", _maybe_fail)
+
+        with pytest.raises(OSError):
+            backfill_default_on_builtins()
+
+        # Nothing persisted: still disabled, still unflagged.
+        meta = _read_installed("write-fails")
+        assert meta is not None
+        assert meta.enabled is False
+        assert meta.defaultOnBackfilled is False
+
+        boom["on"] = False
+        assert backfill_default_on_builtins() == ["write-fails"]
+        assert _read_installed("write-fails").enabled is True
+
+    def test_records_the_promotion_when_it_flips_nothing(self, app_home, monkeypatch, tmp_path):
+        """An already-enabled app is FLAGGED without being reported as flipped.
+
+        The flag is what stops a later start from reading the user's subsequent
+        disable as a promotion still owed; the return value stays empty because
+        nothing was activated.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _ship_builtin(monkeypatch, tmp_path, "on-and-unflagged")
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "on-and-unflagged",
+            "version": "1.0.0",
+            "displayName": "On and unflagged",
+            "description": "Enabled by the user before the promotion shipped",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BUILTINS", frozenset({"on-and-unflagged"}))
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset())
+        register_builtin_apps()
+        meta = _read_installed("on-and-unflagged")
+        assert meta.enabled is True and meta.defaultOnBackfilled is False  # precondition
+
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"on-and-unflagged"}))
+        assert backfill_default_on_builtins() == []
+        assert _read_installed("on-and-unflagged").defaultOnBackfilled is True
+
+    def test_a_fresh_registration_is_born_flagged(self, app_home, monkeypatch, tmp_path):
+        """A record created under the promoted default owes nothing.
+
+        Without this, "install, disable the app in that same session, restart"
+        re-enables it: the backfill would find a disabled record it had never
+        flagged and read the user's own choice as a promotion still owed. There is
+        no ordering fix for that, because on a fresh install the record may not
+        exist yet when first-run setup runs.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins, disable_app
+
+        _ship_builtin(monkeypatch, tmp_path, "born-flagged")
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "born-flagged",
+            "version": "1.0.0",
+            "displayName": "Born flagged",
+            "description": "Registered on a fresh install under the promoted default",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BUILTINS", frozenset({"born-flagged"}))
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"born-flagged"}))
+
+        register_builtin_apps()
+        assert _read_installed("born-flagged").defaultOnBackfilled is True
+
+        disable_app("born-flagged")
+        assert backfill_default_on_builtins() == []
+        assert _read_installed("born-flagged").enabled is False
+
+    def test_a_governance_denied_registration_is_still_owed_the_promotion(
+        self, app_home, monkeypatch, tmp_path
+    ):
+        """A fresh install that governance DENIED did not receive the promotion.
+
+        Registration gates the app off, so flagging the record would strand it:
+        relaxing the policy later could never deliver the launcher, because the
+        record would claim it already had. Matches the rule the backfill applies
+        to the same situation.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        _ship_builtin(monkeypatch, tmp_path, "denied-at-birth")
+        monkeypatch.setattr(mgr, "_BUILTIN_APPS", [{
+            "name": "denied-at-birth",
+            "version": "1.0.0",
+            "displayName": "Denied at birth",
+            "description": "Promoted builtin that governance denied on first registration",
+            "author": "kirocrew",
+            "defaultEnabled": True,
+        }])
+        monkeypatch.setattr(mgr, "_orphaned_builtins_cache", None)
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BUILTINS", frozenset({"denied-at-birth"}))
+        monkeypatch.setattr(mgr, "_DEFAULT_ON_BACKFILL", frozenset({"denied-at-birth"}))
+        monkeypatch.setattr(mgr, "_app_activation_denied", lambda name: "denied by policy")
+
+        register_builtin_apps()
+        meta = _read_installed("denied-at-birth")
+        assert meta is not None
+        assert meta.enabled is False
+        assert meta.defaultOnBackfilled is False, "denied app was recorded as already promoted"
+
+        # Policy relaxed: the promotion is still owed, so it is delivered.
+        monkeypatch.setattr(mgr, "_app_activation_denied", lambda name: None)
+        assert backfill_default_on_builtins() == ["denied-at-birth"]
+        assert _read_installed("denied-at-birth").enabled is True
+
+    def test_a_later_promotion_is_not_swallowed_by_an_earlier_one(
+        self, app_home, monkeypatch, tmp_path
+    ):
+        """A promotion added in a LATER release still reaches the install.
+
+        Simulates the real sequence: release N delivers one promotion, release N+1
+        adds a second name to the set. Any design that records "the backfill has
+        run" once for the whole install -- rather than once per app -- would make
+        the second run a no-op and the app added later would never arrive.
+        """
+        import kiro_crew.apps.manager as mgr
+        from kiro_crew.apps.manager import backfill_default_on_builtins
+
+        # Release N: one promotion, delivered.
+        _register_builtin_disabled(monkeypatch, tmp_path, "shipped-earlier", backfilled=True)
+        assert backfill_default_on_builtins() == ["shipped-earlier"]
+
+        # Release N+1: a second name joins the set. Its record is still disabled
+        # on this install, exactly like the first one was.
+        _register_builtin_disabled(monkeypatch, tmp_path, "added-later", backfilled=True)
+        monkeypatch.setattr(
+            mgr, "_DEFAULT_ON_BACKFILL", frozenset({"shipped-earlier", "added-later"})
+        )
+
+        assert backfill_default_on_builtins() == ["added-later"]

--- a/test/test_installer_shim_and_cleanup.py
+++ b/test/test_installer_shim_and_cleanup.py
@@ -367,6 +367,86 @@ def test_first_run_is_best_effort(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# Default-on builtin backfill — runs ONCE, and must reach EXISTING installs
+# --------------------------------------------------------------------------
+def _spy_backfill(monkeypatch, calls, *, raises=None):
+    """Replace the backfill with a spy recording each invocation."""
+
+    def _fake() -> list[str]:
+        calls.append(True)
+        if raises is not None:
+            raise raises
+        return ["command-bar"]
+
+    monkeypatch.setattr("kiro_crew.apps.manager.backfill_default_on_builtins", _fake)
+
+
+def test_first_run_runs_the_default_on_backfill(tmp_path, monkeypatch):
+    """First-run invokes the backfill on every start.
+
+    The one-shot guarantee is NOT first-run's job: it lives on the app record
+    itself (``InstalledApp.defaultOnBackfilled``, written in the same atomic write
+    that flips ``enabled``), so calling unconditionally is correct and there is no
+    marker file for this layer to own. See test_builtin_app_optional_enable.py for
+    the once-only property.
+    """
+    exe = _fake_bundle_launcher(tmp_path)
+    _sandbox_first_run(tmp_path, monkeypatch, exe)
+    calls: list[bool] = []
+    _spy_backfill(monkeypatch, calls)
+
+    agent.run_first_run_setup()
+
+    assert calls == [True]
+
+
+def test_first_run_backfills_on_an_install_that_already_purged_mcp(tmp_path, monkeypatch):
+    """An install holding the stale-MCP marker still gets the backfill.
+
+    Existing installs are the ONLY ones this step has anything to do, and every
+    one of them already holds that marker. A backfill placed after the
+    stale-MCP early return would therefore run for nobody.
+    """
+    exe = _fake_bundle_launcher(tmp_path)
+    marker, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
+    _seed_global_mcp(mcp)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("done\n")
+    calls: list[bool] = []
+    _spy_backfill(monkeypatch, calls)
+
+    agent.run_first_run_setup()
+
+    assert calls == [True]
+
+
+def test_first_run_survives_a_failing_backfill(tmp_path, monkeypatch):
+    """A raising backfill must not break gateway startup.
+
+    Continuation is asserted through the stale-MCP purge, a LATER step, rather
+    than through the `~/.local/bin` shim: that shim is POSIX-only (Windows uses
+    pip's `Scripts\\kirocrew.exe`), and skipping the whole case on Windows would
+    drop coverage of the one property here that is not platform-specific.
+    """
+    exe = _fake_bundle_launcher(tmp_path)
+    _, mcp = _sandbox_first_run(tmp_path, monkeypatch, exe)
+    _seed_global_mcp(mcp)
+    _install_superseded(
+        managed_mcp_names=("predecessor-core", "predecessor-cron"),
+        stale_mcp_binaries=("predecessor",),
+    )
+    calls: list[bool] = []
+    _spy_backfill(monkeypatch, calls, raises=RuntimeError("backfill boom"))
+
+    agent.run_first_run_setup()
+
+    assert calls == [True]
+    # A step AFTER the failing one still ran, so the failure did not abort setup.
+    remaining = set(json.loads(mcp.read_text(encoding="utf-8"))["mcpServers"])
+    assert "predecessor-core" not in remaining
+
+
+# --------------------------------------------------------------------------
 # Resolver: the running interpreter is never the answer
 # --------------------------------------------------------------------------
 def test_resolver_never_returns_the_interpreter(tmp_path, monkeypatch):


### PR DESCRIPTION
## 1. What is the problem?

`defaultEnabled` is read on an app's **first** registration only. `register_builtin_apps()` states the contract explicitly:

> The `defaultEnabled` field controls the initial enabled state for **newly registered** apps. Existing apps preserve their user-set enabled state regardless of the definition's `defaultEnabled` value.

So adding a name to `manager._DEFAULT_ON_BUILTINS` reaches **new installs only**. An install that registered the app while it was still default-off keeps `enabled: false` forever: the record lives in the user's data home, a code update does not touch it, and every restart re-runs a registration path that deliberately refreshes version/displayName/origin and never writes `enabled`.

`command-bar` was promoted to default-on in #4890, dated after installs that already carried it. Those installs are the majority, and for this app the stuck flag is terminal rather than inconvenient:

- **Not in the launcher.** `appNavTarget()` returns `null` for an app with no `ui.pages`, and the palette's apps provider is built from `appNavTargets` ("an app is a pure navigation target"). Command Bar declares only `ui.overlays`, so it can never be a row -- it cannot surface its own switch.
- **Not in Discover.** `browseApps` is built from the published catalog and is "deliberately NOT topped up from local manifests". The catalog carries no `command-bar` row, so the App Store search box cannot match it. The ~20 builtins users *can* find are visible only because the catalog carries theirs.
- **Library only.** `keepInLibrary` (#4890) keeps the disabled row there, which is what makes the app recoverable -- but Library is an inventory of what you already have. Nobody browses it to discover a feature they have never heard of.

The remaining paths are `kirocrew app enable command-bar` and `POST /api/apps/command-bar/enable`.

## 2. Why this issue matters to the user

An existing user cannot enable an app they have no way to learn exists. #4890 decided this launcher should be on by default; that decision currently applies to new installs and silently skips everyone else, with no notification and no discoverable control. The population that never receives the feature grows with every release, because nothing in the update path will ever flip the flag.

## 3. How our fix solves it

Symptom -> root cause -> fix:

- *Symptom*: existing installs never get the launcher, and cannot find the switch.
- *Root cause*: the default-on flip has no backfill; `defaultEnabled` is a first-registration-only input.
- *Fix*: `manager.backfill_default_on_builtins()` enables the apps named in `_DEFAULT_ON_BACKFILL` whose record is still disabled, and returns the names flipped so the caller logs them.

`_DEFAULT_ON_BACKFILL` is a SECOND set, deliberately not `_DEFAULT_ON_BUILTINS`, and the separation is load-bearing rather than bookkeeping. The first answers "what does a fresh install enable"; the second answers "which promotion has not yet reached installs that predate it". Reading the first for the second question reverses deliberate opt-outs: `projects` (Task Runner) has shipped `defaultEnabled: true` since #985 on 2026-08-02, three weeks before the allowlist existed, so it has been enabled and visible in the sidebar on every existing install -- a disabled record for it is a user who FOUND it and turned it off, the exact opposite of the population a backfill serves. A name qualifies only when a fresh install enables it AND existing installs were never in a position to choose, and two ratchet tests pin both halves.

Wiring and the properties that matter:

- Invoked from `agent.run_first_run_setup()`, which already exists for exactly this class of work (the desktop app runs `kirocrew gateway`, never `kirocrew setup`) and already carries the marker-guarded migration pattern under `<data home>/.migrations`.
- **Placed before the stale-MCP early return.** Existing installs are the only ones this step has anything to do, and every one of them already holds that marker -- a backfill placed after the return would run for nobody. This is the failure mode the adjacent admission-policy seed comment already warns about.
- **One-shot, recorded in the SAME atomic write** that flips `enabled`, on the app's own record (`InstalledApp.defaultOnBackfilled`). Disabling the app is the only way to get the replaced host surface back, so a backfill that re-ran each start would make the promotion impossible to opt out of.

  One document rather than a marker file, because a separate marker has no correct ordering -- whichever write goes first leaves a window the other one owns. Marker-last loses the record of an enable that happened, so every later start re-applies the promotion and reverses the user's own disable forever. Marker-first can outlive a flip that failed, so the app is skipped forever and the promotion is never delivered. Both are real (review rounds 2 and 3 raised them in that order); one document makes both unreachable, since the flag and the state it guards land or fail together.

- **A record created under the promoted default is born flagged**, because a first registration with `defaultEnabled` IS the promotion being received. Without it, "install, disable the app in the same session, restart" re-enables the app, and no write ordering fixes that: on a fresh install the record may not exist yet when first-run setup runs.

- **A governance-denied app is left unflagged**, so the promotion is still delivered if policy later permits.
- **Boundaries re-applied, not assumed.** A user's own install under the same name is skipped via `_builtin_owns_install`, and `_app_activation_denied` is re-checked so a deny-by-default host policy is not bypassed by arriving through the backfill instead of through first registration. The activation itself is recorded in the SEL, because it moves an app from inactive to active with no user request behind it -- the same reasoning the trust-grant withdrawal path in this file already states.
- **Best-effort.** A raising backfill is logged and startup continues; the marker is not written, so the next start retries.

Known cost, disclosed rather than papered over: the record holds one bool and no toggle history, so within the set's own scope "never saw it" stays indistinguishable from "saw it and turned it off". A user who installed *after* #4890 and then disabled Command Bar is re-enabled once. That is a single occurrence, reversible from Library in one click, and it is the price of reaching the much larger population that never had the choice. Scoping the set to genuine promotions is what keeps that population small; sweeping in an app that was always default-on would make it the majority.

Not in scope, deliberately: the missing catalog row (a PR on the catalog repo, not this one), the launcher's inability to surface an app that has no page, and the absence of any enable/disable *command*. Those are real and separate.

## 4. What tests we did

15 new tests, every guard mutation-verified -- each guard was removed in turn and the named test confirmed to go red:

`test/test_builtin_app_optional_enable.py` (`TestDefaultOnBackfill`), records written through the real registration path so provenance is genuine:

| test | mutation that kills it |
|---|---|
| flips a disabled promoted builtin | -- (the positive case) |
| does not read the fresh-install allowlist | read `_DEFAULT_ON_BUILTINS` in the loop |
| `projects` is not backfilled | -- (ratchet on the real sets) |
| backfill targets are all default-on | -- (ratchet on the real sets) |
| does not touch a user-owned entry | drop the `_builtin_owns_install` check |
| reports nothing when already enabled | drop the `existing.enabled` guard |
| honors governance deny | `if denied:` -> `if False:` |
| ignores an app this install never registered | -- (no record must not become one) |
| runs once, then respects a disable | stop consulting `defaultOnBackfilled` |
| records the promotion when it flips nothing | stop setting the flag |
| a fresh registration is born flagged | drop the born-flagged initialiser |
| a later promotion is not swallowed by an earlier one | -- (any once-per-install record fails it) |
| audits the activation | delete the SEL emission |
| a failing audit sink does not lose the promotion | -- (pins the non-fatal half) |
| a failed write delivers nothing and is retried | -- (pins the persisted outcome) |

`test/test_installer_shim_and_cleanup.py`:

| test | mutation that kills it |
|---|---|
| runs the backfill, handing it the migrations dir | -- (asserts the marker home it is given) |
| backfills on an install that already purged MCP | move the step after the stale-MCP early return |
| survives a failing backfill | -- (asserts the rest of setup still ran) |

Gates: `529 passed` across `test_builtin_app_optional_enable.py`, `test_installer_shim_and_cleanup.py`, `test_app_manager.py`, `test_cpp_wiring_standalone.py`, `test_app_manifest.py`, `test_builtin_projects_manifest.py`, `test_app_dev_mode.py`, `test_gateway_appkit_endpoints.py`. isort, flake8 and mypy clean on the changed files; the baselined black gate passes over the changed files.

Specs updated where the policy is documented: app-kit-platform section 12 (the exemption's single source of truth) and the Command Bar module spec.

## 5. Any other suggestions on the work

- The per-record bool this ships was my SECOND choice and I was wrong to rank it second. It was initially rejected on tidiness -- it writes an inert `false` into every app's `installed.json` for a one-time event -- in favour of a `.migrations` marker file, which "already models this installation has run X". Two review rounds then demonstrated that the tidy option has no correct write ordering, and the untidy one is correct by construction because it is a single atomic write. A `schemaVersion` bump was also considered and remains rejected: the record's *shape* does not change, and renumbering a shared schema for one app-specific concern would break five unrelated assertions that pin `schemaVersion == 2`.
- The discoverability holes this exposes are worth their own issues: an overlay-only app is invisible to the launcher it *is*, there is no command kind for enabling or disabling an app, and a query matching nothing returns three unrelated SETTINGS rows rather than an empty state -- which reads as "the feature does not exist" instead of "no match".
- Publishing a `command-bar` row on the catalog repo remains worth doing on its own merits (browsing, and re-enabling after a deliberate disable). It is not a substitute for this change: a catalog row makes the app *findable*, while this makes it *arrive*.

- Three verification notes, since they say more about the change than a clean claim would. One probe in the first round was itself wrong: `^        if denied:` matches two sites in `manager.py`, and a non-global `s///` mutated the unrelated one, so the governance guard reported as surviving when the test was fine. Re-probed by line number, it dies. The same trap caught the per-app-marker test in round two -- there the test really was weak (it hand-placed a marker, which a whole-set design also satisfies), so it was rewritten to simulate two releases: deliver one promotion, then add a second name and assert it still arrives.
- A probe in the third round SURVIVED, and the response was to demote the claim rather than to add an assertion around it: a comment had said `flipped` is appended after the write "so a failed write is never reported as delivered", but a failing write propagates out of the whole call, so no caller ever sees the return value and the ordering protects nothing observable. The comment now states what is true. An untested claim in a comment is worse than no claim.
