### PR TITLE
test(i18n): widen the memo subscription ratchet to format-only consumers

### DIFF
--- a/website/src/i18n/LanguageProvider.tsx
+++ b/website/src/i18n/LanguageProvider.tsx
@@ -295,6 +295,14 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   )
 
   return (
+    // The value object is DELIBERATELY rebuilt every render — do not wrap it in
+    // useMemo([language, resolved, …]). The post-swap repaint of memoized
+    // useLanguage() consumers rides on this identity changing when `setActive`
+    // re-renders the provider AFTER the async catalog swap (none of the would-be
+    // deps change on that render, so memoizing would freeze the identity and
+    // leave memo() consumers rendering the previous catalog).
+    // MemoI18nSubscriptionRatchet.test.ts's format branch counts a useLanguage()
+    // read as a valid subscription on exactly this guarantee.
     <LanguageContext.Provider value={{ language, resolved, detected, setLanguage, syncFailed }}>
       {refreshed}
     </LanguageContext.Provider>

--- a/website/src/i18n/format.ts
+++ b/website/src/i18n/format.ts
@@ -18,9 +18,13 @@
  * two are used side by side without ceremony: formatting happens inside
  * `.map()` callbacks, in comparator functions passed to `.sort()`, and in plain
  * helper modules with no component around them — all positions a hook cannot
- * legally go. A language switch remounts the tree (`<App>` is keyed on the
- * active language in `main.tsx`), so a function that reads the language at call
- * time re-evaluates on switch without subscribing to anything.
+ * legally go. A language switch repaints the tree (`LanguageProvider` re-renders
+ * via `cloneElement` after the catalog swap — an update, not a remount), so a
+ * function that reads the language at call time re-evaluates on switch without
+ * subscribing to anything. The one shape that repaint cannot reach is a
+ * `React.memo` boundary, whose props-equality bailout swallows it —
+ * `MemoI18nSubscriptionRatchet.test.ts` pins the subscription every such
+ * boundary needs.
  *
  * ## Why `localeMatcher: 'lookup'`
  *

--- a/website/src/test/MemoI18nSubscriptionRatchet.test.ts
+++ b/website/src/test/MemoI18nSubscriptionRatchet.test.ts
@@ -15,6 +15,33 @@
  * at a time — which is why this reads the tree (same shape as
  * `ImeEnterClaimRatchet.test.ts`).
  *
+ * ## Why importing `i18n/format` also counts as language-dependent
+ *
+ * `i18nT()` is not the only standalone language reader: every formatter in
+ * `src/i18n/format.ts` reads the ACTIVE UI language at call time (dates,
+ * numbers, lists, collation). A memoized component whose translated output
+ * comes solely from those formatters goes stale after a language switch by the
+ * exact mechanism above, without a single `i18nT(` for the narrower trigger to
+ * see. So a file counts as language-dependent when it calls `i18nT(` OR imports
+ * from `i18n/format`.
+ *
+ * The two branches accept different subscriptions, deliberately:
+ *
+ *  - `i18nT(` files must call `useLanguageGeneration()` per boundary — the
+ *    contract #5543 converted the whole tree to. Whether `useLanguage()` should
+ *    also satisfy this branch is a separate loosening decision, out of scope
+ *    here.
+ *  - format-only files may instead consume the `useLanguage()` context: context
+ *    propagation re-renders consumers THROUGH `memo` (the props bailout does
+ *    not apply to context), and the formatters read the language at call time.
+ *    Precisely: the repaint that lands AFTER the async catalog swap is the
+ *    provider re-rendering on its `languageChanged` handler (`setActive`),
+ *    which rebuilds the (deliberately unmemoized) inline context value object —
+ *    see the provider's own ordering notes. Memoizing that value on
+ *    `[language, resolved, …]` would silently break this branch's guarantee;
+ *    `LanguageProvider` documents why the value must stay identity-fresh.
+ *    Forcing `useLanguageGeneration()` onto such a consumer would be redundant.
+ *
  * The rule is counted per boundary, not per file: a file with three memo
  * components and one subscription would still leave two subtrees stale, so the
  * number of `useLanguageGeneration()` calls must be at least the number of
@@ -53,13 +80,29 @@ export function stripComments(src: string): string {
  */
 const MEMO_BOUNDARY = /(?<![\w$])(?:React\.)?memo\s*[<(]/g
 
+/**
+ * An import from the locale-formatting seam, any relative depth (`./i18n/format`,
+ * `../../i18n/format`). Type-only imports are deliberately NOT excluded: the
+ * regex is a trigger for a per-file audit, and a type-only importer with memo
+ * boundaries and zero subscriptions is rare enough to exempt explicitly.
+ */
+const FORMAT_IMPORT = /from\s+['"][^'"]*\bi18n\/format['"]/
+
 /** Count memo boundaries and subscriptions in one file's source. */
-export function scanFile(src: string): { boundaries: number; subscriptions: number; usesI18nT: boolean } {
+export function scanFile(src: string): {
+  boundaries: number
+  subscriptions: number
+  usesI18nT: boolean
+  importsFormat: boolean
+  languageContextReads: number
+} {
   const code = stripComments(src)
   const boundaries = [...code.matchAll(MEMO_BOUNDARY)].length
   const subscriptions = [...code.matchAll(/\buseLanguageGeneration\(\)/g)].length
   const usesI18nT = /\bi18nT\(/.test(code)
-  return { boundaries, subscriptions, usesI18nT }
+  const importsFormat = FORMAT_IMPORT.test(code)
+  const languageContextReads = [...code.matchAll(/\buseLanguage\(\)/g)].length
+  return { boundaries, subscriptions, usesI18nT, importsFormat, languageContextReads }
 }
 
 function sourceFiles(): string[] {
@@ -88,6 +131,32 @@ describe('memo() + i18nT() subscription ratchet', () => {
     ).toEqual([])
   })
 
+  it('every memo() boundary in a format-consuming file subscribes or reads the language context', () => {
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (EXEMPT.has(rel)) continue
+      const { boundaries, subscriptions, importsFormat, languageContextReads } =
+        scanFile(readFileSync(join(SRC, rel), 'utf8'))
+      if (boundaries === 0 || !importsFormat) continue
+      // useLanguage() consumers re-render THROUGH memo on a switch (context
+      // bypasses the props bailout) and format.ts reads the language at call
+      // time, so either subscription shape keeps the boundary fresh.
+      if (subscriptions + languageContextReads < boundaries) {
+        offenders.push(
+          `${rel}: ${boundaries} memo() boundaries, ${subscriptions} useLanguageGeneration() + ` +
+          `${languageContextReads} useLanguage() calls`,
+        )
+      }
+    }
+    expect(
+      offenders,
+      'src/i18n/format.ts formatters read the active language at call time, so a memoized component ' +
+      'rendering their output goes stale after a language switch exactly like an i18nT() one; each ' +
+      'memo() boundary in a file importing i18n/format must call useLanguageGeneration() or consume ' +
+      'the useLanguage() context (which re-renders through memo), or be exempted here with a reason.',
+    ).toEqual([])
+  })
+
   it('the exemption list holds only files that still exist', () => {
     const files = new Set(sourceFiles())
     for (const rel of EXEMPT) expect(files.has(rel), `stale exemption: ${rel}`).toBe(true)
@@ -102,7 +171,13 @@ describe('memo() + i18nT() subscription ratchet', () => {
 describe('scanFile predicate', () => {
   it('counts a bare memo(function …) boundary', () => {
     const r = scanFile(`const X = memo(function X() { return <a>{i18nT('k')}</a> })`)
-    expect(r).toEqual({ boundaries: 1, subscriptions: 0, usesI18nT: true })
+    expect(r).toEqual({
+      boundaries: 1,
+      subscriptions: 0,
+      usesI18nT: true,
+      importsFormat: false,
+      languageContextReads: 0,
+    })
   })
 
   it('counts React.memo and generic memo<Props>() spellings', () => {
@@ -119,5 +194,41 @@ describe('scanFile predicate', () => {
     const r = scanFile(`const X = memo(function X() { useLanguageGeneration(); return i18nT('k') })`)
     expect(r.subscriptions).toBe(1)
     expect(r.boundaries).toBe(1)
+  })
+
+  it('detects an i18n/format import at any relative depth', () => {
+    for (const spec of ['./i18n/format', '../i18n/format', '../../i18n/format']) {
+      const r = scanFile(`import { fmtDate } from '${spec}'\nconst X = memo(() => <a>{fmtDate(d)}</a>)`)
+      expect(r.importsFormat, spec).toBe(true)
+      expect(r.usesI18nT, spec).toBe(false)
+      expect(r.boundaries, spec).toBe(1)
+    }
+  })
+
+  it('a format-consuming memo boundary with no subscription is the defect shape', () => {
+    const r = scanFile(`import { fmtDate } from '../i18n/format'\nexport default memo(function X({ d }) { return <a>{fmtDate(d)}</a> })`)
+    expect(r.importsFormat).toBe(true)
+    expect(r.boundaries).toBe(1)
+    expect(r.subscriptions + r.languageContextReads).toBe(0)
+  })
+
+  it('a useLanguage() context read satisfies the format branch without the hook', () => {
+    const r = scanFile(
+      `import { fmtDate } from '../i18n/format'\n` +
+      `export default memo(function X({ d }) { const { language } = useLanguage(); return <a>{fmtDate(d)}</a> })`,
+    )
+    expect(r.languageContextReads).toBe(1)
+    expect(r.subscriptions).toBe(0)
+    expect(r.boundaries).toBe(1)
+  })
+
+  it('does not count a format import mentioned only in a comment', () => {
+    const r = scanFile(`// import { fmtDate } from '../i18n/format'\nconst X = memo(() => null)`)
+    expect(r.importsFormat).toBe(false)
+  })
+
+  it('does not mistake another module for the format seam', () => {
+    const r = scanFile(`import { x } from '../i18n/formatters'\nimport { y } from './format'`)
+    expect(r.importsFormat).toBe(false)
   })
 })


### PR DESCRIPTION
## What is the problem?

The memo()+i18n subscription ratchet added in #5543 (`website/src/test/MemoI18nSubscriptionRatchet.test.ts`) keys language-dependence on a single trigger: a standalone `i18nT(` call. But `i18nT()` is not the only standalone language reader -- every formatter in `src/i18n/format.ts` (dates, numbers, lists, collation) reads the ACTIVE UI language at call time. A `memo()` boundary whose translated output comes solely from those formatters goes stale after a language switch by the exact mechanism the ratchet pins (the provider's `cloneElement` repaint defeats only the root element's referential bailout; `memo` compares props, and formatter output is not a prop) -- while the ratchet sees no `i18nT(` and passes. First Principles flagged this coverage gap on #5543's review. Counted today: zero such files -- a guard gap, not a live defect.

## Why this issue matters to the user

The defect class this leaves open is user-visible mixed-language UI: after switching the dashboard language, a memoized card keeps showing dates like `7/30/2026` inside otherwise-Chinese UI until its props happen to change. The combination is added one innocent `export default memo(X)` at a time; without the widened trigger, the first format-only memo boundary ships unguarded and the regression is only caught by a human eye.

## How our fix solves it

Chain from symptom to root cause: stale formatter output in a memoized subtree -> `memo` props-bailout swallows the provider-level repaint -> the ratchet's trigger (`i18nT(` only) never audits the file -> widen the trigger. `scanFile` now also reports `importsFormat` (any relative depth of `from '.../i18n/format'`) and `languageContextReads` (`useLanguage()` calls), and a second tree-scan branch requires every `memo()` boundary in a format-importing file to have `useLanguageGeneration() + useLanguage() >= boundaries`.

The format branch deliberately accepts a `useLanguage()` context read as a valid subscription: context propagation re-renders consumers THROUGH `memo` (the props bailout does not apply to context), and the formatters read the language at call time -- so a consumer wired that way repaints correctly and forcing `useLanguageGeneration()` onto it would be redundant (the issue's explicit requirement). The post-swap ordering this rides on is subtle -- the repaint that lands AFTER the async catalog swap is the provider re-rendering on its `languageChanged` handler, which rebuilds the deliberately-unmemoized inline context value -- so that guarantee is now documented as load-bearing at the provider's value site (`LanguageProvider.tsx`), where a routine `useMemo` "optimization" would otherwise silently break it. `format.ts`'s docstring claim that a language switch "remounts the tree (`<App>` is keyed...)" was stale (the provider explicitly uses `cloneElement`, not a key, to preserve state) and contradicted this ratchet's premise; corrected in the same change.

The two branches stay asymmetric on purpose: `i18nT(` files still require `useLanguageGeneration()` per boundary (the contract #5543 converted the tree to); whether `useLanguage()` should also satisfy that branch is a separate loosening decision, out of scope here.

## What tests we did

- New fixtures beside the existing ones pin: import detection at `./`, `../`, `../../` depths; the defect shape (format import + memo + zero subscriptions); the satisfied shape (`useLanguage()` read, no hook); a comment-only import mention not counting; and the `i18n/formatters` / bare `./format` near-misses not matching. Existing fixtures updated for the widened `scanFile` return shape. 12/12 pass.
- Mutation-verified: breaking `FORMAT_IMPORT` fails 2 fixtures; dropping the `useLanguage()` credit fails the satisfied-shape fixture. Both reverted.
- Tree scan on current main: zero offenders on the new branch (matches the issue's "0 such files today"), zero change to the existing branch's verdicts (for any file also using `i18nT`, the new branch is weaker-or-equal, so a green tree cannot regress).
- Gates from `website/`: `npx tsc -b` clean; full `I18N_BASE_REF=origin/main npx vitest run` -- 24122 passed, 1 failed: `src/i18n/style/hiStyle.test.ts` (formal-aap count 120 vs 119 baseline), which reproduces on pristine main content and is MAIN-OWNED -- filed as #5843; this diff touches no catalog.
- Two pre-push review lanes: both NO BLOCKING; the ordering-precision advisory (the useLanguage() justification must name the post-swap `setActive` render as the load-bearing mechanism) was folded into the header comment and the provider guard note.

## Any other suggestions on the work

- The per-file aggregate count (`subscriptions + reads >= boundaries`) inherits the existing branch's known crudeness -- a 2-boundary file with both subscriptions in one component passes. Tightening to true per-boundary attribution is a shared follow-up for both branches, not widened here.
- The latent hazard both reviewers noted -- memoizing the provider's context value would break format-only `useLanguage()` consumers while this ratchet still passes -- is mitigated by the new guard comment at the value site; a compile-time pin (e.g. a provider-level test asserting value identity changes across a `setActive` render) would close it fully.

Closes #5545
