### PR TITLE
fix: unlink the mkstemp frame when a screenshot write fails (#5760)

### DIFF
--- a/src/kiro_crew/computer_use/capture_macos.py
+++ b/src/kiro_crew/computer_use/capture_macos.py
@@ -238,10 +238,51 @@ def persist_jpeg(raw: bytes) -> str:
         handle_fd, path = tempfile.mkstemp(
             prefix=prefix, suffix=SCREENSHOT_FILE_SUFFIX, dir=directory
         )
-        with os.fdopen(handle_fd, "wb") as handle:
+    except OSError:
+        # Allocation itself failed — ``mkstemp`` raised, so no file exists and
+        # there is nothing to remove.
+        logger.warning("could not persist computer-use screenshot", exc_info=True)
+        return ""
+    try:
+        handle = os.fdopen(handle_fd, "wb")
+    except OSError:
+        logger.warning(
+            "could not write computer-use screenshot; removing the partial frame",
+            exc_info=True,
+        )
+        # ``fdopen`` raised before adopting the descriptor (fd pressure), so
+        # nothing will ever close it — close it here, or the unlink below fails
+        # on Windows, which refuses to remove a file with an open handle. This
+        # is the ONLY branch that may close the raw fd: once ``fdopen`` returns,
+        # the file object owns it, and a second ``os.close`` on the number could
+        # hit an unrelated descriptor another executor thread was just handed.
+        try:
+            os.close(handle_fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return ""
+    try:
+        with handle:
             handle.write(raw)
     except OSError:
-        logger.warning("could not persist computer-use screenshot", exc_info=True)
+        logger.warning(
+            "could not write computer-use screenshot; removing the partial frame",
+            exc_info=True,
+        )
+        # The ``mkstemp`` above succeeded, so this invocation owns *path* and no
+        # caller will ever receive it — without the unlink the partially-written
+        # frame (which can hold sensitive screen pixels) sits in the spool as an
+        # orphan until the ring trim happens to reach it. Best-effort: cleanup
+        # must never mask the original failure. The ``with`` has already closed
+        # the descriptor; do NOT close the fd number again (see above).
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
         return ""
     try:
         platform_compat.restrict_to_owner(path)

--- a/src/kiro_crew/computer_use/capture_windows.py
+++ b/src/kiro_crew/computer_use/capture_windows.py
@@ -414,10 +414,51 @@ def persist_jpeg(raw: bytes) -> str:
         handle_fd, path = tempfile.mkstemp(
             prefix=prefix, suffix=SCREENSHOT_FILE_SUFFIX, dir=directory
         )
-        with os.fdopen(handle_fd, "wb") as handle:
+    except OSError:
+        # Allocation itself failed — ``mkstemp`` raised, so no file exists and
+        # there is nothing to remove.
+        logger.warning("could not persist computer-use screenshot", exc_info=True)
+        return ""
+    try:
+        handle = os.fdopen(handle_fd, "wb")
+    except OSError:
+        logger.warning(
+            "could not write computer-use screenshot; removing the partial frame",
+            exc_info=True,
+        )
+        # ``fdopen`` raised before adopting the descriptor (fd pressure), so
+        # nothing will ever close it — close it here, or the unlink below fails
+        # on Windows, which refuses to remove a file with an open handle. This
+        # is the ONLY branch that may close the raw fd: once ``fdopen`` returns,
+        # the file object owns it, and a second ``os.close`` on the number could
+        # hit an unrelated descriptor another executor thread was just handed.
+        try:
+            os.close(handle_fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return ""
+    try:
+        with handle:
             handle.write(raw)
     except OSError:
-        logger.warning("could not persist computer-use screenshot", exc_info=True)
+        logger.warning(
+            "could not write computer-use screenshot; removing the partial frame",
+            exc_info=True,
+        )
+        # The ``mkstemp`` above succeeded, so this invocation owns *path* and no
+        # caller will ever receive it — without the unlink the partially-written
+        # frame (which can hold sensitive screen pixels) sits in the spool as an
+        # orphan until the ring trim happens to reach it. Best-effort: cleanup
+        # must never mask the original failure. The ``with`` has already closed
+        # the descriptor; do NOT close the fd number again (see above).
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
         return ""
     try:
         platform_compat.restrict_to_owner(path)

--- a/test/test_computer_use_capture.py
+++ b/test/test_computer_use_capture.py
@@ -278,6 +278,104 @@ def test_persist_returns_empty_when_the_write_fails(spool: Path, monkeypatch: py
     assert capture_macos.persist_jpeg(_JPEG) == ""
 
 
+def test_a_failed_write_removes_the_partial_frame(spool: Path, monkeypatch: pytest.MonkeyPatch):
+    """A write failure must not strand the just-allocated frame in the spool.
+
+    ``mkstemp`` succeeds and the SUBSEQUENT write raises: the caller is handed
+    ``""`` and can never learn the path, so a leftover here is an invisible,
+    partially-written file of the operator's screen pixels that nothing owns —
+    it sits in the spool until the ring trim happens to reach it. The path is
+    this invocation's own allocation, so removing exactly it is safe.
+    """
+    allocated: list[str] = []
+    allocated_fds: list[int] = []
+    real_mkstemp = capture_macos.tempfile.mkstemp
+
+    def _recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        allocated_fds.append(fd)
+        allocated.append(path)
+        return fd, path
+
+    closed_by_os_close: list[int] = []
+    real_close = capture_macos.os.close
+
+    def _recording_close(fd):
+        closed_by_os_close.append(fd)
+        real_close(fd)
+
+    real_fdopen = capture_macos.os.fdopen
+
+    def _failing_fdopen(fd, *args, **kwargs):
+        handle = real_fdopen(fd, *args, **kwargs)
+
+        class _FailingHandle:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                # Close like the real ``with`` would, so the unlink under test
+                # runs against a closed file — the same state Windows requires.
+                handle.close()
+                return False
+
+            def write(self, data):
+                raise OSError("disk full")
+
+        return _FailingHandle()
+
+    monkeypatch.setattr(capture_macos.tempfile, "mkstemp", _recording_mkstemp)
+    monkeypatch.setattr(capture_macos.os, "fdopen", _failing_fdopen)
+    monkeypatch.setattr(capture_macos.os, "close", _recording_close)
+    assert capture_macos.persist_jpeg(_JPEG) == ""
+    assert allocated, "the seam never allocated a file, so the test exercised nothing"
+    assert not Path(allocated[0]).exists()
+    assert _spooled(spool) == []
+    # ``fdopen`` ADOPTED the descriptor, so the ``with`` owns closing it. An
+    # explicit ``os.close`` on the raw number here would be a double-close that
+    # can hit an unrelated descriptor another thread was just handed.
+    assert not (set(allocated_fds) & set(closed_by_os_close))
+
+
+def test_a_failed_fdopen_closes_the_fd_and_removes_the_frame(
+    spool: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``fdopen`` raising BEFORE adopting the fd must not leak it or the file.
+
+    Nothing else will ever close that descriptor, and Windows refuses to unlink
+    a file with an open handle — so this branch (and only this branch) closes
+    the raw fd before the unlink.
+    """
+    allocated: list[str] = []
+    allocated_fds: list[int] = []
+    real_mkstemp = capture_macos.tempfile.mkstemp
+
+    def _recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        allocated_fds.append(fd)
+        allocated.append(path)
+        return fd, path
+
+    closed_by_os_close: list[int] = []
+    real_close = capture_macos.os.close
+
+    def _recording_close(fd):
+        closed_by_os_close.append(fd)
+        real_close(fd)
+
+    def _boom_fdopen(fd, *args, **kwargs):
+        raise OSError("out of file descriptors")
+
+    monkeypatch.setattr(capture_macos.tempfile, "mkstemp", _recording_mkstemp)
+    monkeypatch.setattr(capture_macos.os, "fdopen", _boom_fdopen)
+    monkeypatch.setattr(capture_macos.os, "close", _recording_close)
+    assert capture_macos.persist_jpeg(_JPEG) == ""
+    assert allocated, "the seam never allocated a file, so the test exercised nothing"
+    assert not Path(allocated[0]).exists()
+    assert _spooled(spool) == []
+    assert closed_by_os_close.count(allocated_fds[0]) == 1
+
+
 def test_frame_names_never_collide_even_within_one_millisecond(
     spool: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/test/test_computer_use_capture_windows.py
+++ b/test/test_computer_use_capture_windows.py
@@ -488,6 +488,108 @@ class TestPersistJpeg:
         monkeypatch.setattr(C, "ensure_shots_dir", boom)
         assert C.persist_jpeg(b"JPEGBYTES") == ""
 
+    def test_a_failed_write_removes_the_partial_frame(self, monkeypatch, tmp_path) -> None:
+        """A write failure must not strand the just-allocated frame in the spool.
+
+        ``mkstemp`` succeeds and the SUBSEQUENT write raises: the caller is handed
+        ``""`` and can never learn the path, so a leftover here is an invisible,
+        partially-written file of the operator's screen pixels that nothing owns.
+        The path is this invocation's own allocation, so removing exactly it is
+        safe — pre-existing frames are untouched.
+        """
+        allocated: list[str] = []
+        allocated_fds: list[int] = []
+        real_mkstemp = C.tempfile.mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            allocated_fds.append(fd)
+            allocated.append(path)
+            return fd, path
+
+        closed_by_os_close: list[int] = []
+        real_close = C.os.close
+
+        def recording_close(fd):
+            closed_by_os_close.append(fd)
+            real_close(fd)
+
+        real_fdopen = C.os.fdopen
+
+        def failing_fdopen(fd, *args, **kwargs):
+            handle = real_fdopen(fd, *args, **kwargs)
+
+            class _FailingHandle:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    # Close like the real ``with`` would, so the unlink under
+                    # test runs against a closed file — the state Windows needs.
+                    handle.close()
+                    return False
+
+                def write(self, data):
+                    raise OSError("disk full")
+
+            return _FailingHandle()
+
+        monkeypatch.setattr(C, "shots_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(C, "trim_shots_dir", lambda: None)
+        monkeypatch.setattr(C, "_dir_ready", True)
+        monkeypatch.setattr(C.tempfile, "mkstemp", recording_mkstemp)
+        monkeypatch.setattr(C.os, "fdopen", failing_fdopen)
+        monkeypatch.setattr(C.os, "close", recording_close)
+        assert C.persist_jpeg(b"JPEGBYTES") == ""
+        assert allocated, "the seam never allocated a file, so the test exercised nothing"
+        assert not pathlib.Path(allocated[0]).exists()
+        assert list(tmp_path.iterdir()) == []
+        # ``fdopen`` ADOPTED the descriptor, so the ``with`` owns closing it. An
+        # explicit ``os.close`` on the raw number here would be a double-close
+        # that can hit an unrelated descriptor another thread was just handed.
+        assert not (set(allocated_fds) & set(closed_by_os_close))
+
+    def test_a_failed_fdopen_closes_the_fd_and_removes_the_frame(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """``fdopen`` raising BEFORE adopting the fd must not leak it or the file.
+
+        Nothing else will ever close that descriptor, and Windows refuses to
+        unlink a file with an open handle — so this branch (and only this
+        branch) closes the raw fd before the unlink.
+        """
+        allocated: list[str] = []
+        allocated_fds: list[int] = []
+        real_mkstemp = C.tempfile.mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            allocated_fds.append(fd)
+            allocated.append(path)
+            return fd, path
+
+        closed_by_os_close: list[int] = []
+        real_close = C.os.close
+
+        def recording_close(fd):
+            closed_by_os_close.append(fd)
+            real_close(fd)
+
+        def boom_fdopen(fd, *args, **kwargs):
+            raise OSError("out of file descriptors")
+
+        monkeypatch.setattr(C, "shots_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(C, "trim_shots_dir", lambda: None)
+        monkeypatch.setattr(C, "_dir_ready", True)
+        monkeypatch.setattr(C.tempfile, "mkstemp", recording_mkstemp)
+        monkeypatch.setattr(C.os, "fdopen", boom_fdopen)
+        monkeypatch.setattr(C.os, "close", recording_close)
+        assert C.persist_jpeg(b"JPEGBYTES") == ""
+        assert allocated, "the seam never allocated a file, so the test exercised nothing"
+        assert not pathlib.Path(allocated[0]).exists()
+        assert list(tmp_path.iterdir()) == []
+        assert closed_by_os_close.count(allocated_fds[0]) == 1
+
 
 class TestEnsureShotsDir:
     def test_it_creates_the_directory_owner_only(self, monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Both `persist_jpeg()` implementations (`src/kiro_crew/computer_use/capture_macos.py` and `capture_windows.py`) allocate the screenshot file with `mkstemp` and then write into it inside the same `try` block. (The module has a third spool writer with the same shape, `service.py::_persist_image` — currently latent, deliberately out of this PR's scope, tracked as #5775.) When the write raises `OSError` (disk full, quota, I/O error), the caller is handed an empty path — but the just-allocated file stays in the spool as a partially-written orphan. No caller ever receives its path, yet it can contain sensitive screen pixels, and it lingers until the ring trim happens to reach it.

## Why it matters

The spool holds pixels of the operator's own windows. A file that nothing owns and nothing reports defeats the module's own hygiene posture: it is invisible to the caller, unaccounted for by the observation, and survives on disk exactly in the failure scenarios (disk pressure) where the spool is least likely to be trimmed promptly.

## What changed (motivation → approach → change)

Symptom: a failed write returns `""` but leaves the frame on disk. Root cause: allocation (`mkstemp`) and write (`fdopen` + `write`) share one `try`, so the failure handler cannot distinguish "no file was created" from "a file was created and abandoned".

The change splits the two phases in both implementations:

- **Allocation failure** (`mkstemp` itself raises): unchanged behaviour — warn and return `""`; no file exists, nothing to remove.
- **Write failure** (post-allocation): two sub-branches. `fdopen` itself raising (fd was never adopted by a file object): best-effort `os.close(handle_fd)` — nothing else will ever close it, and Windows refuses to unlink a file with an open handle — then best-effort `os.unlink(path)`. The write raising: the `with` already closed the descriptor, so the branch ONLY unlinks — an explicit close of the raw fd number there could hit an unrelated descriptor another executor thread was just handed (fd reuse). Both branches return `""` and swallow secondary `OSError`s so cleanup never masks the original failure. Both cleanups swallow a secondary `OSError` so cleanup never masks the original failure. The path is exactly this invocation's own `mkstemp` result, so the cleanup is bounded to it — pre-existing frames and caller-supplied paths are untouched.

Successful writes, the per-file `restrict_to_owner`, and ring-trim behaviour are unchanged. The write-failure branch also gets a distinct log message (`could not write … removing the partial frame`) so an operator can tell from the log whether a file was created and cleaned up or never existed.

## Tests

One deterministic red-before test per implementation (both failed on the pre-fix code at exactly the orphan-file assertion, then passed post-fix):

- `test/test_computer_use_capture.py::test_a_failed_write_removes_the_partial_frame` — records the `mkstemp`-allocated path, forces the post-allocation write to raise `OSError` through the existing monkeypatch seams, and asserts (a) `persist_jpeg` returns `""`, (b) the allocated file no longer exists, (c) the spool is empty.
- `test/test_computer_use_capture_windows.py::TestPersistJpeg::test_a_failed_write_removes_the_partial_frame` — same shape through the Windows module's existing fakes (`shots_dir`/`trim_shots_dir`/`_dir_ready` seams). The failing-handle stub closes the descriptor in `__exit__` like the real `with` would, so the unlink under test runs against a closed file — the state Windows requires. Both write-failure tests also record every `os.close` call and assert the adopted fd is never re-closed (mutation-verified: re-adding the unconditional close turns them red). A second test per implementation forces `fdopen` itself to raise and asserts the never-adopted fd is closed exactly once and the allocated file removed.

## Manual verification

N/A — unit coverage sufficient: the failure branch is fully deterministic under the test seams, and the success path is pinned by the existing 137 tests in the two capture test modules (all pass).

## Related Issues

Closes #5760

Follow-up for the third spool writer (`service.py::_persist_image`, same defect class, latent): #5775

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: `docs/system-specs/modules/computer-use.md` constrains only spool naming and creation mode, both preserved verbatim
- [x] No secrets, credentials, or internal references in the diff


