### PR TITLE
fix(dashboard): gate hold mode on exported gesture ownership (#5753)

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -2322,14 +2322,8 @@ function ChatInput({
    * cannot do. Suspending hands the textarea back for exactly as long as there is
    * something in it, then returns the hold bar without the user re-choosing it.
    *
-   * `voiceRecording` OVERRIDES the draft check, and that clause is load-bearing
-   * rather than defensive. Under streaming STT the transcript does not wait for
-   * the release — `onPartial` writes each hypothesis into the composer WHILE the
-   * finger is still down. Suspending on that draft would unmount the hold target
-   * mid-gesture, and unmounting it takes the pointer listeners with it: the
-   * release and the slide-up would both land on nothing while capture kept
-   * running, stranding an open microphone under a button that no longer exists.
-   * A draft may only reclaim the textarea once no capture is in flight.
+   * When a capture the touch gesture OWNS is in flight, the draft check is
+   * overridden — the mechanics and the reason live with `voiceHoldMode` below.
    */
   /** "Is capture in flight at all" — see the `voiceCaptureActive` prop doc. Falls
    *  back to the gated flag so the prop stays optional for other callers. */
@@ -2339,26 +2333,8 @@ function ChatInput({
   const transcribeInFlight = voiceTranscribeActive ?? voiceTranscribing
   /** State, not a ref: the hold target mounts only once hold mode is on, and the
    *  gesture hook can only bind its listeners when that arrival is observable.
-   *  Declared above `voiceHoldMode` because that predicate reads it — see there. */
+   *  Declared above `touchPtt` because the hook binds to it. */
   const [holdTarget, setHoldTarget] = useState<HTMLButtonElement | null>(null)
-  /*
-   * A draft suspends hold mode, EXCEPT while the gesture's own capture is still
-   * running — otherwise a transcript landing in the composer would unmount the
-   * bar from under the finger that is still holding it.
-   *
-   * `holdTarget !== null` is what distinguishes the gesture's capture from any
-   * other, and it has to be asked: `captureInFlight` alone also matches capture
-   * started from the mic-as-record-button, which is the ONLY dictation route a
-   * draft leaves open. That capture would then promote a draft composer into
-   * hold mode, where the bar renders `settling` (disabled) and the mic renders a
-   * disabled mode switch — an open microphone with nothing on screen that can
-   * stop it. The bar only exists while hold mode is already on, so its target is
-   * the memory of which route opened this capture, and it survives into the
-   * render that observes `captureInFlight` because unmounting it is what clears
-   * it.
-   */
-  const voiceHoldMode = voiceModeAvailable && voiceModePref
-    && (!composerHasDraft || (captureInFlight && holdTarget !== null))
   const touchVoice = useMemo(
     () => ({
       recording: captureInFlight,
@@ -2368,10 +2344,49 @@ function ChatInput({
     }),
     [captureInFlight, onVoiceStart, onVoiceStop, onVoiceCancel],
   )
+  /*
+   * `disabled` deliberately omits `!voiceHoldMode`, and that omission is what
+   * lets `voiceHoldMode` read the hook's ownership below without a cycle. The
+   * term is implied rather than lost: the hook binds only to `holdTarget`, the
+   * only writer of `holdTarget` is the hold bar's ref, and the bar renders under
+   * `voiceHoldMode &&` — so outside hold mode the hook has no element, no
+   * listeners, and nothing left to disable. Leaving hold mode unmounts the bar,
+   * which clears the target and runs the hook's own abandon path.
+   */
   const touchPtt = useTouchPushToTalk(touchVoice, {
     target: holdTarget,
-    disabled: !voiceHoldMode || disabled || transcribeInFlight || optimizing,
+    disabled: disabled || transcribeInFlight || optimizing,
   })
+  /*
+   * A draft suspends hold mode, EXCEPT while the touch gesture's own capture is
+   * still running — otherwise a transcript landing in the composer would unmount
+   * the bar from under the finger that is still holding it.
+   *
+   * `touchPtt.owns` is what distinguishes the gesture's capture from any other,
+   * and it has to be asked: `captureInFlight` alone also matches capture opened
+   * elsewhere — the mic-as-record-button, or the keyboard push-to-talk binding
+   * on a coarse-pointer device that also has a hardware keyboard. The previous
+   * proxy, `holdTarget !== null`, could not tell those apart either: the bar is
+   * mounted for EVERY capture that happens while hold mode is on, so a keyboard
+   * dictation whose streaming partial landed in the composer kept hold mode
+   * alive and rendered a disabled `settling` bar beside a disabled mode switch —
+   * two dead touch controls describing a capture neither of them owned (#5753).
+   * Ownership comes from the hook's own state machine instead, recorded at the
+   * pointerdown that opens capture and relinquished when the gesture resolves.
+   *
+   * Relinquished AT THE RELEASE, deliberately: a draft the gesture itself
+   * streamed in drops hold mode the moment the finger lifts, and the mic — a
+   * record toggle again once hold mode drops — is the live stop control for
+   * whatever drain remains. The old proxy instead held the surface as a
+   * disabled `settling` bar until capture fully ended: a window where nothing
+   * on screen was pressable. (What is VISIBLE through that drain depends on the
+   * dictation panel: its own gate reads `voiceRecording`, so when enabled — the
+   * default — it stays up and the textarea returns when capture ends; the
+   * panel's `gestureDriven` carries the settling term for the same window, see
+   * the render site.)
+   */
+  const voiceHoldMode = voiceModeAvailable && voiceModePref
+    && (!composerHasDraft || (captureInFlight && touchPtt.owns))
   /**
    * True when the mic press changes MODE rather than starting a recording.
    *
@@ -2890,7 +2905,15 @@ function ChatInput({
 
 
         {showDictation ? (
-          <VoiceDictationPanel sampleRef={showDictation} value={value} partial={voicePartial} deviceLabel={voiceDeviceLabel} deviceId={voiceDeviceId} onSelectDevice={onSelectVoiceDevice || noopSelectDevice} deviceSwitchIsLive={voiceDeviceSwitchIsLive} streaming={voiceStreaming} gestureDriven={voiceHoldMode} />
+          /* `gestureDriven` carries the settling term because ownership ends at
+             the release while this panel outlives it: `showDictation` is gated
+             on `voiceRecording`, which stays true through the streaming drain.
+             `bar === 'settling'` can only name the gesture's OWN drain (the
+             hook records `draining` solely on its own commit path), so the
+             keyboard hint stays suppressed for exactly the drain the finger
+             just committed — and stays SHOWN for a keyboard-binding capture,
+             where Esc/Enter genuinely work. */
+          <VoiceDictationPanel sampleRef={showDictation} value={value} partial={voicePartial} deviceLabel={voiceDeviceLabel} deviceId={voiceDeviceId} onSelectDevice={onSelectVoiceDevice || noopSelectDevice} deviceSwitchIsLive={voiceDeviceSwitchIsLive} streaming={voiceStreaming} gestureDriven={voiceHoldMode || touchPtt.bar === 'settling'} />
         ) : (
           <VoiceStatusBar recording={voiceRecording} level={voiceLevel} deviceLabel={voiceDeviceLabel} deviceId={voiceDeviceId} error={voiceError} onDismissError={onClearVoiceError} onSelectDevice={onSelectVoiceDevice || noopSelectDevice} deviceSwitchIsLive={voiceDeviceSwitchIsLive} />
         )}

--- a/website/src/hooks/useTouchPushToTalk.test.ts
+++ b/website/src/hooks/useTouchPushToTalk.test.ts
@@ -523,4 +523,56 @@ describe('useTouchPushToTalk', () => {
     upInCancelZone()
     expect(voice.calls).toEqual(['start', 'cancel'])
   })
+
+  // Ownership is EXPORTED (#5753): the consumer's hold-mode predicate asks "does
+  // the capture in flight belong to this gesture?", and `owns` is the hook's own
+  // answer, from `ownerRef` — never inferred out there from a mounted DOM node or
+  // a recording flag, both of which also match captures opened elsewhere.
+  it('exports ownership for exactly the pointerdown → resolution window', () => {
+    const voice = makeVoice()
+    // A stop that DRAINS (like the real streaming stop), so the post-release
+    // window is observable: ownership must already be gone while `settling`
+    // still names the leftover drain.
+    voice.stop = vi.fn(() => { voice.calls.push('stop') })
+    const { result } = mount(voice)
+    expect(result.current.owns).toBe(false)
+
+    down()
+    expect(result.current.owns).toBe(true)
+
+    passThreshold()
+    expect(result.current.owns).toBe(true)
+
+    // Commit relinquishes AT the release: the drain that remains is `settling`,
+    // not ownership — a consumer gating on `owns` hands the surface back here.
+    up()
+    expect(result.current.owns).toBe(false)
+    expect(result.current.bar).toBe('settling')
+  })
+
+  it('relinquishes exported ownership on a cancel-zone discard', () => {
+    const voice = makeVoice()
+    const { result } = mount(voice)
+    down()
+    passThreshold()
+    expect(result.current.owns).toBe(true)
+
+    upInCancelZone()
+    expect(result.current.owns).toBe(false)
+  })
+
+  // A rejected start() must disown too: ownership without a session would hold
+  // the consumer's hold-mode gate open over a draft with no capture behind it.
+  it('relinquishes exported ownership when the start() it launched rejects', async () => {
+    let reject: (e: Error) => void = () => {}
+    const voice = makeVoice({
+      start: vi.fn(() => new Promise<void>((_, rej) => { reject = rej })),
+    })
+    const { result } = mount(voice)
+    down()
+    expect(result.current.owns).toBe(true)
+
+    await act(async () => { reject(new Error('handshake failed')); await Promise.resolve() })
+    expect(result.current.owns).toBe(false)
+  })
 })

--- a/website/src/hooks/useTouchPushToTalk.ts
+++ b/website/src/hooks/useTouchPushToTalk.ts
@@ -97,6 +97,20 @@ export interface TouchPushToTalkState {
   /** True while the finger is inside the cancel zone — release will DISCARD. */
   armedCancel: boolean
   /**
+   * True while a live gesture owns the capture session: set at the pointerdown
+   * that opens capture, relinquished when the gesture resolves — release,
+   * cancel, failed start, abandon. Exported from `ownerRef` itself so the
+   * consumer never has to infer ownership from a mounted DOM node or from a
+   * recording flag: both proxies also match captures opened elsewhere (the mic
+   * button, the keyboard binding on a device that has both inputs), which is the
+   * defect class this export closes (#5753).
+   *
+   * Deliberately NOT true through the post-release drain — a commit relinquishes
+   * ownership at the release, and `bar === 'settling'` is the name for what
+   * remains of that session.
+   */
+  owns: boolean
+  /**
    * Every visible state of the hold bar, named by the state machine that owns
    * them. The consumer renders one label and one appearance per value and does
    * NOT reassemble them: reconstructing `settling` out here as
@@ -132,6 +146,8 @@ export function useTouchPushToTalk(
     setArmedCancelState(v)
   }, [])
 
+  const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   /**
    * Whether this gesture owns the capture session.
    *
@@ -144,9 +160,16 @@ export function useTouchPushToTalk(
    * state cleared on some exit paths and not others is the exact defect class
    * this hook has already been fixed for twice.
    */
-  const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const ownerRef = useRef<'gesture' | null>(null)
+  /**
+   * Render-visible mirror of `ownerRef`, exported as `owns`. Written ONLY by
+   * `setOwner`, so the ref keeps its sole-writer property and stays the
+   * synchronous authority the handlers read; this is the same fact at render
+   * time. A ref alone cannot be exported — reading it during render is
+   * unobservable, so a consumer's predicate would not recompute when ownership
+   * changes. Mirrored the same way `phase` is, and for the same reason.
+   */
+  const [owns, setOwns] = useState(false)
   const startPendingRef = useRef(false)
   /**
    * This gesture committed and its capture has not finished draining yet.
@@ -252,6 +275,7 @@ export function useTouchPushToTalk(
    *  anything. */
   const setOwner = useCallback((owner: 'gesture' | null) => {
     ownerRef.current = owner
+    setOwns(owner !== null)
     if (owner === null) {
       startSeqRef.current++
       startPendingRef.current = false
@@ -502,5 +526,5 @@ export function useTouchPushToTalk(
           ? 'tap-too-short'
           : 'idle'
 
-  return { phase, holding: phase === 'holding', armedCancel, bar }
+  return { phase, holding: phase === 'holding', armedCancel, owns, bar }
 }

--- a/website/src/test/ChatInput.holdToTalk.test.tsx
+++ b/website/src/test/ChatInput.holdToTalk.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, act } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 import ChatInput from '../components/ChatInput'
 import { createAudioSample } from '../hooks/mic'
+import { HOLD_MS_DEFAULT } from '../lib/pushToTalk'
 
 /**
  * Hold-to-talk mode: the WeChat-style swap where the mic becomes a mode switch
@@ -13,6 +14,14 @@ import { createAudioSample } from '../hooks/mic'
  * ChatInput owns: which surface is mounted, and — the part a reviewer caught —
  * that a draft arriving mid-capture does not tear the hold target out from under
  * the finger.
+ *
+ * Cases that claim a gesture DRIVE one, via the pointer helpers below. Hold-mode
+ * survival over a draft is gated on the hook's exported ownership now, and
+ * ownership is recorded only by the hook's own pointerdown — simulating capture
+ * through props leaves the hook owning nothing, which is a DIFFERENT scenario
+ * (the keyboard binding, or the mic-as-record-button). Two earlier tests here
+ * asserted the wrong outcome precisely because their prop-only setup could not
+ * tell the two apart (#5753).
  */
 
 vi.mock('../components/Strands', () => ({
@@ -49,6 +58,22 @@ function stubTouch(coarse: boolean) {
     removeEventListener: vi.fn(),
   }))
 }
+
+/** Where the test finger starts, in client coords. Well clear of the cancel zone. */
+const ORIGIN_Y = 400
+
+/** One real pointer event on the hold target — the hook listens natively, so
+ *  these are dispatched, not fired through React's synthetic layer. */
+function pointer(el: Element, type: string, init: PointerEventInit = {}) {
+  act(() => {
+    el.dispatchEvent(new PointerEvent(type, {
+      pointerId: 1, pointerType: 'touch', isPrimary: true,
+      bubbles: true, cancelable: true, clientX: 100, clientY: ORIGIN_Y, ...init,
+    }))
+  })
+}
+const pressHoldTarget = (el: Element) => pointer(el, 'pointerdown')
+const releaseHoldTarget = (el: Element) => pointer(el, 'pointerup')
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -96,45 +121,152 @@ describe('ChatInput — hold-to-talk mode', () => {
   // hypothesis into the composer WHILE the finger is still down, so suspending on
   // that draft would unmount the hold target mid-gesture — taking the pointer
   // listeners with it, so the release and the slide-up land on nothing while
-  // capture keeps running.
-  it('keeps the hold target mounted when a streaming partial lands mid-capture', () => {
-    localStorage.setItem('mc-voice-mode', '1')
-    const { rerender } = renderWithProviders(
-      <ChatInput {...base} {...voiceProps} voiceRecording />,
-    )
-    expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
+  // capture keeps running. The finger goes down FOR REAL here: hold-mode survival
+  // is gated on the hook's ownership, and only the hook's own pointerdown records
+  // it — rendering with capture props alone is the not-owned scenario below.
+  it('keeps the hold target mounted when a streaming partial lands mid-hold', () => {
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem('mc-voice-mode', '1')
+      voiceProps.onVoiceStart.mockClear()
+      voiceProps.onVoiceStop.mockClear()
+      const { rerender } = renderWithProviders(<ChatInput {...base} {...voiceProps} />)
+      const bar = screen.getByTestId('hold-to-talk')
 
-    // A partial arrives: the composer now holds text, but the finger is still down.
-    rerender(<ChatInput {...base} {...voiceProps} voiceRecording value="arm auto merge on" />)
-    expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Switch to keyboard' })).toBeTruthy()
+      pressHoldTarget(bar)
+      expect(voiceProps.onVoiceStart).toHaveBeenCalledTimes(1)
+      // Past the hold threshold: the press is a recognised HOLD, not a tap.
+      act(() => { vi.advanceTimersByTime(HOLD_MS_DEFAULT) })
 
-    // Capture ends — only now may the draft reclaim the textarea.
-    rerender(<ChatInput {...base} {...voiceProps} value="arm auto merge on" />)
-    expect(screen.queryByTestId('hold-to-talk')).toBeNull()
+      // Capture goes live and a partial arrives: the composer now holds text, but
+      // the finger is still down — the bar must not be unmounted from under it.
+      rerender(<ChatInput {...base} {...voiceProps} voiceRecording value="arm auto merge on" />)
+      expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Switch to keyboard' })).toBeTruthy()
+
+      // The finger lifts, committing the capture. Ownership ends AT the release,
+      // so the draft reclaims the textarea immediately; the drain that remains
+      // belongs to the mic, which is a record toggle again and can stop it —
+      // instead of a disabled `settling` bar owning the surface for it.
+      releaseHoldTarget(bar)
+      expect(voiceProps.onVoiceStop).toHaveBeenCalledTimes(1)
+      expect(screen.queryByTestId('hold-to-talk')).toBeNull()
+      const mic = screen.getByRole('button', { name: 'Stop recording' })
+      expect((mic as HTMLButtonElement).disabled).toBe(false)
+
+      // Capture ends — the draft keeps the textarea.
+      rerender(<ChatInput {...base} {...voiceProps} value="arm auto merge on" />)
+      expect(screen.queryByTestId('hold-to-talk')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  // `voiceRecording` is ownership-gated (`owned && recording`) and ownership lands
-  // only after the streaming handshake, so during that window capture is real and
-  // the gated flag still reads false. The hold target must not vanish there — that
+  // `voiceRecording` is ownership-gated (`owned && recording`) and lands only
+  // after the streaming handshake, so during that window capture is real and the
+  // gated flag still reads false. The hold target must not vanish there — that
   // is the mid-gesture unmount hazard, and it would also make the hook's commit
-  // veto answer "no capture" for audio that exists.
-  it('keeps the hold target mounted on ungated capture, before ownership lands', () => {
+  // veto answer "no capture" for audio that exists. The gesture's own ownership
+  // is already held (it is recorded at the pointerdown, before any handshake),
+  // so what this case exercises is the UNGATED capture flag being the one the
+  // hold-mode predicate pairs it with.
+  it('keeps the hold target mounted on ungated capture, while the handshake is pending', () => {
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem('mc-voice-mode', '1')
+      const { rerender } = renderWithProviders(
+        <ChatInput {...base} {...voiceProps} voiceRecording={false} />,
+      )
+      pressHoldTarget(screen.getByTestId('hold-to-talk'))
+      // Past the hold threshold: the press is a recognised HOLD, as the name says.
+      act(() => { vi.advanceTimersByTime(HOLD_MS_DEFAULT) })
+
+      // Ownership held, handshake pending (`voiceRecording` still false) while a
+      // partial already fills the composer: the bar must survive on the gesture's
+      // ownership plus the ungated flag alone.
+      rerender(
+        <ChatInput {...base} {...voiceProps} voiceRecording={false} voiceCaptureActive value="a streaming partial" />,
+      )
+      expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The scenario #5753 exists for: a coarse-pointer device that ALSO has a
+  // hardware keyboard (an iPad with a keyboard case). Hold mode is on and the
+  // composer empty, so the bar is mounted — and dictation starts from the
+  // keyboard push-to-talk binding, which this composer's touch hook never sees.
+  // The capture is real, but the gesture owns nothing, and a mounted bar must no
+  // longer stand in for ownership: the old proxy (`holdTarget !== null`) kept
+  // hold mode alive when the streaming partial landed, rendering a disabled
+  // `settling` bar beside a disabled mode switch — two dead touch controls
+  // describing a capture neither of them owned.
+  it('does not keep a keyboard-binding capture in hold mode once its partial lands', () => {
     localStorage.setItem('mc-voice-mode', '1')
-    // Hold mode must be established FIRST. Rendering straight into a draft with
-    // capture live is the *other* scenario — dictation started from the mic over a
-    // draft — and asserting the bar there is what locked in an unstoppable mic.
-    const { rerender } = renderWithProviders(
-      <ChatInput {...base} {...voiceProps} voiceRecording={false} voiceCaptureActive />,
-    )
+    const { rerender } = renderWithProviders(<ChatInput {...base} {...voiceProps} />)
     expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
 
-    // Ownership has not landed yet (`voiceRecording` still false) while a partial
-    // already fills the composer: the bar must survive on the ungated flag alone.
-    rerender(
-      <ChatInput {...base} {...voiceProps} voiceRecording={false} voiceCaptureActive value="a streaming partial" />,
-    )
+    // Keyboard PTT starts capture: no pointer ever touches the bar. While the
+    // composer is still empty there is no draft to read, so hold mode
+    // legitimately stays — the bar doubles as a "one mic at a time" stop target.
+    rerender(<ChatInput {...base} {...voiceProps} voiceRecording voiceCaptureActive />)
     expect(screen.getByTestId('hold-to-talk')).toBeTruthy()
+
+    // A streaming partial lands. The draft suspends hold mode exactly as if no
+    // capture were running, because the touch gesture owns none of it: the
+    // keyboard dictation keeps the ordinary composer surface.
+    rerender(<ChatInput {...base} {...voiceProps} voiceRecording voiceCaptureActive value="a keyboard partial" />)
+    expect(screen.queryByTestId('hold-to-talk')).toBeNull()
+    // ...and the capture keeps its own live stop control: the mic is a record
+    // toggle again, enabled, labelled for the session it can actually end.
+    const stop = screen.getByRole('button', { name: 'Stop recording' })
+    expect((stop as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  // The dictation panel OUTLIVES the gesture: its gate reads `voiceRecording`,
+  // which stays true through the streaming drain after the release, while hold
+  // mode has already dropped with the draft. The keyboard hint must stay
+  // suppressed for that window — the drain is the gesture's own, and a thumb
+  // has no Esc key — which is what the `settling` term in `gestureDriven`
+  // carries.
+  it("keeps the dictation panel keyboard hint suppressed through the gesture's own drain", () => {
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem('mc-voice-mode', '1')
+      const { rerender } = renderWithProviders(
+        <ChatInput {...base} {...voiceProps} voiceDictationPanel />,
+      )
+      pressHoldTarget(screen.getByTestId('hold-to-talk'))
+      act(() => { vi.advanceTimersByTime(HOLD_MS_DEFAULT) })
+      rerender(
+        <ChatInput {...base} {...voiceProps} voiceDictationPanel voiceRecording value="a streaming partial" />,
+      )
+
+      // Release with the draft present: hold mode drops, capture keeps draining.
+      releaseHoldTarget(screen.getByTestId('hold-to-talk'))
+      rerender(
+        <ChatInput {...base} {...voiceProps} voiceDictationPanel voiceRecording value="a streaming partial" />,
+      )
+
+      expect(screen.getByTestId('voice-dictation-panel')).toBeTruthy()
+      expect(screen.queryByText(/Esc to cancel/)).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // ...and the same panel over a capture the gesture does NOT own keeps the
+  // hint: a keyboard-binding dictation has a real Esc key and a mic that
+  // finishes the recording, so suppressing the row there would hide a working
+  // affordance.
+  it('keeps the dictation panel keyboard hint for a keyboard-binding capture', () => {
+    localStorage.setItem('mc-voice-mode', '1')
+    renderWithProviders(
+      <ChatInput {...base} {...voiceProps} voiceDictationPanel voiceRecording value="a keyboard partial" />,
+    )
+    expect(screen.getByTestId('voice-dictation-panel')).toBeTruthy()
+    expect(screen.getByText(/Esc to cancel/)).toBeTruthy()
   })
 
   it('does not promote a draft composer into hold mode when dictation starts from the mic', () => {
@@ -159,22 +291,29 @@ describe('ChatInput — hold-to-talk mode', () => {
   // keyboard" (hold mode is still on, capture overrides the draft) while the click
   // stopped the recording instead.
   it('keeps the mic label and its action in agreement during streaming capture', () => {
-    localStorage.setItem('mc-voice-mode', '1')
-    // Establish hold mode before the draft exists, so this is a transcript landing
-    // mid-gesture rather than dictation started over a draft.
-    const { rerender } = renderWithProviders(
-      <ChatInput {...base} {...voiceProps} voiceRecording voiceCaptureActive />,
-    )
-    rerender(
-      <ChatInput {...base} {...voiceProps} voiceRecording voiceCaptureActive value="a streaming partial" />,
-    )
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem('mc-voice-mode', '1')
+      // The gesture is REAL, so this is a transcript landing mid-gesture rather
+      // than dictation started over a draft — only ownership tells them apart.
+      const { rerender } = renderWithProviders(<ChatInput {...base} {...voiceProps} />)
+      pressHoldTarget(screen.getByTestId('hold-to-talk'))
+      // Past the hold threshold: the press is a recognised HOLD.
+      act(() => { vi.advanceTimersByTime(HOLD_MS_DEFAULT) })
+      rerender(
+        <ChatInput {...base} {...voiceProps} voiceRecording voiceCaptureActive value="a streaming partial" />,
+      )
 
-    // Hold mode survives the draft while capture is live, so this is still a switch.
-    const mic = screen.getByRole('button', { name: 'Switch to keyboard' })
-    // ...and a mode cannot be changed mid-capture, so the switch is disabled rather
-    // than silently doing the other job.
-    expect((mic as HTMLButtonElement).disabled).toBe(true)
-    expect(screen.queryByRole('button', { name: 'Stop recording' })).toBeNull()
+      // Hold mode survives the draft while the gesture owns the capture, so this is
+      // still a switch.
+      const mic = screen.getByRole('button', { name: 'Switch to keyboard' })
+      // ...and a mode cannot be changed mid-capture, so the switch is disabled rather
+      // than silently doing the other job.
+      expect((mic as HTMLButtonElement).disabled).toBe(true)
+      expect(screen.queryByRole('button', { name: 'Stop recording' })).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('disables the voice controls while ANOTHER session is still transcribing', () => {


### PR DESCRIPTION
## Problem / Motivation

`ChatInput` decides whether the composer is in voice HOLD mode by asking "does the capture in flight belong to the touch gesture?" — and answers it with a proxy, `captureInFlight && holdTarget !== null`. A mounted hold bar matches **every** capture that runs while hold mode is on, not only captures the gesture started.

Reachable consequence, on a coarse-pointer device that also has a hardware keyboard (an iPad with a keyboard case): hold mode on, composer empty (bar mounted) → the user starts dictation with the **keyboard** push-to-talk binding (`usePushToTalk`, which this composer's touch hook never sees) → a streaming partial lands, so the composer holds a draft → `voiceHoldMode` stays true via the proxy. The touch hook owns nothing (`phase` idle), so its bar renders `settling` — disabled — beside a mic rendering a disabled mode switch: two dead touch controls describing a capture neither of them owns. Found by the Opus review lane on 6332f5cbf as the residual on PR #5700's BLOCKING variant; #5753 deliberately deferred it to its own review round rather than take a sixth narrowing in that PR.

## Why it matters

Hybrid-device users (tablet + keyboard case) see the composer taken over by two disabled controls during any keyboard dictation that streams a partial. The keyboard binding still stops the capture, so nobody is stranded — but the on-screen state is wrong in exactly the way #5700 was opened for, and every future fix to this predicate keeps whack-a-moling until ownership is asked directly.

## What changed (motivation → approach → change)

Root cause: the hook that knows the answer (`useTouchPushToTalk`'s `ownerRef`) did not export it, because the dependency ran the other way — `voiceHoldMode` was computed *before* the hook and fed its `disabled`. The issue specified the inversion; this implements exactly that:

- `useTouchPushToTalk` exports `owns: boolean` — a render-visible **state mirror of `ownerRef`**, written only inside `setOwner`, so the ref stays the synchronous authority the handlers read and the sole-writer property carries over. Nothing infers ownership from a mounted DOM node or a recording flag.
- `ChatInput` declaration order inverts to `captureInFlight → holdTarget → touchVoice → touchPtt → voiceHoldMode`, and the predicate becomes `!composerHasDraft || (captureInFlight && touchPtt.owns)`.
- The hook's `disabled` drops the now-redundant `!voiceHoldMode` term — verified implied, not assumed: the hook binds only to `holdTarget`, the only writer of `holdTarget` is the hold bar's ref, and the bar renders under `voiceHoldMode &&`; leaving hold mode unmounts the bar, which clears the target and runs the hook's own abandon path.
- Deliberate consequence (named in the code comment): ownership ends **at the release**, so a draft the gesture itself streamed in drops hold mode the moment the finger lifts; the mic — a record toggle again — is the live, enabled stop control for the remaining drain, replacing the old window where a disabled `settling` bar owned the surface and nothing on screen was pressable.
- Because the dictation panel outlives the gesture through that drain (its gate reads `voiceRecording`), its `gestureDriven` prop carries a `bar === 'settling'` term: the keyboard hint stays suppressed for exactly the drain the finger just committed, and stays shown for keyboard-binding captures, where Esc/Enter genuinely work. (`settling` can only name the gesture's own drain — the hook records `draining` solely on its own commit path.)

Scope discipline: no shared ownership core is extracted behind both push-to-talk hooks — that is #5719 and stays open. `usePushToTalk` is untouched.

Pre-PR review: two model-pinned reviewers (GPT 5.6 Sol: PASS, zero findings; Opus 5: PASS + 2 CONCERNs + 3 advisories). Both CONCERNs are fixed in this diff (the `gestureDriven` drain window above; a stale comment block whose two sentences described the pre-#5753 predicate). Advisories: ownership doc block moved beside `ownerRef`; two tests now pass the hold threshold they name; the micLabel-over-ungated-capture note was declined per the reviewer's own "no change warranted" (reachability near-nil, action stays correct).

## Tests

- `ChatInput.holdToTalk.test.tsx` — the two #5700 tests that simulated capture through props asserted the wrong outcome precisely because prop-only setup cannot tell a gesture capture from a keyboard one; they are **rewritten in place** to drive real `PointerEvent`s on the bar (per the issue, not supplemented beside):
  - mid-hold streaming partial keeps the bar mounted (real press → threshold → partial → release: bar unmounts at release, `onVoiceStop` fires once, mic = enabled "Stop recording");
  - ungated-capture handshake window keeps the bar on ownership + the ungated flag;
  - mic label/action agreement now established by a real gesture;
  - NEW: keyboard-binding capture does not hold the composer in hold mode once its partial lands (the #5753 scenario);
  - NEW: dictation-panel keyboard hint suppressed through the gesture's own drain, and kept for a keyboard-binding capture.
- `useTouchPushToTalk.test.ts` — NEW cases pin the `owns` export: true for exactly the pointerdown→resolution window (with `settling` naming the leftover drain), relinquished on cancel-zone discard and on a rejected `start()`.

Local gates: `npx tsc -b` clean, eslint clean, jscpd clean, targeted suites 74/74, full `npx vitest run` green except one pre-existing failure — the tracked main-red #5843 (`hiStyle` formal-आप ratchet at 120 vs 119, introduced by d805995e3/#5529; repair PRs #5850/#5853 are open). Not chased here per the main-red protocol; this PR needs a fresh merge-ref once a repair lands.

## Manual verification

N/A — the behavior is disabled/enabled state and surface mounting, fully driven by unit tests with real pointer gestures; no visual design changes (see below).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** this is a behavioral gating fix — every surface shown after the fix (hold bar states, dictation panel, mic record-toggle, textarea) already exists unchanged on main; the diff changes only *which* pre-existing surface is mounted in a capture-ownership defect flow, with no styling, layout, or copy change.

## Related Issues

Closes #5753. Related: #5700 (parent fix this is the residual of), #5719 (shared ownership core, deliberately out of scope), #5843 (inherited main-red, tracked separately).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — in-code design comments updated in the same commit
- [x] No secrets, credentials, or internal references in the diff
