### PR TITLE
fix(kiro_prerequisite): unlink launcher under repeat cancellation (#5841)

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -1420,10 +1420,34 @@ async def _prepare_sandboxed_spawn(
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        cleanup_path: str | None = None
-        with contextlib.suppress(Exception):
-            _, _, cleanup_path = await task
-        await _unlink_off_loop(cleanup_path)
+        # A repeat cancellation landing on a bare recovery ``await`` is a
+        # ``BaseException``: it would escape a ``suppress(Exception)`` guard
+        # before the unlink runs, leaking the materialized launcher (#5841).
+        # The settle-then-unlink therefore runs as its own task, shielded
+        # from cancellations aimed at this caller; each absorbed repeat is
+        # ``uncancel()``-ed so an enclosing ``asyncio.timeout`` still reports
+        # ``TimeoutError``, and the ORIGINAL cancellation is re-raised once
+        # the launcher is gone.
+        async def _settle_then_unlink() -> None:
+            cleanup_path: str | None = None
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                _, _, cleanup_path = await task
+            await _unlink_off_loop(cleanup_path)
+
+        current = asyncio.current_task()
+        recovery = asyncio.create_task(_settle_then_unlink())
+        while not recovery.done():
+            try:
+                await asyncio.shield(recovery)
+            except asyncio.CancelledError:
+                uncancel = getattr(current, "uncancel", None)  # 3.11+
+                if uncancel is not None:
+                    uncancel()
+            except Exception:
+                logger.warning(
+                    "sandbox launcher cleanup failed after cancellation",
+                    exc_info=True,
+                )
         raise
 
 

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -2672,6 +2672,123 @@ class TestKiroPrerequisiteWorkflow:
         assert (await process_task).ok is True
 
     @pytest.mark.asyncio
+    async def test_cancelled_sandbox_preparation_unlinks_the_launcher(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """First-cancellation semantics: the recovery waits for the worker to
+        settle, removes the launcher it materialized, and re-raises."""
+        preparation_started = threading.Event()
+        release_preparation = threading.Event()
+        cleanup_path = tmp_path / "sandbox-launcher"
+        cleanup_path.write_text("launcher", encoding="utf-8")
+
+        def sandbox(
+            argv: list[str],
+            **_kwargs: Any,
+        ) -> tuple[list[str], dict[str, str], str]:
+            preparation_started.set()
+            assert release_preparation.wait(timeout=5)
+            return argv, {}, str(cleanup_path)
+
+        monkeypatch.setattr(prerequisite_module, "sandboxed_spawn_argv", sandbox)
+
+        outer = asyncio.create_task(
+            prerequisite_module._prepare_sandboxed_spawn(
+                ["/fixed/tool"],
+                mode=prerequisite_module._UNVERIFIED_SANDBOX_MODE,
+                env={},
+                extra_hidden_dirs=(),
+                extra_visible_dirs=(),
+            )
+        )
+        assert await asyncio.to_thread(preparation_started.wait, 5)
+        outer.cancel()
+        await asyncio.sleep(0)
+        release_preparation.set()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+        assert not cleanup_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_in_sandbox_recovery_still_unlinks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A REPEAT cancellation landing on the recovery await is a
+        ``BaseException``, so it escaped the old ``suppress(Exception)``
+        before ``_unlink_off_loop`` ran, leaking the materialized launcher
+        (#5841). The recovery must absorb repeat cancellations in BOTH of
+        its phases — while the worker settles and while the unlink runs —
+        still remove the launcher, and let the ORIGINAL cancellation (pinned
+        by its message) propagate rather than a repeat."""
+        preparation_started = threading.Event()
+        release_preparation = threading.Event()
+        unlink_started = threading.Event()
+        release_unlink = threading.Event()
+        cleanup_path = tmp_path / "sandbox-launcher"
+        cleanup_path.write_text("launcher", encoding="utf-8")
+        real_unlink = os.unlink
+
+        def sandbox(
+            argv: list[str],
+            **_kwargs: Any,
+        ) -> tuple[list[str], dict[str, str], str]:
+            preparation_started.set()
+            assert release_preparation.wait(timeout=5)
+            return argv, {}, str(cleanup_path)
+
+        def slow_unlink(path: str) -> None:
+            if path == str(cleanup_path):
+                unlink_started.set()
+                assert release_unlink.wait(timeout=5)
+            real_unlink(path)
+
+        monkeypatch.setattr(prerequisite_module, "sandboxed_spawn_argv", sandbox)
+        monkeypatch.setattr(prerequisite_module.os, "unlink", slow_unlink)
+
+        outer = asyncio.create_task(
+            prerequisite_module._prepare_sandboxed_spawn(
+                ["/fixed/tool"],
+                mode=prerequisite_module._UNVERIFIED_SANDBOX_MODE,
+                env={},
+                extra_hidden_dirs=(),
+                extra_visible_dirs=(),
+            )
+        )
+        assert await asyncio.to_thread(preparation_started.wait, 5)
+        # First cancellation: delivered at the shielded hop; the coroutine
+        # enters its recovery block. Its message pins exception identity: if
+        # a repeat cancellation were the one to propagate (or to merge into
+        # the first delivery), the message assertion below goes red.
+        outer.cancel("original-cancellation-5841")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        # REPEAT cancellation while the worker is still settling — the
+        # launcher must still exist for the repeat to be able to leak it.
+        assert cleanup_path.exists()
+        outer.cancel()
+        await asyncio.sleep(0)
+        release_preparation.set()
+        # REPEAT cancellation while the unlink itself is in flight.
+        assert await asyncio.to_thread(unlink_started.wait, 5)
+        assert cleanup_path.exists()
+        outer.cancel()
+        await asyncio.sleep(0)
+        release_unlink.set()
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await outer
+        if sys.version_info >= (3, 11):
+            # 3.10's Task rebuilds the awaiter-visible CancelledError from the
+            # task's LAST cancel message (message-less repeats blank it), so
+            # the original's args are only observable from 3.11, where the
+            # coroutine's actual exception object propagates.
+            assert exc_info.value.args == ("original-cancellation-5841",)
+        assert not cleanup_path.exists()
+
+    @pytest.mark.asyncio
     async def test_process_timeout_escalates_while_supervisor_anchors_group(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# What is the problem?

`_prepare_sandboxed_spawn` in `src/kiro_crew/kiro_prerequisite.py` is the reference shield-recover-unlink pattern for sandbox launcher cleanup. Its cancellation recovery re-awaited the worker under `contextlib.suppress(Exception)` and then unlinked. A REPEAT cancellation landing on that recovery `await` raises `asyncio.CancelledError` -- a `BaseException` that `suppress(Exception)` does not catch -- so it escaped the handler before `_unlink_off_loop` ran, leaking the materialized launcher/profile in temp. This is the same first-order hole that was flagged and fixed in `apple_speech._sandboxed_off_loop` (#5836).

# Why it matters

The leaked file is an executable sandbox launcher left behind in temp. Cancellation storms (shutdown paths that cancel-then-gather, timeouts firing during teardown) are exactly when repeat cancellations arrive, so the reference pattern silently failed its one job -- guaranteeing the launcher is removed -- in the situation it exists for.

# What changed

The recovery (settle the worker, then unlink) now runs as its own task, shielded from cancellations aimed at the caller. The handler loops until the recovery completes, absorbing each repeat cancellation, and re-raises the ORIGINAL cancellation once the launcher is gone. Details:

- Each absorbed repeat is `uncancel()`-ed (guarded `getattr`, 3.11+), so an enclosing `asyncio.timeout` still converts its own cancel to `TimeoutError` instead of propagating `CancelledError` with an inflated count.
- The settlement suppress is spelled `suppress(Exception, asyncio.CancelledError)` -- the exact intent -- instead of `suppress(BaseException)`, so `SystemExit`/`KeyboardInterrupt` are not swallowed.
- A non-cancellation failure out of the recovery is logged (`logger.warning`) rather than silently dropped, and never replaces the in-flight cancellation.
- Success path and first-cancellation semantics are unchanged: the recovery task is only created after a cancellation is caught.

One deliberate trade, stated openly: the caller no longer has a repeat-cancel escape hatch -- the recovery holds it until the worker thread settles and the unlink hop completes, which spans all of `wrap_argv` (including its bounded pre-exec hardlink walk). Base gave the second cancel an escape at the price of the leak this PR fixes. A wall-clock detach ceiling for the recovery belongs to the cross-site owner-consolidation tracked in #5842; this PR stays the narrow single-site fix per the issue.

# Tests

- `test_repeat_cancellation_in_sandbox_recovery_still_unlinks`: drives a first cancellation carrying a unique message, then repeat cancellations in BOTH recovery phases -- while the worker settles and while the unlink itself is blocked in flight -- and asserts the launcher is unlinked, the propagated `CancelledError` carries the original message (a merged or propagated repeat goes red, so the test cannot pass vacuously), and the launcher still existed at each repeat-cancel instant. Verified RED on base (launcher leaked), green on this branch.
- `test_cancelled_sandbox_preparation_unlinks_the_launcher`: pins first-cancellation semantics (settle, unlink, re-raise); green on base and on this branch.
- `test_spawn_audit.py::test_prerequisite_async_adapter_keeps_sandbox_chokepoint` still passes -- `asyncio.to_thread` and `sandboxed_spawn_argv` remain in the adapter.
- Gates: isort, flake8, black baseline gate, mypy (only pre-existing errors in untouched `transcribe.py`/`cloudwatch.py`), `test_kiro_prerequisite.py` + `test_spawn_audit.py` full modules (185 passed). Full backend suite: 68205 passed; the 88 failures reproduce identically on pristine `origin/main` on this host (host-environment state: AF_UNIX path length, live home-dir interference) and touch none of the changed modules.
- Two model-pinned pre-push reviews (GPT, Opus): the fix itself NO BLOCKING on both; their one blocking item (a stray scaffolding file in the commit) and their advisories (uncancel rebalance, narrowed suppress, logged unlink failure, test anti-vacuity via cancel-message identity and unlink-phase repeat cancel, sandbox-mode constant in tests) are all folded into this revision.

# Any other suggestions

The wider consolidation of this pattern under a single owner (and any detach ceiling for the recovery wait) is deliberately out of scope here and tracked in #5842.

Closes #5841
