### PR TITLE
fix: harden the six remaining subprocess.run calls in _update()

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1028,13 +1028,21 @@ def _update(force: bool = False) -> None:
     print(f"  📂 {proj}")
 
     # Detect current branch
-    branch_result = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=proj,
-        capture_output=True,
-        timeout=10,
-        **UTF8_TEXT,
-    )
+    try:
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=10,
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "git rev-parse timed out after %ss during update", exc.timeout
+        )
+        print("❌ Could not determine current branch (git rev-parse timed out)")
+        sys.exit(1)
     if branch_result.returncode != 0:
         print("❌ Could not determine current branch")
         sys.exit(1)
@@ -1054,25 +1062,44 @@ def _update(force: bool = False) -> None:
 
     # Fetch + reset --hard: no merge conflicts, untracked files preserved
     print("  ⬇️  git fetch…")
-    result = subprocess.run(
-        ["git", "fetch", "origin", branch],
-        cwd=proj,
-        capture_output=True,
-        timeout=60,
-        **UTF8_TEXT,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "fetch", "origin", branch],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=60,
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "git fetch timed out after %ss during update", exc.timeout
+        )
+        print(f"  ❌ git fetch timed out after {exc.timeout}s")
+        sys.exit(1)
     if result.returncode != 0:
         print(f"  ❌ git fetch failed:\n{result.stderr.strip()}")
         sys.exit(1)
 
     # Check if there are new commits
-    diff_result = subprocess.run(
-        ["git", "diff", "HEAD", f"origin/{branch}", "--quiet"],
-        cwd=proj,
-        capture_output=True,
-        timeout=10,
-    )
-    if diff_result.returncode == 0:
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "HEAD", f"origin/{branch}", "--quiet"],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=10,
+        )
+        up_to_date = diff_result.returncode == 0
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "git diff timed out after %ss during update", exc.timeout
+        )
+        # Same branch a non-zero exit takes: assume new commits exist and let
+        # the divergence guard below re-classify before anything destructive.
+        print("  ⚠️  git diff timed out — continuing to the divergence check")
+        up_to_date = False
+    if up_to_date:
         print("\n✅ Already up to date!")
         return
 
@@ -1145,13 +1172,24 @@ def _update(force: bool = False) -> None:
         print(f"  ⚠️  --force: discarding {ahead} local commit(s) not on origin/{branch}.")
 
     # Warn about local tracked-file changes before discarding
-    status = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=proj,
-        capture_output=True,
-        timeout=10,
-        **UTF8_TEXT,
-    )
+    try:
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=10,
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "git status timed out after %ss during update", exc.timeout
+        )
+        # Fail closed: this check exists to warn before the hard reset
+        # discards local tracked changes, so an unreadable answer must
+        # refuse the reset — same stance as the unreadable-divergence guard.
+        print("  ❌ Could not check for local changes (git status timed out)")
+        sys.exit(1)
     tracked_changes = [
         line for line in status.stdout.strip().splitlines() if not line.startswith("??")
     ]
@@ -1188,13 +1226,21 @@ def _update(force: bool = False) -> None:
         sys.exit(1)
 
     print(f"  🔄 git reset --hard origin/{branch}…")
-    result = subprocess.run(
-        ["git", "reset", "--hard", f"origin/{branch}"],
-        cwd=proj,
-        capture_output=True,
-        timeout=10,
-        **UTF8_TEXT,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "reset", "--hard", f"origin/{branch}"],
+            cwd=proj,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=10,
+            **UTF8_TEXT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logging.getLogger(__name__).warning(
+            "git reset timed out after %ss during update", exc.timeout
+        )
+        print(f"  ❌ git reset timed out after {exc.timeout}s")
+        sys.exit(1)
     if result.returncode != 0:
         print(f"  ❌ git reset failed:\n{result.stderr.strip()}")
         sys.exit(1)
@@ -1202,7 +1248,18 @@ def _update(force: bool = False) -> None:
     # Update the optional kiro-cli backend if present.
     if shutil.which("kiro-cli"):
         print("  🔄 kiro-cli update")
-        subprocess.run(["kiro-cli", "update"], capture_output=True, timeout=120)
+        try:
+            subprocess.run(
+                ["kiro-cli", "update"],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as exc:
+            logging.getLogger(__name__).warning(
+                "kiro-cli update timed out after %ss; skipping (best-effort)", exc.timeout
+            )
+            print("  ⚠️  kiro-cli update timed out — run manually: kiro-cli update")
 
     # Ensure a supported Node.js for frontend builds
     from kiro_crew.cli import _ensure_node  # circular import: cli -> cli_server -> cli

--- a/test/test_cli_server_more_coverage.py
+++ b/test/test_cli_server_more_coverage.py
@@ -1232,6 +1232,121 @@ class TestUpdateGitPath:
         assert "Agent config refresh failed" in out
 
 
+class TestUpdateSubprocessHardening:
+    """The six ``subprocess.run`` calls in ``_update()`` (issue #5648).
+
+    Two gap classes: (a) every captured-output call must also pass
+    ``stdin=subprocess.DEVNULL`` so a child prompt can never block invisibly on
+    the parent terminal; (b) ``TimeoutExpired`` — which ``subprocess.run``
+    RAISES rather than returns — must land on the same branch that the site's
+    existing failure path already takes, never escape ``_update()``.
+    """
+
+    @staticmethod
+    def _timeout_on(prefix, inner):
+        """A subprocess.run stand-in raising TimeoutExpired for one argv prefix."""
+
+        def _run(argv, **kw):
+            if list(argv[: len(prefix)]) == list(prefix):
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=kw.get("timeout", 0))
+            return inner(argv, **kw)
+
+        return _run
+
+    def test_all_six_calls_pass_stdin_devnull(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """Gap class (a): assert on the kwargs actually passed to subprocess.run."""
+        stub = _GitStub()
+        recorded: list[tuple[list[str], dict]] = []
+
+        def _run(argv, **kw):
+            recorded.append((list(argv), kw))
+            return stub(argv, **kw)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        # A findable kiro-cli makes the sixth (best-effort) site reachable.
+        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        cli_server._update()
+        assert "Kiro Crew updated!" in capsys.readouterr().out
+
+        six = [
+            ["git", "rev-parse"],
+            ["git", "fetch"],
+            ["git", "diff"],
+            ["git", "status"],
+            ["git", "reset"],
+            ["kiro-cli", "update"],
+        ]
+        for prefix in six:
+            matching = [kw for argv, kw in recorded if argv[: len(prefix)] == prefix]
+            assert matching, f"call {prefix} never ran"
+            for kw in matching:
+                assert (
+                    kw.get("stdin") is subprocess.DEVNULL
+                ), f"{prefix} ran without stdin=DEVNULL"
+
+    def test_fetch_timeout_takes_the_existing_failure_branch(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """Gap class (b), exit-1 sites: a timeout must not traceback out.
+
+        RED-BEFORE: on unmodified main this raises TimeoutExpired straight
+        through ``kirocrew update`` instead of the SystemExit(1) the fetch
+        failure path already defines.
+        """
+        monkeypatch.setattr(
+            subprocess, "run", self._timeout_on(["git", "fetch"], _GitStub())
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "git fetch timed out" in capsys.readouterr().out
+
+    def test_diff_timeout_proceeds_like_a_nonzero_exit(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """A diff timeout takes the branch a non-zero exit already takes —
+        proceed to the divergence guard — rather than tracing back or lying
+        "up to date"."""
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", self._timeout_on(["git", "diff"], stub))
+        cli_server._update()
+        out = capsys.readouterr().out
+        assert "git diff timed out" in out
+        # The update still completed through the guard + reset path.
+        assert "Kiro Crew updated!" in out
+        assert any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_status_timeout_refuses_the_reset(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """The status call guards the hard reset's data discard: an unreadable
+        answer fails closed, mirroring the unreadable-divergence guard."""
+        stub = _GitStub()
+        monkeypatch.setattr(subprocess, "run", self._timeout_on(["git", "status"], stub))
+        with pytest.raises(SystemExit) as exc:
+            cli_server._update()
+        assert exc.value.code == 1
+        assert "git status timed out" in capsys.readouterr().out
+        assert not any(c[:2] == ["git", "reset"] for c in stub.calls)
+
+    def test_kiro_cli_update_timeout_degrades_best_effort(
+        self, monkeypatch, git_checkout, capsys
+    ) -> None:
+        """The backend update's result is not inspected today, so its timeout
+        warns and the update continues — the #5637 handler shape."""
+        stub = _GitStub()
+        monkeypatch.setattr(
+            subprocess, "run", self._timeout_on(["kiro-cli", "update"], stub)
+        )
+        monkeypatch.setattr(cli_server.shutil, "which", lambda name: "/usr/bin/kiro-cli")
+        cli_server._update()
+        out = capsys.readouterr().out
+        assert "kiro-cli update timed out" in out
+        assert "Kiro Crew updated!" in out
+
+
 class TestUpdateWheelDispatch:
     """No git checkout means the wheel path gets a correctly shaped layout."""
 


### PR DESCRIPTION
## Problem / Motivation

`_update()` in `src/kiro_crew/cli_server.py` makes seven `subprocess.run` calls. PR #5637 hardened one of them (the `setup --agent-only` refresh: `stdin=subprocess.DEVNULL` + a `TimeoutExpired` downgrade). The other six — `git rev-parse` (:1031), `git fetch` (:1057), `git diff` (:1069), `git status` (:1148), `git reset` (:1191), `kiro-cli update` (:1205 at the pre-change line numbers) — shared two gaps:

1. **Captured output with inherited stdin.** All six pass `capture_output=True` but leave `stdin` at its default of inherit. A prompt the child asks is invisible (its text sits in an unread pipe) AND blocking (it waits on the parent terminal) until the call's timeout fires. The `git fetch` site can genuinely prompt today — SSH passphrase or an HTTPS credential helper.
2. **No `TimeoutExpired` handler.** `subprocess.run` *raises* on timeout rather than returning, so any of the six timing out ended `kirocrew update` in a traceback instead of the failure message each site already defines.

## Why it matters

An operator running `kirocrew update` on a checkout whose remote wants credentials sees the command hang silently for up to 60s and then die in a raw `subprocess.TimeoutExpired` traceback — no indication of what stalled or what to do. The same traceback path is reachable from any wedged git invocation (slow filesystem, lock contention).

## What changed (motivation → approach → change)

Symptom: silent hang, then a traceback. Root cause: six piped-output calls with inherited stdin and no handler for the exception `subprocess.run` raises on timeout. Change, mirroring the shape #5637 already established at the seventh call so `_update()` keeps a single convention:

- **`stdin=subprocess.DEVNULL` on all six calls.** A child that asks a question now gets EOF immediately instead of blocking invisibly — the invariant is structural, not dependent on every future prompt author remembering an isatty check.
- **`TimeoutExpired` caught at each site**, logging a warning that names the timeout, then landing on the same branch that site's existing failure path already takes:
  - `rev-parse` / `fetch` / `reset`: print the site's `❌` message and `sys.exit(1)` — exactly what a non-zero exit already does.
  - `git diff --quiet`: a non-zero exit already means "proceed with the update", so a timeout takes the same branch (with a `⚠️` note). Safe because the divergence guard downstream re-classifies before anything destructive runs.
  - `git status`: **fails closed** (`sys.exit(1)`). This call has no explicit failure branch today, but it exists solely to warn before the hard reset discards local tracked changes — an unreadable answer must refuse the reset, the same stance the unreadable-divergence guard in this function already takes.
  - `kiro-cli update`: warn and continue — its result was never inspected, so best-effort degradation matches current semantics (and the #5637 handler shape).
- **Timeout values: unchanged everywhere.** All six sites already carried one (10/60/10/10/10/120s); no site needed a new value chosen.
- The `✅ Kiro Crew updated!` banner is unreachable from any degraded step that invalidates it: every git-path timeout either exits 1 or (diff) re-routes through the divergence guard; the one warn-and-continue site (`kiro-cli update`) is best-effort today by construction.

**Reviewer note:** the seventh `subprocess.run` in the update path (the `setup --agent-only` refresh) is already hardened — landed via #5637 (merged 2026-08-24) — so its absence from this diff is deliberate, not an oversight. The bare `input()` prompt sweep in `cli_setup.py` is explicitly out of scope per the issue. Out-of-scope `subprocess.run` sites elsewhere in `cli_server.py` (:626, :1390, :1810) are untouched.

## Tests

New `TestUpdateSubprocessHardening` in `test/test_cli_server_more_coverage.py`, extending the existing `_GitStub` + `git_checkout` conventions — one test per gap class, not per line:

- `test_all_six_calls_pass_stdin_devnull` — records the kwargs actually passed to `subprocess.run` across the full success path and asserts `stdin is subprocess.DEVNULL` at all six sites.
- `test_fetch_timeout_takes_the_existing_failure_branch` — a fetch timeout produces `SystemExit(1)` + the timeout message, not a propagating `TimeoutExpired` (locks the exit-1 class: rev-parse/fetch/reset).
- `test_diff_timeout_proceeds_like_a_nonzero_exit` — a diff timeout continues to the divergence guard and completes the update, neither tracing back nor lying "up to date".
- `test_status_timeout_refuses_the_reset` — a status timeout exits 1 with no `git reset` ever issued (fail-closed data-discard guard).
- `test_kiro_cli_update_timeout_degrades_best_effort` — a kiro-cli timeout warns and the update still completes.

**Red-before proven:** with the production change stashed, all 5 fail on unmodified main (`TimeoutExpired` propagates / kwargs lack `stdin`).

## Manual verification

N/A — unit coverage sufficient: every touched call site is exercised through `_update()` with `subprocess.run` stubbed at the exact seam, both success and timeout paths; no UI or external-service surface.

## Related Issues

Closes #5648

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, internal hardening
- [x] No secrets, credentials, or internal references in the diff
