### PR TITLE
fix: drop sandbox launcher temps at apple_speech spawn sites (#5776)

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -349,6 +349,14 @@ def _sandboxed(argv: list[str]) -> tuple[list[str], dict[str, str], str | None]:
     protects; keeping the probe out of ``availability()`` was necessary but not
     sufficient, because these three call sites are themselves async.
 
+    Returns:
+        ``(wrapped_argv, scrubbed_env, cleanup_path_or_None)`` — the chokepoint's
+        own contract. The third element is a real temp launcher/profile whenever
+        the backend materializes one (``None`` for the nested-sandbox
+        passthrough), and the CALLER must unlink it after the child exits
+        (:func:`_drop_sandbox_launcher`); discarding it leaks one file per call,
+        forever.
+
     Raises:
         SandboxUnavailableError: propagated from the chokepoint when the host has no
             sandbox backend. Callers MUST catch this and surface the message, which
@@ -357,6 +365,24 @@ def _sandboxed(argv: list[str]) -> tuple[list[str], dict[str, str], str | None]:
             deliberate — see the callers.
     """
     return sandbox.sandboxed_spawn_argv(argv, mode="strict", env=_build_env())
+
+
+def _drop_sandbox_launcher(path: str | None) -> None:
+    """Remove the sandbox's temp launcher/profile once the child is done.
+
+    ``sandboxed_spawn_argv`` makes the caller responsible for unlinking the
+    cleanup path after the child exits (the Linux namespace launcher script or
+    the macOS ``sandbox-exec`` profile). Same shape as
+    ``mcp_gateway/resolve_once.py``: idempotent and silent, because a failed
+    unlink is a leaked temp file, never a reason to fail a transcription that
+    otherwise succeeded.
+    """
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _mkstemp_path(suffix: str) -> str:
@@ -597,7 +623,7 @@ async def transcribe(
         argv.append(native_path)
 
         try:
-            argv, spawn_env, _sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
+            argv, spawn_env, sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
         except sandbox.SandboxUnavailableError as exc:
             logger.warning("apple_speech: %s%s", _NO_SANDBOX_HINT, exc)
             return None, {"error": f"{_NO_SANDBOX_HINT}{exc}"}
@@ -619,6 +645,12 @@ async def transcribe(
                 return None, {"error": f"timed out after {timeout_secs}s"}
         except OSError as exc:
             return None, {"error": f"could not run speech helper: {exc}"}
+        finally:
+            # Covers the success, timeout and spawn-failure exits alike: the
+            # leak is per-call, so a launcher dropped only on success still
+            # accumulates. The sandbox-unavailable return above yields no
+            # tuple, hence no file to drop.
+            _drop_sandbox_launcher(sb_cleanup)
     finally:
         if is_temp:
             try:
@@ -647,9 +679,14 @@ async def inventory() -> dict:
     helper = await asyncio.to_thread(helper_path)
     if not helper:
         return {"error": "speech helper unavailable"}
+    # None until `_sandboxed` returns: its unavailable-raise yields no tuple and
+    # hence no file, so the `finally` below is a no-op on that branch.
+    inv_cleanup: str | None = None
     try:
         try:
-            inv_argv, inv_env, _ = await asyncio.to_thread(_sandboxed, [helper, "--inventory"])
+            inv_argv, inv_env, inv_cleanup = await asyncio.to_thread(
+                _sandboxed, [helper, "--inventory"]
+            )
         except sandbox.SandboxUnavailableError as exc:
             return {"error": f"{_NO_SANDBOX_HINT}{exc}"}
         proc = await asyncio.create_subprocess_exec(
@@ -658,10 +695,25 @@ async def inventory() -> dict:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60)
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60)
+        except asyncio.TimeoutError:
+            # Reap before the finally unlinks, honouring the "after the child
+            # exits" contract — and a helper wedged past the ceiling must not
+            # be left running with nobody waiting on it. Same shape as
+            # transcribe(); the outer except turns the re-raise into the same
+            # error dict this path always returned.
+            try:
+                proc.kill()
+                await proc.communicate()
+            except (OSError, ProcessLookupError):
+                pass
+            raise
         return dict(json.loads(stdout.decode().strip().splitlines()[-1]))
     except (OSError, asyncio.TimeoutError, json.JSONDecodeError, IndexError) as exc:
         return {"error": str(exc)}
+    finally:
+        _drop_sandbox_launcher(inv_cleanup)
 
 
 # ─────────────────────────── live streaming ───────────────────────────────────
@@ -701,6 +753,11 @@ class StreamingSession:
         self._queue: asyncio.Queue[dict | None] = asyncio.Queue()
         self._pump: asyncio.Task | None = None
         self._final_text = ""
+        #: Sandbox temp launcher/profile for the live helper. The child OUTLIVES
+        #: :meth:`start`, so unlike the batch sites this cannot be dropped in a
+        #: ``finally`` there — it is held for the session and unlinked in
+        #: :meth:`close`, once the process is torn down.
+        self._sb_cleanup: str | None = None
 
     async def start(self) -> str:
         """Spawn the helper and wait for ``ready``. Returns "" on success, else why not."""
@@ -712,7 +769,7 @@ class StreamingSession:
             return "streaming speech helper could not be built"
         try:
             try:
-                stream_argv, stream_env, _ = await asyncio.to_thread(
+                stream_argv, stream_env, self._sb_cleanup = await asyncio.to_thread(
                     _sandboxed,
                     [helper, "--locale", self.locale, "--sample-rate", str(self.sample_rate)],
                 )
@@ -726,6 +783,10 @@ class StreamingSession:
                 stderr=asyncio.subprocess.DEVNULL,
             )
         except OSError as exc:
+            # The launcher exists but no child ever held it; the readiness
+            # failures below instead reach the same unlink through `close()`.
+            cleanup, self._sb_cleanup = self._sb_cleanup, None
+            _drop_sandbox_launcher(cleanup)
             return f"could not start streaming helper: {exc}"
 
         self._pump = asyncio.create_task(self._read_events())
@@ -820,3 +881,7 @@ class StreamingSession:
         if self._pump is not None:
             self._pump.cancel()
             self._pump = None
+        # After the kill/wait above, so the launcher is never unlinked out from
+        # under a live child. The swap keeps a double close from re-unlinking.
+        cleanup, self._sb_cleanup = self._sb_cleanup, None
+        _drop_sandbox_launcher(cleanup)

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -15,7 +15,7 @@ import os
 import platform
 import sys
 from contextlib import ExitStack
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -374,6 +374,26 @@ def _passthrough_sandbox():
     return patch.object(apple_speech, "_sandboxed", side_effect=lambda argv: (argv, {}, None))
 
 
+def _cleanup_file_sandbox(tmp_path):
+    """Stub `_sandboxed` like a host WITH a sandbox backend: a real cleanup file.
+
+    `sandboxed_spawn_argv` returns a real temp launcher/profile as its third
+    element on any host with a backend, and the caller must unlink it after the
+    child exits. Returns ``(patcher, created)`` where *created* collects every
+    file handed out, so a test can assert the call site dropped each one on the
+    exit path under test.
+    """
+    created: list = []
+
+    def _fake(argv):
+        launcher = tmp_path / f"sb-launcher-{len(created)}"
+        launcher.write_text("# fake sandbox launcher/profile")
+        created.append(launcher)
+        return argv, {}, str(launcher)
+
+    return patch.object(apple_speech, "_sandboxed", side_effect=_fake), created
+
+
 class TestTranscribePlumbing:
     @pytest.mark.asyncio
     async def test_unavailable_returns_reason_not_exception(self):
@@ -673,6 +693,232 @@ class TestStreamingSession:
         session = apple_speech.StreamingSession()
         await session.close()
         await session.close()
+
+
+class TestSandboxCleanupPathIsDropped:
+    """Every `_sandboxed` call site must unlink the returned cleanup path (#5776).
+
+    The third tuple element is a real temp file on any host with a sandbox
+    backend (Linux namespace launcher / macOS ``.sb`` profile), and the
+    ``sandboxed_spawn_argv`` contract makes the CALLER unlink it after the child
+    exits. A site that discards it leaks one file per call, forever — and the
+    leak is per-call, so a launcher dropped only on the success path still
+    accumulates. Each test hands back a real file and asserts it is gone on the
+    exit path under test.
+    """
+
+    @staticmethod
+    def _availability_ok():
+        return patch.object(
+            apple_speech, "availability", return_value=apple_speech.Availability(True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_transcribe_drops_launcher_on_success(self, tmp_path):
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(json.dumps({"text": "hi"}).encode(), b""))
+        proc.returncode = 0
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            text, _ = await apple_speech.transcribe("/tmp/x.wav")
+        assert text == "hi"
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_drops_launcher_on_timeout(self, tmp_path):
+        """The timeout exit kills the child, and must drop the launcher too."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        killed = asyncio.Event()
+        proc = AsyncMock()
+
+        async def communicate():
+            # Hangs until kill(), like a wedged helper; returns once killed, so
+            # the reap in the timeout handler completes instead of hanging.
+            # No timing flake: the wait is unbounded-until-kill, and the small
+            # positive timeout (NOT 0: wait_for's `timeout <= 0` fast path
+            # cancels before the first step) only decides when kill() happens.
+            if not killed.is_set():
+                await killed.wait()
+            return b"", b""
+
+        proc.communicate = communicate
+        proc.kill = Mock(side_effect=killed.set)
+        proc.returncode = None
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            text, meta = await apple_speech.transcribe("/tmp/x.wav", timeout_secs=0.01)
+        assert text is None
+        assert "timed out" in meta["error"]
+        proc.kill.assert_called_once()
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_drops_launcher_on_spawn_failure(self, tmp_path):
+        """OSError from the spawn means no child ever held the launcher."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("boom")),
+            sandbox_patch,
+        ):
+            text, meta = await apple_speech.transcribe("/tmp/x.wav")
+        assert text is None
+        assert "could not run speech helper" in meta["error"]
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_inventory_drops_launcher_on_success(self, tmp_path):
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(
+            return_value=(json.dumps({"supported": ["en-US"], "installed": []}).encode(), b"")
+        )
+        with (
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            result = await apple_speech.inventory()
+        assert result == {"supported": ["en-US"], "installed": []}
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_inventory_drops_launcher_on_spawn_failure(self, tmp_path):
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        with (
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("boom")),
+            sandbox_patch,
+        ):
+            result = await apple_speech.inventory()
+        assert "error" in result
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_inventory_timeout_kills_then_drops_launcher(self, tmp_path):
+        """The timeout exit must reap the wedged helper BEFORE the finally
+        unlinks — the contract is 'after the child exits', and a helper past
+        the ceiling must not be left running with nobody waiting on it."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        killed = asyncio.Event()
+        proc = AsyncMock()
+
+        async def communicate():
+            if not killed.is_set():
+                raise asyncio.TimeoutError  # stands in for the wait_for ceiling
+            return b"", b""
+
+        proc.communicate = communicate
+        proc.kill = Mock(side_effect=killed.set)
+        proc.returncode = None
+        with (
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            result = await apple_speech.inventory()
+        assert "error" in result
+        proc.kill.assert_called_once()
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_failure_drops_launcher(self, tmp_path):
+        """The spawn-OSError exit has a launcher but no child; it must drop it."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", side_effect=OSError("boom")),
+            sandbox_patch,
+        ):
+            problem = await session.start()
+        assert "could not start streaming helper" in problem
+        assert created and not any(f.exists() for f in created)
+        assert session._sb_cleanup is None
+
+    @pytest.mark.asyncio
+    async def test_streaming_launcher_survives_start_and_drops_on_close(self, tmp_path):
+        """The streaming child OUTLIVES start(): unlinking there would pull the
+        profile/launcher out from under a live process. It is held on the
+        session and dropped in close(), after the process teardown — and a
+        double close must not trip over the already-removed file."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+        proc.stdout.readline = AsyncMock(side_effect=[b'{"type": "ready"}\n', b""])
+        proc.kill = Mock()
+        proc.returncode = None
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            assert await session.start() == ""
+            assert created and all(f.exists() for f in created), "unlinked under a live child"
+            await session.close()
+            assert not any(f.exists() for f in created)
+            await session.close()  # idempotent: the swap keeps this from re-unlinking
+
+    @pytest.mark.asyncio
+    async def test_streaming_finish_then_close_drops_launcher_once(self, tmp_path):
+        """The production teardown order (stt_stream.py) is finish() then
+        close(). finish() may leave the process draining, so the unlink belongs
+        to close() alone — a refactor moving it into finish() fails here."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+        proc.stdout.readline = AsyncMock(side_effect=[b'{"type": "ready"}\n', b""])
+        proc.kill = Mock()
+        proc.returncode = None
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            assert await session.start() == ""
+            await session.finish()
+            assert created and all(f.exists() for f in created), "finish() must not unlink"
+            await session.close()
+            assert not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_streaming_ready_timeout_drops_launcher(self, tmp_path, monkeypatch):
+        """The readiness-timeout exit reaches the unlink through the close()
+        that start() already performs there."""
+        monkeypatch.setattr(apple_speech, "_READY_TIMEOUT_SECS", 0.05)
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+
+        async def never_ready(*_a, **_k):
+            await asyncio.sleep(60)
+            return b""
+
+        proc.stdout.readline = never_ready
+        proc.kill = Mock()
+        proc.returncode = None
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            problem = await session.start()
+        assert problem == "streaming helper did not become ready"
+        assert created and not any(f.exists() for f in created)
 
 
 class TestStreamingEndpointGate:


### PR DESCRIPTION
## Problem / Motivation

`sandbox.sandboxed_spawn_argv()` returns `(wrapped_argv, scrubbed_env, cleanup_path_or_None)` and its docstring makes the **caller** responsible for unlinking `cleanup_path` after the child exits. On any host where the backend materializes a launcher it is a real temp file — the Linux namespace launcher script or the macOS `sandbox-exec` `.sb` profile.

`src/kiro_crew/apple_speech/__init__.py` routes every helper spawn through the local `_sandboxed()` wrapper and then discarded that third element at **all three call sites** (`transcribe()`, `inventory()`, `StreamingSession.start()`): one temp file leaked per helper spawn, forever. Same accumulation class as #5758 (transcode temps), different resource. The issue was filed by this pipeline's own review lane while driving #5758 and deliberately kept out of that PR.

## Why it matters

Every batch transcription, locale-inventory call and live-dictation session on a sandbox-capable host (i.e. every supported macOS host, and Linux hosts with user namespaces) permanently leaks a file in the temp dir. Voice-heavy installs accumulate thousands; nothing ever cleans them because the contract places the unlink on the caller that dropped it.

## What changed (motivation → approach → change)

Honour the existing contract at each site — no signature change, no self-cleaning wrapper, no context-manager abstraction (four other callers live with this contract; changing it would turn a three-site leak fix into a cross-module refactor). The shape copied is `mcp_gateway/resolve_once.py`'s `_drop_sandbox_launcher`, called on **every** exit path, because the leak is per-call: a temp removed only on the success path still accumulates.

- **`_drop_sandbox_launcher(path)`** — new module helper, idempotent and silent (a failed unlink is a leaked temp file, never a reason to fail a transcription that succeeded).
- **`transcribe()`** — `sb_cleanup` was already bound; drop it in the `finally` that already covers the spawn, the wait, the timeout kill and the `OSError` exit.
- **`inventory()`** — bind the previously-discarded element and drop it in a `finally` over the existing `try`. The timeout exit now **kills and reaps the wedged helper first**, so the unlink honours the after-exit contract and the helper is no longer left running with nobody waiting on it (adopted from pre-push review). The `SandboxUnavailableError` branch yields no tuple, hence no path — untouched.
- **`StreamingSession`** — the child outlives `start()`, so unlinking there would pull the profile/launcher out from under a live process. The path is stored on the session (`self._sb_cleanup`) and unlinked in `close()` **after** the process teardown; `start()`'s readiness-failure exits (timeout, early exit, error event) already reach it through their existing `close()` calls. The spawn-`OSError` exit (launcher exists, no child ever held it) drops it in place. Swap-to-`None` keeps the documented idempotent double `close()` from re-unlinking. `close()` is called in the production WS handler's `finally` (`dashboard/stt_stream.py`), so the session path is covered end to end.

Pre-push dual review (GPT 5.6 + Opus): both PASS, zero blocking. Adopted advisories: the inventory timeout reap, a timeout-test fix (a `timeout=0` fast path in `wait_for` never entered the branch under test), a docstring correction (`None` for the nested-sandbox passthrough), and a `finish()`-then-`close()` production-order test. The remaining advisory class — millisecond cancellation windows around the launcher lifecycle (cancelled `to_thread` hop; cancelled `start()`) — is filed as follow-up #5796 rather than widening this PR.

## Tests

New `TestSandboxCleanupPathIsDropped` (10 tests) with a `_sandboxed` stub handing back a **real** `tmp_path` file, spawn mocked so Linux CI runners never need a macOS host or a Swift helper. All fail on pre-fix code. Locked in:

- `transcribe()`: launcher gone on success, on timeout (kill → reap → unlink ordering, kill asserted), and on spawn `OSError`.
- `inventory()`: launcher gone on success, on spawn failure, and on timeout — where the wedged helper is killed and reaped before the unlink.
- `StreamingSession`: launcher **survives** `start()` (never unlinked under a live child), drops exactly on `close()`, double `close()` safe; the production `finish()`-then-`close()` order (a refactor moving the unlink into `finish()` fails the test); spawn-`OSError` drops in place; readiness-timeout reaches the unlink through `start()`'s own `close()`.

Full local gates green: isort / flake8 / mypy / black-ratchet / subprocess-encoding gate / full `pytest` (67610 passed; the 83 failures + 2 errors on this host were proven pre-existing by an identical run on a pristine `main` worktree).

## Manual verification

N/A — unit coverage sufficient: the change is pure Python resource lifecycle around mocked spawns; the macOS end-to-end path is exercised by the existing `TestEndToEndMacOS` on macOS hosts.

Closes #5776