### PR TITLE
feat(updates): background auto-check for managed (externally-managed) installs

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -777,6 +777,7 @@ function initAutoUpdate(deps) {
 
     let foundVersion = null; // last version discovered by the checkCommand, awaiting apply
     let managedQuitArmed = false; // is a before-quit auto-apply handler installed?
+    let managedInstalling = false; // an apply is in progress — pause the poll
 
     // Mirror emitError's renderer contract (emitError itself is defined further
     // down, after this early return, so it is out of scope here): a failure
@@ -899,6 +900,7 @@ function initAutoUpdate(deps) {
       }
       event.preventDefault();
       (async () => {
+        managedInstalling = true;
         emit("installing", { version: foundVersion });
         try { if (onInstallDispatched) onInstallDispatched(); } catch { /* advisory */ }
         try { if (stopGateway) await stopGateway(); } catch (err) {
@@ -996,6 +998,7 @@ function initAutoUpdate(deps) {
     }
 
     async function managedInstall() {
+      managedInstalling = true;
       emit("installing", { version: foundVersion });
       try { if (onInstallDispatched) onInstallDispatched(); } catch { /* advisory */ }
       try { if (stopGateway) await stopGateway(); } catch (err) {
@@ -1012,6 +1015,24 @@ function initAutoUpdate(deps) {
       try { if (onInstallFailed) onInstallFailed(); } catch { /* advisory */ }
       emitManagedError("install", new Error(`managed update command exited ${code}`));
     }
+
+    // Auto-check on launch and on the same interval as the feed path, so a
+    // managed install DISCOVERS updates without the user clicking Check
+    // (auto-update is on by default). Background checks only discover — an
+    // apply still requires the auto-download preference or an explicit install.
+    // The poll skips windows where an apply is already in flight, and both
+    // timers are unref'd so they never hold the process open (Electron quit,
+    // tests).
+    const managedLaunchTimer = setTimeout(() => {
+      managedCheck().catch((err) => log.error("[update] managed launch check threw", err));
+    }, LAUNCH_CHECK_DELAY_MS);
+    const managedPollTimer = setInterval(() => {
+      if (!managedInstalling) {
+        managedCheck().catch((err) => log.error("[update] managed poll check threw", err));
+      }
+    }, CHECK_INTERVAL_MS);
+    if (typeof managedLaunchTimer.unref === "function") managedLaunchTimer.unref();
+    if (typeof managedPollTimer.unref === "function") managedPollTimer.unref();
 
     return {
       check: () => managedCheck(),

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -846,6 +846,33 @@ test("managed download() lights the Install action (downloaded) without applying
   assert.ok(!commands.includes("apply"), "download must NOT run the apply command");
 });
 
+test("managed updater auto-checks on launch + arms a poll (no user action needed)", async (t) => {
+  const { deps, states } = makeDeps({
+    externallyManaged: { managedBy: "m", updateCommand: "apply", checkCommand: "check" },
+  });
+  const realST = global.setTimeout;
+  const realSI = global.setInterval;
+  let launchCb = null;
+  let pollArmed = false;
+  // Capture the scheduling done DURING synchronous init; the managed updater
+  // returns before the feed path, so these are its only timers. Restore the
+  // real timers immediately after init, before running the captured callback.
+  global.setTimeout = (fn) => { launchCb = fn; return { unref() {} }; };
+  global.setInterval = () => { pollArmed = true; return { unref() {} }; };
+  const { commands, restore } = stubSpawn({ code: 0, out: "0.5.0.6" });
+  t.after(() => { global.setTimeout = realST; global.setInterval = realSI; restore(); });
+  initAutoUpdate(deps);
+  global.setTimeout = realST;
+  global.setInterval = realSI;
+  assert.strictEqual(typeof launchCb, "function", "a launch check must be scheduled automatically");
+  assert.ok(pollArmed, "a background polling interval must be armed");
+  launchCb();
+  await new Promise((r) => setImmediate(() => setImmediate(r)));
+  assert.deepStrictEqual(commands, ["check"], "the scheduled launch check shells checkCommand");
+  const found = states.find((s) => s.state === "found");
+  assert.ok(found && found.version === "0.5.0.6", "the background check discovers the update on its own");
+});
+
 test("readExternallyManaged: absent marker -> null", (t) => {
   const fs = require("node:fs");
   const os = require("node:os");


### PR DESCRIPTION
## Summary

Follow-up to the marker-driven managed updater for externally-managed installs. That change made a managed desktop install **self-update on an explicit check/install**, but it did NOT auto-poll: a user who never opened the About panel would never see a managed update surface on its own. This adds the same **launch + polling auto-check** the feed path already runs, so a managed install discovers updates in the background — matching "auto-update is on by default".

## Changes

**`website/electron/auto-update.js`**
- The managed updater now schedules `managedCheck()` on launch (`LAUNCH_CHECK_DELAY_MS`) and on the feed path's polling interval (`CHECK_INTERVAL_MS`). Both timers are `unref()`'d so they never hold the process open. The poll skips windows where an apply is already in flight (`managedInstalling`).
- Background checks only **discover** (emit `found`); applying still requires the auto-download preference (auto-on-restart) or an explicit install — unchanged.
- Execution stays hardened as before (narrowed system PATH so a bare command name will not resolve, `cwd="/"`, bounded output, timeout). The marker command is operator-authored text, not agent/user input.

## Testing
- electron `auto-update` suite **113 passed / 0 failed**, incl. a new test asserting the updater schedules a launch check + a poll and the launch check shells `checkCommand` and discovers the update with no user action.

## Review note
Two AI lanes flag the marker-command execution on the same trust boundary as the original PR (GPT: marker executes shell; Design: background execution of a marker in a user-writable install). On a **per-user package-manager install the marker lives in the same user-writable tree as the app's own JS**, so anything that can rewrite the marker can already rewrite the executable code it would run — same trust domain, no new privilege — and gating on non-writability would disable auto-update for exactly the per-user installs this targets. These are resolved by a repository-writer `/ai-review override` (as on the original PR), not a code change.
