### PR TITLE
fix: remove stale router vulnerability exceptions

### DIFF
--- a/.vulnerability-exceptions.json
+++ b/.vulnerability-exceptions.json
@@ -1,21 +1,4 @@
 {
   "version": 1,
-  "exceptions": [
-    {
-      "package": "react-router",
-      "advisory": "GHSA-qwww-vcr4-c8h2",
-      "paths": ["website/package-lock.json"],
-      "reason": "The advisory requires unstable React Server Components APIs; this application uses declarative BrowserRouter APIs only. Version 7.18.2 fixes every compatible-line advisory, while the 8.3.0 fix requires Node 22 and React 19. Remove this exception during that migration.",
-      "owner": "@pepmach",
-      "expires": "2026-08-31"
-    },
-    {
-      "package": "react-router-dom",
-      "advisory": "GHSA-qwww-vcr4-c8h2",
-      "paths": ["website/package-lock.json"],
-      "reason": "Transitive mirror of the exact react-router finding above. The application does not use unstable React Server Components APIs; remove this exception with the Node 22, React 19, and React Router 8 migration.",
-      "owner": "@pepmach",
-      "expires": "2026-08-31"
-    }
-  ]
+  "exceptions": []
 }

--- a/test/test_dependency_vulnerability_gate.py
+++ b/test/test_dependency_vulnerability_gate.py
@@ -190,18 +190,7 @@ class TestExceptionContract:
         )
 
         rules = gate.validate_exception_document(registry, today=TODAY)
-        assert {
-            (rule.package, rule.advisory, rule.paths, rule.owner, rule.expires) for rule in rules
-        } == {
-            (
-                package,
-                "GHSA-qwww-vcr4-c8h2",
-                (LOCKFILE,),
-                "@pepmach",
-                TODAY + timedelta(days=30),
-            )
-            for package in ("react-router", "react-router-dom")
-        }
+        assert rules == []
 
     @pytest.mark.parametrize(
         ("entry", "message"),


### PR DESCRIPTION
## Problem / Motivation

The nightly Production Dependency Vulnerability Gate passes, but it emits expiry warnings for `react-router` and `react-router-dom` exceptions for GHSA-qwww-vcr4-c8h2. The repository already uses patched React Router 7.18.2, and the production audit reports no governed finding for either package.

## Why it matters

The exceptions expire on 2026-08-31. Leaving stale entries in the registry would make the audit fail closed from 2026-09-01 even though there is no matching production vulnerability to waive.

## What changed (motivation → approach → change)

Because the installed React Router version is patched and the audit has zero matching findings, remove the two unused exceptions instead of extending them. Update the committed registry contract test to require an empty exception list, so stale waivers cannot be reintroduced unnoticed.

## Tests

- `py -3.12 -m pytest test/test_dependency_vulnerability_gate.py -q` — 42 passed.
- `py -3.12 scripts/check_npm_audit.py` — 3 production lockfiles passed with 0 governed exceptions.
- Canonical backend selector — 62,643 passed, 2,592 skipped, 6 expected failures.
- Canonical frontend selector — 151 files and 4,136 tests passed.
- Full local formatting, lint, type, build, i18n, Electron, bundle-budget, and repository policy gates passed.
- Tests covering subsequently landed `main` changes passed after each freshness rebase (37 context-block tests; 236 app/messaging tests with 3 skipped).

## Manual verification

Confirmed the linked nightly run passed the production audit with zero governed findings and emitted only the two stale exception-expiry warnings addressed here.

## Related Issues

no linked issue: this fixes the expiring CI warnings in nightly run https://github.com/kirodotdev/KiroCrew/actions/runs/32791639414.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
