### PR TITLE
fix(i18n): catch hardcoded plural glue via a growth ceiling (#5785)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1227,7 +1227,7 @@ jobs:
         # unrecognised flag makes those scripts refuse to run rather than fall through to
         # their destructive conversion path.
         #
-        # ONLY TWO KINDS OF CHECK CAN FAIL THIS STEP.
+        # ONLY THREE KINDS OF CHECK CAN FAIL THIS STEP.
         #
         #   DIFF-SCOPED, zero tolerance — a finding on a line you wrote is yours and there
         #   is no number to raise:
@@ -1243,8 +1243,16 @@ jobs:
         #                       reference and its catalog entry are edited independently, so
         #                       a catalog-only rename dangles references in files the PR
         #                       never opens. Needs no base ref, so it cannot skip itself.
-        #     [plurals]         a `{n} {t('item')}s` concatenation.
+        #     [plurals]         an i18nT-adjacent `{n} {t('item')}s` concatenation.
         #     [pseudolocale]    `en-XA.json` stale against its generator.
+        #
+        #   WHOLE-REPO CEILING — fails only when the class GROWS:
+        #     [plurals-hardcoded] the same plural-glue defect with NO i18nT in it, e.g.
+        #                       a fully hardcoded aria-label gluing `?'s':''` onto a
+        #                       noun. The frozen sites are pinned at HARDCODED_CEILING
+        #                       in i18n-plural-codemod.mjs and ratchet DOWN as they are
+        #                       converted; a failure lists every site with file:line so
+        #                       the added one is findable.
         #
         # EVERYTHING ELSE IS REPORT ONLY — [untranslated], [allcaps], [extractable] and
         # [dynamic-keys]. Each is a stored whole-repo total, written by whichever branch

--- a/docs/ci/i18n-gates.md
+++ b/docs/ci/i18n-gates.md
@@ -58,7 +58,7 @@ conversion path.
 
 ## The table
 
-Thirteen checks over eight scripts. The split is by the only question an author
+Fourteen checks over eight scripts. The split is by the only question an author
 has: **is this mine to fix?** A `diff`-scoped finding is on a line this branch
 wrote or in a file it touched. A `repo`-scoped finding is a whole-repo measurement
 the branch may simply have inherited.
@@ -70,7 +70,8 @@ the branch may simply have inherited.
 | `[source-strings]` | diff | zero tolerance | badly shaped copy among only the English keys your branch adds |
 | `[changed-values]` | diff | zero tolerance | catalog QA over every value the branch added or changed, all languages |
 | `[key-refs]` | repo | hard zero | a `t('key')` naming a key that does not exist |
-| `[plurals]` | repo | hard zero | a plural suffix concatenated outside the translation call |
+| `[plurals]` | repo | hard zero | an i18nT-adjacent plural suffix concatenated outside the translation call |
+| `[plurals-hardcoded]` | repo | ceiling — fails on growth | the same plural glue with NO `i18nT` in it, fully hardcoded |
 | `[pseudolocale]` | repo | hard zero | `en-XA.json` stale relative to its generator |
 | `[dnt]` | repo | hard zero | a do-not-translate term respelt in a shipped catalog |
 | `[manifest-sync]` | repo | hard zero | a built-in `app.json` string and its `en.json` value stopped matching |
@@ -79,7 +80,7 @@ the branch may simply have inherited.
 | `[untranslated]` | repo | report only | per-file ceilings over the frozen untranslated debt |
 | `[allcaps]` | repo | report only | untranslated strings inside ALL-CAPS module constants |
 
-### Only two kinds of check can fail the step
+### Only three kinds of check can fail the step
 
 1. **A diff-scoped one.** A finding on a line you wrote is yours and there is no
    number to raise.
@@ -89,6 +90,24 @@ the branch may simply have inherited.
    references in files the PR never opens. It also needs no base ref, so it cannot
    skip itself. The user-visible symptom it prevents is a raw dotted key rendered
    into the UI, because a missing key is returned as its own fallback.
+3. **A whole-repo CEILING that fails only on growth.** `[plurals-hardcoded]` is the
+   one check of this kind, and it exists because the class it counts cannot be a
+   hard zero (the frozen sites need manual conversion, so a hard zero would have
+   failed on arrival and been disabled) and was invisible to the gate entirely —
+   the hard-zero tier keys on an adjacent `i18nT` call, so a fully hardcoded
+   literal reported zero to it and the class regrew silently. The ceiling is
+   pinned at `HARDCODED_CEILING` in `website/scripts/i18n-plural-codemod.mjs` and
+   ratchets DOWN as sites are converted. What keeps it out of the stored-total
+   trap below: it is pinned at the frozen debt's worst point, so main crosses it
+   only when a PR adds a site — unlike the `[untranslated]`/`[allcaps]` totals,
+   which move whenever any counted file changes. Lowering the constant after a
+   conversion is suggested on every run but optional, for the same recorded
+   reason as `[extractable]`'s `--baseline`: forcing every improving branch to
+   edit one shared line makes it a merge conflict between all of them. The cost
+   of that choice is bounded and accepted — a site re-added inside unclaimed
+   slack rides free until the constant is tightened. A failure prints every site
+   with `file:line`, so a red always names lines an author can check against
+   their own diff.
 
 Everything else is **report only**. A stored whole-repo total is written by
 whichever branch measured it last, so another branch can push it past its number

--- a/website/docs/i18n-catalog.md
+++ b/website/docs/i18n-catalog.md
@@ -154,6 +154,17 @@ to verify none crept back in. Which keys are plural comes from that registry,
 never from sniffing a `_one` / `_other` suffix, because real copy ends in those
 words (`panel_to_add_one` is "panel to add one.").
 
+A **fully hardcoded** literal commits the same defect with no `i18nT` in it:
+
+```tsx
+// WRONG for the same reason — the suffix is chosen in JS, in English
+aria-label={`Retry ${n} failed subagent${n > 1 ? 's' : ''}`}
+```
+
+`--check` counts these too (`[plurals-hardcoded]`), against a ceiling that fails
+only when the class grows: the frozen sites each need a new catalog key, so they
+are converted by hand and the ceiling ratchets down with them.
+
 ## One key, one meaning
 
 **Never reuse a key across two grammatical roles.** English collapses distinctions

--- a/website/scripts/i18n-check.mjs
+++ b/website/scripts/i18n-check.mjs
@@ -96,16 +96,19 @@ const section = (title, pick) => {
   }
   out('')
 }
-// Three sections, because "can this fail" is now a different question from "is this
-// mine". Only a diff-scoped check and a whole-repo HARD ZERO can fail the step: a hard
-// zero has no ceiling, so a new one is always somebody's diff. Every other whole-repo
-// number is a stored total that another branch can move without touching your files, and
-// those are reported.
+// Four sections, because "can this fail" is now a different question from "is this
+// mine". A diff-scoped check and a whole-repo HARD ZERO fail the step: a hard zero has
+// no ceiling, so a new one is always somebody's diff. A whole-repo CEILING fails only
+// when its class GROWS — the frozen sites are inherited, a new one is a diff, and the
+// failure lists every site so yours is findable. Every other whole-repo number is a
+// stored total that another branch can move without touching your files, and those are
+// reported.
 section('YOURS — diff-scoped, fails on any finding', r => r.scope === 'diff')
 section('WHOLE REPO, ENFORCED — no ceiling to inherit', r => r.scope === 'repo' && r.enforce === 'hard-zero')
+section('WHOLE REPO, CEILING — fails only on growth', r => r.scope === 'repo' && r.enforce === 'ceiling')
 section('WHOLE REPO, REPORT ONLY — cannot fail this step', r => r.scope === 'repo' && r.enforce === 'info')
 
-const ceilings = rows.filter(r => r.enforce === 'info' && r.note)
+const ceilings = rows.filter(r => (r.enforce === 'info' || r.enforce === 'ceiling') && r.note)
 for (const r of ceilings) out(`  [${r.id}] ${r.summary} — ${r.note}`)
 if (ceilings.length) out('')
 
@@ -125,6 +128,13 @@ for (const r of bad) {
     out(`  -> [${r.id}] is whole-repo but a HARD ZERO, so there is no ceiling and no`)
     out('     inherited number to blame — a new one almost always comes from this diff.')
     out(`     The offending sites are in the ${fileOf(r.script)} group below.\n`)
+  } else if (r.enforce === 'ceiling') {
+    out(`  -> [${r.id}] is a growth ratchet: the frozen sites are inherited debt, but the`)
+    out('     count only GROWS when a diff adds a site. Every site is listed with file:line')
+    out(`     in the ${fileOf(r.script)} group below — the one(s) matching your diff are the`)
+    out('     growth. If none is yours, a concurrent merge grew the count under you:')
+    out('     convert the added site, or raise the ceiling in the same PR with a line')
+    out('     explaining the growth is inherited.\n')
   } else {
     out(`  -> [${r.id}] is a STORED COUNT (${ENFORCE_LABEL[r.enforce]}), so your diff may not`)
     out('     have caused it: another branch can move this number without touching your')

--- a/website/scripts/i18n-plural-codemod.mjs
+++ b/website/scripts/i18n-plural-codemod.mjs
@@ -39,17 +39,44 @@
  * diffs, and it can be re-run if an upstream sync reintroduces the pattern.
  * Run with `--check` in CI to fail on reintroduction.
  *
+ * ## The `--check` contract has two tiers
+ *
+ * 1. **i18nT-adjacent glue — HARD ZERO.** The patterns below, where the plural
+ *    ternary follows an `i18nT('key')` call. All 33 were converted, so any
+ *    match is a reintroduction and fails outright.
+ * 2. **Fully hardcoded literals — CEILING, fails only on growth.** The same
+ *    defect with no `i18nT` anywhere in it (`scripts/lib/hardcoded-plural.mjs`
+ *    is the detector). Those sites cannot be auto-converted — each needs a new
+ *    catalog key plus translations — so the frozen debt is pinned at
+ *    `HARDCODED_CEILING` and only a NEW site fails the check. The ceiling
+ *    ratchets DOWN as sites are converted; see the constant's comment for the
+ *    one sanctioned reason to raise it.
+ *
  *   node scripts/i18n-plural-codemod.mjs [--check]
  */
 
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { findHardcodedPluralSites } from './lib/hardcoded-plural.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
 const SRC = path.join(ROOT, 'src')
 const CHECK = process.argv.includes('--check')
+
+/**
+ * Ceiling for the SECOND tier (see the header): fully hardcoded plural
+ * literals, which the i18nT-anchored patterns below cannot see. `--check`
+ * fails only when the count GROWS past this number; lower it as sites are
+ * converted. Raising it is reserved for exactly one case: a concurrent merge
+ * added a site, so an unrelated PR inherits the red — that PR may raise the
+ * ceiling with a line explaining the growth is inherited, or convert the added
+ * site. A measured count, not a target: it equals the number of matching sites
+ * in `src/` when the detector landed, because a hard zero would have failed on
+ * arrival and been disabled.
+ */
+const HARDCODED_CEILING = 37
 
 /**
  * The two shapes in the codebase, both anchored so the count expression is
@@ -93,10 +120,18 @@ function walk(dir, out = []) {
 const touchedKeys = new Set()
 const changedFiles = []
 const skipped = []
+const hardcodedSites = []
 
 for (const file of walk(SRC)) {
   const before = fs.readFileSync(file, 'utf-8')
   let after = before
+
+  // Tier two, counted but never rewritten: fully hardcoded plural glue. Each
+  // site needs a NEW catalog key plus translations, which no codemod can
+  // invent — so it is only counted against HARDCODED_CEILING.
+  for (const site of findHardcodedPluralSites(before)) {
+    hardcodedSites.push({ file: path.relative(ROOT, file), line: site.line, text: site.text })
+  }
 
   for (const re of PATTERNS) {
     after = after.replace(re, (m, countExpr, gap, key, ternaryExpr) => {
@@ -147,7 +182,13 @@ if (!CHECK && touchedKeys.size) {
 }
 
 if (CHECK) {
+  // Both tiers are evaluated and printed before the exit, for the same reason
+  // `i18n-check.mjs` replaced the `&&` chain: short-circuiting on the first
+  // failure means an author learns about the second one a CI round later.
+  let failed = false
+
   if (changedFiles.length) {
+    failed = true
     console.error(
       `\nFAIL: ${changedFiles.length} file(s) still use the literal-'s' plural hack:\n`
       + changedFiles.map(f => `  ${f}`).join('\n')
@@ -155,10 +196,45 @@ if (CHECK) {
       + ` catalog forms. Appending 's' outside i18nT() cannot be fixed by any`
       + ` translation — see scripts/i18n-plural-codemod.mjs.\n`,
     )
-    process.exit(1)
+  } else {
+    console.log('OK: no literal-\'s\' pluralization found.')
   }
-  console.log('OK: no literal-\'s\' pluralization found.')
+
+  const n = hardcodedSites.length
+  if (n > HARDCODED_CEILING) {
+    failed = true
+    console.error(
+      `\nFAIL: ${n} hardcoded plural literal(s) — ${n - HARDCODED_CEILING} above the ceiling of ${HARDCODED_CEILING}:\n`
+      + hardcodedSites.map(s => `  ${s.file}:${s.line}  ${s.text}`).join('\n')
+      + `\n\nEvery site is listed so yours is findable: the one(s) this branch added are`
+      + `\nthe growth. Replace the glued suffix with i18nT('key', { count: n }) and`
+      + `\n_one/_other catalog forms — see this script's header for why no hardcoded`
+      + `\nspelling can be correct in 12 languages. If no listed site is yours, a`
+      + `\nconcurrent merge grew the count under you: convert the added site, or raise`
+      + `\nHARDCODED_CEILING in the same PR with a line explaining the growth is`
+      + `\ninherited.\n`,
+    )
+  } else if (n < HARDCODED_CEILING) {
+    console.log(
+      `OK: ${n} hardcoded plural literal(s), below the ceiling of ${HARDCODED_CEILING}. `
+      + `Optional: lower HARDCODED_CEILING to ${n} in scripts/i18n-plural-codemod.mjs to tighten the ratchet.`,
+    )
+  } else {
+    console.log(`OK: ${n} hardcoded plural literal(s), at the ceiling of ${HARDCODED_CEILING}.`)
+  }
+
+  // exitCode rather than process.exit(): an immediate exit can terminate the
+  // process before piped stdout/stderr flush, and the runner reads a silent
+  // child as MISSING rows — a truncated verdict, not a fast one.
+  process.exitCode = failed ? 1 : 0
 } else {
   console.log(`rewrote ${changedFiles.length} file(s), ${touchedKeys.size} key(s)`)
   console.log([...touchedKeys].sort().join('\n'))
+  if (hardcodedSites.length) {
+    console.log(
+      `\n${hardcodedSites.length} hardcoded plural literal(s) need MANUAL conversion `
+      + `(each needs a new catalog key, so no codemod can rewrite them):\n`
+      + hardcodedSites.map(s => `  ${s.file}:${s.line}  ${s.text}`).join('\n'),
+    )
+  }
 }

--- a/website/scripts/lib/hardcoded-plural.mjs
+++ b/website/scripts/lib/hardcoded-plural.mjs
@@ -1,0 +1,66 @@
+/**
+ * Detector for FULLY HARDCODED plural glue — the count-adjacent template-literal
+ * shape with no `i18nT()` anywhere in it:
+ *
+ *     `Retry ${failedIds.length} failed subagent${failedIds.length > 1 ? 's' : ''}`
+ *
+ * ## Why this exists next to the i18nT-anchored patterns
+ *
+ * The hard-zero patterns in `i18n-plural-codemod.mjs` key on an `i18nT('key')`
+ * call sitting immediately before the plural ternary. That is the INCIDENTAL
+ * property of those sites, not the defining one: the defect is that JavaScript
+ * chose a plural marker outside the translate call, and a fully hardcoded
+ * literal commits it just the same while containing no `i18nT` for those
+ * patterns to anchor on. Such a site reports zero to the hard-zero tier, so the
+ * class regrows silently and each instance costs a separately filed bug.
+ *
+ * ## What matches
+ *
+ * Inside one template literal: an interpolated expression (the displayed
+ * count), then literal text ending in a letter (the noun the suffix glues to),
+ * then a ternary interpolation yielding exactly `'s'` or `''`. All three
+ * comparison spellings found in this codebase are covered: `> 1`, `!== 1`, and
+ * the inverted `=== 1 ? '' : 's'`.
+ *
+ * The two expressions are deliberately NOT required to be the same: a suffix
+ * driven by a different variable than the number on display is the same defect
+ * (a plural form chosen in JS), plus a count/form disagreement on top.
+ *
+ * ## Known limits, accepted
+ *
+ * Purely lexical, like every pattern in the codemod. Whitespace around the
+ * operator and ternary tokens is tolerated and either quote style matches, so
+ * a compact or reformatted spelling of the same glue cannot slip past — but an
+ * expression containing braces (an object literal) will not match. The scan is
+ * a growth ratchet, not an exhaustive census; a miss keeps the count low,
+ * never fails anyone.
+ */
+
+export const HARDCODED_PLURAL_PATTERNS = [
+  /\$\{([^{}]+?)\}([^`$]*[A-Za-z])\$\{([^{}]+?)\s*>\s*1\s*\?\s*(['"])s\4\s*:\s*(['"])\5\s*\}/g,
+  /\$\{([^{}]+?)\}([^`$]*[A-Za-z])\$\{([^{}]+?)\s*!==\s*1\s*\?\s*(['"])s\4\s*:\s*(['"])\5\s*\}/g,
+  /\$\{([^{}]+?)\}([^`$]*[A-Za-z])\$\{([^{}]+?)\s*===\s*1\s*\?\s*(['"])\4\s*:\s*(['"])s\5\s*\}/g,
+]
+
+/**
+ * Scan one file's source text.
+ *
+ * @param {string} source
+ * @returns {{ index: number, line: number, text: string }[]} one entry per
+ *   match, sorted by position; `line` is 1-based so a report can print
+ *   `file:line` an editor can jump to.
+ */
+export function findHardcodedPluralSites(source) {
+  const sites = []
+  for (const re of HARDCODED_PLURAL_PATTERNS) {
+    re.lastIndex = 0
+    for (const m of source.matchAll(re)) {
+      sites.push({
+        index: m.index,
+        line: source.slice(0, m.index).split('\n').length,
+        text: m[0],
+      })
+    }
+  }
+  return sites.sort((a, b) => a.index - b.index)
+}

--- a/website/scripts/lib/i18n-gate-table.mjs
+++ b/website/scripts/lib/i18n-gate-table.mjs
@@ -37,7 +37,7 @@ export const SCRIPTS = [
 ]
 
 /**
- * The eighteen checks, in reading order within their section.
+ * The nineteen checks, in reading order within their section.
  *
  * `find` pulls the numbers out of the owning script's output on the PASSING path;
  * `whenFailed` does the same for the failing path, because most of these scripts print
@@ -120,9 +120,40 @@ export const CHECKS = [
     id: 'plurals', script: 'plural', scope: 'repo', enforce: 'hard-zero',
     find: /^OK: no literal-'s' pluralization found\./m,
     summary: () => "0 literal-'s' concatenations",
+    // The script hosts a second, independent tier (`plurals-hardcoded`): a
+    // failure THERE also exits the script non-zero, so this row must judge
+    // itself by its own printed line, not inherit the shared exit code.
+    ok: () => true,
     whenFailed: {
       find: /^FAIL: (\d+) file\(s\) still use the literal-'s'/m,
       summary: m => `${m[1]} file(s) use the literal-'s' plural hack`,
+    },
+  },
+  {
+    // The ONE whole-repo ceiling that can fail the step, and deliberately so.
+    // The i18nT-adjacent tier above keys on an incidental property (an i18nT
+    // call is adjacent), so a FULLY hardcoded plural literal reports zero to
+    // it and the class regrows silently. What exempts this row from the
+    // stored-total rule: the ceiling is pinned at the frozen debt's worst
+    // point, so main crosses it only when a PR ADDS a site — the totals
+    // behind `[untranslated]`/`[allcaps]` move whenever any counted file
+    // changes, this one moves only with the defect class itself. Slack can
+    // open when a conversion declines the optional tightening (the runner
+    // suggests it on every run), and a site re-added inside that slack rides
+    // free — accepted deliberately: forcing every improving branch to edit
+    // one shared constant makes it a merge conflict between all of them,
+    // the same recorded reason lowering `[extractable]`'s --baseline is
+    // optional. A failure prints every site with file:line, so a red names
+    // lines an author can check against their own diff. The ceiling only
+    // ratchets down (see HARDCODED_CEILING in the owning script).
+    id: 'plurals-hardcoded', script: 'plural', scope: 'repo', enforce: 'ceiling',
+    find: /^OK: (\d+) hardcoded plural literal\(s\), (?:at|below) the ceiling of (\d+)\./m,
+    summary: m => `${m[1]} hardcoded plural literal(s)`,
+    note: m => `ceiling ${m[2]}, slack ${Number(m[2]) - Number(m[1])}`,
+    ok: () => true,
+    whenFailed: {
+      find: /^FAIL: (\d+) hardcoded plural literal\(s\) — (\d+) above the ceiling of (\d+)/m,
+      summary: m => `${m[1]} hardcoded plural literal(s) — ${m[2]} over the ceiling of ${m[3]}`,
     },
   },
   {
@@ -236,6 +267,7 @@ export const CHECKS = [
 export const ENFORCE_LABEL = {
   zero: 'zero tolerance',
   'hard-zero': 'hard zero',
+  ceiling: 'ceiling — fails on growth',
   info: 'report only',
 }
 

--- a/website/src/test/hardcodedPlural.test.ts
+++ b/website/src/test/hardcodedPlural.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HARDCODED_PLURAL_PATTERNS,
+  findHardcodedPluralSites,
+} from '../../scripts/lib/hardcoded-plural.mjs'
+
+/**
+ * The hardcoded-plural detector behind the `[plurals-hardcoded]` ceiling.
+ *
+ * What it must catch is the plural-glue defect with NO `i18nT()` anywhere in
+ * it — the shape the i18nT-anchored hard-zero patterns are structurally blind
+ * to, because they key on an adjacent translate call that these sites simply
+ * do not have. What it must NOT catch is pinned just as hard: a false positive
+ * here fails CI on a healthy line, and a ceiling gate is only trustworthy when
+ * a match is a defect every time.
+ */
+describe('findHardcodedPluralSites — true positives', () => {
+  it('catches the count-adjacent template-literal shape', () => {
+    // The reference shape (a real aria-label in this codebase): interpolated
+    // count, literal noun, glued conditional suffix — all hardcoded English.
+    const src = 'aria-label={`Retry ${failedIds.length} failed subagent${failedIds.length > 1 ? \'s\' : \'\'}`}'
+    const sites = findHardcodedPluralSites(src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].text).toContain('failed subagent')
+  })
+
+  it.each([
+    ['greater-than-1', '`${n} session${n > 1 ? \'s\' : \'\'}`'],
+    ['not-equals-1', '`${res.failed.length} session${res.failed.length !== 1 ? \'s\' : \'\'}`'],
+    ['equals-1 inverted', '`${hiddenCount} more app${hiddenCount === 1 ? \'\' : \'s\'}`'],
+  ])('catches the %s spelling', (_name, src) => {
+    expect(findHardcodedPluralSites(src)).toHaveLength(1)
+  })
+
+  it.each([
+    ['compact, no spaces', '`${n} item${n>1?\'s\':\'\'}`'],
+    ['double quotes', '`${n} item${n > 1 ? "s" : ""}`'],
+    ['line break inside the ternary', '`${n} item${n > 1\n  ? \'s\'\n  : \'\'}`'],
+  ])('catches a reformatted spelling: %s', (_name, src) => {
+    // The defect is the same however a formatter (or an evader) spells it, so
+    // whitespace and quote style must not be load-bearing in the patterns.
+    expect(findHardcodedPluralSites(src)).toHaveLength(1)
+  })
+
+  it('does not mix quote styles within one ternary arm pair', () => {
+    // A backreference pins the closing quote to the opening one; mixed quotes
+    // are not valid JS string literals and must not be counted.
+    expect(findHardcodedPluralSites('`${n} item${n > 1 ? \'s" : \'\'}`')).toHaveLength(0)
+  })
+
+  it('catches a parenthesised count expression', () => {
+    const src = '`${wfActive?.count ?? 0} workflow${(wfActive?.count ?? 0) > 1 ? \'s\' : \'\'}`'
+    expect(findHardcodedPluralSites(src)).toHaveLength(1)
+  })
+
+  it('matches when the suffix is driven by a DIFFERENT variable than the count', () => {
+    // Still the defect (a plural form chosen in JS), plus a count/form
+    // disagreement on top — requiring the expressions to be equal would hide
+    // the buggier variant of the same class.
+    const src = '`${shown} item${total > 1 ? \'s\' : \'\'}`'
+    expect(findHardcodedPluralSites(src)).toHaveLength(1)
+  })
+
+  it('reports a 1-based line number an editor can jump to', () => {
+    const src = 'const a = 1\nconst b = 2\nconst label = `${n} file${n === 1 ? \'\' : \'s\'}`\n'
+    const sites = findHardcodedPluralSites(src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].line).toBe(3)
+  })
+
+  it('counts every site in a file, sorted by position', () => {
+    const src = [
+      'const a = `${x} tool${x > 1 ? \'s\' : \'\'}`',
+      'const b = `${y} agent${y === 1 ? \'\' : \'s\'}`',
+      'const c = `${z} run${z !== 1 ? \'s\' : \'\'}`',
+    ].join('\n')
+    const sites = findHardcodedPluralSites(src)
+    expect(sites.map(s => s.line)).toEqual([1, 2, 3])
+  })
+})
+
+describe('findHardcodedPluralSites — pinned NON-matches', () => {
+  it('ignores a plural handled INSIDE i18nT with a count', () => {
+    // The correct form this gate steers people toward must never trip it.
+    const src = [
+      "{i18nT('pages.chat.subagentProgressBar.retry_failed_count', { count: failedIds.length })}",
+      '`${i18nT(\'pages.overview.session\', { count: n })}`',
+    ].join('\n')
+    expect(findHardcodedPluralSites(src)).toHaveLength(0)
+  })
+
+  it('ignores a ternary yielding non-plural text', () => {
+    // A conditional that appends something other than a bare plural marker is
+    // ordinary conditional copy, not plural glue.
+    const src = '`${n} item${open ? \' (open)\' : \'\'}` and `${n} thing${n > 1 ? \'!\' : \'\'}`'
+    expect(findHardcodedPluralSites(src)).toHaveLength(0)
+  })
+
+  it('ignores the i18nT-adjacent form owned by the hard-zero tier', () => {
+    // Double-counting would bill one site to two checks with different
+    // enforcement. The JSX form is not a template literal at all, and in the
+    // template form the translate call leaves no literal noun for the suffix
+    // to glue to.
+    const src = [
+      "{n} {i18nT('pages.overview.memoryTab.session')}{n === 1 ? '' : 's'}",
+      "`${i18nT('pages.overview.memoryTab.session')}${n === 1 ? '' : 's'}`",
+    ].join('\n')
+    expect(findHardcodedPluralSites(src)).toHaveLength(0)
+  })
+
+  it('does not match across template-literal boundaries', () => {
+    // Two adjacent healthy literals must not be stitched into one finding.
+    const src = 'const a = `${n} done`; const b = `ready${flag > 1 ? \'s\' : \'\'}`'
+    expect(findHardcodedPluralSites(src)).toHaveLength(0)
+  })
+})
+
+describe('the pattern set itself', () => {
+  it('covers exactly the three comparison spellings, all global', () => {
+    // `matchAll` throws on a non-global regex, and a fourth spelling should be
+    // added consciously (with its true-positive test), not discovered here.
+    expect(HARDCODED_PLURAL_PATTERNS).toHaveLength(3)
+    for (const re of HARDCODED_PLURAL_PATTERNS) expect(re.flags).toContain('g')
+  })
+})

--- a/website/src/test/i18nGateTable.test.ts
+++ b/website/src/test/i18nGateTable.test.ts
@@ -35,7 +35,7 @@ const HEALTHY: Record<string, { status: number, text: string }> = {
   pseudo: run(0, 'OK: en-XA.json matches 5811 English keys.'),
   keys: run(0, 'OK: 6459 static key references all resolve, 1 dynamic site(s) at baseline (99.98% static coverage), no shadowing.'),
   codemod: run(0, '2 unextracted string(s) — below the baseline of 3.'),
-  plural: run(0, "OK: no literal-'s' pluralization found."),
+  plural: run(0, "OK: no literal-'s' pluralization found.\nOK: 37 hardcoded plural literal(s), at the ceiling of 37."),
   dnt: run(0, 'OK: 19 DNT term(s) intact across 9 catalog(s) — 62207 value(s) scanned.'),
   manifest: run(0, 'OK: 16 built-in manifests, 147 strings match locales/en.json exactly.'),
   units: run(0, '[added-lines] 0 number+unit literal(s) on lines you wrote\n[vs-base] 0 touched file(s) gained number+unit literals\nOK: 52 un-migrated number+unit literal(s) across 1026 file(s), baseline 74.'),
@@ -270,17 +270,76 @@ describe('the table covers the chain it replaced', () => {
     // this mine to fix", enforcement answers "can this fail when it improves".
     for (const c of CHECKS) {
       expect(['diff', 'repo'], c.id).toContain(c.scope)
-      expect(['zero', 'hard-zero', 'info'], c.id).toContain(c.enforce)
+      expect(['zero', 'hard-zero', 'ceiling', 'info'], c.id).toContain(c.enforce)
     }
-    // Only a diff-scoped check or a whole-repo HARD ZERO may fail the step. Every other
-    // whole-repo number is a stored total another branch can move without touching your
-    // files, so it reports. `dynamic-keys` was the last bidirectional ratchet in the repo.
+    // Three kinds of check may fail the step: a diff-scoped one, a whole-repo HARD
+    // ZERO, and a whole-repo CEILING that fails only on GROWTH. The ceiling kind is
+    // deliberately confined to the one check below: unlike the info rows, whose
+    // stored totals another branch can move without touching your files AND whose
+    // failure names no diff anyone can fix, a ceiling failure prints every site with
+    // file:line, so a red always names lines an author can check against their own
+    // diff. Every other whole-repo number reports. `dynamic-keys` was the last
+    // bidirectional ratchet in the repo.
+    expect(CHECKS.filter(c => c.enforce === 'ceiling').map(c => c.id))
+      .toEqual(['plurals-hardcoded'])
     expect(CHECKS.filter(c => c.enforce === 'info').map(c => c.id))
       .toEqual(['unit-ceiling', 'dynamic-keys', 'extractable', 'untranslated', 'allcaps',
         'untranslated-passthrough'])
-    for (const c of CHECKS.filter(x => x.scope === 'repo' && x.enforce !== 'hard-zero')) {
-      expect(c.enforce, `${c.id} is whole-repo and not a hard zero, so it must be info`)
+    for (const c of CHECKS.filter(x => x.scope === 'repo'
+      && x.enforce !== 'hard-zero' && x.enforce !== 'ceiling')) {
+      expect(c.enforce, `${c.id} is whole-repo and not a hard zero or ceiling, so it must be info`)
         .toBe('info')
+    }
+  })
+})
+
+describe('the plural script hosts two tiers that fail independently', () => {
+  // One script, two verdicts: the i18nT-adjacent HARD ZERO and the hardcoded-literal
+  // CEILING. The script prints BOTH before exiting (learning the second failure a CI
+  // round later is the `&&`-chain defect the runner exists to remove), so each row
+  // must judge itself by its own line — inheriting the shared exit code would mark
+  // the passing tier FAIL whenever its sibling is the one that failed. One cost of
+  // the second row, accepted: `ownedBy` is now 2, so a plural-script crash that
+  // prints nothing recognisable resolves BOTH rows NOT RUN and fails through the
+  // generic unexplained path instead of naming `[plurals]` — fails closed either
+  // way (the it.each(SCRIPTS) invariant above covers it).
+  //
+  // Mocks are assembled stdout-then-stderr with the blank line the script's
+  // console.error emits, because that is how the runner concatenates a real run's
+  // streams — a mock in the other order would pin an adjacency no real output has.
+  it('attributes ceiling growth to plurals-hardcoded while the hard zero stays PASS', () => {
+    const { rows, bad, failed } = decide({
+      plural: run(1, "OK: no literal-'s' pluralization found.\n"
+        + '\nFAIL: 38 hardcoded plural literal(s) — 1 above the ceiling of 37:\n'
+        + "  src/pages/A.tsx:12  ${n} widget${n > 1 ? 's' : ''}\n"),
+    })
+    expect(row(rows, 'plurals').state).toBe('PASS')
+    expect(row(rows, 'plurals-hardcoded').state).toBe('FAIL')
+    expect(bad.map(r => r.id)).toEqual(['plurals-hardcoded'])
+    expect(failed).toBe(true)
+  })
+
+  it('attributes a reintroduced i18nT-adjacent site while the ceiling stays PASS', () => {
+    const { rows, bad, failed } = decide({
+      plural: run(1, 'OK: 37 hardcoded plural literal(s), at the ceiling of 37.\n'
+        + "\nFAIL: 2 file(s) still use the literal-'s' plural hack:\n  src/A.tsx\n"),
+    })
+    expect(row(rows, 'plurals').state).toBe('FAIL')
+    expect(row(rows, 'plurals-hardcoded').state).toBe('PASS')
+    expect(bad.map(r => r.id)).toEqual(['plurals'])
+    expect(failed).toBe(true)
+  })
+
+  it('reads the ceiling line below AND exactly at the ceiling', () => {
+    // Same trap `extractable` fell into: the at-ceiling and below-ceiling sentences
+    // differ, and a pattern that misses one makes the row MISSING on a healthy tree.
+    for (const line of [
+      "OK: no literal-'s' pluralization found.\nOK: 30 hardcoded plural literal(s), below the ceiling of 37. Optional: lower HARDCODED_CEILING to 30 in scripts/i18n-plural-codemod.mjs to tighten the ratchet.",
+      "OK: no literal-'s' pluralization found.\nOK: 37 hardcoded plural literal(s), at the ceiling of 37.",
+    ]) {
+      const { rows, failed } = decide({ plural: run(0, line) })
+      expect(row(rows, 'plurals-hardcoded').state, line).toBe('PASS')
+      expect(failed, line).toBe(false)
     }
   })
 })


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The `[plurals]` gate (`website/scripts/i18n-plural-codemod.mjs --check`), documented as hard-zero for a plural suffix concatenated outside the translation call, only matches patterns where an `i18nT('key')` call sits immediately before the plural ternary. That keys on the incidental property (an i18nT call is adjacent) instead of the defining one (JavaScript chose a plural marker outside the translate call). A fully hardcoded literal that interpolates a count and glues a conditional suffix onto a noun — e.g. `` `Retry ${n} failed subagent${n > 1 ? 's' : ''}` `` — commits the same defect while containing no `i18nT` for those patterns to anchor on, so it reports zero. This is why #5761 had to be human-reported despite a green gate, and why the residual sites tracked in #5784 report zero today.

## Why it matters

The class regrows silently and each instance costs a separately filed issue. Every such site renders a non-word in 11 of the 12 shipped languages (`会话s`, `3 sesións`, `এজেন্টs`) — the `s` is appended outside the catalog, so no translation can ever fix it. A gate that cannot see the defect's dominant spelling protects nothing.

## What changed (motivation → approach → change)

Symptom: hardcoded plural glue passes the gate. Root cause: the detector anchors on an adjacent `i18nT` call rather than on the plural marker itself. Change: a second detector tier keyed on the ternary yielding a plural marker with no `i18nT` at all.

- **New detector** (`website/scripts/lib/hardcoded-plural.mjs`): matches the count-adjacent template-literal shape — an interpolated expression, literal noun text, then a ternary yielding exactly `'s'`/`''` — in all three comparison spellings (`> 1`, `!== 1`, and the inverted `=== 1`), tolerant of whitespace and either quote style so a reformatted spelling cannot slip past. Purely lexical, matching the codemod's existing structure.
- **Ceiling, not hard zero**: the 37 existing sites (measured on main, not guessed) each need a new catalog key plus translations, so a hard zero would have failed on arrival and been disabled. `--check` fails only when the count grows past `HARDCODED_CEILING`; it ratchets down as #5784's sites are converted (lowering is suggested on every run, optional for the same recorded reason as `[extractable]`'s `--baseline`). A failure prints every site with `file:line` so the added one is findable, and names the sanctioned remedy for inherited cross-merge growth.
- **The existing i18nT-anchored hard-zero patterns are unchanged.** Both tiers are evaluated and printed before the script exits (`process.exitCode`, so a failure cannot truncate piped output), so a second failure is not learned a CI round later.
- **Gate table + runner** (`i18n-gate-table.mjs`, `i18n-check.mjs`): a new `ceiling — fails on growth` enforcement kind with its own report section, slack note, and failure guidance; both plural rows judge themselves by their own printed line so a failure in one tier is never mis-attributed to the other.
- **Docs**: the two-tier contract is stated in the script header, `ci.yml`'s step comment, `docs/ci/i18n-gates.md` (now three kinds of check can fail the step), and `website/docs/i18n-catalog.md`.

Companion issue #5784 (same operator) converts the sites; the two PRs are deliberately independent.

## Tests

- `website/src/test/hardcodedPlural.test.ts` (new): true positives — the `SubagentProgressBar.tsx` aria-label reference shape, all three comparison spellings, compact/double-quoted/multiline reformattings, parenthesised count expressions, a suffix driven by a different variable, 1-based line numbers, multi-site ordering. Pinned non-matches — a plural handled inside `i18nT` with `count`, a ternary yielding non-plural text, the i18nT-adjacent form owned by the hard-zero tier (no double-counting), text spanning template-literal boundaries, and mixed quote styles. Plus the pattern-set contract (exactly three global regexes).
- `website/src/test/i18nGateTable.test.ts` (updated): the two tiers fail independently with correct attribution (ceiling growth → `plurals-hardcoded` FAIL while `plurals` stays PASS, and vice versa); the ceiling line is read below AND exactly at the ceiling (the `extractable` trap); the enforcement-kind invariant now pins `ceiling` to exactly this one check; mocks assemble stdout-then-stderr as the runner concatenates real streams.

## Manual verification

- `node scripts/i18n-plural-codemod.mjs --check` on this branch: both tiers OK, count exactly 37 = ceiling, exit 0.
- Full `node scripts/i18n-check.mjs` run: 19 checks, PASS, the new `WHOLE REPO, CEILING` section renders with the slack note.
- Ceiling measured with the final regexes over `src/` (test files excluded, matching the codemod's walk): 37.

## Screenshots / video

N/A — CI script and documentation change only; no rendered UI delta.

## Related Issues

Closes #5785

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
