### PR TITLE
feat(dashboard): dismiss the image viewer by dragging it down on touch

### DIFF
--- a/website/capture/lightbox-swipe.html
+++ b/website/capture/lightbox-swipe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Image viewer swipe-to-dismiss capture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/capture/lightbox-swipe.tsx"></script>
+  </body>
+</html>

--- a/website/capture/lightbox-swipe.tsx
+++ b/website/capture/lightbox-swipe.tsx
@@ -1,0 +1,117 @@
+/**
+ * Isolated capture entry for the image viewer's swipe-down-to-dismiss gesture.
+ *
+ * WHY ISOLATED: the behaviour under test is real input injection against real
+ * layout. The gesture only exists for a COARSE pointer, tracks the finger with a
+ * live transform, and its threshold is measured against the viewport — none of
+ * which happy-dom can observe (it computes no layout) and none of which a still
+ * unit test can show as motion. The live dashboard cannot stand in either: it is
+ * token-gated, and reaching a chat message with an image is many steps of setup
+ * the gesture does not depend on.
+ *
+ * The faithful part is the COMPONENT: the real `Lightbox` is imported and opened
+ * through the same `lightbox` CustomEvent `dispatchLightbox()` fires in
+ * production, so the overlay being dragged is exactly the shipped one.
+ *
+ * The subject image is an inline SVG data URI rather than a file, so the capture
+ * has no network dependency and renders identically on every machine.
+ *
+ * window.__swipe() reports the live gesture state — the wrapper's transform and
+ * the backdrop's computed background — so a capture run can assert the image
+ * actually moved instead of only producing a frame that looks plausible.
+ */
+import { useEffect } from 'react'
+import { createRoot } from 'react-dom/client'
+import { initI18n } from '../src/i18n'
+import { Lightbox } from '../src/components/MarkdownRenderer'
+import '../src/index.css'
+
+const params = new URLSearchParams(location.search)
+// Light by default ON PURPOSE: the overlay is `bg-black/80` in every theme, so a
+// bright page behind it is what makes the dim — and its fade during a drag —
+// legible in a still. A dark page behind a dark scrim shows nothing.
+const theme = params.get('theme') || 'light'
+
+document.documentElement.setAttribute('data-theme', theme === 'light' ? 'kiro-light' : 'kiro-dark')
+
+/** A stand-in "screenshot" with enough structure that a shrink or a translate is
+ *  visible at a glance, and enough contrast to read against the dimmed backdrop. */
+const SUBJECT = `data:image/svg+xml;utf8,${encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="1400" viewBox="0 0 900 1400">
+  <rect width="900" height="1400" fill="#0e1116"/>
+  <rect x="0" y="0" width="900" height="96" fill="#1b212b"/>
+  <circle cx="56" cy="48" r="18" fill="#7c5cff"/>
+  <rect x="92" y="38" width="220" height="20" rx="10" fill="#38404d"/>
+  <rect x="48" y="152" width="804" height="220" rx="18" fill="#151a22"/>
+  <rect x="80" y="188" width="420" height="22" rx="11" fill="#3d4756"/>
+  <rect x="80" y="228" width="640" height="16" rx="8" fill="#2b333f"/>
+  <rect x="80" y="258" width="560" height="16" rx="8" fill="#2b333f"/>
+  <rect x="80" y="288" width="600" height="16" rx="8" fill="#2b333f"/>
+  <rect x="48" y="416" width="804" height="420" rx="18" fill="#151a22"/>
+  <rect x="80" y="452" width="300" height="22" rx="11" fill="#3d4756"/>
+  <rect x="80" y="500" width="740" height="280" rx="12" fill="#10151c"/>
+  <rect x="112" y="540" width="380" height="14" rx="7" fill="#2b333f"/>
+  <rect x="112" y="576" width="520" height="14" rx="7" fill="#2b333f"/>
+  <rect x="112" y="612" width="300" height="14" rx="7" fill="#2b333f"/>
+  <rect x="112" y="648" width="460" height="14" rx="7" fill="#2b333f"/>
+  <rect x="48" y="880" width="804" height="220" rx="18" fill="#151a22"/>
+  <rect x="80" y="916" width="500" height="22" rx="11" fill="#3d4756"/>
+  <rect x="80" y="956" width="700" height="16" rx="8" fill="#2b333f"/>
+  <rect x="80" y="986" width="620" height="16" rx="8" fill="#2b333f"/>
+  <rect x="48" y="1144" width="804" height="200" rx="18" fill="#151a22"/>
+  <rect x="80" y="1180" width="360" height="22" rx="11" fill="#3d4756"/>
+  <rect x="80" y="1220" width="680" height="16" rx="8" fill="#2b333f"/>
+  <rect x="80" y="1250" width="540" height="16" rx="8" fill="#2b333f"/>
+</svg>`)}`
+
+interface SwipeState {
+  open: boolean
+  transform: string
+  backdrop: string
+}
+
+declare global {
+  interface Window {
+    __swipe: () => SwipeState
+  }
+}
+
+window.__swipe = () => {
+  const overlay = document.querySelector<HTMLElement>('[role="button"].fixed.inset-0')
+  if (!overlay) return { open: false, transform: 'none', backdrop: 'none' }
+  const inner = overlay.firstElementChild as HTMLElement
+  return {
+    open: true,
+    transform: getComputedStyle(inner).transform,
+    backdrop: getComputedStyle(overlay).backgroundColor,
+  }
+}
+
+function Scene() {
+  // Open through the production event path rather than a prop, so the capture
+  // exercises the same listener a real image click goes through.
+  useEffect(() => {
+    window.dispatchEvent(new CustomEvent('lightbox', {
+      detail: { images: [{ src: SUBJECT, alt: 'A dashboard screenshot' }], index: 0 },
+    }))
+  }, [])
+  return (
+    <div className="bg-bg text-text min-h-[844px]">
+      {/* Page content behind the overlay, so the backdrop's dim (and its fade
+          during a drag) is visible rather than black-on-black. */}
+      <div className="p-4 space-y-3">
+        <div className="h-6 w-40 rounded bg-chrome" />
+        <div className="h-4 w-full rounded bg-chrome" />
+        <div className="h-4 w-5/6 rounded bg-chrome" />
+        <div className="h-40 w-full rounded-lg bg-chrome" />
+        <div className="h-4 w-2/3 rounded bg-chrome" />
+        <div className="h-4 w-full rounded bg-chrome" />
+        <div className="h-24 w-full rounded-lg bg-chrome" />
+      </div>
+      <Lightbox />
+    </div>
+  )
+}
+
+initI18n('en')
+createRoot(document.getElementById('root')!).render(<Scene />)

--- a/website/scripts/capture-lightbox-swipe.mjs
+++ b/website/scripts/capture-lightbox-swipe.mjs
@@ -1,0 +1,120 @@
+/**
+ * Evidence for swipe-down-to-dismiss on the image viewer.
+ *
+ * Drives the ISOLATED capture entry (website/capture/lightbox-swipe.html), which
+ * mounts the REAL `Lightbox` opened through the same `lightbox` CustomEvent
+ * production dispatches.
+ *
+ * The gesture is injected as a GENUINE touch sequence via CDP
+ * Input.dispatchTouchEvent, not a mouse drag: the handler is gated on
+ * `pointerType !== 'mouse'`, so a synthetic mouse drag would prove nothing. The
+ * dispatched touches make Chromium synthesize the same pointerdown/move/up with
+ * `pointerType: 'touch'` a phone produces.
+ *
+ * Two runs, because the interesting states are motion and a threshold:
+ *
+ *   dismiss     390px, coarse pointer — a slow 320px pull released past the 96px
+ *               threshold. Recorded as video (the whole point is that the image
+ *               tracks the finger), plus stills at rest / mid-drag / dismissed.
+ *   springback  the same viewport, a 60px pull released short of the threshold.
+ *               Stills only: the image returns and the viewer stays open.
+ *
+ * Each run asserts the live transform and backdrop through window.__swipe(), so a
+ * regression that renders a plausible frame without moving anything fails here
+ * rather than in review.
+ *
+ * Usage:
+ *   npx vite --host 127.0.0.1 --port 6841 --strictPort   # in another shell
+ *   node scripts/capture-lightbox-swipe.mjs http://127.0.0.1:6841 ../temp-screenshots/lightbox-swipe
+ */
+import { chromium } from 'playwright'
+import { mkdirSync, renameSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BASE = process.argv[2] || 'http://127.0.0.1:6841'
+const OUT = process.argv[3] || '../temp-screenshots/lightbox-swipe'
+mkdirSync(OUT, { recursive: true })
+
+const VIEWPORT = { width: 390, height: 844 }
+const START = { x: 195, y: 300 }
+
+/** Dispatch one touch frame. `points` empty ends the sequence (touchEnd). */
+async function touch(cdp, type, y) {
+  await cdp.send('Input.dispatchTouchEvent', {
+    type,
+    touchPoints: type === 'touchEnd' ? [] : [{ x: START.x, y, id: 1 }],
+  })
+}
+
+/** Pull the finger from START.y down by `distance`px over `steps` frames, holding
+ *  ~16ms between frames so the injected gesture arrives at roughly a real touch
+ *  frame rate rather than as one teleporting jump. */
+async function drag(page, cdp, distance, steps, onFrame) {
+  await touch(cdp, 'touchStart', START.y)
+  for (let i = 1; i <= steps; i++) {
+    await touch(cdp, 'touchMove', START.y + Math.round((distance * i) / steps))
+    await page.waitForTimeout(16)
+    if (onFrame) await onFrame(i)
+  }
+}
+
+async function run({ name, distance, steps, video }) {
+  const ctx = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    isMobile: true,
+    hasTouch: true,
+    ...(video ? { recordVideo: { dir: OUT, size: VIEWPORT } } : {}),
+  })
+  const page = await ctx.newPage()
+  const cdp = await ctx.newCDPSession(page)
+  await page.goto(`${BASE}/capture/lightbox-swipe.html?theme=light`)
+  await page.waitForSelector('[role="button"].fixed.inset-0', { timeout: 20000 })
+  // Let the subject image decode and the open transition settle before the
+  // at-rest frame, so "no transform" is a real reading rather than a race.
+  await page.waitForTimeout(500)
+
+  const atRest = await page.evaluate(() => window.__swipe())
+  if (!atRest.open) throw new Error(`${name}: the viewer did not open`)
+  if (atRest.transform !== 'none') throw new Error(`${name}: expected no transform at rest, got ${atRest.transform}`)
+  await page.screenshot({ path: `${OUT}/${name}-01-at-rest.png` })
+
+  let mid = null
+  await drag(page, cdp, distance, steps, async i => {
+    if (i === Math.round(steps / 2)) {
+      mid = await page.evaluate(() => window.__swipe())
+      await page.screenshot({ path: `${OUT}/${name}-02-mid-drag.png` })
+    }
+  })
+  if (!mid || mid.transform === 'none') throw new Error(`${name}: the image did not move during the drag`)
+  if (mid.backdrop === atRest.backdrop) throw new Error(`${name}: the backdrop did not fade during the drag`)
+
+  await touch(cdp, 'touchEnd', START.y + distance)
+  await page.waitForTimeout(500)
+  const after = await page.evaluate(() => window.__swipe())
+  await page.screenshot({ path: `${OUT}/${name}-03-released.png` })
+  console.log(`${name.padEnd(11)} pull ${distance}px · mid ${mid.transform} · after release ${after.open ? 'still open' : 'dismissed'}`)
+
+  const videoPath = video ? await page.video().path() : null
+  await ctx.close() // flushes the video file
+  if (videoPath) {
+    const webm = join(OUT, `${name}.webm`)
+    renameSync(videoPath, webm)
+    console.log(`${name.padEnd(11)} video ${webm}`)
+  }
+  return after
+}
+
+const browser = await chromium.launch()
+
+// Past the 96px threshold: the viewer must be gone.
+const dismissed = await run({ name: 'dismiss', distance: 320, steps: 20, video: true })
+if (dismissed.open) throw new Error('dismiss: a 320px pull left the viewer open')
+
+// Short of it: the image must spring back and the viewer stay open.
+const sprung = await run({ name: 'springback', distance: 60, steps: 8, video: false })
+if (!sprung.open) throw new Error('springback: a 60px pull dismissed the viewer')
+if (sprung.transform !== 'none') throw new Error(`springback: the image did not return, transform is ${sprung.transform}`)
+
+await browser.close()
+console.log('files:', readdirSync(OUT).join(' '))

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -3103,6 +3103,22 @@ const LIGHTBOX_ZOOM_MIN = 1
 const LIGHTBOX_ZOOM_MAX = 5
 const LIGHTBOX_ZOOM_STEP = 0.5
 
+/** Swipe-to-dismiss (touch only, fit zoom only) tuning.
+ *
+ *  `SLOP` is the travel a touch must cover before the drag counts as a gesture
+ *  rather than a tap — below it the tap-to-close/tap-a-button paths are left
+ *  alone. `DISTANCE` is the release threshold that dismisses. `TRAVEL` is the
+ *  distance mapped to the full dim/shrink feedback, so the backdrop fades and
+ *  the image shrinks proportionally to how far the finger has pulled.
+ *
+ *  Distance is deliberately the ONLY dismiss criterion: a velocity path would
+ *  buy a sub-`DISTANCE` flick and cost per-move rate tracking plus its own
+ *  threshold, and the flick a user actually makes travels past `DISTANCE`
+ *  anyway. */
+const LIGHTBOX_DISMISS_SLOP = 8
+const LIGHTBOX_DISMISS_DISTANCE = 96
+const LIGHTBOX_DISMISS_TRAVEL = 260
+
 /** True when a keyboard event originates from an editable element, so global
  *  printable-key shortcuts (like the lightbox 'd' download) don't hijack typing. */
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -3215,6 +3231,83 @@ export function Lightbox() {
     d.active = false
     if (d.dragging) { d.dragging = false; setDragging(false) }
   }, [])
+  // ── swipe-down-to-dismiss ────────────────────────────────────────────────
+  // A touch drag anywhere over the overlay pulls the image with the finger and
+  // dismisses on release. Gated to fit zoom (above it the same gesture already
+  // means "pan", handled on the <img>) and to non-mouse pointers, so the desktop
+  // click-backdrop-to-close behaviour is untouched.
+  const [swipeY, setSwipeY] = useState(0)
+  const [swiping, setSwiping] = useState(false)
+  // `engaged` flips once SLOP is crossed with vertical intent; until then the
+  // gesture is still a candidate tap. `suppressClick` makes the click that
+  // follows a real drag a no-op, so a spring-back does not also close via the
+  // backdrop handler.
+  //
+  // `pointerId` is what keeps a PINCH from reading as a dismiss. Every finger
+  // raises its own pointerdown/move/up, so without an id the second finger
+  // rewrites the gesture's origin and a two-finger zoom attempt walks the image
+  // down and closes the viewer the user was zooming into.
+  const swipeRef = useRef({ pointerId: -1, startX: 0, startY: 0, active: false, engaged: false })
+  const suppressClickRef = useRef(false)
+  // Abandon the in-flight gesture and return the image to rest. Used by the
+  // multi-touch bail-out and by pointercancel.
+  const abortSwipe = useCallback(() => {
+    const s = swipeRef.current
+    s.active = false
+    if (s.engaged) { s.engaged = false; setSwiping(false); suppressClickRef.current = true }
+    s.pointerId = -1
+    setSwipeY(0)
+  }, [])
+  const onOverlayPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // A second finger while a drag is live is a pinch, not a dismiss: hand the
+    // gesture back rather than letting this pointer reseat the drag origin.
+    if (swipeRef.current.active && e.pointerId !== swipeRef.current.pointerId) { abortSwipe(); return }
+    // Every click in this subtree is preceded by a pointerdown, so clearing here
+    // is what keeps the flag from latching when the click is swallowed upstream
+    // (the <img> stops propagation, so the overlay's own handler never runs).
+    suppressClickRef.current = false
+    if (e.pointerType === 'mouse') return
+    if (zoomRef.current > LIGHTBOX_ZOOM_MIN) return // the <img> pan owns this gesture
+    // Toolbar taps must stay taps — never start a drag from a control.
+    if ((e.target as HTMLElement | null)?.closest('button')) return
+    swipeRef.current = { pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, active: true, engaged: false }
+  }, [abortSwipe])
+  const onOverlayPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const s = swipeRef.current
+    if (!s.active || e.pointerId !== s.pointerId) return
+    const dx = e.clientX - s.startX
+    const dy = e.clientY - s.startY
+    if (!s.engaged) {
+      if (Math.hypot(dx, dy) < LIGHTBOX_DISMISS_SLOP) return
+      // Horizontal intent is not a dismiss — drop the gesture rather than
+      // yanking the image sideways.
+      if (Math.abs(dx) > Math.abs(dy)) { s.active = false; return }
+      s.engaged = true
+      setSwiping(true)
+    }
+    // Downward travel tracks the finger 1:1; upward is rubber-banded, since
+    // pulling up is not a dismiss but should not feel dead either.
+    setSwipeY(dy >= 0 ? dy : dy / 4)
+  }, [])
+  const endSwipe = useCallback((e: React.PointerEvent<HTMLDivElement>, cancelled: boolean) => {
+    const s = swipeRef.current
+    if (!s.active || e.pointerId !== s.pointerId) return
+    if (cancelled) { abortSwipe(); return }
+    s.active = false
+    s.pointerId = -1
+    if (!s.engaged) return
+    s.engaged = false
+    setSwiping(false)
+    suppressClickRef.current = true
+    if (e.clientY - s.startY > LIGHTBOX_DISMISS_DISTANCE) setState(null)
+    else setSwipeY(0)
+  }, [abortSwipe])
+  const onOverlayPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, false), [endSwipe])
+  const onOverlayPointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, true), [endSwipe])
+  const onOverlayClick = useCallback(() => {
+    if (suppressClickRef.current) { suppressClickRef.current = false; return }
+    setState(null)
+  }, [])
   // Keep a fresh ref so the global keydown handler (subscribed once per open)
   // can read the current image for the download shortcut without a stale closure.
   const stateRef = useRef<LightboxDetail | null>(null)
@@ -3237,8 +3330,16 @@ export function Lightbox() {
   const isOpen = state !== null
   // Reset the zoom whenever the lightbox opens/closes or the shown image
   // changes, so each image starts fit-to-screen rather than inheriting the
-  // previous one's zoom.
-  useEffect(() => { setZoom(LIGHTBOX_ZOOM_MIN) }, [isOpen, state?.index])
+  // previous one's zoom. The dismiss offset resets with it — a viewer reopened
+  // right after a spring-back must not start half-dragged.
+  useEffect(() => {
+    setZoom(LIGHTBOX_ZOOM_MIN)
+    setSwipeY(0)
+    setSwiping(false)
+    swipeRef.current.active = false
+    swipeRef.current.engaged = false
+    swipeRef.current.pointerId = -1
+  }, [isOpen, state?.index])
   // On any zoom change, recentre at fit and otherwise re-clamp the existing pan
   // to the new (smaller/larger) bounds — zooming out must not strand the image
   // off-screen. Runs post-layout, so offsetWidth already reflects the new box.
@@ -3276,13 +3377,31 @@ export function Lightbox() {
   if (!state) return null
   const img = state.images[state.index]
   const zoomed = zoom > LIGHTBOX_ZOOM_MIN
+  // 0 → untouched, 1 → full dismiss feedback. Downward pull only; the
+  // rubber-banded upward direction keeps the backdrop at full strength.
+  const swipeProgress = Math.min(1, Math.max(0, swipeY) / LIGHTBOX_DISMISS_TRAVEL)
   return (
-    <Clickable className="fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center overflow-hidden cursor-pointer" onClick={() => setState(null)}>
+    <Clickable
+      className={`fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center overflow-hidden cursor-pointer touch-pinch-zoom ${swiping ? '' : 'transition-colors duration-200'}`}
+      // Inline background wins over the class only while a drag is live, so the
+      // default (and every non-touch) render keeps the plain bg-black/80 paint.
+      style={swipeProgress > 0 ? { backgroundColor: `rgba(0, 0, 0, ${(0.8 * (1 - swipeProgress * 0.75)).toFixed(3)})` } : undefined}
+      onClick={onOverlayClick}
+      onPointerDown={onOverlayPointerDown}
+      onPointerMove={onOverlayPointerMove}
+      onPointerUp={onOverlayPointerUp}
+      onPointerCancel={onOverlayPointerCancel}
+    >
       {/* Inner wrapper centres the image; when enlarged, the image is dragged
           around via a translate transform (see pointer handlers) rather than
           scrollbars — a flex-centred overflow container can't scroll to its
-          hidden top/left edges, so drag-to-pan is the reliable mechanism. */}
-      <div className="flex items-center justify-center w-full h-full">
+          hidden top/left edges, so drag-to-pan is the reliable mechanism.
+          This wrapper also carries the swipe-to-dismiss offset, kept off the
+          <img> so it composes with (rather than fights) the pan/zoom transform. */}
+      <div
+        className={`flex items-center justify-center w-full h-full ${swiping ? '' : 'transition-transform duration-200'}`}
+        style={swipeY !== 0 ? { transform: `translateY(${swipeY.toFixed(1)}px) scale(${(1 - swipeProgress * 0.15).toFixed(3)})` } : undefined}
+      >
         {/* The image is a drag surface for panning when zoomed; zoom itself
             lives in the toolbar + keyboard. A plain click only stops the
             backdrop-close from firing (clicking the image should not dismiss

--- a/website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx
+++ b/website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx
@@ -1,0 +1,195 @@
+import { render, fireEvent, act } from '@testing-library/react'
+import { Lightbox } from '../components/MarkdownRenderer'
+
+// Swipe-down-to-dismiss on the image lightbox. The gesture lives on the overlay
+// (so a drag anywhere counts, not just on the image), is gated to non-mouse
+// pointers, and is gated to fit zoom because above fit the same drag pans.
+
+function open(images: { src: string; alt?: string }[], index = 0) {
+  window.dispatchEvent(new CustomEvent('lightbox', {
+    detail: { images: images.map(i => ({ src: i.src, alt: i.alt ?? '' })), index },
+  }))
+}
+
+/** The overlay is the Clickable root; the swipe transform lives on its child. */
+function surfaces(container: HTMLElement) {
+  const overlay = container.querySelector('[role="button"]') as HTMLElement
+  return { overlay, inner: overlay.firstElementChild as HTMLElement }
+}
+
+const touch = (y: number, x = 100, pointerId = 1) => ({ pointerType: 'touch', pointerId, clientX: x, clientY: y })
+
+describe('Lightbox swipe-to-dismiss', () => {
+  it('follows a downward touch drag and dismisses past the release threshold', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    // Below the slop the gesture is still a candidate tap — nothing moves.
+    act(() => { fireEvent.pointerMove(overlay, touch(104)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    // Past the slop the image tracks the finger and the backdrop dims.
+    act(() => { fireEvent.pointerMove(overlay, touch(160)) })
+    expect(inner.getAttribute('style')).toContain('translateY(60.0px)')
+    expect(overlay.getAttribute('style')).toContain('rgba(0, 0, 0, ')
+    // Released past LIGHTBOX_DISMISS_DISTANCE (96px) the viewer closes.
+    act(() => { fireEvent.pointerMove(overlay, touch(240)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(240)) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('springs back when released short of the threshold, without closing via the click', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(150)) })
+    expect(inner.getAttribute('style')).toContain('translateY(50.0px)')
+    act(() => { fireEvent.pointerUp(overlay, touch(150)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    // The click a real drag generates must not fall through to backdrop-close.
+    act(() => { fireEvent.click(overlay) })
+    expect(container.querySelector('img')).not.toBeNull()
+    // …but the NEXT plain tap still closes: the suppression is one-shot.
+    act(() => { fireEvent.pointerDown(overlay, touch(10, 100, 2)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(10, 100, 2)) })
+    act(() => { fireEvent.click(overlay) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('rubber-bands an upward drag and never dismisses on it', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(300)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(100)) })
+    // -200px of pull renders as -50px, and the backdrop keeps its full dim.
+    expect(inner.getAttribute('style')).toContain('translateY(-50.0px)')
+    expect(overlay.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, touch(100)) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('drops the gesture when the drag is horizontal', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(130, 220)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    // Once dropped, continuing downward does not resurrect the drag.
+    act(() => { fireEvent.pointerMove(overlay, touch(400, 220)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, touch(400, 220)) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('restores the image when the touch is cancelled mid-drag', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(300)) })
+    expect(inner.getAttribute('style')).toContain('translateY(200.0px)')
+    // Past the dismiss distance, but a cancel is an abort, not a release.
+    act(() => { fireEvent.pointerCancel(overlay, touch(300)) })
+    expect(container.querySelector('img')).not.toBeNull()
+    expect(inner.getAttribute('style')).toBeNull()
+  })
+
+  // ── multi-touch: a pinch must never read as a dismiss ─────────────────────
+
+  it('abandons the drag when a second finger lands, so a pinch cannot dismiss', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(200)) })
+    expect(inner.getAttribute('style')).toContain('translateY(100.0px)')
+    // Second finger: the gesture is a pinch, so the image returns to rest…
+    act(() => { fireEvent.pointerDown(overlay, touch(600, 100, 2)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    // …and neither finger's continued travel or release can dismiss it, even
+    // well past the 96px threshold.
+    act(() => { fireEvent.pointerMove(overlay, touch(400)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(300, 100, 2)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, touch(400)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(300, 100, 2)) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('ignores a second finger that never owned the drag', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    // A stray move/up from an id that never started a drag cannot steer or end
+    // the live one.
+    act(() => { fireEvent.pointerMove(overlay, touch(500, 100, 9)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, touch(500, 100, 9)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(250)) })
+    expect(inner.getAttribute('style')).toContain('translateY(150.0px)')
+    act(() => { fireEvent.pointerUp(overlay, touch(250)) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('keeps the browser pinch by declaring pinch-zoom rather than no touch action', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    expect(overlay.className).toContain('touch-pinch-zoom')
+    expect(overlay.className).not.toContain('touch-none')
+  })
+
+  // ── the gesture must not take anything away ───────────────────────────────
+
+  it('ignores a mouse drag so desktop click-to-close is unchanged', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, { pointerType: 'mouse', pointerId: 1, clientX: 100, clientY: 100 }) })
+    act(() => { fireEvent.pointerMove(overlay, { pointerType: 'mouse', pointerId: 1, clientX: 100, clientY: 400 }) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, { pointerType: 'mouse', pointerId: 1, clientX: 100, clientY: 400 }) })
+    // No suppression was armed, so the click still closes.
+    act(() => { fireEvent.click(overlay) })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('yields to pan once the image is zoomed past fit', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.keyDown(window, { key: '+' }) })
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(400)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(overlay, touch(400)) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('does not start a drag from a toolbar control', () => {
+    const { container, getByLabelText } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { inner } = surfaces(container)
+    const zoomIn = getByLabelText('Zoom in (+)')
+    act(() => { fireEvent.pointerDown(zoomIn, touch(100)) })
+    act(() => { fireEvent.pointerMove(zoomIn, touch(300)) })
+    expect(inner.getAttribute('style')).toBeNull()
+    act(() => { fireEvent.pointerUp(zoomIn, touch(300)) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('starts each newly shown image undragged', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }, { src: 'b.png', alt: 'b' }]))
+    const { overlay, inner } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(160)) })
+    expect(inner.getAttribute('style')).toContain('translateY(60.0px)')
+    act(() => { fireEvent.keyDown(window, { key: 'ArrowRight' }) })
+    expect(surfaces(container).inner.getAttribute('style')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

On a phone the image viewer can only be closed two ways: hit the `X`, or land a tap on the backdrop. The backdrop is the dimmed strip around a fit-to-width image — on a portrait phone that is a few dozen pixels top and bottom, and a tap that lands on the image itself is deliberately swallowed (clicking the image must not dismiss). Every native photo viewer closes on a downward drag, so the gesture users actually reach for did nothing at all.

## Change

The overlay now owns a pointer gesture. A touch drag pulls the image down with the finger while the backdrop fades and the image shrinks, and on release past **96px** of travel it dismisses. Short of that it springs back.

**Distance is the only dismiss criterion.** A velocity/flick path was in the first revision and is out: its whole yield is dismissing a *sub-96px* flick, and it cost two tuned constants, per-move rate tracking, and a test harness that had to hand-build native events to pin `timeStamp`. A flick a user actually makes travels well past 96px, so the zero option costs one slightly longer drag.

The gesture is scoped so it cannot take anything away:

- **non-mouse pointers only** — desktop click-to-close is byte-identical, and the fine-pointer render is unchanged down to the inline `style` attribute being absent
- **fit zoom only** — above fit the same drag already means *pan*, and that handler stays on the `<img>`
- a `pointerdown` on a toolbar button never starts a drag
- a **horizontal** drag is dropped rather than yanking the image sideways
- an **upward** drag is rubber-banded to a quarter of its travel and never dismisses
- **`pointercancel` is an abort, not a release** — an interrupted touch springs back even past the threshold

**Pinch keeps working**, which took two things (see the UX Review disposition below):

- the overlay declares **`touch-action: pinch-zoom`**, not `none` — the browser still owns two-finger gestures (and cancels ours, which the abort path already handles) while single-finger panning stays ours
- the gesture tracks its **`pointerId`** — every finger raises its own `pointerdown`, so without an id the second finger rewrites the drag's origin and a pinch attempt walks the image down and closes the viewer the user was zooming into. A second finger now abandons the drag and the image returns to rest.

Two more details worth review attention:

- The click that follows a real drag is suppressed **once**, so a spring-back does not fall through to the backdrop's close handler. The flag is cleared on the next `pointerdown` rather than in the click handler, because the `<img>` stops click propagation — a drag that starts on the image never reaches the overlay's own click handler to clear it there.
- The offset lives on the **centring wrapper**, not the `<img>`, so it composes with the existing pan/zoom transform instead of fighting it.

## Evidence

Recorded against the real `Lightbox`, opened through the same `lightbox` CustomEvent `dispatchLightbox()` fires in production, at a 390×844 coarse-pointer viewport. The gesture is injected as a **genuine touch sequence** (CDP `Input.dispatchTouchEvent`) — a synthetic mouse drag would prove nothing here, since the handler is gated on `pointerType !== 'mouse'`. The page behind is rendered light on purpose: the overlay is `bg-black/80` in every theme, and a bright page is what makes the dim and its fade legible.

**Dismiss — 320px pull, released past the threshold**

![Dragging the image viewer down dismisses it](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/dismiss.gif)

| At rest | Mid-drag (160px) | Released |
|---|---|---|
| ![viewer at rest](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/dismiss-01-at-rest.png) | ![image pulled down, backdrop faded](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/dismiss-02-mid-drag.png) | ![viewer dismissed](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/dismiss-03-released.png) |

**Spring back — 60px pull, released short of the threshold**

| Mid-drag (30px) | Released — still open, image returned |
|---|---|
| ![image pulled down 30px](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/springback-02-mid-drag.png) | ![viewer still open at rest](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-lightbox-swipe/shots/springback-03-released.png) |

The capture script asserts the live readings rather than trusting the frames — measured transform `matrix(0.908, 0, 0, 0.908, 0, 160)` mid-dismiss and `matrix(0.983, 0, 0, 0.983, 0, 30)` mid-springback, a backdrop colour that differs from at-rest, and `transform: none` after the spring-back. A regression that renders a plausible frame without moving anything fails the capture run. Re-run after the `touch-action: pinch-zoom` change: identical readings, so the single-finger drag is unaffected by handing two-finger gestures back to the browser.

## Tests

`website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx` — 12 specs: dismiss past distance, spring-back plus the one-shot click suppression, upward rubber-band, horizontal drop, `pointercancel` abort, **a second finger abandoning the drag so a pinch cannot dismiss**, **a foreign `pointerId` unable to steer or end the live drag**, the `touch-pinch-zoom` declaration itself, mouse drag ignored, zoomed drag yields to pan, toolbar `pointerdown` is not a drag, and a newly shown image starting undragged.

## Manual verification

Covered by the capture run above (real touch injection against the real component at a phone viewport). Not yet done: a pass on a physical notched iPhone — the logic is pointer-event based and Chromium's touch injection exercises it, but iOS Safari's own `touch-action` handling is worth confirming before release.

no linked issue: reported directly in chat as a mobile ergonomics gap, no tracker item was filed first.
