### PR TITLE
fix(computer-use): unlink the mkstemp frame when the service spool write fails

### DIFF
--- a/src/kiro_crew/computer_use/service.py
+++ b/src/kiro_crew/computer_use/service.py
@@ -384,14 +384,27 @@ class ComputerUseService:
                 handle_fd, path = tempfile.mkstemp(
                     prefix=prefix, suffix=SCREENSHOT_FILE_SUFFIX, dir=shot_dir
                 )
-                with os.fdopen(handle_fd, "wb") as handle:
-                    handle.write(snap.image_jpeg)
-                # Owner-only, fail-loud on POSIX and a real DACL on Windows. The
-                # frame can contain anything that was on screen, so a
-                # world-readable temp file would be a disclosure even though the
-                # directory is 0o700.
-                platform_compat.restrict_to_owner(path)
-                _trim_ring(shot_dir)
+                try:
+                    with os.fdopen(handle_fd, "wb") as handle:
+                        handle.write(snap.image_jpeg)
+                    # Owner-only, fail-loud on POSIX and a real DACL on Windows. The
+                    # frame can contain anything that was on screen, so a
+                    # world-readable temp file would be a disclosure even though the
+                    # directory is 0o700.
+                    platform_compat.restrict_to_owner(path)
+                    _trim_ring(shot_dir)
+                except Exception:
+                    # ``mkstemp`` already created the file, so a failure ANYWHERE
+                    # after it — the write, the permission tighten, the ring trim —
+                    # would orphan a frame in the spool with no reference and no
+                    # owner. Unlink it before degrading; best-effort only, because
+                    # this method is fail-soft by design and a cleanup error must
+                    # not turn a cosmetic spool failure into a call failure.
+                    try:
+                        os.unlink(path)
+                    except Exception:
+                        pass
+                    raise
             return replace(snap, image_path=path)
         except Exception:
             logger.debug("computer-use screenshot spool failed", exc_info=True)

--- a/test/test_computer_use_snapshot.py
+++ b/test/test_computer_use_snapshot.py
@@ -410,6 +410,115 @@ class TestScreenshotSpoolNamesAreUnique:
         assert result.image_jpeg == b""
 
 
+class TestSpoolFailureLeavesNoOrphanFrame:
+    """A post-allocation spool failure must not orphan the ``mkstemp`` frame.
+
+    ``mkstemp`` allocates the name AND creates the file, so every raiser after
+    it — the write, the permission tighten, the ring trim — used to leave a
+    zero-owner frame behind in the spool when the blanket fail-soft handler
+    discarded the path without unlinking. The degraded return value alone
+    passes on the unfixed code; the no-new-file assertion is the point.
+    """
+
+    def _service(self, tmp_path, monkeypatch):
+        from kiro_crew.computer_use import service as service_mod
+
+        monkeypatch.setattr(service_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+        return service_mod
+
+    def _snap(self, service_mod, payload: bytes):
+        from kiro_crew.computer_use.types import AppRef, Snapshot
+
+        return Snapshot(
+            app=AppRef(name="A", pid=1, bundle_id="com.acme.a", window_id=7),
+            elements=(),
+            captured_at=time.monotonic(),
+            image_jpeg=payload,
+            image_width=10,
+            image_height=10,
+        )
+
+    def _spool_files(self, service_mod, tmp_path):
+        import os
+
+        shot_dir = os.path.join(str(tmp_path), service_mod.SCREENSHOT_DIR_NAME)
+        if not os.path.isdir(shot_dir):
+            return []
+        return os.listdir(shot_dir)
+
+    def _assert_degraded_and_clean(self, service_mod, tmp_path, result):
+        assert result.image_path == ""
+        assert result.image_jpeg == b""
+        assert result.image_width == 0 and result.image_height == 0
+        # THE assertion: the allocated frame was unlinked, not orphaned.
+        assert self._spool_files(service_mod, tmp_path) == []
+
+    def test_a_failing_write_leaves_no_file_behind(self, tmp_path, monkeypatch):
+        import os
+
+        service_mod = self._service(tmp_path, monkeypatch)
+        real_fdopen = os.fdopen
+
+        class _BoomHandle:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+            def write(self, _data):
+                raise OSError("no space left on device")
+
+        monkeypatch.setattr(
+            service_mod.os, "fdopen", lambda fd, mode: _BoomHandle(real_fdopen(fd, mode))
+        )
+        svc = service_mod.ComputerUseService()
+        result = svc._persist_image(self._snap(service_mod, b"AAAA"))
+        self._assert_degraded_and_clean(service_mod, tmp_path, result)
+
+    def test_a_failing_permission_tighten_leaves_no_file_behind(self, tmp_path, monkeypatch):
+        service_mod = self._service(tmp_path, monkeypatch)
+
+        def boom(_path):
+            raise OSError("chmod refused")
+
+        monkeypatch.setattr(service_mod.platform_compat, "restrict_to_owner", boom)
+        svc = service_mod.ComputerUseService()
+        result = svc._persist_image(self._snap(service_mod, b"AAAA"))
+        self._assert_degraded_and_clean(service_mod, tmp_path, result)
+
+    def test_a_failing_ring_trim_leaves_no_file_behind(self, tmp_path, monkeypatch):
+        service_mod = self._service(tmp_path, monkeypatch)
+
+        def boom(_shot_dir):
+            raise RuntimeError("trim exploded")
+
+        monkeypatch.setattr(service_mod, "_trim_ring", boom)
+        svc = service_mod.ComputerUseService()
+        result = svc._persist_image(self._snap(service_mod, b"AAAA"))
+        self._assert_degraded_and_clean(service_mod, tmp_path, result)
+
+    def test_the_happy_path_still_spools_an_owner_only_frame(self, tmp_path, monkeypatch):
+        """The cleanup must never fire on success: the frame survives, 0o600."""
+        import os
+        import stat
+
+        service_mod = self._service(tmp_path, monkeypatch)
+        svc = service_mod.ComputerUseService()
+        result = svc._persist_image(self._snap(service_mod, b"AAAA"))
+        assert result.image_path
+        assert os.path.isfile(result.image_path)
+        with open(result.image_path, "rb") as handle:
+            assert handle.read() == b"AAAA"
+        if os.name == "posix":
+            assert stat.S_IMODE(os.stat(result.image_path).st_mode) == 0o600
+        assert self._spool_files(service_mod, tmp_path) == [os.path.basename(result.image_path)]
+
+
 class TestSnapshotIndex:
     # Every entry is namespaced by session, so the tests name one explicitly
     # rather than relying on a default the API deliberately does not provide.


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

`service._persist_image` spools a snapshot's JPEG bytes to the screenshot ring via `tempfile.mkstemp`, which allocates the name AND creates the file (0o600). Every statement after the allocation — the write, `platform_compat.restrict_to_owner`, and `_trim_ring` — can raise, and the method's blanket fail-soft handler discarded the path without unlinking. The result is an orphaned frame in the spool directory: a file with no reference and no owner that only the size-based ring trim will ever reclaim.

**This defect is latent, not live.** `_persist_image` returns early when `snap.image_path` is already set, and every production `Snapshot` producer that sets `image_jpeg` sets `image_path` in the same call. Today only `testing/fake_computer_use.py` (and a future bytes-only driver) reaches this writer. This is a correctness/parity fix, not an incident fix.

## Why it matters

The module treats `_persist_image` and `capture_macos.persist_jpeg` as a matched pair of spool writers. `persist_jpeg`'s identical orphaned-frame defect is being fixed in #5774, which deliberately left this writer out — so without this change the pair becomes asymmetric: one writer cleans up its allocation on failure, the other leaks it. `_persist_image` is also the broader of the two (three post-allocation raisers vs one), so any future bytes-only snapshot producer would inherit the leak on day one.

## What changed (motivation → approach → change)

Symptom: a post-allocation failure orphans the `mkstemp` frame. Root cause: allocation and write share one blanket `except Exception` that discards `path` without unlinking. Change: wrap everything after the `mkstemp` in an inner `try` whose `except` best-effort-unlinks the allocated file (`os.unlink(path)` inside `try/except Exception: pass`) and re-raises into the existing outer handler. One cleanup branch covers all three post-allocation raisers. The cleanup can never itself raise — the method is fail-soft by design and a cleanup error must not turn a cosmetic spool failure into a call failure.

Contract preserved exactly: success still returns `replace(snap, image_path=path)`; failure still returns the degraded tree-only snapshot (`image_jpeg=b""`, zero dimensions) and still logs at `debug` with `exc_info=True`. No observable return value or log level changes; the only behavioral delta is the removed leak.

Deliberately NOT done here: no shared helper across the two spool writers (an architecture change that would collide with the open #5774), and no edits to `capture_macos.py` / `capture_windows.py` (those files are #5774's).

## Tests

New class `TestSpoolFailureLeavesNoOrphanFrame` in `test/test_computer_use_snapshot.py`:

- Three red-before leak tests — one per post-allocation raiser (`handle.write`, `restrict_to_owner`, `_trim_ring` each patched to raise) — asserting BOTH the degraded snapshot AND that the spool directory gained no file. The no-new-file assertion is the point: the return value alone passes on the unfixed code. All three fail on `main` (verified by stashing the fix) and pass with it.
- One happy-path preservation test: a normal call returns an `image_path` that exists on disk with the payload bytes, is 0o600 on POSIX, and is the only file in the spool — so the cleanup cannot fire on success.
- Mutation-checked: removing the `os.unlink` fails exactly the three leak tests; removing the guard around the unlink breaks nothing else.

All tests use a `tmp_path`-scoped spool (patched `tempfile.gettempdir`) so the no-new-file assertion is not polluted by other tests' frames.

## Manual verification

N/A — unit coverage sufficient: the change is confined to one method's failure path and the tests assert the exact filesystem state before/after.

## Related Issues

Fixes #5775

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the module spec's "Both spool writers" line stays true and gets more true
- [x] No secrets, credentials, or internal references in the diff
