### PR TITLE
fix(schedule): skip no-op cron folder moves in the row action menu

### DIFF
--- a/website/src/components/CronRowActions.cov80.test.tsx
+++ b/website/src/components/CronRowActions.cov80.test.tsx
@@ -141,6 +141,22 @@ describe('CronRowActions', () => {
     await waitFor(() => expect(spies.onMove).toHaveBeenCalledWith(''))
   })
 
+  it('picking the folder the job is already in is a no-op (no API round-trip)', async () => {
+    const spies = setup({ folder_id: 'f1' })
+    await openMoveSubmenu()
+    fireEvent.click(screen.getByText('zzq-alpha'))
+    await waitFor(() => expect(screen.queryByText('zzq-alpha')).toBeNull())
+    expect(spies.onMove).not.toHaveBeenCalled()
+  })
+
+  it('picking Ungrouped while the job is already ungrouped is a no-op', async () => {
+    const spies = setup()
+    await openMoveSubmenu()
+    fireEvent.click(screen.getByText('Ungrouped'))
+    await waitFor(() => expect(screen.queryByText('Ungrouped')).toBeNull())
+    expect(spies.onMove).not.toHaveBeenCalled()
+  })
+
   it('New folder in the submenu moves the job into what it created', async () => {
     const onNewFolder = vi.fn().mockResolvedValue('f-new')
     const spies = setup({}, { onNewFolder })

--- a/website/src/components/CronRowActions.tsx
+++ b/website/src/components/CronRowActions.tsx
@@ -43,6 +43,15 @@ export default function CronRowActions({
   const sortedFolders = [...folders].sort((a, b) => a.order - b.order)
   const hasResult = !!job.has_result || !!job.has_slot
 
+  // Skip the API round-trip when the job is already in the chosen folder:
+  // selecting the currently-checked row would otherwise fire updateCron with
+  // no real change (and a follow-up reload). Normalize a missing folder_id to
+  // '' so "Ungrouped" while already ungrouped is also a no-op.
+  const move = (folderId: string) => {
+    if (folderId !== (job.folder_id ?? '')) onMove(folderId)
+    setOpen(false)
+  }
+
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
@@ -103,14 +112,14 @@ export default function CronRowActions({
             <span>{i18nT('pages.schedulePage.cronFolders.move_to_folder')}</span>
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="min-w-[160px] max-h-[240px] overflow-y-auto">
-            <DropdownMenuItem onSelect={() => { onMove(''); setOpen(false) }}>
+            <DropdownMenuItem onSelect={() => move('')}>
               <Folder size={13} className="shrink-0 text-muted" />
               <span>{i18nT('pages.schedulePage.cronFolders.ungrouped')}</span>
               {!job.folder_id && <Check size={13} className="ml-auto shrink-0 text-accent" />}
             </DropdownMenuItem>
             {sortedFolders.length > 0 && <DropdownMenuSeparator />}
             {sortedFolders.map(f => (
-              <DropdownMenuItem key={f.id} onSelect={() => { onMove(f.id); setOpen(false) }}>
+              <DropdownMenuItem key={f.id} onSelect={() => move(f.id)}>
                 <Folder size={13} className="shrink-0 text-accent" />
                 <span className="truncate">{f.name}</span>
                 {job.folder_id === f.id && <Check size={13} className="ml-auto shrink-0 text-accent" />}


### PR DESCRIPTION
## Problem / Motivation

In the Schedule page's per-row action menu, selecting the folder a job is **already in** fired `api.updateCron(...)` with no real change, followed by a `load()` — a wasted round-trip.

## Why it matters

Low severity — no correctness impact — but it is a needless server write + reload on every no-op folder selection.

## What changed (motivation → approach → change)

- **Where the defect actually lives:** the per-row folder move UI is `CronRowActions`' own submenu (`CronRowActions.tsx`), which knows the job's current folder via `job.folder_id`. (`CronJobMoveMenu` is only used by the bulk-selection toolbar, which has no single "current folder", so the no-op case does not arise there.)
- **Change:** route both the "Ungrouped" and per-folder selections in `CronRowActions` through a `move()` helper that skips `onMove` when the target equals the job's current folder (missing `folder_id` normalized to `''`). The menu still closes.

## Tests

- `CronRowActions.cov80.test.tsx`: two new tests — picking the folder the job is already in is a no-op (no `onMove`), and picking Ungrouped while already ungrouped is a no-op. Existing move/new-folder/checkmark tests still pass (14 total).

## Manual verification

N/A — unit coverage sufficient. The change only removes a redundant network call; rendered output is unchanged.

## Related Issues

Fixes #5767

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** behavioral-only guard in the row action menu (skips a no-op move API call). The menu renders identically — no rendered pixel difference to capture.
