### PR TITLE
fix: remove owned transcode temps on pre-helper failure paths (#5758)

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -508,20 +508,50 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
     # `tempfile.mkstemp` is the heavier half — it creates a file — and leaving it
     # on the loop while offloading only the close would be the worse split.
     out = await asyncio.to_thread(_mkstemp_path, ".wav")
-    proc = await asyncio.create_subprocess_exec(
-        ffmpeg,
-        "-y",
-        "-i",
-        audio_path,
-        "-ar",
-        "16000",
-        "-ac",
-        "1",
-        out,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    _, err = await proc.communicate()
+    # The `.wav` stays invocation-owned until the success return below hands it
+    # to the caller. A spawn failure or a cancellation (`CancelledError` is a
+    # `BaseException`, so `except Exception` would miss it) never transfers
+    # ownership, so remove the temp before propagating. Stop AND reap a live
+    # ffmpeg first: Windows keeps the output file locked until the child fully
+    # exits (the unlink would fail and the temp would survive), and on POSIX a
+    # still-running child can race the removal. Every cleanup step is
+    # best-effort — the exception in flight is the one that must surface.
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-y",
+            "-i",
+            audio_path,
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            out,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _, err = await proc.communicate()
+        except BaseException:
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass
+            else:
+                try:
+                    await proc.communicate()
+                except BaseException:
+                    # A repeat cancellation can land on this await; swallow it
+                    # so the unlink below still runs and the ORIGINAL exception
+                    # is the one that propagates.
+                    pass
+            raise
+    except BaseException:
+        try:
+            os.unlink(out)
+        except OSError:
+            pass
+        raise
     if proc.returncode != 0:
         logger.warning(
             "apple_speech: ffmpeg transcode failed: %s", err.decode(errors="replace")[-300:]
@@ -556,34 +586,39 @@ async def transcribe(
         return None, {"error": "speech helper could not be built"}
 
     native_path, is_temp = await _to_native_audio(audio_path)
-    argv = [helper, "--locale", locale]
-    if install:
-        argv.append("--install")
-    argv.append(native_path)
+    # When `is_temp` is true this invocation owns the transcode temp from here
+    # on, so every exit — the sandbox rejection included — must route through
+    # the cleanup `finally` below. An original input (`is_temp` false) is the
+    # caller's file and is never removed on any path.
+    try:
+        argv = [helper, "--locale", locale]
+        if install:
+            argv.append("--install")
+        argv.append(native_path)
 
-    try:
-        argv, spawn_env, _sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
-    except sandbox.SandboxUnavailableError as exc:
-        logger.warning("apple_speech: %s%s", _NO_SANDBOX_HINT, exc)
-        return None, {"error": f"{_NO_SANDBOX_HINT}{exc}"}
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            env=spawn_env,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
-        except asyncio.TimeoutError:
+            argv, spawn_env, _sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
+        except sandbox.SandboxUnavailableError as exc:
+            logger.warning("apple_speech: %s%s", _NO_SANDBOX_HINT, exc)
+            return None, {"error": f"{_NO_SANDBOX_HINT}{exc}"}
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                env=spawn_env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
             try:
-                proc.kill()
-                await proc.communicate()
-            except (OSError, ProcessLookupError):
-                pass
-            return None, {"error": f"timed out after {timeout_secs}s"}
-    except OSError as exc:
-        return None, {"error": f"could not run speech helper: {exc}"}
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.communicate()
+                except (OSError, ProcessLookupError):
+                    pass
+                return None, {"error": f"timed out after {timeout_secs}s"}
+        except OSError as exc:
+            return None, {"error": f"could not run speech helper: {exc}"}
     finally:
         if is_temp:
             try:

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -8,6 +8,7 @@ fallback), and one genuine end-to-end run marked macOS-only.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import os
@@ -464,6 +465,158 @@ class TestTranscribePlumbing:
             text, meta = await apple_speech.transcribe("/tmp/x.wav")
         assert text == "hello there"
         assert meta["transcribe_secs"] == 0.15
+
+
+class TestTranscodeTempOwnership:
+    """The transcode temp is invocation-owned until explicitly handed over.
+
+    `_to_native_audio` creates the `.wav` with `mkstemp`, so it owns the file
+    until the success return transfers it to the caller; `transcribe` then owns
+    the received temp until its cleanup `finally`. Every failure exit on either
+    side must remove the owned temp, while an original input path — not created
+    by these invocations — is never removed on any path.
+    """
+
+    @staticmethod
+    def _owned_temp(tmp_path, monkeypatch):
+        """Pin `_mkstemp_path` to a known file so the tests can watch it."""
+        owned = tmp_path / "owned.wav"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(apple_speech, "_mkstemp_path", lambda suffix: str(owned))
+        return owned
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_removes_the_owned_temp(self, tmp_path, monkeypatch):
+        """An ffmpeg that fails to spawn never ran, so nothing else will ever
+        remove the mkstemp output — the invocation must."""
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("spawn failed")),
+        ):
+            with pytest.raises(OSError):
+                await apple_speech._to_native_audio(str(src))
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_ffmpeg_before_removing_the_owned_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """`CancelledError` is a `BaseException`, so an `except Exception` guard
+        would miss it. The child must also be killed AND reaped before the
+        unlink: Windows keeps the output file locked until the child fully
+        exits, so an unlink issued earlier fails and the temp survives."""
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        events: list[str] = []
+
+        class _Proc:
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise asyncio.CancelledError()
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        real_unlink = os.unlink
+
+        def tracked_unlink(path, *args, **kwargs):
+            if str(path) == str(owned):
+                events.append("unlinked")
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(apple_speech.os, "unlink", tracked_unlink)
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("asyncio.create_subprocess_exec", return_value=_Proc()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await apple_speech._to_native_audio(str(src))
+        assert events == ["killed", "reaped", "unlinked"]
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_successful_transcode_still_hands_the_temp_to_the_caller(
+        self, tmp_path, monkeypatch
+    ):
+        """The cleanup must not eat the success path: the caller's existing
+        cleanup relies on receiving the temp path with ownership."""
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            path, is_temp = await apple_speech._to_native_audio(str(src))
+        assert (path, is_temp) == (str(owned), True)
+        assert owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_rejection_removes_the_owned_native_temp(self, tmp_path, monkeypatch):
+        """The fail-closed sandbox refusal returns after `transcribe` received an
+        owned temp but used to exit before the cleanup `finally` was armed."""
+        from kiro_crew import sandbox as sb
+
+        owned = tmp_path / "native.wav"
+        owned.write_bytes(b"x")
+
+        async def fake_native(_path):
+            return str(owned), True
+
+        def boom(argv):
+            raise sb.SandboxUnavailableError(
+                "no backend: unshare(CLONE_NEWNS) EPERM", "no_backend", "EPERM"
+            )
+
+        monkeypatch.setattr(apple_speech, "_to_native_audio", fake_native)
+        monkeypatch.setattr(apple_speech, "availability", lambda: apple_speech.Availability(True))
+        monkeypatch.setattr(apple_speech, "helper_path", lambda *a, **k: "/fake/helper")
+        monkeypatch.setattr(apple_speech, "_sandboxed", boom)
+        text, meta = await apple_speech.transcribe(str(tmp_path / "orig.webm"))
+        assert text is None
+        assert "no backend" in meta["error"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_sandbox_rejection_never_removes_an_original_input(self, tmp_path, monkeypatch):
+        """A non-temp native path is the caller's own file; the widened cleanup
+        must stay keyed on the ownership flag, not on reaching the exit."""
+        from kiro_crew import sandbox as sb
+
+        original = tmp_path / "voice.wav"
+        original.write_bytes(b"x")
+
+        def boom(argv):
+            raise sb.SandboxUnavailableError(
+                "no backend: unshare(CLONE_NEWNS) EPERM", "no_backend", "EPERM"
+            )
+
+        monkeypatch.setattr(apple_speech, "availability", lambda: apple_speech.Availability(True))
+        monkeypatch.setattr(apple_speech, "helper_path", lambda *a, **k: "/fake/helper")
+        monkeypatch.setattr(apple_speech, "_sandboxed", boom)
+        text, meta = await apple_speech.transcribe(str(original))
+        assert text is None
+        assert "no backend" in meta["error"]
+        assert original.exists()
 
 
 class TestStreamingSession:


### PR DESCRIPTION
## Summary

`_to_native_audio()` creates its output `.wav` with `mkstemp` before spawning ffmpeg. A spawn failure or a cancellation of `communicate()` propagated without ever transferring the path to the caller or removing it, leaking the invocation-owned temp. `transcribe()` had a second pre-helper seam: the fail-closed sandbox rejection returned after receiving an owned native temp but before the cleanup `finally` was armed.

- `_to_native_audio()`: any raise or cancellation (`CancelledError` is a `BaseException`, so an `except Exception` guard would miss it) now kills AND reaps a live ffmpeg, then unlinks the owned temp best-effort before re-raising. The reap runs before the unlink because Windows keeps the output file locked until the child fully exits, and a POSIX child can race the removal; the reap await is guarded so a repeat cancellation still reaches the unlink and the original exception propagates.
- `transcribe()`: the cleanup `try`/`finally` now begins at ownership receipt, so the `SandboxUnavailableError` early-return routes through it. The guard stays keyed on `is_temp`, so original input paths are never removed on any path.
- Successful transcodes still return the temp path to the caller unchanged (the caller's existing cleanup owns it from there).

Closes #5758

## Tests

`test/test_apple_speech.py::TestTranscodeTempOwnership` (5 deterministic regressions):
- spawn failure removes the owned temp, original input survives
- cancellation kills → reaps → unlinks in that order (stateful fake process + tracked `os.unlink`)
- successful transcode still hands the temp to the caller
- sandbox rejection removes an owned native temp
- sandbox rejection never removes an original (non-temp) input

Mutation-verified: with the source fix reverted, the three failure-seam tests fail; with only the reap removed, the ordering test fails. Full local gates green: black gate, subprocess-encoding, isort, flake8 7.1.0, mypy 1.14.1, brand check; `python -m pytest` 67617 passed (4 failures are pre-existing host-environment issues, reproduced identically on unmodified main).

## Review disposition (pre-push lanes)

- GPT (gpt-5.6-sol), 1 Medium: unlink could fire before the killed ffmpeg exited (Windows file lock) — **fixed** (reap before unlink) with an ordering regression.
- Opus (claude-opus-5), 1 HIGH: `sandboxed_spawn_argv`'s documented MUST-unlink `cleanup_path` is discarded at all three `apple_speech` call sites — **pre-existing class**, not introduced or worsened by this diff; dispositioned per the reviewer's own alternative as follow-up #5776 to keep this PR single-purpose. Advisory nits (comment precision, hardcoded `/tmp` path in a test) taken.

<!-- no-visual-delta --> Backend-only change; no UI surface.