### PR TITLE
fix(computer-use): clean partial screenshot files

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -323,8 +323,9 @@ and touches no other application, so it is neither observe nor mutate). The
 class labels above are the code-owned `governance._CU_ACTION_CLASSES` table —
 see [governance.md](governance.md).
 
-Both spool writers (`service._persist_image` and `capture_macos.persist_jpeg`) name
-their files with `tempfile.mkstemp`, not a millisecond timestamp. `_shot_lock`
+The screenshot spool writers (`service._persist_image`, `capture_macos.persist_jpeg`,
+and `capture_windows.persist_jpeg`) name their files with `tempfile.mkstemp`, not a
+millisecond timestamp. `_shot_lock`
 serializes writers within one service instance but cannot serialize a second
 PROCESS — the gateway, the CLI and the permission-probe child all spool into the
 same `tempfile.gettempdir()` directory — so a timestamp-only name let two captures
@@ -333,7 +334,9 @@ leaving its caller holding a screenshot of an application it never asked about
 (a cross-capture pixel leak, reviewer finding). `mkstemp` also creates the file
 `0o600` from the outset, so there is no window in which it exists world-readable
 before `restrict_to_owner` runs. The timestamp stays in the *prefix* because the
-ring trim orders by name.
+ring trim orders by name. If a persistence write fails after allocation, the writer
+removes that exact invocation-owned path before returning no screenshot; a partial
+frame is never left in the spool without a caller that owns it.
 
 **`computer_list_apps` only omits an app it cannot name.** It used to carry a
 per-app governance filter (`gate.app_is_disclosable` against the `computer_use.apps`

--- a/src/kiro_crew/computer_use/capture_macos.py
+++ b/src/kiro_crew/computer_use/capture_macos.py
@@ -221,6 +221,8 @@ def persist_jpeg(raw: bytes) -> str:
     """
     if not raw:
         return ""
+    handle_fd: int | None = None
+    path = ""
     try:
         directory = ensure_shots_dir()
         # ATOMIC unique allocation, not a millisecond timestamp. The gateway
@@ -238,10 +240,22 @@ def persist_jpeg(raw: bytes) -> str:
         handle_fd, path = tempfile.mkstemp(
             prefix=prefix, suffix=SCREENSHOT_FILE_SUFFIX, dir=directory
         )
-        with os.fdopen(handle_fd, "wb") as handle:
+        handle = os.fdopen(handle_fd, "wb")
+        handle_fd = None
+        with handle:
             handle.write(raw)
     except OSError:
         logger.warning("could not persist computer-use screenshot", exc_info=True)
+        if handle_fd is not None:
+            try:
+                os.close(handle_fd)
+            except OSError:
+                pass
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
         return ""
     try:
         platform_compat.restrict_to_owner(path)

--- a/src/kiro_crew/computer_use/capture_windows.py
+++ b/src/kiro_crew/computer_use/capture_windows.py
@@ -408,16 +408,30 @@ def persist_jpeg(raw: bytes) -> str:
     """
     if not raw:
         return ""
+    handle_fd: int | None = None
+    path = ""
     try:
         directory = ensure_shots_dir()
         prefix = f"{SCREENSHOT_FILE_PREFIX}{int(time.time() * 1000)}-"
         handle_fd, path = tempfile.mkstemp(
             prefix=prefix, suffix=SCREENSHOT_FILE_SUFFIX, dir=directory
         )
-        with os.fdopen(handle_fd, "wb") as handle:
+        handle = os.fdopen(handle_fd, "wb")
+        handle_fd = None
+        with handle:
             handle.write(raw)
     except OSError:
         logger.warning("could not persist computer-use screenshot", exc_info=True)
+        if handle_fd is not None:
+            try:
+                os.close(handle_fd)
+            except OSError:
+                pass
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
         return ""
     try:
         platform_compat.restrict_to_owner(path)

--- a/test/test_computer_use_capture.py
+++ b/test/test_computer_use_capture.py
@@ -278,6 +278,20 @@ def test_persist_returns_empty_when_the_write_fails(spool: Path, monkeypatch: py
     assert capture_macos.persist_jpeg(_JPEG) == ""
 
 
+def test_persist_removes_the_owned_file_when_write_fails(
+    spool: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Allocation succeeded, so a rejected write has one exact owned path."""
+
+    def _fail_after_allocation(fd, *args, **kwargs):
+        os.close(fd)
+        raise OSError("disk full")
+
+    monkeypatch.setattr(capture_macos.os, "fdopen", _fail_after_allocation)
+    assert capture_macos.persist_jpeg(_JPEG) == ""
+    assert _spooled(spool) == []
+
+
 def test_frame_names_never_collide_even_within_one_millisecond(
     spool: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/test/test_computer_use_capture_windows.py
+++ b/test/test_computer_use_capture_windows.py
@@ -488,6 +488,19 @@ class TestPersistJpeg:
         monkeypatch.setattr(C, "ensure_shots_dir", boom)
         assert C.persist_jpeg(b"JPEGBYTES") == ""
 
+    def test_a_failed_write_removes_the_owned_file(self, monkeypatch, tmp_path) -> None:
+        """A file allocated by this call must not survive a rejected write."""
+
+        def fail_after_allocation(fd, *args, **kwargs):
+            C.os.close(fd)
+            raise OSError("disk full")
+
+        monkeypatch.setattr(C, "shots_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(C, "_dir_ready", True)
+        monkeypatch.setattr(C.os, "fdopen", fail_after_allocation)
+        assert C.persist_jpeg(b"JPEGBYTES") == ""
+        assert list(tmp_path.iterdir()) == []
+
 
 class TestEnsureShotsDir:
     def test_it_creates_the_directory_owner_only(self, monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Problem / Motivation

The macOS and Windows persist_jpeg implementations allocate a unique JPEG with mkstemp, then degrade to an empty result when fdopen or the write fails. The invocation-owned partial file remained in the screenshot spool even though no caller received its path.

## Why it matters

A partial screenshot can contain sensitive screen pixels. It is both orphaned and retained in a persistent ring without any successful observation owning it.

## What changed

- Track the descriptor and exact path after successful allocation.
- Close a descriptor if fdopen itself fails.
- Remove only the exact invocation-owned JPEG on persistence failure.
- Keep successful screenshots, per-file tightening, and ring trimming unchanged.
- Document the spool ownership/failure contract for macOS and Windows.

## Red-before evidence

Both platform implementations returned an empty path but left one allocated JPEG behind: 2/2 focused failures.

## Tests

- test/test_computer_use_capture.py + test/test_computer_use_capture_windows.py — 137 passed
- focused ownership regressions — 2 passed after 2/2 red-before
- isort, flake8, touched-source mypy, scoped Black, docs-lint, and git diff --check passed

## Related Issues

Fixes #5760

## Checklist

- [x] macOS/Windows parity
- [x] Deterministic regression at the post-allocation write seam
- [x] Exact-path cleanup only
- [x] Owning system spec updated

## Contribution License Agreement

N/A — project CLA wording is not yet supplied.