### PR TITLE
fix(schedule): persist a new cron folder before exposing it

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -7014,6 +7014,20 @@ class DashboardState:
         except Exception:
             logger.warning("Failed to load cron folders", exc_info=True)
 
+    def _persist_cron_folders(self, folders: list[dict[str, Any]]) -> None:
+        """Atomically write ``folders`` to the cron-folders file.
+
+        Takes the list to persist explicitly so a caller can save a candidate
+        list before committing it to ``_cron_folders`` (see ``create_cron_folder``),
+        keeping in-memory state and disk from diverging mid-operation. Any
+        malformed entries preserved at load time (``_unparsed_cron_folder_entries``)
+        are appended, so a save cannot erase bytes a hand-edit left in a shape
+        the loader could not validate.
+        """
+        path = config_dir() / self._CRON_FOLDERS_FILE
+        unparsed = getattr(self, "_unparsed_cron_folder_entries", [])
+        self._atomic_write_json_strict(path, [*folders, *unparsed])
+
     def save_cron_folders(self) -> None:
         """Persist cron folder definitions to disk (atomic write).
 
@@ -7023,25 +7037,27 @@ class DashboardState:
         shape this loader could not validate. Raises on I/O failure so callers
         can surface a 500 to the client rather than silently losing the write.
         """
-        path = config_dir() / self._CRON_FOLDERS_FILE
-        unparsed = getattr(self, "_unparsed_cron_folder_entries", [])
-        payload: list[Any] = [*self._cron_folders, *unparsed]
-        self._atomic_write_json_strict(path, payload)
+        self._persist_cron_folders(self._cron_folders)
 
     def create_cron_folder(self, name: str, folder_id: str) -> dict:
         """Create a new cron folder and persist.
 
         Returns the created folder dict. Raises on persistence failure
-        (callers should surface a 500); in-memory state is rolled back.
+        (callers should surface a 500).
+
+        The folder is persisted BEFORE it is exposed in ``_cron_folders``: a
+        concurrent ``GET /api/cron-folders`` reads the live list, so appending
+        first and saving second would let a reader observe (and the frontend
+        render) a folder that a failed save then removes — a transient "ghost"
+        folder inconsistent with disk. Building the candidate list, persisting
+        it, and only then committing the reference means a reader sees either
+        the pre-create list or the durably-saved one, never an intermediate.
         """
         order = max((f["order"] for f in self._cron_folders), default=-1) + 1
         folder = {"id": folder_id, "name": name, "order": order}
-        self._cron_folders.append(folder)
-        try:
-            self.save_cron_folders()
-        except Exception:
-            self._cron_folders.pop()
-            raise
+        candidate = [*self._cron_folders, folder]
+        self._persist_cron_folders(candidate)
+        self._cron_folders = candidate
         return folder
 
     def rename_cron_folder(self, folder_id: str, name: str) -> dict | None:

--- a/test/test_dashboard_cron_folders.py
+++ b/test/test_dashboard_cron_folders.py
@@ -486,6 +486,48 @@ class TestCronFoldersPersistence:
         with pytest.raises(OSError):
             state.save_cron_folders()
 
+    def test_create_does_not_mutate_live_list_before_save_succeeds(self, tmp_path, monkeypatch):
+        """Ghost-folder regression that distinguishes persist-first from the old
+        append-then-save-then-pop: capture the LIVE ``_cron_folders`` at the
+        moment the persist runs. The old code had already appended the new
+        folder to the live list by then (a concurrent GET would see the ghost);
+        the fix persists a candidate and leaves the live list untouched until
+        the save returns, so the live list must NOT contain the folder at
+        persist time. Reverting the fix makes this assertion fail.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "existing", "name": "Keep", "order": 0}]
+        live_at_persist: list[bool] = []
+
+        def _observe(path, data):
+            # Read the LIVE attribute (not the data being written): the fix must
+            # not have committed the new folder to _cron_folders yet.
+            live_at_persist.append(any(f["id"] == "newid" for f in state._cron_folders))
+
+        monkeypatch.setattr(state, "_persist_cron_folders", lambda folders: _observe(None, folders))
+        state.create_cron_folder("New", "newid")
+        # At persist time the live list still held only the pre-existing folder.
+        assert live_at_persist == [False]
+        # After a successful create the folder is committed to the live list.
+        assert [f["id"] for f in state._cron_folders] == ["existing", "newid"]
+
+    def test_create_leaves_live_list_unchanged_on_save_failure(self, tmp_path, monkeypatch):
+        """A failed create must leave ``_cron_folders`` exactly as it was — the
+        new folder is never exposed."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+        state = DashboardState.__new__(DashboardState)
+        state._cron_folders = [{"id": "existing", "name": "Keep", "order": 0}]
+        before = list(state._cron_folders)
+
+        def _boom(self, path, data):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(DashboardState, "_atomic_write_json_strict", _boom, raising=True)
+        with pytest.raises(OSError):
+            state.create_cron_folder("New", "newid")
+        assert state._cron_folders == before
+
     def test_startup_wiring_calls_load_cron_folders(self):
         # The two gateway startup paths call load_folders(); each must also
         # call load_cron_folders() immediately after.


### PR DESCRIPTION
## Problem / Motivation

`create_cron_folder` appended the new folder to the live `_cron_folders` list and only then persisted, popping it back off on a save failure:

```python
self._cron_folders.append(folder)
try:
    self.save_cron_folders()
except Exception:
    self._cron_folders.pop()
    raise
```

`GET /api/cron-folders` returns that live list (`web.json_response(state._cron_folders)`). A reader arriving in the append→save window observes a folder that a **failed** save then removes — a transient "ghost" folder inconsistent with disk that vanishes on the next GET.

## Why it matters

Low severity — self-corrects on the next GET, no persistence, no security impact — but it is an observable inconsistency between the API response and durable state during a failed create.

## What changed (motivation → approach → change)

- **Symptom:** a concurrent GET during a failing create can serialize a folder that isn't (and won't be) on disk.
- **Root cause:** the live list is mutated *before* the durability decision (the save), so the intermediate state is observable.
- **Change:** build the candidate list, persist it, and commit the reference to `_cron_folders` **only after** the save succeeds. A reader now sees either the pre-create list or the durably-saved one, never an intermediate. Extract `_persist_cron_folders(folders)` so a candidate list can be written before it becomes live; `save_cron_folders` delegates to it. No positional `pop()` rollback is needed anymore (it also removed the future-caller fragility where `pop()` could remove the wrong element under concurrent append).

## Tests

- `test_create_does_not_mutate_live_list_before_save_succeeds` — captures the **live** `_cron_folders` at persist time and asserts the new folder is not yet present (persist-first ordering); the folder is committed only after the save returns.
- `test_create_leaves_live_list_unchanged_on_save_failure` — a failed create leaves `_cron_folders` exactly as it was.

**On proof:** this is a mid-operation concurrency-window hardening — old and new code have identical *end* state (the old code's `pop()` restored the list on failure too), so the defect is only observable by a reader interleaved with the write. A single-threaded revert (`prove.py`) therefore can't produce a distinguishing assertion failure: the tests lock in the persist-first *ordering* by construction rather than a before/after end-state delta. Flagging this honestly rather than overclaiming a revert-proof.

## Manual verification

N/A — unit coverage sufficient for the ordering invariant; the race window itself is not reproducible deterministically in-process.

## Related Issues

Fixes #5766

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only ordering change in the folder create path; no rendered UI delta.
