### PR TITLE
fix: reap children and keep temp cleanup on cancellation in whisper CLI and TTS paths (#5821)

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -805,7 +805,6 @@ async def _run_whisper_cli(
     two CLIs use hyphenated vs underscored option names).
     """
     out_dir = await asyncio.to_thread(tempfile.mkdtemp)
-    proc = None
     try:
         clean_env = _thread_capped_env()
         proc = await asyncio.create_subprocess_exec(
@@ -815,7 +814,47 @@ async def _run_whisper_cli(
             stderr=asyncio.subprocess.PIPE,
             env=clean_env,
         )
-        _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
+        try:
+            _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            else:
+                # Reap via communicate(), not wait(): it drains the PIPEs, so a
+                # child that died with a full pipe buffer cannot deadlock the
+                # reap. Deliberately ``except Exception`` (narrower than the
+                # cancellation arm's ``BaseException`` swallow below): a
+                # cancellation arriving during THIS reap should win over the
+                # ``return None``, and the ``finally`` still removes the
+                # directory either way.
+                try:
+                    await proc.communicate()
+                except Exception:
+                    logger.debug("%s wait after kill failed", label, exc_info=True)
+            logger.error("%s transcription timed out after %ds", label, timeout_secs)
+            return None
+        except BaseException:
+            # A cancellation mid-``communicate`` is a ``BaseException``, which
+            # the ``except asyncio.TimeoutError`` arm above never sees — the
+            # whisper child kept running as an orphan (#5821). Kill AND reap it
+            # before re-raising: Windows keeps the output files locked until
+            # the child fully exits, and on POSIX a live child can race the
+            # directory removal in the ``finally`` below.
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            else:
+                try:
+                    await proc.communicate()
+                except BaseException:
+                    # A repeat cancellation can land on the reap await; swallow
+                    # it so the directory removal still runs and the ORIGINAL
+                    # exception is the one that propagates.
+                    pass
+            raise
         return await asyncio.to_thread(
             _collect_whisper_output,
             proc.returncode,
@@ -823,17 +862,18 @@ async def _run_whisper_cli(
             out_dir,
             label,
         )
-    except asyncio.TimeoutError:
-        if proc is not None:
-            try:
-                proc.kill()
-            except OSError:
-                pass
-            await proc.wait()
-        logger.error("%s transcription timed out after %ds", label, timeout_secs)
-        return None
     finally:
-        await asyncio.to_thread(shutil.rmtree, out_dir, ignore_errors=True)
+        # The removal stays OFF the event loop, and scheduling it as its own
+        # task BEFORE awaiting is what closes the #5821 leak: a repeat
+        # cancellation (or KeyboardInterrupt) landing on this await abandons
+        # only the wait — the already-scheduled task still runs the removal to
+        # completion in its worker thread. ``shield`` keeps that cancellation
+        # from propagating INTO the removal task, while the exception itself
+        # still reaches the awaiter.
+        rm = asyncio.ensure_future(
+            asyncio.to_thread(shutil.rmtree, out_dir, ignore_errors=True)
+        )
+        await asyncio.shield(rm)
 
 
 # Defense in depth: ``mlx_model`` is read from config.json. The dashboard PUT

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -323,10 +323,11 @@ async def _synthesize_piper(
                     proc.communicate(text.encode("utf-8")),
                     timeout=60,
                 )
-            except (asyncio.TimeoutError, asyncio.CancelledError) as exc:
-                # asyncio.wait_for cancels communicate() on timeout — and a
-                # caller cancellation (client disconnect) arrives here as
-                # CancelledError — but neither terminates the child process:
+            except BaseException as exc:
+                # ``asyncio.wait_for`` cancels ``communicate()`` on timeout —
+                # and a caller cancellation (client disconnect) arrives here as
+                # CancelledError, as do interpreter-exit signals such as
+                # KeyboardInterrupt — but none of them terminate the child:
                 # kill it explicitly to avoid a zombie piper consuming CPU
                 # after we exit. Temp-file discard is owned by the ``finally``
                 # invariant below.
@@ -335,14 +336,25 @@ async def _synthesize_piper(
                     logger.error("piper timed out after 60s; killing subprocess")
                 try:
                     proc.kill()
-                except ProcessLookupError:
+                except OSError:
                     pass
+                # Reap via communicate(), not wait(): wait_for already
+                # cancelled the pipe readers, so a killed child blocked on a
+                # full PIPE would never be drained and wait() would hang.
                 try:
-                    await proc.wait()
+                    await proc.communicate()
                 except Exception:
                     logger.debug("piper wait after kill failed", exc_info=True)
+                except BaseException:
+                    # A repeat cancellation can land on the reap await. When we
+                    # are already propagating (non-timeout path) swallow it so
+                    # the ORIGINAL exception is the one that propagates; on the
+                    # timeout path it is a genuinely new cancellation, so let
+                    # it out.
+                    if timed_out:
+                        raise
                 if not timed_out:
-                    raise  # CancelledError must propagate to the caller
+                    raise  # cancellation/interrupt must propagate to the caller
                 return None
             if proc.returncode != 0:
                 logger.error(
@@ -532,26 +544,39 @@ async def _synthesize_polly(
             )
             try:
                 _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            except (asyncio.TimeoutError, asyncio.CancelledError) as exc:
+            except BaseException as exc:
                 # ``asyncio.wait_for`` cancels ``proc.communicate()`` on
                 # timeout — and a caller cancellation (client disconnect)
-                # arrives here as CancelledError — but neither terminates the
-                # child: kill it explicitly to avoid a hung ``aws polly``
-                # process consuming resources after we exit. Temp-file discard
-                # is owned by the ``finally`` invariant below.
+                # arrives here as CancelledError, as do interpreter-exit
+                # signals such as KeyboardInterrupt — but none of them
+                # terminate the child: kill it explicitly to avoid a hung
+                # ``aws polly`` process consuming resources after we exit.
+                # Temp-file discard is owned by the ``finally`` invariant
+                # below.
                 timed_out = isinstance(exc, asyncio.TimeoutError)
                 if timed_out:
                     logger.error("Polly timed out after 30s; killing subprocess")
                 try:
                     proc.kill()
-                except ProcessLookupError:
+                except OSError:
                     pass
+                # Reap via communicate(), not wait(): wait_for already
+                # cancelled the pipe readers, so a killed child blocked on a
+                # full PIPE would never be drained and wait() would hang.
                 try:
-                    await proc.wait()
+                    await proc.communicate()
                 except Exception:
                     logger.debug("polly wait after kill failed", exc_info=True)
+                except BaseException:
+                    # A repeat cancellation can land on the reap await. When we
+                    # are already propagating (non-timeout path) swallow it so
+                    # the ORIGINAL exception is the one that propagates; on the
+                    # timeout path it is a genuinely new cancellation, so let
+                    # it out.
+                    if timed_out:
+                        raise
                 if not timed_out:
-                    raise  # CancelledError must propagate to the caller
+                    raise  # cancellation/interrupt must propagate to the caller
                 return None
             if proc.returncode != 0:
                 logger.error("Polly failed: %s", stderr.decode())

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -1824,3 +1824,237 @@ class TestTranscribeAwsTempOwnership:
         # is exception identity, not removal.
         assert owned.exists()
         assert src.exists()
+
+
+# ---------------------------------------------------------------------------
+# _run_whisper_cli child/temp-dir ownership under cancellation (#5821)
+# ---------------------------------------------------------------------------
+
+
+class TestRunWhisperCliTempOwnership:
+    """``_run_whisper_cli`` owns its child and ``out_dir`` until every exit reaps
+    and removes them.
+
+    A cancellation mid-``communicate`` (``CancelledError`` is a
+    ``BaseException``, so the ``except asyncio.TimeoutError`` arm misses it)
+    must kill AND reap the whisper child before the directory removal — Windows
+    keeps the output files locked until the child fully exits — and the
+    ``finally`` removal is shielded so a REPEAT cancellation cannot
+    land on it and skip the cleanup. Reference pattern:
+    ``test_apple_speech.py::TestTranscodeTempOwnership`` (#5777).
+    """
+
+    @staticmethod
+    def _pin_out_dir(tmp_path, monkeypatch):
+        """Pin ``tempfile.mkdtemp`` to a known directory so tests can watch it."""
+        out_dir = tmp_path / "whisper-out"
+        out_dir.mkdir()
+        monkeypatch.setattr(transcribe.tempfile, "mkdtemp", lambda: str(out_dir))
+        return out_dir
+
+    @staticmethod
+    def _track_rmtree(monkeypatch, out_dir, events):
+        real_rmtree = transcribe.shutil.rmtree
+
+        def tracked(path, *args, **kwargs):
+            if str(path) == str(out_dir):
+                events.append("rmtree")
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(transcribe.shutil, "rmtree", tracked)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_the_child_before_removing_out_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation mid-``communicate`` must kill the child, reap it, THEN
+        remove ``out_dir``, and re-raise — the old code only killed on the
+        ``TimeoutError`` branch, orphaning the child (#5821)."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+        events: list[str] = []
+        self._track_rmtree(monkeypatch, out_dir, events)
+
+        class _Proc:
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise asyncio.CancelledError()
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        with patch("asyncio.create_subprocess_exec", return_value=_Proc()):
+            with pytest.raises(asyncio.CancelledError):
+                await transcribe._run_whisper_cli(
+                    "/fake/whisper", lambda d: [d], 10, label="test"
+                )
+        assert events == ["killed", "reaped", "rmtree"]
+        assert not out_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_on_the_reap_still_removes_out_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """A REPEAT cancellation landing on the ``finally`` removal await
+        abandons only the wait: the removal was already scheduled as its own
+        task, so it still runs to completion off-loop — the old code awaited
+        the hop directly, so the repeat cancellation skipped the removal and
+        leaked the directory (#5821)."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+        events: list[str] = []
+        self._track_rmtree(monkeypatch, out_dir, events)
+
+        # Model the repeat cancellation landing on the ``finally`` removal
+        # await: hold the removal hop open on an Event, cancel the task while
+        # it awaits, and only then release the hop. The removal must still run
+        # to completion — the old code awaited the hop directly, so abandoning
+        # the await abandoned the removal and leaked the directory. The
+        # ``func is ...rmtree`` predicate is load-bearing: ``asyncio.to_thread``
+        # is patched process-wide, so a wider predicate would capture any
+        # concurrent off-loop hop (the ``mkdtemp`` allocation included).
+        hop_reached = asyncio.Event()
+        hop_release = asyncio.Event()
+        real_to_thread = asyncio.to_thread
+
+        async def held_rmtree_hop(func, *args, **kwargs):
+            if func is transcribe.shutil.rmtree:
+                hop_reached.set()
+                await hop_release.wait()
+                return func(*args, **kwargs)
+            return await real_to_thread(func, *args, **kwargs)
+
+        monkeypatch.setattr(asyncio, "to_thread", held_rmtree_hop)
+
+        class _Proc:
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise asyncio.CancelledError()
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        with patch("asyncio.create_subprocess_exec", return_value=_Proc()):
+            task = asyncio.ensure_future(
+                transcribe._run_whisper_cli("/fake/whisper", lambda d: [d], 10, label="test")
+            )
+            await hop_reached.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # The await was abandoned by the repeat cancellation, but the
+            # removal had already been scheduled as its own task: releasing
+            # the hop lets it finish.
+            assert "rmtree" not in events
+            hop_release.set()
+            for _ in range(50):
+                if "rmtree" in events:
+                    break
+                await asyncio.sleep(0)
+        assert events == ["killed", "reaped", "rmtree"]
+        assert not out_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_permission_error_from_kill_does_not_replace_the_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        """``kill()`` raising ``PermissionError`` (an ``OSError``, e.g. a child
+        in a state the OS refuses to signal) is swallowed: the removal still
+        runs and the in-flight cancellation — not the ``PermissionError`` —
+        reaches the awaiter."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+        events: list[str] = []
+        self._track_rmtree(monkeypatch, out_dir, events)
+
+        class _Proc:
+            async def communicate(self):
+                raise asyncio.CancelledError()
+
+            def kill(self):
+                events.append("kill_attempted")
+                raise PermissionError("operation not permitted")
+
+        with patch("asyncio.create_subprocess_exec", return_value=_Proc()):
+            with pytest.raises(asyncio.CancelledError):
+                await transcribe._run_whisper_cli(
+                    "/fake/whisper", lambda d: [d], 10, label="test"
+                )
+        assert events == ["kill_attempted", "rmtree"]
+        assert not out_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_timeout_still_reaps_and_returns_none(self, tmp_path, monkeypatch):
+        """The new cancellation arm must not eat the established timeout
+        contract: kill, reap, log, return None, remove ``out_dir``."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+        events: list[str] = []
+        self._track_rmtree(monkeypatch, out_dir, events)
+
+        class _Proc:
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    await asyncio.sleep(3600)
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        with patch("asyncio.create_subprocess_exec", return_value=_Proc()):
+            result = await transcribe._run_whisper_cli(
+                "/fake/whisper", lambda d: [d], 0.01, label="test"
+            )
+        assert result is None
+        assert events == ["killed", "reaped", "rmtree"]
+        assert not out_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_success_still_hands_the_transcript_to_the_caller(
+        self, tmp_path, monkeypatch
+    ):
+        """The cleanup must not eat the success path: the transcript written
+        into ``out_dir`` is collected before the directory is removed."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+        (out_dir / "voice.txt").write_text("hello world")
+
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await transcribe._run_whisper_cli(
+                "/fake/whisper", lambda d: [d], 10, label="test"
+            )
+        assert result == "hello world"
+        assert not out_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_spawn_still_removes_out_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation landing on ``create_subprocess_exec`` itself means no
+        child exists — ``out_dir`` must still be removed and the cancellation
+        must propagate."""
+        out_dir = self._pin_out_dir(tmp_path, monkeypatch)
+
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=asyncio.CancelledError()
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await transcribe._run_whisper_cli(
+                    "/fake/whisper", lambda d: [d], 10, label="test"
+                )
+        assert not out_dir.exists()

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -617,7 +617,10 @@ class TestSynthesizePiper:
             assert await _synthesize_piper("hello", piper_model=str(model)) is None
 
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        # The reap goes through communicate(), not wait(): wait_for already
+        # cancelled the pipe readers, so wait() on a full-PIPE child hangs.
+        proc.communicate.assert_awaited()
+        proc.wait.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_timeout_survives_process_lookup_error(self, tmp_path) -> None:
@@ -674,8 +677,11 @@ class TestSynthesizePiper:
 
         # wait_for cancels communicate() but does not terminate the child;
         # the child must be killed and reaped, and the owned temp discarded.
+        # The reap goes through communicate(), not wait(): wait_for already
+        # cancelled the pipe readers, so wait() on a full-PIPE child hangs.
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        assert proc.communicate.await_count >= 2
+        proc.wait.assert_not_awaited()
         assert len(allocated) == 1
         assert not os.path.exists(allocated[0])
 
@@ -984,7 +990,10 @@ class TestSynthesizePolly:
             assert await _synthesize_polly("<speak>hi</speak>") is None
 
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        # The reap goes through communicate(), not wait(): wait_for already
+        # cancelled the pipe readers, so wait() on a full-PIPE child hangs.
+        proc.communicate.assert_awaited()
+        proc.wait.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_timeout_survives_process_lookup_error(self, tmp_path) -> None:
@@ -1025,8 +1034,11 @@ class TestSynthesizePolly:
 
         # wait_for cancels communicate() but does not terminate the child;
         # the child must be killed and reaped, and the owned temp discarded.
+        # The reap goes through communicate(), not wait(): wait_for already
+        # cancelled the pipe readers, so wait() on a full-PIPE child hangs.
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        assert proc.communicate.await_count >= 2
+        proc.wait.assert_not_awaited()
         assert len(allocated) == 1
         assert not os.path.exists(allocated[0])
 
@@ -1601,3 +1613,280 @@ class TestStitchMp3s:
             # the mkstemp file behind as test residue.
             if allocated and os.path.exists(allocated[0]):
                 os.unlink(allocated[0])
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_piper / _synthesize_polly temp ownership under cancellation (#5821)
+# ---------------------------------------------------------------------------
+
+
+class _CancelOnceProc:
+    """Process double: first ``communicate`` raises ``CancelledError``, the
+    second (the reap) records itself and returns."""
+
+    def __init__(self, events: list[str]):
+        self._events = events
+        self._calls = 0
+
+    async def communicate(self, _input: bytes | None = None):
+        self._calls += 1
+        if self._calls == 1:
+            raise asyncio.CancelledError()
+        self._events.append("reaped")
+        return b"", b""
+
+    def kill(self):
+        self._events.append("killed")
+
+
+class _CancelAlwaysProc:
+    """Process double: EVERY ``communicate`` raises ``CancelledError`` — the
+    second raise is the repeat cancellation landing on the reap await."""
+
+    def __init__(self, events: list[str]):
+        self._events = events
+
+    async def communicate(self, _input: bytes | None = None):
+        raise asyncio.CancelledError()
+
+    def kill(self):
+        self._events.append("killed")
+
+
+def _pin_mkstemp(monkeypatch, owned) -> None:
+    """Pin ``tempfile.mkstemp`` to a known file so the tests can watch it."""
+
+    def fake_mkstemp(suffix: str = ""):
+        return os.open(str(owned), os.O_WRONLY | os.O_CREAT), str(owned)
+
+    monkeypatch.setattr("kiro_crew.voice_reply.tempfile.mkstemp", fake_mkstemp)
+
+
+def _track_unlink(monkeypatch, owned, events: list[str]) -> None:
+    real_unlink = os.unlink
+
+    def tracked(path, *args, **kwargs):
+        if str(path) == str(owned):
+            events.append("unlinked")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr("kiro_crew.voice_reply.os.unlink", tracked)
+
+
+class TestSynthesizePiperCancelOwnership:
+    """``_synthesize_piper`` owns the ``.wav`` until every exit removes it.
+
+    A cancellation mid-``communicate`` (``CancelledError`` is a
+    ``BaseException``, so the ``except Exception`` guard missed it) must kill
+    AND reap the piper child before the unlink — Windows keeps the output file
+    locked until the child fully exits — then remove the ``.wav`` and
+    re-raise. Reference pattern:
+    ``test_apple_speech.py::TestTranscodeTempOwnership`` (#5777).
+    """
+
+    @staticmethod
+    def _piper_env(tmp_path, monkeypatch):
+        bin_path = tmp_path / "piper"
+        _make_executable(str(bin_path))
+        model = tmp_path / "voice.onnx"
+        model.write_bytes(b"m")
+        owned = tmp_path / "owned.wav"
+        _pin_mkstemp(monkeypatch, owned)
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply._resolve_piper_binary", lambda cfg: str(bin_path)
+        )
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply.wrap_argv", lambda c, mode: (list(c), None)
+        )
+        return model, owned
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_piper_before_removing_the_wav(
+        self, tmp_path, monkeypatch
+    ):
+        model, owned = self._piper_env(tmp_path, monkeypatch)
+        events: list[str] = []
+        _track_unlink(monkeypatch, owned, events)
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelOnceProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+        assert events == ["killed", "reaped", "unlinked"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_on_the_reap_still_unlinks(
+        self, tmp_path, monkeypatch
+    ):
+        """A REPEAT cancellation landing on the reap await is swallowed so the
+        unlink still runs and the ORIGINAL cancellation propagates."""
+        model, owned = self._piper_env(tmp_path, monkeypatch)
+        events: list[str] = []
+        _track_unlink(monkeypatch, owned, events)
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelAlwaysProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+        assert events == ["killed", "unlinked"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_locked_wav_does_not_replace_the_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        """Worst case on Windows: the child still holds the ``.wav`` so the
+        unlink raises ``PermissionError``. That must not REPLACE the in-flight
+        cancellation — the ``OSError`` guard swallows it and the original
+        propagates."""
+        model, owned = self._piper_env(tmp_path, monkeypatch)
+        events: list[str] = []
+
+        def locked_unlink(path, *args, **kwargs):
+            if str(path) == str(owned):
+                events.append("unlink_attempted")
+                raise PermissionError("file is locked by the child")
+            return os.remove(path)
+
+        monkeypatch.setattr("kiro_crew.voice_reply.os.unlink", locked_unlink)
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelOnceProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+        assert events == ["killed", "reaped", "unlink_attempted"]
+        # The locked unlink never removed the file — the guarantee under test
+        # is exception identity, not removal.
+        assert owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_spawn_still_removes_the_wav(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation landing on the spawn itself means no child exists —
+        the ``.wav`` must still be removed and the cancellation propagate."""
+        model, owned = self._piper_env(tmp_path, monkeypatch)
+
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=asyncio.CancelledError()
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_still_unlinks_the_sandbox_cleanup_path(
+        self, tmp_path, monkeypatch
+    ):
+        """The outer ``finally`` owns the wrap_argv cleanup path; a cancelled
+        synthesis must not leak the launcher script either."""
+        model, owned = self._piper_env(tmp_path, monkeypatch)
+        launcher = tmp_path / "launcher.sh"
+        launcher.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply.wrap_argv",
+            lambda c, mode: (list(c), str(launcher)),
+        )
+        events: list[str] = []
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelOnceProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+        assert not owned.exists()
+        assert not launcher.exists()
+
+
+class TestSynthesizePollyCancelOwnership:
+    """``_synthesize_polly`` owns the ``.mp3`` until every exit removes it.
+
+    Same cancellation contract as the piper path above: kill AND reap the AWS
+    CLI child before the unlink, remove the ``.mp3``, re-raise the original
+    cancellation (#5821).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _sandbox_and_consent(self, monkeypatch, _polly_consented):
+        monkeypatch.setattr(
+            "kiro_crew.voice_reply.wrap_argv", lambda argv, **k: (list(argv), None)
+        )
+        _patch_aws_on_path(monkeypatch)
+
+    @staticmethod
+    def _owned_mp3(tmp_path, monkeypatch):
+        owned = tmp_path / "owned.mp3"
+        _pin_mkstemp(monkeypatch, owned)
+        return owned
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_the_cli_before_removing_the_mp3(
+        self, tmp_path, monkeypatch
+    ):
+        owned = self._owned_mp3(tmp_path, monkeypatch)
+        events: list[str] = []
+        _track_unlink(monkeypatch, owned, events)
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelOnceProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+        assert events == ["killed", "reaped", "unlinked"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_on_the_reap_still_unlinks(
+        self, tmp_path, monkeypatch
+    ):
+        owned = self._owned_mp3(tmp_path, monkeypatch)
+        events: list[str] = []
+        _track_unlink(monkeypatch, owned, events)
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelAlwaysProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+        assert events == ["killed", "unlinked"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_locked_mp3_does_not_replace_the_cancellation(
+        self, tmp_path, monkeypatch
+    ):
+        owned = self._owned_mp3(tmp_path, monkeypatch)
+        events: list[str] = []
+
+        def locked_unlink(path, *args, **kwargs):
+            if str(path) == str(owned):
+                events.append("unlink_attempted")
+                raise PermissionError("file is locked by the child")
+            return os.remove(path)
+
+        monkeypatch.setattr("kiro_crew.voice_reply.os.unlink", locked_unlink)
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=_CancelOnceProc(events)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+        assert events == ["killed", "reaped", "unlink_attempted"]
+        # The locked unlink never removed the file — the guarantee under test
+        # is exception identity, not removal.
+        assert owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_spawn_still_removes_the_mp3(
+        self, tmp_path, monkeypatch
+    ):
+        owned = self._owned_mp3(tmp_path, monkeypatch)
+
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=asyncio.CancelledError()
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+        assert not owned.exists()


### PR DESCRIPTION
## Problem / Motivation

Cancelling a chat turn (or shutting down the gateway) while speech is in flight leaked a live child process and its temp file:

1. `transcribe._run_whisper_cli` kills the whisper/mlx child only on the `asyncio.TimeoutError` branch. A `CancelledError` mid-`communicate` is a `BaseException` that arm never sees, so the child keeps running as an orphan — and the `finally` directory removal rode a cancellable `asyncio.to_thread` hop, so a repeat cancellation delivered during unwinding skipped the removal and leaked the `mkdtemp` directory too.
2. `voice_reply._synthesize_piper` / `_synthesize_polly`: since #5844 landed on main, the base already kills+reaps on timeout/cancellation and a `finally` invariant discards the temp file on every unsuccessful exit. What remains at these sites: the base reaps via `proc.wait()` (which can hang — `wait_for` already cancelled the pipe readers, so a killed child blocked writing to a full PIPE is never drained), and interpreter-exit signals (`KeyboardInterrupt`, `GeneratorExit`, `SystemExit`) escape the `(TimeoutError, CancelledError)` arm entirely, leaving the child unkilled and unreaped.

## Why it matters

Every cancelled voice turn strands a CPU-consuming child (whisper decodes are the heavy case) and, at the whisper site, a temp directory that survives for the life of the host. On Windows the ordering defect is worse: the child holds its output file locked until it fully exits, so cleanup that runs before the reap fails and re-leaks the file. This is the same residue class fixed by #5777 (apple_speech transcode) and #5844 (piper/polly cancellation), and in flight for `_transcribe_aws` in #5809.

## What changed (motivation → approach → change)

Applied the cancel-safe sequence established by merged #5777 at the whisper site — catch the cancellation, **kill** the child, **reap** it via `proc.communicate()` with a repeat-cancellation swallow so the cleanup still runs and the ORIGINAL exception propagates — and tightened the piper/polly reap semantics on top of #5844's base. Kill+reap stays BEFORE the cleanup because Windows holds the output file until the child exits.

Per-site notes:

- `_run_whisper_cli`: new `except BaseException` arm kills and reaps a cancelled child; the timeout arm's reap also moved from `proc.wait()` to `proc.communicate()` (full-PIPE hang, see above). The `finally` keeps the directory removal on an off-loop `to_thread` hop for loop hygiene, wrapped as `await asyncio.shield(asyncio.ensure_future(...))` — a repeat cancellation delivered during teardown cancels only the shielded await, not the removal task, so the directory is still removed while the interrupting exception reaches the awaiter (it must — suppressing it would swallow a first-delivery cancellation on the clean-return path; an original exception rides along as `__context__`).
- `_synthesize_piper` / `_synthesize_polly`: the base's `except (TimeoutError, CancelledError)` arm is widened to a single `except BaseException` arm per function — same kill, but the reap moves from `wait()` to `communicate()` (full-PIPE hang) and interpreter-exit signals are now covered. A repeat cancellation landing on the reap await is swallowed only while an original exception is already propagating; on the timeout path it is a genuinely new cancellation and propagates. Temp-file discard stays owned by the base's `finally ... if not succeeded` invariant (#5844); this PR adds no unlink arms. The existing `wrap_argv` sandbox-cleanup `finally` already covers the launcher script on all paths.

Deliberately NOT touched: `_transcribe_aws` (owned by in-flight #5809) and the `stitch_mp3s` / ffmpeg-helper `wait()` reaps (pre-existing, tracked separately). No shared helper: the sites span two modules and the merged reference (#5777) inlines the same arms; a cross-module helper would add coupling for ~10 lines.

## Tests

Three new regression classes mirroring `test_apple_speech.py::TestTranscodeTempOwnership` (#5777), mutation-verified on the pre-fix source:

- `test_transcribe.py::TestRunWhisperCliTempOwnership` — cancellation kills→reaps→removes in that order (event-list assertion, not just end state); a REPEAT cancellation on the reap still removes the directory and the original cancellation propagates (with the shielded off-loop removal hop pinned by injecting a `CancelledError` into it); `PermissionError` from `kill()` never replaces the cancellation; cancellation during spawn still removes the directory; timeout and success contracts preserved.
- `test_voice_reply.py::TestSynthesizePiperCancelOwnership` / `TestSynthesizePollyCancelOwnership` — same shapes per site, plus: a locked (`PermissionError`) unlink preserves exception identity, and a cancelled piper synthesis still unlinks the `wrap_argv` sandbox launcher.
- Existing timeout tests and #5844's cancellation tests updated to pin the `communicate()` reap (`communicate` awaited, `wait.assert_not_awaited()`).

## Manual verification

N/A — unit coverage sufficient: the defect and fix are exception-flow ordering, deterministically pinned by the event-list tests; no UI or external service involved.

## Related Issues

Closes #5821

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — inline comments document the invariants; no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff
