### PR TITLE
fix(voice): clean rejected stitch outputs

### DIFF
--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -646,10 +646,13 @@ async def stitch_mp3s(paths: list[str], output: str | None = None) -> str | None
             shutil.copy2(paths[0], output)
             return output
         return paths[0]
+    owns_output = False
     if output is None:
+        owns_output = True
         fd, output = tempfile.mkstemp(suffix=".mp3")
         os.close(fd)
     concat = "|".join(paths)
+    transfer_output = False
     try:
         proc = await asyncio.create_subprocess_exec(
             "ffmpeg",
@@ -665,10 +668,17 @@ async def stitch_mp3s(paths: list[str], output: str | None = None) -> str | None
         await asyncio.wait_for(proc.communicate(), timeout=30)
         if proc.returncode != 0 or not os.path.exists(output):
             return None
+        transfer_output = True
         return output
     except Exception:
         logger.exception("ffmpeg stitch failed")
         return None
+    finally:
+        if owns_output and not transfer_output:
+            try:
+                os.unlink(output)
+            except OSError:
+                pass
 
 
 async def streaming_voice_reply(

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -25,6 +25,7 @@ from kiro_crew.voice_reply import (
     _validate_rate,
     is_available,
     split_sentences,
+    stitch_mp3s,
     strip_markdown,
     synthesize_speech,
     text_to_ssml,
@@ -32,6 +33,34 @@ from kiro_crew.voice_reply import (
     validate_length_scale,
     voice_reply,
 )
+
+
+class TestStitchMp3sOwnership:
+    @pytest.mark.asyncio
+    async def test_spawn_failure_removes_internally_allocated_output(self, tmp_path) -> None:
+        owned = tmp_path / "owned.mp3"
+        fd = os.open(owned, os.O_CREAT | os.O_WRONLY)
+        with (
+            patch("kiro_crew.voice_reply.tempfile.mkstemp", return_value=(fd, str(owned))),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("ffmpeg missing")),
+        ):
+            assert await stitch_mp3s(["first.mp3", "second.mp3"]) is None
+
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_preserves_caller_owned_output(self, tmp_path) -> None:
+        caller_output = tmp_path / "caller.mp3"
+        caller_output.write_bytes(b"keep")
+        with patch("asyncio.create_subprocess_exec", side_effect=OSError("ffmpeg missing")):
+            assert (
+                await stitch_mp3s(
+                    ["first.mp3", "second.mp3"], output=str(caller_output)
+                )
+                is None
+            )
+
+        assert caller_output.read_bytes() == b"keep"
 
 
 class TestStripMarkdown:


### PR DESCRIPTION
## Problem / Motivation

stitch_mp3s allocates its own MP3 output when the caller does not provide one. Every unsuccessful ffmpeg exit returned None without transferring the path, but left that output on disk.

## Why it matters

The abandoned file has no surviving owner and repeated dashboard voice failures accumulate it. Caller-provided output is a different ownership domain and must remain untouched.

## What changed

- Track whether the output came from this invocation's mkstemp call.
- Transfer an internally allocated output only after a successful stitch.
- Best-effort unlink the exact internal output on every unsuccessful exit.
- Preserve caller-supplied output paths on the same failures.

## Red-before evidence

The internal-output case failed because the owned MP3 remained; the caller-output negative control passed and proved the cleanup boundary.

## Tests

- test/test_voice_reply.py — 90 passed, 4 skipped
- test/test_chat_voice.py — 20 passed
- focused red-before — 1 failed / 1 ownership control passed; both pass after
- isort, flake8, touched-source mypy, scoped Black ratchet, and git diff --check passed

## Related Issues

Fixes #5759

## Checklist

- [x] One focused behavior change
- [x] Deterministic regression with caller-owned negative control
- [x] No caller-owned path cleanup
- [x] No secrets or unrelated files

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.