### PR TITLE
fix: reap ffmpeg and unlink temp on transcribe cancellation (#5780)

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -80,6 +80,5 @@ src/kiro_crew/suggestions.py 18.7   # 31/166
 src/kiro_crew/telegram/client.py 61.8   # 306/495
 src/kiro_crew/telegram/gateway.py 15.5   # 11/71
 src/kiro_crew/tips.py 64.9   # 335/516
-src/kiro_crew/transcribe.py 74.6   # 258/346
 src/kiro_crew/webex/client.py 64.1   # 173/270
 src/kiro_crew/weixin/gateway.py 20.4   # 11/54

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -533,6 +533,7 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
             logger.error("ffmpeg required to remux webm to ogg for Transcribe")
             return None
         tmp_ogg = await asyncio.to_thread(_make_temp_ogg)
+        proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 ffmpeg_bin,
@@ -558,6 +559,42 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
             if tmp_ogg:
                 await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
             return None
+        except BaseException:
+            # ``CancelledError`` derives from ``BaseException``, so the
+            # ``Exception`` guard above never sees it: a cancellation landing
+            # mid-``communicate`` used to leave the ffmpeg child running and the
+            # owned temp on disk (#5780). Mirror ``_to_native_audio``'s cleanup
+            # (#5777): stop AND reap the child BEFORE the unlink — Windows keeps
+            # the output file locked until the child fully exits, and on POSIX a
+            # live child can race the removal. Every step is best-effort, and
+            # the unlink stays synchronous (one-file unlink, matching #5777): a
+            # repeat cancellation could eat an off-loop hop before it runs. The
+            # exception in flight is the one that must surface.
+            if proc is not None:
+                try:
+                    proc.kill()
+                except (OSError, ProcessLookupError):
+                    logger.debug(
+                        "ffmpeg kill during cancellation cleanup failed",
+                        exc_info=True,
+                    )
+                else:
+                    try:
+                        await proc.communicate()
+                    except BaseException:
+                        # A repeat cancellation can land on this await; swallow
+                        # it so the unlink below still runs and the ORIGINAL
+                        # exception is the one that propagates.
+                        pass
+            if tmp_ogg:
+                try:
+                    _unlink_if_exists(tmp_ogg)
+                except OSError:
+                    # A not-yet-exited child can still hold the file (Windows
+                    # lock); letting that escape would REPLACE the in-flight
+                    # cancellation with a PermissionError.
+                    pass
+            raise
         actual_path = tmp_ogg
 
     transcript_parts: list[str] = []
@@ -609,13 +646,31 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
         logger.exception("AWS Transcribe streaming STT failed")
         return None
     finally:
-        if stream is not None:
-            try:
-                await stream.input_stream.end_stream()
-            except Exception:
-                pass
-        if tmp_ogg:
-            await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
+        # Nested ``finally`` so the unlink is unconditional: the ``end_stream``
+        # await can itself raise on a REPEAT cancellation (``CancelledError`` is
+        # a ``BaseException``, so its ``Exception`` guard misses it), and that
+        # escape used to skip the temp removal below (#5780).
+        try:
+            if stream is not None:
+                try:
+                    await stream.input_stream.end_stream()
+                except Exception:
+                    pass
+        finally:
+            if tmp_ogg:
+                try:
+                    await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
+                except BaseException:
+                    # A repeat cancellation can land on this await before the
+                    # off-loop hop runs; unlink synchronously (one file,
+                    # matching #5777) and let the cancellation propagate. The
+                    # OSError guard keeps a locked/contended file from
+                    # REPLACING the exception already in flight.
+                    try:
+                        _unlink_if_exists(tmp_ogg)
+                    except OSError:
+                        pass
+                    raise
 
 
 def _collect_whisper_output(

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -1491,3 +1491,336 @@ class TestPython3BinDirIsolation:
         )
 
         assert transcribe._python3_bin_dir() == ""
+
+
+# ---------------------------------------------------------------------------
+# _transcribe_aws remux/streaming temp ownership under cancellation (#5780)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAwsTempOwnership:
+    """``_transcribe_aws`` owns ``tmp_ogg`` until every exit removes it.
+
+    The webm→ogg remux creates the temp with ``_make_temp_ogg``; a cancellation
+    (``CancelledError`` is a ``BaseException``, so an ``except Exception`` guard
+    misses it) must kill AND reap the ffmpeg child before the unlink — Windows
+    keeps the output file locked until the child fully exits — and then let the
+    cancellation propagate. Reference pattern:
+    ``test_apple_speech.py::TestTranscodeTempOwnership`` (#5777).
+    """
+
+    @staticmethod
+    def _grant_consent(tmp_path, monkeypatch, cfg):
+        """Record Transcribe consent so the paid-service gate lets tests pass."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        from kiro_crew import aws_consent
+        from kiro_crew.config.loader import config_dir
+
+        config_dir().mkdir(parents=True, exist_ok=True)
+        aws_consent.record_grant(
+            aws_consent.SERVICE_TRANSCRIBE,
+            profile=cfg.transcribe_profile,
+            region=cfg.transcribe_region,
+            account="111122223333",
+            arn="arn:aws:iam::111122223333:user/test",
+            granted_at="2026-08-21T00:00:00+00:00",
+        )
+
+        async def _probe(_profile, _region, *, use_cache=True):
+            return aws_consent.Identity(ok=True, account="111122223333")
+
+        monkeypatch.setattr(aws_consent, "probe_identity", _probe)
+
+    @staticmethod
+    def _owned_temp(tmp_path, monkeypatch):
+        """Pin ``_make_temp_ogg`` to a known file so the tests can watch it."""
+        from kiro_crew import transcribe as tr
+
+        owned = tmp_path / "owned.ogg"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(tr, "_make_temp_ogg", lambda: str(owned))
+        return owned
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_ffmpeg_before_removing_the_owned_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation mid-``communicate`` must kill the child, reap it, THEN
+        remove ``tmp_ogg``, and re-raise — the old ``except Exception`` guard
+        did none of that (#5780)."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        events: list[str] = []
+
+        class _Proc:
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise asyncio.CancelledError()
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        real_unlink = tr._unlink_if_exists
+
+        def tracked_unlink(path):
+            if str(path) == str(owned):
+                events.append("unlinked")
+            return real_unlink(path)
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (object, object)
+        )
+        monkeypatch.setattr(tr, "_unlink_if_exists", tracked_unlink)
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=_Proc()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await tr._transcribe_aws(str(src), cfg)
+        assert events == ["killed", "reaped", "unlinked"]
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_remux_failure_still_unlinks_and_returns_none(
+        self, tmp_path, monkeypatch
+    ):
+        """The new cancellation path must not eat the established ``Exception``
+        contract: a failed remux logs, removes the temp, and returns None."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 1
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (object, object)
+        )
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            result = await tr._transcribe_aws(str(src), cfg)
+        assert result is None
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_in_stream_cleanup_still_unlinks(
+        self, tmp_path, monkeypatch
+    ):
+        """A REPEAT cancellation landing on the cleanup ``end_stream`` await
+        escapes its ``except Exception`` guard; the nested ``finally`` must
+        still remove ``tmp_ogg`` and let the cancellation propagate (#5780)."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        remux_proc = AsyncMock()
+        remux_proc.communicate = AsyncMock(return_value=(b"", b""))
+        remux_proc.returncode = 0
+
+        input_stream = SimpleNamespace(
+            # First cancellation: aborts the streaming phase from inside the
+            # ``try``. Second: lands on the cleanup ``end_stream`` in ``finally``.
+            send_audio_event=AsyncMock(side_effect=asyncio.CancelledError()),
+            end_stream=AsyncMock(side_effect=asyncio.CancelledError()),
+        )
+        stream = SimpleNamespace(input_stream=input_stream, output_stream=object())
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def start_stream_transcription(self, **kwargs):
+                return stream
+
+        class FakeHandler:
+            def __init__(self, output_stream, transcript_parts):
+                pass
+
+            async def handle_events(self):
+                pass
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(tr, "_read_audio_bytes", lambda path: b"fake audio")
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (FakeClient, FakeHandler)
+        )
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=remux_proc),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await tr._transcribe_aws(str(src), cfg)
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_and_locked_file_keep_the_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        """Worst case on Windows: a repeat cancellation interrupts the reap, so
+        the child may still hold the file and the unlink raises
+        ``PermissionError``. That must not REPLACE the in-flight cancellation
+        — the guard swallows the ``OSError`` and the original propagates."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        events: list[str] = []
+
+        class _Proc:
+            async def communicate(self):
+                # First call: the cancellation under test. Second call (the
+                # reap): a REPEAT cancellation lands on the cleanup await.
+                raise asyncio.CancelledError()
+
+            def kill(self):
+                events.append("killed")
+
+        def locked_unlink(path):
+            events.append("unlink_attempted")
+            raise PermissionError("file is locked by the child")
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (object, object)
+        )
+        monkeypatch.setattr(tr, "_unlink_if_exists", locked_unlink)
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=_Proc()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await tr._transcribe_aws(str(src), cfg)
+        assert events == ["killed", "unlink_attempted"]
+        # The locked unlink never removed the file — the guarantee under test
+        # is exception identity, not removal.
+        assert owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_spawn_still_removes_the_owned_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation landing on ``create_subprocess_exec`` itself means no
+        child exists — the owned temp must still be removed and the
+        cancellation must propagate."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (object, object)
+        )
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=asyncio.CancelledError(),
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await tr._transcribe_aws(str(src), cfg)
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
+    async def test_stream_cleanup_sync_fallback_swallows_locked_file(
+        self, tmp_path, monkeypatch
+    ):
+        """When the off-loop unlink hop is itself cancelled AND the synchronous
+        fallback hits a locked file, the ``OSError`` must be swallowed so the
+        cancellation — not a ``PermissionError`` — reaches the awaiter."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        remux_proc = AsyncMock()
+        remux_proc.communicate = AsyncMock(return_value=(b"", b""))
+        remux_proc.returncode = 0
+
+        input_stream = SimpleNamespace(
+            send_audio_event=AsyncMock(side_effect=asyncio.CancelledError()),
+            end_stream=AsyncMock(),
+        )
+        stream = SimpleNamespace(input_stream=input_stream, output_stream=object())
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def start_stream_transcription(self, **kwargs):
+                return stream
+
+        class FakeHandler:
+            def __init__(self, output_stream, transcript_parts):
+                pass
+
+            async def handle_events(self):
+                pass
+
+        def locked_unlink(path):
+            raise PermissionError("file is locked")
+
+        real_to_thread = asyncio.to_thread
+
+        async def cancelled_unlink_hop(func, *args, **kwargs):
+            # Simulate a repeat cancellation eating the off-loop hop for the
+            # unlink only; every other to_thread call runs normally.
+            if func is tr._unlink_if_exists:
+                raise asyncio.CancelledError()
+            return await real_to_thread(func, *args, **kwargs)
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(tr, "_read_audio_bytes", lambda path: b"fake audio")
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (FakeClient, FakeHandler)
+        )
+        monkeypatch.setattr(tr, "_unlink_if_exists", locked_unlink)
+        monkeypatch.setattr(asyncio, "to_thread", cancelled_unlink_hop)
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=remux_proc),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await tr._transcribe_aws(str(src), cfg)
+        # The locked unlink never removed the file — the guarantee under test
+        # is exception identity, not removal.
+        assert owned.exists()
+        assert src.exists()


### PR DESCRIPTION
## Problem / Motivation

In `src/kiro_crew/transcribe.py::_transcribe_aws`, the webm→ogg remux creates an owned temp file (`_make_temp_ogg`) and wraps the ffmpeg spawn/`communicate` in a broad `except Exception`. `asyncio.CancelledError` derives from `BaseException`, so a cancellation arriving mid-`wait_for` escapes that guard entirely: the ffmpeg child is neither killed nor reaped, and `tmp_ogg` is never unlinked. Only the explicit `asyncio.TimeoutError` branch kills and waits today.

The streaming phase has the same class one level deeper: its `tmp_ogg` unlink lives in a `finally` (so a single cancellation is safe), but the `end_stream()` await before it is guarded only by `except Exception`, so a REPEAT cancellation landing on that await escapes and skips the unlink.

## Why it matters

Every cancelled voice transcription (user aborts, timeout cascade, gateway shutdown) leaks an orphaned ffmpeg process and a temp file on disk. Orphaned children accumulate and consume resources for the life of the gateway; leaked temps accumulate in the temp dir. The same defect class was already fixed for `apple_speech._to_native_audio` in #5777 (issue #5758); this PR fixes the `_transcribe_aws` instance. Three further siblings of the class (`_run_whisper_cli`, and the piper/Polly paths in `voice_reply.py`) remain and are tracked in #5821 — each needs its own tests and is out of this PR's scope.

## What changed (motivation → approach → change)

Symptom → root cause: `except Exception` cannot see `CancelledError`, so no cleanup path ran on cancellation. Approach: mirror the merged #5777 pattern at the remux seam, keeping the established `Exception` contract untouched.

- **Remux seam:** a new `except BaseException` path kills the ffmpeg child if alive (kill failure logged at debug, observable), reaps it via `await proc.communicate()` BEFORE the unlink — Windows keeps the output file locked until the child fully exits, and `communicate()` (not `wait()`) drains the PIPE buffers per the asyncio docs and the #5777 precedent — then best-effort unlinks `tmp_ogg` and re-raises. A repeat cancellation landing on the reap await is swallowed so the unlink still runs and the ORIGINAL exception propagates. The unlink is wrapped in `except OSError: pass`: a still-locked file raising `PermissionError` must not REPLACE the in-flight cancellation (this matches #5777's `except OSError` cleanup; `_unlink_if_exists` itself tolerates only `FileNotFoundError` and its contract is deliberately unchanged for other callers).
- **Existing behavior preserved:** the `except Exception` branch (log + unlink + return None) and the `asyncio.TimeoutError` branch are unchanged, pinned by a test.
- **Streaming phase (covered — the same class applies under repeat cancellation):** a nested `finally` makes the unlink unconditional even when the `end_stream()` await raises on a repeat cancellation, and if the off-loop unlink hop is itself cancelled, a synchronous fallback unlink runs (one-file unlink, matching #5777's inline `os.unlink`), also `OSError`-guarded, before the cancellation propagates.

The sync unlinks in the cancellation paths are deliberate: a cancelled task cannot rely on an off-loop hop being scheduled, and merged #5777 uses the same inline cleanup — a single `os.unlink` is O(1) metadata, not a blocking-call-on-loop violation.

## Tests

Six tests in `test/test_transcribe.py::TestTranscribeAwsTempOwnership`, modeled on `test_apple_speech.py::TestTranscodeTempOwnership` (#5777), all mutation-verified (each cancellation test fails on the unfixed code):

- `test_cancellation_reaps_ffmpeg_before_removing_the_owned_temp` — cancellation mid-`communicate` kills, reaps, THEN unlinks (order asserted via an events list) and `CancelledError` propagates.
- `test_remux_failure_still_unlinks_and_returns_none` — pins the unchanged `Exception` contract.
- `test_repeat_cancellation_in_stream_cleanup_still_unlinks` — a repeat cancellation escaping the `end_stream` guard no longer skips the streaming-phase unlink.
- `test_repeat_cancellation_and_locked_file_keep_the_cancellation` — worst case on Windows: repeat cancellation interrupts the reap AND the file is still locked; the `PermissionError` is swallowed and the original `CancelledError` reaches the awaiter.
- `test_cancellation_during_spawn_still_removes_the_owned_temp` — cancellation landing on `create_subprocess_exec` itself (no child exists) still removes the temp.
- `test_stream_cleanup_sync_fallback_swallows_locked_file` — the streaming-phase synchronous fallback swallows a locked-file `OSError` and propagates the cancellation.

Full backend suite: 67720 passed; the 13 failures are host-environment (identical on unmodified main, verified by re-running the same set on a stashed tree).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are exception-flow logic fully exercised by deterministic tests with a faked ffmpeg process; no UI or external-service path is involved.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only exception-handling change in `src/kiro_crew/transcribe.py`; no rendered UI is touched.

## Related Issues

Closes #5780

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff
