### PR TITLE
feat: cross-session send (split view button + send_to_session MCP tool)

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5477,6 +5477,7 @@
         "prevent_sleep": false,
         "quick_send": false,
         "session_grid": false,
+        "cross_session_send": false,
         "mcp_app_panel": false,
         "auto_open_git_panel": false,
         "terminal": {
@@ -5893,6 +5894,20 @@
       "tags": [],
       "label": "Session Grid (Split View)",
       "help": "Opt-in: enable terminal-style split view to run multiple chat sessions side by side.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "dashboard.cross_session_send",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Cross-Session Send",
+      "help": "Opt-in: send messages from one chat session to another (split view button and send_to_session tool).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": false

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2951,6 +2951,13 @@ class DashboardConfig:
             "Opt-in: enable terminal-style split view to run multiple chat sessions side by side.",
         ),
     )
+    cross_session_send: bool = field(
+        default=False,
+        metadata=_meta(
+            "Cross-Session Send",
+            "Opt-in: send messages from one chat session to another (split view button and send_to_session tool).",
+        ),
+    )
     mcp_app_panel: bool = field(
         default=False,
         metadata=_meta(
@@ -7389,6 +7396,7 @@ class KiroCrewConfig:
                 prevent_sleep=_safe_bool(dashboard_data.get("prevent_sleep"), False),
                 quick_send=dashboard_data.get("quick_send", False),
                 session_grid=dashboard_data.get("session_grid", False),
+                cross_session_send=dashboard_data.get("cross_session_send", False),
                 mcp_app_panel=dashboard_data.get("mcp_app_panel", False),
                 auto_open_git_panel=_safe_bool(dashboard_data.get("auto_open_git_panel"), False),
                 widget_density=dashboard_data.get("widget_density", "more"),

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -2911,7 +2911,7 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
                 session_key="dashboard", tool_name="dashboard_config_write", outcome="failure"
             )
             return web.json_response({"error": "request body must be a JSON object"}, status=400)
-        _allowed = {"restore_sessions", "restore_window_minutes", "merge_queued_messages", "widget_density", "use_builtin_browser", "verbosity", "quick_send", "session_grid", "tail_fork_enabled", "link_previews", "mcp_app_panel", "auto_open_git_panel", "folder_suggestions_enabled"}
+        _allowed = {"restore_sessions", "restore_window_minutes", "merge_queued_messages", "widget_density", "use_builtin_browser", "verbosity", "quick_send", "session_grid", "tail_fork_enabled", "link_previews", "mcp_app_panel", "auto_open_git_panel", "folder_suggestions_enabled", "cross_session_send"}
         # One-release backward-compat shim for removed key; delete after all clients update.
         deprecated_ignored_keys = {"tail_fork_head_handling"}
         # Read-only keys the GET exposes: both settings surfaces save with
@@ -3061,6 +3061,16 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
                     {"error": "session_grid must be a boolean"}, status=400
                 )
             updates["session_grid"] = val
+        if "cross_session_send" in body:
+            val = body["cross_session_send"]
+            if not isinstance(val, bool):
+                _sel().log_tool_invocation(
+                    session_key="dashboard", tool_name="dashboard_config_write", outcome="failure"
+                )
+                return web.json_response(
+                    {"error": "cross_session_send must be a boolean"}, status=400
+                )
+            updates["cross_session_send"] = val
         if "mcp_app_panel" in body:
             val = body["mcp_app_panel"]
             if not isinstance(val, bool):
@@ -3173,6 +3183,7 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
             "verbosity": cfg.dashboard.verbosity,
             "quick_send": cfg.dashboard.quick_send,
             "session_grid": cfg.dashboard.session_grid,
+            "cross_session_send": cfg.dashboard.cross_session_send,
             "mcp_app_panel": cfg.dashboard.mcp_app_panel,
             "auto_open_git_panel": cfg.dashboard.auto_open_git_panel,
             "tail_fork_enabled": cfg.dashboard.tail_fork_enabled,

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -306,6 +306,32 @@ def schemas() -> list[dict[str, Any]]:
                 "required": ["path"],
             },
         },
+        {
+            "name": "send_to_session",
+            "description": (
+                "Send a message into ANOTHER chat session (by slot key). The target "
+                "session receives it as input: if idle, it starts a new agent turn; "
+                "if busy, it is queued for the next turn. The message is prefixed "
+                "with cross-session provenance so the receiving agent knows its origin. "
+                "Requires the dashboard.cross_session_send feature flag (Settings > Chat). "
+                "Use to coordinate work between split-view sessions or hand off "
+                "context/results to a parallel session."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "slot": {
+                        "type": "string",
+                        "description": "Target session slot key (e.g. 'chat-3-1712793600').",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Message text to inject into the target session.",
+                    },
+                },
+                "required": ["slot", "message"],
+            },
+        },
     ]
 
 
@@ -732,10 +758,155 @@ def file_send(name: str, args: dict[str, Any]) -> str:
     return msg + slack_warning
 
 
+def send_to_session(name: str, args: dict[str, Any]) -> str:
+    """Send a message into another chat session (cross-session messaging)."""
+    from kiro_crew.config.loader import KiroCrewConfig
+    from kiro_crew.validation import SEND_TO_SESSION_SCHEMA, ValidationError, validate_tool_args
+
+    # Resolve the caller identity ONCE, fail-closed.
+    try:
+        origin = mcp_core._resolve_session_key_strict()
+    except Exception:
+        origin = ""
+
+    # Defense-in-depth: re-validate here so a direct/unvalidated call degrades
+    # to a clean error string, and audit the failure.
+    try:
+        args = validate_tool_args(args, SEND_TO_SESSION_SCHEMA)
+    except ValidationError as exc:
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="error",
+        )
+        return f"Error: {exc}"
+
+    # Cross-session messaging is opt-in: gated on the dashboard config flag.
+    try:
+        _flag = KiroCrewConfig.load().dashboard.cross_session_send
+    except Exception:
+        _flag = False
+    if not _flag:
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="denied",
+        )
+        return (
+            "Error: cross_session_send is disabled — enable it in "
+            "Settings > Chat > Cross-Session Send (dashboard.cross_session_send)."
+        )
+
+    target_slot = args.get("slot", "")
+    text = args.get("message", "")
+
+    # Deny-by-default: positively require the namespaced key format.
+    origin_slot = origin.split(":", 1)[1] if ":" in origin else ""
+    _validation_error = None
+    if not target_slot:
+        _validation_error = "Error: slot is required."
+    elif not text:
+        _validation_error = "Error: message is required."
+    elif not origin or ":" not in origin:
+        _validation_error = (
+            "Error: cannot resolve origin session — cross-session send "
+            "requires a known source."
+        )
+    elif not origin.startswith("dashboard:"):
+        _validation_error = (
+            "Error: cross-session send requires a dashboard origin session."
+        )
+    elif target_slot == origin_slot:
+        _validation_error = (
+            f"Error: cannot send to your own session ({target_slot})."
+        )
+    if _validation_error:
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="error",
+        )
+        return _validation_error
+
+    # Workspace isolation: reads refuse cross-workspace access, so this WRITE
+    # path must not cross the same boundary.
+    try:
+        cl = mcp_core.ConversationLog()
+        # Existence probe first: a missing session must not spawn a new one.
+        if not cl.has_log(f"dashboard:{target_slot}"):
+            mcp_core.sel().log_tool_invocation(
+                session_key=origin,
+                source="mcp",
+                tool_name="send_to_session",
+                outcome="error",
+            )
+            return f"Error: no session found for slot {target_slot}."
+        caller_ws = mcp_core._caller_workspace(cl, origin)
+        target_ws = mcp_core._ws_bucket(
+            cl.get_metadata(f"dashboard:{target_slot}").get("workspace")
+        )
+    except Exception:
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="error",
+        )
+        return "Error: unable to verify workspace isolation."
+
+    if target_ws != caller_ws:
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="denied",
+        )
+        return "Error: target session belongs to a different workspace."
+
+    # Redact credentials/exfiltration before injecting into another session.
+    text, _ = redact_exfiltration_urls(text)
+    text, _ = redact_credentials(text)
+    wrapped = f"[Cross-session message from {origin}]\n\n{text}"
+
+    # ws=1 → gateway returns JSON immediately.
+    resp = mcp_core._post("/api/chat?ws=1", {"message": wrapped, "slot": target_slot})
+    if resp.get("error"):
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="error",
+        )
+        return f"Failed to send to session {target_slot}: {resp['error']}"
+
+    if resp.get("queued") or resp.get("ok"):
+        mcp_core.sel().log_tool_invocation(
+            session_key=origin,
+            source="mcp",
+            tool_name="send_to_session",
+            outcome="success",
+        )
+        if resp.get("queued"):
+            return f"Message queued in busy session {target_slot} — it will be processed after the current turn."
+        return f"Message sent to session {target_slot} — a new agent turn started."
+
+    mcp_core.sel().log_tool_invocation(
+        session_key=origin,
+        source="mcp",
+        tool_name="send_to_session",
+        outcome="error",
+    )
+    return f"Failed: unexpected response {resp}"
+
+
 HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {
     "send_message": send_message,
     "send_notification": send_notification,
     "delete_message": delete_message,
     "read_slack_profile": read_slack_profile,
     "file_send": file_send,
+    "send_to_session": send_to_session,
 }

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2453,6 +2453,20 @@ REGISTER_HOOK_SCHEMA = ToolSchema(
     ],
 )
 
+SEND_TO_SESSION_SCHEMA = ToolSchema(
+    tool_name="send_to_session",
+    fields=[
+        # Anchored pattern: slot keys follow a fixed grammar (chat-<n>-<ts>).
+        # Rejects namespaced values (dashboard:chat-...) that would bypass the
+        # handler's self-target and workspace-isolation comparisons.
+        FieldSpec(
+            "slot", str, required=True, max_len=MAX_SHORT_STRING,
+            pattern=re.compile(r"^chat-\d+-\d+$", flags=re.ASCII),
+        ),
+        FieldSpec("message", str, required=True, max_len=MAX_MEDIUM_STRING),
+    ],
+)
+
 # select_crew: `crew` is optional — omitted/empty returns the roster. When
 # present it is NOT pattern-validated here: crew creation only strips the name
 # (agents.py), so names may contain spaces/dots; the deny-by-default gate is the
@@ -2597,6 +2611,7 @@ MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
     "read_slack_profile": READ_SLACK_PROFILE_SCHEMA,
     "wait": WAIT_SCHEMA,
     "register_hook": REGISTER_HOOK_SCHEMA,
+    "send_to_session": SEND_TO_SESSION_SCHEMA,
     "file_send": FILE_SEND_SCHEMA,
     "autonudge_stop": AUTONUDGE_STOP_SCHEMA,
     "monitor_start": MONITOR_START_SCHEMA,

--- a/test/test_send_to_session.py
+++ b/test/test_send_to_session.py
@@ -1,0 +1,306 @@
+"""Tests for the send_to_session MCP tool (cross-session messaging)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.mcp_tools import messaging
+
+ORIGIN = "dashboard:chat-1-1712790000"
+TARGET = "chat-2-1712793600"
+
+
+@pytest.fixture(autouse=True)
+def _resolvable_origin():
+    """Give every test a realistic namespaced origin session key.
+
+    The tool fails closed when the origin cannot be resolved. Tests that
+    exercise origin-specific behavior re-patch the resolver inside their
+    own `with` block, which takes precedence over this fixture.
+    """
+    with patch(
+        "kiro_crew.mcp_core._resolve_session_key_strict",
+        return_value=ORIGIN,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _same_workspace_store():
+    """Mock ConversationLog so the workspace-isolation gate is deterministic.
+
+    Without this, tests would construct a real ConversationLog and read the
+    ambient session store. Tests that exercise cross-workspace or
+    missing-session behavior re-patch ConversationLog inside their own
+    `with` block.
+    """
+    with patch("kiro_crew.mcp_core.ConversationLog") as mock_cl_cls:
+        mock_cl_cls.return_value.has_log.return_value = True
+        mock_cl_cls.return_value.get_metadata.return_value = {"workspace": "default"}
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_sel():
+    with patch("kiro_crew.mcp_core.sel") as m:
+        instance = MagicMock()
+        m.return_value = instance
+        yield instance
+
+
+def _cfg_with_flag(enabled: bool) -> MagicMock:
+    cfg = MagicMock()
+    cfg.dashboard.cross_session_send = enabled
+    return cfg
+
+
+def _call(args: dict) -> str:
+    return messaging.send_to_session("send_to_session", args)
+
+
+class TestSendToSessionFlagGate:
+    def test_disabled_flag_rejects_without_posting(self):
+        """When cross_session_send is off, the tool refuses and never hits the API."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(False)
+
+            result = _call({"slot": TARGET, "message": "hello"})
+
+            assert "disabled" in result.lower()
+            mock_post.assert_not_called()
+
+    def test_flag_gate_denial_is_audited(self, _mock_sel):
+        with patch("kiro_crew.mcp_core._post"), patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(False)
+
+            _call({"slot": TARGET, "message": "hello"})
+
+            _mock_sel.log_tool_invocation.assert_called_once_with(
+                session_key=ORIGIN,
+                source="mcp",
+                tool_name="send_to_session",
+                outcome="denied",
+            )
+
+    def test_enabled_flag_posts_to_chat_api(self):
+        """When enabled, the tool posts to /api/chat?ws=1 with the target slot."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"ok": True, "slot": TARGET}
+
+            result = _call({"slot": TARGET, "message": "hello"})
+
+            assert "sent" in result.lower()
+            mock_post.assert_called_once()
+            path, payload = mock_post.call_args[0][0], mock_post.call_args[0][1]
+            assert path == "/api/chat?ws=1"
+            assert payload["slot"] == TARGET
+
+    def test_message_carries_cross_session_provenance(self):
+        """The injected message is prefixed with the origin session key."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"ok": True, "slot": TARGET}
+
+            _call({"slot": TARGET, "message": "hello"})
+
+            payload = mock_post.call_args[0][1]
+            assert payload["message"].startswith(f"[Cross-session message from {ORIGIN}]")
+            assert "hello" in payload["message"]
+
+    def test_message_credentials_are_redacted(self):
+        """LLM-generated text is scanned before landing in another session."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"ok": True, "slot": TARGET}
+
+            _call(
+                {
+                    "slot": TARGET,
+                    "message": "key is AKIAIOSFODNN7EXAMPLE ok",
+                }
+            )
+
+            payload = mock_post.call_args[0][1]
+            assert "AKIAIOSFODNN7EXAMPLE" not in payload["message"]
+            assert "ok" in payload["message"]
+
+
+class TestSendToSessionValidation:
+    def test_self_target_is_rejected(self):
+        """Sending to the origin session would create a feedback loop."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+
+            result = _call({"slot": "chat-1-1712790000", "message": "hi"})
+
+            assert "own session" in result.lower()
+            mock_post.assert_not_called()
+
+    def test_unresolvable_origin_rejected(self):
+        """Fail closed: an origin without a namespace cannot bypass the guards."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls, patch(
+            "kiro_crew.mcp_core._resolve_session_key_strict",
+            return_value="",
+        ):
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "error" in result.lower()
+            mock_post.assert_not_called()
+
+    def test_non_dashboard_origin_rejected(self):
+        """cron:/hook: origins would bypass the dashboard self-target guard."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls, patch(
+            "kiro_crew.mcp_core._resolve_session_key_strict",
+            return_value="cron:job-123",
+        ):
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "dashboard origin" in result.lower()
+            mock_post.assert_not_called()
+
+    def test_invalid_slot_shape_rejected(self):
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+
+            result = _call({"slot": "../../etc/passwd", "message": "hi"})
+
+            assert "error" in result.lower()
+            mock_post.assert_not_called()
+
+
+class TestSendToSessionWorkspaceIsolation:
+    def test_nonexistent_target_rejected_before_workspace_check(self):
+        """A missing session has empty metadata that buckets to 'default' and
+        would pass the workspace comparison open — and /api/chat would then
+        silently CREATE a session for the typo'd slot. The existence probe
+        must run first."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls, patch(
+            "kiro_crew.mcp_core.ConversationLog"
+        ) as mock_cl_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_cl_cls.return_value.has_log.return_value = False
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "no session found" in result.lower()
+            mock_post.assert_not_called()
+
+    def test_cross_workspace_target_rejected(self):
+        """Writes must not cross the workspace boundary the read paths guard."""
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls, patch(
+            "kiro_crew.mcp_core.ConversationLog"
+        ) as mock_cl_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_cl_cls.return_value.has_log.return_value = True
+
+            def _meta(key: str) -> dict:
+                if key == ORIGIN:
+                    return {"workspace": "default"}
+                return {"workspace": "other-workspace"}
+
+            mock_cl_cls.return_value.get_metadata.side_effect = _meta
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "different workspace" in result.lower()
+            mock_post.assert_not_called()
+
+
+class TestSendToSessionOutcomes:
+    def test_queued_response_reported(self):
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"queued": True, "slot": TARGET}
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "queued" in result.lower()
+
+    def test_api_error_reported(self):
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"error": "boom"}
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "boom" in result or "failed" in result.lower()
+
+    def test_success_is_audited(self, _mock_sel):
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"ok": True, "slot": TARGET}
+
+            _call({"slot": TARGET, "message": "hi"})
+
+            _mock_sel.log_tool_invocation.assert_called_once_with(
+                session_key=ORIGIN,
+                source="mcp",
+                tool_name="send_to_session",
+                outcome="success",
+            )
+
+    def test_unexpected_response_audited_as_error(self, _mock_sel):
+        with patch("kiro_crew.mcp_core._post") as mock_post, patch(
+            "kiro_crew.config.loader.KiroCrewConfig"
+        ) as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = _cfg_with_flag(True)
+            mock_post.return_value = {"weird": True}
+
+            result = _call({"slot": TARGET, "message": "hi"})
+
+            assert "failed" in result.lower()
+            _mock_sel.log_tool_invocation.assert_called_once_with(
+                session_key=ORIGIN,
+                source="mcp",
+                tool_name="send_to_session",
+                outcome="error",
+            )
+
+
+class TestToolRegistration:
+    def test_tool_is_advertised_and_dispatchable(self):
+        names = [t["name"] for t in messaging.schemas()]
+        assert "send_to_session" in names
+        assert messaging.HANDLERS["send_to_session"] is messaging.send_to_session
+
+
+class TestConfigFlag:
+    def test_dashboard_flag_defaults_false(self):
+        from kiro_crew.config.loader import DashboardConfig
+
+        assert DashboardConfig().cross_session_send is False

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
-import { X } from 'lucide-react'
+import { X, SendHorizontal } from 'lucide-react'
 import { SplitGlyph } from './SplitGlyph'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { useModelsDegraded } from '../providers/modelListHealth'
@@ -59,6 +59,7 @@ export default function ChatPane({
   onSplitRight,
   onSplitDown,
   onOpenFull,
+  sendTargets,
 }: {
   slotKey: string
   focused?: boolean
@@ -70,6 +71,9 @@ export default function ChatPane({
    *  the earlier-messages row is hidden rather than shown inert. The optional ts
    *  anchors the destination near the pane's oldest message, not the newest. */
   onOpenFull?: (slot: string, anchorTs?: string, anchorMid?: string) => void
+  /** Other grid sessions this pane can send its composed text to (cross_session_send flag).
+   *  Absent/empty → the "Send to" control is not rendered. */
+  sendTargets?: { key: string; title?: string }[]
 }) {
   // One instance covers both dropdown filter inputs (never open at once).
   const dispatch = useAppDispatch()
@@ -430,6 +434,65 @@ export default function ChatPane({
   }, [input, pendingFiles, busy, slotKey, dispatch, restoreIntoComposer])
 
   const onStop = useCallback(() => { dispatch(requestStop({ slotId: slotKey, force: false })) }, [dispatch, slotKey])
+
+  // ── Cross-session send (cross_session_send flag) ──
+  const [sendToOpen, setSendToOpen] = useState(false)
+  const [sendToBtnRect, setSendToBtnRect] = useState<DOMRect | null>(null)
+  const sendToWrapRef = useRef<HTMLDivElement>(null)
+  const sendToBtnRef = useRef<HTMLButtonElement>(null)
+  const sendToMenuRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!sendToOpen) return
+    const handler = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (sendToWrapRef.current?.contains(t) || sendToMenuRef.current?.contains(t)) return
+      setSendToOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [sendToOpen])
+  const [sendToError, setSendToError] = useState('')
+  const doSendToSession = useCallback(async (targetSlot: string) => {
+    const text = input.trim()
+    setSendToOpen(false)
+    setSendToError('')
+    if (!text) {
+      sendToBtnRef.current?.focus()
+      return
+    }
+    if (pendingFiles.length) {
+      setSendToError('Not sent \u2014 attachments not supported')
+      sendToBtnRef.current?.focus()
+      return
+    }
+    const wrapped = `[Cross-session message from ${slotKey}]\n\n${text}`
+    try {
+      const res = await api.sendChat(wrapped, targetSlot)
+      if (!res.ok) throw new Error(`send failed: ${res.status}`)
+      setInput('')
+    } catch {
+      setSendToError('Send failed \u2014 input preserved')
+    } finally {
+      sendToBtnRef.current?.focus()
+    }
+  }, [input, pendingFiles, slotKey])
+  const sendToKeyboardRef = useRef<HTMLElement | null>(null)
+  const { onListKeyDown: onSendToKeyDown } = useListboxKeyboard({
+    open: sendToOpen,
+    dropdownRef: sendToMenuRef,
+    inputRef: sendToKeyboardRef,
+    hasFilterInput: false,
+    filteredCount: sendTargets?.length ?? 0,
+    onEnterSingleMatch: () => {
+      const t = sendTargets?.[0]
+      if (t) void doSendToSession(t.key)
+    },
+    closeToTrigger: () => {
+      setSendToOpen(false)
+      sendToBtnRef.current?.focus()
+    },
+  })
+
   const onCancelQueued = useCallback((queueId: string) => {
     dispatch(cancelQueuedMessage({ slot: slotKey, queue_id: queueId }))
     api.cancelQueuedMessage(slotKey, queueId).catch(() => undefined)
@@ -526,6 +589,61 @@ export default function ChatPane({
           )}
           <span className="flex-1" />
           {running && <span className="shrink-0 text-[10px] text-ok font-mono">{streamState}</span>}
+          {(sendTargets?.length ?? 0) > 0 && (
+            <div ref={sendToWrapRef} className="relative shrink-0">
+              {sendToError && (
+                <span role="alert" className="text-[10px] text-danger mr-1">{sendToError}</span>
+              )}
+              <button
+                ref={sendToBtnRef}
+                onClick={() => setSendToOpen((v) => {
+                  const next = !v
+                  if (next) {
+                    setSendToError('')
+                    setSendToBtnRect(sendToBtnRef.current?.getBoundingClientRect() ?? null)
+                  }
+                  return next
+                })}
+                title="Send composed message to another session"
+                aria-label="Send to session"
+                aria-expanded={sendToOpen}
+                aria-haspopup="listbox"
+                className="shrink-0 p-1 rounded text-muted hover:text-text hover:bg-bg-hover cursor-pointer bg-transparent border-none transition-colors"
+              >
+                <SendHorizontal size={15} />
+              </button>
+              {sendToOpen && sendToBtnRect && createPortal(
+                <div
+                  ref={sendToMenuRef}
+                  tabIndex={-1}
+                  onKeyDown={onSendToKeyDown}
+                  role="listbox"
+                  aria-label="Send input to session"
+                  className="fixed z-[9999] min-w-[180px] max-w-[280px] bg-bg-elevated border border-border rounded-md shadow-lg py-1"
+                  style={(() => {
+                    const left = Math.max(8, Math.min(sendToBtnRect.right - 180, window.innerWidth - 288))
+                    return { top: sendToBtnRect.bottom + 4, left }
+                  })()}
+                >
+                  <div className="px-2 py-1 text-[10px] text-muted uppercase">Send input to…</div>
+                  {sendTargets!.map((t) => (
+                    <button
+                      key={t.key}
+                      role="option"
+                      aria-selected={false}
+                      tabIndex={-1}
+                      onClick={() => doSendToSession(t.key)}
+                      className="w-full text-left px-2 py-1.5 text-[12px] text-text hover:bg-bg-hover cursor-pointer bg-transparent border-none truncate"
+                      title={t.key}
+                    >
+                      {t.title || t.key}
+                    </button>
+                  ))}
+                </div>,
+                document.body,
+              )}
+            </div>
+          )}
           {onSplitRight && (
             <button onClick={onSplitRight} title={i18nT('components.chatPane.split_right_d')} aria-label={i18nT('components.chatPane.split_right')} className="shrink-0 p-1 rounded text-muted hover:text-text hover:bg-bg-hover cursor-pointer bg-transparent border-none transition-colors">
               <SplitGlyph />

--- a/website/src/components/SessionGridView.tsx
+++ b/website/src/components/SessionGridView.tsx
@@ -94,6 +94,15 @@ export default function SessionGridView({
     refetchInterval: 3000,
   })
 
+  // Cross-session send is opt-in (Settings > Chat > Cross-Session Send). When
+  // enabled, each pane gets the OTHER visible sessions as send targets.
+  const { data: dashCfg } = useQuery<{ cross_session_send?: boolean }>({
+    queryKey: ['dashboardConfig'],
+    queryFn: () => api.dashboardConfig(),
+    staleTime: 30_000,
+  })
+  const crossSendEnabled = dashCfg?.cross_session_send === true
+
   // Once the slot list loads, heal a restored layout: drop panes whose session was
   // deleted/archived while away. Runs once (the first non-empty slots payload).
   const prunedRef = useRef(false)
@@ -125,6 +134,12 @@ export default function SessionGridView({
 
   const renderLeaf = (leaf: GridLeaf) => {
     if (leaf.kind === 'session' && leaf.slot) {
+      // Other visible sessions this pane can send to (flag-gated).
+      const sendTargets = crossSendEnabled
+        ? grid.occupiedSlots
+            .filter((s) => s !== leaf.slot)
+            .map((s) => ({ key: s, title: slots.find((x) => x.key === s)?.title }))
+        : undefined
       return (
         <ChatPane
           slotKey={leaf.slot}
@@ -134,6 +149,7 @@ export default function SessionGridView({
           onSplitRight={() => grid.splitLeaf(leaf.id, 'right')}
           onSplitDown={() => grid.splitLeaf(leaf.id, 'down')}
           onOpenFull={onCollapse}
+          sendTargets={sendTargets}
         />
       )
     }

--- a/website/src/components/commandPalette/settingsRegistry.gen.ts
+++ b/website/src/components/commandPalette/settingsRegistry.gen.ts
@@ -504,6 +504,14 @@ export const SETTINGS_REGISTRY: SettingEntry[] =
     "occurrence": 1
   },
   {
+    "id": "chat.cross-session-send",
+    "label": "Cross-Session Send",
+    "description": "Opt-in: send messages from one session to another (split view button and send_to_session agent tool). Experimental.",
+    "tab": "chat",
+    "type": "toggle",
+    "occurrence": 1
+  },
+  {
     "id": "chat.default-model",
     "label": "Default Model",
     "labelKey": "pages.settings.chatPanel.default_model",

--- a/website/src/pages/chat/ChatSettings.tsx
+++ b/website/src/pages/chat/ChatSettings.tsx
@@ -112,6 +112,7 @@ export interface DashboardConfig {
   quick_send: boolean
   session_grid: boolean
   tail_fork_enabled: boolean
+  cross_session_send: boolean
   link_previews: boolean
   mcp_app_panel: boolean
   auto_open_git_panel: boolean

--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -105,7 +105,7 @@ export function ChatPanel() {
     queryKey: ['dashboardConfig'],
     queryFn: () => api.dashboardConfig(),
   })
-  const dashCfg = dashQ.data ?? { restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' as const, verbosity: 'default' as const, quick_send: false, session_grid: false, tail_fork_enabled: false, link_previews: false, mcp_app_panel: false, auto_open_git_panel: false, folder_suggestions_enabled: true, use_builtin_browser: true }
+  const dashCfg = dashQ.data ?? { restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' as const, verbosity: 'default' as const, quick_send: false, session_grid: false, tail_fork_enabled: false, cross_session_send: false, link_previews: false, mcp_app_panel: false, auto_open_git_panel: false, folder_suggestions_enabled: true, use_builtin_browser: true }
 
   // ── Feature Tips opt-out (server-side per-user state) ──
   const tipsQ = useQuery<{ enabled_config: boolean; opted_out: boolean }>({
@@ -573,6 +573,7 @@ export function ChatPanel() {
       <SettingsSection title={i18nT('pages.settings.chatPanel.sessions')}>
         <SettingsCard index={7}>
           <SettingsToggle label={i18nT('pages.settings.chatPanel.split_view_session_grid')} description={i18nT('pages.settings.chatPanel.opt_in_split_the_chat_into_resizable_session_pan', { mod: isMac ? '⌘' : 'Ctrl' })} checked={dashCfg.session_grid} onChange={v => setDash({ session_grid: v })} disabled={dashDisabled} />
+          <SettingsToggle label="Cross-Session Send" description="Opt-in: send messages from one session to another (split view button and send_to_session agent tool). Experimental." checked={dashCfg.cross_session_send} onChange={v => setDash({ cross_session_send: v })} disabled={dashDisabled} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.history_expanded')} description={i18nT('pages.settings.chatPanel.expand_history_sidebar_by_default')} checked={chatCfg.historyExpanded} onChange={v => setChat('historyExpanded', v)} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.confirm_before_closing_session')} description={i18nT('pages.settings.chatPanel.show_a_confirmation_dialog_when_closing_a_sessio')} checked={chatCfg.confirmCloseSession} onChange={v => setChat('confirmCloseSession', v)} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.default_to_autopilot_mode')} description={i18nT('pages.settings.chatPanel.new_sessions_start_in_autopilot_mode_plan_approv')} checked={chatCfg.defaultAutopilot} onChange={v => setChat('defaultAutopilot', v)} />


### PR DESCRIPTION
## Problem / Motivation

Sessions are fully isolated — there is no way for a user in split view (session grid) to route a composed message to another visible session, nor for an agent to hand context to a sibling session. Coordinating parallel sessions today requires copy-paste between panes.

## Why it matters

Split view (`dashboard.session_grid`) makes running parallel sessions a first-class workflow, but without a message path between panes the grid is view-only coordination. Cross-session send closes that loop: draft in one pane, dispatch to another; or let an agent delegate follow-up work to a sibling session — with explicit user opt-in.

## What changed (motivation → approach → change)

Goal: a message path between sessions that (a) cannot be used by an agent without the user's explicit opt-in, and (b) cannot become a feedback loop or a cross-workspace leak.

Approach: no new endpoint — `/api/chat` already routes by slot and queues when the target is busy, so the tool POSTs there. A single feature flag (`dashboard.cross_session_send`, default `false`) gates both surfaces: the UI button does not render without it, and the MCP tool rejects server-side, so an agent cannot move messages between sessions unless the user enabled it in Settings > Chat.

Backend (`src/kiro_crew/`):
- New MCP tool `send_to_session(slot, message)` in `mcp_tools/messaging.py` (descriptor + handler, registered in `HANDLERS` and `MCP_CORE_SCHEMAS`).
- Messages carry a `[Cross-session message from <origin>]` provenance prefix.
- Security hardening, each guard fixing a concrete hole found during review:
  - LLM output is scanned (`redact_exfiltration_urls` + `redact_credentials`) before injection into another session.
  - Deny-by-default origin resolution (strict resolver, fail-closed), restricted to `dashboard:` origins so cron/hook callers cannot bypass the self-target guard.
  - Namespace-aware self-target guard (feedback-loop prevention).
  - Anchored slot-key schema pattern (`^chat-\d+-\d+$`) rejecting namespaced or path-like values.
  - Target-session existence probe (`has_log`) **before** the workspace comparison — a missing session has empty metadata that buckets to the default workspace and would otherwise pass the check open, and `/api/chat` would then silently create a session for the typo'd slot.
  - Workspace isolation mirroring the chat-history read paths (`_caller_workspace` / `_ws_bucket`).
  - SEL audit events on denied/error/success paths with consistent strict-resolver identity.
- `dashboard.cross_session_send` flag: dataclass field, loader parse, PUT validation + GET exposure in the dashboard config handler, `config-baseline.json` regenerated.

Frontend (`website/src/`):
- Send-to-session button (lucide `SendHorizontal`) in split view pane headers with a keyboard-operable listbox dropdown (`useListboxKeyboard`: focus-on-open, arrow nav, Escape-to-trigger, ARIA roles, roving tabindex, outside-click dismissal), portaled to `document.body` so it is not clipped by pane overflow.
- The composer clears only after a confirmed 2xx; failures preserve the user's text and show a per-cause inline indicator (send failure vs. unsupported attachments). Focus returns to the trigger.
- `SessionGridView` passes the other visible grid sessions as send targets, flag-gated.
- Settings > Chat toggle; `settingsRegistry.gen.ts` regenerated via `scripts/gen-settings-registry.mjs`.

Known limitation (documented in code): `_caller_workspace` falls back to the default bucket for sessions whose metadata has not been written yet — same limitation as the existing chat-history read paths.

## Tests

17 new tests in `test/test_send_to_session.py`:
- Flag gate: disabled flag refuses without hitting the API, denial is SEL-audited; enabled flag posts to `/api/chat?ws=1` with the target slot.
- Provenance prefix and credential redaction of the injected message.
- Validation chain: self-target rejected, unresolvable origin rejected (fail-closed), non-dashboard origin rejected, malformed slot rejected.
- Workspace isolation: nonexistent target rejected before the workspace check (never spawns a session), cross-workspace target rejected.
- Outcomes: queued/error/success/unexpected responses each reported and audited with the right SEL outcome.
- Registration: tool advertised in `schemas()` and dispatchable via `HANDLERS`; config flag defaults to `false`.

Regression: `test_config_loader.py` + `test_mcp_tool_registry.py` (474 passed, 5 skipped).

## Manual verification

Validated end-to-end in the internal (pre-fork) codebase this is ported from, in an isolated gateway with both flags enabled: UI button send between grid panes and agent-initiated `send_to_session` both worked, including the busy-target queueing path. Website `tsc -b` and `vite build` clean on this branch.

## Screenshots / video

N/A — happy to add a short clip if reviewers want one; the UI surface is a small header button + dropdown in split view.
