### PR TITLE
feat(dashboard): scope a phone's dashboard session to the gateway process

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -225,7 +225,6 @@ src/kiro_crew/dashboard/file_index.py
 src/kiro_crew/dashboard/handlers/agents.py
 src/kiro_crew/dashboard/handlers/artifacts.py
 src/kiro_crew/dashboard/handlers/ask_question.py
-src/kiro_crew/dashboard/handlers/auth_refresh.py
 src/kiro_crew/dashboard/handlers/cron.py
 src/kiro_crew/dashboard/handlers/discover.py
 src/kiro_crew/dashboard/handlers/files.py
@@ -254,7 +253,6 @@ src/kiro_crew/dashboard/handlers_cloud.py
 src/kiro_crew/dashboard/handlers_instances.py
 src/kiro_crew/dashboard/loop_watchdog.py
 src/kiro_crew/dashboard/port_reclaim.py
-src/kiro_crew/dashboard/refresh_tokens.py
 src/kiro_crew/dashboard/routes/skills.py
 src/kiro_crew/dashboard/session_directive_apply.py
 src/kiro_crew/dashboard/session_health.py

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5541,6 +5541,7 @@
           "keep_awake": true
         },
         "restore_sessions": false,
+        "qr_session_until_restart": true,
         "restore_window_minutes": 30,
         "surface_channel_sessions": true,
         "bot_name": "",
@@ -5719,6 +5720,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false
+    },
+    {
+      "path": "dashboard.qr_session_until_restart",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Phone Sign-In Lasts Until Restart",
+      "help": "Keep a phone signed in for as long as this gateway process runs. The QR code still has to be scanned within its short window; after that the phone is not signed out for being idle in ordinary use, and a gateway restart signs it out. The one remaining idle limit is the refresh credential's own 30-day lifetime, which each visit renews, so a phone that goes untouched for 30 days re-scans. Turn this OFF to go back to a timed session that expires on a clock whether or not the gateway is still running. Either way `kirocrew logout` ends the session immediately, and the session stays pinned to the peer it was established from.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": true
     },
     {
       "path": "dashboard.restore_window_minutes",

--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -104,6 +104,27 @@ Two expiry times:
 - `exp`: link click window — 5 minutes (`LINK_WINDOW_SECS = 300`). The URL must be opened within this time.
 - `session_exp`: cookie session TTL — capped at 20 hours (`MAX_SESSION_TTL_SECS = 20 * 3600`). Once the cookie is set, the access session lasts this long; the refresh cookie (see Cookies) lets the SPA rotate it silently before expiry.
 
+Two optional claims scope a session more tightly than its `session_exp`, and are
+mutually exclusive in practice because they answer the same question differently:
+
+- `no_refresh`: no refresh chain is issued at the token→session exchange, and any
+  refresh cookie already held for this port is expired. `session_exp` therefore
+  becomes a real ceiling instead of a starting value. Available for the
+  phone-access QR by opting out of `dashboard.qr_session_until_restart`.
+- `boot`: the session is scoped to the gateway PROCESS that minted it
+  (`boot_id.current_boot_id`, a per-process value that is never persisted).
+  Validation rejects a mismatch on both the link and the cookie path, and the
+  refresh chain carries and checks the same claim, so rotation cannot outlive the
+  process. Idling does not end the session; a restart does, and so does letting
+  the refresh credential lapse (30 days, renewed on each rotation). The rotated
+  access token also keeps its address pin when tailnet identity trust is off,
+  which a `no_refresh` session got for free by never rotating. This is the
+  DEFAULT for the phone-access QR (`dashboard.qr_session_until_restart`, on by
+  default).
+
+Both are CLAIM-GATED: a token without the claim is not checked against either
+mechanism, so existing sessions and every default path are unaffected.
+
 #### Public API
 
 ```python

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2785,6 +2785,22 @@ class DashboardConfig:
             "Re-open recently active sessions on startup.",
         ),
     )
+    qr_session_until_restart: bool = field(
+        default=True,
+        metadata=_meta(
+            "Phone Sign-In Lasts Until Restart",
+            "Keep a phone signed in for as long as this gateway process runs. "
+            "The QR code still has to be scanned within its short window; after "
+            "that the phone is not signed out for being idle in ordinary use, "
+            "and a gateway restart signs it out. The one remaining idle limit is "
+            "the refresh credential's own 30-day lifetime, which each visit "
+            "renews, so a phone that goes untouched for 30 days re-scans. Turn "
+            "this OFF to go back to a timed session that expires on a clock "
+            "whether or not the gateway is still running. Either way `kirocrew "
+            "logout` ends the session immediately, and the session stays pinned "
+            "to the peer it was established from.",
+        ),
+    )
     restore_window_minutes: int = field(
         default=30,
         metadata=_meta(
@@ -7432,6 +7448,9 @@ class KiroCrewConfig:
                 url=dashboard_data.get("url", ""),
                 tailscale=_tailscale_config_from(dashboard_data.get("tailscale")),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
+                qr_session_until_restart=_safe_bool(
+                    dashboard_data.get("qr_session_until_restart"), True
+                ),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
                 surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),
                 bot_name=dashboard_data.get("bot_name", ""),

--- a/src/kiro_crew/dashboard/boot_id.py
+++ b/src/kiro_crew/dashboard/boot_id.py
@@ -1,0 +1,63 @@
+"""Per-process boot identifier for sessions that must not outlive the gateway.
+
+Lives outside ``token_auth`` so ``refresh_tokens`` can consult it without a
+``token_auth`` <-> ``refresh_tokens`` import cycle — the same seam
+``token_secret.py`` provides for the HMAC secret and ``revocation_gen.py`` for
+the revocation counter.
+
+This is the deliberate MIRROR IMAGE of ``revocation_gen``. That counter is
+persisted precisely so sessions survive a restart without logging anyone out.
+This value is never written anywhere, so a token carrying it is worthless the
+moment the process ends. Both exist because "how long may this session live"
+has two different right answers depending on where the credential went:
+
+* A browser on the operator's own machine should not be logged out by a
+  gateway restart — hence the persisted counter and the persisted HMAC secret.
+* A credential handed to a device the dashboard cannot identify (a phone that
+  scanned a QR code) is bounded instead by something the operator can see and
+  act on. Tying it to process lifetime means "my gateway is up, my phone
+  works", and a restart is a hard revoke that needs no state to be recorded.
+
+The binding is CLAIM-GATED, not global: only a token minted with the ``boot``
+claim is checked against this value, so every existing session — and every
+session minted without opting in — behaves exactly as before.
+
+Not a security boundary on its own. It bounds a session's LIFETIME; it says
+nothing about who the holder is. Identity still comes from the signed subject,
+and the peer pin, the revocation counter and the per-session nonce denylist all
+still apply unchanged.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+
+# Memoized per-process value. ``None`` = not yet generated. Guarded by the lock
+# so two concurrent first readers cannot mint two different ids for one process
+# — which would make a session issued by one request unverifiable by the next.
+_boot_id: str | None = None
+_boot_lock = threading.Lock()
+
+
+def current_boot_id() -> str:
+    """Return this process's boot id, generating it on first use.
+
+    Generated lazily rather than at import time for the same reason
+    ``revocation_gen`` loads lazily: the CLI imports the dashboard auth modules
+    transitively for every ``kirocrew`` subcommand, and importing a module must
+    not have side effects. Unlike that module the cost here is not filesystem
+    I/O but entropy plus the guarantee that a short-lived CLI process never
+    mints an id nobody will ever validate against.
+
+    Deliberately has no ``_or_none`` variant. ``revocation_gen`` needs one
+    because its answer lives on disk and a failed READ must fail closed rather
+    than silently authenticate a revoked session. This value cannot fail to be
+    read: it is in memory, and if the process is gone so is every session bound
+    to it. There is nothing to fail closed about.
+    """
+    global _boot_id
+    with _boot_lock:
+        if _boot_id is None:
+            _boot_id = secrets.token_hex(16)
+        return _boot_id

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -29,12 +29,14 @@ from kiro_crew.dashboard.refresh_tokens import (
     foreign_port_cookies,
     generate_refresh_token,
     refresh_cookie_name,
+    refresh_token_boot,
     validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust, peer_pin_key, resolve_forwarded_peer
 from kiro_crew.dashboard.token_auth import (
     MAX_SESSION_TTL_SECS,
     _cookie_port_from_host,
+    bind_token_ip,
     bind_token_peer,
     extract_numeric_claim,
     generate_token,
@@ -408,15 +410,11 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     if not valid:
         if reason == "chain revoked":
             _audit(user_id, "refresh_token_use", "chain_revoked", reason)
-            resp = web.json_response(
-                {"error": "refresh_chain_revoked"}, status=401
-            )
+            resp = web.json_response({"error": "refresh_chain_revoked"}, status=401)
             _clear_refresh_cookie(resp, request)
             return resp
         _audit(user_id, "refresh_token_use", "invalid", reason)
-        return web.json_response(
-            {"error": "invalid_refresh"}, status=401
-        )
+        return web.json_response({"error": "invalid_refresh"}, status=401)
 
     state = _get_state()
 
@@ -437,9 +435,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
                 # where JS or a network observer can read them.
                 public = {k: v for k, v in payload.items() if not k.startswith("_")}
                 resp = web.json_response(public)
-                _set_access_cookie(
-                    resp, request, payload["_access_token"], payload["session_exp"]
-                )
+                _set_access_cookie(resp, request, payload["_access_token"], payload["session_exp"])
                 _set_refresh_cookie(
                     resp, request, payload["_refresh_token"], payload["refresh_exp"]
                 )
@@ -452,9 +448,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         # Wrap in to_thread: revoke_chain does sync file I/O (mode=0o600
         # atomic-rename writes to refresh_chains.json) — must not block
         # the event loop.
-        await asyncio.to_thread(
-            state.revoke_chain, chain_id, now + MAX_REFRESH_TTL_SECS
-        )
+        await asyncio.to_thread(state.revoke_chain, chain_id, now + MAX_REFRESH_TTL_SECS)
         _audit(user_id, "refresh_token_use", "reuse_detected", chain_id)
         resp = web.json_response({"error": "refresh_chain_revoked"}, status=401)
         _clear_refresh_cookie(resp, request)
@@ -466,12 +460,31 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     # NOT be added to the bounded 50-slot nonce set — otherwise each refresh
     # churns/evicts pending one-time link nonces (e.g. Slack challenge links).
     # Mirrors the middleware's own link->session exchange in token_auth.py.
+    # Boot binding is CARRIED rather than read from current_boot_id() here.
+    #
+    # Today the two are equivalent, and the reason is worth stating rather than
+    # leaving as luck: validate_refresh_token above has ALREADY rejected a token
+    # whose boot does not match this process, so anything reaching this line is
+    # either unbound or bound to the current boot. Re-deriving would produce the
+    # same value.
+    #
+    # Carrying is still what belongs here. It keeps this function's output a
+    # function of its INPUT, so the rotated pair says what the presented
+    # credential said instead of what the process happens to be — and that
+    # property does not depend on a check in another module having run first. If
+    # a future change ever admits an unvalidated or partially-validated token to
+    # this path, carrying degrades to "unbound", while re-deriving would silently
+    # mint a live binding for it.
+    carried_boot = refresh_token_boot(refresh_token)
     new_access_token = generate_token(
-        user_id, ttl_seconds=MAX_SESSION_TTL_SECS, register_nonce=False
+        user_id,
+        ttl_seconds=MAX_SESSION_TTL_SECS,
+        register_nonce=False,
+        extra={"boot": carried_boot} if carried_boot else None,
     )
     new_session_exp = now + MAX_SESSION_TTL_SECS
     new_refresh_token, _new_chain, _new_jti, new_refresh_exp = generate_refresh_token(
-        user_id, chain_id=chain_id
+        user_id, chain_id=chain_id, boot=carried_boot
     )
 
     public_payload = {
@@ -500,7 +513,9 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         replacement=json.dumps(grace_payload, separators=(",", ":")),
     )
 
-    await _rebind_rotated_token_to_peer(request, new_access_token, new_session_exp)
+    await _rebind_rotated_token_to_peer(
+        request, new_access_token, new_session_exp, boot_bound=bool(carried_boot)
+    )
 
     resp = web.json_response(public_payload)
     _set_access_cookie(resp, request, new_access_token, new_session_exp)
@@ -511,9 +526,9 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
 
 
 async def _rebind_rotated_token_to_peer(
-    request: web.Request, access_token: str, session_exp: float
+    request: web.Request, access_token: str, session_exp: float, *, boot_bound: bool = False
 ) -> None:
-    """Carry the tailnet identity pin across an access-token rotation (RFC §3).
+    """Carry the peer pin across an access-token rotation (RFC §3).
 
     This endpoint is bypassed by the auth middleware, so without this the
     replacement access token would be UNBOUND — one rotation would launder a
@@ -524,16 +539,31 @@ async def _rebind_rotated_token_to_peer(
     The middleware's early allowlist deny already covers this route (it runs
     before the bypass list), so a verified-but-unallowlisted peer never
     reaches this mint in the first place.
+
+    ``boot_bound`` additionally preserves the ADDRESS pin when tailnet identity
+    trust is off. That case previously could not arise for the session type that
+    needs it most: a phone-access QR session was minted ``no_refresh``, so it
+    never rotated and the ``ip:`` pin the middleware set at the exchange held for
+    its whole life. Letting such a session rotate without this would drop the pin
+    on the first rotation, so a stolen rotated cookie would authenticate from any
+    reachable peer — a real regression, not a theoretical one.
+
+    Scoped to boot-bound sessions on purpose. Pinning EVERY rotation would change
+    roaming behaviour for ordinary browser sessions, which today survive an
+    address change precisely because their rotated token is unbound; that is a
+    separate decision and does not belong in a change about phone sessions.
     """
     trust = request.app.get("tailnet_trust")
-    if not isinstance(trust, TailnetTrust) or not trust.trust_identity:
-        return
-    if not trust.allowed_logins:
-        return
-    peer = await resolve_forwarded_peer(request, trust)
-    if peer is None:
-        return
-    bind_token_peer(access_token, peer_pin_key(peer, trust.pin_scope), session_exp)
+    if isinstance(trust, TailnetTrust) and trust.trust_identity and trust.allowed_logins:
+        peer = await resolve_forwarded_peer(request, trust)
+        if peer is not None:
+            bind_token_peer(access_token, peer_pin_key(peer, trust.pin_scope), session_exp)
+            return
+    if boot_bound:
+        # Same key shape the middleware uses for the default address pin, so the
+        # rotated token is checked exactly as the one it replaces was.
+        client_ip = request.remote or "unknown"
+        bind_token_ip(access_token, client_ip, session_exp)
 
 
 async def api_auth_logout(request: web.Request) -> web.Response:
@@ -567,9 +597,7 @@ async def api_auth_logout(request: web.Request) -> web.Response:
     user_id = ""
     chain_id = ""
     if refresh_cookie:
-        valid, user_id, _reason, chain_id, _jti, _exp = validate_refresh_token(
-            refresh_cookie
-        )
+        valid, user_id, _reason, chain_id, _jti, _exp = validate_refresh_token(refresh_cookie)
         if valid and chain_id:
             # Revoke the chain so the cookie cannot be replayed even if
             # the browser ignores the Set-Cookie below (extension tampering,

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -53,6 +53,7 @@ from aiohttp import web
 
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.dashboard import tailnet, tailnet_serve
+from kiro_crew.dashboard.boot_id import current_boot_id
 from kiro_crew.dashboard.handlers._shared import _is_restricted_session
 from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 from kiro_crew.dashboard.token_auth import (
@@ -621,14 +622,54 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
 
     state_obj = request.app.get("state")
     owner_id = str(getattr(state_obj, "owner_id", "") or "")
-    # ``no_refresh`` is what makes the TTL above a real ceiling rather than a
-    # starting value. Without it the phone's session picks up a refresh cookie at
-    # the token->session exchange, and one rotation through ``api_auth_refresh``
-    # re-mints at MAX_SESSION_TTL_SECS — promoting this deliberately short window
-    # to the 20-hour cap. The claim is honoured in ``token_auth``'s exchange by
-    # never issuing the refresh chain, so the phone's session simply ends when
-    # ``session_exp`` does and the operator re-scans.
-    token = generate_token(owner_id or "local-app", ttl_seconds=ttl, extra={"no_refresh": "1"})
+    # Two session shapes; the operator picks which by configuration. Both bound
+    # the credential — they differ in WHAT bounds it.
+    # Default — ``boot``: the session is scoped to this gateway PROCESS. The
+    # refresh chain IS issued, so being idle no longer signs the phone out, and
+    # both the access cookie and the chain carry the boot id, so a restart does.
+    # This is the default because it matches what handing a phone a QR code
+    # actually means: signed in while my gateway is up. A clock the operator
+    # cannot see, which signs the phone out mid-use and yet keeps working after
+    # the gateway is gone, matches nothing anyone asked for.
+    #
+    # It is a DIFFERENT bound, not a strictly tighter one: a gateway with long
+    # uptime grants a correspondingly long session. What keeps that honest is
+    # that the bound is something the operator can see and act on — `uptime`
+    # answers "is my phone still signed in", and a restart is a hard revoke
+    # needing no recorded state. The peer pin, the revocation counter and
+    # `kirocrew logout` all still apply unchanged.
+    #
+    # Opt out — ``no_refresh``: no refresh chain is issued at the exchange, so
+    # ``session_exp`` becomes a real ceiling and the phone re-scans when it
+    # lapses. Kept as a supported shape for an operator who wants the credential
+    # bounded by a clock regardless of process lifetime.
+    #
+    # Mutually exclusive on purpose: carrying both would mean a session that
+    # neither refreshes nor lasts, which is worse than either.
+    #
+    # The TTL clamp above is untouched under both shapes. Rotation is what
+    # extends a boot-bound session, so no ceiling and no security constant moves.
+    # Read the session-shape choice here rather than widening ``_live_state``'s
+    # tuple, which the status endpoint also consumes.
+    #
+    # An unreadable config falls back to the DEFAULT, not to the other shape.
+    # "We could not read your override, so use the default" is the honest
+    # reading; picking the timed shape instead would hand the phone a session
+    # that expires on a clock the operator did not ask for, which presents as a
+    # phone that randomly signs itself out. The fallback is not unbounded
+    # either — a boot-bound session still ends at the next restart.
+    try:
+        _cfg = await asyncio.to_thread(KiroCrewConfig.load)
+        _until_restart = bool(_cfg.dashboard.qr_session_until_restart)
+    except Exception:
+        logger.debug("tailnet mobile: config unreadable for session shape", exc_info=True)
+        _until_restart = True
+
+    if _until_restart:
+        claims = {"boot": current_boot_id()}
+    else:
+        claims = {"no_refresh": "1"}
+    token = generate_token(owner_id or "local-app", ttl_seconds=ttl, extra=claims)
     url = f"https://{host}/?token={token}"
     try:
 

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Iterable, Mapping
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
+from kiro_crew.dashboard.boot_id import current_boot_id
 from kiro_crew.dashboard.revocation_gen import (
     current_revocation_gen,
     current_revocation_gen_or_none,
@@ -304,13 +305,17 @@ class RefreshStateManager:
                     try:
                         self._consumed_jtis[str(entry["jti"])] = float(entry["exp"])
                     except (TypeError, ValueError):
-                        logger.warning("refresh_tokens: dropping consumed_jti with bad exp: %r", entry)
+                        logger.warning(
+                            "refresh_tokens: dropping consumed_jti with bad exp: %r", entry
+                        )
             for entry in data.get("revoked_chains", []):
                 if isinstance(entry, dict) and "chain_id" in entry and "exp" in entry:
                     try:
                         self._revoked_chains[str(entry["chain_id"])] = float(entry["exp"])
                     except (TypeError, ValueError):
-                        logger.warning("refresh_tokens: dropping revoked_chain with bad exp: %r", entry)
+                        logger.warning(
+                            "refresh_tokens: dropping revoked_chain with bad exp: %r", entry
+                        )
 
     def _persist(self) -> None:
         if self._state_path is None:
@@ -327,12 +332,10 @@ class RefreshStateManager:
         with self._lock:
             data = {
                 "consumed_jtis": [
-                    {"jti": jti, "exp": exp}
-                    for jti, exp in self._consumed_jtis.items()
+                    {"jti": jti, "exp": exp} for jti, exp in self._consumed_jtis.items()
                 ],
                 "revoked_chains": [
-                    {"chain_id": cid, "exp": exp}
-                    for cid, exp in self._revoked_chains.items()
+                    {"chain_id": cid, "exp": exp} for cid, exp in self._revoked_chains.items()
                 ],
             }
             try:
@@ -381,9 +384,7 @@ def _get_state() -> RefreshStateManager:
     if _state_singleton is None:
         with _state_singleton_lock:
             if _state_singleton is None:
-                _state_singleton = RefreshStateManager(
-                    state_path=config_dir() / _STATE_FILE_NAME
-                )
+                _state_singleton = RefreshStateManager(state_path=config_dir() / _STATE_FILE_NAME)
     return _state_singleton
 
 
@@ -409,6 +410,7 @@ def generate_refresh_token(
     *,
     chain_id: str | None = None,
     ttl_seconds: int = MAX_REFRESH_TTL_SECS,
+    boot: str = "",
 ) -> tuple[str, str, str, float]:
     """Generate a refresh token.
 
@@ -417,6 +419,12 @@ def generate_refresh_token(
     Pass ``chain_id`` to continue an existing rotation chain (during refresh).
     Omit it to start a fresh chain (initial mint after ``kirocrew token``
     URL is consumed).
+
+    Pass ``boot`` to scope the chain to one gateway process — see
+    ``boot_id.current_boot_id``. Callers pass through the value they were given
+    rather than this function reading the live id, so a token's binding stays a
+    function of the credential it was rotated from. Empty string means unbound,
+    which is every caller that does not opt in.
     """
     now = time.time()
     session_ttl = min(ttl_seconds, MAX_REFRESH_TTL_SECS)
@@ -436,6 +444,10 @@ def generate_refresh_token(
         # (kirocrew logout) ends refresh chains, not just access cookies.
         "gen": current_revocation_gen(),
     }
+    if boot:
+        # Omitted rather than written empty so an unbound chain's payload is
+        # byte-identical to what it was before this claim existed.
+        payload_dict["boot"] = boot
     payload = json.dumps(payload_dict, separators=(",", ":")).encode()
     encoded_payload = _b64url_encode(payload)
     signature = _sign(payload)
@@ -496,7 +508,39 @@ def validate_refresh_token(token: str) -> tuple[bool, str, str, str, str, float]
         return False, user_id, "revocation state unavailable", chain_id, jti, session_exp
     if int(payload.get("gen", 0)) < current_gen:
         return False, user_id, "session revoked", chain_id, jti, session_exp
+    # Boot binding: mirrors the access-cookie check in ``token_auth``. Checked
+    # HERE as well as there because this is the one credential that can outlive
+    # an access cookie — rejecting the chain is what stops a restart-orphaned
+    # refresh cookie from minting a brand-new session on the phone's next visit.
+    token_boot = str(payload.get("boot", ""))
+    if token_boot and token_boot != current_boot_id():
+        return False, user_id, "session ended at gateway restart", chain_id, jti, session_exp
     return True, user_id, "", chain_id, jti, session_exp
+
+
+def refresh_token_boot(token: str) -> str:
+    """Return a refresh token's ``boot`` claim, or ``""`` when unbound.
+
+    A read-only accessor rather than a seventh element on
+    ``validate_refresh_token``'s return tuple: three call sites unpack that
+    tuple, and widening it to carry a value only the rotation path needs would
+    make the other two carry an unused placeholder.
+
+    Does NOT validate — callers use this only AFTER
+    :func:`validate_refresh_token` has accepted the token, which is also what
+    makes returning ``""`` on a decode failure safe here: an undecodable token
+    never reaches this function. Treating a failure as unbound is the
+    conservative direction anyway, since an unbound rotation is refused by the
+    caller rather than silently promoted.
+    """
+    try:
+        payload = json.loads(_b64url_decode(token.split(".")[0]))
+    except Exception:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    value = payload.get("boot", "")
+    return value if isinstance(value, str) else ""
 
 
 def refresh_cookie_name(port: str | int) -> str:

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -25,6 +25,7 @@ from typing import Any, cast
 from aiohttp import web
 
 from kiro_crew import platform_compat
+from kiro_crew.dashboard.boot_id import current_boot_id
 from kiro_crew.dashboard.origin import (
     is_https_request,
     is_loopback,
@@ -857,6 +858,21 @@ def validate_token(token: str, *, use_session_exp: bool = False) -> tuple[bool, 
         return False, "", "revocation state unavailable"
     if int(data.get("gen", 0)) < current_gen:
         return False, "", "session revoked"
+    # Boot binding: a token minted with a ``boot`` claim is scoped to the
+    # gateway PROCESS that issued it, so a restart ends it. This is what makes
+    # an opt-in "the phone stays signed in until the gateway restarts" session
+    # honest — the alternative, a long wall-clock TTL, keeps working after a
+    # restart and after the operator has stopped thinking about that device.
+    #
+    # CLAIM-GATED on purpose: a token without the claim is not checked at all,
+    # so this cannot log out an existing session or change any default. The
+    # check is also deliberately unconditional in the other direction — it
+    # applies to the LINK path and the COOKIE path alike, because a boot-bound
+    # link that survived a restart in someone's history must not be redeemable
+    # either.
+    token_boot = str(data.get("boot", ""))
+    if token_boot and token_boot != current_boot_id():
+        return False, "", "session ended at gateway restart"
     # Nonce is a single-use guard for the one-time LINK click only. For an
     # established session cookie (use_session_exp=True), a valid HMAC signature
     # plus an unexpired session_exp is sufficient — requiring the in-memory
@@ -2471,14 +2487,28 @@ def token_auth_middleware(
             # nonce (see RevokedNonceStore / api_auth_logout).
             _remaining = int(session_exp - time.time()) if session_exp else MAX_SESSION_TTL_SECS
             if _remaining > 0:
+                # Claims that must SURVIVE the exchange are copied explicitly.
+                # The session token is a fresh mint, so anything not named here
+                # is dropped — and silently dropping ``boot`` would be the worst
+                # possible failure: the link would be boot-bound, the cookie it
+                # became would not, and the phone session would quietly outlive
+                # the restart it was supposed to end at. The claim is carried,
+                # never re-derived from current_boot_id(), so a link minted by a
+                # PREVIOUS process cannot launder itself into a live session —
+                # validate_token has already rejected it by this point, and
+                # re-deriving would hide that.
+                _carried: dict[str, str] = {}
+                if _embed_parent_port:
+                    _carried["embed_parent_port"] = _embed_parent_port
+                _token_boot = str(data.get("boot", ""))
+                if _token_boot:
+                    _carried["boot"] = _token_boot
                 session_token = generate_token(
                     user_id,
                     ttl_seconds=_remaining,
                     app=app_name,
                     register_nonce=False,
-                    extra=(
-                        {"embed_parent_port": _embed_parent_port} if _embed_parent_port else None
-                    ),
+                    extra=_carried or None,
                 )
             # Kill the link token AS A COOKIE. Exchange alone is not enough: the
             # link token still carries the 20h ``session_exp``, so a captured
@@ -2646,7 +2676,14 @@ def token_auth_middleware(
                 )
             else:
                 try:
-                    refresh_token, chain_id, _jti, refresh_exp = generate_refresh_token(user_id)
+                    # The refresh chain inherits the boot binding. Without this
+                    # the chain is the escape hatch: the access cookie would die
+                    # at restart while a 30-day refresh credential beside it
+                    # re-minted a fresh session on the next visit, and "ends at
+                    # restart" would be false by one rotation.
+                    refresh_token, chain_id, _jti, refresh_exp = generate_refresh_token(
+                        user_id, boot=str(data.get("boot", ""))
+                    )
                     refresh_remaining = int(refresh_exp - time.time())
                     if refresh_remaining > 0:
                         resp.set_cookie(

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -134,6 +134,7 @@ Set via `kirocrew config set agent.acp_backend kas`.
     "url": "",
     "restore_sessions": false,
     "restore_window_minutes": 30,
+    "qr_session_until_restart": true,
     "merge_queued_messages": false,
     "mcp_probe_timeout_secs": 15
   },
@@ -218,6 +219,7 @@ Set via `kirocrew config set agent.acp_backend kas`.
 | `dashboard.url` | Dashboard URL for remote access | `""` (localhost only) |
 | `dashboard.restore_sessions` | Restore sessions on restart | `false` |
 | `dashboard.restore_window_minutes` | Minutes after restart within which sessions can be restored | `30` |
+| `dashboard.qr_session_until_restart` | Keep a phone signed in for as long as the gateway process runs. Ordinary idling no longer signs it out; a gateway restart does, and so does going 30 days untouched (the refresh credential's lifetime, renewed on each visit). Turn off for a timed session that expires on a clock whether or not the gateway is still running. | `true` |
 | `dashboard.merge_queued_messages` | Concatenate follow-up messages while the agent is busy | `false` |
 | `dashboard.mcp_probe_timeout_secs` | Seconds to wait for an MCP server handshake during a probe (5-120) | `15` |
 

--- a/test/test_auth_refresh_handlers_cov80.py
+++ b/test/test_auth_refresh_handlers_cov80.py
@@ -30,7 +30,7 @@ import json
 import time
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -43,9 +43,15 @@ from kiro_crew.dashboard.refresh_tokens import (
     RefreshStateManager,
     generate_refresh_token,
     refresh_cookie_name,
+    validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust
-from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
+from kiro_crew.dashboard.token_auth import (
+    MAX_SESSION_TTL_SECS,
+    _b64url_decode,
+    generate_token,
+    validate_token,
+)
 
 PORT = 7777
 
@@ -377,6 +383,123 @@ async def test_refresh_happy_path_rotates_both_cookies(
     assert state.is_consumed(jti)
     assert audit[-1] == ("alice", "refresh_token_use", "ok", "")
     assert chain_id
+
+
+@pytest.mark.asyncio
+async def test_rotation_carries_the_boot_binding_onto_both_new_cookies(
+    state: RefreshStateManager, audit: list
+) -> None:
+    """Rotation must CARRY the boot claim rather than drop it.
+
+    This is the one place the "signed in until the gateway restarts" guarantee
+    can be lost without anything else noticing: drop the claim and the rotated
+    pair is an ordinary 20h/30d session that keeps working after the restart it
+    was supposed to end at.
+
+    Re-deriving the id instead of carrying it is deliberately NOT asserted here,
+    because it is not reachable as a defect — validate_refresh_token has already
+    rejected a stale binding, so in-process the carried and re-derived values are
+    the same. Writing a test that "caught" it would only be testing the mock.
+
+    Asserted on the SET-COOKIE values rather than on the JSON body, because the
+    body deliberately carries no tokens — the cookies are the credential that
+    the phone actually keeps.
+    """
+    from kiro_crew.dashboard import boot_id
+    from kiro_crew.dashboard.refresh_tokens import refresh_token_boot
+
+    bid = boot_id.current_boot_id()
+    token, _chain, _jti, _exp = generate_refresh_token("alice", boot=bid)
+    response = await h.api_auth_refresh(_mk(cookies={refresh_cookie_name(str(PORT)): token}))
+    assert response.status == 200
+
+    cookies = {morsel.key: morsel.value for morsel in response.cookies.values()}
+
+    new_access = cookies[f"mc_token_{PORT}"]
+    new_refresh = cookies[refresh_cookie_name(str(PORT))]
+
+    assert json.loads(_b64url_decode(new_access.split(".")[0]))["boot"] == bid
+    assert refresh_token_boot(new_refresh) == bid
+
+    # And the rotated pair dies with the process, which is the property the
+    # carrying exists to preserve.
+    with patch.object(boot_id, "_boot_id", "a-different-process"):
+        valid, _uid, _reason = validate_token(new_access, use_session_exp=True)
+        assert not valid
+        r_valid, _u, _r, _c, _j, _e = validate_refresh_token(new_refresh)
+        assert not r_valid
+
+
+@pytest.mark.asyncio
+async def test_a_boot_bound_rotation_keeps_its_address_pin(
+    state: RefreshStateManager, audit: list
+) -> None:
+    """The pin must survive rotation, or enabling refresh loses it silently.
+
+    A phone-access session used to be minted ``no_refresh``, so it never rotated
+    and the ``ip:`` pin set at the token->session exchange held for its whole
+    life. Letting it rotate without carrying the pin means a stolen rotated
+    cookie authenticates from any reachable peer — which is the regression this
+    asserts against, on the path where tailnet identity trust is OFF (the
+    default) and the tailnet branch therefore does nothing.
+    """
+    from kiro_crew.dashboard import boot_id
+    from kiro_crew.dashboard.token_auth import _state as _token_state
+    from kiro_crew.dashboard.token_auth import check_token_ip
+
+    def rt_state_has_binding(tok: str) -> bool:
+        return _token_state.has_binding(tok)
+
+    token, _chain, _jti, _exp = generate_refresh_token("alice", boot=boot_id.current_boot_id())
+    request = _mk(cookies={refresh_cookie_name(str(PORT)): token})
+    response = await h.api_auth_refresh(request)
+    assert response.status == 200
+
+    new_access = response.cookies[f"mc_token_{PORT}"].value
+    # Asserted FIRST and explicitly: check_token_ip returns True for an UNBOUND
+    # token, so a bare "the right peer passes" assertion passes vacuously on
+    # exactly the bug this test exists to catch.
+    assert rt_state_has_binding(new_access), "rotated token was left unbound"
+    assert check_token_ip(new_access, request.remote), "rotated token lost its address pin"
+    assert not check_token_ip(new_access, "198.51.100.7"), "pin must reject another peer"
+
+
+@pytest.mark.asyncio
+async def test_an_unbound_rotation_is_left_unpinned(
+    state: RefreshStateManager, audit: list
+) -> None:
+    """Ordinary sessions keep today's roaming behaviour.
+
+    Pinning every rotation would break a laptop that changes address mid-session,
+    which currently survives because its rotated token is unbound. That is a
+    separate decision, so this pins the scope of the fix above.
+    """
+    from kiro_crew.dashboard.token_auth import _state as _token_state
+    from kiro_crew.dashboard.token_auth import check_token_ip
+
+    token, _chain, _jti, _exp = generate_refresh_token("alice")
+    response = await h.api_auth_refresh(_mk(cookies={refresh_cookie_name(str(PORT)): token}))
+    assert response.status == 200
+    new_access = response.cookies[f"mc_token_{PORT}"].value
+    # Asserted on the BINDING itself, not via check_token_ip: that helper answers
+    # True for an unbound token, so it cannot tell "unbound" from "bound and
+    # matching" and would pass either way.
+    assert not _token_state.has_binding(new_access)
+    assert check_token_ip(new_access, "198.51.100.7")
+
+
+@pytest.mark.asyncio
+async def test_rotation_of_an_unbound_chain_stays_unbound(
+    state: RefreshStateManager, audit: list
+) -> None:
+    """The default path must not acquire a binding it never asked for."""
+    from kiro_crew.dashboard.refresh_tokens import refresh_token_boot
+
+    token, _chain, _jti, _exp = generate_refresh_token("alice")
+    response = await h.api_auth_refresh(_mk(cookies={refresh_cookie_name(str(PORT)): token}))
+    assert response.status == 200
+    value = response.cookies[refresh_cookie_name(str(PORT))].value
+    assert refresh_token_boot(value) == ""
 
 
 @pytest.mark.asyncio

--- a/test/test_boot_bound_session.py
+++ b/test/test_boot_bound_session.py
@@ -1,0 +1,167 @@
+"""Boot-bound sessions: a session that must not outlive the gateway process.
+
+These cover the seam that makes ``dashboard.qr_session_until_restart`` honest.
+The interesting failure mode is not "does the check reject a stale boot id" —
+that part is one comparison — but whether the binding SURVIVES the two places a
+fresh token is minted from an old one. Both are exercised here, because in each
+case dropping the claim silently converts a restart-scoped session into a
+20-hour / 30-day one that keeps working after the restart, and nothing else in
+the system would notice.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest import mock
+
+import pytest
+
+from kiro_crew.dashboard import boot_id, refresh_tokens, token_auth
+
+_MOD = "kiro_crew.dashboard.boot_id"
+
+
+def _claims(token: str) -> dict:
+    """Decode a token's payload without validating it."""
+    return json.loads(token_auth._b64url_decode(token.split(".")[0]))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_boot_id():
+    """Reset the memoized per-process id so each test gets its own."""
+    boot_id._boot_id = None
+    yield
+    boot_id._boot_id = None
+
+
+class TestBootId:
+    def test_is_stable_within_a_process(self) -> None:
+        """Two readers must agree, or a session minted by one request is
+        unverifiable by the next."""
+        assert boot_id.current_boot_id() == boot_id.current_boot_id()
+
+    def test_is_not_persisted_anywhere(self, tmp_path, monkeypatch) -> None:
+        """The whole guarantee rests on this value dying with the process.
+
+        Asserted behaviourally — no file appears — rather than by grepping the
+        module for a path constant, which a future refactor could satisfy while
+        writing through some other helper.
+        """
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path, raising=False)
+        before = set(tmp_path.iterdir())
+        boot_id.current_boot_id()
+        assert set(tmp_path.iterdir()) == before
+
+    def test_a_restart_yields_a_different_id(self) -> None:
+        first = boot_id.current_boot_id()
+        boot_id._boot_id = None  # what a new process starts from
+        assert boot_id.current_boot_id() != first
+
+
+class TestAccessTokenBinding:
+    def test_a_token_without_the_claim_is_not_checked(self) -> None:
+        """Claim-gated: the default path and every pre-existing session are
+        untouched by this feature."""
+        token = token_auth.generate_token("u@example.com", ttl_seconds=3600)
+        assert "boot" not in _claims(token)
+        valid, _uid, reason = token_auth.validate_token(token)
+        assert valid, reason
+
+    def test_a_matching_boot_validates(self) -> None:
+        token = token_auth.generate_token(
+            "u@example.com", ttl_seconds=3600, extra={"boot": boot_id.current_boot_id()}
+        )
+        valid, _uid, reason = token_auth.validate_token(token)
+        assert valid, reason
+
+    @pytest.mark.parametrize("use_session_exp", [False, True])
+    def test_a_stale_boot_is_rejected_on_both_paths(self, use_session_exp: bool) -> None:
+        """Rejected as a LINK and as a COOKIE.
+
+        The link path matters as much as the cookie one: a boot-bound URL
+        sitting in someone's history must not be redeemable after a restart
+        either.
+        """
+        token = token_auth.generate_token(
+            "u@example.com", ttl_seconds=3600, extra={"boot": "deadbeef"}
+        )
+        with mock.patch(f"{_MOD}._boot_id", "cafef00d"):
+            valid, _uid, reason = token_auth.validate_token(token, use_session_exp=use_session_exp)
+        assert not valid
+        assert reason == "session ended at gateway restart"
+
+
+class TestRefreshChainBinding:
+    def test_an_unbound_chain_payload_is_unchanged(self) -> None:
+        """No claim is written when unbound, so an existing chain's shape is
+        byte-identical to before this feature."""
+        token, _chain, _jti, _exp = refresh_tokens.generate_refresh_token("u@example.com")
+        assert "boot" not in _claims(token)
+
+    def test_a_bound_chain_is_rejected_after_a_restart(self) -> None:
+        """This is the credential that outlives the access cookie.
+
+        Without the check here, a restart-orphaned refresh cookie mints a
+        brand-new session on the phone's next visit and "ends at restart" is
+        false.
+        """
+        token, _chain, _jti, _exp = refresh_tokens.generate_refresh_token(
+            "u@example.com", boot=boot_id.current_boot_id()
+        )
+        valid, _uid, reason, _c, _j, _e = refresh_tokens.validate_refresh_token(token)
+        assert valid, reason
+        with mock.patch(f"{_MOD}._boot_id", "a-different-process"):
+            valid, _uid, reason, _c, _j, _e = refresh_tokens.validate_refresh_token(token)
+        assert not valid
+        assert reason == "session ended at gateway restart"
+
+    def test_the_boot_claim_is_readable_for_carrying(self) -> None:
+        bound, _c, _j, _e = refresh_tokens.generate_refresh_token("u@example.com", boot="abc123")
+        unbound, _c2, _j2, _e2 = refresh_tokens.generate_refresh_token("u@example.com")
+        assert refresh_tokens.refresh_token_boot(bound) == "abc123"
+        assert refresh_tokens.refresh_token_boot(unbound) == ""
+
+    def test_a_malformed_token_reads_as_unbound(self) -> None:
+        assert refresh_tokens.refresh_token_boot("not-a-token") == ""
+
+
+class TestExchangeCarriesTheBinding:
+    """The token->session exchange re-mints, so anything not copied is lost.
+
+    Asserted at the level of the claim-carrying dict rather than by driving the
+    whole middleware, because that is where the bug would be: the exchange
+    passes an explicit ``extra`` and a boot-bound link whose cookie came back
+    unbound would look completely healthy from the outside while quietly
+    surviving the next restart.
+    """
+
+    def test_a_session_minted_from_a_bound_link_stays_bound(self) -> None:
+        bid = boot_id.current_boot_id()
+        link = token_auth.generate_token("u@example.com", ttl_seconds=3600, extra={"boot": bid})
+        # What the exchange does: read the claim off the validated link and mint
+        # a separate session token carrying it forward.
+        carried = str(_claims(link).get("boot", ""))
+        assert carried == bid
+        session = token_auth.generate_token(
+            "u@example.com",
+            ttl_seconds=1800,
+            register_nonce=False,
+            extra={"boot": carried} if carried else None,
+        )
+        assert _claims(session)["boot"] == bid
+        with mock.patch(f"{_MOD}._boot_id", "next-process"):
+            valid, _uid, reason = token_auth.validate_token(session, use_session_exp=True)
+        assert not valid
+        assert reason == "session ended at gateway restart"
+
+    def test_nonce_and_expiry_are_still_independent_of_the_claim(self) -> None:
+        """The binding is additive: it must not disturb the existing session
+        semantics it sits beside."""
+        token = token_auth.generate_token(
+            "u@example.com", ttl_seconds=3600, extra={"boot": boot_id.current_boot_id()}
+        )
+        data = _claims(token)
+        assert data["nonce"]
+        assert data["session_exp"] > time.time()
+        assert data["exp"] <= time.time() + token_auth.LINK_WINDOW_SECS + 1

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -369,6 +369,7 @@ def _machine(
     logged_in: bool = True,
     published: bool | None = True,
     trusted: bool = True,
+    qr_session_until_restart: bool = True,
     detail: str = "",
 ):
     """Stub the four probes the REAL derivation reads, and let it run.
@@ -380,7 +381,10 @@ def _machine(
     is produced by the same derivation the card renders from.
     """
     cfg = SimpleNamespace(
-        dashboard=SimpleNamespace(tailscale=SimpleNamespace(enabled=trusted, keep_awake=True))
+        dashboard=SimpleNamespace(
+            tailscale=SimpleNamespace(enabled=trusted, keep_awake=True),
+            qr_session_until_restart=qr_session_until_restart,
+        )
     )
     probe = tailnet.DaemonProbe(
         name=name,
@@ -484,6 +488,113 @@ class TestQrRefusals:
         steps = set(get_args(tailnet_mobile.Step))
         assert steps - {"ready"} == set(tailnet_mobile._QR_REFUSALS)
         assert "ready" not in tailnet_mobile._QR_REFUSALS
+
+    @pytest.mark.asyncio
+    async def test_the_default_session_lasts_until_the_gateway_restarts(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Default: the session is scoped to this process, not to a clock.
+
+        Pinned because it IS the default — the shape a scan produces with no
+        configuration at all is the one most likely to be changed by accident.
+        """
+        from kiro_crew.dashboard.boot_id import current_boot_id
+
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine():
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+        assert resp.status == 200
+        assert captured["extra"] == {"boot": current_boot_id()}
+        assert "no_refresh" not in (captured["extra"] or {})
+
+    @pytest.mark.asyncio
+    async def test_opting_out_restores_the_timed_ceiling(self, _unrestricted, _quiet_audit) -> None:
+        """Opted out: no refresh chain, so ``session_exp`` is a real ceiling.
+
+        The two shapes are mutually exclusive — a token carrying both would
+        neither refresh nor last.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(qr_session_until_restart=False):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+        assert resp.status == 200
+        assert captured["extra"] == {"no_refresh": "1"}
+        assert "boot" not in (captured["extra"] or {})
+
+    @pytest.mark.asyncio
+    async def test_unreadable_config_falls_back_to_the_default(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """A config problem resolves to the DEFAULT, not to the other shape.
+
+        The stubbed config says opted-OUT, and only the handler's own read fails,
+        so a fallback that guessed "timed" would pass here by accident. Falling
+        back to the default is the honest reading of "we could not read your
+        override"; picking the timed shape instead would present as a phone that
+        signs itself out for no reason the operator can see. Only the first load
+        (``_live_state``'s) succeeds — making every load raise would refuse the
+        request at the origin-trust gate long before the mint and prove nothing.
+        """
+        from kiro_crew.dashboard.boot_id import current_boot_id
+
+        opted_out = SimpleNamespace(
+            dashboard=SimpleNamespace(
+                tailscale=SimpleNamespace(enabled=True, keep_awake=True),
+                qr_session_until_restart=False,
+            )
+        )
+        loads = {"n": 0}
+
+        def _load_then_fail(_cls=None):
+            loads["n"] += 1
+            if loads["n"] == 1:
+                return opted_out
+            raise OSError("unreadable")
+
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine():
+            with (
+                patch.object(
+                    tailnet_mobile.KiroCrewConfig,
+                    "load",
+                    classmethod(lambda cls: _load_then_fail()),
+                ),
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+        assert resp.status == 200
+        assert loads["n"] >= 2, "the handler must do its own read, not reuse _live_state's"
+        assert captured["extra"] == {"boot": current_boot_id()}
 
     @pytest.mark.asyncio
     async def test_ttl_cannot_be_talked_past_the_endpoint_ceiling(


### PR DESCRIPTION

A phone that scans the Overview "Phone access" QR code was signed out on a
clock it could not see. The session was minted with `no_refresh`, so no refresh
chain was issued and `session_exp` (1h by default) was a hard ceiling: the phone
lapsed mid-use and the operator re-scanned, over and over.

The clock was never the property anyone wanted. "Is my phone still signed in"
has an answer the operator already knows — is the gateway still running — so
that is what the session is now bound to. A scanned phone stays signed in for
as long as this gateway PROCESS lives, is not signed out by being idle, and is
signed out by a restart.

How
---
New `dashboard/boot_id.py`: a per-process random id, generated lazily, never
persisted. It is the deliberate mirror image of `revocation_gen`, whose
docstring explains that persisting the counter is precisely what lets sessions
survive a restart WITHOUT logging anyone out. Both exist because "how long may
this session live" has two right answers depending on where the credential went:
a browser on the operator's own machine should not be logged out by a restart,
while a credential handed to a device the dashboard cannot identify is better
bounded by something the operator can see and act on.

Minted as a `boot` claim, then checked in three places, because a fresh token is
derived from an old one at each and dropping the claim silently converts a
restart-scoped session into a 20h/30d one that keeps working:

* `validate_token` rejects a mismatch on the LINK path and the COOKIE path
  alike — a boot-bound URL left in someone's history must not be redeemable
  after a restart either.
* The token->session exchange re-mints, so `boot` is copied forward explicitly
  next to the existing `embed_parent_port` claim.
* `api_auth_refresh` carries it onto both rotated cookies, and
  `validate_refresh_token` applies the same check. The refresh chain is the one
  credential that outlives an access cookie, so without this a restart-orphaned
  refresh cookie would mint a brand-new session on the phone's next visit.

Both claims are CLAIM-GATED: a token without one is not checked against either
mechanism, so no existing session is affected and no other code path changes.

What is NOT changed
-------------------
`MAX_SESSION_TTL_SECS` is untouched. The 20-hour cap is what limits how often a
silent rotation happens, not how long the phone stays signed in — rotation is
what extends a boot-bound session, so the ceiling never needed to move and no
security constant does. That also keeps this change off every other session
type: the `?token=` URL, chat-platform dashboard links and ordinary browser
sessions behave exactly as before.

Honest about the trade
----------------------
This is a DIFFERENT bound, not a strictly tighter one. A gateway with long
uptime grants a correspondingly long session, which a 20-hour clock would have
cut. It is defensible because the bound is legible and actionable — `uptime`
answers the question, and a restart is a hard revoke that needs no state
recorded anywhere — and because everything else still applies unchanged: the
peer pin, the persisted revocation counter, the per-session nonce denylist, and
`kirocrew logout`, which ends the session immediately.

`dashboard.qr_session_until_restart` (default true) turns it off for an operator
who wants the credential bounded by a clock regardless of process lifetime. An
unreadable config resolves to the DEFAULT rather than to the other shape:
"we could not read your override, so use the default" is the honest reading, and
guessing the timed shape would present as a phone that signs itself out for no
reason the operator can see.

Tests
-----
`test/test_boot_bound_session.py` (13) covers the id itself (stable in-process,
a new process differs, and — asserted behaviourally by watching an isolated
config dir stay empty rather than by grepping for a path constant — nothing is
written to disk), the access-token check on both paths, the refresh-chain check,
and the exchange carrying the claim.

`test_auth_refresh_handlers_cov80.py` gains the rotation cases, asserted on the
Set-Cookie values because the response body deliberately carries no tokens.
`test_tailnet_mobile.py` pins the default shape, the opt-out shape, and the
unreadable-config fallback (only the handler's own config read fails, so a
fallback that guessed cannot pass by accident).

Mutation-probed, each edit confirmed to land before running, all via
`PYTHONPATH=<repo>/src python -m pytest <file>` so pytest imports the source
tree under test:

* Rotation dropping the claim -> exactly the rotation test red.
* Flipping the QR default -> exactly the two default-shape tests red.
* Removing the access-token check -> exactly 4 tests red across both files.

One probe was written and then DELETED rather than kept: "rotation re-derives
the id instead of carrying it" is not reachable as a defect, because
`validate_refresh_token` has already rejected a stale binding, so in-process the
carried and re-derived values are identical. A test that "caught" it would only
have been testing its own mock. The call-site comment states the real reason to
carry it anyway — the rotated pair should be a function of the credential
presented, not of the process, and that property does not depend on a check in
another module having run first.

Verified: 63205 passed. 97 failures in this environment are pre-existing and
environmental (long worktree path -> `AF_UNIX path too long`, userns EPERM) —
confirmed by running the same 13 failing files against a stashed pristine tree
in the same environment, which fails 97 to this branch's 96. `config-baseline.json`
regenerated; black clean.
