### PR TITLE
fix: read Windows kiro-cli identity store from AppData/Local (#5829)

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -790,6 +790,64 @@ def _atomic_write_secret_bytes(path: Path, content: bytes) -> None:
     atomic_write(path, content, fsync=True, restrict_to_owner=True)
 
 
+def _store_write_time(db: Path) -> float:
+    """Newest write across a store's main file and its WAL sidecar.
+
+    The store runs in SQLite WAL mode: a commit lands in the ``-wal`` sidecar
+    and the main file's mtime does not advance until a checkpoint, so the main
+    file alone under-reports recency on exactly the side being written. The
+    ``-shm`` index file is not consulted -- it is mapped shared memory, not a
+    write record. Raises ``OSError`` if the main file vanished; a missing
+    sidecar is normal (checkpointed or non-WAL store).
+    """
+
+    newest = db.stat().st_mtime
+    wal = db.with_name(db.name + "-wal")
+    try:
+        newest = max(newest, wal.stat().st_mtime)
+    except OSError:
+        pass
+    return newest
+
+
+def _win32_identity_store_path(home: Path) -> Path:
+    """Pick between the Local anchor and the legacy Roaming store on Windows.
+
+    Current kiro-cli writes ``AppData/Local/kiro-cli``; older layouts used
+    ``AppData/Roaming/kiro-cli``. When only one store exists it is the store.
+    When BOTH exist, the most recently written one wins: an upgraded host
+    carries a stale Roaming leftover next to its live Local store (upgrades do
+    not clean up the old directory), while a downgraded host writes Roaming
+    next to a stale Local leftover -- and preferring either fixed side reads
+    the leftover on the other shape, yielding a confident fingerprint of an
+    account nobody is signed into. Reporting both-present as absent instead
+    would silently disable identity tracking on every upgraded host, the
+    common shape. The mtime signal is as trustworthy as the stores
+    themselves: both paths sit inside the ``_SENSITIVE_HOME_DIRS`` fence, so
+    anything that could move their timestamps could already author the rows
+    outright -- no new forgeable surface. Equal timestamps prefer Local, the
+    current layout.
+    """
+
+    local = home / "AppData" / "Local" / "kiro-cli" / _AUTH_SQLITE_DB
+    roaming = home / "AppData" / "Roaming" / "kiro-cli" / _AUTH_SQLITE_DB
+    if not roaming.exists():
+        return local
+    if not local.exists():
+        return roaming
+    try:
+        # Recency is per STORE, not per file: in WAL mode a commit advances
+        # the -wal sidecar while the main file's mtime stays frozen until a
+        # checkpoint, so each side reports the newest of the pair.
+        if _store_write_time(roaming) > _store_write_time(local):
+            return roaming
+    except OSError:
+        # A store vanished between the existence probe and the stat; the
+        # Local anchor is the current layout and the safe default.
+        pass
+    return local
+
+
 def kiro_identity_store_path(
     platform_name: str,
     home: Path,
@@ -801,8 +859,9 @@ def kiro_identity_store_path(
     different product's credential, so it cannot answer "which account is this
     CLI signed in as".
 
-    Every platform resolves to a FIXED, home-anchored location, matching the
-    trusted live-store list in ``dashboard/handlers/kiro_usage_api.py``. No
+    Every platform resolves among FIXED, home-anchored locations, drawn from the
+    same set as the trusted live-store list in
+    ``dashboard/handlers/kiro_usage_api.py`` (``_CLI_SQLITE_DBS``). No
     environment variable is consulted -- not ``XDG_DATA_HOME`` on Linux, not
     ``APPDATA`` or ``LOCALAPPDATA`` on Windows -- because the fence that makes
     this store unwritable by agent file tools (``_SENSITIVE_HOME_DIRS``) is
@@ -811,6 +870,16 @@ def kiro_identity_store_path(
     this function reads: it could then forge an identity that keeps matching and
     the children signed in as the previous account would never be retired. A
     fixed anchor cannot be pointed at something the agent may write.
+
+    On Windows current kiro-cli writes its store under the local app-data
+    directory (``AppData/Local/kiro-cli``); older layouts used the roaming one
+    (``AppData/Roaming/kiro-cli``). When only one store exists it is chosen;
+    when both exist the most recently written one wins, so a leftover from
+    the other layout never masks the live store's account (see
+    :func:`_win32_identity_store_path`). Both anchors sit inside the
+    ``_SENSITIVE_HOME_DIRS`` fence, so neither choice widens what an agent
+    can forge. This branch stats the filesystem, so callers on the event loop
+    should resolve the path inside the same worker thread as the read itself.
 
     The cost is that a host which relocates its data home is read as having no
     identity, so the change is reported as "absent" -- which errs toward retiring
@@ -822,7 +891,7 @@ def kiro_identity_store_path(
     if platform_name == "darwin":
         return home / "Library" / "Application Support" / "kiro-cli" / _AUTH_SQLITE_DB
     if platform_name == "win32":
-        return home / "AppData" / "Roaming" / "kiro-cli" / _AUTH_SQLITE_DB
+        return _win32_identity_store_path(home)
     return home / ".local" / "share" / "kiro-cli" / _AUTH_SQLITE_DB
 
 
@@ -846,16 +915,32 @@ def identity_store_is_relocated(
     absent: no read, no false confidence, and the absent path already means "never
     reconciled, re-sweep every turn".
 
-    Only variables that actually move the store count. ``LOCALAPPDATA`` is not
-    consulted: the identity lives under Roaming. A variable set to exactly the
-    default location is not a relocation.
+    Both variables count, unconditionally. The live store's directory is
+    resolved by the CLI from ``LOCALAPPDATA`` (current layout) or ``APPDATA``
+    (legacy layout), and which generation is writing cannot be observed --
+    so once EITHER variable is redirected, a database at a fixed anchor
+    cannot be attributed to a live writer: it may be the live store of the
+    other generation, or a leftover of either, and reading a leftover yields
+    a confident fingerprint of an account nobody is signed into. Refusing to
+    guess errs toward absent, the module's safe side. The cost is that a
+    host with Group-Policy folder redirection (which targets Roaming)
+    reports absent even when a current-layout Local store is healthy -- the
+    same answer such hosts got when the anchor lived under Roaming, so the
+    posture is status quo there, and the once-per-service log in
+    :meth:`KiroPrerequisiteService.current_identity_fingerprint` makes it
+    diagnosable. A variable set to exactly the default location is not a
+    relocation.
     """
 
     if platform_name == "win32":
-        configured = environ.get("APPDATA", "").strip()
-        if not configured:
-            return False
-        return Path(configured) != home / "AppData" / "Roaming"
+        for variable, default in (
+            ("LOCALAPPDATA", home / "AppData" / "Local"),
+            ("APPDATA", home / "AppData" / "Roaming"),
+        ):
+            configured = environ.get(variable, "").strip()
+            if configured and Path(configured) != default:
+                return True
+        return False
     if platform_name == "darwin":
         # No standard variable relocates ~/Library/Application Support.
         return False
@@ -1913,6 +1998,10 @@ class KiroPrerequisiteService:
         # Real-time cache bounding the store reads and their SEL audit events.
         self._identity_cache = _AUTH_FINGERPRINT_ABSENT
         self._identity_cache_at = 0.0
+        # Whether the relocation refusal has been logged. The relocated arm runs
+        # on every identity poll, so the diagnostic logs once per service rather
+        # than flooding; see current_identity_fingerprint.
+        self._relocation_logged = False
 
     @property
     def initial_setup_complete(self) -> bool:
@@ -2258,18 +2347,35 @@ class KiroPrerequisiteService:
             and now - self._identity_cache_at < _AUTH_FINGERPRINT_CACHE_SECS
         ):
             return self._identity_cache
-        if identity_store_is_relocated(self._platform, self._home, self._environ):
-            # Do not read the default path: with the CLI pointed elsewhere, a
-            # leftover database there would fingerprint an account nobody is signed
-            # into, and a logout in the real store would change nothing we can see.
-            # Absent is never reconciled, so this re-sweeps every turn instead of
-            # trusting a stale file.
-            self._identity_cache = _AUTH_FINGERPRINT_ABSENT
-            self._identity_cache_at = now
-            return _AUTH_FINGERPRINT_ABSENT
-        path = kiro_identity_store_path(self._platform, self._home, self._environ)
+
+        def _read() -> str:
+            # Both the relocation guard and the win32 path resolver stat the
+            # filesystem, so the whole resolve-and-read runs in this worker
+            # thread and stats stay off the event loop.
+            if identity_store_is_relocated(self._platform, self._home, self._environ):
+                # Do not read the default path: with the CLI pointed elsewhere, a
+                # leftover database there would fingerprint an account nobody is
+                # signed into, and a logout in the real store would change nothing
+                # we can see. Absent is never reconciled, so this re-sweeps every
+                # turn instead of trusting a stale file.
+                if not self._relocation_logged:
+                    # Once per service: this arm runs on every poll, and without
+                    # the log an absent-because-relocated host is indistinguishable
+                    # from a signed-out user -- the silence that made the identity
+                    # probe's failures undiagnosable without reading source.
+                    self._relocation_logged = True
+                    logger.info(
+                        "Kiro identity store is env-relocated on %s; reporting the "
+                        "identity as absent instead of reading the fixed anchor",
+                        self._platform,
+                    )
+                return _AUTH_FINGERPRINT_ABSENT
+            return identity_fingerprint(
+                kiro_identity_store_path(self._platform, self._home, self._environ)
+            )
+
         try:
-            fingerprint = await asyncio.to_thread(identity_fingerprint, path)
+            fingerprint = await asyncio.to_thread(_read)
         except Exception:
             # An unreadable store reports "no identity", matching
             # identity_fingerprint's own contract, rather than "unchanged" --

--- a/test/test_external_logout_detection.py
+++ b/test/test_external_logout_detection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sqlite3
 from pathlib import Path
 
@@ -475,26 +476,90 @@ class TestStorePathSelection:
             tmp_path / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3"
         )
 
-    def test_windows_reads_roaming_not_local(self, tmp_path: Path) -> None:
-        """The identity lives under Roaming; Local holds no credential.
+    def test_windows_defaults_to_local_when_no_store_exists(self, tmp_path: Path) -> None:
+        """Current kiro-cli writes under AppData/Local; that is the anchor.
 
-        Reading Local on Windows would make every fingerprint "absent", so a
-        logout would look identical to a signed-in state and no child would ever
-        be retired there.
+        Anchoring at the legacy Roaming location would make every fingerprint
+        "absent" on a current host, so a logout would look identical to a
+        signed-in state and no child would ever be retired there.
         """
 
         path = kp.kiro_identity_store_path("win32", tmp_path, {})
-        assert path == tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
         # Anchor on the tail BELOW the home we passed, never on global parts: on
         # Windows CI tmp_path itself lives under AppData\Local\Temp, so a bare
-        # `"Local" not in path.parts` asserts something about the fixture's prefix
-        # rather than about which directory this function chose.
+        # `"Roaming" not in path.parts` asserts something about the fixture's
+        # prefix rather than about which directory this function chose.
         assert path.relative_to(tmp_path).parts == (
             "AppData",
-            "Roaming",
+            "Local",
             "kiro-cli",
             "data.sqlite3",
         )
+
+    def test_windows_current_layout_resolves_local(self, tmp_path: Path) -> None:
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        local.parent.mkdir(parents=True)
+        local.touch()
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == local
+
+    def test_windows_legacy_roaming_only_host_falls_back(self, tmp_path: Path) -> None:
+        """Older kiro-cli layouts kept the store under Roaming; keep reading them."""
+
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        roaming.parent.mkdir(parents=True)
+        roaming.touch()
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == roaming
+
+    def test_windows_both_present_reads_the_most_recently_written(self, tmp_path: Path) -> None:
+        """With both layouts present, the live store is the one being written.
+
+        An upgraded host carries a stale Roaming leftover next to its live
+        Local store; a downgraded host writes Roaming next to a stale Local
+        leftover. Preferring either fixed side would read the leftover on the
+        other shape -- a confident fingerprint of an account nobody is signed
+        into -- so recency decides. Both paths are inside the agent-write
+        fence, so the timestamp is as trustworthy as the rows themselves.
+        """
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        for db in (local, roaming):
+            db.parent.mkdir(parents=True)
+            db.touch()
+
+        os.utime(local, (1_000_000, 1_000_000))
+        os.utime(roaming, (2_000_000, 2_000_000))
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == roaming
+
+        os.utime(local, (3_000_000, 3_000_000))
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == local
+
+        # Equal timestamps prefer Local, the current layout.
+        os.utime(roaming, (3_000_000, 3_000_000))
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == local
+
+    def test_windows_recency_counts_the_wal_sidecar(self, tmp_path: Path) -> None:
+        """A commit in WAL mode advances the -wal file, not the main file.
+
+        An actively-written store can have a frozen main-file mtime until the
+        next checkpoint, so recency compares the newest of (db, db-wal) per
+        side -- otherwise the live side loses the tie-break to a stale main
+        file that merely got touched later.
+        """
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        for db in (local, roaming):
+            db.parent.mkdir(parents=True)
+            db.touch()
+        wal = roaming.with_name(roaming.name + "-wal")
+        wal.touch()
+
+        # Roaming main file is old, but its WAL carries the newest write.
+        os.utime(roaming, (1_000_000, 1_000_000))
+        os.utime(local, (2_000_000, 2_000_000))
+        os.utime(wal, (3_000_000, 3_000_000))
+        assert kp.kiro_identity_store_path("win32", tmp_path, {}) == roaming
 
     def test_windows_path_ignores_a_redirected_appdata(self, tmp_path: Path) -> None:
         """Fixed anchor, not %APPDATA%.
@@ -602,11 +667,48 @@ class TestStoreRelocation:
             "win32", tmp_path, {"APPDATA": str(tmp_path / "AppData" / "Roaming")}
         )
 
-    def test_localappdata_is_not_a_relocation_signal(self, tmp_path: Path) -> None:
-        """The identity lives under Roaming; LOCALAPPDATA does not move it."""
+    def test_either_appdata_redirect_relocates_regardless_of_stores(self, tmp_path: Path) -> None:
+        """A fixed-anchor DB under redirection cannot be attributed to a live writer.
 
-        assert not kp.identity_store_is_relocated(
+        The CLI resolves its data dir from LOCALAPPDATA (current layout) or
+        APPDATA (legacy layout), and which generation is writing cannot be
+        observed. Once either variable is redirected, a database at a fixed
+        anchor may be a leftover of either layout, and reading a leftover
+        yields a confident fingerprint of an account nobody is signed into --
+        so the guard refuses to guess, whatever stores exist. Absent is the
+        module's safe side, and this matches the pre-change posture for
+        Group-Policy Roaming redirection (the anchor then lived under
+        Roaming), so redirected enterprise hosts lose nothing they had.
+        """
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        local.parent.mkdir(parents=True)
+        local.touch()
+        # Even with a healthy Local store, either redirect relocates.
+        assert kp.identity_store_is_relocated(
+            "win32", tmp_path, {"APPDATA": str(tmp_path / "elsewhere")}
+        )
+        assert kp.identity_store_is_relocated(
             "win32", tmp_path, {"LOCALAPPDATA": str(tmp_path / "elsewhere")}
+        )
+        # Both variables at their defaults is never a relocation.
+        assert not kp.identity_store_is_relocated(
+            "win32",
+            tmp_path,
+            {
+                "APPDATA": str(tmp_path / "AppData" / "Roaming"),
+                "LOCALAPPDATA": str(tmp_path / "AppData" / "Local"),
+            },
+        )
+
+    def test_localappdata_relocation_is_detected(self, tmp_path: Path) -> None:
+        """LOCALAPPDATA moves the local app-data home where the identity now lives."""
+
+        assert kp.identity_store_is_relocated(
+            "win32", tmp_path, {"LOCALAPPDATA": str(tmp_path / "elsewhere")}
+        )
+        assert not kp.identity_store_is_relocated(
+            "win32", tmp_path, {"LOCALAPPDATA": str(tmp_path / "AppData" / "Local")}
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to a Windows path resolver and its tests; no rendered UI delta.

## Problem / Motivation

`kiro_identity_store_path` anchors the Windows kiro-cli identity database at the legacy Roaming location (`AppData/Roaming/kiro-cli`), but current kiro-cli on Windows writes its store under the local app-data directory (`AppData/Local/kiro-cli`) — the layout already reflected in the trusted live-store tuple in `dashboard/handlers/kiro_usage_api.py`. On a current Windows host the identity probe therefore reads a missing or stale Roaming DB and reports the identity "absent".

## Why it matters

The failure direction is fail-safe (absent errs toward retiring children signed in as a previous account), but the retire-on-account-switch feature effectively never sees the real identity on current Windows kiro-cli builds — a silent feature gap: an account switch a Windows user performs in kiro-cli is invisible to the sweep that exists to catch it. Two stale docstring claims (the usage-api-matching claim, and `identity_store_is_relocated`'s "the identity lives under Roaming" rationale) also mislead the next reader.

## What changed (motivation → approach → change)

Symptom: absent identity on every current Windows host. Root cause: the win32 anchor points at the Roaming layout current kiro-cli no longer writes. Change, recognizing both layouts like the usage-api tuple (`_CLI_SQLITE_DBS`) does:

- `kiro_identity_store_path` (win32) resolves between the two fixed anchors via `_win32_identity_store_path`: when only one store exists it is chosen; when both exist the **most recently written** one wins, so a leftover from the other layout never masks the live store's account — a stale Roaming DB after an upgrade (the common shape) and a stale Local DB after a downgrade are both defeated by recency, where preferring either fixed side would read the leftover on the other shape. Equal timestamps prefer Local, the current layout. Both anchors sit inside the `_SENSITIVE_HOME_DIRS` fence (`security.py`), so the recency signal is as trustworthy as the rows themselves — anything that could steer the timestamps could already author the rows. The deliberate FIXED-path posture is kept: no `%LOCALAPPDATA%`/`%APPDATA%` redirection is followed, for the same fence reason as the Linux entry ignoring `XDG_DATA_HOME`.
- `identity_store_is_relocated` (win32) enforces one invariant: once `LOCALAPPDATA` or `APPDATA` is redirected, a database at a fixed anchor cannot be attributed to a live writer — it may be the other generation's live store or either generation's leftover — so the identity is reported absent, the module's safe side. For Group-Policy-redirected hosts this is the same answer they already got when the anchor lived under Roaming (status quo, not a regression), and the once-per-service log makes it diagnosable.
- Both the relocation guard and the win32 resolver now stat the filesystem, so `current_identity_fingerprint` runs the whole resolve-and-read inside the existing `asyncio.to_thread` worker; no stat remains on the event loop.
- The relocation refusal logs once per service (`logger.info`), so an absent-because-relocated host is diagnosable from logs instead of being indistinguishable from a signed-out user — the silence that let this gap survive unnoticed.
- Both stale docstrings refreshed.

## Tests

In `test/test_external_logout_detection.py`:
- `test_windows_defaults_to_local_when_no_store_exists` — bare host resolves the Local anchor (tail-anchored below the fixture home, so Windows CI's `AppData\Local\Temp` tmp roots can't false-pass).
- `test_windows_current_layout_resolves_local` — a present Local DB is chosen.
- `test_windows_legacy_roaming_only_host_falls_back` — Roaming-only layout still read.
- `test_windows_both_present_reads_the_most_recently_written` — recency decides when both layouts exist (Roaming newer → Roaming; Local newer → Local; equal → Local).
- `test_localappdata_relocation_is_detected` / `test_windows_appdata_relocation_is_detected` — a redirected variable reports relocation; the default spelling does not.
- `test_either_appdata_redirect_relocates_regardless_of_stores` — the invariant: either redirect relocates whatever stores exist (even a healthy Local one), and both-at-defaults never does.
- Existing pins (env never steers the path, hostile-env matrix, darwin/linux anchors) all hold unchanged or were updated to the new anchor.

## Manual verification

N/A — unit coverage sufficient: the resolver and guard are pure-ish path/stat functions fully exercised by the matrix above, and the threading change is covered by the module's existing async fingerprint/caching tests.

## Related Issues

Fixes #5829

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
