### PR TITLE
fix: reap killed ffmpeg children via communicate() instead of wait() (#5834)

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -550,7 +550,7 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
                 await asyncio.wait_for(proc.communicate(), timeout=10)
             except asyncio.TimeoutError:
                 proc.kill()
-                await proc.wait()
+                await proc.communicate()
                 raise
             if proc.returncode != 0:
                 raise RuntimeError(f"ffmpeg exited with {proc.returncode}")

--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -723,7 +723,7 @@ async def stitch_mp3s(paths: list[str], output: str | None = None) -> str | None
             except ProcessLookupError:
                 pass
             try:
-                await proc.wait()
+                await proc.communicate()
             except Exception:
                 logger.debug("ffmpeg wait after kill failed", exc_info=True)
             raise

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -1825,6 +1825,45 @@ class TestTranscribeAwsTempOwnership:
         assert owned.exists()
         assert src.exists()
 
+    @pytest.mark.asyncio
+    async def test_timeout_reaps_ffmpeg_via_communicate(self, tmp_path, monkeypatch):
+        """When the ffmpeg remux times out, the killed child must be reaped via
+        ``communicate()`` -- not ``wait()`` -- so the PIPE buffers are drained
+        and a child blocked writing to a full stderr PIPE cannot hang the
+        event loop (#5834)."""
+        from kiro_crew import transcribe as tr
+
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        self._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        proc.kill = MagicMock()
+        proc.returncode = -9
+
+        monkeypatch.setattr(tr, "boto3", object())
+        monkeypatch.setattr(
+            tr, "_load_aws_transcribe_components", lambda: (object, object)
+        )
+        with (
+            patch("kiro_crew.transcribe._find_ffmpeg", return_value="/fake/ffmpeg"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
+            result = await tr._transcribe_aws(str(src), cfg)
+
+        # The timeout is caught by ``except Exception``; returns None.
+        assert result is None
+        proc.kill.assert_called_once()
+        # The critical pin: reap via communicate(), not wait(). The remux
+        # call itself awaits communicate once; the reap must award a SECOND
+        # await, and wait() must never be touched.
+        assert proc.communicate.await_count == 2
+        proc.wait.assert_not_awaited()
+        assert not owned.exists()
+        assert src.exists()
 
 # ---------------------------------------------------------------------------
 # _run_whisper_cli child/temp-dir ownership under cancellation (#5821)

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -1524,10 +1524,12 @@ class TestStitchMp3s:
 
         assert result is None
         # wait_for cancels communicate() but does not terminate the child;
-        # the child must be killed and reaped BEFORE the unlink, or Windows
-        # refuses to remove the still-open output file.
+        # the child must be killed and reaped via communicate() (which drains
+        # the pipes) BEFORE the unlink, or Windows refuses to remove the
+        # still-open output file. Using wait() instead of communicate() can
+        # hang when the child is blocked writing to a full stderr PIPE (#5834).
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        proc.communicate.assert_awaited()
         assert len(allocated) == 1
         assert not os.path.exists(allocated[0])
 
@@ -1549,7 +1551,7 @@ class TestStitchMp3s:
                 await stitch_mp3s(self._two_inputs(tmp_path))
 
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited()
+        proc.communicate.assert_awaited()
         assert len(allocated) == 1
         assert not os.path.exists(allocated[0])
 
@@ -1613,6 +1615,34 @@ class TestStitchMp3s:
             # the mkstemp file behind as test residue.
             if allocated and os.path.exists(allocated[0]):
                 os.unlink(allocated[0])
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaps_child_via_communicate_not_wait(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """After a timeout kills the ffmpeg child, the cleanup must call
+        ``communicate()`` -- not ``wait()`` -- so that PIPE buffers are
+        drained. A child blocked writing to a full stderr PIPE would hang
+        the event loop if only ``wait()`` were used (#5834)."""
+        allocated = _capture_mkstemp(monkeypatch)
+        proc = _mock_subprocess(returncode=0)
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+
+        async def fake_exec(*cmd, **kwargs):
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await stitch_mp3s(self._two_inputs(tmp_path))
+
+        assert result is None
+        proc.kill.assert_called_once()
+        # The critical pin: reap via communicate(), not wait(). The stitch
+        # call itself awaits communicate once; the reap must award a SECOND
+        # await, and wait() must never be touched.
+        assert proc.communicate.await_count == 2
+        proc.wait.assert_not_awaited()
+        assert len(allocated) == 1
+        assert not os.path.exists(allocated[0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Converts two `await proc.wait()` sites to `await proc.communicate()` after killing ffmpeg children, preventing potential hangs when the child is blocked writing to a full `stderr=PIPE`. One further sibling of the same class remains at `dashboard/chat_voice.py:382` (a non-ffmpeg `describe-voices` child), filed as follow-up #5975 — found by the First Principles review's 25-site audit.

Closes #5834.

## Problem

`asyncio.wait_for` cancels the pipe readers before the kill lands, so a killed child that was blocked writing to a full stderr PIPE is never drained — `wait()` then hangs the task indefinitely. This is the same class of bug addressed in #5821 and #5833; these two sites were left out of scope. (#5975 tracks the last remaining sibling, `dashboard/chat_voice.py:382`.)

## Changes

**Source (2 one-line changes):**
- `src/kiro_crew/transcribe.py` (line 553): `await proc.wait()` → `await proc.communicate()` in the ffmpeg remux `TimeoutError` arm
- `src/kiro_crew/voice_reply.py` (line 696): `await proc.wait()` → `await proc.communicate()` in `stitch_mp3s` `(TimeoutError, CancelledError)` arm

**Tests (2 new pins):**
- `test/test_transcribe.py`: `test_timeout_reaps_ffmpeg_via_communicate` — asserts `proc.communicate.assert_awaited()`
- `test/test_voice_reply.py`: `test_timeout_reaps_child_via_communicate_not_wait` + updated existing timeout/cancellation tests to assert `communicate` instead of `wait`

## Rationale

The correct pattern already exists in the same file at the `BaseException` cleanup arm (from merged #5809). This PR copies that established precedent to the two remaining sites.

## Testing

Syntax-validated all modified files. Full pytest suite requires network access for dependencies (pytest-asyncio, hypothesis) which was unavailable in the sandbox.
