### PR TITLE
fix: conservative subagent downgrade flag, single provenance write (#5394)

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -5566,17 +5566,27 @@ class SubagentManager:
         # in the window between the event and the later session_id state write
         # cannot lose it — orphan recovery reads these from disk (GPT review on
         # #3582). Off-loop (to_thread): update_state does a synchronous fsync, so
-        # a slow FS must not freeze the gateway/heartbeat. Best-effort — a
-        # persistence hiccup must not block the spawn.
-        try:
-            await asyncio.to_thread(
-                update_state,
-                info.id,
-                requested_model=info.requested_model,
-                resolved_model=info.resolved_model,
-            )
-        except Exception:
-            logger.debug("Failed to persist model provenance for %s", info.id, exc_info=True)
+        # a slow FS must not freeze the gateway/heartbeat. Best-effort with ONE
+        # bounded retry: this write is the SINGLE owner of these two fields on
+        # the spawn path (#5394) — the later session_id write no longer doubles
+        # as a fallback, so a transient failure gets its second chance HERE
+        # rather than from a second writer downstream. update_state reports a
+        # silently-skipped merge (unreadable state) as False, which counts as a
+        # failure for the retry — only a REPORTED write ends the loop. A
+        # persistence hiccup must still never block the spawn.
+        for _provenance_attempt in range(2):
+            try:
+                _wrote = await asyncio.to_thread(
+                    update_state,
+                    info.id,
+                    requested_model=info.requested_model,
+                    resolved_model=info.resolved_model,
+                )
+                if _wrote:
+                    break
+                logger.debug("Provenance write skipped (unreadable state) for %s", info.id)
+            except Exception:
+                logger.debug("Failed to persist model provenance for %s", info.id, exc_info=True)
         await self._fire_event(
             "subagent_spawn",
             info,
@@ -5605,11 +5615,15 @@ class SubagentManager:
             state_update: dict[str, object] = {
                 "session_id": session_id,
                 "provider": provider_type,
-                # Persist the resolved/requested models so orphan-recovery
-                # completions (which rebuild the record from disk, not memory)
-                # can still show provenance (Design suggestion on #3582).
-                "resolved_model": info.resolved_model,
-                "requested_model": info.requested_model,
+                # Model provenance (requested_model/resolved_model) is NOT
+                # re-written here: the crash-safe write BEFORE the
+                # subagent_spawn event above is the single owner of those two
+                # fields on the spawn path, and a transient failure there is
+                # handled by that write's own bounded retry (#5394). This write
+                # still performs the same read-merge-rewrite either way, so the
+                # point is one authoritative writer, not saved I/O. The CC-path
+                # refinement below still updates resolved_model when it first
+                # becomes known.
                 # keep marks this run's session files as resume material: the
                 # orphan reconciler and tombstone pruner skip file deletion
                 # for keep runs (restart-safe — read from disk, not memory).

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -140,17 +140,26 @@ def read_state(agent_id: str) -> dict | None:
         return None
 
 
-def update_state(agent_id: str, **fields: object) -> None:
-    """Merge *fields* into state.json (atomic rewrite)."""
+def update_state(agent_id: str, **fields: object) -> bool:
+    """Merge *fields* into state.json (atomic rewrite).
+
+    Returns True when the merge was written, False when it was SKIPPED because
+    the current state could not be read (missing/corrupt/unreadable). The skip
+    is deliberate -- fabricating a fresh state here would resurrect a record
+    the reaper deleted -- but callers with a durability contract (the pre-spawn
+    provenance write, #5394) need to see the skip to retry rather than mistake
+    a silent no-op for success.
+    """
     p = _agent_dir(agent_id) / "state.json"
     try:
         state = json.loads(p.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         logger.debug("update_state: cannot read state for %s, skipping", agent_id)
-        return
+        return False
     state.update(fields)
     state["updated_at"] = time.time()
     _atomic_write(p, state)
+    return True
 
 
 # ── result streaming ─────────────────────────────────────────────────

--- a/test/test_subagent_provenance_write.py
+++ b/test/test_subagent_provenance_write.py
@@ -1,0 +1,241 @@
+"""Model provenance is persisted ONCE, at the crash-safe pre-spawn point.
+
+``SubagentInfo.requested_model`` / ``resolved_model`` are written to disk
+before the ``subagent_spawn`` event fires, so a gateway restart in the window
+between the event and any later state write cannot lose them — orphan recovery
+rebuilds the record from disk (GPT review on #3582). The later ``session_id``
+state write in ``_run`` used to re-write the same two fields; that second write
+was pure redundant I/O on the spawn hot path and was dropped (#5394). These
+tests pin both halves: exactly one provenance write, ordered before the spawn
+event, and a session_id write that no longer carries the provenance fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+# ``SubagentManager.spawn`` refuses while the host looks short of memory, which
+# is the runner's state, not this test's input.
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+
+def _mock_sessions(served_model: str) -> MagicMock:
+    """A mock SessionManager whose provider serves *served_model* and streams
+    nothing (zero turns) — enough to drive ``_run_inner`` end to end."""
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    provider = AsyncMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    provider.context_usage_pct = lambda: 0.0
+    # Public accessor read by _resolved_model_of at spawn time. Plain string
+    # attribute: an auto-created AsyncMock child would stringify to a mock repr
+    # and masquerade as a served model id.
+    provider.served_model = served_model
+
+    async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        return
+        yield  # noqa: unreachable — makes this an async generator
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _empty_stream())
+    sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    sessions.get_agent = MagicMock(return_value="")
+    return sessions
+
+
+def _mock_ctx_builder() -> MagicMock:
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = False
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_provenance_written_once_before_the_spawn_event() -> None:
+    """One write carries requested_model/resolved_model, and it lands BEFORE
+    the ``subagent_spawn`` event — the crash-safe ordering orphan recovery
+    depends on. The later session_id write must NOT re-write those fields."""
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    # Per-spawn pin: becomes the requested side of the downgrade comparison.
+    info = SubagentInfo(id="prov01", task="provenance task", model="model-req")
+    manager._agents[info.id] = info
+
+    # Ordered trace of every update_state call and every fired event, so the
+    # pre-spawn ordering is asserted on one timeline. update_state runs via
+    # asyncio.to_thread for the provenance write, but that thread is awaited
+    # before the event fires, so the trace order is deterministic.
+    trace: list[tuple[str, dict[str, Any]]] = []
+
+    def _spy_update(agent_id: str, **kwargs: Any) -> bool:
+        trace.append(("update_state", dict(kwargs)))
+        return True
+
+    orig_fire = manager._fire_event
+
+    async def _spy_fire(kind: str, *args: Any, **kwargs: Any) -> None:
+        trace.append(("event", {"kind": kind}))
+        await orig_fire(kind, *args, **kwargs)
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", side_effect=_spy_update),
+        patch.object(manager, "_fire_event", _spy_fire),
+    ):
+        await manager._run_inner(info, f"subagent:{info.id}")
+
+    writes = [kw for tag, kw in trace if tag == "update_state"]
+    prov_writes = [kw for kw in writes if "requested_model" in kw or "resolved_model" in kw]
+    # Exactly one provenance write on this path (the empty stream never reaches
+    # the CC first-chunk refinement, which only fills a still-empty value).
+    assert len(prov_writes) == 1, f"expected one provenance write, got {prov_writes}"
+    assert prov_writes[0]["requested_model"] == "model-req"
+    assert prov_writes[0]["resolved_model"] == "model-served"
+
+    # The session_id bookkeeping write no longer re-writes provenance (#5394).
+    sid_writes = [kw for kw in writes if "session_id" in kw]
+    assert sid_writes, "expected the session_id state write to still happen"
+    for kw in sid_writes:
+        assert (
+            "requested_model" not in kw and "resolved_model" not in kw
+        ), f"session_id write re-persists provenance: {kw}"
+
+    # Crash-safe ordering: the provenance write precedes the spawn event.
+    prov_idx = next(
+        i for i, (tag, kw) in enumerate(trace) if tag == "update_state" and "requested_model" in kw
+    )
+    spawn_idx = next(
+        i
+        for i, (tag, kw) in enumerate(trace)
+        if tag == "event" and kw.get("kind") == "subagent_spawn"
+    )
+    assert prov_idx < spawn_idx, "provenance must persist before subagent_spawn"
+
+
+@pytest.mark.asyncio
+async def test_provenance_write_retries_once_on_transient_failure() -> None:
+    """The pre-spawn write is the SINGLE owner of the provenance fields, so a
+    transient failure gets its second chance from that write's own bounded
+    retry -- not from a second writer downstream (the dropped session_id
+    re-write). The retry must still land before the spawn event, and a
+    persistence failure must never block the spawn."""
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="prov02", task="provenance retry task", model="model-req")
+    manager._agents[info.id] = info
+
+    trace: list[tuple[str, dict[str, Any]]] = []
+    provenance_attempts = {"n": 0}
+
+    def _flaky_update(agent_id: str, **kwargs: Any) -> bool:
+        if "requested_model" in kwargs:
+            provenance_attempts["n"] += 1
+            if provenance_attempts["n"] == 1:
+                raise OSError("transient fs hiccup")
+        trace.append(("update_state", dict(kwargs)))
+        return True
+
+    orig_fire = manager._fire_event
+
+    async def _spy_fire(kind: str, *args: Any, **kwargs: Any) -> None:
+        trace.append(("event", {"kind": kind}))
+        await orig_fire(kind, *args, **kwargs)
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", side_effect=_flaky_update),
+        patch.object(manager, "_fire_event", _spy_fire),
+    ):
+        await manager._run_inner(info, f"subagent:{info.id}")
+
+    # The failure was retried exactly once and the retry landed the write.
+    assert provenance_attempts["n"] == 2
+    landed = [
+        (i, kw)
+        for i, (tag, kw) in enumerate(trace)
+        if tag == "update_state" and "requested_model" in kw
+    ]
+    assert len(landed) == 1, f"expected the retry to land one write, got {landed}"
+    assert landed[0][1]["requested_model"] == "model-req"
+    spawn_idx = next(
+        i
+        for i, (tag, kw) in enumerate(trace)
+        if tag == "event" and kw.get("kind") == "subagent_spawn"
+    )
+    assert landed[0][0] < spawn_idx, "retried write must still precede subagent_spawn"
+    # The spawn itself completed despite the transient failure.
+    assert info.error == ""
+
+
+@pytest.mark.asyncio
+async def test_provenance_write_retries_on_silently_skipped_merge() -> None:
+    """``update_state`` SKIPS the merge (returns False) when the current state
+    cannot be read, without raising. The retry loop must treat that reported
+    skip as a failure -- only a reported successful write ends the loop
+    (GPT review round 2 on #5824: a silent no-op must not pass for success)."""
+    sessions = _mock_sessions(served_model="model-served")
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="prov03", task="provenance skip task", model="model-req")
+    manager._agents[info.id] = info
+
+    provenance_attempts = {"n": 0}
+    landed: list[dict[str, Any]] = []
+
+    def _skippy_update(agent_id: str, **kwargs: Any) -> bool:
+        if "requested_model" in kwargs:
+            provenance_attempts["n"] += 1
+            if provenance_attempts["n"] == 1:
+                return False  # the silent skip: no exception, nothing written
+            landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", side_effect=_skippy_update),
+    ):
+        await manager._run_inner(info, f"subagent:{info.id}")
+
+    assert provenance_attempts["n"] == 2, "a reported skip must trigger the retry"
+    assert len(landed) == 1 and landed[0]["requested_model"] == "model-req"
+    assert info.error == ""
+
+
+def test_update_state_reports_write_vs_skip(tmp_path: object) -> None:
+    """The return contract the retry depends on: True when the merge was
+    written, False when it was skipped because state.json is unreadable."""
+    from kiro_crew.subagent_persistence import (
+        create_agent_folder,
+        read_state,
+        update_state,
+    )
+
+    create_agent_folder("prov-rc1", task="task")
+    assert update_state("prov-rc1", requested_model="model-req") is True
+    state = read_state("prov-rc1")
+    assert state is not None and state["requested_model"] == "model-req"
+    # No folder / no state.json: the merge is skipped and reported as such.
+    assert update_state("prov-rc-missing", requested_model="model-req") is False

--- a/website/src/pages/chat/subagentCompletion.ts
+++ b/website/src/pages/chat/subagentCompletion.ts
@@ -98,14 +98,28 @@ const OUTCOME_BY_GLYPH: Record<string, SubagentOutcome> = {
  * `normalizeModelKey` does NOT fold a provider/partition prefix or a version
  * suffix, so a served canonical id (`us.anthropic.claude-opus-4-8-...-v1:0`)
  * would still differ from its alias pin (`claude-opus-4.8`). Rather than diverge
- * the shared key here, we strip ONLY a leading provider/partition prefix and a
- * trailing version/revision suffix from the served key, then require EXACT
- * equality with the pin. This deliberately does NOT accept an arbitrary
- * `-`-delimited substring: a pin `claude-opus-4` against served `claude-opus-4-1`
- * is a genuine version-family change and must still flag (UX review on #3582) —
- * a loose containment check would silently pass it, the exact miss this feature
- * exists to catch. (A full alias→canonical fold belongs in the shared registry —
- * tracked separately, #5339.)
+ * the shared key here, we strip a KNOWN leading provider/partition prefix from
+ * BOTH sides (symmetric — a pin can be given in canonical form too), fold a
+ * trailing version/revision tail only when the OTHER side has none (two present
+ * tails must agree: dated snapshots are distinct models), then require EXACT
+ * equality. This deliberately does NOT accept an arbitrary `-`-delimited
+ * substring: a pin `claude-opus-4` against served `claude-opus-4-1` is a
+ * genuine version-family change and must still flag (UX review on #3582) — a
+ * loose containment check would silently pass it, the exact miss this feature
+ * exists to catch.
+ *
+ * CONSERVATIVE ON UNRECOGNIZED SHAPES (#5394): this is an audit surface, and a
+ * missed downgrade is safer than a false one — a false amber on an honored pin
+ * trains users to ignore the exact signal the flag exists to provide. A served
+ * id whose routing prefix is OUTSIDE the known strip set (a new partition like
+ * `apac.`, a new provider) folds to `<unknown-prefix>-<bare pin>`: still a
+ * `!==` against the pin, but not evidence of a different model. So when one
+ * folded id names the whole tail of the other at a `-` token boundary, the
+ * comparison is INCONCLUSIVE and the flag is skipped. The token boundary keeps
+ * the version-family guarantee: `claude-opus-4-1` does not END with
+ * `-claude-opus-4`, so that case still flags. (The durable fix — routing both
+ * sides through the shared registry alias→canonical fold — is #5339; this
+ * guard is the interim measure until it lands.)
  */
 export function isModelDowngrade(requestedModel: string, resolvedModel: string): boolean {
   const req = requestedModel.trim()
@@ -117,16 +131,48 @@ export function isModelDowngrade(requestedModel: string, resolvedModel: string):
   if (reqKey === 'auto') return false
   const resKey = normalizeModelKey(res)
   if (reqKey === resKey) return false
-  // Fold the served key to its bare model id: drop a KNOWN leading
-  // provider/partition prefix and a trailing version/revision suffix, then
-  // require exact equality — never an arbitrary substring.
-  // Leading: `us-`/`eu-`/… region, `anthropic-`/`openai-`/`bedrock-`/`global-`.
-  // Trailing: a version/revision tail like `-v1:0`, `:0`, `-20250101`.
-  let bare = resKey
-  bare = bare.replace(/^(?:[a-z]{2}-)?(?:anthropic-|openai-|bedrock-|global-)+/, '')
-  bare = bare.replace(/(?::\d+|-v\d+(?::\d+)?|-\d{6,})$/g, '')
-  if (bare === reqKey) return false
+  const pReq = stripKnownRoutingPrefix(reqKey)
+  const pRes = stripKnownRoutingPrefix(resKey)
+  // A version/date tail is folded only to MEET a side that has none — the
+  // canonical-pin-vs-bare-alias shape. When BOTH sides carry a tail the tails
+  // are kept and must agree: dated snapshot ids are first-class pins
+  // (model_registry.py carries e.g. two -YYYYMMDD snapshots of one base), and
+  // stripping both tails would silently equate two different snapshots —
+  // exactly the version-family miss this comparison must catch.
+  const reqTail = VERSION_TAIL_RE.test(pReq)
+  const resTail = VERSION_TAIL_RE.test(pRes)
+  const bareReq = reqTail && !resTail ? pReq.replace(VERSION_TAIL_RE, '') : pReq
+  const bareRes = resTail && !reqTail ? pRes.replace(VERSION_TAIL_RE, '') : pRes
+  // A fold that consumed the whole id (nothing but prefix/suffix matter) left
+  // nothing to compare — inconclusive, never a flag.
+  if (!bareReq || !bareRes) return false
+  if (bareReq === bareRes) return false
+  // One bare id is the token-suffix of the other: an unstripped routing prefix
+  // (unknown partition/provider), not a demonstrably different model.
+  if (isTokenSuffix(bareReq, bareRes)) return false
   return true
+}
+
+/** Trailing version/revision tail: `-v1:0`, `:0`, or a date like `-20250101`.
+ *  No `g` flag — `$`-anchored, and a stateful `lastIndex` would poison
+ *  `.test()` across calls. */
+const VERSION_TAIL_RE = /(?::\d+|-v\d+(?::\d+)?|-\d{6,})$/
+
+/** Drop a KNOWN leading provider/partition prefix from a normalized model key.
+ *  Leading: `us-`/`eu-`/… region, `anthropic-`/`openai-`/`bedrock-`/`global-`. */
+function stripKnownRoutingPrefix(key: string): string {
+  return key.replace(/^(?:[a-z]{2}-)?(?:anthropic-|openai-|bedrock-|global-)+/, '')
+}
+
+/** True when the shorter of the two ids names the WHOLE tail of the longer one
+ *  at a `-` token boundary — the shape an unrecognized routing prefix leaves
+ *  behind (checked by length, so it is inconclusive in BOTH directions: an
+ *  unknown prefix on the served id or on the pin). Anchored on the boundary so
+ *  a version-family extension (`claude-opus-4` vs `claude-opus-4-1`) never
+ *  matches: the longer id there ends in `-1`, not in `-claude-opus-4`. */
+function isTokenSuffix(a: string, b: string): boolean {
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a]
+  return long.endsWith('-' + short)
 }
 
 

--- a/website/src/test/SubagentCompletionCard.test.tsx
+++ b/website/src/test/SubagentCompletionCard.test.tsx
@@ -616,6 +616,49 @@ describe('isModelDowngrade / normalizeModelId (GPT review on #3582)', () => {
     // Boundary: opus-4-8 must NOT be treated as the same as opus-4-80.
     expect(isModelDowngrade('claude-opus-4-8', 'claude-opus-4-80')).toBe(true)
   })
+
+  it('treats an UNRECOGNIZED routing prefix as inconclusive, never a downgrade (#5394)', () => {
+    // A partition/provider outside the known strip set (a new region token,
+    // a vendor the fold has never heard of) leaves the served id as
+    // `<unknown-prefix>-<bare pin>` — an unstripped routing shape, not
+    // evidence of a different model. A missed downgrade is safer than a
+    // false amber on an honored pin.
+    expect(isModelDowngrade('claude-opus-4.8', 'apac.anthropic.claude-opus-4-8-v1:0')).toBe(false)
+    expect(isModelDowngrade('claude-opus-4.8', 'newvendor.claude-opus-4-8')).toBe(false)
+    expect(isModelDowngrade('gpt-5.6-sol', 'azure.openai.gpt-5.6-sol')).toBe(false)
+  })
+
+  it('folds BOTH sides symmetrically: a canonical-form pin vs its bare served id (#5394)', () => {
+    // A pin can itself be written in provider-canonical form; stripping only
+    // the served side would false-flag the honored pin.
+    expect(isModelDowngrade('us.anthropic.claude-opus-4-8-v1:0', 'claude-opus-4-8')).toBe(false)
+    expect(isModelDowngrade('anthropic.claude-opus-4-8:0', 'claude-opus-4.8')).toBe(false)
+  })
+
+  it('still flags a genuinely different model under an unknown prefix (#5394)', () => {
+    // The inconclusive guard requires the WHOLE tail to match at a token
+    // boundary — a different bare model under an unknown prefix is not a
+    // suffix match and must keep flagging.
+    expect(isModelDowngrade('claude-opus-4.8', 'apac.anthropic.claude-opus-4-7-v1:0')).toBe(true)
+  })
+
+  it('still flags when BOTH sides carry version/date tails that differ (#5394)', () => {
+    // Dated snapshot ids are first-class pins (model_registry carries two
+    // -YYYYMMDD snapshots of one base): a tail is folded only to MEET a
+    // tail-less side, so two PRESENT tails must agree — different snapshots
+    // or revisions of the same base are different models and must flag.
+    expect(isModelDowngrade('claude-3-5-sonnet-20241022', 'claude-3-5-sonnet-20240620')).toBe(true)
+    expect(
+      isModelDowngrade(
+        'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        'anthropic.claude-3-5-sonnet-20240620-v1:0',
+      ),
+    ).toBe(true)
+    // Matching tails on both sides are an honored pin, not a downgrade.
+    expect(
+      isModelDowngrade('us.anthropic.claude-opus-4-8-v1:0', 'anthropic.claude-opus-4-8-v1:0'),
+    ).toBe(false)
+  })
 })
 
 describe('downgrade is visible, not hover-only (UX review on #3582)', () => {


### PR DESCRIPTION
## Problem / Motivation

Two follow-ups on the subagent model-provenance feature (#3582 / #5306), raised by its Design and First Principles reviews:

1. The completion card's downgrade heuristic (`isModelDowngrade`) folds only the SERVED id, and only for a known set of provider/partition prefixes. A served id outside that set (a new partition such as `apac.`, an unknown vendor prefix) -- or a pin written in canonical form against a bare served id -- normalizes differently from the id it actually names and renders a false "Requested X, served Y" downgrade banner on an honored pin.
2. `SubagentInfo` provenance (`requested_model`/`resolved_model`) is persisted crash-safely before the `subagent_spawn` event, then re-written by the later `session_id` `update_state` in `_run` -- two writers for the same two fields on one path.

## Why it matters

Model provenance is an audit surface: it is only useful if the downgrade flag is trustworthy. A false amber on an honored pin trains users to ignore the exact signal the feature exists to provide. For this surface a missed downgrade is safer than a false one. On the backend, two writers for one pair of fields is a maintenance hazard (a future edit to one drifts from the other); the pre-spawn write is the one orphan recovery depends on.

## What changed (motivation -> approach -> change)

**Frontend (`website/src/pages/chat/subagentCompletion.ts`):**
- The known prefix strip is now applied to BOTH sides (a pin can itself be canonical-form), and a version/date tail is folded only to MEET a side that has none. Two PRESENT tails are kept and must agree -- dated snapshot ids are first-class pins (`model_registry.py` carries two `-YYYYMMDD` snapshots of one base), so collapsing both tails would equate two different snapshots. (This tail rule was tightened from a fully symmetric strip after a pre-push review lane demonstrated the dated-snapshot miss.)
- When one folded id names the whole tail of the other at a `-` token boundary, the served id is an unstripped routing shape (unknown partition/provider) -- the comparison is INCONCLUSIVE and the flag is skipped rather than guessed. The token boundary preserves the version-family guarantee from #3582's UX review: `claude-opus-4` vs `claude-opus-4-1` still flags.
- This is the interim measure until the shared registry alias->canonical fold (#5339) lands, at which point the local fold can be simplified away.

**Backend (`src/kiro_crew/subagent.py`):**
- The `session_id` state write in `_run` no longer re-writes `requested_model`/`resolved_model`; the crash-safe pre-spawn write (which orphan recovery reads) is the single owner of those fields on the spawn path. Because the dropped re-write also served as an incidental fallback, the owning write now carries ONE bounded retry (per this PR's GPT review finding and the Design review's suggested shape: retry the one owner, never reintroduce a second writer). A persistence failure still never blocks the spawn. Note this is a single-writer/ownership change, not an I/O optimization -- the session_id write performs the same read-merge-rewrite either way.
- The CC-path refinement still fills `resolved_model` when it first becomes known.

## Tests

- `website/src/test/SubagentCompletionCard.test.tsx`: new cases pin (a) an unrecognized routing prefix is inconclusive, never a downgrade; (b) a canonical-form pin vs its bare served id does not flag (symmetric prefix fold); (c) a genuinely different model under an unknown prefix STILL flags; (d) two differing version/date tails STILL flag (dated snapshots, revision tails) while matching tails do not. All prior downgrade cases (version-family shift, the `-4-8` vs `-4-80` boundary) unchanged and green. Each new mechanism was mutation-verified (disabling the guard, de-symmetrizing the fold, and always-stripping tails each turn exactly the corresponding test red).
- `test/test_subagent_provenance_write.py` (new): drives `_run_inner` with a served-model provider and asserts (1) provenance is written exactly once, ordered BEFORE the `subagent_spawn` event, and the `session_id` write no longer carries the two fields (mutation-verified: re-adding the redundant write turns it red); (2) a transiently failing first write is retried exactly once, the retry still lands before the spawn event, and the spawn completes regardless (mutation-verified: reducing the retry loop to a single attempt turns it red).

## Manual verification

N/A -- unit coverage sufficient: both changes are pure logic (a comparison function and a persistence-ownership change) with no rendering or integration delta; the completion-card rendering paths are already covered by the existing suite (49 prior cases in the same file).

Closes #5394
