### PR TITLE
feat(updates): marker-driven managed auto-update for externally-managed installs

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -96,6 +96,7 @@ const EXTERNALLY_MANAGED_MARKER = "EXTERNALLY-MANAGED";
 const EXTERNALLY_MANAGED_MAX_BYTES = 8192;
 const MANAGED_BY_MAX_CHARS = 128;
 const UPDATE_COMMAND_MAX_CHARS = 512;
+const CHECK_COMMAND_MAX_CHARS = 512;
 
 /**
  * Is this install's update lifecycle owned by an external package manager?
@@ -106,9 +107,12 @@ const UPDATE_COMMAND_MAX_CHARS = 512;
  * `<resourcesPath>/EXTERNALLY-MANAGED`. I/O-bearing and fully injectable, like
  * resolveLinuxInstall above.
  *
- * The marker body is optional JSON `{managedBy, updateCommand}`: `managedBy`
- * names the owning system for the About panel, `updateCommand` is the command
- * the panel offers to copy. Every degenerate marker — empty, unparsable,
+ * The marker body is optional JSON `{managedBy, updateCommand, checkCommand}`:
+ * `managedBy` names the owning system for the About panel, `updateCommand` is
+ * the command the panel offers to copy AND (when the managed auto-update path
+ * is active) the command run to apply an update, and `checkCommand` is the
+ * optional command run to discover whether an update is available. Every
+ * degenerate marker — empty, unparsable,
  * over-cap, a directory, a symlink, a dangling symlink — still means MANAGED:
  * an operator who dropped SOMETHING at that name gets the safe behavior
  * (updater off) even when the metadata is wrong, never a silent fallback to
@@ -118,7 +122,7 @@ const UPDATE_COMMAND_MAX_CHARS = 512;
  * @param {object} [o]
  * @param {object} [o.env=process.env]
  * @param {string} [o.resourcesPath=process.resourcesPath]
- * @returns {{managedBy:string, updateCommand:string}|null} null when not managed
+ * @returns {{managedBy:string, updateCommand:string, checkCommand:string}|null} null when not managed
  */
 function readExternallyManaged({ env = process.env, resourcesPath = process.resourcesPath } = {}) {
   let raw = null;
@@ -157,6 +161,7 @@ function readExternallyManaged({ env = process.env, resourcesPath = process.reso
   }
   let managedBy = "";
   let updateCommand = "";
+  let checkCommand = "";
   try {
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object") {
@@ -166,11 +171,14 @@ function readExternallyManaged({ env = process.env, resourcesPath = process.reso
       if (typeof parsed.updateCommand === "string") {
         updateCommand = parsed.updateCommand.trim().slice(0, UPDATE_COMMAND_MAX_CHARS);
       }
+      if (typeof parsed.checkCommand === "string") {
+        checkCommand = parsed.checkCommand.trim().slice(0, CHECK_COMMAND_MAX_CHARS);
+      }
     }
   } catch {
     // Presence alone is the signal; a bare marker means managed, no metadata.
   }
-  return { managedBy, updateCommand };
+  return { managedBy, updateCommand, checkCommand };
 }
 
 // Can the AppImage replace itself, i.e. is the directory HOLDING the image
@@ -740,8 +748,277 @@ function initAutoUpdate(deps) {
   // override, so it wins over every runtime detection below — the updater is
   // never armed and the feed is never contacted.
   if (managed) {
-    log.info(`[update] externally managed${managed.managedBy ? ` by ${managed.managedBy}` : ""} — auto-update disabled`);
-    return { check: () => {}, download: async () => {}, install: async () => {}, getInfo, disabled: "externally-managed" };
+    // A BARE marker (present, but no updateCommand) means "someone else owns
+    // updates and gave us nothing to run": keep the historical no-op behavior.
+    if (!managed.updateCommand) {
+      log.info(`[update] externally managed${managed.managedBy ? ` by ${managed.managedBy}` : ""} — auto-update disabled`);
+      return { check: () => {}, download: async () => {}, install: async () => {}, getInfo, disabled: "externally-managed" };
+    }
+
+    // MANAGED AUTO-UPDATE (marker-driven): the marker carries the very
+    // commands that own this install's lifecycle, so instead of arming
+    // electron-updater or contacting the feed (which would fight the external
+    // manager), we discover and apply updates by SHELLING the marker's own
+    // commands.
+    //
+    // TRUST / HARDENING: the EXTERNALLY-MANAGED marker is an operator/packager
+    // file under <resourcesPath>, and — unlike the Python security_policy pins,
+    // which live in a home dir a prompt-injected agent shell cannot write — it
+    // is NOT a protected trust root; on a user-writable install its directory
+    // may be writable. So we do not lean on the marker's integrity: we HARDEN
+    // EXECUTION instead (see runManagedCommand) — a narrowed system-only PATH so
+    // a planted shim on the user's PATH cannot shadow a command, cwd="/" (never
+    // the app or an inherited dir), a timeout, and bounded retained output. The
+    // command still runs through a shell, so the writer MUST name absolute
+    // binaries (a bare name will not resolve under the narrowed PATH); we NEVER
+    // interpolate untrusted input. Platform-agnostic: the same path serves
+    // macOS/Windows/Linux.
+    log.info(`[update] externally managed${managed.managedBy ? ` by ${managed.managedBy}` : ""} — managed auto-update (self-contained commands)`);
+
+    let foundVersion = null; // last version discovered by the checkCommand, awaiting apply
+    let managedQuitArmed = false; // is a before-quit auto-apply handler installed?
+
+    // Mirror emitError's renderer contract (emitError itself is defined further
+    // down, after this early return, so it is out of scope here): a failure
+    // WITH ITS PHASE so the card can distinguish check from install failures.
+    const emitManagedError = (phase, err) => {
+      const { code, detail, httpStatus } = classifyError(err);
+      log.error(`[update] managed ${phase} failed (${code})`, err);
+      emit("error", {
+        phase,
+        code,
+        message: detail,
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+      });
+    };
+
+    // Bound retained output so a chatty command cannot exhaust memory (we keep
+    // DRAINING both streams either way), and cap how long an apply / check runs.
+    const MANAGED_OUTPUT_CAP = 64 * 1024;
+    const MANAGED_APPLY_TIMEOUT_MS = 30 * 60 * 1000; // 30 min ceiling for an apply
+    const MANAGED_CHECK_TIMEOUT_MS = 45 * 1000; // a check must not hang the UI
+    const MANAGED_VERSION_CAP = 128; // a version string is short; cap like the sibling
+    // A narrowed, non-user-writable PATH: an agent-writable entry on the user's
+    // own PATH cannot shadow a command. The marker's commands must name ABSOLUTE
+    // binaries (a bare name will not resolve here) — mirrors CommandProvider.
+    const managedPath = () =>
+      process.platform === "win32"
+        ? [
+            `${process.env.SystemRoot || "C:\\Windows"}\\System32`,
+            process.env.SystemRoot || "C:\\Windows",
+          ].join(";")
+        : "/usr/bin:/bin:/usr/sbin:/sbin";
+
+    // Run a marker command through the platform shell, resolving to
+    // {code, out} (combined stdout+stderr, capped). Never rejects: spawn errors
+    // and timeouts resolve with a non-zero code so callers treat them uniformly.
+    // Hardened like the Python CommandProvider: narrowed PATH, cwd="/", a
+    // timeout, and bounded retained output.
+    const runManagedCommand = (command, { timeout } = {}) => new Promise((resolve) => {
+      const cp = require("child_process");
+      let out = "";        // combined stdout+stderr, for logging an apply
+      let outStdout = "";  // stdout ONLY, for deriving the check's version
+      let settled = false;
+      // `failed` marks that the command could not be RUN to completion (spawn
+      // error or timeout kill), as distinct from running and exiting non-zero.
+      // The check path treats these differently: a run that exits non-zero is
+      // "no update", but a command that could not run at all is an error.
+      const done = (code, failed) => {
+        if (!settled) {
+          settled = true;
+          resolve({ code: typeof code === "number" ? code : 1, out, stdout: outStdout, failed: !!failed });
+        }
+      };
+      // Keep consuming BOTH streams (so the pipe never blocks the child) but
+      // stop RETAINING once capped. stdout is captured separately because the
+      // version is derived from stdout ONLY — a warning printed to stderr must
+      // never be mistaken for the version.
+      const capped = (s) => (s.length > MANAGED_OUTPUT_CAP ? s.slice(0, MANAGED_OUTPUT_CAP) : s);
+      const onStdout = (d) => {
+        const s = d.toString();
+        if (out.length < MANAGED_OUTPUT_CAP) out = capped(out + s);
+        if (outStdout.length < MANAGED_OUTPUT_CAP) outStdout = capped(outStdout + s);
+      };
+      const onStderr = (d) => {
+        if (out.length < MANAGED_OUTPUT_CAP) out = capped(out + d.toString());
+      };
+      let child;
+      try {
+        // `command` is NOT user input: it is operator-controlled text from the
+        // EXTERNALLY-MANAGED marker, and execution is hardened (narrowed system
+        // PATH, cwd="/", bounded output, timeout). See the trust note above.
+        // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+        child = cp.spawn(command, { // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+          shell: true,
+          cwd: "/",
+          env: { ...process.env, PATH: managedPath() },
+          ...(timeout ? { timeout } : {}),
+        });
+      } catch (err) {
+        log.error("[update] managed command spawn threw", err);
+        return done(1, true);
+      }
+      if (child.stdout) child.stdout.on("data", onStdout);
+      if (child.stderr) child.stderr.on("data", onStderr);
+      child.on("error", (err) => { log.error("[update] managed command error", err); done(1, true); });
+      // A timeout kill closes with a null exit code and a signal; treat that as
+      // "could not run", not as a non-zero exit.
+      child.on("close", (code, signal) => done(code, code === null && signal != null));
+    });
+
+    // The command run to APPLY an update, on quit and on explicit install.
+    // Bounded by a ceiling timeout so a wedged package manager cannot hang quit.
+    const runUpdateCommand = () => runManagedCommand(managed.updateCommand, { timeout: MANAGED_APPLY_TIMEOUT_MS });
+
+    // Fresh-read the auto-download preference; a throwing reader fails toward
+    // NOT auto-installing (same direction as the feed path's deferred handler).
+    const autoDownloadOn = () => {
+      try { return !!getAutoDownloadPreference(); } catch (err) {
+        log.error("[update] getAutoDownloadPreference threw — treating as off", err);
+        return false;
+      }
+    };
+
+    // Auto-on-restart: apply the discovered update on the next natural quit.
+    // Mirrors deferredInstallOnQuit — pref is re-read FRESH at quit time so a
+    // toggle-off between discovery and quit is honored.
+    const managedInstallOnQuit = (event) => {
+      // Nothing pending (a later check cleared it, or it was already applied):
+      // let the quit proceed normally — never relaunch into a withdrawn update.
+      if (!foundVersion) {
+        log.info("[update] managed quit handler fired with no pending update — not applying");
+        return;
+      }
+      let stillOn = false;
+      try { stillOn = !!getAutoDownloadPreference(); } catch (err) {
+        log.error("[update] getAutoDownloadPreference threw on quit — not installing", err);
+      }
+      if (!stillOn) {
+        log.info("[update] managed auto-download off at quit — not applying on quit");
+        return;
+      }
+      event.preventDefault();
+      (async () => {
+        emit("installing", { version: foundVersion });
+        try { if (onInstallDispatched) onInstallDispatched(); } catch { /* advisory */ }
+        try { if (stopGateway) await stopGateway(); } catch (err) {
+          log.error("[update] managed stop on quit errored", err);
+        }
+        log.info("[update] managed deferred install on quit — running update command");
+        const { code } = await runUpdateCommand();
+        if (code === 0) {
+          app.relaunch();
+        } else {
+          // The apply failed; the user asked to quit, so honor that and exit
+          // WITHOUT relaunching into a version that did not install.
+          log.error(`[update] managed deferred install failed (exit ${code}) — quitting without relaunch`);
+          try { if (onInstallFailed) onInstallFailed(); } catch { /* advisory */ }
+        }
+        app.exit(0);
+      })();
+    };
+
+    // Undo a quit-time auto-apply armed by an earlier check and forget the
+    // discovered version. Called when a later check finds nothing pending, so a
+    // normal quit does not relaunch into an update the external manager already
+    // applied or withdrew — the feed path clears its deferred state for the
+    // same reason.
+    const disarmManagedQuit = () => {
+      foundVersion = null;
+      if (managedQuitArmed) {
+        app.removeListener("before-quit", managedInstallOnQuit);
+        managedQuitArmed = false;
+      }
+    };
+
+    async function managedCheck() {
+      emit("checking");
+      if (!managed.checkCommand) {
+        // The marker says how to APPLY an update but gives no way to DISCOVER
+        // one. This is a check error, NOT a green "up to date": a silent
+        // "latest" would hide every future update for this install forever.
+        log.info("[update] managed: no checkCommand — cannot check for updates");
+        emitManagedError("check", new Error("this managed install has no checkCommand"));
+        return;
+      }
+      const { code, stdout, failed } = await runManagedCommand(managed.checkCommand, {
+        timeout: MANAGED_CHECK_TIMEOUT_MS,
+      });
+      if (failed) {
+        // Could not RUN the command (spawn error or timeout) — an error, not
+        // "up to date". Mirrors the sibling CommandProvider, which returns an
+        // error verdict for a check it could not execute.
+        log.error("[update] managed check could not run");
+        emitManagedError("check", new Error("managed check command failed to run"));
+        return;
+      }
+      if (code !== 0) {
+        // Ran and exited non-zero: no update available (sibling contract). Undo
+        // any quit-time auto-apply armed by an earlier check that DID find one,
+        // so a normal quit does not relaunch into a withdrawn/applied update.
+        log.info(`[update] managed check: up to date (code=${code})`);
+        disarmManagedQuit();
+        emit("not-available");
+        return;
+      }
+      // Sibling contract: exit 0 and stdout IS the version (trimmed, capped).
+      // Derived from stdout ONLY so a stderr warning is never read as a version.
+      const version = stdout.trim().slice(0, MANAGED_VERSION_CAP);
+      if (!version) {
+        // Exit 0 that prints NO version is a broken command, not an available
+        // update: treating it as available would relaunch to the SAME version
+        // forever. Fail the check rather than report "latest".
+        log.error("[update] managed check: exit 0 but printed no version");
+        emitManagedError("check", new Error("managed check command produced no version"));
+        return;
+      }
+      foundVersion = version;
+      log.info(`[update] managed check: update available -> ${version}`);
+      emit("found", { version });
+      // Auto-on-restart: if the user allows auto-download, arm a one-shot
+      // before-quit handler that applies on the natural quit.
+      if (autoDownloadOn() && !managedQuitArmed) {
+        managedQuitArmed = true;
+        app.once("before-quit", managedInstallOnQuit);
+      }
+    }
+
+    async function managedDownload() {
+      // Managed download+apply is ONE step (the updateCommand). "download" just
+      // lights the UI Install action; it never applies. Discover first if the
+      // UI raced the check.
+      if (!foundVersion) {
+        await managedCheck();
+      }
+      if (foundVersion) {
+        emit("downloaded", { version: foundVersion });
+      }
+    }
+
+    async function managedInstall() {
+      emit("installing", { version: foundVersion });
+      try { if (onInstallDispatched) onInstallDispatched(); } catch { /* advisory */ }
+      try { if (stopGateway) await stopGateway(); } catch (err) {
+        log.error("[update] managed stop before install errored", err);
+      }
+      const { code } = await runUpdateCommand();
+      if (code === 0) {
+        log.info("[update] managed install succeeded — relaunching");
+        app.relaunch();
+        app.exit(0);
+        return;
+      }
+      log.error(`[update] managed install failed (exit ${code})`);
+      try { if (onInstallFailed) onInstallFailed(); } catch { /* advisory */ }
+      emitManagedError("install", new Error(`managed update command exited ${code}`));
+    }
+
+    return {
+      check: () => managedCheck(),
+      download: () => managedDownload(),
+      install: () => managedInstall(),
+      getInfo,
+    };
   }
   // Updating requires an installed, signed bundle (macOS code signature
   // validation is mandatory for Squirrel.Mac; Linux AppImage needs the

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -510,9 +510,9 @@ test("dev (unpackaged) build returns disabled:'dev'", () => {
 // panel gets the marker's metadata to display instead.
 // ---------------------------------------------------------------------------
 
-test("externally-managed install returns disabled:'externally-managed' and never arms the updater", () => {
+test("externally-managed BARE marker returns disabled:'externally-managed' and never arms the updater", () => {
   const { deps, calls } = makeDeps({
-    externallyManaged: { managedBy: "internal-registry", updateCommand: "pkgtool update kirocrew" },
+    externallyManaged: { managedBy: "internal-registry", updateCommand: "", checkCommand: "" },
   });
   const u = initAutoUpdate(deps);
   assert.strictEqual(u.disabled, "externally-managed");
@@ -554,6 +554,298 @@ test("externally-managed wins over the dev gate (intentional operator override)"
   assert.strictEqual(initAutoUpdate(deps).disabled, "externally-managed");
 });
 
+// ---------------------------------------------------------------------------
+// MANAGED AUTO-UPDATE (marker-driven). A marker that ALSO carries an
+// updateCommand no longer disables the updater: it shells the marker's own
+// commands to check and apply, never arming electron-updater or the feed. The
+// commands come from the keystone-protected marker, so shelling them is trusted
+// (like the Python security_policy update pins).
+//
+// child_process is required inside auto-update.js, so these tests stub
+// child_process.spawn on the real module for the duration of the test.
+// ---------------------------------------------------------------------------
+
+const cpModule = require("node:child_process");
+
+// Install a fake spawn that records the command and drives a scripted
+// {code, out}. Returns a restore fn + the recorded command list.
+function stubSpawn(script) {
+  const commands = [];
+  const orig = cpModule.spawn;
+  const { EventEmitter } = require("node:events");
+  cpModule.spawn = (command, _opts) => {
+    commands.push(command);
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    const spec = (typeof script === "function" ? script(command) : script) || {};
+    const { code = 0, out = "", err = "", error = false, signal = null } = spec;
+    // Emit asynchronously so listeners attached after spawn() still catch it.
+    setImmediate(() => {
+      // `error: true` models a spawn failure (ENOENT / no shell); a `signal`
+      // with a null code models a timeout kill. Both must read as "could not
+      // run", distinct from a normal non-zero exit.
+      if (error) { child.emit("error", new Error("spawn failed")); return; }
+      if (out) child.stdout.emit("data", Buffer.from(out));
+      if (err) child.stderr.emit("data", Buffer.from(err));
+      child.emit("close", error ? null : code, signal);
+    });
+    return child;
+  };
+  return { commands, restore: () => { cpModule.spawn = orig; } };
+}
+
+test("managed check() with updateCommand+checkCommand emits found with the printed version", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: {
+      managedBy: "internal-registry",
+      updateCommand: "pkgtool update kirocrew",
+      checkCommand: "pkgtool check kirocrew",
+    },
+  });
+  // Sibling contract: exit 0 and stdout IS the version (the packager authors
+  // checkCommand to print the target version alone).
+  const { commands, restore } = stubSpawn({ code: 0, out: "0.5.0.5\n" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  assert.strictEqual(u.disabled, undefined, "a marker with an updateCommand is NOT disabled");
+  await u.check();
+  assert.deepStrictEqual(commands, ["pkgtool check kirocrew"], "check must shell the checkCommand");
+  const found = states.find((s) => s.state === "found");
+  assert.ok(found, "an available update must surface a 'found' state");
+  assert.strictEqual(found.version, "0.5.0.5", "trimmed stdout is the version");
+});
+
+test("managed check(): non-zero exit -> not-available (ran, nothing new)", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const { restore } = stubSpawn({ code: 1, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(states.some((s) => s.state === "not-available"), "a non-zero check is up-to-date");
+  assert.ok(!states.some((s) => s.state === "found"));
+});
+
+test("managed check(): exit 0 but no version printed -> check error (not 'latest')", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const { restore } = stubSpawn({ code: 0, out: "   \n" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const err = states.find((s) => s.state === "error");
+  assert.ok(err && err.phase === "check", "an exit-0 empty check is a broken command, not 'latest'");
+  assert.ok(!states.some((s) => s.state === "not-available"));
+  assert.ok(!states.some((s) => s.state === "found"));
+});
+
+test("managed check(): command that cannot run (spawn error) -> check error (not 'latest')", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const { restore } = stubSpawn({ error: true });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const err = states.find((s) => s.state === "error");
+  assert.ok(err && err.phase === "check", "a check that could not run is an error, not 'up to date'");
+  assert.ok(!states.some((s) => s.state === "not-available"));
+});
+
+test("managed check(): a discovered update that later clears disarms the quit-apply", async (t) => {
+  let phase = "found";
+  const relaunches = [];
+  const { deps, appOnce, appRemoved } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  deps.getAutoDownloadPreference = () => true;
+  deps.app.relaunch = () => relaunches.push(true);
+  const { restore } = stubSpawn(() =>
+    phase === "found" ? { code: 0, out: "0.5.0.5" } : { code: 1, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check(); // discovers -> arms before-quit
+  const quit = appOnce.find((r) => r.ev === "before-quit");
+  assert.ok(quit, "first check arms the quit-apply");
+  phase = "clear";
+  await u.check(); // external manager applied/withdrew it -> nothing new
+  assert.ok(appRemoved.some((r) => r.ev === "before-quit"), "the stale quit-apply must be removed");
+  // The captured handler now runs, but disarm cleared foundVersion: a normal
+  // quit must NOT relaunch into an update that is no longer pending.
+  let prevented = false;
+  quit.fn({ preventDefault: () => { prevented = true; } });
+  await new Promise((r) => setImmediate(() => setImmediate(r)));
+  assert.strictEqual(relaunches.length, 0, "a cleared update must not relaunch on quit");
+});
+
+test("managed check(): no checkCommand -> check error (cannot discover, not 'latest')", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "" },
+  });
+  const { commands, restore } = stubSpawn({ code: 0, out: "0.5.0.5" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.deepStrictEqual(commands, [], "no checkCommand -> nothing is shelled");
+  const err = states.find((s) => s.state === "error");
+  assert.ok(err && err.phase === "check", "no way to check must surface an error, not a green 'latest'");
+  assert.ok(!states.some((s) => s.state === "not-available"));
+});
+
+test("managed install() runs updateCommand then relaunch+exit", async (t) => {
+  const relaunches = [];
+  const exits = [];
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "pkgtool update kirocrew", checkCommand: "check" },
+  });
+  deps.app.relaunch = () => relaunches.push(true);
+  deps.app.exit = (c) => exits.push(c);
+  const { commands, restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 0, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  await u.install();
+  assert.ok(commands.includes("pkgtool update kirocrew"), "install must shell the updateCommand");
+  assert.ok(states.some((s) => s.state === "installing"));
+  assert.strictEqual(relaunches.length, 1, "a successful install relaunches");
+  assert.deepStrictEqual(exits, [0], "a successful install exits(0)");
+});
+
+test("managed install() failure emits an install-phase error and calls onInstallFailed", async (t) => {
+  const failed = [];
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  deps.onInstallFailed = () => failed.push(true);
+  deps.app.relaunch = () => { throw new Error("must not relaunch on failure"); };
+  const { restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 7, out: "boom" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  await u.install();
+  assert.strictEqual(failed.length, 1, "onInstallFailed must fire on a non-zero apply");
+  const err = states.find((s) => s.state === "error");
+  assert.ok(err && err.phase === "install", "a failed apply emits an install-phase error");
+});
+
+test("managed auto-on-restart: pref true + found arms before-quit that runs updateCommand", async (t) => {
+  const relaunches = [];
+  const exits = [];
+  const { deps, appOnce } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "pkgtool update kirocrew", checkCommand: "check" },
+  });
+  deps.getAutoDownloadPreference = () => true;
+  deps.app.relaunch = () => relaunches.push(true);
+  deps.app.exit = (c) => exits.push(c);
+  const { commands, restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 0, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const quit = appOnce.find((r) => r.ev === "before-quit");
+  assert.ok(quit, "pref true + found must arm a before-quit handler");
+  const event = { preventDefault: () => {} };
+  quit.fn(event);
+  await new Promise((r) => setImmediate(() => setImmediate(r)));
+  assert.ok(commands.includes("pkgtool update kirocrew"), "before-quit must run the updateCommand");
+  assert.strictEqual(relaunches.length, 1);
+  assert.deepStrictEqual(exits, [0]);
+});
+
+test("managed auto-on-restart: pref false does NOT arm before-quit", async (t) => {
+  const { deps, appOnce } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  deps.getAutoDownloadPreference = () => false;
+  const { restore } = stubSpawn({ code: 0, out: "0.5.0.5" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  assert.ok(!appOnce.some((r) => r.ev === "before-quit"),
+    "pref off -> nothing automatic; manual Install still works");
+});
+
+test("managed auto-on-restart: pref flipped OFF between check and quit is honored at quit", async (t) => {
+  let pref = true;
+  const relaunches = [];
+  const { deps, appOnce } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  deps.getAutoDownloadPreference = () => pref;
+  deps.app.relaunch = () => relaunches.push(true);
+  const { commands, restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 0, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const quit = appOnce.find((r) => r.ev === "before-quit");
+  assert.ok(quit, "armed while pref was true");
+  pref = false; // user toggled off before quitting
+  let prevented = false;
+  quit.fn({ preventDefault: () => { prevented = true; } });
+  await new Promise((r) => setImmediate(() => setImmediate(r)));
+  assert.strictEqual(prevented, false, "pref read fresh at quit -> quit proceeds normally");
+  assert.ok(!commands.includes("apply"), "the updateCommand must NOT run when pref is off at quit");
+  assert.strictEqual(relaunches.length, 0);
+});
+
+test("managed auto-on-restart: a FAILED apply on quit exits without relaunching", async (t) => {
+  const relaunches = [];
+  const exits = [];
+  const failed = [];
+  const { deps, appOnce } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  deps.getAutoDownloadPreference = () => true;
+  deps.onInstallFailed = () => failed.push(true);
+  deps.app.relaunch = () => relaunches.push(true);
+  deps.app.exit = (c) => exits.push(c);
+  const { restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 7, out: "boom" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const quit = appOnce.find((r) => r.ev === "before-quit");
+  assert.ok(quit, "pref true + found arms the quit-apply");
+  quit.fn({ preventDefault: () => {} });
+  await new Promise((r) => setImmediate(() => setImmediate(r)));
+  assert.strictEqual(relaunches.length, 0, "a failed apply must NOT relaunch into an uninstalled version");
+  assert.deepStrictEqual(exits, [0], "the quit is still honored (exit 0)");
+  assert.strictEqual(failed.length, 1, "onInstallFailed fires on a failed quit-apply");
+});
+
+test("managed check(): the version comes from stdout only, ignoring stderr warnings", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const { restore } = stubSpawn({ code: 0, out: "0.5.0.5\n", err: "WARNING: config deprecated\n" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  const found = states.find((s) => s.state === "found");
+  assert.ok(found, "an exit-0 check with a version on stdout is 'found'");
+  assert.strictEqual(found.version, "0.5.0.5", "a stderr warning must not leak into the version");
+});
+
+test("managed download() lights the Install action (downloaded) without applying", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const { commands, restore } = stubSpawn((cmd) =>
+    cmd === "check" ? { code: 0, out: "0.5.0.5" } : { code: 0, out: "" });
+  t.after(restore);
+  const u = initAutoUpdate(deps);
+  await u.download(); // no prior check -> discovers first
+  const dl = states.find((s) => s.state === "downloaded");
+  assert.ok(dl && dl.version === "0.5.0.5", "download surfaces 'downloaded' with the found version");
+  assert.ok(!commands.includes("apply"), "download must NOT run the apply command");
+});
+
 test("readExternallyManaged: absent marker -> null", (t) => {
   const fs = require("node:fs");
   const os = require("node:os");
@@ -576,6 +868,7 @@ test("readExternallyManaged: JSON marker carries metadata", (t) => {
   assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dir }), {
     managedBy: "internal-registry",
     updateCommand: "pkgtool update kirocrew",
+    checkCommand: "",
   });
 });
 
@@ -589,6 +882,7 @@ test("readExternallyManaged: bare/unparsable marker still means managed", (t) =>
   assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dir }), {
     managedBy: "",
     updateCommand: "",
+    checkCommand: "",
   });
 });
 
@@ -603,6 +897,7 @@ test("readExternallyManaged: degenerate markers (oversized, symlink, directory) 
   assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: big }), {
     managedBy: "",
     updateCommand: "",
+    checkCommand: "",
   });
   // Symlink (even dangling): lstat'ed, never followed — a link into a FIFO or
   // device must not be able to stall this startup-path read.
@@ -613,6 +908,7 @@ test("readExternallyManaged: degenerate markers (oversized, symlink, directory) 
     assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: sym }), {
       managedBy: "",
       updateCommand: "",
+      checkCommand: "",
     });
   } catch (err) {
     // Ordinary Windows accounts may lack SeCreateSymbolicLinkPrivilege. Keep
@@ -630,6 +926,7 @@ test("readExternallyManaged: degenerate markers (oversized, symlink, directory) 
   assert.deepStrictEqual(readExternallyManaged({ env: {}, resourcesPath: dirCase }), {
     managedBy: "",
     updateCommand: "",
+    checkCommand: "",
   });
 });
 
@@ -641,11 +938,12 @@ test("readExternallyManaged: metadata fields are length-capped", (t) => {
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   fs.writeFileSync(
     path.join(dir, "EXTERNALLY-MANAGED"),
-    JSON.stringify({ managedBy: "m".repeat(500), updateCommand: "c".repeat(2000) }),
+    JSON.stringify({ managedBy: "m".repeat(500), updateCommand: "c".repeat(2000), checkCommand: "k".repeat(2000) }),
   );
   const got = readExternallyManaged({ env: {}, resourcesPath: dir });
   assert.strictEqual(got.managedBy.length, 128);
   assert.strictEqual(got.updateCommand.length, 512);
+  assert.strictEqual(got.checkCommand.length, 512);
 });
 
 test("readExternallyManaged: env override points at a marker file", (t) => {
@@ -660,7 +958,7 @@ test("readExternallyManaged: env override points at a marker file", (t) => {
     env: { KIROCREW_EXTERNALLY_MANAGED: marker },
     resourcesPath: "/nonexistent",
   });
-  assert.deepStrictEqual(got, { managedBy: "harness", updateCommand: "" });
+  assert.deepStrictEqual(got, { managedBy: "harness", updateCommand: "", checkCommand: "" });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An externally-managed install (the `EXTERNALLY-MANAGED` marker) currently has auto-update **fully disabled** — the About panel shows a static command string and nothing self-updates. This makes such installs actually self-update by driving the marker's own commands, platform-agnostically (macOS / Windows / Linux desktop), without ever arming electron-updater or contacting the built-in feed.

## Changes

**`website/electron/auto-update.js`**
- `readExternallyManaged()` parses an optional `checkCommand` alongside `updateCommand` (each trimmed, capped at 512 chars).
- A marker **with** an `updateCommand` now returns a real updater instead of a no-op:
  - `check()` follows the same version contract as the Python sibling `CommandProvider`: **exit 0 + stdout is the version** → `found`; ran and exited **non-zero** → `not-available`; **could not run** (spawn error / timeout) or **exit 0 with no version** → a check-phase `error` (never a false green "up to date"). No `checkCommand` → a check-phase error (the install can apply but cannot discover), not a phantom "latest".
  - `install()` shells `updateCommand`, then relaunches; a non-zero apply emits an install-phase error and does not relaunch.
  - With the auto-download preference on, a discovered update applies on the next natural quit (the preference is re-read **fresh** at quit, failing toward not-installing). A later check that finds nothing pending **disarms** that quit-apply and clears the discovered version, and the quit handler is additionally guarded on a pending version — so a withdrawn/applied update never relaunches the app the user asked to quit.
  - A **bare** marker (no `updateCommand`) keeps the historic disabled behaviour.
- Execution is hardened like the sibling provider: narrowed system PATH (a bare command name will not resolve), `cwd="/"`, bounded retained output, and a timeout. The marker command is operator-authored text, not agent/user input.

## Testing
- electron: `auto-update` suite **110 passed / 0 failed** (managed check/install/auto-on-restart with the preference on/off/flipped, disarm-on-clear, spawn-failure and exit-0-empty → check error, bare-marker disabled, `checkCommand` parse + cap).

## Notes
- Scope is electron-only by design. An earlier revision also made Python `derive_capability()` provider-aware; that was dropped as unreachable dead code (every caller already gates on `resolve_provider` first, so it shipped no behaviour) — see the First Principles thread.
