### PR TITLE
fix(mcp-gateway): run _ensure_ssl_certs() prelude in gatewayd

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -415,6 +415,7 @@ per-file-ignores =
     # _ensure_ssl_certs() must run before any library caches its SSL context
     src/kiro_crew/cli.py: E402
     src/kiro_crew/__main__.py: E402
+    src/kiro_crew/mcp_gateway/gatewayd.py: E402
     # Builtin app backends use compact continuation indent style
     src/kiro_crew/apps/builtins/*: E128
 # Uncomment to enforce a maximum cyclomatic complexity - more info https://en.wikipedia.org/wiki/Cyclomatic_complexity

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -27,6 +27,16 @@ installed by the caller should just forward into ``stop_event.set()``.
 
 from __future__ import annotations
 
+# Ensure SSL certs are found before any library caches its SSL context.
+# This daemon is spawned directly as ``python -m kiro_crew.mcp_gateway.gatewayd``
+# (see manager.py), so it bypasses both ``__main__.py`` and ``cli.py`` and never
+# runs their ``_ensure_ssl_certs()`` prelude. Its module-scope imports below pull
+# in aiohttp-touching modules (e.g. ``.backend``), so this must run BEFORE them —
+# once a library caches its default SSL context, a later fix is too late.
+from kiro_crew._ssl_compat import _ensure_ssl_certs
+
+_ensure_ssl_certs()
+
 import argparse
 import asyncio
 import contextlib

--- a/test/test_ssl_certs.py
+++ b/test/test_ssl_certs.py
@@ -173,3 +173,22 @@ class TestEnsureSslCerts:
 
             importlib.reload(kiro_crew.cli)
         mock_fn.assert_called()
+
+    def test_gatewayd_invokes_ensure_ssl_certs(self):
+        """Reloading gatewayd.py must trigger _ensure_ssl_certs().
+
+        The gateway daemon is spawned directly as
+        ``python -m kiro_crew.mcp_gateway.gatewayd`` (see manager.py), bypassing
+        both cli.py and __main__.py, so it must run the prelude itself or TLS to
+        MCP endpoints validates against the wrong CA store (regression: #5602).
+        """
+        import importlib
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
+
+        mock_fn = MagicMock()
+        with _patch("kiro_crew._ssl_compat._ensure_ssl_certs", mock_fn):
+            import kiro_crew.mcp_gateway.gatewayd
+
+            importlib.reload(kiro_crew.mcp_gateway.gatewayd)
+        mock_fn.assert_called()


### PR DESCRIPTION
## Problem / Motivation

The MCP gateway daemon is spawned directly as `python -m kiro_crew.mcp_gateway.gatewayd` (see `mcp_gateway/manager.py`), so it bypasses both `__main__.py` and `cli.py` and never ran their `_ensure_ssl_certs()` prelude. Every other production entry point runs that prelude before any HTTPS library caches its default SSL context; the gateway daemon was the one that did not.

## Why it matters

There are two ways CA configuration can reach the gateway daemon, and they cover different launch paths:

- **Env inheritance (already works):** `GatewayManager._spawn_once` builds the child env as `_scrub_sensitive_env(dict(os.environ))` and passes it to `create_subprocess_exec(..., env=env)`. `_scrub_sensitive_env` only drops credential-prefixed keys, so `SSL_CERT_FILE` survives and is inherited. An env-var-shaped CA fix therefore reaches manager-spawned daemons for free — this prelude is **not** a prerequisite for that path.
- **Per-process prelude (this PR):** a `gatewayd` launched directly / adopted (not inheriting an already-fixed parent env), and any future non-env fix that must run per-process (e.g. an in-process context build or `truststore.inject_into_ssl()`), need the daemon to run the bootstrap itself.

So this PR is the belt-and-suspenders for the launch paths env inheritance does not reach, not a gate on the env fix. It is the missing-bootstrap piece of #5602: the daemon previously ran no CA bootstrap of any kind, so even the existing Linux CA-candidate logic never fired in this process.

## What changed (motivation → approach → change)

- **Symptom:** the gateway daemon's TLS setup never went through the project's CA bootstrap, unlike every other entry point.
- **Root cause:** `_ensure_ssl_certs()` is invoked only from `cli.py:26` and `__main__.py:24`; `gatewayd.py` is launched as its own module and imports neither, yet pulls in aiohttp-touching modules (e.g. `.backend`) at module scope.
- **Change:** add the same module-top `_ensure_ssl_certs()` prelude to `gatewayd.py`, placed **before** those imports (a CA bundle set after import is too late once a library caches its context), and list `gatewayd.py` in the `E402` `per-file-ignores` group in `setup.cfg` beside the two files that already carry the identical prelude.

## Tests

- Added `test/test_ssl_certs.py::TestEnsureSslCerts::test_gatewayd_invokes_ensure_ssl_certs`, mirroring the existing `test_cli_invokes_ensure_ssl_certs`: it reloads `kiro_crew.mcp_gateway.gatewayd` with `_ensure_ssl_certs` mocked and asserts the prelude fires. This locks in that the gateway entry point runs the CA bootstrap, so the regression cannot silently return.

## Manual verification

N/A — unit coverage sufficient. The change is a startup prelude with no user-visible surface; the new test asserts the invocation and `flake8`/`isort`/`mypy` pass on the edited files.

## Related Issues

Refs #5602 — this is the missing-bootstrap piece only. `_ensure_ssl_certs()` is still effectively a no-op on macOS (it returns as soon as the default `/etc/ssl/cert.pem` exists, never consulting the Keychain), so this PR does **not** close #5602; the macOS Keychain fix is tracked separately in that issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
