### PR TITLE
fix(schedule): validate cron-folder URL folder_id on PATCH and DELETE

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -1401,6 +1401,10 @@ async def api_cron_folders_update(request: web.Request) -> web.Response:
     """PATCH /api/cron-folders/{folder_id} — rename a cron folder."""
     state: DashboardState = request.app["state"]
     folder_id = request.match_info["folder_id"]
+    if not folder_id or len(folder_id) > MAX_SHORT_STRING:
+        return web.json_response(
+            {"error": "invalid folder_id format", "code": "invalid_folder_id"}, status=400
+        )
     try:
         body = await request.json()
     except Exception:
@@ -1435,6 +1439,10 @@ async def api_cron_folders_delete(request: web.Request) -> web.Response:
     """DELETE /api/cron-folders/{folder_id} — delete folder and clear assignments."""
     state: DashboardState = request.app["state"]
     folder_id = request.match_info["folder_id"]
+    if not folder_id or len(folder_id) > MAX_SHORT_STRING:
+        return web.json_response(
+            {"error": "invalid folder_id format", "code": "invalid_folder_id"}, status=400
+        )
     async with _get_cron_folders_lock():
         try:
             found = await asyncio.to_thread(state.delete_cron_folder, folder_id)

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -20,6 +20,7 @@ from kiro_crew.dashboard.handlers.cron import (
     api_cron_folders_update,
 )
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.validation import MAX_SHORT_STRING
 
 
 @pytest.fixture(autouse=True)
@@ -160,6 +161,33 @@ class TestCronFoldersUpdate:
         assert resp.status == 404
 
     @pytest.mark.asyncio
+    async def test_rename_rejects_oversized_folder_id(self, tmp_path):
+        """An over-long URL path folder_id is rejected with 400 before any
+        lock/thread/state work — parity with the body-param guard on the job
+        routes."""
+        state = _make_state(tmp_path)
+        state.rename_cron_folder = MagicMock(return_value=None)
+        request = _request(
+            state,
+            body={"name": "X"},
+            match_info={"folder_id": "a" * (MAX_SHORT_STRING + 1)},
+        )
+        resp = await api_cron_folders_update(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_folder_id"
+        state.rename_cron_folder.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rename_rejects_empty_folder_id(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.rename_cron_folder = MagicMock(return_value=None)
+        request = _request(state, body={"name": "X"}, match_info={"folder_id": ""})
+        resp = await api_cron_folders_update(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_folder_id"
+        state.rename_cron_folder.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_rename_save_failure_returns_500_and_rolls_back(self, tmp_path):
         """When persistence fails on rename, returns 500."""
         state = _make_state(tmp_path)
@@ -192,6 +220,28 @@ class TestCronFoldersDelete:
         request = _request(state, match_info={"folder_id": "nope"})
         resp = await api_cron_folders_delete(request)
         assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_oversized_folder_id(self, tmp_path):
+        """An over-long URL path folder_id is rejected with 400 before any
+        lock/thread/state work — parity with the body-param guard."""
+        state = _make_state(tmp_path)
+        state.delete_cron_folder = MagicMock(return_value=False)
+        request = _request(state, match_info={"folder_id": "a" * (MAX_SHORT_STRING + 1)})
+        resp = await api_cron_folders_delete(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_folder_id"
+        state.delete_cron_folder.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_empty_folder_id(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.delete_cron_folder = MagicMock(return_value=False)
+        request = _request(state, match_info={"folder_id": ""})
+        resp = await api_cron_folders_delete(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_folder_id"
+        state.delete_cron_folder.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_clears_folder_id_via_state_method(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

The `folder_id` supplied in the **request body** on the job routes (`POST /api/crons`, `PATCH /api/crons/{id}`) is validated for type and length (`MAX_SHORT_STRING`). The `folder_id` supplied as a **URL path parameter** on `PATCH /api/cron-folders/{folder_id}` and `DELETE /api/cron-folders/{folder_id}` had **no equivalent guard**: the router registers a bare `{folder_id}` with no regex constraint, and the handlers read `request.match_info["folder_id"]` and passed it straight into `rename_cron_folder` / `delete_cron_folder`.

## Why it matters

Asymmetric input-validation perimeter: the same logical value is guarded on one entry path and unguarded on another. An over-long or non-conforming id currently only results in a 404, but only after acquiring the folders lock, dispatching to a thread, iterating the full folder list, and potentially logging the oversized string. Future callers of `rename_cron_folder` / `delete_cron_folder` may not share that safety assumption.

## What changed (motivation → approach → change)

- **Gap:** the URL path `folder_id` on the folder rename/delete routes has no length/type guard, unlike the body param on the job routes.
- **Approach:** add the same guard the body param already uses, as a pre-flight check before any lock/thread work.
- **Change:** both `api_cron_folders_update` and `api_cron_folders_delete` now return `400 invalid_folder_id` when `folder_id` is empty or longer than `MAX_SHORT_STRING`, before acquiring `_cron_folders_lock` or dispatching to the state method. The change is exactly the 8 added lines — no reformatting of the surrounding file.

## Tests

- `test_rename_rejects_oversized_folder_id` / `test_rename_rejects_empty_folder_id` — PATCH returns 400 `invalid_folder_id` and `rename_cron_folder` is never called.
- `test_delete_rejects_oversized_folder_id` / `test_delete_rejects_empty_folder_id` — DELETE returns 400 `invalid_folder_id` and `delete_cron_folder` is never called.
- Verified via the repo's `prove.py` (reverting the guard makes these tests fail: `PROVEN`).

## Manual verification

N/A — unit coverage sufficient. Pure request-validation branch fully exercised by the tests above, including a revert-proof.

## Related Issues

Fixes #5765

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only request-validation guard; no rendered UI delta.
