### PR TITLE
fix(schedule): preserve malformed cron_folders.json entries across saves

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4777,6 +4777,10 @@ class DashboardState:
         self._context_snapshots_flush_lock = threading.Lock()
         self._folders: list[dict[str, Any]] = []  # project folder definitions
         self._cron_folders: list[dict[str, Any]] = []  # cron job folder groupings
+        # Malformed cron_folders.json entries dropped at load time, kept verbatim
+        # so save_cron_folders round-trips them back instead of erasing bytes it
+        # could not parse (mirrors the hooks store's unparsed-entry preservation).
+        self._unparsed_cron_folder_entries: list[Any] = []
         self._chat_pins: list[dict[str, Any]] = []  # pinned chat messages
         # Serializes pin mutation + persistence so concurrent requests cannot
         # interleave snapshots and replace chat_pins.json out of order.
@@ -6959,10 +6963,13 @@ class DashboardState:
         """Load cron folder definitions from disk.
 
         Validates the loaded shape: the file must contain a JSON array of
-        folder objects. Anything else (a hand-edited ``{}``, a string, or
-        malformed entries) is discarded with a warning instead of being
-        assigned verbatim — a non-list value would flow to the frontend
-        and crash grouping (``folders.map is not a function``).
+        folder objects. A non-list root (a hand-edited ``{}``, a string) is
+        ignored wholesale — it would crash frontend grouping
+        (``folders.map is not a function``). Individual malformed entries are
+        dropped from the active list but kept verbatim in
+        ``_unparsed_cron_folder_entries`` so the next ``save_cron_folders``
+        round-trips them back to disk rather than silently erasing a user's
+        hand-edited-but-typo'd folder (mirrors the hooks store's contract).
         """
         path = config_dir() / self._CRON_FOLDERS_FILE
         try:
@@ -6975,35 +6982,45 @@ class DashboardState:
                         type(loaded).__name__,
                     )
                     return
-                valid = [
-                    f
-                    for f in loaded
-                    if isinstance(f, dict)
-                    and isinstance(f.get("id"), str)
-                    and f.get("id")
-                    and isinstance(f.get("name"), str)
-                    and f.get("name")
-                    and isinstance(f.get("order"), (int, float))
-                    and not isinstance(f.get("order"), bool)
-                ]
-                if len(valid) != len(loaded):
+
+                def _is_valid(f: Any) -> bool:
+                    return (
+                        isinstance(f, dict)
+                        and isinstance(f.get("id"), str)
+                        and bool(f.get("id"))
+                        and isinstance(f.get("name"), str)
+                        and bool(f.get("name"))
+                        and isinstance(f.get("order"), (int, float))
+                        and not isinstance(f.get("order"), bool)
+                    )
+
+                valid = [f for f in loaded if _is_valid(f)]
+                unparsed = [f for f in loaded if not _is_valid(f)]
+                if unparsed:
                     logger.warning(
-                        "Dropped %d malformed entr(ies) while loading %s",
-                        len(loaded) - len(valid),
+                        "Preserving %d malformed entr(ies) while loading %s "
+                        "(kept verbatim, not active)",
+                        len(unparsed),
                         self._CRON_FOLDERS_FILE,
                     )
                 self._cron_folders = valid
+                self._unparsed_cron_folder_entries = unparsed
         except Exception:
             logger.warning("Failed to load cron folders", exc_info=True)
 
     def save_cron_folders(self) -> None:
         """Persist cron folder definitions to disk (atomic write).
 
-        Raises on I/O failure so callers can surface a 500 to the client
-        rather than silently losing the write.
+        Writes the active folders plus any malformed entries preserved at load
+        time (``_unparsed_cron_folder_entries``), so a save triggered by an
+        unrelated folder operation cannot erase bytes a hand-edit left in a
+        shape this loader could not validate. Raises on I/O failure so callers
+        can surface a 500 to the client rather than silently losing the write.
         """
         path = config_dir() / self._CRON_FOLDERS_FILE
-        self._atomic_write_json_strict(path, self._cron_folders)
+        unparsed = getattr(self, "_unparsed_cron_folder_entries", [])
+        payload: list[Any] = [*self._cron_folders, *unparsed]
+        self._atomic_write_json_strict(path, payload)
 
     def create_cron_folder(self, name: str, folder_id: str) -> dict:
         """Create a new cron folder and persist.

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -379,10 +379,12 @@ class TestCronFoldersPersistence:
             fresh.load_cron_folders()
             assert fresh._cron_folders == [], f"shape {bad!r} should be ignored"
 
-    def test_load_drops_malformed_entries(self, tmp_path, monkeypatch):
+    def test_load_keeps_malformed_entries_inactive(self, tmp_path, monkeypatch):
         """Non-dict entries and entries with a missing/invalid id, name, or
-        order are dropped; valid entries survive. A non-string ``name`` would
-        render as a React child and crash the Schedule page."""
+        order are excluded from the ACTIVE folder list (a non-string ``name``
+        would render as a React child and crash the Schedule page) but are
+        preserved verbatim in ``_unparsed_cron_folder_entries`` so a later save
+        does not erase them."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
         (tmp_path / "cron_folders.json").write_text(
             json.dumps(
@@ -405,8 +407,68 @@ class TestCronFoldersPersistence:
         )
         fresh = DashboardState.__new__(DashboardState)
         fresh._cron_folders = []
+        fresh._unparsed_cron_folder_entries = []
         fresh.load_cron_folders()
+        # Only well-formed entries are active.
         assert [f["id"] for f in fresh._cron_folders] == ["good1", "good2"]
+        # Every malformed entry is preserved verbatim (10 of the 12 above).
+        assert len(fresh._unparsed_cron_folder_entries) == 10
+        assert "not-a-dict" in fresh._unparsed_cron_folder_entries
+
+    def test_malformed_entry_survives_a_subsequent_save(self, tmp_path, monkeypatch):
+        """Regression: a hand-edited file with a typo'd entry must NOT lose that
+        entry when an unrelated folder operation triggers a save. Previously the
+        malformed entry was dropped in-memory and the next save erased its bytes.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        path = tmp_path / "cron_folders.json"
+        # User hand-edits the file and typos "order" as "oder" on one folder.
+        path.write_text(
+            json.dumps(
+                [
+                    {"id": "aaa", "name": "Backups", "order": 0},
+                    {"id": "bbb", "name": "Reports", "oder": 1},  # malformed
+                    {"id": "ccc", "name": "Alerts", "order": 2},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = []
+        state._unparsed_cron_folder_entries = []
+        state.load_cron_folders()
+        assert [f["id"] for f in state._cron_folders] == ["aaa", "ccc"]
+
+        # An unrelated folder operation persists — the malformed entry must ride along.
+        state.create_cron_folder("NewFolder", "ddd")
+
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        ids_and_raw = [f.get("id") if isinstance(f, dict) else f for f in on_disk]
+        # The typo'd "Reports" folder is still on disk, not erased.
+        assert "bbb" in ids_and_raw
+        malformed = next(f for f in on_disk if isinstance(f, dict) and f.get("id") == "bbb")
+        assert malformed == {"id": "bbb", "name": "Reports", "oder": 1}
+        # And the valid + newly created folders are all present.
+        assert {"aaa", "ccc", "ddd"}.issubset(
+            {f["id"] for f in on_disk if isinstance(f, dict) and "order" in f}
+        )
+
+    def test_no_unparsed_entries_leaves_payload_clean(self, tmp_path, monkeypatch):
+        """When nothing was malformed, the persisted file is exactly the active
+        folder list — no empty/sentinel padding leaks in."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        path = tmp_path / "cron_folders.json"
+        path.write_text(
+            json.dumps([{"id": "aaa", "name": "Backups", "order": 0}]), encoding="utf-8"
+        )
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = []
+        state._unparsed_cron_folder_entries = []
+        state.load_cron_folders()
+        assert state._unparsed_cron_folder_entries == []
+        state.create_cron_folder("NewFolder", "ddd")
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert [f["id"] for f in on_disk] == ["aaa", "ddd"]
 
     def test_save_raises_on_write_failure(self, tmp_path, monkeypatch):
         """save_cron_folders propagates I/O errors (not swallowed)."""


### PR DESCRIPTION
## Problem / Motivation

`DashboardState.load_cron_folders` validates each entry in `cron_folders.json` and keeps only the well-formed ones. Entries that fail validation were dropped from the in-memory list and preserved nowhere. Because `save_cron_folders` overwrites the file with the (valid-only) in-memory list, the **next** create/rename/delete permanently erased the malformed entries' bytes.

A user who hand-edits `cron_folders.json` and introduces a typo in one folder (e.g. `"oder"` instead of `"order"`), then performs any subsequent folder operation, silently loses that folder — the only trace is a `logger.warning`.

## Why it matters

Silent, unrecoverable user-data loss triggered by a benign hand-edit. This diverges from the persistence-boundary contract already used for the hooks store, which preserves unparsed/malformed records across writes rather than overwriting bytes it could not parse.

## What changed (motivation → approach → change)

- **Symptom:** a hand-edited-but-typo'd folder disappears on the user's next folder operation.
- **Root cause:** `load_cron_folders` computes `valid` and assigns `self._cron_folders = valid`, discarding the rest; `save_cron_folders` then writes only `self._cron_folders`, so the dropped entries' bytes are overwritten.
- **Change:** dropped entries are now captured verbatim in a new `_unparsed_cron_folder_entries` list and appended back by `save_cron_folders`, mirroring the hooks store's unparsed-entry contract. The **active** in-memory list stays valid-only (a non-string `name` would crash Schedule-page grouping), so nothing malformed ever reaches the frontend; and once the user repairs the file, the entries reload as active on the next boot. `save_cron_folders` reads the field via `getattr` so states constructed without `__init__` (tests, some boot paths) still persist correctly.

## Tests

- `test_load_keeps_malformed_entries_inactive` — malformed entries are excluded from the active list but preserved verbatim in `_unparsed_cron_folder_entries` (10 of 12 sample entries).
- `test_malformed_entry_survives_a_subsequent_save` — the regression: a typo'd folder survives a later `create_cron_folder` instead of being erased. Verified via the repo's `prove.py` (reverting the fix makes this test fail: `PROVEN`).
- `test_no_unparsed_entries_leaves_payload_clean` — a clean file persists exactly the active list with no sentinel padding.
- The prior `test_load_drops_malformed_entries` is replaced by the preservation-oriented test above.

## Manual verification

N/A — unit coverage sufficient. The behavior is a pure backend load/save round-trip fully exercised by the tests above, including a revert-proof (`prove.py`).

## Related Issues

Fixes #5764

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to `cron_folders.json` load/save; no rendered UI delta.
