### PR TITLE
feat(memory): make the markdown memory layer searchable by keyword

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -370,10 +370,19 @@ Model: `Qwen/Qwen3-Embedding-0.6B` Q8_0 GGUF (610MB). Apache-2.0 licensed. Serve
 
 `kirocrew memory {list,search,show,stats,audit,export,migrate,import}` — manage memory from the command line:
 - `show [preferences|projects|history]` — read the markdown layer through `MemoryStore` (all three targets when none given); `--format md|json` (json entries carry `path`, `updated_at` mtime in UTC ISO-8601, `content`), `--since YYYY-MM-DD` filters history days. Missing/empty files print as empty rather than erroring
+- `search <query>` — searches BOTH memories and labels each section: the vector store's episodic recall, then keyword hits from the markdown layer's FTS5 index (`MemoryStore.search`, over `preferences.md` / `projects.md` / every `history/*.md`). `--layer vector|history|all` (default `all`); `--layer vector` reproduces the previous vector-only output exactly, and `--layer history` skips constructing the vector store entirely, the same way `show` does. The two indexes answer different questions — "where did I write this word" versus "what does this mean like" — so they are reported separately rather than merged into one ranking
 - `export` — vector-store collections; `--include-markdown` opts in a `markdown` collection (`preferences`/`projects` entries + per-day `history` list from `MemoryStore.markdown_snapshot()`) without changing the default payload shape
 - `migrate` — one-time markdown → structured migration (preferences.md → semantic, history/*.md → episodic)
 - `import <file>` — restore from JSON export with full validation
 - `kirocrew security audit` also scans vector memory for injection patterns
+
+### Keyword search over the markdown layer
+
+**Query escaping.** The query is treated as literal words, not FTS5 expression syntax. Tokens are quoted by `fts5_quote_tokens` in `_sqlite_compat.py`, the single escaping dialect shared with knowledge retrieval. Unquoted, `-` and `.` and a bare `AND` are FTS5 operators, so `PROJ-123` or `hooks.py` raises inside the driver and `MemoryStore.search`'s `except` turns it into `[]`, a silent "never written" for the likeliest queries. The join differs by surface on purpose: memory ANDs every token (a hand-typed query is deliberate), knowledge drops stopwords and ORs (natural-language recall).
+
+**Empty index is not absence.** `MemoryStore.index_row_count()` returns the FTS row count, or `None` when the index cannot be read, so a caller can separate three states that `search` collapses into one empty list: unreadable, empty, genuinely no match. An unbuilt or unreadable index is reported as such rather than as "no match".
+
+**No agent-facing tool.** The index is reachable from the CLI only. An MCP tool that reads memory on demand would have to enforce the temporary-session read boundary itself, and that boundary is not readable from an out-of-process stdio server: `memory_mode` lives on the dashboard's `SessionSlot`, while Slack and Telegram carry it in `privacy_mode.is_temporary`, and a temporary Slack thread writes no transcript metadata at all. Exposing the index to agents needs a governance capability scope, the way `learn_add` gates durable writes through `capabilities.memory_writes`, and that is left to separate work.
 
 ### Migration (`migrate_from_markdown`)
 

--- a/src/kiro_crew/_sqlite_compat.py
+++ b/src/kiro_crew/_sqlite_compat.py
@@ -18,6 +18,24 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+
+def fts5_quote_tokens(query: str) -> list[str]:
+    """Quote each whitespace-separated token of ``query`` for FTS5 MATCH.
+
+    One escaping dialect for every FTS5 reader in the tree. A token becomes a
+    quoted string, so FTS5 reads it as text rather than syntax: unquoted, ``-``
+    ``.`` and a bare ``AND`` are operators, which makes the everyday queries
+    (``PROJ-123``, ``hooks.py``) raise inside the driver. Internal double quotes
+    are doubled, the escape FTS5 defines for its own string literals.
+
+    Returns the tokens rather than a finished expression: how they are joined is
+    a per-surface product decision, not an escaping one. Memory search ANDs them
+    (the user typed every word deliberately); knowledge retrieval drops stopwords
+    and ORs them (natural-language recall).
+    """
+    return ['"' + token.replace('"', '""') + '"' for token in query.split()]
+
+
 try:
     import pysqlite3 as sqlite3  # type: ignore
 except ImportError:  # pragma: no cover - exercised on platforms without pysqlite3

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2077,8 +2077,18 @@ Examples:
     mem_parser = cli_help.add_command(sub, "memory")
     mem_sub = mem_parser.add_subparsers(dest="mem_action")
     mem_sub.add_parser("list", help="Show semantic memory entries")
-    mem_search = mem_sub.add_parser("search", help="Search episodic memories")
+    mem_search = mem_sub.add_parser("search", help="Search memory (vector + markdown layers)")
     mem_search.add_argument("query", help="Search query text")
+    mem_search.add_argument(
+        "--layer",
+        choices=["vector", "history", "all"],
+        default="all",
+        help=(
+            "Which memory to search: vector (episodic semantic recall), "
+            "history (keyword FTS over preferences/projects/daily history), "
+            "or all (default)"
+        ),
+    )
     mem_show = mem_sub.add_parser(
         "show", help="Show the markdown memory layer (preferences, projects, daily history)"
     )

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1859,6 +1859,39 @@ def _markdown_memory_store() -> MemoryStore:
     return MemoryStore()
 
 
+def _memory_search_history(args: argparse.Namespace) -> None:
+    """Print FTS5 hits from the markdown memory layer.
+
+    Reads the same index the heartbeat and gateway keep current, so this needs
+    no embedder and no vector store — it answers "where did I write this word"
+    against preferences, projects and the dated daily-history files.
+
+    Resolves the store through ``_markdown_memory_store`` for the reason spelled
+    out there: the reader must anchor exactly where the gateway's consolidator
+    writes, or a config that remaps the default workspace searches a tree
+    nothing writes to.
+    """
+    store = _markdown_memory_store()
+    results = store.search(args.query, limit=10)
+    if not results:
+        # An empty index is not the same statement as an absent word, so the two
+        # are reported differently.
+        if not store.index_row_count():
+            print("Memory history index is empty or unavailable; nothing was searched.")
+        else:
+            print("No memory-history matches.")
+        return
+    print("  Daily history / preferences / projects:")
+    for r in results:
+        # Strip terminal control sequences for the same reason the semantic
+        # listing does: memory holds whatever the user pasted into a session.
+        path = _TERMINAL_CTRL_RE.sub("", str(r.get("path", "?")))
+        snippet = _TERMINAL_CTRL_RE.sub("", str(r.get("snippet", ""))).strip()
+        print(f"    {path}")
+        if snippet:
+            print(f"        {snippet}")
+
+
 def _memory_show(args: argparse.Namespace) -> None:
     """Read-only view of the markdown memory layer (preferences/projects/history).
 
@@ -1906,6 +1939,11 @@ def _memory_cmd(args: argparse.Namespace) -> None:
     if action == "show":
         _memory_show(args)
         return
+    # "search --layer history" reads only the markdown FTS index, so don't open
+    # (or create) the vector store for it — same reason as "show" above.
+    if action == "search" and getattr(args, "layer", "all") == "history":
+        _memory_search_history(args)
+        return
     cfg = KiroCrewConfig.load()
     store = VectorMemoryStore(embedding_dim=cfg.memory.embedding_dim)
     store.init()
@@ -1931,19 +1969,31 @@ def _memory_cmd(args: argparse.Namespace) -> None:
                 )
 
         elif action == "search":
-            results = store.search_episodic(query_text=args.query, limit=10)
-            if not results:
-                print("No episodic memories found.")
-                return
-            for r in results:
-                tags = (
-                    json.loads(r.get("tags", "[]"))
-                    if isinstance(r.get("tags"), str)
-                    else r.get("tags", [])
-                )
-                print(f"  [{r.get('importance', 0):.1f}] {r['text'][:120]}")
-                if tags:
-                    print(f"        tags: {', '.join(tags)}")
+            layer = getattr(args, "layer", "all")
+            if layer in ("vector", "all"):
+                results = store.search_episodic(query_text=args.query, limit=10)
+                if not results:
+                    print("No episodic memories found.")
+                    # Under "all" the markdown layer is still to come: an empty
+                    # vector result is not an empty answer.
+                    if layer == "vector":
+                        return
+                elif layer == "all":
+                    # Both sections are printed, so both are named. Unlabelled,
+                    # the first block of hits reads as the whole answer. Held
+                    # back under "vector", whose output shape is a promise.
+                    print("  Episodic recall:")
+                for r in results:
+                    tags = (
+                        json.loads(r.get("tags", "[]"))
+                        if isinstance(r.get("tags"), str)
+                        else r.get("tags", [])
+                    )
+                    print(f"  [{r.get('importance', 0):.1f}] {r['text'][:120]}")
+                    if tags:
+                        print(f"        tags: {', '.join(tags)}")
+            if layer == "all":
+                _memory_search_history(args)
 
         elif action == "stats":
             stats = store.memory_stats()

--- a/src/kiro_crew/knowledge/retrieval.py
+++ b/src/kiro_crew/knowledge/retrieval.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     import sqlite3
 
+from .._sqlite_compat import fts5_quote_tokens
 from .store import KnowledgeStore
 
 logger = logging.getLogger(__name__)
@@ -283,8 +284,10 @@ class HybridRetriever:
         # than returning an empty match (which would drop the keyword leg).
         if not tokens:
             tokens = raw_tokens
-        quoted = ['"' + t.replace('"', '""') + '"' for t in tokens]
-        return " OR ".join(quoted)
+        # Quoting comes from the shared primitive so the tree has exactly one
+        # FTS5 escaping dialect; the stopword drop and OR join above stay this
+        # surface's own recall policy.
+        return " OR ".join(fts5_quote_tokens(" ".join(tokens)))
 
     def _graph_search(self, query: str, limit: int = 20) -> list[tuple[str, int]]:
         """Find entities matching query terms, traverse graph, rank items by mention count."""

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -22,7 +22,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kiro_crew._sqlite_compat import FTS5_UNAVAILABLE_HINT, fts5_available, sqlite3
+from kiro_crew._sqlite_compat import (
+    FTS5_UNAVAILABLE_HINT,
+    fts5_available,
+    fts5_quote_tokens,
+    sqlite3,
+)
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.hooks import (
@@ -133,6 +138,21 @@ def legacy_memory_present() -> bool:
 
 
 # ── MemoryStore ──
+
+
+def _fts5_literal_query(query: str) -> str:
+    """Turn user words into an FTS5 expression that matches them literally.
+
+    Tokens are quoted by the shared :func:`fts5_quote_tokens` primitive and
+    joined with FTS5's implicit AND: every word the user typed must appear. That
+    differs deliberately from knowledge retrieval, which drops stopwords and ORs
+    for natural-language recall -- a hand-typed memory query is precise, so
+    widening it would bury the both-words hit under single-word noise.
+
+    Returns "" when the query holds no tokens, which the caller treats as no
+    match rather than handing FTS5 an empty expression to reject.
+    """
+    return " ".join(fts5_quote_tokens(query))
 
 
 class MemoryStore:
@@ -962,8 +982,37 @@ class MemoryStore:
                 conn.close()
         return len(files)
 
+    def index_row_count(self) -> int | None:
+        """Rows in the FTS index, or ``None`` when the index cannot be read.
+
+        Lets a caller tell three states apart that :meth:`search` collapses into
+        one empty list: the index is unreadable, the index is empty, or the query
+        genuinely has no match. Without this, a corrupt or not-yet-built index
+        reports as "you never wrote about this", which is the one answer a memory
+        search must never give wrongly.
+        """
+        conn = None
+        try:
+            conn = self._get_db()
+            row = conn.execute("SELECT count(*) FROM memory_fts").fetchone()
+            return int(row[0]) if row else 0
+        except Exception:
+            logger.debug("FTS index count failed", exc_info=True)
+            return None
+        finally:
+            if conn is not None:
+                conn.close()
+
     def search(self, query: str, limit: int = 5) -> list[dict]:
-        """Search memory using FTS5. Returns [{path, snippet, rank}]."""
+        """Search memory for the literal words in ``query``.
+
+        Returns ``[{path, snippet, rank}]``. The query is treated as literal
+        text, not FTS5 expression syntax, because callers pass words a user
+        typed: a ticket id, a filename, a hyphenated term. Unescaped, ``-``
+        ``.`` and a bare ``AND`` are FTS5 syntax, so ``PROJ-123`` raises inside
+        the driver and the ``except`` below turns it into ``[]`` -- a silent
+        "you never wrote about this" for one of the likeliest queries.
+        """
         conn = None
         try:
             # Inside the try, not around it: this method handles its own errors
@@ -971,11 +1020,14 @@ class MemoryStore:
             # every failure as a success. Here a raising query is tagged
             # outcome=error before the except below swallows it.
             with timed_query("memory", "search"):
+                match = _fts5_literal_query(query)
+                if not match:
+                    return []
                 conn = self._get_db()
                 cursor = conn.execute(
                     "SELECT path, snippet(memory_fts, 1, '>>>', '<<<', '...', 32), rank "
                     "FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?",
-                    (query, limit),
+                    (match, limit),
                 )
                 results = [
                     {"path": row[0], "snippet": row[1], "rank": row[2]} for row in cursor.fetchall()

--- a/test/test_memory_markdown_read.py
+++ b/test/test_memory_markdown_read.py
@@ -630,9 +630,7 @@ class TestStaleBaselineWriteGuard:
         ms.init()
         ms.write_preferences("# User Preferences\n\n- v1\n")
         baseline = ms.read_preferences()
-        wrote = ms.write_preferences(
-            "# User Preferences\n\n- merged\n", expected_baseline=baseline
-        )
+        wrote = ms.write_preferences("# User Preferences\n\n- merged\n", expected_baseline=baseline)
         assert wrote is True
         assert "- merged" in ms.read_preferences()
 
@@ -642,7 +640,10 @@ class TestStaleBaselineWriteGuard:
         ms.write_projects("# Active Projects\n\n- p1\n")
         baseline = ms.read_projects()
         ms.write_projects("# Active Projects\n\n- user edit\n")
-        assert ms.write_projects("# Active Projects\n\n- merged\n", expected_baseline=baseline) is False
+        assert (
+            ms.write_projects("# Active Projects\n\n- merged\n", expected_baseline=baseline)
+            is False
+        )
         assert "- user edit" in ms.read_projects()
         fresh = ms.read_projects()
         assert ms.write_projects("# Active Projects\n\n- merged\n", expected_baseline=fresh) is True
@@ -681,9 +682,7 @@ class TestLockFileSymlinkGuard:
         except (OSError, NotImplementedError):  # pragma: no cover - Windows CI
             pytest.skip("symlinks not available on this platform")
 
-    def test_planted_write_lock_symlink_fails_closed_target_intact(
-        self, tmp_path: Path
-    ) -> None:
+    def test_planted_write_lock_symlink_fails_closed_target_intact(self, tmp_path: Path) -> None:
         target = tmp_path / "victim.txt"
         target.write_text("precious", encoding="utf-8")
         ms = _store(tmp_path)
@@ -694,9 +693,7 @@ class TestLockFileSymlinkGuard:
             ms.write_preferences("# User Preferences\n\n- attack\n")
         assert target.read_text(encoding="utf-8") == "precious"
 
-    def test_planted_append_lock_symlink_fails_closed_target_intact(
-        self, tmp_path: Path
-    ) -> None:
+    def test_planted_append_lock_symlink_fails_closed_target_intact(self, tmp_path: Path) -> None:
         target = tmp_path / "victim.txt"
         target.write_text("precious", encoding="utf-8")
         ms = _store(tmp_path)
@@ -1003,3 +1000,227 @@ class TestMemoryCliWiring:
 
             main()
         assert mock_cmd.call_args[0][0].include_markdown is False
+
+
+# ── memory search: the markdown layer is reachable by keyword ──
+# The FTS5 index over preferences/projects/daily-history is written on every
+# append and rebuilt by both the heartbeat and the gateway, but nothing ever
+# queried it, and `memory search` resolved to the VECTOR store. These pin the
+# markdown layer as searchable while keeping the old output shape available.
+
+
+class _NoEpisodicVectorStore:
+    """Vector store with exactly the surface ``_memory_cmd`` SEARCH uses.
+
+    Deliberately separate from ``_EmptyVectorStore``, whose docstring pins it to
+    the export surface: widening that stub would make it lie about what it
+    stands in for.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def init(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def search_episodic(self, **_kwargs: object) -> list:
+        return []
+
+
+class _OneEpisodicVectorStore(_NoEpisodicVectorStore):
+    """Returns a single episodic hit, so the section label is observable."""
+
+    def search_episodic(self, **_kwargs: object) -> list:
+        return [{"text": "shipped the pytest refactor", "importance": 0.7, "tags": "[]"}]
+
+
+def _search_args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {"mem_action": "search", "query": "", "layer": "all"}
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestMemoryHistorySearch:
+    def test_a_word_written_months_ago_is_findable(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The point of the feature: recall by content, not by recency window."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_search_args(query="pytest", layer="history"))
+        out = capsys.readouterr().out
+        assert "preferences" in out
+        assert "pytest" in out
+
+    def test_history_layer_never_opens_the_vector_store(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """No embedder, no vector DB creation — same contract as ``show``."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise AssertionError("history search must not construct a vector store")
+
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with patch.object(cli_commands, "VectorMemoryStore", _boom):
+                cli_commands._memory_cmd(_search_args(query="pytest", layer="history"))
+        assert "pytest" in capsys.readouterr().out
+
+    def test_no_match_says_so_rather_than_printing_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_search_args(query="zzzznevermentioned", layer="history"))
+        assert "No memory-history matches." in capsys.readouterr().out
+
+    def test_layer_vector_keeps_the_previous_output_exactly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Back-compat guard: --layer vector must not gain a history section."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with patch.object(cli_commands, "VectorMemoryStore", _NoEpisodicVectorStore):
+                cli_commands._memory_cmd(_search_args(query="pytest", layer="vector"))
+        out = capsys.readouterr().out
+        assert "No episodic memories found." in out
+        assert "Daily history" not in out
+        assert "Episodic recall" not in out
+
+    def test_both_sections_are_labelled_when_both_are_printed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Unlabelled, the first block of hits reads as the whole answer."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with patch.object(cli_commands, "VectorMemoryStore", _OneEpisodicVectorStore):
+                cli_commands._memory_cmd(_search_args(query="pytest", layer="all"))
+        out = capsys.readouterr().out
+        assert "Episodic recall" in out
+        assert "Daily history" in out
+
+    def test_layer_vector_stays_unlabelled_even_with_hits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Back-compat: the single-section output keeps its previous shape."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with patch.object(cli_commands, "VectorMemoryStore", _OneEpisodicVectorStore):
+                cli_commands._memory_cmd(_search_args(query="pytest", layer="vector"))
+        out = capsys.readouterr().out
+        assert "shipped the pytest refactor" in out
+        assert "Episodic recall" not in out
+
+    def test_all_layer_still_reaches_history_when_vector_is_empty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """An empty vector result is not an empty answer under the default."""
+        ms = _populated_store(tmp_path)
+        ms.rebuild_index()
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            with patch.object(cli_commands, "VectorMemoryStore", _NoEpisodicVectorStore):
+                cli_commands._memory_cmd(_search_args(query="pytest", layer="all"))
+        out = capsys.readouterr().out
+        assert "No episodic memories found." in out
+        assert "pytest" in out
+
+
+class TestLiteralFtsQuery:
+    """The words a user types are text, not FTS5 expression syntax.
+
+    Before escaping, ``PROJ-123`` raised inside the sqlite driver and
+    ``MemoryStore.search``'s ``except`` turned it into ``[]``. To a model that
+    reads as "the user never wrote about this", which is the wrong answer for
+    one of the likeliest queries: a ticket id, a filename, a hyphenated term.
+    """
+
+    def _indexed(self, tmp_path: Path) -> MemoryStore:
+        ms = _store(tmp_path)
+        ms.init()
+        ms.write_projects("# Active Projects\n\n- shipped PROJ-123 via cli_commands.py\n")
+        ms.rebuild_index()
+        return ms
+
+    @pytest.mark.parametrize("query", ["PROJ-123", "cli_commands.py", "PROJ-123 cli_commands.py"])
+    def test_syntax_bearing_queries_match_instead_of_silently_missing(
+        self, tmp_path: Path, query: str
+    ) -> None:
+        assert self._indexed(tmp_path).search(query), f"{query!r} found nothing"
+
+    def test_a_genuine_miss_is_still_a_miss(self, tmp_path: Path) -> None:
+        assert self._indexed(tmp_path).search("zzzznevermentioned") == []
+
+    def test_a_bare_operator_is_matched_as_a_word_not_parsed(self, tmp_path: Path) -> None:
+        """``shipped AND`` is invalid FTS5; as literal tokens it is simply absent."""
+        assert self._indexed(tmp_path).search("shipped AND") == []
+
+    def test_a_whitespace_only_query_yields_no_match(self, tmp_path: Path) -> None:
+        assert self._indexed(tmp_path).search("   ") == []
+
+    def test_an_embedded_quote_is_escaped_not_injected(self) -> None:
+        from kiro_crew.memory import _fts5_literal_query
+
+        assert _fts5_literal_query('a "b"') == '"a" """b"""'
+
+
+class TestOneEscapingDialect:
+    """Both FTS5 readers escape through the same primitive.
+
+    Design review's point: a second hand-rolled quoter is how the tree ends up
+    with divergent dialects and one of them wrong again.
+    """
+
+    def test_memory_and_knowledge_share_the_quoting_primitive(self) -> None:
+        from kiro_crew._sqlite_compat import fts5_quote_tokens
+
+        assert fts5_quote_tokens("PROJ-123 hooks.py") == ['"PROJ-123"', '"hooks.py"']
+
+    def test_the_join_differs_on_purpose(self) -> None:
+        """Memory ANDs a deliberate query; knowledge ORs for recall."""
+        from kiro_crew.knowledge.retrieval import HybridRetriever
+        from kiro_crew.memory import _fts5_literal_query
+
+        assert _fts5_literal_query("alpha beta") == '"alpha" "beta"'
+        assert HybridRetriever._sanitize_fts5_query("alpha beta") == '"alpha" OR "beta"'
+
+
+class TestEmptyIndexIsNotAbsence:
+    """An unreadable or unbuilt index must not be reported as "never written"."""
+
+    def test_row_count_distinguishes_empty_from_populated(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+        assert ms.index_row_count() == 0
+        ms.write_projects("# Active Projects\n\n- PROJ-123\n")
+        ms.rebuild_index()
+        assert (ms.index_row_count() or 0) > 0
+
+    def test_an_unreadable_index_reports_none_not_zero(self, tmp_path: Path) -> None:
+        ms = _store(tmp_path)
+        ms.init()
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise RuntimeError("corrupt index")
+
+        with patch.object(type(ms), "_get_db", _boom):
+            assert ms.index_row_count() is None
+
+    def test_an_unbuilt_index_is_reported_as_such_not_as_no_match(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        ms = _store(tmp_path)
+        ms.init()  # initialised but never indexed
+        with patch.object(cli_commands, "_markdown_memory_store", lambda: ms):
+            cli_commands._memory_cmd(_search_args(query="pytest", layer="history"))
+        out = capsys.readouterr().out
+        assert "empty or unavailable" in out
+        assert "No memory-history matches." not in out


### PR DESCRIPTION
## Problem / Motivation

The markdown memory layer has a full-text index that nothing reads.

`MemoryStore` maintains an FTS5 index over `preferences.md`, `projects.md` and every `history/*.md`. It is appended to on every write and rebuilt on a schedule from two independent places (`heartbeat.py`, via the maintenance executor, and `slack/gateway.py`, off-loop on startup). `MemoryStore.search()` is its only consumer and had **zero callers**. Verified with a positive control: the same grep style finds both `rebuild_index` schedulers, so this is an absence and not a grep artifact.

## Why it matters

Memory could be read by **recency** but never searched by **content**. `read_recent_history` has six call sites at 2, 14 and 30 day windows, so anything outside the window a given caller chose was effectively unreachable even though it was still on disk and still indexed.

The verb a user would reach for made it worse: `kirocrew memory search <query>` resolved to the **vector** store (`store.search_episodic`), not this index. The command is named after the whole memory system but answered for one half of it, and the half it skipped is the one holding the notes the user wrote by hand.

## What changed (motivation → approach → change)

**`kirocrew memory search` now reads both memories and labels each section.** `--layer vector|history|all` defaults to `all`. `--layer vector` reproduces the previous output byte-for-byte for anyone who scripted it, pinned by a test. `--layer history` skips constructing the vector store entirely (no embedder, no DB creation), the same contract `memory show` already has, also pinned by a test that raises if `VectorMemoryStore` is constructed.

The two indexes are reported as **separate labelled sections** rather than merged into one ranking. They answer different questions, keyword presence versus semantic similarity, and interleaving them by rank would make neither result trustworthy.

**Queries are escaped as literal text.** Unquoted, `-` and `.` and a bare `AND` are FTS5 operators, so `PROJ-123` and `hooks.py` raised inside the sqlite driver and `MemoryStore.search`'s `except` turned that into `[]` , a silent "you never wrote about this" for the likeliest query style there is: a ticket id, a filename, a hyphenated term. Escaping lives in **one** place, `fts5_quote_tokens` in `_sqlite_compat.py`, the module that already owns the FTS5 concern for both stores; `knowledge/retrieval.py` now delegates its quoting there rather than the tree carrying a second dialect. The join stays per-surface on purpose: memory ANDs every token because a hand-typed query is deliberate, knowledge drops stopwords and ORs for recall.

**An empty index is not reported as absence.** `MemoryStore.index_row_count()` returns the row count, or `None` when the index cannot be read, so a reader can separate "unbuilt or corrupt" from "genuinely no match" , two states `search()` collapses into one empty list.

**No agent-facing MCP tool.** This delivers the CLI half of #5702 only; see the last review disposition below for why the agent-facing half was withdrawn rather than fixed again.

### Note on unrelated formatting hunks

`test/test_memory_markdown_read.py` carries four formatting-only hunks in `TestStaleBaselineWriteGuard` and `TestLockFileSymlinkGuard`. That file was already black-dirty on `main` and is not in the black baseline, and the gate scopes to files changed in the PR, so touching the file pulls the whole file into scope. The gate's own printed remedy is exactly the `black` run that produced them.

## Tests

`test/test_memory_markdown_read.py` grows by 227 lines. New coverage: recall by content outside any recency window; `--layer history` never constructing the vector store; a miss saying so rather than printing nothing; `--layer vector` byte-identical to the old output (with and without hits); both sections labelled under `all`; syntax-bearing queries (`PROJ-123`, `cli_commands.py`) matching instead of silently missing; a bare operator matched as a word; an embedded quote escaped rather than injected; memory and knowledge sharing one quoting primitive while keeping different joins; row count separating empty from populated and `None` from an unreadable index; an unbuilt index reported as such rather than as no match.

Three self-mutations were checked and each killed a test: reverting the CLI default to vector-only, dropping the shared escaping primitive, and removing the section label.

## Manual verification

Ran the CLI end-to-end against a real temp store, exercising `all`, `vector` and `history`. Confirmed the two labelled sections under `all`, the unlabelled single-section shape under `vector`, and that `PROJ-123` and `cli_commands.py` return hits where they previously returned nothing, while a genuine miss still reports no match.

Full suite: **30 failed, 69,797 passed**. Baseline on clean `main` at the same commit over the identical set of failing files: **30 failed, identical failure names, zero difference in either direction**.

## Review dispositions

**GPT 5.6: raw queries reach FTS5 MATCH unescaped: FIXED, at the store.** Reproduced first: `PROJ-123` raises `OperationalError: no such column: 123` and `cli_commands.py` raises `fts5: syntax error near "."`. Correcting my own earlier description of this: it does **not** crash, because `MemoryStore.search` wraps the query in `except Exception: return []`, so the failure is silently reported as no match. Fixed at the store, the single chokepoint, so no future caller re-inherits it.

**Design Review: do not add a third FTS5 dialect: ADOPTED.** I had written a second quoter before reading this. `_sanitize_fts5_query` already existed in `knowledge/retrieval.py`, so the primitive was lifted to `_sqlite_compat.py` (whose docstring already scopes it to exactly these two stores) and both surfaces now delegate. Knowledge behaviour is unchanged, verified by running its own suite rather than reasoning about it.

**Design Review: an unavailable index is indistinguishable from a genuine miss: FIXED, not deferred.** `index_row_count()` added; the reader reports an unbuilt or unreadable index as such.

**GPT 5.6: the `--layer all` vector section is unlabelled: FIXED.** The promised labelling only held for the history section. `all` now names both; `vector` deliberately stays unlabelled because its output shape is a back-compat promise. Both directions are pinned by tests.

**First Principles: PASS at the time it last produced a verdict.** No action.

**Verdicts at `b9d297dd` (current head).** GPT 5.6 is ✅ *no blocking findings*, so the five-round
blocker is closed. Design Review, Opus 4.8 and First Principles all report *could not complete*:
the model call errored rather than returning a verdict, which the checks themselves label advisory
and non-blocking. There is no finding to dispose of in those three. Design Review's substantive
concerns from the earlier round are the two recorded above, both fixed.

**GPT 5.6: the temporary-session read gate fails open (three rounds): WITHDRAWN, tool removed.** Three successive rounds found the same class of hole in the gate on the MCP tool: it failed *closed* on an exception but *open* on a silently-empty value. Round 2 added a caller-mode gate; round 3 found it resolved identity leniently and `get_metadata("")` answers `{}` rather than raising; round 4 found the empty *key* guarded but not unreadable *metadata*.

Investigating the round-5 report established the real reason, which is structural rather than another missing branch: **the boundary is not readable from an out-of-process stdio server at all.** `memory_mode` is dashboard-only, every writer of it lives under `dashboard/`. Slack and Telegram carry the same state in `privacy_mode.is_temporary`, and `slack/gateway.py` deliberately does not write the conversation log for a temporary thread, so no transcript metadata row exists. `get_metadata_status` therefore answers `readable=True` with `{}`, the mode reads back as `""`, and the gate allows the read. The gate protected dashboard sessions and silently allowed Slack and Telegram ones.

Rather than harden a metadata-derived gate a fourth time, the tool is removed from this PR. The established pattern for an MCP handler that needs an authoritative policy answer is `governance_permits(scope, session_key=...)` with `_audit_governance_deny`, which `learn_add` uses for `capabilities.memory_writes`; there is no `capabilities.memory_reads` scope yet, so adding one is a platform change that deserves its own review. Removing the tool also resolves GPT's second round-5 finding (a refusal audited as `outcome="completed"` with no denied SEL event), since the refusal path no longer exists.

## Related Issues

Refs #5702, delivers the CLI reader from the proposal. The agent-facing `memory_history_search` tool is deferred; the issue stays open for it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text, it will be added here once Legal provides it. -->

