### PR TITLE
refactor: simplify the webex channel module

### DIFF
--- a/src/kiro_crew/webex/client.py
+++ b/src/kiro_crew/webex/client.py
@@ -162,8 +162,7 @@ _PERSON_CACHE_MAX = 256
 # Bounded because the user is waiting on a reply, and this runs before the turn
 # starts: past this the honest answer is "still scanning, re-send shortly".
 _SCAN_WAIT_BUDGET_S = 60.0
-# Bounds on the server-supplied Retry-After: a missing header must not mean zero
-# (a hot loop) and a hostile one must not park the turn.
+
 # Host suffixes a Device Manager URL may name. The bearer token rides device
 # registration, so the destination cannot be free-form — and both inputs that can
 # name it are untrusted in different ways:
@@ -200,6 +199,11 @@ def _is_webex_host(url: str) -> bool:
 #: Refusal reason for a scan that outlasted the budget. Reaches the user through
 #: ``messaging.attachments``, so it reads as an instruction rather than an error.
 _STILL_SCANNING = "still being scanned, re-send shortly"
+
+# Bounds on the server-supplied Retry-After for the SCAN-WAIT ladder (the 423 path
+# in ``download_content``, via ``_retry_after``): a missing header must not mean zero
+# (a hot loop) and a hostile one must not park the turn. The 429 API back-off in
+# ``_api`` is a separate policy with its own narrower bounds, and does not read these.
 _RETRY_AFTER_MIN_S = 1.0
 _RETRY_AFTER_MAX_S = 15.0
 # Chunk size for streaming a download to disk, so a 100 MB file never lands in
@@ -538,7 +542,7 @@ class WebexClient:
         error yields ``[]``: history is supplementary and must not fail a turn.
         """
         result = await self._api("GET", f"/messages{query}", None)
-        items = (result or {}).get("items") if isinstance(result, dict) else None
+        items = result.get("items") if isinstance(result, dict) else None
         return [i for i in (items or []) if isinstance(i, dict)]
 
     async def head_content(self, url: str) -> tuple[str, str, int]:
@@ -1090,7 +1094,7 @@ class WebexClient:
         if cached is not None:
             return cached
         person = await self._api("GET", f"/people/{person_id}", None)
-        emails = (person or {}).get("emails") or [] if isinstance(person, dict) else []
+        emails = (person.get("emails") or []) if isinstance(person, dict) else []
         email = str(emails[0]).lower() if emails else ""
         # Bounded: a room's membership is small, but a long-lived gateway seeing
         # many rooms should not accumulate without limit.
@@ -1115,7 +1119,7 @@ class WebexClient:
         if cached is not None:
             return cached
         room = await self._api("GET", f"/rooms/{room_id}", None)
-        room_type = str((room or {}).get("type") or "") if isinstance(room, dict) else ""
+        room_type = str(room.get("type") or "") if isinstance(room, dict) else ""
         if len(self._room_types) >= _PERSON_CACHE_MAX:
             self._room_types.pop(next(iter(self._room_types)), None)
         # Cached even when empty: a bot removed from the room would otherwise
@@ -1166,11 +1170,13 @@ class WebexClient:
                     timeout=aiohttp.ClientTimeout(total=timeout),
                 ) as resp:
                     if resp.status == 429 and attempt == 0:
-                        retry_after = 1.0
                         try:
                             retry_after = float(resp.headers.get("Retry-After", "1"))
                         except (TypeError, ValueError):
-                            pass
+                            # Mirrors the header default above, so a malformed value
+                            # paces exactly like a missing one. The clamp below is
+                            # what bounds the wait either way.
+                            retry_after = 1.0
                         await asyncio.sleep(min(max(retry_after, 0.5), 10.0))
                         continue
                     if 200 <= resp.status < 300:

--- a/src/kiro_crew/webex/commands.py
+++ b/src/kiro_crew/webex/commands.py
@@ -36,22 +36,41 @@ _QUEUE_ALIASES = frozenset(("/queue",))
 _STEER_ALIASES = frozenset(("/steer",))
 _MID_TURN_ALIASES = _QUEUE_ALIASES | _STEER_ALIASES
 
+#: alias -> canonical name, and the one mapping :func:`parse_command` and
+#: :data:`_ALL_COMMANDS` both read, so a command reaching one and not the other
+#: cannot happen: an alias missing from the parser answers as ordinary chat, and
+#: one missing from the token set is answered with "unknown command".
+#:
+#: The aliases stay as the named sets above rather than being spelled inline here,
+#: and ``_STOP_ALIASES`` MUST keep that name: a cross-channel tripwire ``getattr``s
+#: it off this module to check the shared cancel-during-a-governance-deny exemption
+#: covers every spelling this channel accepts. Inlining it costs nothing visible —
+#: the probe falls back to its default, and these two spellings are a subset of what
+#: the other channels contribute, so the union it asserts on does not move. The
+#: coverage just stops. The rest are named for symmetry; only that one has a reader
+#: outside this module.
+_ALIAS_TO_COMMAND: dict[str, str] = {
+    alias: canonical
+    for canonical, aliases in (
+        ("new", _NEW_ALIASES),
+        ("compact", _COMPACT_ALIASES),
+        ("help", _HELP_ALIASES),
+        ("stop", _STOP_ALIASES),
+        ("link", _LINK_ALIASES),
+        ("unlink", _UNLINK_ALIASES),
+        ("model", _MODEL_ALIASES),
+        ("sessions", _SESSIONS_ALIASES),
+        ("yolo", _YOLO_ALIASES),
+        ("dashboard", _DASHBOARD_ALIASES),
+    )
+    for alias in aliases
+}
+
 #: Every command token, so a caller can tell "a command the user misspelled"
-#: from "ordinary chat that happens to start with a slash".
-_ALL_COMMANDS = (
-    _NEW_ALIASES
-    | _COMPACT_ALIASES
-    | _HELP_ALIASES
-    | _STOP_ALIASES
-    | _LINK_ALIASES
-    | _UNLINK_ALIASES
-    | _MODEL_ALIASES
-    | _SESSIONS_ALIASES
-    | _YOLO_ALIASES
-    | _DASHBOARD_ALIASES
-    | _QUEUE_ALIASES
-    | _STEER_ALIASES
-)
+#: from "ordinary chat that happens to start with a slash". The mid-turn
+#: directives are added here and NOT to the mapping above, because they are
+#: prefixes rather than commands (see :func:`parse_command`).
+_ALL_COMMANDS = frozenset(_ALIAS_TO_COMMAND) | _MID_TURN_ALIASES
 
 
 def _first_token(text: str) -> str:
@@ -75,32 +94,11 @@ def parse_command(text: str) -> str | None:
 
     ``/queue`` and ``/steer`` deliberately do NOT resolve here: they are mid-turn
     prefixes handled by :func:`parse_mid_turn_override`, and treating a
-    ``/queue do the thing`` as a command would swallow the message body.
+    ``/queue do the thing`` as a command would swallow the message body — which is
+    why they are absent from :data:`_ALIAS_TO_COMMAND`.
     """
-    cmd = _first_token(text)
-    if not cmd:
-        return None
-    if cmd in _NEW_ALIASES:
-        return "new"
-    if cmd in _COMPACT_ALIASES:
-        return "compact"
-    if cmd in _HELP_ALIASES:
-        return "help"
-    if cmd in _STOP_ALIASES:
-        return "stop"
-    if cmd in _LINK_ALIASES:
-        return "link"
-    if cmd in _UNLINK_ALIASES:
-        return "unlink"
-    if cmd in _MODEL_ALIASES:
-        return "model"
-    if cmd in _SESSIONS_ALIASES:
-        return "sessions"
-    if cmd in _YOLO_ALIASES:
-        return "yolo"
-    if cmd in _DASHBOARD_ALIASES:
-        return "dashboard"
-    return None
+    # ``""`` is never a key, so ordinary chat falls through as None.
+    return _ALIAS_TO_COMMAND.get(_first_token(text))
 
 
 def parse_command_argument(text: str) -> str:

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -959,7 +959,9 @@ class WebexDispatcher:
             resolved = _APPROVALS.resolve(
                 approval_scope, approved, request_id=request_id, expected_nonce=nonce
             )
-            outcome = ("approved" if approved else "denied") if resolved else "denied"
+            # Only a resolve that actually landed can record an approval: a press
+            # the registry refused (stale nonce, wrong request id) decided nothing.
+            outcome = "approved" if resolved and approved else "denied"
         sel().log_api_access(
             caller=f"webex:{inbound.person_email}",
             operation="webex.tool_approval",
@@ -1090,13 +1092,11 @@ class WebexDispatcher:
             texts: list[str] = []
             files: list[str] = []
             remainder: list[tuple[str, str, dict]] = []
-            # The room this drained turn answers into, taken from the FIRST entry
-            # rather than from *inbound*: the turn that just finished may have been
-            # opened by a different person on a shared unified key.
             # The CONVERSATION this drained turn answers into: room AND thread
             # root, because that pair is what the reply envelope carries. Taken
             # from the FIRST entry rather than from *inbound*, whose turn may have
-            # been opened by another person or in another thread.
+            # been opened by another person (a shared unified key puts two humans
+            # on one queue) or in another thread.
             convo: tuple[str, str] | None = None
             email = ""
             async with self._queue.lock:

--- a/test/test_webex_dispatch.py
+++ b/test/test_webex_dispatch.py
@@ -1972,6 +1972,35 @@ class TestApprovalCardPress:
         assert operations.count("webex.tool_approval") == 2
 
     @pytest.mark.asyncio
+    async def test_a_refused_press_never_audits_as_an_approval(self) -> None:
+        """The audit LABEL follows the resolve, not the button that was pressed.
+
+        A press the registry refused — stale nonce, wrong request id — decided
+        nothing, so recording the decision it ASKED for would put an approval in
+        the SEL log that no tool ever received. That record is the only trace a
+        forged or replayed press leaves, and the reply it draws is the same one a
+        genuinely expired card draws, so nothing else would contradict it.
+        """
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient())
+        key = d._session_key(_EMAIL)
+        task = await self._pending(d, key)
+        nonce = webex_dispatch._APPROVALS.reserve(key, "1")
+
+        with mock.patch("kiro_crew.webex.transport_dispatch.sel") as fake_sel:
+            await d.handle_message(_approval_press("approve", "FORGED"))
+            # Still open: the refused press must not have spent the decision.
+            assert webex_dispatch._APPROVALS.has_pending(key)
+            await d.handle_message(_approval_press("approve", nonce))
+
+        assert await task is True
+        outcomes = [
+            c.kwargs["outcome"]
+            for c in fake_sel.return_value.log_api_access.mock_calls
+            if c.kwargs.get("operation") == "webex.tool_approval"
+        ]
+        assert outcomes == ["denied", "approved"]
+
+    @pytest.mark.asyncio
     async def test_governance_blocks_an_approve_but_still_resolves_a_deny(self) -> None:
         """A policy that forbids this channel has no interest in keeping a tool
         request alive for its whole window."""


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/webex/` carried a small pile of readability debt that the
module-simplification detector and a manual pass over all nine files turned up:

- **A chained ternary in a security-relevant audit label.** The card-approval
  path recorded its SEL outcome as
  `("approved" if approved else "denied") if resolved else "denied"` — a ternary
  nested inside a ternary, where a reader has to build the truth table to see
  the invariant it encodes.
- **The command vocabulary lived in three places.** `commands.py` had the named
  alias frozensets, a ten-branch `if cmd in _X_ALIASES: return "x"` chain in
  `parse_command`, and a hand-maintained twelve-way `|` union in
  `_ALL_COMMANDS`. A command added to the aliases but forgotten in either read
  as ordinary chat or was answered with "unknown command", and nothing reported
  it.
- **A comment attached to the wrong constant.** In `client.py` the two-line
  comment describing the Retry-After bounds sat twenty lines above
  `_RETRY_AFTER_MIN_S`/`_RETRY_AFTER_MAX_S` and directly on top of
  `_WDM_HOST_SUFFIXES`, the unrelated host allowlist that keeps the bot token
  from being POSTed to an attacker-named host — so a reader arriving at that
  allowlist read a preamble about HTTP back-off.
- **A superseded duplicate comment.** `_drain_queue` carried two adjacent
  comment blocks on the same variable; the first still called `convo` "the
  room", which it has not been since it became a `(room, thread root)` pair.
- Three `(x or {})` guards that the enclosing `isinstance(x, dict)` already
  guarantees, and a `retry_after = 1.0` pre-assignment shadowed by a
  `try`/`except … pass`.

## Why it matters

None of this is a live bug — that is the point, and it is also why it persists.
The cost is paid by the next person to change this module: the approval label is
the only trace a forged or replayed card press leaves in the audit log, and a
nested ternary is where a reader stops verifying and starts assuming. The
three-place command vocabulary is worse than untidy: it has no gate, so the
failure mode (a command that parses but is reported unknown, or vice versa) ships
silently.

While pinning the approval label I also found that nothing asserted it. The
existing `test_every_press_outcome_is_audited` counted the SEL emits and never
read their `outcome`, so that value could be reshaped — including into recording
a refused press as `approved` — with the whole suite green.

## What changed (motivation → approach → change)

**The audit label.** `outcome = "approved" if resolved and approved else "denied"`.
Truth-table identical over all four `(resolved, approved)` states; the `and`
fails closed in the same direction the old form did. The `resources=` string
still carries the raw `resolved` value, so "refused press" stays distinguishable
from "explicit deny" in the log. A new test
(`test_a_refused_press_never_audits_as_an_approval`) pins both directions: a
forged-nonce approve audits as `denied` and leaves the decision open, and the
honoured press that follows audits as `approved`. Verified by mutation — dropping
`resolved and` makes that test fail with
`assert ['approved', 'approved'] == ['denied', 'approved']`.

**The command table.** One `_ALIAS_TO_COMMAND` mapping now feeds both readers:
`parse_command` is a single `.get(_first_token(text))` and `_ALL_COMMANDS` is
`frozenset(_ALIAS_TO_COMMAND) | _MID_TURN_ALIASES`. The resulting set is
element-identical (16 tokens) and still a `frozenset`; all ten alias sets are
pairwise disjoint, so the if-chain's first-match and the comprehension's
last-write cannot disagree. `/queue` and `/steer` stay out of the mapping and in
the token set, which is what keeps a bare `/queue` on the usage path instead of
being resolved as a command that would swallow its message body.

The named frozensets are deliberately **kept**. A cross-channel tripwire in
`test_messaging_dispatch.py` `getattr`s `_STOP_ALIASES` off every channel's
`commands` module to check the shared cancel-during-a-governance-deny exemption
covers each channel's spellings. Folding that set inline would have dropped
webex out of the tripwire **silently** — the probe falls back to its default,
webex is not in that test's channel allowlist, its module docstring does not
mention `/stop`, and its two spellings are a subset of what the other channels
contribute, so the union assertion never moves. The comment on the mapping now
says exactly that, so the next simplification pass does not walk into it.

**The local cleanups.** The Retry-After comment moved onto the constants it
describes and is now qualified as the scan-wait (423) policy, since the 429
back-off in `_api` is a separate policy with its own narrower bounds and does not
read them. The `retry_after` default moved into the `except` that is its only
consumer. The three redundant `(x or {})` guards are gone; the five remaining
ones in the module are load-bearing (a possibly-absent nested key, or a
`dict | None` with no `isinstance` above it) and are untouched. The stale
duplicate comment is gone, with its one unique fact — why two people can share
one queue — folded into the survivor.

Not done, deliberately: the `_api` 429 clamp still uses inline `0.5`/`10.0`
rather than owning constants. Routing it through `_RETRY_AFTER_MIN_S`/`MAX_S`
would change its behaviour (floor 1.0, ceiling 15.0), which is not a
simplification.

## Tests

- **Added** `test_a_refused_press_never_audits_as_an_approval` — pins that the
  card-approval audit label follows the resolve rather than the button, in both
  directions. Mutation-verified as above.
- **Unchanged and re-run:** every test module that references webex — 44 files,
  **3069 passed, 5 xfailed**. That includes `test_webex_dispatch.py`,
  `test_webex_client.py`, `test_webex_transport.py`, `test_webex_renderer.py`,
  `test_webex_cards.py`, and the cross-channel `test_messaging_dispatch.py`
  tripwire, which still discovers webex's `{/stop, /cancel}`.

No test was weakened, skipped, or retried.

## Manual verification

N/A — unit coverage sufficient. This is a behaviour-preserving refactor with no
new surface: every rewrite is either truth-table identical, a dead guard
removal, or a comment. A review fleet proved each one equivalent against the
pre-diff code (truth tables for the ternary, a 200,000-input differential over
`parse_command`/`is_unknown_command` against `origin/main`'s module, and
per-shape tables for the three `(x or {})` sites including `None`, `{}`, missing
key, `null`, `[]`, `[""]`, and non-list values).

Local gates, all exit 0 on the Python 3.12 CI-parity venv: `flake8`, `isort
--check-only`, `mypy src/kiro_crew` (1102 files), `black --check` on the four
changed files, `check_black_formatting.py`, `check_subprocess_encoding.py`,
`check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only — the diff touches three files under
`src/kiro_crew/webex/` and one test, nothing under `website/`, so there is no
rendered surface to show. The one user-visible string family (the approval
replies) is byte-unchanged.

## Related Issues

no linked issue: campaign-driven readability pass, not a filed defect.

Two follow-ups worth their own PRs, found while reviewing this one and
deliberately left out of scope:

1. **The cross-channel cancel tripwire under-counts its own channels.** The
   discovery loop in `test_messaging_dispatch.py` hard-codes `{"discord",
   "telegram", "wecom", "teams", "whatsapp"}` as "the channels known to ship a
   cancel today", but it actually finds **seven** — `webex` and `weixin` are
   missing from that set, so either dropping out of the tripwire would go
   unnoticed. Adding only `webex` here would be the same one-of-a-pair
   inconsistency; it wants one PR that fixes both.
2. **The nested-ternary audit label has one unfixed sibling.** `teams`
   records the same shape at `src/kiro_crew/teams/transport_dispatch.py:557`
   — `("approved" if approved else "denied") if resolved else
   "denied_stale_card"` — in the same SEL `outcome=` position. It is not
   truth-table identical to webex's (its stale branch carries a third label),
   so it needs its own equivalence proof and its own test, and it is a
   different module: one module per PR is what keeps each of these reviewable.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented API, schema, or
      behaviour changed. `docs/system-specs/modules/messaging.md` documents
      `parse_command`'s behaviour, not its structure, and that behaviour is
      unchanged.
- [x] No secrets, credentials, or internal references in the diff

