### PR TITLE
test: drop stale folder-panel marker block deleted with #4072 (#5860)

### DIFF
--- a/website/src/test/gitPanelAutoOpen.test.ts
+++ b/website/src/test/gitPanelAutoOpen.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
 const GIT_PANEL_KEY_PREFIX = 'mc-git-panel-opened:'
-const FOLDER_PANEL_KEY_PREFIX = 'mc-folder-panel-opened:'
 
 beforeEach(() => {
   localStorage.clear()
@@ -51,22 +50,5 @@ describe('git panel auto-open-once localStorage marker', () => {
 
     expect(localStorage.getItem(keyA)).toBe('1')
     expect(localStorage.getItem(keyB)).toBeNull()
-  })
-})
-
-describe('folder panel auto-open-once localStorage marker', () => {
-  it('marker prevents re-opening the folder tab for the same slot+path', () => {
-    const slot = 'slot-1'
-    const path = '/home/user/project'
-    const key = `${FOLDER_PANEL_KEY_PREFIX}${slot}:${path}`
-
-    // First visit: no marker
-    expect(localStorage.getItem(key)).toBeNull()
-
-    // Simulate auto-open
-    localStorage.setItem(key, '1')
-
-    // Second visit: marker present
-    expect(localStorage.getItem(key)).toBe('1')
   })
 })


### PR DESCRIPTION
## Summary

`website/src/test/gitPanelAutoOpen.test.ts` still carried a describe block asserting the `mc-folder-panel-opened:<slot>:<path>` localStorage marker. PR #4072 (commit 54c8ffdee) deleted the folder auto-open mechanism and its marker, leaving the test pinning a contract no production code implements: it could never catch a regression and misled readers into thinking the marker still exists.

This PR removes the stale describe block and the now-unused `FOLDER_PANEL_KEY_PREFIX` constant. Test-only deletion, 18 lines removed, no production change.

Closes #5860

## Verification

- Confirmed commit 54c8ffdee removed the `mc-folder-panel-opened` write from `ChatPage.tsx`; on base main the only remaining `website/` references were this test's own constant (line 10) and its single use (line 61)
- After deletion: repo-wide grep for `mc-folder-panel-opened` and `FOLDER_PANEL_KEY_PREFIX` under `website/` returns zero hits
- The live git-panel marker (`mc-git-panel-opened`, `ChatPage.tsx`) is untouched; its four test assertions remain and pass: `npx vitest run src/test/gitPanelAutoOpen.test.ts` → 4 passed
- `npx tsc -b` clean

## Pre-push review

Two model-pinned reviewers ran on the diff before opening this PR:

- GPT lane: PASS, 0 findings
- Opus lane: PASS, 0 blocking, 1 advisory — the remaining git-panel tests build keys from a locally re-declared prefix constant rather than importing the production key builder, so a future prefix change or mechanism deletion would not fail these tests (the same structural gap that let the folder block sit green). The reviewer itself noted a deletion-only cleanup is not obliged to fix this. **Disposition: deferred** — exporting a key builder from `ChatPage.tsx` is a production refactor out of scope for this test-only removal; it can be filed as a follow-up if maintainers want the coupling.

## Notes

- No UI change, so no screenshots.
