### PR TITLE
fix(apple-speech): clean rejected transcode temps

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -508,30 +508,36 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
     # `tempfile.mkstemp` is the heavier half — it creates a file — and leaving it
     # on the loop while offloading only the close would be the worse split.
     out = await asyncio.to_thread(_mkstemp_path, ".wav")
-    proc = await asyncio.create_subprocess_exec(
-        ffmpeg,
-        "-y",
-        "-i",
-        audio_path,
-        "-ar",
-        "16000",
-        "-ac",
-        "1",
-        out,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    _, err = await proc.communicate()
-    if proc.returncode != 0:
-        logger.warning(
-            "apple_speech: ffmpeg transcode failed: %s", err.decode(errors="replace")[-300:]
+    transfer_temp = False
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-y",
+            "-i",
+            audio_path,
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            out,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
         )
-        try:
-            os.unlink(out)
-        except OSError:
-            pass
-        return audio_path, False
-    return out, True
+        _, err = await proc.communicate()
+        if proc.returncode != 0:
+            logger.warning(
+                "apple_speech: ffmpeg transcode failed: %s",
+                err.decode(errors="replace")[-300:],
+            )
+            return audio_path, False
+        transfer_temp = True
+        return out, True
+    finally:
+        if not transfer_temp:
+            try:
+                os.unlink(out)
+            except OSError:
+                pass
 
 
 async def transcribe(
@@ -565,6 +571,11 @@ async def transcribe(
         argv, spawn_env, _sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
     except sandbox.SandboxUnavailableError as exc:
         logger.warning("apple_speech: %s%s", _NO_SANDBOX_HINT, exc)
+        if is_temp:
+            try:
+                os.unlink(native_path)
+            except OSError:
+                pass
         return None, {"error": f"{_NO_SANDBOX_HINT}{exc}"}
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -404,6 +404,47 @@ class TestTranscribePlumbing:
         assert (path, is_temp) == ("/tmp/voice.webm", False)
 
     @pytest.mark.asyncio
+    async def test_transcode_spawn_failure_removes_owned_temp(self, tmp_path):
+        """A failed ffmpeg spawn never transfers ownership of its output path."""
+        owned = tmp_path / "owned.wav"
+        owned.write_bytes(b"")
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch.object(apple_speech, "_mkstemp_path", return_value=str(owned)),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("spawn failed")),
+            pytest.raises(OSError, match="spawn failed"),
+        ):
+            await apple_speech._to_native_audio("/tmp/voice.webm")
+
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_rejection_removes_owned_native_temp(self, tmp_path):
+        """A pre-helper rejection still retires the transcode result we own."""
+        owned = tmp_path / "owned.wav"
+        owned.write_bytes(b"native")
+        with (
+            patch.object(
+                apple_speech, "availability", return_value=apple_speech.Availability(True)
+            ),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch.object(apple_speech, "_to_native_audio", return_value=(str(owned), True)),
+            patch.object(
+                apple_speech,
+                "_sandboxed",
+                side_effect=apple_speech.sandbox.SandboxUnavailableError(
+                    "unavailable", "no_backend", "test"
+                ),
+            ),
+        ):
+            text, meta = await apple_speech.transcribe("/tmp/voice.webm")
+
+        assert text is None
+        assert "unavailable" in meta["error"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
     async def test_helper_error_json_is_propagated(self):
         """The helper reports failures as JSON on stdout; that payload is the
         diagnostic the caller logs, so it must survive intact."""


### PR DESCRIPTION
## Problem / Motivation

Apple Speech creates an invocation-owned WAV before ffmpeg starts. Spawn/communication failures abandoned that path, and a sandbox rejection after transcoding returned before the existing helper cleanup block.

## Why it matters

No caller receives either rejected path, so repeated failures leak files with no surviving owner. Cleanup is safe only because each path is the direct result of this invocation's successful mkstemp allocation.

## What changed

- Keep ownership of a transcode temp until ffmpeg succeeds and the path is returned.
- Remove the exact owned temp on spawn, communication, non-zero, and cancellation exits.
- Retire an owned native temp when the speech-helper sandbox refuses the next stage.
- Never remove caller-provided native audio.

## Red-before evidence

Two focused cases failed on current main: the ffmpeg spawn failure and the pre-helper sandbox rejection both left their owned WAV behind.

## Tests

- test/test_apple_speech.py — 42 passed, 5 skipped
- focused ownership regressions — 2 passed after 2/2 red-before
- isort, flake8, touched-source mypy, scoped Black, and git diff --check passed

## Related Issues

Fixes #5758

## Checklist

- [x] One focused behavior change
- [x] Deterministic regression and ownership negative boundary
- [x] No caller-owned path cleanup
- [x] No secrets or unrelated files

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.