### PR TITLE
fix(taskrunner): clean rejected plan directories

### DIFF
--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -280,6 +280,9 @@ Loaded on `__init__` — survives gateway restarts.
 - Persisted on: task completion, task delete
 - Each run stores: task_id, spec_path, status, timestamps, error, tokens, replans, step_details (result truncated to 2K)
 - Delete via `DELETE /api/taskrunner/{task_id}` removes from memory and disk
+- A plan's default work directory is provisional until the plan is accepted. A
+  failed attempt removes that taskrunner-owned directory; an explicit caller
+  workspace is never removed.
 
 ## Access Paths
 

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -638,9 +638,14 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
         if task_id:
             run = await state.task_runner.update_plan(task_id, steps)
         else:
-            new_id = f"plan_{uuid.uuid4().hex[:8]}"
-            task_dir = state.task_runner._work_dir / new_id
-            task_dir.mkdir(parents=True, exist_ok=True)
+            while True:
+                new_id = f"plan_{uuid.uuid4().hex[:8]}"
+                task_dir = state.task_runner._work_dir / new_id
+                try:
+                    task_dir.mkdir(parents=True, exist_ok=False)
+                    break
+                except FileExistsError:
+                    continue
             run = Project(
                 spec_path="",
                 spec_content="",
@@ -655,6 +660,10 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
                 run = await state.task_runner.update_plan(new_id, steps)
             except ValueError:
                 state.task_runner._runs.pop(new_id, None)
+                try:
+                    task_dir.rmdir()
+                except OSError:
+                    logger.warning("Failed to remove rejected chat plan directory %s", task_dir)
                 raise
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -332,8 +332,17 @@ class TaskRunner:
         task_id = f"plan_{int(time.time())}"
         _override = _resolve_workspace_dir(workspace_dir)
         _effective_ws = _override or self._workspace_dir
+        owns_task_dir = not _effective_ws
         task_dir = Path(_effective_ws) if _effective_ws else self._work_dir / f"plan_{task_id}"
-        task_dir.mkdir(parents=True, exist_ok=True)
+        created_task_dir = False
+        if owns_task_dir:
+            try:
+                task_dir.mkdir(parents=True, exist_ok=False)
+                created_task_dir = True
+            except FileExistsError:
+                pass
+        else:
+            task_dir.mkdir(parents=True, exist_ok=True)
         run = Project(
             spec_path=spec_path or "",
             spec_content=spec_content,
@@ -344,20 +353,30 @@ class TaskRunner:
             work_dir=str(task_dir),
             name=auto_name(spec_content or original_input, spec_path),
         )
-        if source == "yaml":
-            run.tasks = _decompose_yaml_with_audit(decompose_input, task_id)
-        else:
-            try:
-                run.tasks = await asyncio.wait_for(
-                    self._decompose(decompose_input, run.work_dir, task_id),
-                    timeout=180,
-                )
-            except asyncio.TimeoutError:
-                raise ValueError("Planning timed out. Try simplifying.")
-            except asyncio.CancelledError:
-                raise ValueError("Planning was cancelled.")
-        if not run.tasks:
-            raise ValueError("Could not generate a plan. Try rephrasing.")
+        try:
+            if source == "yaml":
+                run.tasks = _decompose_yaml_with_audit(decompose_input, task_id)
+            else:
+                try:
+                    run.tasks = await asyncio.wait_for(
+                        self._decompose(decompose_input, run.work_dir, task_id),
+                        timeout=180,
+                    )
+                except asyncio.TimeoutError:
+                    raise ValueError("Planning timed out. Try simplifying.")
+                except asyncio.CancelledError:
+                    raise ValueError("Planning was cancelled.")
+            if not run.tasks:
+                raise ValueError("Could not generate a plan. Try rephrasing.")
+        except Exception:
+            # Only the default plan directory belongs to this attempt. A caller's
+            # workspace is an input and must survive a rejected plan unchanged.
+            if created_task_dir:
+                try:
+                    task_dir.rmdir()
+                except OSError:
+                    logger.warning("Failed to remove rejected plan directory %s", task_dir)
+            raise
         self._runs[task_id] = run
         await self._apersist_runs()
         return run

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -1035,6 +1035,7 @@ class TestFromChat:
         assert _body(resp)["error"] == "bad step"
         # The placeholder run must not survive a rejected plan.
         assert runner._runs == {}
+        assert list(runner._work_dir.glob("plan_*")) == []
 
 
 # ── refine ──

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -280,6 +280,7 @@ class TestPlan:
             with pytest.raises(ValueError, match="timed out"):
                 await runner.plan(input_text="go", source="text")
         assert runner._runs == {}
+        assert list(tmp_path.glob("plan_*")) == []
 
     @pytest.mark.asyncio
     async def test_decompose_cancelled_becomes_value_error(self, tmp_path: Path) -> None:
@@ -289,6 +290,7 @@ class TestPlan:
         ):
             with pytest.raises(ValueError, match="cancelled"):
                 await runner.plan(input_text="go", source="text")
+        assert list(tmp_path.glob("plan_*")) == []
 
     @pytest.mark.asyncio
     async def test_empty_plan_rejected(self, tmp_path: Path) -> None:
@@ -296,6 +298,23 @@ class TestPlan:
         with patch.object(TaskRunner, "_decompose", AsyncMock(return_value=[])):
             with pytest.raises(ValueError, match="Could not generate a plan"):
                 await runner.plan(input_text="go", source="text")
+        assert list(tmp_path.glob("plan_*")) == []
+
+    @pytest.mark.asyncio
+    async def test_failed_plan_preserves_caller_workspace(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "caller-owned"
+        workspace.mkdir()
+        marker = workspace / "keep.txt"
+        marker.write_text("owned by caller", encoding="utf-8")
+        runner = _runner(tmp_path / "runner")
+        with patch.object(TaskRunner, "_decompose", AsyncMock(return_value=[])):
+            with pytest.raises(ValueError, match="Could not generate a plan"):
+                await runner.plan(
+                    input_text="go",
+                    source="text",
+                    workspace_dir=str(workspace),
+                )
+        assert marker.read_text(encoding="utf-8") == "owned by caller"
 
     def test_cancel_plan_cancels_live_task_only(self, tmp_path: Path) -> None:
         runner = _runner(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

Both task-planning entry points created a work directory before a plan was accepted, then left it behind when planning failed. The core `TaskRunner.plan()` path leaked a default `plan_plan_<timestamp>/` directory on timeout, cancellation, empty output, or decomposition failure; `/api/taskrunner/from-chat` removed its rejected placeholder run but leaked `plan_<id>/` on disk.

## Why it matters

Repeated rejected plans accumulated directories that no run owned and the dashboard could not delete. Their names were indistinguishable from accepted plan work directories, so operators had no authoritative way to tell which ones were safe to remove.

## What changed

- Treat the core default plan directory as provisional and remove it when planning fails.
- Preserve explicit caller workspaces; they remain caller-owned even on failure.
- Allocate from-chat plan directories collision-safely and remove the exact directory owned by a rejected placeholder.
- Document the ownership contract in the taskrunner system spec.

Cleanup is best-effort and never replaces the original planning error.

## Red-before evidence

On `origin/main` (`203491d3b`):

- `TestPlan::test_decompose_timeout_becomes_value_error` failed because `plan_plan_1787624912/` remained after the expected `ValueError`.
- `TestFromChat::test_failed_new_plan_is_rolled_back` failed because `work/plan_757645bd/` remained after the expected HTTP 400, even though `_runs` was empty.

## Tests

- `pytest test/test_taskrunner_coverage.py test/test_handlers_taskrunner_coverage.py -n 2 --dist loadgroup -q` — 203 passed
- targeted fail-before cases plus caller-workspace negative control — 14 passed
- `isort --check-only` — passed on all touched Python files
- `flake8` — passed on all touched Python and test files
- `mypy` — passed on both touched source files
- owning system spec updated; no new link or index surface
- `git diff --check` — passed

## Related issue

Fixes #5751