### PR TITLE
fix(sandbox): give the shielded spawn wrapper one owner, migrate 6 sites

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -23,7 +23,7 @@ otherwise.
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import functools
 import json
 import logging
 import os
@@ -392,30 +392,19 @@ async def _sandboxed_off_loop(argv: list[str]) -> tuple[list[str], dict[str, str
     A plain ``asyncio.to_thread`` hop is the leak: cancelling the awaiting
     coroutine abandons the hop while the worker thread is still inside
     ``sandboxed_spawn_argv``, the thread goes on to materialize the
-    launcher/profile, and the returned tuple is never bound — so no ``finally``
-    and no session field can ever reach the cleanup path. Shielding the hop
-    keeps the worker's result recoverable: on cancellation, wait for it to
-    settle, drop the launcher it made, then re-raise. Same shape as
-    ``kiro_prerequisite``'s sandboxed-spawn preparation.
+    launcher/profile, and the returned tuple is never bound -- so no ``finally``
+    and no session field can ever reach the cleanup path.
 
-    ``SandboxUnavailableError`` still propagates to the caller unchanged — the
-    shield only intercepts cancellation, and that raise carries no tuple and
-    hence no file to drop.
+    Delegates to the shared :func:`sandbox.shielded_prepare_off_loop`, which
+    owns the shield-and-recover pattern (worker-thread hop + settle-then-unlink
+    under cancellation, repeat-cancellation safe per #5841) for every async
+    caller of the chokepoint.  Preparation stays behind :func:`_sandboxed` so
+    this module keeps owning its own ``mode="strict"`` + ``_build_env()``
+    policy.  ``SandboxUnavailableError`` still propagates to the caller
+    unchanged -- the shield only intercepts cancellation, and that raise carries
+    no tuple and hence no file to drop.
     """
-    task = asyncio.create_task(asyncio.to_thread(_sandboxed, argv))
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        cleanup: str | None = None
-        # `BaseException`, not `Exception`: a repeat cancellation can land on
-        # this recovery await, and letting it out of the handler would skip the
-        # drop below — the exact leak this helper exists to close. Swallow it
-        # so the drop still runs and the ORIGINAL cancellation is the one that
-        # propagates (same shape as `_to_native_audio`'s reap-on-cancel).
-        with contextlib.suppress(BaseException):
-            _, _, cleanup = await task
-        _drop_sandbox_launcher(cleanup)
-        raise
+    return await sandbox.shielded_prepare_off_loop(functools.partial(_sandboxed, argv))
 
 
 def _mkstemp_path(suffix: str) -> str:

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -64,6 +64,7 @@ from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     create_subprocess_limited,
     sandboxed_spawn_argv,
+    shielded_prepare_off_loop,
 )
 from kiro_crew.security import (
     redact_credentials,
@@ -1121,10 +1122,9 @@ async def _run_cmd(
     try:
         # sandboxed_spawn_argv can cold-probe the sandbox backend with a
         # synchronous subprocess (blocking base rule) — run it on the executor.
-        loop = asyncio.get_running_loop()
-        cmd, env, cleanup = await loop.run_in_executor(
-            subprocess_executor(),
+        cmd, env, cleanup = await shielded_prepare_off_loop(
             functools.partial(sandboxed_spawn_argv, cmd, mode, env=base_env),
+            executor=subprocess_executor(),
         )
     except RuntimeError as exc:
         # Fail closed: no sandbox backend and unsandboxed exec not opted in.
@@ -2893,13 +2893,14 @@ async def _pod_provision(name: str) -> dict:
             if running:
                 return {"ok": False, "error": "provision already running", "run_id": prev}
         await _warm_build_path()
-        loop = asyncio.get_running_loop()
-        p_argv, p_env, p_cleanup = await loop.run_in_executor(
-            subprocess_executor(),
+        p_argv, p_env, p_cleanup = await shielded_prepare_off_loop(
             functools.partial(
                 sandboxed_spawn_argv,
-                _find_cli() + ["pod", "provision", name], "strict", env=_pod_env(),
+                _find_cli() + ["pod", "provision", name],
+                "strict",
+                env=_pod_env(),
             ),
+            executor=subprocess_executor(),
         )
         rid = await _start_run(
             "provision " + name, p_argv, cwd=_repo(), env=p_env,
@@ -3855,11 +3856,10 @@ async def _sync_start_locked() -> dict:
         # order, and a directory cannot go until it is empty.
         cleanups += [str(dep_sync_snapshot), str(dep_sync_snapshot.parent)]
     wrapped_steps: list[dict] = []
-    loop = asyncio.get_running_loop()
     for argv, mode, base_env, label in raw_steps:
-        w_argv, w_env, cleanup = await loop.run_in_executor(
-            subprocess_executor(),
+        w_argv, w_env, cleanup = await shielded_prepare_off_loop(
             functools.partial(sandboxed_spawn_argv, argv, mode, env=base_env),
+            executor=subprocess_executor(),
         )
         if cleanup:
             cleanups.append(cleanup)

--- a/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/gitops.py
@@ -21,6 +21,7 @@ push commits back. Every git invocation here follows the same three rules as
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import os
 import re
@@ -40,6 +41,7 @@ from kiro_crew.sandbox import (
     SandboxUnavailableError,
     create_subprocess_limited,
     sandboxed_spawn_argv,
+    shielded_prepare_off_loop,
 )
 from kiro_crew.sel import sel
 
@@ -426,8 +428,9 @@ async def _git(
     # heartbeat — for up to five seconds. Same form and reason as `latex._run` and
     # `apps/builtins/dev_fleet/server.py`.
     try:
-        wrapped, env, cleanup = await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), sandboxed_spawn_argv, argv
+        wrapped, env, cleanup = await shielded_prepare_off_loop(
+            functools.partial(sandboxed_spawn_argv, argv),
+            executor=subprocess_executor(),
         )
     except SandboxUnavailableError as exc:
         # Translated, not bypassed. See `GitSandboxUnavailable` — the wrap is what

--- a/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
@@ -48,6 +48,7 @@ from kiro_crew.sandbox import (
     SandboxUnavailableError,
     create_subprocess_limited,
     sandboxed_spawn_argv,
+    shielded_prepare_off_loop,
 )
 from kiro_crew.sel import sel
 
@@ -383,8 +384,7 @@ async def _run(
     and same reason as ``apps/builtins/dev_fleet/server.py``.
     """
     try:
-        wrapped, scrubbed, cleanup = await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(),
+        wrapped, scrubbed, cleanup = await shielded_prepare_off_loop(
             functools.partial(
                 sandboxed_spawn_argv,
                 argv,
@@ -392,6 +392,7 @@ async def _run(
                 env=env,
                 extra_hidden_dirs=_sensitive_hidden_dirs(),
             ),
+            executor=subprocess_executor(),
         )
     except SandboxUnavailableError as exc:
         # Fail-closed is CORRECT here and is deliberately not bypassed: this

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
@@ -21,6 +21,7 @@ Responsibilities:
 from __future__ import annotations
 
 import asyncio
+import functools
 import hashlib
 import json
 import logging
@@ -89,10 +90,15 @@ except Exception:  # pragma: no cover - hooks always present in prod
     safe_read_file_bytes_nolink = None  # type: ignore[assignment]
 
 try:
-    from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
+    from kiro_crew.sandbox import (
+        create_subprocess_limited,
+        sandboxed_spawn_argv,
+        shielded_prepare_off_loop,
+    )
 except Exception:  # pragma: no cover - sandbox always present in prod
     create_subprocess_limited = None  # type: ignore[assignment]
     sandboxed_spawn_argv = None  # type: ignore[assignment]
+    shielded_prepare_off_loop = None  # type: ignore[assignment]
 
 try:
     from kiro_crew.autonudge import AutoNudgeService as _AutoNudgeService
@@ -5676,7 +5682,9 @@ async def _git(cwd: str, *args: str) -> tuple[int, str, str]:
         # Off-loop: the sandbox backend probe can shell out (subprocess.run) the
         # first time it runs on a host, and it writes the scrubbed-env temp file.
         # Neither is the cheap in-memory call it looks like.
-        argv, env, cleanup = await asyncio.to_thread(_prepare_git_spawn, ["git", "-C", cwd, *args])
+        argv, env, cleanup = await shielded_prepare_off_loop(
+            functools.partial(_prepare_git_spawn, ["git", "-C", cwd, *args])
+        )
     except Exception as exc:
         # Sandbox unavailable / argv build failure: report it, do not 500 the
         # caller. Every caller already treats a non-zero rc as "not a git repo".

--- a/src/kiro_crew/dashboard/terminal_commands.py
+++ b/src/kiro_crew/dashboard/terminal_commands.py
@@ -100,6 +100,7 @@ from kiro_crew.sandbox import (
     SandboxUnavailableError,
     create_subprocess_limited,
     sandboxed_spawn_argv,
+    shielded_prepare_off_loop,
 )
 
 logger = logging.getLogger(__name__)
@@ -784,8 +785,9 @@ async def _run_probe(argv: list[str], cwd: str | None) -> str | None:
         #   escapes the route as an HTTP 500 on a keystroke — for a tier whose
         #   entire contract is "no completions is a normal answer", the right
         #   degradation is no menu, not an error the client must special-case.
-        wrapped, env, cleanup = await loop.run_in_executor(
-            discovery_executor(), functools.partial(_prepare_probe, argv),
+        wrapped, env, cleanup = await shielded_prepare_off_loop(
+            functools.partial(_prepare_probe, argv),
+            executor=discovery_executor(),
         )
     except (SandboxUnavailableError, OSError, RuntimeError):
         return None

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import hashlib
 import json
 import logging
@@ -64,6 +65,7 @@ from kiro_crew.sandbox import (
     SandboxUnavailableError,
     resource_limit_supervisor_argv,
     sandboxed_spawn_argv,
+    shielded_prepare_off_loop,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -1545,12 +1547,14 @@ async def _prepare_sandboxed_spawn(
 ) -> tuple[list[str], dict[str, str], str | None]:
     """Prepare filesystem-heavy sandbox state on a worker thread.
 
-    Cancellation waits for preparation to settle so a launcher/profile created
-    by the worker is still removed instead of becoming an untracked temp file.
+    Delegates to the shared :func:`shielded_prepare_off_loop`, which owns the
+    shield-and-recover pattern (including the repeat-cancellation semantics of
+    #5841) for every async caller of the chokepoint.  The chokepoint call itself
+    stays in this module so the ``mode``/``strip_python_env`` policy — and this
+    module's own seam over ``sandboxed_spawn_argv`` — remain local.
     """
-
-    task = asyncio.create_task(
-        asyncio.to_thread(
+    return await shielded_prepare_off_loop(
+        functools.partial(
             sandboxed_spawn_argv,
             argv,
             mode=mode,
@@ -1560,38 +1564,6 @@ async def _prepare_sandboxed_spawn(
             extra_visible_dirs=extra_visible_dirs,
         )
     )
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        # A repeat cancellation landing on a bare recovery ``await`` is a
-        # ``BaseException``: it would escape a ``suppress(Exception)`` guard
-        # before the unlink runs, leaking the materialized launcher (#5841).
-        # The settle-then-unlink therefore runs as its own task, shielded
-        # from cancellations aimed at this caller; each absorbed repeat is
-        # ``uncancel()``-ed so an enclosing ``asyncio.timeout`` still reports
-        # ``TimeoutError``, and the ORIGINAL cancellation is re-raised once
-        # the launcher is gone.
-        async def _settle_then_unlink() -> None:
-            cleanup_path: str | None = None
-            with contextlib.suppress(Exception, asyncio.CancelledError):
-                _, _, cleanup_path = await task
-            await _unlink_off_loop(cleanup_path)
-
-        current = asyncio.current_task()
-        recovery = asyncio.create_task(_settle_then_unlink())
-        while not recovery.done():
-            try:
-                await asyncio.shield(recovery)
-            except asyncio.CancelledError:
-                uncancel = getattr(current, "uncancel", None)  # 3.11+
-                if uncancel is not None:
-                    uncancel()
-            except Exception:
-                logger.warning(
-                    "sandbox launcher cleanup failed after cancellation",
-                    exc_info=True,
-                )
-        raise
 
 
 async def _run_process(

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -20,6 +20,7 @@ Config: ``"sandbox": "auto" | "off"`` in ``~/.kiro/crew/config.json``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import ctypes
 import ctypes.util
 import errno
@@ -52,6 +53,7 @@ except ImportError:  # non-POSIX (Windows)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
+    from concurrent.futures import ThreadPoolExecutor
     from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -4111,6 +4113,85 @@ def sandboxed_spawn_argv(
     # (e.g. ``npx @playwright/mcp``).
     scrubbed[KIROCREW_SPAWNED_ENV] = KIROCREW_SPAWNED_VALUE
     return wrapped, scrubbed, cleanup
+
+
+async def shielded_prepare_off_loop(
+    prepare: Callable[[], tuple[list[str], dict[str, str], str | None]],
+    *,
+    executor: ThreadPoolExecutor | None = None,
+) -> tuple[list[str], dict[str, str], str | None]:
+    """Run a spawn-preparation callable off the loop, shielded from cancellation.
+
+    ``prepare`` must follow the :func:`sandboxed_spawn_argv` contract: it returns
+    ``(wrapped_argv, scrubbed_env, cleanup_path_or_None)`` where the third element
+    is a temp launcher/profile the CALLER must unlink after the child exits.
+
+    Every async caller reaches the sync chokepoint through a worker hop.
+    Cancelling that hop abandons the returned tuple while the worker still
+    materializes the launcher/profile, leaking the temp file forever.  Shielding
+    the hop keeps the worker's result recoverable: on cancellation we wait for
+    the thread to settle, unlink the launcher it created, and re-raise.
+
+    A REPEAT cancellation landing on a bare recovery ``await`` is a
+    ``BaseException`` that would abandon the recovery before the unlink runs,
+    leaking the materialized launcher (#5841).  The settle-then-unlink therefore
+    runs as its own task, shielded from cancellations aimed at this caller; each
+    absorbed repeat is ``uncancel()``-ed so an enclosing ``asyncio.timeout``
+    still reports ``TimeoutError``, and the ORIGINAL cancellation is re-raised
+    once the launcher is gone.
+
+    ``executor`` keeps pool choice with the CALLER, because which pool absorbs a
+    wedged preparation is per-site policy, not a shield concern: the chokepoint
+    can cold-probe the sandbox backend with a synchronous subprocess, and
+    :mod:`kiro_crew.executors` partitions blocking work into named pools so such
+    a probe cannot occupy the workers another subsystem (the orphan-reaping
+    sweep) needs.  Defaulting it to ``None`` — the loop's default pool, via
+    ``asyncio.to_thread`` — would silently collapse that partition for callers
+    that had chosen a pool, so every site that had one passes it explicitly.
+    """
+
+    Prepared = tuple[list[str], dict[str, str], str | None]
+    task: asyncio.Future[Prepared]
+    if executor is None:
+        task = asyncio.ensure_future(asyncio.to_thread(prepare))
+    else:
+        task = asyncio.get_running_loop().run_in_executor(executor, prepare)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+
+        async def _settle_then_unlink() -> None:
+            cleanup: str | None = None
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                _, _, cleanup = await task
+            if not cleanup:
+                return
+            target = cleanup
+
+            def _unlink() -> None:
+                with contextlib.suppress(OSError):
+                    os.unlink(target)
+
+            if executor is None:
+                await asyncio.to_thread(_unlink)
+            else:
+                await asyncio.get_running_loop().run_in_executor(executor, _unlink)
+
+        current = asyncio.current_task()
+        recovery = asyncio.create_task(_settle_then_unlink())
+        while not recovery.done():
+            try:
+                await asyncio.shield(recovery)
+            except asyncio.CancelledError:
+                uncancel = getattr(current, "uncancel", None)  # 3.11+
+                if uncancel is not None:
+                    uncancel()
+            except Exception:
+                logger.warning(
+                    "sandbox launcher cleanup failed after cancellation",
+                    exc_info=True,
+                )
+        raise
 
 
 # ── cgroup v2 scope enforcement (fork bomb + memory DoS) ──

--- a/test/test_sandbox_off_loop.py
+++ b/test/test_sandbox_off_loop.py
@@ -1,0 +1,238 @@
+"""Tests for ``shielded_prepare_off_loop`` — the shared shield over the chokepoint.
+
+Cancel-injection test: verifies that cancelling the awaiting coroutine while the
+worker is still inside ``sandboxed_spawn_argv`` recovers the cleanup path and
+unlinks the temp launcher/profile, rather than leaking it.
+
+Executor test: the caller's pool is honoured, so consolidating the shield does
+not silently collapse each site's ``executors.py`` pool onto the default one.
+
+AST guard test: scans ``src/kiro_crew/`` for bare ``run_in_executor`` AND
+``asyncio.to_thread`` hops referencing ``sandboxed_spawn_argv`` (the sync
+version) without going through the shared shield. Prevents regressions.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import functools
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure the source tree is importable without pip install.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from kiro_crew.sandbox import shielded_prepare_off_loop  # noqa: E402
+
+
+def _prepare(argv: list[str]):
+    """Bind the chokepoint the way every production call site does."""
+    from kiro_crew import sandbox
+
+    return functools.partial(sandbox.sandboxed_spawn_argv, argv)
+
+
+class TestSandboxOffLoopCancellation:
+    """Cancellation during the worker hop must not orphan the temp launcher."""
+
+    @staticmethod
+    def _blocking_sandbox(tmp_path):
+        """A ``sandboxed_spawn_argv`` stub that parks the worker until released.
+
+        Reproduces the race deterministically: the awaiting coroutine is
+        cancelled while the thread is still inside the chokepoint, and the
+        launcher only comes into being AFTER the cancellation landed.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        created: list[Path] = []
+
+        def _fake(argv, mode="standard", **_kwargs):
+            entered.set()
+            assert release.wait(timeout=10), "test never released the worker"
+            launcher = tmp_path / f"sb-launcher-{len(created)}"
+            launcher.write_text("# fake sandbox launcher/profile")
+            created.append(launcher)
+            return argv, {}, str(launcher)
+
+        return _fake, entered, release, created
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_hop_drops_launcher(self, tmp_path):
+        fake, entered, release, created = self._blocking_sandbox(tmp_path)
+        with patch("kiro_crew.sandbox.sandboxed_spawn_argv", side_effect=fake):
+            task = asyncio.create_task(shielded_prepare_off_loop(_prepare(["/bin/true"])))
+            # Wait for the worker to enter the stub (implies awaiter is
+            # suspended at the shielded hop).
+            await asyncio.to_thread(entered.wait, 10)
+            task.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        # The launcher was created by the worker thread and should have been
+        # unlinked by the recovery path in the CancelledError handler.
+        assert created, "stub was never called"
+        assert not any(f.exists() for f in created), "launcher was NOT cleaned up on cancellation"
+
+    @pytest.mark.asyncio
+    async def test_cancel_on_a_caller_pool_still_drops_launcher(self, tmp_path):
+        """The recovery works on a caller-supplied pool, not just the default one."""
+        fake, entered, release, created = self._blocking_sandbox(tmp_path)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            with patch("kiro_crew.sandbox.sandboxed_spawn_argv", side_effect=fake):
+                task = asyncio.create_task(
+                    shielded_prepare_off_loop(_prepare(["/bin/true"]), executor=pool)
+                )
+                await asyncio.to_thread(entered.wait, 10)
+                task.cancel()
+                release.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+        assert created, "stub was never called"
+        assert not any(f.exists() for f in created), "launcher was NOT cleaned up on cancellation"
+
+    @pytest.mark.asyncio
+    async def test_the_callers_executor_is_the_one_used(self):
+        """Pool choice stays with the caller — the whole point of the parameter.
+
+        Pinned by the worker thread's identity: the preparation must run on a
+        thread belonging to the pool that was passed in, not on the loop's
+        default executor.
+        """
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="pinned-pool") as pool:
+            names: list[str] = []
+
+            def _fake(argv, mode="standard", **_kwargs):
+                names.append(threading.current_thread().name)
+                return argv, {}, None
+
+            with patch("kiro_crew.sandbox.sandboxed_spawn_argv", side_effect=_fake):
+                await shielded_prepare_off_loop(_prepare(["/bin/true"]), executor=pool)
+        assert names and names[0].startswith("pinned-pool"), names
+
+    @pytest.mark.asyncio
+    async def test_normal_return_passes_through(self, tmp_path):
+        """Non-cancelled calls pass through the chokepoint result unchanged."""
+        launcher = tmp_path / "sb-launcher"
+        launcher.write_text("# fake")
+
+        def _fake(argv, mode="standard", **_kwargs):
+            return ["wrapped"] + argv, {"PATH": "/usr/bin"}, str(launcher)
+
+        with patch("kiro_crew.sandbox.sandboxed_spawn_argv", side_effect=_fake):
+            result = await shielded_prepare_off_loop(_prepare(["/bin/true"]))
+        assert result == (
+            ["wrapped", "/bin/true"],
+            {"PATH": "/usr/bin"},
+            str(launcher),
+        )
+
+
+class TestNoBareSandboxedSpawnArgvHops:
+    """AST guard: no async code may hop to the sync chokepoint without a shield.
+
+    Every async caller must go through ``shielded_prepare_off_loop`` so a
+    cancelled awaiter cannot abandon the worker's tuple and leak the launcher.
+
+    Two things this guard has to get right, or it passes vacuously:
+
+    * BOTH spellings of a bare hop -- ``loop.run_in_executor(pool, fn, ...)``
+      and ``asyncio.to_thread(fn, ...)``. The private copies this PR collapsed
+      used the second one, so covering only the first closes half the class.
+    * ONE LEVEL OF INDIRECTION. Most sites do not hand the chokepoint to the
+      hop directly; they hand it a module-level preparer that calls it
+      (``_prepare_probe``, ``_sandboxed``, ``_prepare_git_spawn``), whose name
+      says nothing about the chokepoint. A guard matching only the literal
+      ``sandboxed_spawn_argv`` at the hop site is blind to exactly the sites
+      this PR had to fix, so per file we first collect the functions that call
+      the chokepoint and treat a hop to any of them as a hop to it.
+
+    There is deliberately no exemption list: a site that unlinks in its own
+    ``finally`` is NOT covered, because a cancellation at the hop never binds
+    the tuple, so that ``finally`` sees no cleanup path to remove.
+    """
+
+    _CHOKEPOINT = "sandboxed_spawn_argv"
+
+    @staticmethod
+    def _src_root() -> Path:
+        return Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+
+    def _python_files(self) -> list[Path]:
+        root = self._src_root()
+        return sorted(root.rglob("*.py"))
+
+    @classmethod
+    def _names_that_reach_the_chokepoint(cls, tree: ast.Module) -> set[str]:
+        """Names a hop may be handed that end up calling the chokepoint.
+
+        The chokepoint itself, plus every function in this module whose body
+        calls it — the preparer indirection every real call site uses.
+        """
+        reaching = {cls._CHOKEPOINT}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Call):
+                    continue
+                fn = child.func
+                hits = (isinstance(fn, ast.Name) and fn.id == cls._CHOKEPOINT) or (
+                    isinstance(fn, ast.Attribute) and fn.attr == cls._CHOKEPOINT
+                )
+                if hits:
+                    reaching.add(node.name)
+                    break
+        return reaching
+
+    @staticmethod
+    def _is_bare_hop_call(node: ast.Call) -> bool:
+        """Return True for a ``*.run_in_executor(...)`` or ``*.to_thread(...)`` call."""
+        func = node.func
+        return isinstance(func, ast.Attribute) and func.attr in {
+            "run_in_executor",
+            "to_thread",
+        }
+
+    @staticmethod
+    def _references_any(node: ast.Call, names: set[str]) -> str | None:
+        """The first of ``names`` referenced anywhere in the call's arguments.
+
+        Walks each argument, so a ``functools.partial(fn, ...)`` wrapper and a
+        plain reference are both caught.
+        """
+        for arg in [*node.args, *[kw.value for kw in node.keywords]]:
+            for child in ast.walk(arg):
+                if isinstance(child, ast.Name) and child.id in names:
+                    return child.id
+                if isinstance(child, ast.Attribute) and child.attr in names:
+                    return child.attr
+        return None
+
+    def test_no_bare_hops_to_sandboxed_spawn_argv(self):
+        violations: list[str] = []
+        for path in self._python_files():
+            rel = path.relative_to(self._src_root())
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except SyntaxError:
+                continue
+            reaching = self._names_that_reach_the_chokepoint(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not self._is_bare_hop_call(node):
+                    continue
+                hit = self._references_any(node, reaching)
+                if hit is not None:
+                    violations.append(f"{rel}:{node.lineno}: bare hop to {hit}")
+        assert not violations, (
+            "Found bare run_in_executor / to_thread hops that reach sandboxed_spawn_argv "
+            "(must go through sandbox.shielded_prepare_off_loop):\n" + "\n".join(violations)
+        )

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1394,7 +1394,14 @@ def test_every_spawn_is_routed_or_allowlisted():
 
 
 def test_prerequisite_async_adapter_keeps_sandbox_chokepoint():
-    """The off-loop prerequisite adapter must remain a thin sandbox wrapper."""
+    """The off-loop prerequisite adapter must remain a thin sandbox wrapper.
+
+    The off-loop hop itself now lives one level down, in
+    ``sandbox.shielded_prepare_off_loop`` (the single owner of the
+    shield-and-recover pattern), so this pins both halves where they actually
+    live: the adapter must still name the chokepoint and route through that
+    owner, and the owner must still take the work off the loop.
+    """
 
     path = _SRC_ROOT / "kiro_prerequisite.py"
     source = path.read_text(encoding="utf-8")
@@ -1405,8 +1412,19 @@ def test_prerequisite_async_adapter_keeps_sandbox_chokepoint():
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "_prepare_sandboxed_spawn"
     )
     adapter_source = ast.get_source_segment(source, adapter) or ""
-    assert "asyncio.to_thread" in adapter_source
+    assert "shielded_prepare_off_loop" in adapter_source
     assert "sandboxed_spawn_argv" in adapter_source
+
+    sandbox_path = _SRC_ROOT / "sandbox.py"
+    sandbox_source = sandbox_path.read_text(encoding="utf-8")
+    sandbox_tree = ast.parse(sandbox_source, str(sandbox_path))
+    owner = next(
+        node
+        for node in ast.walk(sandbox_tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "shielded_prepare_off_loop"
+    )
+    owner_source = ast.get_source_segment(sandbox_source, owner) or ""
+    assert "asyncio.to_thread" in owner_source or "run_in_executor" in owner_source
 
 
 def test_benign_allowlist_has_no_stale_entries():


### PR DESCRIPTION
fix(sandbox): give the shielded spawn wrapper one owner, migrate 7 sites

Closes #5842. Follow-up from PR #5836 (fix for #5796).

Every async caller of the sync `sandboxed_spawn_argv` chokepoint reaches it
through a worker hop. Cancelling that hop abandons the returned tuple while the
worker still materializes the launcher/profile, so no `finally` and no session
field can ever reach the cleanup path -- one leaked temp file per cancelled
call, forever. Seven call sites had no shield at all and two carried their own
private copy of the pattern.

## One owner for the shield; policy stays with the caller

`sandbox.shielded_prepare_off_loop(prepare, *, executor=None)` owns the whole
pattern for any callable following the chokepoint's
`(wrapped_argv, scrubbed_env, cleanup_or_None)` contract:

- runs `prepare` off the loop and shields the hop
- on cancellation, settles the worker, unlinks the launcher it made, re-raises
- the settle-then-unlink runs as its OWN shielded task, and each repeat
  cancellation absorbed while it completes is `uncancel()`-ed, so an enclosing
  `asyncio.timeout` still reports `TimeoutError` and the ORIGINAL cancellation
  is what propagates. This preserves the repeat-cancellation semantics of
  #5841 rather than regressing them to a `suppress(BaseException)` that
  abandons the recovery.

Two things stay with the CALLER, because both are per-site policy a shared
shield has no business deciding:

- **What runs.** It takes a CALLABLE, not an argv, so each site passes
  `functools.partial(sandboxed_spawn_argv, ...)` bound to its OWN module-level
  name. Each module keeps owning its mode / env / hidden-dirs choice and keeps
  its existing test seam over that name -- reaching for the chokepoint inside
  the helper would have silently moved the seam out from under 37 patch points
  across 7 test files.
- **Which pool absorbs a wedge.** `executor` is explicit because
  `executors.py` partitions blocking work into named pools precisely so a
  cold-probe subprocess cannot occupy the workers the orphan-reaping sweep
  needs. `dev_fleet` and both papyrus sites pass `subprocess_executor()`,
  `terminal_commands` passes `discovery_executor()`; the two that were already
  on the default pool pass nothing.

## 7 unshielded call sites migrated

- `apps/builtins/papyrus/backend/gitops.py`
- `apps/builtins/papyrus/backend/latex.py` (with `extra_hidden_dirs`)
- `apps/builtins/dev_fleet/server.py` -- 3 sites (`_run_cmd`,
  `_pod_provision`, the raw_steps loop)
- `dashboard/terminal_commands.py` -- its `_prepare_probe` must build the env
  ON the worker, which the callable form preserves exactly
- `apps/builtins/spec_builder/backend/routes.py` -- the `_prepare_git_spawn`
  hop. Its `finally` unlink does NOT cover this: a cancellation at the hop
  never binds the tuple, so that `finally` has no cleanup path to remove.

## 2 private copies collapsed

- `kiro_prerequisite.py:_prepare_sandboxed_spawn`
- `apple_speech/__init__.py:_sandboxed_off_loop` -- preparation stays behind
  `_sandboxed`, so `mode="strict"` + `_build_env()` remain this module's own.
  `SandboxUnavailableError` still propagates unchanged: the shield only
  intercepts cancellation, and that raise carries no tuple, hence no file to
  drop.

## Tests

`test/test_sandbox_off_loop.py` (new):
- cancel-injection: parks the worker on a `threading.Event`, cancels the
  awaiter, asserts the launcher the worker went on to create is gone -- run
  twice, once on the default pool and once on a caller-supplied one
- pool identity: the preparation runs on a thread of the pool that was passed
  in, so the consolidation cannot silently collapse the partition
- pass-through: a non-cancelled call returns the chokepoint tuple unchanged
- AST guard: flags bare `run_in_executor` AND `asyncio.to_thread` hops that
  reach the chokepoint. It resolves ONE LEVEL of indirection -- per file it
  first collects the functions whose body calls `sandboxed_spawn_argv`, then
  treats a hop to any of them as a hop to it. Without that it was vacuous on
  the majority of real sites, which hand the hop a preparer
  (`_prepare_probe`, `_sandboxed`, `_prepare_git_spawn`) whose name says
  nothing about the chokepoint; verified by mutation -- restoring the
  spec_builder `to_thread` hop makes it fail with
  `bare hop to _prepare_git_spawn`.

Two pre-existing source-inspection guards move with the shield:
`test_spawn_audit.py`'s prerequisite-adapter guard asserted the literal
`asyncio.to_thread` inside `_prepare_sandboxed_spawn`; the hop now lives in the
shared owner, so it pins both halves where they actually live (the adapter names
the chokepoint and routes through the owner; the owner takes the work off the
loop). The new AST guard reads sources with an explicit `encoding="utf-8"` --
without it the Windows shards die on cp1252 decoding a non-ASCII source byte.

