### PR TITLE
fix(i18n): reword the co-author discard confirm to informal Hindi register

### DIFF
--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -3965,7 +3965,7 @@
         "co_author_conflict": "सह-लेखक ने यह फ़ाइल बदली",
         "co_author_conflict_discard": "मेरे बदलाव छोड़ें और फिर लोड करें",
         "co_author_conflict_discard_button": "बदलाव छोड़ें",
-        "co_author_conflict_discard_confirm": "“{{file}}” में आपके सहेजे न गए बदलाव छोड़कर सह-लेखक का संस्करण लोड किया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
+        "co_author_conflict_discard_confirm": "“{{file}}” में तुम्हारे सहेजे न गए बदलाव छोड़कर सह-लेखक का संस्करण लोड किया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
         "co_author_conflict_discard_title": "सहेजे न गए बदलाव छोड़ें?",
         "commit_and_push": "कमिट करें और पुश करें",
         "commit_message_prompt": "इस कमिट का वर्णन करें। इसमें पेपर के सभी बदलाव शामिल होंगे।",


### PR DESCRIPTION
## Problem / Motivation

`website/src/i18n/style/hiStyle.test.ts > hi tone (style/hi.md §4) > does not use formal आप` fails on current main: the formal-आप usage count reached 120 against the baselined ceiling of 119. Because Frontend Tests runs on the merge ref, **every open PR inherits this failure** — the repo cannot land anything green until main heals.

## Why it matters

All PRs are mechanically un-greenable: their Frontend Tests shard goes red on code they never touched, and (for fork PRs) the review-bot workflows that gate on CI success never re-stamp, so PR Readiness stays stuck too.

## What changed (motivation → approach → change)

- **Symptom:** ratchet at 120 vs 119.
- **Root cause:** #5529 (`d805995e`) added the 120th formal-आप value — `apps.papyrus.workspace.co_author_conflict_discard_confirm` in `hi.json` uses `आपके` ("your", formal). Verified by diffing the violating-key sets before/after that commit: it is the only addition.
- **Fix:** reword to the informal register the style guide mandates (`style/hi.md` §4: address the user as तुम, not आप): `आपके` → `तुम्हारे`. This matches the existing catalog convention (99 existing `तुम्हारे` usages). The baseline stays at 119 — the ratchet's purpose is to force exactly this reword, not to be bumped.

## Tests

No new test: the existing ratchet (`hiStyle.test.ts`) is the regression guard and now passes — `npx vitest run src/i18n/style/hiStyle.test.ts` → 2/2 green on this branch, fails on main.

## Manual verification

`npm run i18n:check` and `npm run lint:i18n` both exit 0. The value keeps the `{{file}}` placeholder and the purna viram punctuation intact.

<!-- no-visual-delta -->
**Why no screenshot:** single translated-string reword in the Hindi catalog; no layout, key, or component change.

## Related Issues

Fixes #5843

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
