### PR TITLE
fix: recognize the Windows kiro-cli sqlite store for credit usage (#5783)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -140,18 +140,26 @@ _JSON_TOKEN_READ_IDS = (
 # running OS is inert, and a platform-independent module constant is what lets
 # tests patch the tuple without becoming host-dependent.
 #
-# The Windows entry is the fixed default Roaming location, NOT resolved from
-# ``%APPDATA%``. Membership here is a trust claim (``from_cli_store=True``)
-# that rests on agent file tools being unable to write the store, and that
-# fence (``_SENSITIVE_HOME_DIRS``) is home-anchored at exactly this path — so
-# an APPDATA-resolved location either equals this entry or falls outside the
-# fence and must not be trusted. A redirected Roaming profile therefore keeps
-# the text-scrape fallback rather than gaining a forgeable trusted path; the
-# same posture as the Linux entry, which does not follow ``XDG_DATA_HOME``
-# redirection either.
+# The Windows entries are the fixed default locations, NOT resolved from
+# ``%LOCALAPPDATA%`` / ``%APPDATA%``. Membership here is a trust claim
+# (``from_cli_store=True``) that rests on agent file tools being unable to
+# write the store, and that fence (``_SENSITIVE_HOME_DIRS``) is home-anchored
+# at exactly these paths -- so an env-resolved location either equals an entry
+# or falls outside the fence and must not be trusted. A redirected profile
+# therefore keeps the text-scrape fallback rather than gaining a forgeable
+# trusted path; the same posture as the Linux entry, which does not follow
+# ``XDG_DATA_HOME`` redirection either.
+#
+# ``AppData/Local`` is where current kiro-cli actually writes on Windows (its
+# data dir resolves to the local, non-roaming app-data directory -- the same
+# resolver family that yields ``~/.local/share`` on Linux and
+# ``~/Library/Application Support`` on macOS, both matching the entries
+# above). ``AppData/Roaming`` is retained for layouts that used the roaming
+# location; a path that does not exist on the running host is inert.
 _CLI_SQLITE_DBS = (
     Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3",
     Path.home() / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
+    Path.home() / "AppData" / "Local" / "kiro-cli" / "data.sqlite3",
     Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
 )
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4798,10 +4798,15 @@ _SENSITIVE_HOME_DIRS: list[str] = [
     ".local/share/amazon-q",
     "Library/Application Support/kiro-cli",
     "Library/Application Support/amazon-q",
-    # Windows layout of the same stores (%APPDATA% defaults to
-    # ~/AppData/Roaming). This matcher is home-anchored, so a Roaming profile
-    # redirected outside the home directory is not covered — the default
-    # location is what agent file tools can reach by a fixed relative path.
+    # Windows layouts of the same stores. Current kiro-cli writes the local,
+    # non-roaming app-data directory (%LOCALAPPDATA% defaults to
+    # ~/AppData/Local); the Roaming entries cover layouts that used
+    # %APPDATA% (defaults to ~/AppData/Roaming). These matchers are
+    # home-anchored, so a profile redirected outside the home directory is not
+    # covered -- the default location is what agent file tools can reach by a
+    # fixed relative path.
+    "AppData/Local/kiro-cli",
+    "AppData/Local/amazon-q",
     "AppData/Roaming/kiro-cli",
     "AppData/Roaming/amazon-q",
 ]
@@ -5528,6 +5533,9 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # by their remainder.
     appdata_var = (
         r"(?:%APPDATA(?::[^%\s]*)?%"
+        # cmd.exe delayed expansion (`cmd /V:ON`): `!APPDATA!` names the same
+        # location as `%APPDATA%`, with the same expansion modifiers.
+        r"|!APPDATA(?::[^!\s]*)?!"
         rf"|{re.escape('$env:APPDATA')}"
         rf"|{re.escape('${env:APPDATA}')})"
     )
@@ -5541,6 +5549,32 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     appdata_sensitive_path = (
         rf"{appdata_var}(?:{win_sep}\.\.{win_sep}Roaming)*"
         rf"{win_gsep}(?:{appdata_remainders})(?:{win_sep}|\s|$|['\"])"
+    )
+    # ``%LOCALAPPDATA%`` is the same shape one directory over: it points INTO
+    # ``AppData\Local``, so ``%LOCALAPPDATA%\kiro-cli\data.sqlite3`` names a
+    # fenced store without the ``AppData\Local`` text the home-anchored branch
+    # requires. Without this branch the shell tier would not cover the very
+    # spelling that names the CURRENT kiro-cli store on Windows, while the
+    # tuple in ``kiro_usage_api._CLI_SQLITE_DBS`` treats that store as a trust
+    # anchor — the fence the trust claim rests on must hold at this tier too.
+    localappdata_var = (
+        r"(?:%LOCALAPPDATA(?::[^%\s]*)?%"
+        # cmd.exe delayed expansion (`cmd /V:ON`): `!LOCALAPPDATA!` names the
+        # same location as `%LOCALAPPDATA%`, with the same expansion modifiers.
+        r"|!LOCALAPPDATA(?::[^!\s]*)?!"
+        rf"|{re.escape('$env:LOCALAPPDATA')}"
+        rf"|{re.escape('${env:LOCALAPPDATA}')})"
+    )
+    localappdata_remainders = "|".join(
+        win_gsep.join(re.escape(part) for part in d.split("/")[2:])
+        for d in _SENSITIVE_HOME_DIRS
+        if d.startswith("AppData/Local/")
+    )
+    # ``%LOCALAPPDATA%`` ends in ``Local`` by definition, so ``\..\Local``
+    # right after it is this anchor's canonical no-op.
+    localappdata_sensitive_path = (
+        rf"{localappdata_var}(?:{win_sep}\.\.{win_sep}Local)*"
+        rf"{win_gsep}(?:{localappdata_remainders})(?:{win_sep}|\s|$|['\"])"
     )
     # Windows-native spelling of the write-protected leaves. The POSIX leaf
     # branch above anchors on ``/`` separators, so on Windows the resolved home
@@ -5649,13 +5683,15 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|(?:^|.*[\s'\"=:,;]){write_protected_path}"
         # (4) Windows-native spelling, verb-independent (same token anchor):
         # covers quoted backslash paths AND embedded-script literals that the
-        # tokenizing passes cannot see. (5) the %APPDATA% alias of the fenced
-        # Roaming stores. (6) the write-protected leaves in that same native
-        # spelling, which branch (3) cannot see. (7) the distinctive leaves as a
-        # bare path SEGMENT, with no anchor at all, because branches (3) and (6)
-        # both fall to a ``cd`` plus a relative name.
+        # tokenizing passes cannot see. (5) the %APPDATA% / %LOCALAPPDATA%
+        # aliases of the fenced Roaming/Local stores. (6) the write-protected
+        # leaves in that same native spelling, which branch (3) cannot see.
+        # (7) the distinctive leaves as a bare path SEGMENT, with no anchor at
+        # all, because branches (3) and (6) both fall to a ``cd`` plus a
+        # relative name.
         rf"|(?:^|.*[\s'\"=:,;]){win_sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){appdata_sensitive_path}"
+        rf"|(?:^|.*[\s'\"=:,;]){localappdata_sensitive_path}"
         rf"|(?:^|.*[\s'\"=:,;]){win_write_protected_path}"
         # (8) ~/.kiro/agents (POSIX and Windows-native spelling, plus the
         # ``$KIRO_HOME`` override), matched verb-INDEPENDENTLY with the same token

--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -411,13 +411,15 @@ class TestLoadBearerToken:
 
 
 class TestWindowsCliStore:
-    """kiro-cli on Windows keeps the same auth store under ``%APPDATA%\\kiro-cli``
-    (``~/AppData/Roaming/kiro-cli`` by default).
+    """kiro-cli on Windows keeps the same auth store under
+    ``%LOCALAPPDATA%\\kiro-cli`` (``~/AppData/Local/kiro-cli`` by default);
+    older layouts used ``%APPDATA%\\kiro-cli`` (``~/AppData/Roaming/kiro-cli``).
 
-    Absent from ``_CLI_SQLITE_DBS``, a Windows host's only candidate was the
-    JSON SSO cache (``from_cli_store=False``), which can never satisfy the
-    provenance path -- so whenever the ARN anchor also failed, every candidate
-    was rejected and the credit pill silently disappeared.
+    With only the Roaming location in ``_CLI_SQLITE_DBS``, a current Windows
+    host's store was never discovered: no candidate carried
+    ``from_cli_store=True``, the source-anchored provenance path could never be
+    satisfied, and whenever the ARN anchor also failed the usage API returned
+    unavailable and the credit pill silently disappeared.
     """
 
     @pytest.fixture(autouse=True)
@@ -428,13 +430,17 @@ class TestWindowsCliStore:
         api._PROFILE_ARN_CACHE.clear()
         api._PROFILE_NAME_CACHE.clear()
 
-    def test_windows_store_is_a_default_candidate(self):
-        # The FIXED default Roaming location, not %APPDATA%-resolved: the
-        # sensitive-path fence that makes membership a trust claim is
-        # home-anchored at exactly this path, so an APPDATA-resolved location
-        # either equals it or falls outside the fence and must not be trusted.
-        expected = Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
-        assert expected in api._CLI_SQLITE_DBS
+    def test_windows_stores_are_default_candidates(self):
+        # The FIXED default locations, not %LOCALAPPDATA%/%APPDATA%-resolved:
+        # the sensitive-path fence that makes membership a trust claim is
+        # home-anchored at exactly these paths, so an env-resolved location
+        # either equals an entry or falls outside the fence and must not be
+        # trusted. Local is where current kiro-cli writes; Roaming stays for
+        # older layouts.
+        local = Path.home() / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        assert local in api._CLI_SQLITE_DBS
+        assert roaming in api._CLI_SQLITE_DBS
 
     def test_windows_store_token_is_trusted_without_arn(self, tmp_path):
         # End-to-end: a token read out of a Windows-layout store carries
@@ -473,6 +479,45 @@ class TestWindowsCliStore:
             out = api.fetch_usage_limits(expected_arn=None)
         assert out is not None
         assert out["credits_used"] == 7.0
+
+    def test_local_appdata_store_token_is_trusted_without_arn(self, tmp_path):
+        # Same end-to-end path for the CURRENT Windows layout
+        # (%LOCALAPPDATA%\kiro-cli): a token read out of a Local-layout store
+        # carries from_cli_store=True, so the provenance path accepts it when
+        # whoami reports no profile ARN -- the exact case #5783 reports, where
+        # the store exists only under AppData/Local and the pill vanished.
+        db = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        db.parent.mkdir(parents=True)
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        con.execute(
+            "INSERT INTO auth_kv VALUES (?, ?)",
+            ("kirocli:odic:token",
+             json.dumps({"access_token": "local-tok", "expires_at": future})),
+        )
+        con.commit()
+        con.close()
+
+        usage_body = {"usageBreakdownList": [
+            {"resourceType": "CREDIT", "currentUsage": 3.0, "usageLimit": 100.0}]}
+
+        def fake_post(token, target, payload):
+            if target == api._TARGET_LIST_PROFILES:
+                return _resp(200, {"profiles": []})
+            return _resp(200, usage_body)
+
+        with patch("kiro_crew.hooks.safe_read_file_internal", return_value=None), \
+             patch("kiro_crew.hooks.emit_internal_read_audit", return_value=True), \
+             patch.object(api, "_CLI_SQLITE_DBS", (db,)), \
+             patch.object(api, "_OTHER_SQLITE_DBS", ()), \
+             patch.object(api, "_post", side_effect=fake_post):
+            cands = api._candidate_tokens()
+            assert [c.token for c in cands] == ["local-tok"]
+            assert cands[0].from_cli_store is True
+            out = api.fetch_usage_limits(expected_arn=None)
+        assert out is not None
+        assert out["credits_used"] == 3.0
 
 
 class TestPostSecurityControls:
@@ -1092,7 +1137,8 @@ class TestTokenStoreSensitivePath:
 
         from kiro_crew.security import is_sensitive_path
         home = Path.home()
-        for base in (".local/share", "Library/Application Support", "AppData/Roaming"):
+        for base in (".local/share", "Library/Application Support",
+                     "AppData/Local", "AppData/Roaming"):
             for app in ("kiro-cli", "amazon-q"):
                 # The DB and its WAL/SHM/journal sidecars must all be sensitive.
                 assert is_sensitive_path(str(home / base / app / "data.sqlite3"))

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -5580,11 +5580,56 @@ class TestWindowsPathShapes:
             'cmd /c copy "%APPDATA:~0%\\kiro-cli\\data.sqlite3" .\\loot.db',
             # Braced PowerShell spelling.
             'del "${env:APPDATA}\\kiro-cli\\data.sqlite3"',
+            # cmd.exe delayed expansion names the same location.
+            'cmd /V:ON /c copy /Y evil.sqlite "!APPDATA!\\kiro-cli\\data.sqlite3"',
         ]
         for cmd in cmds:
             assert is_sensitive_bash_command(cmd) is not None, cmd
         # Other %APPDATA% content stays allowed.
         assert is_sensitive_bash_command('type "%APPDATA%\\SomeApp\\config.json"') is None
+
+    def test_localappdata_alias_of_fenced_store_is_blocked(self) -> None:
+        # %LOCALAPPDATA% points INTO AppData\Local -- where CURRENT kiro-cli
+        # keeps its store, now a trust anchor in kiro_usage_api._CLI_SQLITE_DBS
+        # -- so this spelling names the fenced store without the AppData\Local
+        # text the home-anchored branch matches on. Without its own alias
+        # branch, a shell command could WRITE the very file whose
+        # unwritability the from_cli_store trust claim rests on.
+        cmds = [
+            'del "%LOCALAPPDATA%\\kiro-cli\\data.sqlite3"',
+            "type '%LOCALAPPDATA%\\amazon-q\\data.sqlite3'",
+            "cat '%LOCALAPPDATA%/kiro-cli/data.sqlite3'",
+            'del "$env:LOCALAPPDATA\\kiro-cli\\data.sqlite3"',
+            # A write verb: the exact forgery the trust claim must exclude.
+            'cmd /c copy /Y evil.sqlite "%LOCALAPPDATA%\\kiro-cli\\data.sqlite3"',
+            # Single-dot segments are canonical-equivalent to their absence.
+            'cmd /c copy /Y evil.sqlite "%LOCALAPPDATA%\\.\\kiro-cli\\data.sqlite3"',
+            # cmd.exe expansion modifiers resolve to the same location.
+            'cmd /c copy "%LOCALAPPDATA:~0%\\kiro-cli\\data.sqlite3" .\\loot.db',
+            # Braced PowerShell spelling.
+            'del "${env:LOCALAPPDATA}\\kiro-cli\\data.sqlite3"',
+            # cmd.exe delayed expansion names the same location, with the
+            # same expansion modifiers.
+            'cmd /V:ON /c copy /Y evil.sqlite "!LOCALAPPDATA!\\kiro-cli\\data.sqlite3"',
+            'cmd /V:ON /c type "!LOCALAPPDATA:~0!\\kiro-cli\\data.sqlite3"',
+            # %LOCALAPPDATA% ends in Local, so \..\Local is a canonical no-op.
+            'del "%LOCALAPPDATA%\\..\\Local\\kiro-cli\\data.sqlite3"',
+        ]
+        for cmd in cmds:
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        # Other %LOCALAPPDATA% content stays allowed.
+        assert (
+            is_sensitive_bash_command('type "%LOCALAPPDATA%\\SomeApp\\config.json"')
+            is None
+        )
+        # The home-anchored native spelling of the Local store is fenced too
+        # (via the _SENSITIVE_HOME_DIRS entry, not the alias branch).
+        assert (
+            is_sensitive_bash_command(
+                "type 'C:\\Users\\u\\AppData\\Local\\kiro-cli\\data.sqlite3'"
+            )
+            is not None
+        )
 
     def test_backslash_relative_traversal_is_blocked(self) -> None:
         assert is_sensitive_bash_command("type ..\\..\\.aws\\credentials") is not None


### PR DESCRIPTION
## Problem / Motivation

On Windows, the desktop title bar shows the CPU/memory/disk pills but never the credit-usage pill. `_CLI_SQLITE_DBS` in `src/kiro_crew/dashboard/handlers/kiro_usage_api.py` listed the Linux, macOS, and Windows *Roaming* locations of the kiro-cli sqlite auth store -- but current kiro-cli on Windows writes its store under the local, non-roaming app-data directory (`%LOCALAPPDATA%` default: `~/AppData/Local/kiro-cli/data.sqlite3`). That location was never a candidate, so no token was recognized as `from_cli_store`, the source-anchored provenance proof could never be satisfied, and whenever the ARN anchor also failed the usage API returned `available:false` and the pill was suppressed.

## Why it matters

Every Windows user on a current kiro-cli build silently loses the credit pill -- there is no error, the feature just never appears, which reads as "broken on Windows". The issue carries `channel: insider` (candidate release blocker). Related history: #2782 / PR #2799 added the Roaming entry with the right trust argument but at the legacy location.

## What changed (motivation -> approach -> change)

Symptom: pill absent on Windows -> root cause: the store's real Windows location is not in the trusted candidate tuple -> change:

1. **`kiro_usage_api.py`**: add the fixed home-anchored `~/AppData/Local/kiro-cli/data.sqlite3` entry to `_CLI_SQLITE_DBS`. The Roaming entry is retained for older layouts; entries stay existence-checked and platform-unconditional, matching the tuple's existing design. Deliberately NOT resolved from `%LOCALAPPDATA%`: membership in this tuple is a trust claim that rests on agent file tools being unable to write the store, and that fence is home-anchored -- an env-resolved location either equals the anchored entry or falls outside the fence and must not be trusted (same posture as the Linux entry ignoring `XDG_DATA_HOME`). `test/test_host_isolation_floor.py` pins this constant as a security anchor that must name the real home.
2. **`security.py` `_SENSITIVE_HOME_DIRS`**: add `AppData/Local/kiro-cli` and `AppData/Local/amazon-q`, so the new trusted location is inside the write fence the trust claim rests on (the amazon-q sibling keeps the list's existing per-store pairing at every location).
3. **`security.py` raw-text shell matcher**: add a `LOCALAPPDATA` alias branch parallel to the existing `APPDATA` one. `%LOCALAPPDATA%` points INTO `AppData\Local`, so `%LOCALAPPDATA%\kiro-cli\data.sqlite3` names the newly trusted store without the `AppData\Local` text the home-anchored branch requires. Covers cmd.exe expansion modifiers, both PowerShell spellings, and the `\..\Local` canonical no-op. Both pre-push reviewers (GPT and Opus lanes) independently flagged this gap as High: without it, a shell command could write the very file whose unwritability the `from_cli_store` trust claim rests on.

No env var is consulted anywhere; backend-only; no frontend changes.

## Tests

- `test_windows_stores_are_default_candidates`: pins both the Local and Roaming entries in `_CLI_SQLITE_DBS`.
- `test_local_appdata_store_token_is_trusted_without_arn`: end-to-end -- a token read out of a Local-layout store carries `from_cli_store=True` and the provenance path accepts it when whoami reports no profile ARN, the exact case the issue reports.
- `test_sqlite_token_stores_are_sensitive`: extended to assert the `AppData/Local` DB and its WAL/SHM/journal sidecars are classified sensitive for both kiro-cli and amazon-q.
- `test_localappdata_alias_of_fenced_store_is_blocked`: the `%LOCALAPPDATA%` / `$env:LOCALAPPDATA` / `${env:LOCALAPPDATA}` spellings (plus expansion modifiers, single-dot segments, and `\..\Local` re-entry) are refused by the shell gate; unrelated `%LOCALAPPDATA%` content stays allowed; the home-anchored native spelling is fenced via the dirs entry.
- Mutation-verified A/B: the pre-fix module loaded side by side with the new one confirms the pre-fix version does NOT block the `%LOCALAPPDATA%` spellings and the new one does.
- Full local gates: isort, flake8, mypy (only pre-existing stub-drift errors in untouched `transcribe.py`/`cloudwatch.py`), `test_security.py` + `test_kiro_usage_api.py` fully green (720 passed), full pytest run with failures only in known environment-sensitive modules unrelated to this change.

## Manual verification

N/A -- unit coverage sufficient: the change is a candidate-path constant plus a regex fence branch, both pinned end-to-end by the tests above; no Windows host available in this environment.

Closes #5783
