### PR TITLE
fix(ci): feed PR-body greps from here-strings, not pipes (#5835)

### DIFF
--- a/.github/workflows/screenshot-evidence.yml
+++ b/.github/workflows/screenshot-evidence.yml
@@ -100,8 +100,12 @@ jobs:
           # temp-screenshots path, or a GitHub user-attachment URL. Real
           # evidence satisfies the gate outright, so it is checked before any
           # waiver: a body carrying both a screenshot and the marker passes on
-          # the screenshot.
-          if printf '%s' "$body" | grep -qiE '!\[[^]]*\]\([^)]+\)|<img[[:space:]]|<video[[:space:]]|temp-screenshots/|user-attachments/'; then
+          # the screenshot. Every body check reads from a here-string, never a
+          # `printf | grep` pipe: grep -q exits on the first match, the writer
+          # can die of SIGPIPE (141), and pipefail then makes that the
+          # pipeline's status, so a body that DID match would be misread as
+          # carrying no evidence.
+          if grep -qiE '!\[[^]]*\]\([^)]+\)|<img[[:space:]]|<video[[:space:]]|temp-screenshots/|user-attachments/' <<< "$body"; then
             echo "Visual evidence found in the PR description."
             exit 0
           fi
@@ -115,11 +119,11 @@ jobs:
           # body text is never read as a pattern; in both matches below the
           # untrusted body only ever reaches grep as stdin data, never as a
           # pattern or part of a command.
-          if printf '%s' "$body" | grep -qF -- '<!-- no-visual-delta -->'; then
+          if grep -qF -- '<!-- no-visual-delta -->' <<< "$body"; then
             # The justification needs visible content after the colon: literal
             # asterisks are skipped so a bare bold "**Why no screenshot:**"
             # does not count, while a reason opening with emphasis does.
-            if printf '%s' "$body" | grep -qiE 'why no screenshots?:(\*\*)?[[:space:]]*\**[^*[:space:]]'; then
+            if grep -qiE 'why no screenshots?:(\*\*)?[[:space:]]*\**[^*[:space:]]' <<< "$body"; then
               echo "::warning::'<!-- no-visual-delta -->' marker present in the PR body -- visual-evidence requirement waived. The author's justification is in the PR description."
               exit 0
             fi

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -9,6 +9,7 @@ Design Review.
 """
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -80,6 +81,42 @@ class TestScreenshotEvidence:
             "::warning::'<!-- no-visual-delta -->' marker present" in wf
         ), "waiver must emit a warning annotation naming the marker"
 
+    def test_body_reaches_grep_via_here_strings_not_pipes(self):
+        # Under `set -uo pipefail` a `printf '%s' "$body" | grep -q` pipeline
+        # can report 141: grep -q exits on the first match, the printf writer
+        # dies of SIGPIPE, and the `if` reads false even though the pattern
+        # matched -- real evidence misreported as missing. A here-string has
+        # no writer process to kill, so the status is grep's alone.
+        wf = yaml.safe_load(_read("screenshot-evidence.yml"))
+        steps = wf["jobs"]["screenshot-evidence"]["steps"]
+        step = next(
+            (s for s in steps if s.get("name") == "Require visual evidence in the PR body"),
+            None,
+        )
+        assert step is not None, "step 'Require visual evidence in the PR body' not found"
+        # The rationale comments legitimately name the forbidden form, so only
+        # code lines are scanned. The invariant is positive: every grep in the
+        # step reads from a here-string and none sits behind a pipe, which a
+        # substring test for "| grep" cannot pin (`|grep`, `| /bin/grep`, and
+        # `| LC_ALL=C grep` would all slip past it).
+        code = [ln for ln in step["run"].splitlines() if not ln.lstrip().startswith("#")]
+        grep_lines = [ln for ln in code if re.search(r"\bgrep\b", ln)]
+        assert len(grep_lines) == 3, (
+            "expected exactly three body checks (evidence, marker, justification), got: "
+            f"{grep_lines}"
+        )
+        # A grep pattern may legitimately contain literal `|` alternation, so
+        # the pipe test targets "a pipe feeding grep" (with or without spacing,
+        # a path prefix, or interposed env assignments), not any `|` at all.
+        piped_grep = re.compile(r"\|\s*(?:[\w./=-]+\s+)*(?:[\w./-]+/)?grep\b")
+        for ln in grep_lines:
+            assert not piped_grep.search(
+                ln
+            ), f"the PR body must never reach grep through a pipe: {ln!r}"
+            assert re.search(
+                r'<<<\s*"\$\{?body\}?"', ln
+            ), f"each body check must read from a here-string: {ln!r}"
+
 
 @pytest.mark.skipif(
     os.name == "nt" or shutil.which("bash") is None,
@@ -138,9 +175,17 @@ class TestScreenshotEvidenceBodyLogic:
             "REPO": "example/repo",
             "PR": "1",
             "GITHUB_STEP_SUMMARY": str(summary),
+            # A here-string larger than the pipe buffer is backed by a temp
+            # file; keep that file under the test's own directory instead of
+            # the shared /tmp.
+            "TMPDIR": str(tmp_path),
         }
         result = subprocess.run(
             ["bash", "-c", step["run"]],
+            # Every write the script performs is at an absolute path, but the
+            # child must still not inherit pytest's CWD (the repo root): any
+            # future relative write belongs under the test's own directory.
+            cwd=tmp_path,
             env=env,
             capture_output=True,
             text=True,
@@ -198,6 +243,17 @@ class TestScreenshotEvidenceBodyLogic:
     def test_image_in_body_still_passes(self, tmp_path):
         result = self._run_step(tmp_path, "![shot](https://example.test/x.png)\n")
         assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_oversized_body_with_early_evidence_passes(self, tmp_path):
+        # Regression pin for the SIGPIPE misreport: with `printf | grep -q`
+        # under pipefail, a body larger than the pipe buffer whose evidence
+        # sits in the first chunk makes grep exit before the writer finishes,
+        # the writer dies of SIGPIPE, and the pipeline reports 141 -- real
+        # evidence read as absent. The here-string form must pass this.
+        body = "![shot](https://example.test/x.png)\n" + "x" * (1 << 20) + "\n"
+        result = self._run_step(tmp_path, body)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Visual evidence found" in result.stdout
 
     def test_label_waiver_unchanged(self, tmp_path):
         # The marker is an additional path; the label path must keep working.


### PR DESCRIPTION
## Problem / Motivation

`.github/workflows/screenshot-evidence.yml` runs its PR-body gate step under `set -uo pipefail` and fed the captured body to `grep -q` through a `printf '%s' "$body" |` pipe at three sites: visual-evidence detection, the `<!-- no-visual-delta -->` marker, and the justification line. `grep -q` exits as soon as it matches, so `printf` can be killed by SIGPIPE before its write completes; under `pipefail` the pipeline then reports 141 and the enclosing `if` evaluates FALSE even though the pattern matched. At the evidence site that means a PR carrying real screenshot evidence is reported as having none — a spurious red check. A PR body can also reach GitHub's 65,536-character limit, which sits right at the typical 64 KiB pipe buffer, so the writer can block outright.

## Why it matters

A contributor who did everything right (attached screenshots, embedded them in the body) gets a red **Screenshot Evidence** check they cannot explain, on a gate whose entire point is determinism. The failure is body-size- and timing-dependent, so it lands as an unreproducible flake and burns maintainer attention. The same mechanism is being fixed for the two UX scope gates (`ux-review.yml`, `fork-ux-review.yml`) by the still-open PR #3854 (refs #3447, defect 3), which deliberately leaves this file alone; issue #5835 is the explicit carve-out for the one site neither that PR nor anything else covers. Until #3854 merges, the two sibling sites remain on the pipe form on main — they are owned there, not here.

## What changed (motivation → approach → change)

Observed symptom → root cause: the false branch is not a grep mismatch but pipeline-status poisoning — the writer's SIGPIPE death (141) is promoted to the pipeline's status by `pipefail`.

Change: convert the three pipes to here-strings, the same shape open PR #3854 applies to the UX gates: `if grep -qiE '...' <<< "$body"; then`. A here-string hands grep its stdin without a writer process, so there is no SIGPIPE and no pipeline status to poison. The patterns and the `--`/`-F` flags are byte-identical: the untrusted body still reaches grep only as stdin DATA, never as a pattern or part of a command. The trailing newline a here-string appends cannot affect any of the three patterns (none is end-anchored). Scope is deliberately minimal: only the input plumbing changed; the UX and first-principles gates stay untouched (#3854 owns those).

Mechanism verified both ways on bash 5.2 with the exact evidence pattern and a 1 MiB body: the pipe form reports 141 and misreads a matching body; the here-string form reports 0.

## Tests

Both in `test/test_pr_quality_gates.py`, both verified to FAIL against the pre-fix workflow and pass after it:

- `TestScreenshotEvidence::test_body_reaches_grep_via_here_strings_not_pipes` — anti-drift ratchet on the YAML-extracted gate step: exactly three grep body checks, none fed by a pipe (regex that also catches `|grep`, `| /bin/grep`, `| LC_ALL=C grep` respellings), each reading from a `<<< "$body"` here-string. Comment lines are excluded so the in-file rationale may name the forbidden form.
- `TestScreenshotEvidenceBodyLogic::test_oversized_body_with_early_evidence_passes` — behavioral regression pin: a 1 MiB body with the image on the first line. Deterministic against the old form (the body exceeds the pipe buffer, so the writer cannot finish before grep exits).
- `_run_step` hardening in the same file: `cwd=tmp_path` and a pinned `TMPDIR` so the bash child and the here-string's backing temp file stay inside the test's own directory.

## Manual verification

Ran the extracted step under bash 5.2 against fixture bodies (evidence / marker+justification / oversized) in both the pipe and here-string forms; observed 141 vs 0 as described. Full local gate run: black/encoding ratchets, isort, flake8, mypy, full pytest (68205 passed; the 84 failures are this host's pre-existing environment noise, fingerprint-identical to a clean main run).

## Screenshots / video

N/A — CI-only change with no user-visible frontend surface; the Screenshot Evidence gate itself skips this PR (no watched path is touched).

## Related Issues

Closes #5835

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented in-file
- [x] No secrets, credentials, or internal references in the diff

