### PR TITLE
fix(voice): discard synth temp files and reap children on cancellation (#5779)

### DIFF
--- a/src/kiro_crew/voice_reply.py
+++ b/src/kiro_crew/voice_reply.py
@@ -295,6 +295,7 @@ async def _synthesize_piper(
     fd, path = tempfile.mkstemp(suffix=".wav")
     os.close(fd)
     sandbox_cleanup: str | None = None
+    succeeded = False
     try:
         try:
             cmd: list[str] = [bin_path, "-m", model, "-f", path]
@@ -322,11 +323,16 @@ async def _synthesize_piper(
                     proc.communicate(text.encode("utf-8")),
                     timeout=60,
                 )
-            except asyncio.TimeoutError:
-                # asyncio.wait_for cancels communicate() on timeout but does NOT
-                # terminate the child process — kill it explicitly to avoid a
-                # zombie piper consuming CPU after we return.
-                logger.error("piper timed out after 60s; killing subprocess")
+            except (asyncio.TimeoutError, asyncio.CancelledError) as exc:
+                # asyncio.wait_for cancels communicate() on timeout — and a
+                # caller cancellation (client disconnect) arrives here as
+                # CancelledError — but neither terminates the child process:
+                # kill it explicitly to avoid a zombie piper consuming CPU
+                # after we exit. Temp-file discard is owned by the ``finally``
+                # invariant below.
+                timed_out = isinstance(exc, asyncio.TimeoutError)
+                if timed_out:
+                    logger.error("piper timed out after 60s; killing subprocess")
                 try:
                     proc.kill()
                 except ProcessLookupError:
@@ -335,10 +341,8 @@ async def _synthesize_piper(
                     await proc.wait()
                 except Exception:
                     logger.debug("piper wait after kill failed", exc_info=True)
-                try:
-                    os.unlink(path)
-                except OSError:
-                    pass
+                if not timed_out:
+                    raise  # CancelledError must propagate to the caller
                 return None
             if proc.returncode != 0:
                 logger.error(
@@ -346,12 +350,11 @@ async def _synthesize_piper(
                     proc.returncode,
                     stderr.decode(errors="replace")[:500],
                 )
-                os.unlink(path)
                 return None
             if os.path.getsize(path) < 100:
                 logger.error("piper output too small")
-                os.unlink(path)
                 return None
+            succeeded = True
             return path
         except SandboxUnavailableError as exc:
             # Same fail-closed sandbox refusal as the Polly path — relay the
@@ -363,19 +366,19 @@ async def _synthesize_piper(
                 exc.kind,
                 exc,
             )
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
             return None
         except Exception:
             logger.exception("piper synthesis error")
+            return None
+    finally:
+        # Invariant, not per-exit cleanup: EVERY unsuccessful exit — including
+        # CancelledError, which ``except Exception`` does not catch — must
+        # discard the owned temp file, or a new exit path re-opens the leak.
+        if not succeeded:
             try:
                 os.unlink(path)
             except OSError:
                 pass
-            return None
-    finally:
         # Clean up the sandbox launcher script / seatbelt profile spawned
         # by wrap_argv (None on platforms without a sandbox backend).
         if sandbox_cleanup:
@@ -493,6 +496,7 @@ async def _synthesize_polly(
     fd, path = tempfile.mkstemp(suffix=".mp3")
     os.close(fd)
     sandbox_cleanup: str | None = None
+    succeeded = False
     try:
         try:
             cmd: list[str] = [aws_bin, "polly", "synthesize-speech"]
@@ -528,12 +532,16 @@ async def _synthesize_polly(
             )
             try:
                 _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            except asyncio.TimeoutError:
+            except (asyncio.TimeoutError, asyncio.CancelledError) as exc:
                 # ``asyncio.wait_for`` cancels ``proc.communicate()`` on
-                # timeout but does NOT terminate the child — kill it
-                # explicitly to avoid a hung ``aws polly`` process consuming
-                # resources after we return.
-                logger.error("Polly timed out after 30s; killing subprocess")
+                # timeout — and a caller cancellation (client disconnect)
+                # arrives here as CancelledError — but neither terminates the
+                # child: kill it explicitly to avoid a hung ``aws polly``
+                # process consuming resources after we exit. Temp-file discard
+                # is owned by the ``finally`` invariant below.
+                timed_out = isinstance(exc, asyncio.TimeoutError)
+                if timed_out:
+                    logger.error("Polly timed out after 30s; killing subprocess")
                 try:
                     proc.kill()
                 except ProcessLookupError:
@@ -542,19 +550,16 @@ async def _synthesize_polly(
                     await proc.wait()
                 except Exception:
                     logger.debug("polly wait after kill failed", exc_info=True)
-                try:
-                    os.unlink(path)
-                except OSError:
-                    pass
+                if not timed_out:
+                    raise  # CancelledError must propagate to the caller
                 return None
             if proc.returncode != 0:
                 logger.error("Polly failed: %s", stderr.decode())
-                os.unlink(path)
                 return None
             if os.path.getsize(path) < 100:
                 logger.error("Polly output too small")
-                os.unlink(path)
                 return None
+            succeeded = True
             return path
         except SandboxUnavailableError as exc:
             # A host with no OS sandbox backend (every Windows host, and Linux
@@ -575,19 +580,19 @@ async def _synthesize_polly(
                 exc.kind,
                 exc,
             )
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
             return None
         except Exception:
             logger.exception("Polly synthesis error")
+            return None
+    finally:
+        # Invariant, not per-exit cleanup: EVERY unsuccessful exit — including
+        # CancelledError, which ``except Exception`` does not catch — must
+        # discard the owned temp file, or a new exit path re-opens the leak.
+        if not succeeded:
             try:
                 os.unlink(path)
             except OSError:
                 pass
-            return None
-    finally:
         # Clean up the sandbox launcher script / seatbelt profile spawned
         # by wrap_argv (None on platforms without a sandbox backend).
         if sandbox_cleanup:

--- a/test/test_voice_reply.py
+++ b/test/test_voice_reply.py
@@ -216,6 +216,20 @@ def _mock_subprocess(
     return proc
 
 
+def _capture_mkstemp(monkeypatch) -> list[str]:
+    """Record every path the module allocates via ``tempfile.mkstemp``."""
+    allocated: list[str] = []
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        allocated.append(path)
+        return fd, path
+
+    monkeypatch.setattr("kiro_crew.voice_reply.tempfile.mkstemp", recording_mkstemp)
+    return allocated
+
+
 def _make_executable(path: str) -> None:
     """Touch *path* and flag it executable so shutil.which / os.access pass."""
     with open(path, "wb") as f:
@@ -632,6 +646,68 @@ class TestSynthesizePiper:
             assert await _synthesize_piper("hello", piper_model=str(model)) is None
 
     @pytest.mark.asyncio
+    async def test_cancellation_kills_child_and_removes_owned_temp(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # CancelledError is a BaseException: it bypasses ``except Exception``,
+        # so only the finally-based invariant discards the owned temp file —
+        # and the cancellation must still propagate to the caller.
+        bin_path = tmp_path / "piper"
+        _make_executable(str(bin_path))
+        model = tmp_path / "voice.onnx"
+        model.write_bytes(b"m")
+
+        allocated = _capture_mkstemp(monkeypatch)
+        proc = _mock_subprocess(returncode=0)
+        proc.communicate = AsyncMock(side_effect=asyncio.CancelledError)
+
+        async def fake_exec(*cmd, **kwargs):
+            return proc
+
+        with patch(
+            "kiro_crew.voice_reply._resolve_piper_binary", return_value=str(bin_path),
+        ), patch(
+            "kiro_crew.voice_reply.wrap_argv", side_effect=lambda c, mode: (c, None),
+        ), patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+
+        # wait_for cancels communicate() but does not terminate the child;
+        # the child must be killed and reaped, and the owned temp discarded.
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+        assert len(allocated) == 1
+        assert not os.path.exists(allocated[0])
+
+    @pytest.mark.asyncio
+    async def test_prespawn_cancellation_removes_owned_temp(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A cancellation delivered BEFORE the child exists (here: from the
+        # subprocess spawn itself) bypasses the kill/reap branch entirely —
+        # only the ``finally`` invariant discards the owned temp file.
+        bin_path = tmp_path / "piper"
+        _make_executable(str(bin_path))
+        model = tmp_path / "voice.onnx"
+        model.write_bytes(b"m")
+
+        allocated = _capture_mkstemp(monkeypatch)
+
+        async def cancelled_exec(*cmd, **kwargs):
+            raise asyncio.CancelledError
+
+        with patch(
+            "kiro_crew.voice_reply._resolve_piper_binary", return_value=str(bin_path),
+        ), patch(
+            "kiro_crew.voice_reply.wrap_argv", side_effect=lambda c, mode: (c, None),
+        ), patch("asyncio.create_subprocess_exec", side_effect=cancelled_exec):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_piper("hello", piper_model=str(model))
+
+        assert len(allocated) == 1
+        assert not os.path.exists(allocated[0])
+
+    @pytest.mark.asyncio
     async def test_exec_exception_returns_none(self, tmp_path) -> None:
         bin_path = tmp_path / "piper"
         _make_executable(str(bin_path))
@@ -928,6 +1004,50 @@ class TestSynthesizePolly:
             "asyncio.create_subprocess_exec", return_value=proc,
         ), patch("asyncio.wait_for", side_effect=hang_wait_for):
             assert await _synthesize_polly("<speak>hi</speak>") is None
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_child_and_removes_owned_temp(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # CancelledError is a BaseException: it bypasses ``except Exception``,
+        # so only the finally-based invariant discards the owned temp file —
+        # and the cancellation must still propagate to the caller.
+        allocated = _capture_mkstemp(monkeypatch)
+        proc = _mock_subprocess(returncode=0)
+        proc.communicate = AsyncMock(side_effect=asyncio.CancelledError)
+
+        async def fake_exec(*cmd, **kwargs):
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+
+        # wait_for cancels communicate() but does not terminate the child;
+        # the child must be killed and reaped, and the owned temp discarded.
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+        assert len(allocated) == 1
+        assert not os.path.exists(allocated[0])
+
+    @pytest.mark.asyncio
+    async def test_prespawn_cancellation_removes_owned_temp(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A cancellation delivered BEFORE the child exists (here: from the
+        # subprocess spawn itself) bypasses the kill/reap branch entirely —
+        # only the ``finally`` invariant discards the owned temp file.
+        allocated = _capture_mkstemp(monkeypatch)
+
+        async def cancelled_exec(*cmd, **kwargs):
+            raise asyncio.CancelledError
+
+        with patch("asyncio.create_subprocess_exec", side_effect=cancelled_exec):
+            with pytest.raises(asyncio.CancelledError):
+                await _synthesize_polly("<speak>hi</speak>")
+
+        assert len(allocated) == 1
+        assert not os.path.exists(allocated[0])
 
     @pytest.mark.asyncio
     async def test_sandbox_cleanup_unlinked(self, tmp_path) -> None:
@@ -1340,20 +1460,6 @@ class TestStitchMp3s:
     """
 
     @staticmethod
-    def _capture_mkstemp(monkeypatch) -> list[str]:
-        """Record every path the module allocates via ``tempfile.mkstemp``."""
-        allocated: list[str] = []
-        real_mkstemp = tempfile.mkstemp
-
-        def recording_mkstemp(*args, **kwargs):
-            fd, path = real_mkstemp(*args, **kwargs)
-            allocated.append(path)
-            return fd, path
-
-        monkeypatch.setattr("kiro_crew.voice_reply.tempfile.mkstemp", recording_mkstemp)
-        return allocated
-
-    @staticmethod
     def _two_inputs(tmp_path) -> list[str]:
         """Two fake MP3 inputs — one path short-circuits before ffmpeg runs."""
         paths = []
@@ -1365,7 +1471,7 @@ class TestStitchMp3s:
 
     @pytest.mark.asyncio
     async def test_spawn_failure_removes_owned_temp(self, tmp_path, monkeypatch) -> None:
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
 
         async def fake_exec(*cmd, **kwargs):
             raise FileNotFoundError("ffmpeg not on PATH")
@@ -1379,7 +1485,7 @@ class TestStitchMp3s:
 
     @pytest.mark.asyncio
     async def test_nonzero_exit_removes_owned_temp(self, tmp_path, monkeypatch) -> None:
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         proc = _mock_subprocess(returncode=1, stderr=b"concat error")
 
         async def fake_exec(*cmd, **kwargs):
@@ -1394,7 +1500,7 @@ class TestStitchMp3s:
 
     @pytest.mark.asyncio
     async def test_timeout_kills_child_and_removes_owned_temp(self, tmp_path, monkeypatch) -> None:
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         proc = _mock_subprocess(returncode=0)
         proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
 
@@ -1419,7 +1525,7 @@ class TestStitchMp3s:
     ) -> None:
         # CancelledError is a BaseException: it bypasses ``except Exception``,
         # so only a finally-based invariant discards the owned output here.
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         proc = _mock_subprocess(returncode=0)
         proc.communicate = AsyncMock(side_effect=asyncio.CancelledError)
 
@@ -1439,7 +1545,7 @@ class TestStitchMp3s:
     async def test_empty_output_removes_owned_temp(self, tmp_path, monkeypatch) -> None:
         # The mkstemp allocation always exists on disk, so "ffmpeg produced no
         # output" manifests as a zero-byte file, never an absent one.
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         proc = _mock_subprocess(returncode=0)
 
         async def fake_exec(*cmd, **kwargs):
@@ -1456,7 +1562,7 @@ class TestStitchMp3s:
     async def test_failure_leaves_caller_supplied_output_untouched(
         self, tmp_path, monkeypatch
     ) -> None:
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         caller_output = tmp_path / "caller.mp3"
         caller_output.write_bytes(b"pre-existing caller data")
         proc = _mock_subprocess(returncode=1)
@@ -1474,7 +1580,7 @@ class TestStitchMp3s:
 
     @pytest.mark.asyncio
     async def test_success_returns_owned_output_intact(self, tmp_path, monkeypatch) -> None:
-        allocated = self._capture_mkstemp(monkeypatch)
+        allocated = _capture_mkstemp(monkeypatch)
         proc = _mock_subprocess(returncode=0)
 
         async def fake_exec(*cmd, **kwargs):


### PR DESCRIPTION
## Problem / Motivation

`_synthesize_piper` and `_synthesize_polly` in `src/kiro_crew/voice_reply.py` allocate their output file via `tempfile.mkstemp` and clean it up only in `except asyncio.TimeoutError` / `except Exception` branches. `asyncio.CancelledError` is a `BaseException` and bypasses both — when the caller's task is cancelled mid-synthesis (client disconnect during a streaming voice reply), the temp file leaks and the piper / `aws polly` child process is orphaned. PR #5773 fixed the identical defect in `stitch_mp3s` in the same file; these two sibling mkstemp sites were left on the old per-exit-path pattern.

## Why it matters

The gateway is a long-lived process serving disconnect-prone clients. Each cancelled synthesis leaks one temp file (`.wav`/`.mp3`) onto the temp volume and leaves a child process consuming CPU (piper) or holding resources (`aws polly`) with no surviving owner — steady accumulation over days, with no log signal pointing at the cause.

## What changed (motivation → approach → change)

Symptom: leaked temp files and orphaned children on cancellation → root cause: cleanup lived in exception branches that structurally cannot see `CancelledError`, and child kill/reap ran only on `TimeoutError` → change: apply the exact structure already merged for `stitch_mp3s` (#5773) to both helpers:

1. A `succeeded` flag set on exactly one line, immediately before the success `return path`.
2. A `finally` invariant that discards the owned mkstemp file whenever `not succeeded` — every unsuccessful exit, including `CancelledError`, is covered by construction; the now-redundant inline `os.unlink(path)` calls in the error branches are removed so the invariant is the single owner of cleanup.
3. The timeout handler widened to `except (asyncio.TimeoutError, asyncio.CancelledError)`: both paths kill and reap the child (`asyncio.wait_for` cancels `communicate()` but never terminates the child; on Windows the unreaped child would hold the output handle and defeat the unlink). Timeout keeps its existing log message and `return None`; `CancelledError` re-raises so cancellation semantics are unchanged.

The diff is scoped to the two helpers and their tests; no unrelated code in the file is restructured.

## Tests

- `TestSynthesizePiper::test_cancellation_kills_child_and_removes_owned_temp` and `TestSynthesizePolly::test_cancellation_kills_child_and_removes_owned_temp` — mirror the merged `TestStitchMp3s` cancellation test: `communicate` raises `CancelledError`; assert propagation, child `kill()` + `wait()` called, and the recorded mkstemp path removed. Both fail on main (red-before verified: `kill` never called, temp leaked).
- `test_prespawn_cancellation_removes_owned_temp` (both classes) — cancellation raised from the subprocess spawn itself, before any child exists. This bypasses the kill/reap branch entirely, so it pins the `finally` invariant specifically: a refactor moving the unlink back into the exception branch turns these red.
- The duplicated mkstemp-capture helper is hoisted to a single module-level `_capture_mkstemp`; `TestStitchMp3s` call sites repointed.

Full `test/test_voice_reply.py` module: 103 passed. Gates: isort, flake8 7.1.0, mypy (1102 files), black (source file clean; test file is a pre-existing black-baseline entry).

## Manual verification

N/A — unit coverage sufficient: the change is pure control-flow around mocked subprocess lifecycles, and the tests assert the exact observable contract (propagation, reap, unlink).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no UI surface touched.

## Related Issues

Fixes #5779

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff
