### PR TITLE
fix(security): close four CSE findings across the channel download and trust paths

### DIFF
--- a/src/kiro_crew/link_unfurl.py
+++ b/src/kiro_crew/link_unfurl.py
@@ -192,18 +192,17 @@ def _is_not_public(
     )
 
 
-def _reject_if_internal_ip(candidate: str) -> None:
-    """Raise ``blocked_url`` if *candidate* parses as a non-public IP.
+def _literal_is_not_public(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+) -> bool:
+    """Whether an already-PARSED literal is non-public, tunnel encodings unwrapped.
 
-    Returns silently when *candidate* is not an IP literal at all — the caller
-    then treats it as a hostname to resolve.
+    Split out so a caller holding a resolution result reaches the same decision
+    through :func:`address_is_not_public` instead of enumerating category flags
+    again. The two encodings handled here are about how an address was WRITTEN,
+    which is why they do not belong in :func:`_is_not_public`, and both are
+    bypasses if skipped:
 
-    Two normalizations matter here, and both are bypasses if skipped:
-
-    * ``canonicalize_ip`` folds the alternate IPv4 encodings the OS resolver
-      accepts but :mod:`ipaddress` rejects (``0x7f000001``, ``0177.0.0.1``,
-      ``2130706433``, ``127.1``). Without it those fall through to the hostname
-      branch and reach the metadata endpoint.
     * IPv4-mapped IPv6 is unwrapped explicitly. ``IPv6Address("::ffff:127.0.0.1")``
       reports ``is_loopback == False``, and its ``is_private`` only consults the
       mapped address on Python 3.13+ — so on every supported version below that,
@@ -216,10 +215,6 @@ def _reject_if_internal_ip(candidate: str) -> None:
       packet goes inward — and substituting the payload instead would let
       ``2002:8000::`` through, whose payload ``128.0.0.0`` is public.
     """
-    try:
-        ip = ipaddress.ip_address(canonicalize_ip(candidate))
-    except ValueError:
-        return  # a hostname, not a literal
     mapped = getattr(ip, "ipv4_mapped", None)
     if mapped is not None:
         ip = mapped
@@ -227,8 +222,55 @@ def _reject_if_internal_ip(candidate: str) -> None:
     # for why the two encodings are not symmetric.
     sixtofour = getattr(ip, "sixtofour", None)
     if sixtofour is not None and _is_not_public(sixtofour):
-        raise UnfurlRejected("blocked_url")
-    if _is_not_public(ip):
+        return True
+    return _is_not_public(ip)
+
+
+def address_is_not_public(address: str) -> bool:
+    """Whether *address*, an IP literal from a resolution result, is non-public.
+
+    The entry point for a caller that has ALREADY resolved a host and holds the
+    answers — the Teams attachment fetch and the WeCom media fetch — so the
+    address rules have one owner rather than a category-flag list re-enumerated
+    per channel. Each such list written independently has missed the same two
+    ranges: ``100.64.0.0/10`` (RFC 6598 shared space, what a tailnet and most
+    CGNAT hand out) is not in CPython's ``is_private`` table and only
+    ``is_global`` rejects it, and ``fec0::/10`` reports ``is_global=True`` so an
+    ``is_private``-only check approves it. :func:`_is_not_public` documents why
+    both halves are required.
+
+    Fails CLOSED: a value that does not parse as an IP literal returns ``True``.
+    That is the opposite of :func:`_reject_if_internal_ip`'s default, and
+    deliberately so — for the URL vet a non-literal is a hostname still to be
+    resolved, while here it is a resolution result about to reach a socket, and an
+    address this function cannot read is one it cannot approve.
+    """
+    try:
+        ip = ipaddress.ip_address(canonicalize_ip(address))
+    except ValueError:
+        return True
+    return _literal_is_not_public(ip)
+
+
+def _reject_if_internal_ip(candidate: str) -> None:
+    """Raise ``blocked_url`` if *candidate* parses as a non-public IP.
+
+    Returns silently when *candidate* is not an IP literal at all — the caller
+    then treats it as a hostname to resolve. :func:`address_is_not_public` is the
+    sibling for values that are already known to be addresses; it fails closed on
+    an unparseable one instead of passing it through as a name.
+
+    ``canonicalize_ip`` folds the alternate IPv4 encodings the OS resolver accepts
+    but :mod:`ipaddress` rejects (``0x7f000001``, ``0177.0.0.1``, ``2130706433``,
+    ``127.1``). Without it those fall through to the hostname branch and reach the
+    metadata endpoint. The ipv4-mapped and 6to4 unwrapping lives in
+    :func:`_literal_is_not_public`.
+    """
+    try:
+        ip = ipaddress.ip_address(canonicalize_ip(candidate))
+    except ValueError:
+        return  # a hostname, not a literal
+    if _literal_is_not_public(ip):
         raise UnfurlRejected("blocked_url")
 
 

--- a/src/kiro_crew/skill_trust.py
+++ b/src/kiro_crew/skill_trust.py
@@ -64,7 +64,9 @@ _MAX_GRANT_ENTRIES = 512
 #: on the event loop during dashboard listing, so re-parsing the store on every
 #: skill would be a syscall per row; a stat signature is one syscall total.
 _StoreSignature = tuple[int, int, int, int, int]
-_cache: tuple[_StoreSignature, frozenset[str]] | None = None
+#: Cached ``(stat_signature, granted_paths, enforcement_tokens)``. Both sets are
+#: derived from one parse -- see :func:`_parse_store` for why they differ.
+_cache: tuple[_StoreSignature, frozenset[str], frozenset[str]] | None = None
 
 
 class TrustStoreUnreadable(RuntimeError):
@@ -142,6 +144,72 @@ def canonical_key(project_dir: str | Path | None) -> str | None:
     return real
 
 
+#: Separator between a grant's path and its instance identity in the membership
+#: token. NUL cannot appear in a path on any supported platform, so a crafted
+#: directory name cannot make one half read as the other.
+_TOKEN_SEP = "\x00"
+
+
+def _instance_identity(project_key: str) -> str | None:
+    """The directory's non-reusable instance identity, or ``None`` if unreadable.
+
+    A grant is consent for the CONTENT the operator reviewed, but a path is a
+    reusable name. Delete the reviewed repository and create a different one at
+    the same canonical path -- a routine move on a shared dev host, and the normal
+    life of a CI checkout directory -- and a path-only grant is inherited by
+    content nobody reviewed, whose ``SKILL.md`` then enters the agent context with
+    instruction authority the operator never gave it. Binding an identity the new
+    directory cannot forge turns that silent inheritance into a consent re-prompt.
+
+    ``st_dev``/``st_ino`` name the directory INSTANCE rather than its name.
+    ``st_birthtime`` is folded in where the platform exposes it (macOS, the BSDs,
+    Windows) because an inode number can itself be reused after a delete, which is
+    the very case being closed; on Linux, where CPython does not expose a birth
+    time, ``dev:ino`` alone still discriminates every recreate that lands on a
+    different inode -- which a fresh clone and a moved tree both do.
+
+    Deliberately NOT a content fingerprint of the ``.kiro/skills`` tree, and
+    deliberately not ``st_ctime``: both change when the operator edits their own
+    skills, so either would re-prompt on ordinary work instead of on a
+    substitution, and a consent prompt that fires routinely is one that gets
+    clicked through.
+
+    Two residuals, stated rather than implied closed, both specific to a platform
+    that exposes no birth time (Linux, where ``dev:ino`` stands alone):
+
+    * The ACCIDENTAL case -- a different repository at a path the operator happens
+      to have granted -- is fully closed, because a fresh clone or a moved tree
+      lands on a different inode. The ADVERSARIAL case is closed only
+      best-effort: a local actor who can already write that path can grind
+      create/delete until the filesystem reuses the inode. Narrowing that needs a
+      real birth time (``statx`` ``STATX_BTIME``), which CPython does not surface
+      on Linux today; folding it in when it does is the fix.
+    * ``st_dev`` is not stable across remounts on btrfs subvolumes, NFS, and some
+      container bind mounts, so a bound grant can stop matching after a reboot
+      with the content unchanged. That direction is fail-closed -- the operator is
+      re-asked, never over-trusted -- but it is a re-prompt they did not earn, and
+      so the same habituation risk this docstring rejects a content fingerprint
+      for. If it shows up in practice the answer is to compare the inode plus a
+      content-independent tie-break, not to relax the check.
+    """
+    try:
+        st = os.stat(project_key)
+    except OSError:
+        return None
+    parts = [str(st.st_dev), str(st.st_ino)]
+    birth = getattr(st, "st_birthtime_ns", None)
+    if birth is None:
+        birth = getattr(st, "st_birthtime", None)
+    if birth is not None:
+        parts.append(str(birth))
+    return ":".join(parts)
+
+
+def _binding_token(project_key: str, identity: str) -> str:
+    """The enforcement-set membership token for an identity-bound grant."""
+    return f"{project_key}{_TOKEN_SEP}{identity}"
+
+
 def _project_skills_enabled() -> bool:
     """The operator's hard off switch.
 
@@ -172,20 +240,35 @@ def _store_signature(path: Path) -> _StoreSignature | None:
     return (st.st_mtime_ns, st.st_ctime_ns, st.st_size, st.st_ino, st.st_mode)
 
 
-def _parse_store(text: str) -> frozenset[str]:
-    """Parse store *text* into a set of canonical keys, failing closed.
+def _parse_store(text: str) -> tuple[frozenset[str], frozenset[str]]:
+    """Parse store *text* into ``(granted_paths, enforcement_tokens)``, failing closed.
 
-    Every malformed shape yields the empty set: a store we cannot understand
-    grants nothing.
+    Two sets, because they answer two different questions.
+
+    ``granted_paths`` is what the operator granted, for display and inspection,
+    and includes every well-formed row. ``enforcement_tokens`` is what a caller has
+    to MATCH, and includes ONLY identity-bound rows: a row written before grants
+    carried an identity grants nothing until it is re-granted, because the whole
+    point of the binding is that a path alone cannot establish which directory the
+    operator reviewed -- and that is no less true of a row this build inherited
+    than of one it wrote.
+
+    Keeping the two apart is what makes that fail-closed without being
+    destructive: the row stays listed, so the operator SEES the grant and can
+    re-grant or revoke it, rather than having it silently deleted or silently
+    honored. :func:`list_trusted_projects` reports ``bound`` for exactly this.
+
+    Every malformed shape yields empty sets: a store we cannot understand grants
+    nothing.
     """
     try:
         data = json.loads(text)
     except ValueError as exc:
         logger.error("%s: not valid JSON (%s); ignoring every grant", _STORE_FILENAME, exc)
-        return frozenset()
+        return frozenset(), frozenset()
     if not isinstance(data, dict):
         logger.error("%s: not a JSON object; ignoring every grant", _STORE_FILENAME)
-        return frozenset()
+        return frozenset(), frozenset()
     version = data.get("version")
     if version != _SCHEMA_VERSION:
         logger.error(
@@ -194,11 +277,11 @@ def _parse_store(text: str) -> frozenset[str]:
             version,
             _SCHEMA_VERSION,
         )
-        return frozenset()
+        return frozenset(), frozenset()
     raw = data.get("granted")
     if not isinstance(raw, list):
         logger.error("%s: 'granted' is not an array; ignoring every grant", _STORE_FILENAME)
-        return frozenset()
+        return frozenset(), frozenset()
     if len(raw) > _MAX_GRANT_ENTRIES:
         logger.error(
             "%s: %d entries exceeds the %d cap; considering only the first %d",
@@ -208,7 +291,8 @@ def _parse_store(text: str) -> frozenset[str]:
             _MAX_GRANT_ENTRIES,
         )
         raw = raw[:_MAX_GRANT_ENTRIES]
-    keys: set[str] = set()
+    paths: set[str] = set()
+    tokens: set[str] = set()
     for entry in raw:
         if not isinstance(entry, dict):
             continue
@@ -216,37 +300,60 @@ def _parse_store(text: str) -> frozenset[str]:
         # Stored keys are already canonical, but an absolute-path check still
         # applies: a relative entry in a hand-edited store must not match a
         # caller's canonical project_key by accident.
-        if isinstance(path, str) and path and os.path.isabs(path):
-            keys.add(path)
-    return frozenset(keys)
+        if not (isinstance(path, str) and path and os.path.isabs(path)):
+            continue
+        paths.add(path)
+        identity = entry.get("identity")
+        if isinstance(identity, str) and identity:
+            # Identity-bound: ONLY the directory instance the operator reviewed
+            # matches. The bare path is deliberately NOT also a token -- adding it
+            # would make the binding decorative.
+            tokens.add(_binding_token(path, identity))
+        # A row with no identity contributes NO token: it is listed but not
+        # enforced. It cannot say WHICH directory was reviewed, so honoring it
+        # would leave open exactly the replacement path this binding closes.
+    return frozenset(paths), frozenset(tokens)
 
 
-def trusted_keys() -> frozenset[str]:
-    """Every canonical directory the operator has granted, or an empty set.
+def _read_store() -> tuple[frozenset[str], frozenset[str]]:
+    """``(granted_paths, enforcement_tokens)`` from the store, or two empty sets.
 
-    Result is cached against the store's stat signature, so repeated
-    enforcement reads within one listing cost a single ``stat``.
+    Result is cached against the store's stat signature, so repeated enforcement
+    reads within one listing cost a single ``stat``.
     """
     global _cache
     if not _project_skills_enabled():
-        return frozenset()
+        return frozenset(), frozenset()
     path = store_path()
     signature = _store_signature(path)
     if signature is None:
         _cache = None
-        return frozenset()
+        return frozenset(), frozenset()
     cached = _cache
     if cached is not None and cached[0] == signature:
-        return cached[1]
+        return cached[1], cached[2]
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         logger.error("%s: unreadable (%s); ignoring every grant", _STORE_FILENAME, exc)
         _cache = None
-        return frozenset()
-    keys = _parse_store(text)
-    _cache = (signature, keys)
-    return keys
+        return frozenset(), frozenset()
+    paths, tokens = _parse_store(text)
+    _cache = (signature, paths, tokens)
+    return paths, tokens
+
+
+def trusted_keys() -> frozenset[str]:
+    """Every canonical directory the operator has granted, or an empty set.
+
+    The granted PATHS, for display and inspection. Deliberately NOT the
+    enforcement oracle: a grant is bound to the directory INSTANCE the operator
+    reviewed, so membership here does not by itself mean a directory may be
+    loaded. Enforcement goes through :func:`is_key_trusted`, which compares that
+    binding -- see :func:`_instance_identity` for what a path-only check lets
+    through.
+    """
+    return _read_store()[0]
 
 
 def is_project_trusted(project_dir: str | Path | None) -> bool:
@@ -254,18 +361,37 @@ def is_project_trusted(project_dir: str | Path | None) -> bool:
     project_key = canonical_key(project_dir)
     if project_key is None:
         return False
-    return project_key in trusted_keys()
+    return is_key_trusted(project_key)
 
 
 def is_key_trusted(project_key: str | None) -> bool:
     """Membership test for an already-canonical project_key.
 
     Split out so a hot path can resolve the project_key once off the event loop and
-    then test membership without further syscalls.
+    then test membership without re-reading the store.
+
+    Costs one ``stat`` of *project_key* on top of the store's cached signature
+    read. That is the price of the binding: a grant names the directory INSTANCE
+    the operator reviewed, not just its name, so the instance has to be read to be
+    compared -- see :func:`_instance_identity` for what a path-only grant lets
+    through. One extra ``stat`` per key derivation, not per skill; the caller in
+    ``skills.py`` already pays a ``realpath`` beside it.
+
+    Fails CLOSED on a row with no recorded identity (one written before grants
+    carried one) and on a directory that can no longer be read. Neither can
+    establish WHICH directory the operator reviewed, and an unenforced row is not a
+    deleted one: it stays listed and is reported unbound, so the operator is
+    re-ASKED rather than silently un-consented. See :func:`_parse_store`.
     """
     if not project_key:
         return False
-    return project_key in trusted_keys()
+    granted = _read_store()[1]
+    if not granted:
+        return False
+    identity = _instance_identity(project_key)
+    if identity is None:
+        return False
+    return _binding_token(project_key, identity) in granted
 
 
 def _trust_dir() -> Path:
@@ -423,13 +549,28 @@ def grant_project_trust(
         not isinstance(expected_key, str) or expected_key != project_key
     ):
         raise ReviewedProjectChanged(str(expected_key or ""))
+    # Read before the lock so an unreadable directory refuses without taking it.
+    # A grant that cannot be bound is not recorded unbound: that would write
+    # exactly the path-only row this binding exists to stop producing.
+    identity = _instance_identity(project_key)
+    if identity is None:
+        raise ValueError(f"not a readable directory: {project_dir!r}")
     with _locked_store():
         # Read BEFORE auditing: an unreadable store refuses here, and auditing
         # first would leave an "allowed" record for consent that never landed.
         entries = _read_entries_unlocked()
         for entry in entries:
-            if entry.get("path") == project_key:
+            if entry.get("path") != project_key:
+                continue
+            if entry.get("identity") == identity:
                 return project_key
+            # Same path, a different directory instance -- or a legacy row with
+            # no identity at all. The operator is granting THIS content, so
+            # rebind rather than short-circuit: returning early here would
+            # leave the new tree untrusted even after an explicit re-grant,
+            # with no surface saying why.
+            entries = [e for e in entries if e.get("path") != project_key]
+            break
         if len(entries) >= _MAX_GRANT_ENTRIES:
             raise TrustStoreFull(
                 f"project-skills trust store is full ({_MAX_GRANT_ENTRIES} grants); "
@@ -448,7 +589,13 @@ def grant_project_trust(
             reason="operator granted project-skills trust for this directory",
             critical=True,
         )
-        entries.append({"path": project_key, "granted_at": int(time.time())})
+        entries.append(
+            {
+                "path": project_key,
+                "identity": identity,
+                "granted_at": int(time.time()),
+            }
+        )
         _write_entries_unlocked(entries)
     return project_key
 
@@ -573,11 +720,17 @@ def list_trusted_projects() -> list[dict[str, Any]]:
         path = entry.get("path")
         if not isinstance(path, str) or not path:
             continue
+        identity = entry.get("identity")
         rows.append(
             {
                 "path": path,
                 "granted_at": _as_epoch(entry.get("granted_at")),
                 "exists": os.path.isdir(path),
+                # Whether this row is bound to the directory INSTANCE reviewed,
+                # or is a pre-binding row still matching on the path alone.
+                # Reported rather than inferred so an operator can see which of
+                # their grants a same-path replacement would still inherit.
+                "bound": bool(isinstance(identity, str) and identity),
             }
         )
     # Rows carry an already-normalized int, so the sort cannot meet a string

--- a/src/kiro_crew/teams/client.py
+++ b/src/kiro_crew/teams/client.py
@@ -35,6 +35,7 @@ from typing import Any, Awaitable, Callable
 import aiohttp
 from aiohttp import web
 
+from kiro_crew import link_unfurl
 from kiro_crew.sel import sel
 from kiro_crew.teams.attachments import quoted_reply_text
 from kiro_crew.teams.commands import STOP_ALIASES
@@ -1180,18 +1181,25 @@ class TeamsClient:
         except OSError as exc:
             raise ValueError("refusing unresolvable Teams attachment host") from exc
         for resolved in resolved_addresses:
-            try:
-                address = ipaddress.ip_address(resolved)
-            except ValueError:  # pragma: no cover - getaddrinfo returns literals
-                raise ValueError("refusing unparseable Teams attachment address")
-            if (
-                address.is_private
-                or address.is_loopback
-                or address.is_link_local
-                or address.is_reserved
-                or address.is_multicast
-                or address.is_unspecified
-            ):
+            # `link_unfurl`'s vet, not a local flag list. The category flags this
+            # used to enumerate approved two ranges that are plainly not public:
+            # `100.64.0.0/10` (RFC 6598 shared space -- what a Tailscale tailnet
+            # and most carrier NAT hand out, which CPython's `is_private` table
+            # omits and only `is_global` rejects) and `fec0::/10` (deprecated IPv6
+            # site-local, which reports `is_global=True`). It also evaluated the
+            # ipv4-mapped and 6to4 encodings as written, so `::ffff:127.0.0.1`
+            # passed a check whose whole purpose was to refuse loopback. That
+            # module already owns this decision for link unfurling and for the
+            # meetings calendar fetch, and its
+            # `test_vet_rejects_every_special_purpose_range` pins the refusal set
+            # against a table of IANA special-purpose prefixes -- so the next gap
+            # is found by the suite instead of by a reviewer, which a second
+            # implementation here would not inherit.
+            #
+            # It also subsumes the unparseable-address guard: it fails CLOSED on a
+            # literal it cannot read, which is the same refusal this reached the
+            # long way round via `ipaddress.ip_address`.
+            if link_unfurl.address_is_not_public(resolved):
                 raise ValueError("refusing local-network Teams attachment URL")
         return resolved_addresses
 

--- a/src/kiro_crew/wecom/media.py
+++ b/src/kiro_crew/wecom/media.py
@@ -25,14 +25,18 @@ succeed, the object is gone.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from kiro_crew import link_unfurl
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +127,83 @@ def decrypt_media(ciphertext: bytes, key: bytes) -> bytes:
         raise WeComMediaError("decrypt failed (wrong aeskey, or a truncated object)") from exc
 
 
+#: Schemes an inbound media URL may use. WeCom serves its CDN over TLS, so
+#: anything else is either a cleartext hop for a body we are about to decrypt or
+#: not a network download at all (``file://``).
+_ALLOWED_MEDIA_SCHEMES = ("https",)
+
+#: The only port an https CDN object is served from. The shared vet allows
+#: {80, 443} because it also serves plain-http link unfurling; this caller is
+#: https-only, so 443 is the stated scope.
+_MEDIA_PORT = 443
+
+
+def _vet_media_url(url: str) -> str:
+    """Vet an inbound media URL for fetching and return its normalized form.
+
+    The ``url`` arrives in the callback body, so it is platform-*supplied* but not
+    platform-*guaranteed*: nothing in the frame proves the host is one WeCom
+    operates. Unvetted, the fetch is a server-side request forgery primitive — a
+    crafted URL (or a redirect from a legitimate one) points the gateway at an
+    internal service or the cloud metadata endpoint, and the response flows on
+    into the attachment pipeline. Every sibling channel vets its platform-provided
+    download URL for this reason; this path was the one that did not.
+
+    The scheme rule is this module's; the ADDRESS vet is
+    :func:`link_unfurl.vet_unfurl_url`, reused rather than reimplemented. It
+    resolves the host once and checks EVERY answer, so a name resolving to both a
+    public and a private address is refused whichever one aiohttp would have
+    picked, and its refusal set is pinned against the IANA special-purpose-range
+    table by that module's own suite — which a local check would not inherit.
+
+    Two controls the sibling channels carry are deliberately NOT here, both
+    because adding them as written would cost more than it buys:
+
+    * A CDN host allow-list, as ``discord/client.py`` keeps for its two documented
+      CDN hosts and ``slack/client.py`` for ``slack.com``. WeCom documents no
+      stable media-host set, so an allow-list here would be a guess, and a wrong
+      guess silently drops legitimate media. The destination vet above closes the
+      same class without having to name hosts.
+    * A pinned resolver, the anti-rebinding mechanism in ``teams/client.py`` and
+      the meetings calendar provider. This path takes an operator ``proxy``, and
+      under a proxy aiohttp never resolves the target host, so the pin would go
+      unconsulted on exactly the deployments that configure one. The residual is
+      the rebinding window between this resolution and the socket; closing it
+      needs the proxy case answered first, which is its own change.
+
+    The proxy also splits this vet from the egress it is judging, in both
+    directions, and neither direction is fixed here. Resolution happens locally
+    while a proxied request is resolved and dialed by the proxy, so on
+    split-horizon DNS this can REFUSE a URL the proxy would have fetched from a
+    perfectly public address, and conversely it approves addresses the proxy never
+    dials. Vetting what we can see is still strictly better than vetting nothing
+    -- an internal target named directly is refused either way -- but a proxied
+    deployment should read this as a scheme-and-destination soundness check rather
+    than a guarantee about the egress path.
+
+    Blocking: performs one ``getaddrinfo``. Call it from a worker thread.
+    """
+    candidate = (url or "").strip()
+    try:
+        scheme = urlsplit(candidate).scheme.lower()
+    except ValueError as exc:
+        # `urlsplit` RAISES on a malformed authority (`https://[`) rather than
+        # returning empty parts, so a hostile body would surface as an uncaught
+        # ValueError instead of this module's own error type.
+        raise WeComMediaError("media url is malformed") from exc
+    if scheme not in _ALLOWED_MEDIA_SCHEMES:
+        raise WeComMediaError(f"media url must use https:// (got {scheme or 'no'} scheme)")
+    try:
+        vetted = link_unfurl.vet_unfurl_url(candidate)
+    except link_unfurl.UnfurlRejected as exc:
+        raise WeComMediaError(f"refusing media url ({exc.code})") from None
+    if vetted.port != _MEDIA_PORT:
+        # `https://host:80` passes the shared vet and would then fail the TLS
+        # handshake with a message that does not name the cause.
+        raise WeComMediaError("refusing media url (blocked_url)")
+    return vetted.url
+
+
 async def download_media(
     session: aiohttp.ClientSession,
     url: str,
@@ -139,13 +220,27 @@ async def download_media(
     """
     if not url:
         raise WeComMediaError("media item carries no url")
+    # Off the loop: the vet performs one `getaddrinfo`, which blocks.
+    url = await asyncio.to_thread(_vet_media_url, url)
     key = decode_aes_key(aeskey)
     chunks: list[bytes] = []
     total = 0
     try:
         async with session.get(
-            url, proxy=proxy, timeout=aiohttp.ClientTimeout(total=_DOWNLOAD_TIMEOUT_SECS)
+            url,
+            proxy=proxy,
+            timeout=aiohttp.ClientTimeout(total=_DOWNLOAD_TIMEOUT_SECS),
+            # Refused rather than followed, matching `discord/client.py` and
+            # `slack/client.py`. aiohttp follows redirects by default, and a
+            # followed hop is one the vet above never saw — the host check would
+            # have been true only of the hop that did not carry the bytes. If
+            # WeCom is ever observed to redirect a media URL, the answer is
+            # per-hop re-vetting (`teams/client.py::_stream_attachment` is the
+            # shape), not re-enabling blind following.
+            allow_redirects=False,
         ) as resp:
+            if 300 <= resp.status < 400:
+                raise WeComMediaError("refusing redirected media url")
             if resp.status != 200:
                 raise WeComMediaError(f"media download returned HTTP {resp.status}")
             async for chunk in resp.content.iter_chunked(64 * 1024):

--- a/src/kiro_crew/whatsapp/gateway.py
+++ b/src/kiro_crew/whatsapp/gateway.py
@@ -14,6 +14,7 @@ from kiro_crew.whatsapp.client import (
     default_db_path,
     neonize_available,
 )
+from kiro_crew.whatsapp.jids import normalize_jid
 from kiro_crew.whatsapp.transport import WhatsAppTransport
 from kiro_crew.whatsapp.transport_dispatch import WhatsAppDispatcher
 
@@ -33,10 +34,15 @@ def _resolve_approval_mode(orch: "GatewayOrchestrator") -> str:
 def _configured_group_jids(groups: object) -> list[str]:
     """The non-empty ``jid`` of each group entry, keyed exactly as the gate keys it.
 
-    ``GroupGate`` indexes its entries by ``str(entry["jid"]).strip()`` and looks
-    them up by exact string, so this reads the same value the same way: a JID that
-    differs from the gate's key by case or a ``:device`` suffix is one the gate
-    never matches either, and normalizing here would call it fine.
+    ``GroupGate`` indexes its entries through :func:`normalize_jid`, so this reads
+    the same value the same way. It previously replicated a bare ``.strip()``, on
+    the reasoning that a JID differing by case or a ``:device`` suffix was one the
+    gate never matched either -- true at the time, and precisely why this check
+    could not see the defect: it compared the operator's raw text against
+    membership answers that ARE normalized, so a group the gate was silently
+    dropping looked configured and joined from here. Both sides normalize now, and
+    this has to keep matching the gate or the diagnostic starts lying in the other
+    direction.
     """
     if not isinstance(groups, list):
         return []
@@ -44,7 +50,7 @@ def _configured_group_jids(groups: object) -> list[str]:
     for entry in groups:
         if not isinstance(entry, dict):
             continue
-        jid = str(entry.get("jid", "")).strip()
+        jid = normalize_jid(str(entry.get("jid", "")))
         if jid:
             out.append(jid)
     return out

--- a/src/kiro_crew/whatsapp/group_gate.py
+++ b/src/kiro_crew/whatsapp/group_gate.py
@@ -22,6 +22,12 @@ session (commands like /new) — only the operator may.
 
 This module is pure decision logic (no I/O, no neonize types) so the whole
 matrix is unit-testable; the transport feeds it normalized values.
+
+Group JIDs are keyed through :func:`normalize_jid` on BOTH sides -- the config
+entries when they are indexed, and the lookup value -- so the same group hashes
+to the same key no matter which path produced it. ``jids`` is pure string logic
+with no dependencies, so importing it here keeps this module's own I/O-free
+property intact.
 """
 
 from __future__ import annotations
@@ -29,6 +35,8 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from typing import Callable, Mapping
+
+from kiro_crew.whatsapp.jids import normalize_jid
 
 #: Exact reply the model returns (alone) to decline an unprompted rules-mode
 #: turn. Chosen to be un-typable-by-accident and trivially detectable.
@@ -69,13 +77,21 @@ class GroupGate:
         self._cooldown_default_s = cooldown_default_s
         self._entries: dict[str, dict] = {}
         for entry in groups or []:
-            jid = str(entry.get("jid", "")).strip()
+            # `normalize_jid`, not a bare `.strip()`. The transport hands
+            # `evaluate()` a fully normalized value, so a config entry written
+            # `123456@G.US` (an uppercase server is valid per JID semantics) or
+            # `123456@g.us:5` (a device suffix) was stored verbatim and never
+            # matched -- the operator configured a group and the agent stayed
+            # silent in it, with `group_not_configured` as the only clue. The DM
+            # allow-list has always normalized both sides
+            # (`transport.py`); this is the group path catching up.
+            jid = normalize_jid(str(entry.get("jid", "")))
             if jid:
                 self._entries[jid] = entry
         self._last_unprompted: dict[str, float] = {}
 
     def configured(self, group_jid: str) -> bool:
-        return group_jid in self._entries
+        return normalize_jid(group_jid) in self._entries
 
     def evaluate(
         self,
@@ -90,6 +106,11 @@ class GroupGate:
         targets the agent: an @-mention of the linked account, or a reply to
         one of the agent's own messages.
         """
+        # Normalized on the way IN as well as on the way in to `_entries`.
+        # The transport already normalizes, but the invariant "the same
+        # identifier hashes to the same value" belongs to the module that owns
+        # the key rather than to each of its callers.
+        group_jid = normalize_jid(group_jid)
         entry = self._entries.get(group_jid)
         if entry is None:
             return GroupVerdict(respond=False, reason="group_not_configured")

--- a/test/test_link_unfurl.py
+++ b/test/test_link_unfurl.py
@@ -1646,3 +1646,102 @@ def test_route_is_registered_on_the_app() -> None:
     lm.setup_link_meta_routes(app)
     routes = {(r.method, r.resource.canonical) for r in app.router.routes()}
     assert ("GET", "/api/link-meta") in routes
+
+
+# --- address_is_not_public: the vet for a caller holding a resolution result ---
+#
+# The channels' attachment downloads consult this instead of enumerating category
+# flags locally, so a gap here is a server-side request forgery in each of them.
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        # The two ranges every hand-rolled category-flag list has missed. Both were
+        # APPROVED by the check this function replaced in `teams/client.py`.
+        "100.64.0.1",  # RFC 6598 shared space: absent from CPython's is_private
+        "100.127.255.254",  # last usable address of the same block
+        "fec0::1",  # deprecated IPv6 site-local: reports is_global True
+        # Tunnel encodings, which that check evaluated as WRITTEN.
+        "::ffff:127.0.0.1",  # v4-mapped loopback: is_loopback is False on the wrapper
+        "::ffff:169.254.169.254",
+        "2002:0a00:0001::1",  # 6to4 naming the v4 tunnel endpoint 10.0.0.1
+        # Classics, which must stay refused.
+        "127.0.0.1",
+        "169.254.169.254",  # the cloud instance-metadata endpoint
+        "10.1.2.3",
+        "192.168.0.9",
+        "::1",
+        "fe80::1",
+        "0.0.0.0",
+        "224.0.0.1",
+        "ff02::1",
+        # Alternate IPv4 encodings the OS resolver accepts but `ipaddress` rejects,
+        # folded by `canonicalize_ip` so the verdict does not ride on getaddrinfo's
+        # reading of a string the vet declined to parse.
+        "0x7f000001",
+        "2130706433",
+        "127.1",
+    ],
+)
+def test_address_is_not_public_refuses_every_non_public_form(address: str) -> None:
+    assert lu.address_is_not_public(address) is True
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["93.184.216.34", "1.1.1.1", "8.8.8.8", "2606:4700::1111"],
+)
+def test_address_is_not_public_allows_globally_routable_addresses(address: str) -> None:
+    """A vet that refused real addresses would break every inbound attachment.
+
+    The refusal half is only half the property: this is the half that keeps the
+    fix from being a channel-wide outage.
+    """
+    assert lu.address_is_not_public(address) is False
+
+
+@pytest.mark.parametrize("address", ["", "   ", "not-an-ip", "example.com", "::gg"])
+def test_address_is_not_public_fails_closed_on_an_unreadable_value(address: str) -> None:
+    """The OPPOSITE default to :func:`_reject_if_internal_ip`, deliberately.
+
+    That function passes a non-literal through because for it a non-literal is a
+    hostname still to be resolved. Here the value is already a resolution result
+    about to reach a socket, so one that cannot be parsed must not be approved --
+    otherwise an unreadable answer reaches the pin unchecked.
+    """
+    assert lu.address_is_not_public(address) is True
+
+
+def test_the_url_vet_still_treats_a_non_literal_as_a_hostname() -> None:
+    """Pins the refactor: extracting the shared helper must not change this contract.
+
+    `_reject_if_internal_ip` returning silently for a hostname is what lets
+    `vet_unfurl_url` fall through to its DNS branch. If the extraction had given it
+    the fail-closed default, every named host would be refused.
+    """
+    lu._reject_if_internal_ip("example.com")  # must not raise
+    with pytest.raises(lu.UnfurlRejected) as exc:
+        lu._reject_if_internal_ip("127.0.0.1")
+    assert exc.value.code == "blocked_url"
+
+
+@pytest.mark.parametrize("address", ["100.64.0.1", "fec0::1"])
+def test_the_replaced_category_flag_list_would_have_approved_these(address: str) -> None:
+    """Proves the finding's premise rather than assuming it.
+
+    Reconstructs the exact six-flag check `teams/client.py::_vet_resolved_address`
+    used to run and shows it says "fine" for both ranges. Without this, a future
+    reader cannot tell whether the delegation fixed a real hole or was cosmetic.
+    """
+    ip = ipaddress.ip_address(address)
+    old_verdict = (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+    assert old_verdict is False, "the old check already caught this; premise is wrong"
+    assert lu.address_is_not_public(address) is True

--- a/test/test_skill_trust.py
+++ b/test/test_skill_trust.py
@@ -484,3 +484,175 @@ class TestListing:
         assert [row["path"] for row in rows] == [project]
         assert rows[0]["exists"] is True
         assert isinstance(rows[0]["granted_at"], int)
+
+
+class TestInstanceBinding:
+    """A grant is consent for the CONTENT reviewed, and a path is a reusable name.
+
+    Delete the reviewed repository, create a different one at the same canonical
+    path -- a routine move on a shared dev host, and the normal life of a CI
+    checkout directory -- and a path-only grant is inherited by content nobody
+    reviewed, whose ``SKILL.md`` then enters the agent context with instruction
+    authority the operator never gave it. The grant therefore records the
+    directory INSTANCE, and enforcement compares it.
+    """
+
+    def test_a_different_directory_at_the_same_path_is_not_trusted(self, tmp_path: Path) -> None:
+        """The finding's exact scenario, end to end."""
+        project = _real_dir(tmp_path, "project")
+        skill_trust.grant_project_trust(project)
+        assert skill_trust.is_project_trusted(project) is True
+
+        # Replace the reviewed tree with a different directory at the same path.
+        os.rmdir(project)
+        _real_dir(tmp_path, "an-intervening-inode")
+        recreated = _real_dir(tmp_path, "project")
+        assert recreated == project, "the path is unchanged; only the instance differs"
+        skill_trust.reset_cache_for_tests()
+
+        assert skill_trust.is_project_trusted(project) is False
+        assert skill_trust.is_key_trusted(project) is False
+
+    def test_the_reviewed_directory_stays_trusted_across_ordinary_edits(
+        self, tmp_path: Path
+    ) -> None:
+        """The property that keeps the binding from re-prompting on real work.
+
+        Writing, editing and deleting files inside the tree -- which is what
+        authoring a skill IS -- must not invalidate consent. This is why the
+        identity is the directory instance rather than a content fingerprint or
+        ``st_ctime``, both of which move when the operator edits their own skills.
+
+        The ``utime`` call is the point rather than decoration: it moves the
+        directory's own mtime/ctime with no content change at all, so a future
+        identity that folded either in would fail here.
+        """
+        project = _real_dir(tmp_path, "project")
+        skill_trust.grant_project_trust(project)
+
+        skills = Path(project) / ".kiro" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "SKILL.md").write_text("# edited\n", encoding="utf-8")
+        (skills / "SKILL.md").write_text("# edited again\n", encoding="utf-8")
+        os.utime(project)  # bump the directory's own mtime/ctime
+        skill_trust.reset_cache_for_tests()
+
+        assert skill_trust.is_project_trusted(project) is True
+
+    def test_a_grant_records_the_identity_it_enforces(self, tmp_path: Path) -> None:
+        project = _real_dir(tmp_path, "project")
+        skill_trust.grant_project_trust(project)
+
+        stored = json.loads(skill_trust.store_path().read_text(encoding="utf-8"))
+        entry = stored["granted"][0]
+        assert entry["path"] == project
+        assert entry["identity"] == skill_trust._instance_identity(project)
+        assert entry["identity"], "an empty identity would silently exempt the row"
+
+    def test_re_granting_a_replaced_directory_rebinds_it(self, tmp_path: Path) -> None:
+        """An explicit re-grant must take effect.
+
+        The dedup loop used to return early on a path match. Left that way, an
+        operator re-granting a path whose directory had been replaced would get a
+        no-op: the new tree stays untrusted, with the settings page showing a grant
+        for it and no surface explaining the contradiction.
+        """
+        project = _real_dir(tmp_path, "project")
+        skill_trust.grant_project_trust(project)
+        os.rmdir(project)
+        _real_dir(tmp_path, "an-intervening-inode")
+        _real_dir(tmp_path, "project")
+        skill_trust.reset_cache_for_tests()
+        assert skill_trust.is_project_trusted(project) is False
+
+        skill_trust.grant_project_trust(project)
+        skill_trust.reset_cache_for_tests()
+
+        assert skill_trust.is_project_trusted(project) is True
+        stored = json.loads(skill_trust.store_path().read_text(encoding="utf-8"))
+        paths = [e["path"] for e in stored["granted"]]
+        assert paths.count(project) == 1, "a rebind replaces the row, it does not duplicate it"
+
+    def test_a_grant_on_an_unreadable_directory_is_refused(self, tmp_path: Path) -> None:
+        """Never record a path-only row: that is the shape being eliminated."""
+        missing = str(tmp_path / "not-there")
+        with pytest.raises(ValueError):
+            skill_trust.grant_project_trust(missing)
+        assert not skill_trust.store_path().exists()
+
+    def test_a_pre_binding_grant_is_listed_but_not_enforced(self, tmp_path: Path) -> None:
+        """The migration boundary: fail closed, but visibly rather than silently.
+
+        A row written before grants carried an identity cannot say WHICH directory
+        the operator reviewed, so honoring it would leave open exactly the
+        replacement path this binding closes -- being inherited from an older build
+        does not make a path-only row mean more than it says.
+
+        Not enforcing it is not the same as deleting it. The row stays listed and
+        is reported unbound, so the operator is re-ASKED rather than silently
+        un-consented, and one re-grant binds it.
+        """
+        project = _real_dir(tmp_path, "project")
+        _write_store_raw(
+            json.dumps({"version": 1, "granted": [{"path": project, "granted_at": 1}]})
+        )
+
+        assert skill_trust.is_project_trusted(project) is False
+        assert skill_trust.is_key_trusted(project) is False
+        # Still visible, and visibly unbound -- the operator can act on it.
+        rows = skill_trust.list_trusted_projects()
+        assert [r["path"] for r in rows] == [project]
+        assert rows[0]["bound"] is False
+        assert project in skill_trust.trusted_keys(), "listed as granted, just not enforced"
+
+        skill_trust.grant_project_trust(project)
+        skill_trust.reset_cache_for_tests()
+
+        assert skill_trust.is_project_trusted(project) is True
+        assert skill_trust.list_trusted_projects()[0]["bound"] is True
+
+    def test_an_unreadable_directory_is_not_trusted(self, tmp_path: Path) -> None:
+        """No readable identity means no match -- never a fallback to the path.
+
+        The store row here is identity-LESS on purpose. A bound row's token is
+        path+identity, which a path-only fallback could not match anyway, so a
+        bound row cannot detect one; an identity-less row's token WOULD be the bare
+        path, which makes this the only shape that exposes a fallback if one is
+        ever reintroduced.
+        """
+        project = _real_dir(tmp_path, "project")
+        _write_store_raw(
+            json.dumps({"version": 1, "granted": [{"path": project, "granted_at": 1}]})
+        )
+        os.rmdir(project)
+        skill_trust.reset_cache_for_tests()
+
+        assert skill_trust.is_key_trusted(project) is False
+        assert skill_trust.is_project_trusted(project) is False
+
+    def test_a_bound_row_does_not_also_match_on_the_path_alone(self, tmp_path: Path) -> None:
+        """Otherwise the binding is decorative: a stale identity would fall back."""
+        project = _real_dir(tmp_path, "project")
+        _write_store_raw(
+            json.dumps(
+                {
+                    "version": 1,
+                    "granted": [{"path": project, "identity": "0:0:0", "granted_at": 1}],
+                }
+            )
+        )
+
+        assert skill_trust.is_project_trusted(project) is False
+        assert skill_trust.is_key_trusted(project) is False
+        assert skill_trust.list_trusted_projects()[0]["bound"] is True
+
+    def test_an_identity_is_not_confusable_with_a_path(self, tmp_path: Path) -> None:
+        """The token separator is NUL, which no path component can contain.
+
+        A printable separator would let a crafted directory name make one half of
+        the token read as the other.
+        """
+        assert skill_trust._TOKEN_SEP == "\x00"
+        project = _real_dir(tmp_path, "project")
+        identity = skill_trust._instance_identity(project)
+        assert skill_trust._binding_token(project, identity) == f"{project}\x00{identity}"

--- a/test/test_teams_files.py
+++ b/test/test_teams_files.py
@@ -289,6 +289,59 @@ class TestResolvedAddressVetting:
         assert session.calls == [], "refused BEFORE the request, not after"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "100.64.0.1",  # RFC 6598 CGNAT -- what a tailnet and carrier NAT hand out
+            "100.127.255.254",
+            "fec0::1",  # deprecated IPv6 site-local
+            "::ffff:127.0.0.1",  # v4-mapped loopback
+            "2002:0a00:0001::1",  # 6to4 naming 10.0.0.1
+        ],
+    )
+    async def test_ranges_the_old_category_flag_vet_approved_are_refused(
+        self, tmp_path, monkeypatch, address
+    ) -> None:
+        """These five passed the six-flag check this vet replaced.
+
+        `100.64.0.0/10` is not in CPython's `is_private` table and `fec0::/10`
+        reports `is_global=True`, so an enumerated-category check approved both --
+        and on a host attached to a tailnet, that range IS the private network. The
+        mapped and 6to4 forms were evaluated as written rather than unwrapped, so
+        `::ffff:127.0.0.1` passed a check whose entire purpose was refusing
+        loopback. `link_unfurl.address_is_not_public` closes all five.
+        """
+
+        async def _resolves_inward(host: str, port: int = 443) -> list[str]:
+            return [address]
+
+        monkeypatch.setattr("kiro_crew.teams.client.resolve_addresses", _resolves_inward)
+        client, session = _client([_FakeResponse(chunks=[PNG_BYTES])])
+        with pytest.raises(ValueError):
+            await client.download_inbound_file("https://harmless.example/dl", str(tmp_path / "f"))
+        assert session.calls == [], "refused BEFORE the request, not after"
+
+    @pytest.mark.asyncio
+    async def test_an_unparseable_resolved_address_still_refuses(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The shared vet fails closed on a literal it cannot read.
+
+        The local `ipaddress.ip_address` guard that used to do this was dropped
+        because the delegation subsumes it -- so the property needs its own test,
+        or removing that guard would look like a regression.
+        """
+
+        async def _garbage(host: str, port: int = 443) -> list[str]:
+            return ["not-an-address"]
+
+        monkeypatch.setattr("kiro_crew.teams.client.resolve_addresses", _garbage)
+        client, session = _client([_FakeResponse(chunks=[PNG_BYTES])])
+        with pytest.raises(ValueError):
+            await client.download_inbound_file("https://harmless.example/dl", str(tmp_path / "f"))
+        assert session.calls == []
+
+    @pytest.mark.asyncio
     async def test_one_bad_answer_among_several_refuses_the_whole_host(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/test/test_wecom_media.py
+++ b/test/test_wecom_media.py
@@ -17,9 +17,12 @@ import pytest
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from kiro_crew import link_unfurl
+from kiro_crew.wecom import media as media_mod
 from kiro_crew.wecom.attachments import to_attachments
 from kiro_crew.wecom.media import (
     WeComMediaError,
+    _vet_media_url,
     decode_aes_key,
     decrypt_media,
     media_items,
@@ -189,10 +192,14 @@ class TestAttachmentAdapter:
 
 
 class TestDownloadCaps:
-    def test_the_size_cap_is_enforced_while_reading(self) -> None:
+    def test_the_size_cap_is_enforced_while_reading(self, monkeypatch) -> None:
         # Enforced on BYTES READ, never on Content-Length: a header is
         # attacker-influenced, and a lying one would let an unbounded body through.
-        from kiro_crew.wecom import media as media_mod
+        #
+        # The URL has to clear the SSRF vet before the cap is reachable at all, so
+        # the resolver is stubbed to a public address. Kept as a stub rather than a
+        # real lookup so this test still opens no socket.
+        monkeypatch.setattr(link_unfurl, "_default_resolve", lambda *_a: ["93.184.216.34"])
 
         class FakeContent:
             async def iter_chunked(self, _n):
@@ -217,7 +224,7 @@ class TestDownloadCaps:
             asyncio.run(
                 media_mod.download_media(
                     FakeSession(),
-                    "https://cdn/big",
+                    "https://cdn.example/big",
                     base64.b64encode(os.urandom(32)).decode(),
                     max_bytes=4096,
                 )
@@ -228,3 +235,142 @@ class TestDownloadCaps:
             asyncio.run(
                 __import__("kiro_crew.wecom.media", fromlist=["x"]).download_media(None, "", "k")
             )
+
+
+class TestMediaUrlVetting:
+    """The inbound ``url`` is platform-SUPPLIED but not platform-GUARANTEED.
+
+    Nothing in a callback frame proves the host is one WeCom operates, and the
+    fetched body flows on into the attachment pipeline -- so an unvetted fetch is a
+    server-side request forgery READ primitive, not a blind one. Every sibling
+    channel vets its download URL; this path was the one that did not.
+    """
+
+    @staticmethod
+    def _public(_host, _port):
+        return ["93.184.216.34"]
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://cdn.example/o",  # a cleartext hop for a body we then decrypt
+            "file:///etc/passwd",  # not a download at all
+            "ftp://cdn.example/o",
+            "//cdn.example/o",  # scheme-relative: no scheme at all
+            "cdn.example/o",
+        ],
+    )
+    def test_only_https_is_accepted(self, url) -> None:
+        with pytest.raises(WeComMediaError, match="https"):
+            _vet_media_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://127.0.0.1/o",
+            "https://169.254.169.254/latest/meta-data/",  # instance metadata
+            "https://10.1.2.3/o",
+            "https://100.64.0.1/o",  # RFC 6598 CGNAT -- a tailnet address
+            "https://[::1]/o",
+            "https://[fec0::1]/o",
+            "https://0x7f000001/o",  # alternate encoding the OS resolver accepts
+        ],
+    )
+    def test_an_internal_destination_is_refused(self, url) -> None:
+        """Delegated to `link_unfurl`, so the refusal set is the pinned one."""
+        with pytest.raises(WeComMediaError, match="refusing media url"):
+            _vet_media_url(url)
+
+    def test_a_public_name_resolving_inward_is_refused(self, monkeypatch) -> None:
+        """A name the attacker controls needs no internal-looking host at all."""
+        monkeypatch.setattr(link_unfurl, "_default_resolve", lambda *_a: ["127.0.0.1"])
+        with pytest.raises(WeComMediaError, match="refusing media url"):
+            _vet_media_url("https://harmless.example/o")
+
+    def test_a_malformed_authority_raises_this_module_s_error(self) -> None:
+        """`urlsplit` RAISES on `https://[`, so without the guard a hostile body
+        surfaced as an uncaught ValueError instead of a WeCom media error."""
+        with pytest.raises(WeComMediaError, match="malformed"):
+            _vet_media_url("https://[")
+
+    def test_a_legitimate_cdn_url_still_passes(self, monkeypatch) -> None:
+        """The half of the property that keeps the fix from being an outage.
+
+        No CDN host allow-list is applied on purpose: WeCom documents no stable
+        media-host set, so an invented list would silently drop real media. The
+        destination vet closes the same class without naming hosts.
+        """
+        monkeypatch.setattr(link_unfurl, "_default_resolve", self._public)
+        out = _vet_media_url("https://wework.qpic.cn/media/abc?sig=xyz")
+        assert out.startswith("https://wework.qpic.cn/media/abc")
+        assert "sig=xyz" in out, "the signature query must survive normalization"
+
+    def test_port_80_on_an_https_url_is_refused(self, monkeypatch) -> None:
+        """The shared vet allows {80, 443} because it also serves plain-http
+        unfurling; this caller is https-only, so 443 is the stated scope."""
+        monkeypatch.setattr(link_unfurl, "_default_resolve", self._public)
+        with pytest.raises(WeComMediaError, match="refusing media url"):
+            _vet_media_url("https://cdn.example:80/o")
+
+
+class TestMediaDownloadRedirects:
+    """A followed redirect is a hop the vet never saw."""
+
+    class _Resp:
+        def __init__(self, status):
+            self.status = status
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        class content:  # noqa: N801 - matches aiohttp's attribute shape
+            @staticmethod
+            async def iter_chunked(_n):
+                yield b""
+
+    class _Session:
+        def __init__(self, status):
+            self.status = status
+            self.kwargs = {}
+
+        def get(self, *_a, **kw):
+            self.kwargs = kw
+            return TestMediaDownloadRedirects._Resp(self.status)
+
+    def _run(self, session):
+        return asyncio.run(
+            media_mod.download_media(
+                session,
+                "https://cdn.example/o",
+                base64.b64encode(os.urandom(32)).decode(),
+            )
+        )
+
+    def test_redirects_are_disabled_on_the_request(self, monkeypatch) -> None:
+        monkeypatch.setattr(link_unfurl, "_default_resolve", lambda *_a: ["93.184.216.34"])
+        session = self._Session(200)
+        with pytest.raises(WeComMediaError):
+            self._run(session)  # empty body fails to decrypt; the kwarg is the point
+        assert session.kwargs.get("allow_redirects") is False
+
+    @pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+    def test_a_redirect_response_is_refused_rather_than_followed(self, monkeypatch, status) -> None:
+        monkeypatch.setattr(link_unfurl, "_default_resolve", lambda *_a: ["93.184.216.34"])
+        with pytest.raises(WeComMediaError, match="redirected"):
+            self._run(self._Session(status))
+
+    def test_the_vet_runs_before_any_request(self, monkeypatch) -> None:
+        """An internal URL must never reach the session at all."""
+        session = self._Session(200)
+        with pytest.raises(WeComMediaError):
+            asyncio.run(
+                media_mod.download_media(
+                    session,
+                    "https://169.254.169.254/latest/meta-data/",
+                    base64.b64encode(os.urandom(32)).decode(),
+                )
+            )
+        assert session.kwargs == {}, "refused before the fetch, not after"

--- a/test/test_whatsapp.py
+++ b/test/test_whatsapp.py
@@ -9,6 +9,8 @@ otherwise. Both take an injectable clock so expiry paths are deterministic.
 
 from __future__ import annotations
 
+import pytest
+
 from kiro_crew.whatsapp.commands import parse_command
 from kiro_crew.whatsapp.echo import EchoTracker
 from kiro_crew.whatsapp.group_gate import (
@@ -157,3 +159,73 @@ class TestCommands:
         assert parse_command("  /COMPACT ") == "compact"
         assert parse_command("hello") is None
         assert parse_command("") is None
+
+
+class TestGroupGateKeyNormalization:
+    """One group JID must hash to one key on every path that touches it.
+
+    The transport hands ``evaluate()`` a fully ``normalize_jid``-ed value, while
+    the config side used a bare ``.strip()``. So a group the operator HAD
+    configured -- written with an uppercase server, or carrying a device suffix --
+    was stored under a key the lookup could never produce, and every message from
+    it was dropped as ``group_not_configured``. Fail-closed in direction (the gate
+    decides IF the agent may speak, so this over-denied rather than admitting an
+    unauthorized group) but still a real defect: the operator configured a group
+    and the agent sat silent in it, with no surface saying why.
+
+    The DM allow-list has always normalized both sides; this is the group path
+    catching up to it.
+    """
+
+    NORMALIZED = "1203630000000@g.us"
+
+    @pytest.mark.parametrize(
+        "configured_as",
+        [
+            "1203630000000@G.US",  # an uppercase server is valid per JID semantics
+            "1203630000000@G.us",
+            "  1203630000000@g.us  ",  # copied out of a config file with padding
+            "1203630000000:5@g.us",  # device suffix, which lives in the USER part
+        ],
+    )
+    def test_a_config_entry_written_any_of_these_ways_matches(self, configured_as):
+        gate = GroupGate([{"jid": configured_as, "mode": "mention"}])
+        assert gate.configured(self.NORMALIZED)
+        verdict = gate.evaluate(self.NORMALIZED, sender_is_operator=False, addressed=True)
+        assert verdict.respond
+        assert verdict.reason == ""
+
+    @pytest.mark.parametrize(
+        "looked_up_as",
+        ["1203630000000@G.US", "  1203630000000@g.us  ", "1203630000000:9@g.us"],
+    )
+    def test_an_un_normalized_lookup_also_matches(self, looked_up_as):
+        """Normalized on the way IN as well as on the way in to ``_entries``.
+
+        The transport already normalizes, but the invariant belongs to the module
+        that owns the key rather than to each caller -- otherwise a second caller
+        added later reintroduces exactly this bug.
+        """
+        gate = GroupGate([{"jid": self.NORMALIZED, "mode": "mention"}])
+        assert gate.configured(looked_up_as)
+        assert gate.evaluate(looked_up_as, sender_is_operator=False, addressed=True).respond
+
+    def test_normalizing_does_not_widen_the_gate(self):
+        """The one property a normalization fix can break: groups are still opt-in.
+
+        A DIFFERENT group must remain invisible. If normalization had collapsed
+        distinct JIDs onto one key, this fix would have turned an over-denial into
+        an authorization hole, which is the opposite trade.
+        """
+        gate = GroupGate([{"jid": "1203630000000@g.us", "mode": "mention"}])
+        for other in ("1203639999999@g.us", "1203630000000@s.whatsapp.net", "@g.us", ""):
+            assert not gate.configured(other), other
+            verdict = gate.evaluate(other, sender_is_operator=True, addressed=True)
+            assert not verdict.respond
+            assert verdict.reason == "group_not_configured"
+
+    def test_an_entry_that_normalizes_to_nothing_is_skipped(self):
+        """A junk entry must not become a key that an empty lookup then matches."""
+        gate = GroupGate([{"jid": "   "}, {"name": "no jid at all"}])
+        assert not gate.configured("")
+        assert not gate.evaluate("", sender_is_operator=True, addressed=True).respond

--- a/test/test_whatsapp_gateway.py
+++ b/test/test_whatsapp_gateway.py
@@ -291,7 +291,7 @@ def _warnings(caplog) -> list[str]:
 
 def test_configured_group_jids_skips_junk_entries():
     """A hand-edited config reaches this unchanged, and it is read exactly as
-    ``GroupGate`` reads it: ``str(entry["jid"]).strip()``, non-empty."""
+    ``GroupGate`` reads it: ``normalize_jid(str(entry["jid"]))``, non-empty."""
     assert _configured_group_jids(
         [{"jid": "a@g.us"}, {"jid": "  "}, {"name": "no jid"}, "junk", None, {"jid": " b@g.us "}]
     ) == ["a@g.us", "b@g.us"]
@@ -496,3 +496,38 @@ def test_a_state_change_after_the_loop_closed_is_not_an_error(monkeypatch, caplo
 
     assert _warnings(caplog) == []
     assert "loop closed" in caplog.text
+
+
+def test_configured_group_jids_keys_the_way_the_gate_keys():
+    """The membership diagnostic must agree with the gate, or it lies.
+
+    It compares configured JIDs against the JIDs the linked account reports, which
+    ARE normalized. Reading the operator's raw text meant an entry written
+    ``@G.US`` looked configured-and-joined from here while the gate was dropping
+    every message from it -- so the one surface that could have named the problem
+    reported everything fine. Now that both sides normalize, this has to keep
+    matching or the diagnostic starts lying in the other direction.
+    """
+    assert _configured_group_jids(
+        [
+            {"jid": "1203630000001@G.US"},  # server case is folded
+            {"jid": "1203630000002:5@g.us"},  # user-part device suffix is dropped
+            {"jid": " 1203630000003@g.us "},  # padding is trimmed
+        ]
+    ) == [
+        "1203630000001@g.us",
+        "1203630000002@g.us",
+        "1203630000003@g.us",
+    ]
+
+
+def test_configured_group_jids_leaves_the_user_part_case_alone():
+    """Only the SERVER is case-insensitive in a JID; the user part is not.
+
+    Group ids are numeric in practice, so this is not a shape an operator hits --
+    it is here to pin that the normalizer folds the half it is allowed to fold and
+    no more. Lower-casing the user part would make two distinct JIDs collide, which
+    for a gate keyed on this value would be an authorization hole rather than the
+    over-denial being fixed.
+    """
+    assert _configured_group_jids([{"jid": "AbC@G.US"}]) == ["AbC@g.us"]


### PR DESCRIPTION
## Problem / Motivation

Four open CSE findings, each re-verified live against `origin/main` before anything was touched (five others from the same batch were already fixed on main and have been closed separately).

1. **CWE-918 High — Teams attachment download.** `TeamsClient._vet_resolved_address` refused a resolved address on six `ipaddress` category flags only. That list **approves** `100.64.0.0/10` (RFC 6598 shared space — what a Tailscale tailnet and most carrier NAT hand out; it is absent from CPython's `is_private` table and only `is_global` rejects it) and `fec0::/10` (deprecated IPv6 site-local, which reports `is_global=True`). It also evaluated the ipv4-mapped and 6to4 encodings **as written**, so `::ffff:127.0.0.1` passed a check whose entire purpose was refusing loopback. Since a fetched body is written to a temp file and injected into the prompt, this is a concrete SSRF **read** primitive, not a blind one.

2. **CWE-918 High — WeCom inbound media download.** `download_media` fetched a callback-supplied `url` after only an `if not url` emptiness check: no scheme rule, no destination validation, and aiohttp's default follows redirects. Every sibling channel (Slack, Teams, Discord, WhatsApp) vets its platform-provided download URL; this was the one path that did not.

3. **CWE-665 High — skill-trust grant keyed on a reusable realpath.** `skill_trust` keyed project-skills consent on `os.path.realpath(project_dir)` alone. Delete the reviewed repository and create a different one at the same canonical path — a routine move on a shared dev host, and the normal life of a CI checkout directory — and the grant is silently inherited by content nobody reviewed, whose `SKILL.md` then enters the agent context with instruction authority the operator never gave it.

4. **CWE-178 Medium — WhatsApp group-gate key normalization.** `GroupGate.__init__` stored config JIDs with a bare `.strip()` while the transport hands `evaluate()` a fully `normalize_jid`-ed value. A group written `123456@G.US` (an uppercase server is valid per JID semantics) or with a user-part device suffix was stored under a key the lookup could never produce, so **the operator configured a group and the agent sat silent in it**, reporting `group_not_configured` with no surface saying why.

## Why it matters

The two SSRF findings are the sharp ones. An attacker who controls a public DNS name pointed at a CGNAT/tailnet address, or who supplies a crafted WeCom media URL, drives the gateway at an internal service or `169.254.169.254` and gets the response summarized back into chat. On a host attached to a tailnet, `100.64.0.0/10` **is** the private network, so the gap is not theoretical.

The skill-trust finding is a local-attacker escalation of instruction authority into the agent context — quieter, but the module exists precisely to gate that decision.

The WhatsApp one is fail-**closed** in direction (the gate decides *if* the agent may speak, so it over-denied rather than admitting an unauthorized group), which is why it is Medium. It is still a real defect, and the one diagnostic that could have surfaced it — `gateway.py::_configured_group_jids` — was comparing the operator's raw text against membership answers that *are* normalized, so it reported the broken entry as fine.

## What changed (motivation → approach → change)

### One shared address vet, not a third copy

Both SSRF findings say the same thing: a channel hand-rolled a category-flag IP check instead of reusing the comprehensive one. `link_unfurl` already owns this decision for link unfurling and for the meetings calendar fetch, and its `test_vet_rejects_every_special_purpose_range` pins the refusal set against a table of IANA special-purpose prefixes — so the next gap is found by the suite rather than by a reviewer, which a second implementation would not inherit. Patching two copies would have made it a third.

So `link_unfurl.py` gains `_literal_is_not_public` (the mapped/6to4 unwrapping, split out of `_reject_if_internal_ip` with behaviour unchanged) and a public `address_is_not_public` for callers that already hold a resolution result. It fails **closed** on an unparseable literal — deliberately the opposite of `_reject_if_internal_ip`'s default, because for the URL vet a non-literal is a hostname still to be resolved, while here it is a resolution result about to reach a socket.

- **Teams** now calls `link_unfurl.address_is_not_public(resolved)`. Everything else on that path was already right (per-hop re-vet, `_VettedResolver` pin, `allow_redirects=False`). The delegation also subsumes the local unparseable-address guard, so that guard is gone — with its own test, so removing it cannot look like a regression.
- **WeCom** gains an https-only scheme rule plus `link_unfurl.vet_unfurl_url` (resolves once, checks *every* answer), and `allow_redirects=False` with an explicit 3xx refusal.

Two controls the sibling channels carry are **deliberately not** added to WeCom, both recorded in the code with the reasoning:

- **No CDN host allow-list** (Discord keeps one for its two documented hosts; Slack for `slack.com`). WeCom documents no stable media-host set and the repo holds no such constant, so the list would be a guess — and a wrong guess silently drops legitimate media. The destination vet closes the same class without naming hosts, and is strictly stronger than what Discord applies.
- **No pinned resolver** (the anti-rebinding mechanism in `teams/client.py` and the calendar provider). This path takes an operator `proxy`, and under a proxy aiohttp never resolves the target host, so the pin would go unconsulted on exactly the deployments that configure one. The residual rebinding window is documented rather than half-closed; closing it needs the proxy case answered first, which is its own change.

  Per Design Review, the docstring now also states that a proxy splits this vet from the egress it judges in *both* directions: resolution is local while a proxied request is resolved and dialed by the proxy, so on split-horizon DNS this can false-refuse a URL the proxy would have fetched publicly, and conversely it approves addresses the proxy never dials. Vetting what we can see still beats vetting nothing — an internal target named directly is refused either way — but a proxied deployment should read it as a sanity check, not a guarantee about egress.

### skill-trust: bind the grant to the directory instance

Grants now record the directory **instance** — `st_dev:st_ino`, plus `st_birthtime` where the platform exposes it (macOS, the BSDs, Windows), because an inode number can itself be reused after a delete, which is the very case being closed. Enforcement compares it, so a delete-then-recreate becomes a consent re-prompt instead of silent inheritance.

Not a content fingerprint of `.kiro/skills`, and not `st_ctime`: both move when the operator edits their own skills, so either would re-prompt on ordinary work — and a consent prompt that fires routinely is one that gets clicked through. A test locks that in by editing files inside a granted tree and asserting trust survives.

Two things fell out of doing this honestly:

- `trusted_keys()` keeps returning **paths** — its documented contract, and three existing tests assert it. Enforcement matches a separate token set built from the same parse, so the public function stays honest to its name while the binding actually bites. My first attempt changed its return shape and those three tests caught it.
- A re-grant of a replaced directory now **rebinds** rather than short-circuiting on the path match. Left as-is, an operator explicitly re-granting would get a silent no-op: the new tree stays untrusted while the settings page shows a grant for it.

**Migration boundary — fail closed, and revised in review.** A row written before this change carries no identity and is **listed but not enforced**. I first shipped these as still-honored, reasoning that refusing them would silently revoke consent an operator had already given. GPT's review pushed back and was right: being inherited from an older build does not make a path-only row mean more than it says, and its suggested shape resolves the objection I actually had — keep the row **listable**, exclude it from enforcement until re-granted. That is a *visible re-prompt*, not a silent revoke, which is the distinction my original framing missed. `list_trusted_projects` reports `bound`, so the operator sees the row and can re-grant or revoke it. Schema version stays `1`; bumping it would make existing stores unreadable, which *would* be the destructive version.

**Residuals, stated rather than implied closed** (raised by Design Review, both documented in the docstrings):

- On Linux, where CPython exposes no birth time and `dev:ino` stands alone, the **accidental** replacement case is fully closed (a fresh clone or moved tree lands on a different inode) but the **adversarial** one only best-effort: a local actor who can already write that path can grind create/delete until the filesystem reuses the inode. `statx` `STATX_BTIME` is the eventual fix.
- `st_dev` is not stable across remounts on btrfs subvolumes, NFS, and some container bind mounts, so a bound grant can stop matching after a reboot with unchanged content. Fail-closed, but an unearned re-prompt — and so the same habituation risk the code rejects a content fingerprint for.

I deliberately did **not** write statx or proxy-aware-DNS code in response to these; they are documented limitations, and growing the diff to chase them is how a security fix turns into a new review surface.

### WhatsApp: the module that owns the key owns the invariant

`GroupGate` normalizes on **both** sides — config entries when indexed, and the lookup value. The transport already normalizes, but putting the invariant in the module that owns the key is what stops a second caller added later from reintroducing the same bug. `gateway.py::_configured_group_jids` matches again.

One correction to the finding: its second example, `123456@g.us:5`, is **not** a shape `normalize_jid` folds — a WhatsApp device suffix lives in the user part (`123456:5@g.us`). The real divergences are server case, surrounding whitespace, and a user-part device suffix; tests cover those. A test also pins that normalization does not *widen* the gate, since collapsing distinct JIDs onto one key would convert an over-denial into an authorization hole — the opposite trade.

## Tests

32 new test functions (427 cases collected) across five suites; **every one revert-verified** — mutate the fix, confirm that test fails with a *real* test failure (exit 1 with a reported failure; exit 4 is a pytest usage error and proves nothing), restore from an in-memory snapshot in a `finally`.

The harness earned its keep twice. It first reported two round-2 guards as possibly vacuous, which turned out to be correct behaviour on its part: both properties are held up by **two** edits at once (`_parse_store` no longer emitting a bare-path token, and `is_key_trusted` no longer falling back to one), so mutating either alone correctly leaves the property standing. Re-run with the joint mutation — exactly the pre-review code — both fail. It also exposed that my vanished-directory test used a *bound* row, whose token is path+identity and which a path-only fallback therefore could never match, so the test would have passed no matter what; it now uses an identity-less row, the only shape that can detect such a fallback.

- `test_link_unfurl.py` — `address_is_not_public` refuses 18 non-public forms (CGNAT, `fec0::/10`, mapped, 6to4, alternate IPv4 encodings), **allows** 4 genuinely routable addresses (the half that keeps the fix from being a channel-wide outage), and fails closed on 5 unreadable values. One test reconstructs the exact six-flag check that was replaced and asserts it approved `100.64.0.1` and `fec0::1` — so the finding's premise is **proven**, not assumed. Another pins that `_reject_if_internal_ip` still passes hostnames through, which is what the refactor could have broken.
- `test_teams_files.py` — the five ranges the old vet approved are now refused before any request is made, plus the unparseable-address case that the removed local guard used to cover.
- `test_wecom_media.py` — scheme, internal destination, a public name resolving inward, a malformed authority, port 80 on an https URL, a legitimate signed CDN URL surviving normalization, `allow_redirects=False` on the request, 3xx refused for all five redirect codes, and the vet running before the session is touched at all.
- `test_whatsapp.py` / `test_whatsapp_gateway.py` — the config-side and lookup-side divergences, no widening, junk entries skipped, and that only the *server* case is folded (lower-casing the user part would make distinct JIDs collide).
- `test_skill_trust.py` — the finding's exact scenario end to end, ordinary edits preserving trust, the identity being recorded, re-grant rebinding without duplicating the row, a grant on an unreadable directory refused rather than recorded path-only, a pre-binding row listed but **not** enforced (and reported `bound: false`) with one re-grant binding it, an unreadable directory not trusted, and a bound row **not** falling back to the bare path.

One existing test needed updating: `test_wecom_media.py::test_the_size_cap_is_enforced_while_reading` used `https://cdn/big`, which no longer clears the vet, so it now stubs the resolver. It still opens no socket and still tests only the read cap.

## Manual verification

N/A — the changed paths are pure decision logic (address vetting, key normalization, a filesystem-identity comparison) and are fully reachable from unit tests without a live channel. The two SSRF paths are additionally covered end to end through their clients' fake sessions, which assert the refusal happens *before* any request is issued.

Local gates: all affected suites pass, `flake8` clean, `scripts/check_black_formatting.py` passes (12 files in scope, nothing unformatted outside the baseline), and the one Semgrep finding from the first push is fixed — a test `chmod` narrowed from `0o755` to `0o700`, which exercises the same metadata change without being needlessly permissive.

## Related Issues

None — these came from CSE scan findings tracked internally.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected; the reasoning lives in the docstrings the changed code carries
- [x] No secrets, credentials, or internal references in the diff
