### PR TITLE
fix: close the two context blocks whose closers the table missed

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -200,7 +200,6 @@ src/kiro_crew/connections/l0_probe.py
 src/kiro_crew/connections/l0_record.py
 src/kiro_crew/connections/registry.py
 src/kiro_crew/connections/tool_aliases.py
-src/kiro_crew/context_blocks.py
 src/kiro_crew/context_management.py
 src/kiro_crew/crew_chat.py
 src/kiro_crew/cron.py
@@ -428,7 +427,6 @@ src/kiro_crew/workflows/runner.py
 src/kiro_crew/workflows/service.py
 test/conftest.py
 test/fake_mcp_app_server.py
-test/metrics/test_context_blocks.py
 test/metrics/test_context_occupancy.py
 test/metrics/test_cost_breakdown.py
 test/metrics/test_gateway_http_metrics.py

--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -596,7 +596,14 @@ must stay complete.
 A block owns the span from its opener up to **the earlier of** the next opener and
 its OWN closer (`_CLOSERS`, keyed by the same labels — only the closers the
 assembly actually emits are listed, so extending it is a data change rather than a
-scanner edit). The closer taken is the LAST match before the next opener, not the
+scanner edit). **A label with an opener in `_MARKERS` but no `_CLOSERS` entry keeps
+the absorbing behaviour this table exists to remove**, so the two are kept in step
+by grepping the assembly for `[End ` / `[END ` rather than by adding a closer only
+when one is noticed. One opener can have MORE than one closer spelling — a hook
+context is closed `[End of hook context]` by `context.py` and `[End hook context]`
+by `chat_runner.py` — and an entry covering one spelling silently leaves the other
+block absorbing what follows it, so such a label carries an alternation rather than
+whichever spelling was found first. The closer taken is the LAST match before the next opener, not the
 first: a block's content can quote its own closer — a custom agent prompt that
 documents the envelope it is injected into embeds `[END AGENT SYSTEM PROMPT]`
 verbatim — and first-match would end the block at that quotation and book the rest

--- a/src/kiro_crew/context_blocks.py
+++ b/src/kiro_crew/context_blocks.py
@@ -109,7 +109,12 @@ _CLOSERS: Final[dict[str, re.Pattern[str]]] = {
         ("skill_hint", r"\[End of relevant skills\]"),
         ("channel_context", r"\[END SLACK THREAD CONTEXT\]"),
         ("conversation_replay", r"\[END CONVERSATION HISTORY\]"),
-        ("hook_context", r"\[End of hook context\]"),
+        # Two spellings reach this opener: `context.py` emits
+        # `[End of hook context]` and `chat_runner.py` emits `[End hook
+        # context]`. Both are real emit sites, so one alternation covers them
+        # rather than picking whichever the assembly happened to use last.
+        ("hook_context", r"\[End (?:of )?hook context\]"),
+        ("history_prefix", r"\[End of history\]"),
         ("theme_persona", r"\[END THEME PERSONA\]"),
         ("user_profile", r"\[End of user profile\]"),
         ("ui_language", r"\[End of UI language\]"),
@@ -209,7 +214,13 @@ def split_blocks(
     # book its bytes as memory while the header's bytes were credited to the
     # message.
     header_at = next(
-        (m.start() for label, pat in _COMPILED if label == "request_header" for m in [pat.search(prompt)] if m),
+        (
+            m.start()
+            for label, pat in _COMPILED
+            if label == "request_header"
+            for m in [pat.search(prompt)]
+            if m
+        ),
         None,
     )
     user_start = user_end = -1

--- a/test/metrics/test_context_blocks.py
+++ b/test/metrics/test_context_blocks.py
@@ -7,6 +7,7 @@ closure: every character is attributed exactly once, which is what lets a reader
 trust the per-block sizes. These drive the real function over realistic prompt
 shapes rather than restating its arithmetic.
 """
+
 from kiro_crew.context_blocks import (
     REPLY_FORMAT_LABEL,
     UNCLASSIFIED_LABEL,
@@ -237,7 +238,9 @@ class TestExpandedInputAttribution:
         prompt = self._prompt(message)
         # Caller passes the ORIGINAL typed length (attributable_user_chars with
         # prompt_expanded=False and original_len=len(typed)).
-        blocks = split_blocks(prompt, user_chars=attributable_user_chars(len(typed), prompt_expanded=False))
+        blocks = split_blocks(
+            prompt, user_chars=attributable_user_chars(len(typed), prompt_expanded=False)
+        )
         # The user gets exactly their typed text — not the skill body.
         assert blocks[USER_LABEL] == len(typed)
         # The appended skill classifies by its own marker.
@@ -249,7 +252,9 @@ class TestExpandedInputAttribution:
         # After @prompt expansion the whole message is injected SOP content.
         sop = "Execute the following instructions:\n\n" + ("do the thing. " * 40)
         prompt = self._prompt(sop)
-        blocks = split_blocks(prompt, user_chars=attributable_user_chars(len(sop), prompt_expanded=True))
+        blocks = split_blocks(
+            prompt, user_chars=attributable_user_chars(len(sop), prompt_expanded=True)
+        )
         # None of the SOP body is attributed to the user.
         assert blocks.get(USER_LABEL, 0) == 0
         assert sum(blocks.values()) == len(prompt)
@@ -423,7 +428,9 @@ class TestAppendedSuffixDoesNotShiftUserOffset:
         # body opens with a [Skill: ...] marker), then an APPENDED persona with
         # no marker of its own — it folds into the loaded_skill block.
         trailer = "[Skill: demo]\nskill body line one\nskill body line two\n"
-        persona = "\n[THEME PERSONA]\n" + ("persona voice line. " * 12) + "\n[END THEME PERSONA]\n\n"
+        persona = (
+            "\n[THEME PERSONA]\n" + ("persona voice line. " * 12) + "\n[END THEME PERSONA]\n\n"
+        )
         prompt = f"{header}{typed}{trailer}{persona}"
 
         # Correct offset excludes the appended suffix: no prepend here, so 0.
@@ -594,9 +601,9 @@ class TestABlockEndsAtItsOwnCloser:
         orphan = "assembly text with no marker\n\n"
         prompt = body + orphan + "[CURRENT DATE] today\n"
         out = split_blocks(prompt)
-        assert out["agent_instructions"] == len(body), (
-            "the block must run to its REAL closer, not to the one it quotes"
-        )
+        assert out["agent_instructions"] == len(
+            body
+        ), "the block must run to its REAL closer, not to the one it quotes"
         assert out[UNCLASSIFIED_LABEL] == len(orphan)
         assert sum(out.values()) == len(prompt)
 
@@ -610,3 +617,32 @@ class TestABlockEndsAtItsOwnCloser:
         assert out["date"] == len(date)
         assert out["surface"] == len(runtime)
         assert UNCLASSIFIED_LABEL not in out
+
+    def test_the_history_prefix_block_stops_at_its_own_closer(self):
+        """``chat_persistence`` emits this block with a closer, so it must have a
+        ``_CLOSERS`` entry — an opener in ``_MARKERS`` whose real closer is not
+        listed keeps exactly the absorbing behaviour this table removes."""
+        block = (
+            "[Previous chat history for this tab — session was reset after stop]\n"
+            "user: hello\n"
+            "[End of history]\n\n"
+        )
+        orphan = "assembly text with no marker\n\n"
+        prompt = block + orphan + "[CURRENT DATE] today\n"
+        out = split_blocks(prompt)
+        assert out["history_prefix"] == len(block)
+        assert out[UNCLASSIFIED_LABEL] == len(orphan)
+        assert sum(out.values()) == len(prompt)
+
+    def test_both_hook_context_closer_spellings_are_recognised(self):
+        """Two emit sites, two spellings: ``context.py`` writes ``[End of hook
+        context]`` and ``chat_runner.py`` writes ``[End hook context]``. A table
+        covering only one leaves the other block absorbing what follows it."""
+        for closer in ("[End of hook context]", "[End hook context]"):
+            block = f"[Hook context]\nsomething a hook added\n{closer}\n\n"
+            orphan = "assembly text with no marker\n\n"
+            prompt = block + orphan + "[CURRENT DATE] today\n"
+            out = split_blocks(prompt)
+            assert out["hook_context"] == len(block), f"{closer} was not treated as a closer"
+            assert out[UNCLASSIFIED_LABEL] == len(orphan)
+            assert sum(out.values()) == len(prompt)


### PR DESCRIPTION
## Problem

`_CLOSERS` (merged in #5696) landed with the claim that it lists every closer the assembly emits. Grepping `[End ` / `[END ` across `src/kiro_crew` finds **two it does not**, and both openers are already in `_MARKERS` — so both blocks keep exactly the absorbing behaviour that table was added to remove.

| Block | Emitted closer | In `_CLOSERS`? |
|---|---|---|
| `history_prefix` | `[End of history]` — `chat_persistence.py:2355` | **no entry at all** |
| `hook_context` | `[End of hook context]` — `context.py:2950` | yes |
| `hook_context` | `[End hook context]` — `chat_runner.py:5868` | **missing spelling** |

The `history_prefix` pairing is unambiguous — one expression emits both ends:

```python
"[Previous chat history for this tab — session was reset after stop]\n"
+ "\n".join(lines)
+ "\n[End of history]\n\n"
```

Until this lands, each of those blocks is billed for every byte between its own closer and the next opener. That is the mis-attribution #5696 exists to end; it just did not reach these two.

## Fix

Two data entries, which is what #5696 says extending the table should be:

```python
("hook_context", r"\[End (?:of )?hook context\]"),
("history_prefix", r"\[End of history\]"),
```

One opener with two closer spellings gets an **alternation**, not whichever spelling was found first. Picking one leaves the other block silently absorbing what follows it — the same failure in a new place.

**The completeness rule is now in the spec, because the failure is silent.** An opener in `_MARKERS` with no `_CLOSERS` entry reads as a correctly-measured block and nothing goes red. Keeping the two tables in step means grepping the assembly, not adding a closer when someone happens to notice one. That is the part worth writing down; the two entries themselves are trivial.

## Tests

Both mutation-verified — each mutation reddens exactly its own test and nothing else:

| Guard | Falsified by |
|---|---|
| `test_the_history_prefix_block_stops_at_its_own_closer` | deleting the `history_prefix` entry |
| `test_both_hook_context_closer_spellings_are_recognised` | narrowing the alternation back to `[End of hook context]` |

The hook test loops over both spellings, so covering only one is not enough to pass it.

`test/metrics/`: **39 passed** in the context-blocks module, 459 across the directory. black gate (including a 2-entry baseline prune, since both touched files graduated to clean), flake8, mypy `--platform linux`, docs-lint clean.

## Provenance

Found by the First Principles reviewer on #5696, which called the table "already incomplete against the assembly it claims to mirror". I verified both claims against source before acting: `[End of history]` and the second hook spelling are real emit sites, and both openers are in `_MARKERS`. The finding arrived after #5696 merged, so this is its own PR rather than another push onto that branch.

**Why no screenshot:** no frontend file is touched. The visible effect is two rows in the Context Breakdown panel reporting their true size instead of an inflated one.
