### PR TITLE
fix(docker): bind-mount the wheel so no layer ships it (#5778)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,11 @@
 # artifact pip users install — frontend staged in, version stamped), never a
 # raw source tree. Building from source here would duplicate build-wheel.yml
 # and let the Docker bytes drift from the pip bytes for the same version.
-#   docker build -f docker/Dockerfile .        (requires dist/kirocrew-*.whl)
+#   docker build -f docker/Dockerfile .        (requires dist/kirocrew-*.whl
+#                                                and BuildKit — the default
+#                                                builder since Docker 23; on
+#                                                older engines prefix with
+#                                                DOCKER_BUILDKIT=1)
 #
 # Base: python:3.12-slim-trixie is pinned (not bare -slim) because kiro-cli's
 # gnu builds enforce a glibc floor of 2.34 on x86_64 and 2.39 on aarch64;
@@ -114,12 +118,22 @@ RUN set -eux; \
 
 # The CI-built wheel (build-wheel.yml artifact). The glob keeps the Dockerfile
 # version-agnostic; the lane stages exactly one wheel into dist/.
-COPY dist/*.whl /tmp/wheels/
-RUN set -eux; \
+#
+# The wheel is BIND-MOUNTED from the build context, never COPYed. Layers are
+# append-only: a COPY commits the ~48MB wheel to its own layer, and an `rm`
+# in a later instruction can only stack a whiteout on top, so every pull
+# still fetched the wheel next to the installed copy of the same code
+# (#5778, 5.7% of the published image). The mount exists only for the
+# duration of this RUN and commits no wheel bytes to any layer, which makes
+# the cleanup `rm` unnecessary rather than merely late -- do not "simplify"
+# this back to COPY. The mount is read-only (BuildKit default); pip only
+# reads the wheel. .dockerignore's allowlist means the mounted dist/ contains
+# exactly the staged *.whl, so the one-wheel guard keeps its meaning.
+RUN --mount=type=bind,source=dist,target=/tmp/wheels \
+    set -eux; \
     WHEEL_COUNT=$(ls /tmp/wheels/*.whl | wc -l); \
     [ "${WHEEL_COUNT}" -eq 1 ] || { echo "expected exactly one wheel, found ${WHEEL_COUNT}" >&2; exit 1; }; \
     pip install --no-cache-dir /tmp/wheels/*.whl; \
-    rm -rf /tmp/wheels; \
     kirocrew --version
 
 # Re-stamp the provenance the wheel already carries: this image installs the

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -301,6 +301,11 @@ make wheel                                   # builds dist/kirocrew-*.whl
 docker build -f docker/Dockerfile -t kirocrew:dev .
 ```
 
+The Dockerfile consumes the wheel through a BuildKit bind mount, so the build
+requires BuildKit — the default builder since Docker 23. On an older engine
+(where the classic builder rejects `RUN --mount` with `Unknown flag: mount`),
+prefix the build with `DOCKER_BUILDKIT=1`.
+
 ## Troubleshooting
 
 For solutions to common Docker deployment issues — port binding, permission

--- a/test/test_docker_wheel_layer_contract.py
+++ b/test/test_docker_wheel_layer_contract.py
@@ -1,0 +1,121 @@
+"""The CI-built wheel must never be COPYed into a committed image layer.
+
+Image layers are append-only. ``COPY dist/*.whl /tmp/wheels/`` commits the
+~48MB wheel to its own layer, and an ``rm -rf /tmp/wheels`` in a LATER
+instruction can only stack a whiteout on top -- the bytes stay in the layer
+stack, so every ``docker pull`` fetches the wheel and then discards it, next
+to the already-installed copy of the same code. Measured on the published
+artifact (#5778): 48,047,081 compressed bytes, 5.7% of
+``ghcr.io/kirodotdev/kirocrew:latest``; layer 6 contained exactly ``tmp/``,
+``tmp/wheels/`` and the wheel, layer 7 exactly the ``tmp/.wh.wheels``
+whiteout -- the proof the delete happened a layer too late.
+
+The fix consumes the wheel through a BuildKit context bind mount
+(``RUN --mount=type=bind,source=dist,target=/tmp/wheels``): the wheel is
+visible only for the duration of that RUN and never enters a layer, which
+makes the cleanup ``rm`` unnecessary rather than merely late.
+
+Why a ratchet: a future "simplification" back to COPY would reintroduce the
+dead weight SILENTLY -- the image still builds, boots, and passes every
+functional smoke gate, just ~48MB heavier per pull. Static and offline: this
+reads only the Dockerfile text, so it cannot flake and needs no Docker
+daemon (same shape as ``test_workflow_cache_setup_uniqueness.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "docker" / "Dockerfile"
+
+
+def _instructions() -> list[str]:
+    """Logical Dockerfile instructions, continuations joined, comments dropped.
+
+    The Dockerfile parser strips whole-line comments even inside a
+    backslash-continued instruction, so mirror that here before joining.
+    """
+    logical: list[str] = []
+    pending = ""
+    for raw in DOCKERFILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("\\"):
+            pending += line[:-1] + " "
+            continue
+        logical.append((pending + line).strip())
+        pending = ""
+    if pending:
+        logical.append(pending.strip())
+    return logical
+
+
+def _copy_sources_and_dest(inst: str) -> tuple[list[str], str]:
+    """Split a COPY/ADD instruction into (source operands, destination).
+
+    Tokens after the instruction name, minus ``--flag`` options; the last
+    remaining token is the destination, the rest are sources.
+    """
+    operands = [t for t in inst.split()[1:] if not t.startswith("--")]
+    return operands[:-1], operands[-1] if operands else ""
+
+
+def _could_carry_the_wheel(src: str) -> bool:
+    """Could this COPY/ADD source operand sweep the staged wheel in?
+
+    ``.dockerignore``'s inverted allowlist admits ``dist/*.whl`` into the
+    context, so any source that names the wheel, the dist/ tree, or the
+    whole context root can commit the wheel to a layer.
+    """
+    normalized = src.lstrip("./")
+    return src in {".", "./"} or normalized == "" or normalized.startswith("dist") or ".whl" in src
+
+
+def test_dockerfile_exists() -> None:
+    """Guard the guard: a moved Dockerfile would make the ratchet vacuous."""
+    assert DOCKERFILE.is_file(), f"expected image recipe at {DOCKERFILE}"
+
+
+def test_wheel_never_enters_a_committed_layer() -> None:
+    """No COPY/ADD may bring the wheel (or a tree holding it) into the image."""
+    offenders = []
+    for inst in _instructions():
+        if inst.split(maxsplit=1)[0].upper() not in {"COPY", "ADD"}:
+            continue
+        sources, dest = _copy_sources_and_dest(inst)
+        if "/tmp/wheels" in dest or any(map(_could_carry_the_wheel, sources)):
+            offenders.append(inst)
+    assert not offenders, (
+        "the CI wheel must reach pip via the bind mount, never COPY/ADD: a "
+        "copied wheel is committed to its own layer and a later `rm` only "
+        "adds a whiteout, shipping ~48MB of dead weight in every pull "
+        "(#5778). Use RUN --mount=type=bind,source=dist,target=/tmp/wheels "
+        "instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_wheel_is_consumed_via_context_bind_mount() -> None:
+    """The install RUN keeps the mount AND the exactly-one-wheel guard."""
+    runs = [i for i in _instructions() if i.upper().startswith("RUN")]
+    install = [r for r in runs if "pip install" in r and "/tmp/wheels" in r]
+    assert len(install) == 1, (
+        f"expected exactly one wheel-installing RUN, found {len(install)}: "
+        f"{install!r}. The wheel must be consumed from /tmp/wheels via the "
+        "context bind mount -- never COPYed into a layer (#5778)"
+    )
+    run = install[0]
+    # Option order inside --mount is not significant to BuildKit, so assert
+    # the tokens independently rather than one order-sensitive literal.
+    assert "--mount=" in run and all(
+        token in run for token in ("type=bind", "source=dist", "target=/tmp/wheels")
+    ), (
+        "the wheel-installing RUN must bind-mount dist/ from the build "
+        "context so the wheel never lands in a layer (#5778)"
+    )
+    assert "-eq 1" in run and "WHEEL_COUNT" in run, (
+        "the exactly-one-wheel guard must survive: .dockerignore allowlists "
+        "dist/*.whl into the context, and the guard is what keeps the glob "
+        "version-agnostic while refusing an ambiguous multi-wheel context"
+    )


### PR DESCRIPTION
## Problem / Motivation

Every published container image ships the CI-built wheel twice. `docker/Dockerfile` copied the wheel into its own layer (`COPY dist/*.whl /tmp/wheels/`) and deleted it in the NEXT `RUN` (`rm -rf /tmp/wheels`). Image layers are append-only: a later layer cannot remove bytes an earlier layer committed — it can only stack a whiteout on top. Both layers are pushed and pulled, so every `docker pull` fetches the wheel and then discards it, next to the already-installed copy of the same code.

The reporter (`sujeito-operator`) measured this on the published artifact rather than inferring it: **48,047,081 compressed bytes, 5.7% of `ghcr.io/kirodotdev/kirocrew:latest`** (manifest `sha256:de2069aa…`, linux/amd64, 12 layers / 846,629,584 bytes). Layer 6 is the `COPY` and contains exactly `tmp/`, `tmp/wheels/`, and the 48MB wheel; layer 7 is the `RUN` and contains `tmp/.wh.wheels` — the whiteout that proves the delete happened a layer too late. Reproduction without building anything:

```
docker history --no-trunc --format '{{.Size}}\t{{.CreatedBy}}' ghcr.io/kirodotdev/kirocrew:latest | grep wheels
```

## Why it matters

Every user of the container distribution pays ~48MB of dead transfer and storage on every pull, on both architectures, forever — 5.7% of the image for bytes that are deleted immediately after install.

## What changed (motivation → approach → change)

Symptom: the wheel bytes ship in a committed layer despite the `rm`. Root cause: the `rm` runs one instruction too late — but moving it earlier is impossible with `COPY`, because `COPY` itself is what commits the layer. The right fix is to make the wheel never enter a layer at all: consume it through a BuildKit **context bind mount**:

```dockerfile
RUN --mount=type=bind,source=dist,target=/tmp/wheels \
    ...
    pip install --no-cache-dir /tmp/wheels/*.whl; \
    kirocrew --version
```

The mount exists only for the duration of that `RUN`, so the cleanup `rm` becomes unnecessary rather than merely late, and is removed. The exactly-one-wheel guard is preserved unchanged: `.dockerignore`'s inverted allowlist (`*`, `!dist`, `dist/*`, `!dist/*.whl`) means the mounted `dist/` contains exactly the staged wheel(s), so the guard keeps its meaning and the Dockerfile stays version-agnostic. The comment above the `RUN` now explains why the wheel is mounted rather than copied, so a future "simplification" back to `COPY` has to argue with it. `docs/guides/docker.md` ("Building locally") and the Dockerfile's build-contract header now state the BuildKit requirement (default builder since Docker 23; `DOCKER_BUILDKIT=1` on older engines) — on the classic builder `RUN --mount` fails at parse time with `Unknown flag: mount`, loud but previously unexplained.

Deliberately NOT done (scope discipline): no multi-stage restructuring, no change to the kiro-cli install block above or the provenance re-stamp block below, no `.dockerignore` reorganization.

## Tests

`test/test_docker_wheel_layer_contract.py` — a static, offline anti-drift ratchet (same shape as `test_workflow_cache_setup_uniqueness.py`, no Docker daemon needed):

- `test_wheel_never_enters_a_committed_layer` — no `COPY`/`ADD` may name the wheel, the `dist/` tree, or the whole context root as a source (the source-operand parse catches `COPY dist/ …` and `COPY . …` smuggling, not just the literal `.whl` spelling).
- `test_wheel_is_consumed_via_context_bind_mount` — the single wheel-installing `RUN` carries the bind mount (asserted as order-independent tokens) and the exactly-one-wheel guard.
- `test_dockerfile_exists` — guard-the-guard against a vacuous glob.

## Manual verification

The open question the reporter flagged (no Docker daemon on their side) — *is `pip install` happy reading the wheel from a read-only bind mount?* — was **proven locally** on the same base image (`python:3.12-slim-trixie`, Docker 25.0.16/BuildKit): a probe build asserted the mount is actually read-only (`touch` into it fails), `pip install --no-cache-dir` succeeds from it, and the resulting `docker history` shows no wheel layer and no whiteout.

Not proven locally: the full image build (kiro-cli download + provenance re-stamp) with a real kirocrew wheel. That is exactly what the `docker-smoke` gate does on this PR — it is paths-filtered on `docker/**`, so it fires here, builds the real image on amd64, boots it, probes it from the host, and cross-builds arm64.

## Related Issues

Closes #5778

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
