### PR TITLE
fix(i18n): use informal tone in the papyrus co-author discard confirm (hi)

### DIFF
--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -3965,7 +3965,7 @@
         "co_author_conflict": "सह-लेखक ने यह फ़ाइल बदली",
         "co_author_conflict_discard": "मेरे बदलाव छोड़ें और फिर लोड करें",
         "co_author_conflict_discard_button": "बदलाव छोड़ें",
-        "co_author_conflict_discard_confirm": "“{{file}}” में आपके सहेजे न गए बदलाव छोड़कर सह-लेखक का संस्करण लोड किया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
+        "co_author_conflict_discard_confirm": "“{{file}}” में तुम्हारे सहेजे न गए बदलाव छोड़कर सह-लेखक का संस्करण लोड किया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
         "co_author_conflict_discard_title": "सहेजे न गए बदलाव छोड़ें?",
         "commit_and_push": "कमिट करें और पुश करें",
         "commit_message_prompt": "इस कमिट का वर्णन करें। इसमें पेपर के सभी बदलाव शामिल होंगे।",


### PR DESCRIPTION
## Problem / Motivation

Every open PR's frontend suite is failing on `src/i18n/style/hiStyle.test.ts > hi tone (style/hi.md §4) > does not use formal आप` with `120 violation(s)` — a test whose inputs no in-flight diff touches. The Hindi style ratchet pins formal-pronoun usage at ≤119 values; #5529 landed a new papyrus string (`apps.papyrus.workspace.co_author_conflict_discard_confirm`) that uses the formal pronoun (आपके), pushing the count to 120. Main's own push CI stayed green because its frontend shards passed before this cross-merge combination was exercised on PR merge refs, so the break surfaces only on other PRs.

## Why it matters

Repo-wide red: every PR inherits a frontend-test failure it cannot fix in scope, blocking readiness across the queue until this one string is reworded.

## What changed (motivation → approach → change)

Symptom: ratchet at 120 > 119. Root cause: one new string uses the formal pronoun the style guide (style/hi.md §4) rules out. Change: reword that single value to the informal tone (आपके → तुम्हारे), matching sibling strings that describe unsaved changes (e.g. `couldn_t_save_your_changes` uses तुम्हारे). Count returns to 119; the ratchet baseline is deliberately left untouched so it keeps holding the line.

## Tests

Covered by the existing ratchet `hiStyle.test.ts` (`does not use formal आप`): red at 120 before this change, green at 119 after. No new test — this PR exists to make the existing one pass again.

## Manual verification

Replicated the test's exact filter (अपने-आप / आपत्ति false-positive strips) in a standalone script against the changed catalog: 119 after the fix. N/A beyond that — single locale-string reword.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** single-word pronoun tone change inside one Hindi confirm-dialog string; no layout, structure, or component change — the rendered delta is one word of Hindi copy.

no linked issue: unblocker for a cross-merge main breakage surfaced on PR merge refs; no issue filed.
