### PR TITLE
fix(stt): offload blocking file writes off the event loop (#5801)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1240,7 +1240,9 @@ echo "Done. whisper=$(command -v whisper 2>/dev/null || echo 'check PATH') ffmpe
 async def api_stt_transcribe(request: web.Request) -> web.Response:
     """POST /api/stt/transcribe — transcribe uploaded audio via whisper."""
     import tempfile  # noqa: F811
+    import uuid
 
+    from kiro_crew.dashboard import part_stream
     from kiro_crew.transcribe import is_available, transcribe_audio  # noqa: F811
 
     if not is_available():
@@ -1254,19 +1256,19 @@ async def api_stt_transcribe(request: web.Request) -> web.Response:
     # Use uploaded filename extension (recording.webm / .mp4 / .ogg)
     fname = getattr(field, "filename", None) or "recording.webm"
     ext = os.path.splitext(fname)[1] or ".webm"
-    fd, tmp = tempfile.mkstemp(suffix=ext)
+    # A fresh unpublished path: stream_part_to_file writes to a sibling temp
+    # off the event loop and publishes here atomically, so no exit path (413,
+    # backend failure, cancellation) can leave a partial file at this name.
+    tmp = os.path.join(tempfile.gettempdir(), f"kc_stt_{uuid.uuid4().hex}{ext}")
     try:
-        os.close(fd)
-        size = 0
-        with open(tmp, "wb") as f:
-            while True:
-                chunk = await field.read_chunk(8192)  # type: ignore[union-attr]
-                if not chunk:
-                    break
-                size += len(chunk)
-                if size > 25 * 1024 * 1024:  # 25 MB cap
-                    return web.json_response({"error": "audio too large"}, status=413)
-                f.write(chunk)
+        try:
+            await part_stream.stream_part_to_file(
+                field,  # type: ignore[arg-type]
+                Path(tmp),
+                max_bytes=25 * 1024 * 1024,
+            )
+        except part_stream.PartTooLarge:
+            return web.json_response({"error": "audio too large"}, status=413)
 
         text = await transcribe_audio(tmp)
         if text:


### PR DESCRIPTION
## Summary

Fixes #5801. `api_stt_transcribe` was the 4th site that streamed a multipart part to a temp file with synchronous `f.write(chunk)` inside an `async def`, blocking the gateway event loop on every chunk. The other three sites were unified onto `part_stream.stream_part_to_file` (#5704); this PR routes the STT upload through the same hardened helper instead of keeping a hand-rolled copy.

## Changes

One-call replacement: the manual `mkstemp` + read/write loop is replaced by `part_stream.stream_part_to_file(field, Path(tmp), max_bytes=25 MB)` writing to a fresh `kc_stt_<uuid><ext>` path, with `PartTooLarge` mapped to the existing 413 response — the same shape as `portability.py`'s call site. That buys, from the already-reviewed helper rather than new code:

1. **No blocking I/O on the event loop** — open/write/close all run in workers (`_TempSink` + `to_thread(sink.write, ...)`), with the module's documented bounded exception (the on-loop create/discard of one temp).
2. **Cancellation-safe cleanup** — ownership lives in the helper's synchronous context manager, so `CancelledError` cannot skip cleanup or race a worker-side `open` (the module ledger's failure 3, which a `to_thread(open, ...)` variant of this fix would have reintroduced).
3. **Atomic publish + 64 KB chunks** — the temp is published to `tmp` only via `os.replace` from a fully-written sibling, and the read size is the helper's `CHUNK_BYTES`.

The handler's own `finally: os.unlink(tmp)` is unchanged and now only ever sees a fully-published file or nothing.

## Testing

- All 6 existing `TestSttTranscribe` tests pass unchanged (503 / 400×2 / 413 / 200-redaction / 500), confirming the helper is a drop-in for the handler's contract.
- `test/test_part_stream.py` (130 tests) covers the off-loop write, cancellation-cleanup, and atomic-publish invariants this handler now relies on.
- CI-pinned lint gates green locally: black, isort, flake8 7.1.0, mypy 1.14.1.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no rendered UI is touched.
