### PR TITLE
fix(trust): allow input redirects into read verbs at raw scan (#5846)

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1871,24 +1871,35 @@ def _side_effect_reason(segment: str) -> str:
 
 
 def _elided_shell_construct(cmd: str) -> str:
-    """Reason *cmd* carries a construct bash REMOVES but ``shlex`` keeps.
+    """Reason *cmd* carries a COMMENT, which bash removes but ``shlex`` keeps.
 
     Every operand rule in this module reads `shlex.split`'s token list and
-    assumes it is the argv the program receives. Two shell constructs break that
+    assumes it is the argv the program receives. A comment breaks that
     assumption by DELETING words rather than rewriting them, and `shlex` has no
-    concept of either — it hands them back as ordinary tokens:
+    concept of it — it hands the words back as ordinary tokens:
 
         git branch injected # --list      shlex: [… 'injected', '#', '--list']
                                           bash:  git branch injected
-        git branch injected <<< --list    shlex: [… 'injected', '<<<', '--list']
-                                          bash:  git branch injected
 
-    In both, the `--list` this module reads never reaches git. It flips
+    The `--list` this module reads never reaches git. It flips
     `_GIT_REF_LIST_FLAGS` on, the bare `injected` is reclassified from "creates a
     ref" to "a pattern", and the segment auto-approves — while bash creates the
-    ref. Measured against real git: `git branch injected # --list`,
-    `git tag forged # --list` and `git branch injected <<< --list` each created
-    the ref, so this is a live auto-approval bypass rather than a parse curiosity.
+    ref. Measured against real git: `git branch injected # --list` and
+    `git tag forged # --list` each created the ref, so this is a live
+    auto-approval bypass rather than a parse curiosity.
+
+    WHY THIS RUNS ON THE RAW COMMAND, AND WHY ONLY THE COMMENT DOES. A comment
+    elides to the end of the LINE, across the `&&` / `;` boundaries the
+    per-segment split believes in, so it is the one elision that cannot be
+    judged segment-by-segment. The other word-deleting constructs — the input
+    redirect `< f` and the here-string `<<< word` — bind to a single simple
+    command and never cross a segment boundary, so they are deliberately NOT
+    refused here: `_side_effect_reason` refuses them per verb via
+    `_ELISION_SENSITIVE_KEYS`, exactly for the verbs a phantom word can flip
+    (`git branch injected <<< --list` still created the ref and is still
+    refused there). See the note above `_ELISION_SENSITIVE_RE` for why the
+    global spelling of that refusal was the wrong trade — it cost `wc -l < f`
+    and its four pinned siblings, which no phantom word could have made unsafe.
 
     Refused as a CLASS rather than repaired. Repairing it means deciding what
     bash would have deleted — i.e. reimplementing shell word removal on top of
@@ -1898,8 +1909,8 @@ def _elided_shell_construct(cmd: str) -> str:
     lone `'` inside comment TEXT (`echo x # don't`) then leaked quote state
     across the newline, so the next line's forged `# --list` was never removed
     and `git branch evil # --list` auto-approved again. Refusing on the FIRST
-    hit has no "afterwards" to get wrong. A read-only command needs neither
-    construct, and a refused command falls through to the human approval prompt.
+    hit has no "afterwards" to get wrong. A read-only command needs no
+    comment, and a refused command falls through to the human approval prompt.
 
     Every way this scanner can disagree with bash therefore costs a prompt
     rather than an approval. It is deliberately wider than bash in places —
@@ -1907,25 +1918,20 @@ def _elided_shell_construct(cmd: str) -> str:
     `$'…\''` quoting is not modelled — and in this direction that is a false
     refusal, never a false approval.
 
-    Quote-aware on purpose, so it costs no ordinary read. Both constructs are
-    shell syntax only when unquoted, and the common false positives are exactly
-    the quoted and non-word-initial spellings:
+    Quote-aware on purpose, so it costs no ordinary read. A `#` is shell
+    syntax only when unquoted and word-initial, and the common false positives
+    are exactly the quoted and non-word-initial spellings:
 
         grep '#include' file        `#` inside quotes is data
         git log --grep=#123         `#` mid-word is not a comment to bash
-        grep "<div>" file           `<` inside quotes is data
 
     A backslash escape is honoured for the same reason (`grep \\# file`).
 
-    Two costs, stated rather than hidden, and asserted in the tests:
-
-    * An ordinary trailing comment is refused (`git status # note`,
-      `ls -la # list files`). Agent-emitted bash carries one often, so this is
-      the larger everyday cost of the two — a real auto-approve-rate loss, taken
-      knowingly because the alternative above is a live bypass.
-    * An unquoted input redirect is refused even where it is genuinely harmless
-      (`wc -l < file`, `grep pattern < file`), since what makes it dangerous is
-      the token-list divergence, not the direction of the data.
+    One cost, stated rather than hidden, and asserted in the tests: an
+    ordinary trailing comment is refused (`git status # note`,
+    `ls -la # list files`). Agent-emitted bash carries one often, so this is a
+    real everyday auto-approve-rate loss, taken knowingly because the
+    alternative above is a live bypass.
     """
     quote: str | None = None
     # Start-of-string counts as a word boundary: bash reads a leading `#` as a
@@ -1947,7 +1953,7 @@ def _elided_shell_construct(cmd: str) -> str:
             at_word_start = False
             continue
         if ch == "\\" and i + 1 < n:
-            # An escaped character is data, including an escaped `#` or `<`.
+            # An escaped character is data, including an escaped `#`.
             i += 2
             at_word_start = False
             continue
@@ -1958,8 +1964,6 @@ def _elided_shell_construct(cmd: str) -> str:
             continue
         if ch == "#" and at_word_start:
             return "a comment deletes the rest of the line, which `shlex` keeps"
-        if ch == "<":
-            return "an input redirect removes words that `shlex` keeps"
         at_word_start = ch.isspace()
         i += 1
     return ""

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -793,7 +793,8 @@ class HookManager:
         # so a top-level import here would create a boot import cycle.
         if is_shell:
             # A shell read-only classification uses the deny-by-default bash
-            # classifier (rejects redirects/substitution/backgrounding). When the
+            # classifier (rejects output redirects/substitution/backgrounding;
+            # input redirects are judged per verb). When the
             # command could not be recovered we already denied above; a present
             # command that is not read-only falls through to interactive approval.
             from kiro_crew.dashboard.state import is_read_only_bash

--- a/test/test_trust_reads.py
+++ b/test/test_trust_reads.py
@@ -693,9 +693,14 @@ class TestIsReadOnlyBash:
         against real git: `git branch injected # --list`, `git tag forged # --list`
         and `git branch injected <<< --list` each created the ref.
 
-        Refused as a class rather than repaired, since repairing it means deciding
-        what bash would have deleted — reimplementing word removal on top of
-        quoting rules `shlex` already models differently.
+        Refused rather than repaired, since repairing means deciding what bash
+        would have deleted — reimplementing word removal on top of quoting rules
+        `shlex` already models differently. The comment is refused on the RAW
+        command (`_elided_shell_construct`: it elides past segment boundaries);
+        the redirect and here-string forms bind to one simple command, so they
+        are refused per verb (`_ELISION_SENSITIVE_KEYS`) — see
+        `test_a_word_bash_deletes_cannot_forge_a_read_mode` for the read verbs
+        that keep `<`.
         """
         assert is_read_only_bash("git branch injected # --list") is False
         assert is_read_only_bash("git tag forged # --list") is False
@@ -734,10 +739,10 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("$'x\\' # y' ; git branch injected") is False
 
     def test_an_elided_construct_is_detected_quote_aware(self):
-        """Both constructs are shell syntax only when unquoted, so quoting is honoured.
+        """A comment is shell syntax only when unquoted, so quoting is honoured.
 
-        Scanning for a bare `#` or `<` would have cost the ordinary reads that
-        carry one as DATA, which is most of the ones that carry one at all.
+        Scanning for a bare `#` would have cost the ordinary reads that carry
+        one as DATA, which is most of the ones that carry one at all.
         """
         # `#` inside quotes, and `#` mid-word, are not comments to bash.
         assert is_read_only_bash("grep '#include' file") is True
@@ -750,32 +755,35 @@ class TestIsReadOnlyBash:
         assert is_read_only_bash("git branch --list 'feat/*'") is True
         assert is_read_only_bash("cat f | sort -u") is True
 
-    def test_the_two_costs_of_refusing_the_class_are_asserted_not_assumed(self):
+    def test_the_cost_of_refusing_the_class_is_asserted_not_assumed(self):
         """The price of the fail-safe direction, pinned so it cannot drift silently.
 
-        Neither of these is a bypass and neither is blocked — both fall through to
-        the human approval prompt. They are asserted so the auto-approve-rate loss
-        is visible in the suite rather than discovered in use, and so that anyone
-        who later narrows the refusal has a test telling them what they are
-        buying back.
+        The trailing comment is not a bypass and is not blocked — it falls
+        through to the human approval prompt. It is asserted so the
+        auto-approve-rate loss is visible in the suite rather than discovered in
+        use, and so that anyone who later narrows the refusal has a test telling
+        them what they are buying back.
         """
-        # Cost 1, the larger one: an ordinary trailing comment is refused. Bash
-        # would simply delete it, so these ARE reads — but the classifier cannot
-        # tell this `#` from the forged-flag `#` above without reproducing the
-        # deletion, which is what reopened the bypass. Agent-emitted bash carries
-        # a trailing comment often, so this is a real everyday loss.
+        # The cost: an ordinary trailing comment is refused. Bash would simply
+        # delete it, so these ARE reads — but the classifier cannot tell this
+        # `#` from the forged-flag `#` above without reproducing the deletion,
+        # which is what reopened the bypass. Agent-emitted bash carries a
+        # trailing comment often, so this is a real everyday loss.
         assert is_read_only_bash("git status # note") is False
         assert is_read_only_bash("ls -la # list files") is False
         assert is_read_only_bash("grep -rn foo src # find it") is False
         assert "comment" in unsafe_bash_reason("git status # note")
-        # Cost 2: an unquoted input redirect is refused even where it is
-        # harmless, because the danger is the token-list divergence rather than
-        # the direction of the data.
-        assert is_read_only_bash("wc -l < file") is False
-        assert is_read_only_bash("grep pattern < file") is False
-        assert "redirect" in unsafe_bash_reason("wc -l < file")
-        # Quoting is the escape hatch for both: a user who means the `#` as data
-        # keeps their auto-approval.
+        # An input redirect is NOT this scanner's cost: it binds to one simple
+        # command and never crosses a segment boundary, so it is refused per
+        # verb (`_ELISION_SENSITIVE_KEYS`) rather than on the raw command. Into
+        # a flag-decided read verb it keeps the auto-approval; into a verb a
+        # phantom word can flip it still prompts.
+        assert is_read_only_bash("wc -l < file") is True
+        assert is_read_only_bash("grep pattern < file") is True
+        assert is_read_only_bash("git branch injected < --list") is False
+        assert "word bash removes" in unsafe_bash_reason("git branch injected < --list")
+        # Quoting is the escape hatch for the comment: a user who means the `#`
+        # as data keeps their auto-approval.
         assert is_read_only_bash("grep '#note' file") is True
 
     def test_a_positional_or_special_parameter_hides_the_real_argument(self):
@@ -1545,6 +1553,20 @@ class TestIsReadOnlyBash:
             "uniq in # out",
             "date < f",
             "hostname < f",
+        ):
+            assert is_read_only_bash(cmd) is False, cmd
+
+        # The per-verb spelling of the refusal is safe only because a redirect
+        # binds to one simple command: it cannot elide across a `&&`/`;`
+        # boundary the way a comment does. Pinned here so the boundary half of
+        # that argument cannot drift silently -- the flippable segment refuses
+        # whatever segment it sits in, and a quoted separator fails closed on
+        # `shlex` rather than fusing two segments into one.
+        for cmd in (
+            "git status && git branch injected < --list",
+            "git branch injected ';' < --list",
+            "uniq f < -o victim",
+            "git remote < set-url origin https://evil",
         ):
             assert is_read_only_bash(cmd) is False, cmd
 


### PR DESCRIPTION
## Problem / Motivation

main CI is red on Backend Tests shard 4 (3.10, 3.12, Windows): `test/test_trust_reads.py::TestIsReadOnlyBash::test_a_word_bash_deletes_cannot_forge_a_read_mode` fails with `AssertionError: wc -l < f`. This is a semantic cross-merge between two security PRs that were each green on their own base:

- #5541 (merged first) scoped the input-redirect refusal to the verbs a phantom word can flip, and pinned five redirect-read forms as allowed (`wc -l < f`, `grep TODO < f`, `cat < f`, `wc -l <f`, `head -20 < log.txt`).
- #5521 (merged later, branch cut before #5541 landed) added `_elided_shell_construct`, which scans the RAW command ahead of the segment split and refused ALL unquoted input redirects -- silently overriding #5541's pinned allowance.

## Why it matters

The suite carries two directly contradictory assertions (`wc -l < file` must be False at one line and `wc -l < f` must be allowed at another), so every open PR inherits the red. Beyond CI, the global `<` refusal costs auto-approval on ordinary reads that no phantom word could make unsafe -- main's own comment above `_UNSAFE_SHELL_RE` already documented the per-verb behavior as the intended design.

## What changed

`_elided_shell_construct` no longer refuses `<` at the raw-scan stage. The reconciliation is safe because the two elided constructs differ in scope:

- A **comment** elides to the end of the LINE, across the `&&`/`;` boundaries the per-segment split believes in -- it is the one construct that cannot be judged segment-by-segment, so its raw-scan refusal stays.
- An **input redirect / here-string** binds to a single simple command and never crosses a segment boundary, so the pre-existing per-segment guard (`_ELISION_SENSITIVE_KEYS` + `_ELISION_SENSITIVE_RE`, from #5541) refuses it exactly for the verbs a phantom word can flip (`git branch/tag/remote`, `date`, `hostname`, `uniq`). `git branch injected <<< --list` still refuses; `wc -l < f` auto-approves.

Output redirects (`>`, `>>`), process substitution, and backgrounding remain refused by the separate `_UNSAFE_SHELL_RE` check -- untouched. Docstrings in `state.py`, the stale caller comment in `hooks.py`, and the cost-assertion tests were realigned, and the segment-boundary half of the safety argument is now pinned by new refusal assertions (`git status && git branch injected < --list`, quoted-separator, `uniq`/`git remote` forms).

## Tests

- `test/test_trust_reads.py`: 108/108 pass, including both previously-contradictory assertions.
- New pins: 4 multi-segment / quoted-separator redirect refusals, plus `git branch injected < --list` with its per-verb reason.
- Full backend suite: only pre-existing env-owned failures (identical set on clean main in the same environment); zero failures in trust/state tests.
- Gates: isort, flake8, black baseline, mypy (4 pre-existing errors in untouched files only).
- Two pre-push review lanes (GPT + Opus pinned subagents): NO BLOCKING FINDINGS; both Opus Low advisories folded in (stale `hooks.py` comment, segment-boundary coverage).

## Any other suggestions

The elision-sensitive key set is derived from accept-list `operands` values, so a future edit flipping a verb's `operands` to `"any"` silently drops it from the guard; the new boundary pins reduce but do not eliminate that drift surface -- a structural test could pin the derivation itself.

Closes #5846
