### PR TITLE
fix(apple_speech): drop the sandbox launcher on cancellation (#5796)

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -23,6 +23,7 @@ otherwise.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -385,6 +386,38 @@ def _drop_sandbox_launcher(path: str | None) -> None:
         pass
 
 
+async def _sandboxed_off_loop(argv: list[str]) -> tuple[list[str], dict[str, str], str | None]:
+    """Offload :func:`_sandboxed` to a worker thread without a cancellation leak.
+
+    A plain ``asyncio.to_thread`` hop is the leak: cancelling the awaiting
+    coroutine abandons the hop while the worker thread is still inside
+    ``sandboxed_spawn_argv``, the thread goes on to materialize the
+    launcher/profile, and the returned tuple is never bound — so no ``finally``
+    and no session field can ever reach the cleanup path. Shielding the hop
+    keeps the worker's result recoverable: on cancellation, wait for it to
+    settle, drop the launcher it made, then re-raise. Same shape as
+    ``kiro_prerequisite``'s sandboxed-spawn preparation.
+
+    ``SandboxUnavailableError`` still propagates to the caller unchanged — the
+    shield only intercepts cancellation, and that raise carries no tuple and
+    hence no file to drop.
+    """
+    task = asyncio.create_task(asyncio.to_thread(_sandboxed, argv))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        cleanup: str | None = None
+        # `BaseException`, not `Exception`: a repeat cancellation can land on
+        # this recovery await, and letting it out of the handler would skip the
+        # drop below — the exact leak this helper exists to close. Swallow it
+        # so the drop still runs and the ORIGINAL cancellation is the one that
+        # propagates (same shape as `_to_native_audio`'s reap-on-cancel).
+        with contextlib.suppress(BaseException):
+            _, _, cleanup = await task
+        _drop_sandbox_launcher(cleanup)
+        raise
+
+
 def _mkstemp_path(suffix: str) -> str:
     """Create an empty temp file and return its path, descriptor already closed.
 
@@ -623,7 +656,7 @@ async def transcribe(
         argv.append(native_path)
 
         try:
-            argv, spawn_env, sb_cleanup = await asyncio.to_thread(_sandboxed, argv)
+            argv, spawn_env, sb_cleanup = await _sandboxed_off_loop(argv)
         except sandbox.SandboxUnavailableError as exc:
             logger.warning("apple_speech: %s%s", _NO_SANDBOX_HINT, exc)
             return None, {"error": f"{_NO_SANDBOX_HINT}{exc}"}
@@ -684,9 +717,7 @@ async def inventory() -> dict:
     inv_cleanup: str | None = None
     try:
         try:
-            inv_argv, inv_env, inv_cleanup = await asyncio.to_thread(
-                _sandboxed, [helper, "--inventory"]
-            )
+            inv_argv, inv_env, inv_cleanup = await _sandboxed_off_loop([helper, "--inventory"])
         except sandbox.SandboxUnavailableError as exc:
             return {"error": f"{_NO_SANDBOX_HINT}{exc}"}
         proc = await asyncio.create_subprocess_exec(
@@ -769,9 +800,8 @@ class StreamingSession:
             return "streaming speech helper could not be built"
         try:
             try:
-                stream_argv, stream_env, self._sb_cleanup = await asyncio.to_thread(
-                    _sandboxed,
-                    [helper, "--locale", self.locale, "--sample-rate", str(self.sample_rate)],
+                stream_argv, stream_env, self._sb_cleanup = await _sandboxed_off_loop(
+                    [helper, "--locale", self.locale, "--sample-rate", str(self.sample_rate)]
                 )
             except sandbox.SandboxUnavailableError as exc:
                 return f"{_NO_SANDBOX_HINT}{exc}"
@@ -788,6 +818,15 @@ class StreamingSession:
             cleanup, self._sb_cleanup = self._sb_cleanup, None
             _drop_sandbox_launcher(cleanup)
             return f"could not start streaming helper: {exc}"
+        except BaseException:
+            # Cancellation between the tuple binding and the spawn completing:
+            # `CancelledError` is a `BaseException`, so the `OSError` drop above
+            # never sees it, and the caller's teardown only exists after start()
+            # returns. close() is the right teardown even though `_proc` is
+            # still unbound here — it kills+reaps whatever was spawned before
+            # unlinking, and is a no-op for the parts that never came up.
+            await self.close()
+            raise
 
         self._pump = asyncio.create_task(self._read_events())
         try:
@@ -795,6 +834,13 @@ class StreamingSession:
         except asyncio.TimeoutError:
             await self.close()
             return "streaming helper did not become ready"
+        except BaseException:
+            # Cancellation anywhere in the readiness wait leaves a live helper
+            # and a held launcher with no owner yet; run the session's own
+            # teardown — kill+reap, then unlink — before the cancellation
+            # surfaces.
+            await self.close()
+            raise
         if first is None:
             await self.close()
             return "streaming helper exited before becoming ready"

--- a/src/kiro_crew/dashboard/stt_stream.py
+++ b/src/kiro_crew/dashboard/stt_stream.py
@@ -348,7 +348,22 @@ async def _run_apple_session(
         locale=cfg.stt.language_code or "en-US",
         sample_rate=STREAM_SAMPLE_RATE_HZ,
     )
-    problem = await session.start()
+    try:
+        problem = await session.start()
+    except BaseException:
+        # A cancelled start() has no owner on this side yet: the teardown
+        # `finally` below only exists once start() has returned. close() is
+        # idempotent, so running it on top of start()'s own cancellation
+        # cleanup is safe, and the endpointer holds no tasks this early so
+        # its aclose() is a free symmetry with the failure branch below. The
+        # end audit keeps the trail balanced — the stt_stream_start already
+        # emitted would otherwise have no matching end, since the raise
+        # bypasses every later emitter.
+        await session.close()
+        if endpointer is not None:
+            await endpointer.aclose()
+        _emit_end_audit(caller, outcome="error")
+        raise
     if problem:
         try:
             await ws.send_json({"type": "error", "message": problem})

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -14,6 +14,7 @@ import json
 import os
 import platform
 import sys
+import threading
 from contextlib import ExitStack
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -130,10 +131,17 @@ class TestHelperBuild:
 
         The backend probe runs `sandbox-exec` on macOS (measured 17.7ms cold, 0.3ms
         cached) and all three call sites are `async`. Keeping the probe out of
-        `availability()` was necessary but NOT sufficient. Pinned at the source level
-        so a new async call site that forgets `asyncio.to_thread` fails here instead
-        of stalling the gateway's loop in production.
+        `availability()` was necessary but NOT sufficient. Every async caller must
+        route through `_sandboxed_off_loop`, which owns both halves of the
+        invariant: the worker-thread hop (loop safety) and the shield around it
+        (a cancelled awaiter can still recover and drop the launcher the thread
+        made). Pinned at the source level so a new async call site that reaches
+        `_sandboxed` any other way fails here instead of stalling the gateway's
+        loop — or leaking one launcher per cancelled call — in production.
         """
+        hop = inspect.getsource(apple_speech._sandboxed_off_loop)
+        assert "to_thread" in hop, "the hop must stay off the event loop"
+        assert "shield" in hop, "the hop must stay recoverable under cancellation"
         for fn in (
             apple_speech.transcribe,
             apple_speech.inventory,
@@ -142,10 +150,10 @@ class TestHelperBuild:
             body = inspect.getsource(fn)
             if "_sandboxed" not in body:
                 continue
-            assert "to_thread" in body, fn.__name__
+            assert "_sandboxed_off_loop(" in body, fn.__name__
             for line in body.splitlines():
                 stripped = line.strip()
-                if "_sandboxed(" in stripped and "to_thread" not in stripped:
+                if "_sandboxed(" in stripped:
                     raise AssertionError(f"{fn.__name__} calls _sandboxed inline: {stripped}")
 
     def test_every_helper_execution_is_sandboxed(self):
@@ -919,6 +927,163 @@ class TestSandboxCleanupPathIsDropped:
             problem = await session.start()
         assert problem == "streaming helper did not become ready"
         assert created and not any(f.exists() for f in created)
+
+
+class TestSandboxCancellationWindows:
+    """Cancellation around the launcher lifecycle must not orphan the temp.
+
+    `asyncio.CancelledError` is a `BaseException`, so the `except Exception` /
+    `except OSError` paths that own the unlink never see it. Two window shapes
+    are pinned here, at each await point: (1) cancellation DURING the
+    worker-thread `_sandboxed` hop — the thread still creates the launcher, but
+    the returned tuple is never bound, so no `finally` and no session field can
+    ever reach it; (2) `StreamingSession.start()` cancelled AFTER the tuple is
+    bound (mid-spawn, or anywhere in the readiness wait). The caller-side
+    guarantee at the `await session.start()` call site is pinned in
+    test_stt_stream.py.
+    """
+
+    @staticmethod
+    def _availability_ok():
+        return patch.object(
+            apple_speech, "availability", return_value=apple_speech.Availability(True)
+        )
+
+    @staticmethod
+    def _blocking_sandbox(tmp_path):
+        """A `_sandboxed` stub that parks the worker thread until released.
+
+        Reproduces the race deterministically: the awaiting coroutine is
+        cancelled while the thread is still inside `sandboxed_spawn_argv`, and
+        the launcher only comes into being AFTER the cancellation landed.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        created: list = []
+
+        def _fake(argv):
+            entered.set()
+            assert release.wait(timeout=10), "test never released the worker thread"
+            launcher = tmp_path / f"sb-launcher-{len(created)}"
+            launcher.write_text("# fake sandbox launcher/profile")
+            created.append(launcher)
+            return argv, {}, str(launcher)
+
+        patcher = patch.object(apple_speech, "_sandboxed", side_effect=_fake)
+        return patcher, entered, release, created
+
+    @staticmethod
+    async def _cancel_during_hop(task, entered, release):
+        """Cancel *task* while the worker thread is parked inside `_sandboxed`.
+
+        The thread entering the stub implies the awaiter is already suspended at
+        the shielded hop: the executor submission happens inside the inner task,
+        which only runs once the awaiting coroutine has yielded.
+        """
+        await asyncio.to_thread(entered.wait, 10)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_transcribe_cancelled_in_sandbox_hop_drops_launcher(self, tmp_path):
+        sandbox_patch, entered, release, created = self._blocking_sandbox(tmp_path)
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            sandbox_patch,
+        ):
+            task = asyncio.create_task(apple_speech.transcribe("/tmp/x.wav"))
+            await self._cancel_during_hop(task, entered, release)
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_inventory_cancelled_in_sandbox_hop_drops_launcher(self, tmp_path):
+        sandbox_patch, entered, release, created = self._blocking_sandbox(tmp_path)
+        with (
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            sandbox_patch,
+        ):
+            task = asyncio.create_task(apple_speech.inventory())
+            await self._cancel_during_hop(task, entered, release)
+        assert created and not any(f.exists() for f in created)
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_cancelled_in_sandbox_hop_drops_launcher(self, tmp_path):
+        sandbox_patch, entered, release, created = self._blocking_sandbox(tmp_path)
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            sandbox_patch,
+        ):
+            task = asyncio.create_task(session.start())
+            await self._cancel_during_hop(task, entered, release)
+        assert created and not any(f.exists() for f in created)
+        assert session._sb_cleanup is None
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_cancelled_mid_spawn_drops_launcher(self, tmp_path):
+        """After the tuple is bound, a cancelled spawn must still drop the
+        launcher: `CancelledError` is not `OSError`, so the in-place drop on the
+        spawn-failure path never sees it."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        spawn_entered = asyncio.Event()
+
+        async def hanging_spawn(*_a, **_k):
+            spawn_entered.set()
+            await asyncio.sleep(60)
+
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", side_effect=hanging_spawn),
+            sandbox_patch,
+        ):
+            task = asyncio.create_task(session.start())
+            await spawn_entered.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        assert created and not any(f.exists() for f in created)
+        assert session._sb_cleanup is None
+
+    @pytest.mark.asyncio
+    async def test_streaming_start_cancelled_in_ready_wait_reaps_then_drops(self, tmp_path):
+        """Cancellation in the ~20s readiness wait leaves a LIVE helper riding
+        along with the launcher; the teardown must kill+reap it before the
+        unlink (Windows keeps the file locked until the child exits)."""
+        sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
+        proc = AsyncMock()
+
+        async def never_ready(*_a, **_k):
+            await asyncio.sleep(60)
+            return b""
+
+        proc.stdout.readline = never_ready
+        proc.kill = Mock()
+        proc.returncode = None
+        session = apple_speech.StreamingSession()
+        with (
+            self._availability_ok(),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            sandbox_patch,
+        ):
+            task = asyncio.create_task(session.start())
+            # The pump task is created immediately before the readiness wait, so
+            # its appearance means start() is suspended at that wait (create_task
+            # does not yield; the wait_for is the next suspension point).
+            while session._pump is None:
+                await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        proc.kill.assert_called_once()
+        assert created and not any(f.exists() for f in created)
+        assert session._sb_cleanup is None
 
 
 class TestStreamingEndpointGate:

--- a/test/test_stt_stream.py
+++ b/test/test_stt_stream.py
@@ -367,6 +367,51 @@ class TestAppleStreamingSession:
             assert "Command Line Tools" in msg["message"]
             await ws.close()
 
+    @pytest.mark.asyncio
+    async def test_cancelled_start_still_closes_the_session(self, monkeypatch):
+        """`await session.start()` runs BEFORE the teardown `finally` exists.
+
+        A cancellation landing there (client gone, gateway shutdown) therefore
+        has no caller-side owner: without the call-site guard, the helper
+        session — and the sandbox launcher it may hold — is never closed, and
+        the `stt_stream_start` already emitted gets no matching end audit. The
+        guard must close the session, balance the trail, and re-raise.
+        """
+        started = asyncio.Event()
+        closed: list[bool] = []
+        outcomes: list[str] = []
+
+        class HangingSession:
+            def __init__(self, **kwargs):
+                pass
+
+            async def start(self):
+                started.set()
+                await asyncio.sleep(60)
+                return ""
+
+            async def close(self):
+                closed.append(True)
+
+        self._install(monkeypatch, session=HangingSession)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.stt_stream._emit_end_audit",
+            lambda caller, *, outcome: outcomes.append(outcome),
+        )
+        from kiro_crew.dashboard import stt_stream
+
+        task = asyncio.create_task(
+            stt_stream._run_apple_session(
+                MagicMock(), _cfg(provider="apple"), MagicMock(), "test-caller"
+            )
+        )
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed == [True]
+        assert outcomes == ["error"]
+
 
 @pytest.fixture()
 def transcribe_consented(tmp_path_factory, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

After #5776 closed the 100%-of-calls leak of `sandboxed_spawn_argv`'s cleanup path at apple_speech's three spawn sites, three narrow cancellation windows around the sandbox launcher lifecycle remained in `src/kiro_crew/apple_speech/__init__.py`, all reachable from production callers (dashboard request handlers / the STT WebSocket handler). The unifying root cause: `asyncio.CancelledError` is a `BaseException`, so it bypasses the `except Exception` / `except OSError` paths that own unlinking the launcher/profile temp.

1. **Cancellation during the `asyncio.to_thread(_sandboxed, ...)` hop** at all three sites (`transcribe`, `inventory`, `StreamingSession.start`): the worker thread still creates the launcher/profile, but the returned tuple is never bound — no `finally` and no `self._sb_cleanup` can ever see the cleanup path.
2. **`StreamingSession.start()` cancelled after the tuple is bound** (mid `create_subprocess_exec`, or anywhere in the ~20s readiness wait): `CancelledError` is not `OSError`, so the in-place drop is skipped and no `close()` runs — the launcher, and an already-spawned helper, ride along.
3. **`dashboard/stt_stream.py` awaits `session.start()` outside any `try`**: the session teardown `finally` only exists after `start()` returns, so a cancelled `start()` had no caller-side cleanup either.

## Why it matters

Each occurrence orphans one temp file (the Linux namespace launcher script or the macOS `sandbox-exec` profile) — and window 2 also orphans a live helper process holding an OS speech-recognition session. Cancellations here are routine, not exotic: a client closing the dictation WebSocket during the readiness wait, or a gateway shutdown, cancels exactly these awaits. Temp files accumulate forever (same class as #5758); an unreaped helper holds resources until process exit.

## What changed (motivation → approach → change)

The repo already has a proven shape for window 1 — `kiro_prerequisite.py`'s shield-recover-unlink around its sandboxed-spawn preparation — so the fix reuses it rather than inventing a new one:

- **Window 1:** a new `_sandboxed_off_loop()` helper owns the worker-thread hop for all three call sites. It shields the `to_thread(_sandboxed, ...)` task; on cancellation it awaits the task to settle, recovers the cleanup path, drops it, then re-raises. The recovery await is guarded with `suppress(BaseException)` so a repeat cancellation cannot skip the drop (the same shape `_to_native_audio` already uses for its reap-on-cancel). `SandboxUnavailableError` propagates unchanged, so the callers' existing remedy-carrying error paths are untouched.
- **Window 2:** `StreamingSession.start()` guards both post-binding regions (the spawn, and the readiness wait) with `except BaseException: await self.close(); raise`. `close()` is the same teardown every later exit already uses — kill+reap first, then unlink — honouring the reap-before-unlink order Windows requires (the child holds the file locked until it exits).
- **Window 3:** the `await session.start()` call site in `stt_stream.py` now closes the session, closes the endpointer, and emits the balancing `stt_stream_end` audit before re-raising, so a cancellation during the up-to-20s readiness wait neither strands the helper nor leaves the `stt_stream_start` audit unmatched.

Normal success and `OSError` paths are byte-for-byte unchanged in behaviour; the change is scoped to cancellation cleanup.

## Tests

Six new cancel-injection tests, each mutation-verified (guard removed → red; restored → green):

- `test_transcribe_cancelled_in_sandbox_hop_drops_launcher` / `test_inventory_cancelled_in_sandbox_hop_drops_launcher` / `test_streaming_start_cancelled_in_sandbox_hop_drops_launcher` — window 1 at each site: a worker thread parked inside `_sandboxed` is cancelled mid-hop; the launcher it materializes afterwards must still be dropped (deterministic via threading events, no sleeps on the assert path).
- `test_streaming_start_cancelled_mid_spawn_drops_launcher` — window 2, cancellation between tuple binding and spawn completion.
- `test_streaming_start_cancelled_in_ready_wait_reaps_then_drops` — window 2, cancellation in the readiness wait: asserts the live helper is killed AND the launcher dropped (reap before unlink).
- `test_cancelled_start_still_closes_the_session` (test_stt_stream.py) — window 3: the call-site guard closes the session, emits the `error` end audit, and re-raises.

The source-level pin `test_sandbox_wrapping_is_offloaded_off_the_event_loop` is tightened: every async caller must now reach `_sandboxed` only through `_sandboxed_off_loop`, whose own source must carry both the `to_thread` hop (loop safety) and the `shield` (cancellation recoverability).

## Manual verification

N/A — unit coverage sufficient: the windows are pure asyncio control flow, injected deterministically in the tests; no OS sandbox backend or macOS host is involved in the guarded paths.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend file touched and no rendered output changes.

## Related Issues

Fixes #5796

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API/behavior contract changed
- [x] No secrets, credentials, or internal references in the diff
