### PR TITLE
fix(acp): capture resolved model when session/new omits currentModelId

### DIFF
--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -1657,6 +1657,17 @@ class AcpSessionHandle:
             avail = models.get("availableModels", [])
             if isinstance(avail, list):
                 self._available_models = self._normalize_models(avail)
+            # A backend may advertise its model list without echoing
+            # ``currentModelId`` (it is best-effort in the ACP shape). When it
+            # names exactly one model that IS the served model unambiguously, so
+            # adopt it as the resolved id — otherwise ``served_model`` reports
+            # ``""`` for the whole session on an unpinned run (no ``set_model``,
+            # no ``currentModelId``), which is why the panel's model chip stays
+            # blank until completion fills it from a different source. With two
+            # or more advertised and no ``currentModelId`` the served choice is
+            # genuinely unknown, so leave it empty rather than guess.
+            if not self._resolved_model_id and len(self._available_models) == 1:
+                self._resolved_model_id = self._available_models[0]["modelId"]
         elif isinstance(models, list):
             self._available_models = self._normalize_models(models)
 

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -7372,3 +7372,57 @@ async def test_cancel_during_drain_reject_does_not_wedge_handle():
     assert handle.is_turn_active is False  # not wedged
     # The stranded request went back on the queue for the next drain.
     assert not q["sA"].empty()
+
+
+# ── store_session_config: resolved-model capture (issue #5869) ──
+
+
+def test_store_session_config_adopts_sole_advertised_model_when_no_current_id():
+    """An unpinned session whose ``session/new`` advertises exactly one model
+    but omits ``currentModelId`` must still resolve that model, so ``served_model``
+    is non-empty for the whole run (the panel model chip depends on it)."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.store_session_config(
+        {"models": {"availableModels": [{"modelId": "kiro-model-x", "name": "X"}]}}
+    )
+    assert handle._resolved_model_id == "kiro-model-x"
+    assert handle.served_model == "kiro-model-x"
+
+
+def test_store_session_config_current_model_id_wins_over_sole_advertised():
+    """When the backend DOES echo ``currentModelId`` it is authoritative — the
+    sole-advertised fallback must not override it."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.store_session_config(
+        {
+            "models": {
+                "currentModelId": "kiro-current",
+                "availableModels": [{"modelId": "kiro-other", "name": "Other"}],
+            }
+        }
+    )
+    assert handle._resolved_model_id == "kiro-current"
+
+
+def test_store_session_config_leaves_model_empty_when_ambiguous():
+    """Two or more advertised models and no ``currentModelId`` is genuinely
+    ambiguous — do not guess; ``served_model`` stays empty."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.store_session_config(
+        {
+            "models": {
+                "availableModels": [
+                    {"modelId": "kiro-a", "name": "A"},
+                    {"modelId": "kiro-b", "name": "B"},
+                ]
+            }
+        }
+    )
+    assert handle._resolved_model_id == ""
+    assert handle.served_model == ""


### PR DESCRIPTION
## Problem / Motivation

The Subagents panel shows no resolved-model chip for the entire run of an **unpinned** subagent on the Kiro/ACP path. Reloading the panel does not help (the reconnect snapshot rebuilds the same empty value). The chip only appears once the run completes, because the completion card fills the model from a different source. ACP subagents whose session reports a current model show the chip from spawn.

## Why it matters

The subagent model-provenance feature (#3582, PR #5306) exists so a user can see, live, which model each spawned subagent runs on. When the backend does not echo a current-model id, that live signal is silently absent for the whole run — exactly where it is most useful (a long-running agent you might cancel if mis-pinned). It also makes #5326 (live downgrade flag) a no-op for those sessions, since it renders off a resolved model that is never populated.

## What changed (motivation → approach → change)

Symptom: blank model chip on a running subagent card. Root cause: `AcpSessionHandle.served_model` returns `self._model or self._resolved_model_id`. For an unpinned subagent neither `set_model` nor an explicit pin runs, so both fields are populated **only** from the `session/new` response's `models.currentModelId`, via `store_session_config`. `currentModelId` is best-effort in the ACP shape — when the backend advertises its model list but omits it, both fields stay `""` and `served_model` returns `""` for the whole session, so `build_subagent_snapshot` and the live `subagent_spawn` frame carry an empty model.

(An earlier hypothesis that `_resolved_model_of` failed to read `_resolved_model_id` off the client was wrong and has been dropped: that helper receives the provider, and `AcpProvider.served_model` already performs that fallback. The defect is upstream — the resolved id is never captured.)

Change: in `store_session_config`, when the response omits `currentModelId` but advertises **exactly one** model, adopt it as the resolved id — that single advertised model is unambiguously the served one. With two or more advertised and no `currentModelId` the served choice is genuinely unknown, so leave it empty rather than guess (the display choice for the unresolved case is a separate UX decision, out of scope here). Scoped to `session_handle.py`.

## Tests

`test/test_acp_runtime.py`: (a) a `session/new` config advertising exactly one model with no `currentModelId` resolves that model, and `served_model` returns it; (b) an explicit `currentModelId` wins over the sole-advertised fallback; (c) two-or-more advertised with no `currentModelId` leaves `served_model` empty (no guess).

## Manual verification

The fully authoritative fix site depends on capturing the actual `session/new` response for an unpinned subagent (whether `currentModelId` is truly absent or present-but-dropped downstream). The sole-advertised fallback is chosen because it is correct-or-inert in both cases: it populates the common single-model backend case, is a no-op when `currentModelId` is present, and never invents a model among several. If a captured response shows `currentModelId` is present, the remaining break is between `_resolved_model_id` and `build_subagent_snapshot`, to be pinned separately.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; it makes an already-designed chip populate, introducing no new or changed UI element.

## Related Issues

Fixes #5869

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
