### PR TITLE
fix(ci): scope the Windows collect-ignore filter to the test/ root

### DIFF
--- a/scripts/ci-surface-tests.py
+++ b/scripts/ci-surface-tests.py
@@ -189,11 +189,20 @@ def collect(surface: str) -> list[str]:
         # protect this path, and emitting a POSIX-only suite here collects it and
         # fails the Windows shards on any diff that takes the reduced scope.
         #
-        # Split the string rather than going through pathlib: these are already
+        # Rebuild the entries as `test/`-relative paths rather than matching on
+        # the bare filename. The list is consumed by `test/conftest.py`, and
+        # pytest resolves `collect_ignore` relative to the conftest's own
+        # directory -- so the exclusion covers `test/<name>` and nothing else.
+        # A basename match would also drop a same-named suite under `transfer/`
+        # or the apps-builtins tree, which no conftest excludes and Windows
+        # collects fine: a silently skipped guard, the one outcome this
+        # selector's deny-by-default contract forbids.
+        #
+        # Join the string rather than going through pathlib: these are already
         # `as_posix()` forms, so the separator is known, and it keeps the filter
         # independent of which Path flavour the host provides.
-        ignored = _windows_collect_ignore(root)
-        must_run = [rel for rel in must_run if rel.rsplit("/", 1)[-1] not in ignored]
+        excluded = {f"test/{name}" for name in _windows_collect_ignore(root)}
+        must_run = [rel for rel in must_run if rel not in excluded]
 
     return sorted(set(must_run))
 

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -375,3 +375,56 @@ def test_explicit_cli_target_bypasses_collect_ignore(tmp_path) -> None:
         "explicit argument now honours collect_ignore -- the selector-side "
         "filter may no longer be required"
     )
+
+
+# ---------------------------------------------------------------------------
+# The Windows filter must be scoped the way conftest's own exclusion is
+# ---------------------------------------------------------------------------
+
+
+def _seed(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_windows_filter_is_scoped_to_the_test_root(tmp_path, monkeypatch) -> None:
+    """The ignore list governs ``test/`` only, so the filter must too.
+
+    The list holds BARE filenames and ``test/conftest.py`` resolves its
+    ``collect_ignore`` entries relative to its own directory -- so the exclusion
+    covers ``test/<name>`` and nothing else. Matching the emitted paths on their
+    basename instead also drops a same-named suite under ``transfer/`` or the
+    apps-builtins tree, which no conftest excludes and Windows collects fine.
+    That is a silently skipped cross-surface guard, which is the one outcome
+    this selector's deny-by-default contract forbids: a heuristic mistake is
+    supposed to cost CI time, never coverage.
+
+    Loads its own selector instance rather than taking the module-scoped
+    ``selector`` fixture, whose ``collect`` memo is keyed only on
+    ``(surface, _is_windows())`` and would otherwise be shared with -- and
+    poisoned by -- this synthetic repo root.
+    """
+    selector = _load_selector()
+    monkeypatch.setattr(selector, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(selector, "_is_windows", lambda: True)
+
+    _seed(
+        tmp_path / "test" / "windows-collect-ignore.txt",
+        "test_snapshot.py    # POSIX-only replace-while-open semantics\n",
+    )
+    # Both name the frontend tree, so both are cross-surface and would other-
+    # wise be must-run: the only difference between them is where they live.
+    guard = "assert Path('website/src/utils/sanitize.ts').is_file()\n"
+    _seed(tmp_path / "test" / "test_snapshot.py", guard)
+    app_suite = "src/kiro_crew/apps/builtins/demo/tests/test_snapshot.py"
+    _seed(tmp_path / app_suite, guard)
+
+    selected = selector.collect("backend")
+
+    assert (
+        "test/test_snapshot.py" not in selected
+    ), "the POSIX-only suite conftest names must still be filtered out"
+    assert app_suite in selected, (
+        "a same-named suite outside test/ is not covered by conftest's "
+        f"collect_ignore and must keep running on Windows; got {selected}"
+    )


### PR DESCRIPTION
## Problem / Motivation

`scripts/ci-surface-tests.py` emits the reduced set of backend tests that must still run for a single-surface diff. On Windows it additionally filters out the suites `test/windows-collect-ignore.txt` names, because an explicit pytest argument bypasses conftest's `collect_ignore`.

It matched those entries on the **bare filename**:

```python
must_run = [rel for rel in must_run if rel.rsplit("/", 1)[-1] not in ignored]
```

But the list is consumed by `test/conftest.py`, and pytest resolves `collect_ignore` entries relative to the conftest's own directory — so the exclusion covers `test/<name>` and nothing else. The selector walks three roots (`test`, `transfer`, `src/kiro_crew/apps/builtins`), so a basename match also drops a same-named suite in the other two, which no conftest excludes and which Windows collects perfectly well.

## Why it matters

The dropped file is a **cross-surface parity guard that stops running on the Windows shards**, silently, on every diff that takes the reduced scope. That is the one outcome this script's own contract forbids — its module docstring states the guarantee it is built around:

> A mistake in the heuristic therefore costs CI time, not a skipped guard.

A basename collision costs coverage instead, and does it invisibly: the guard simply is not in the emitted list, so nothing reports a skip.

No collision exists on `main` today, so **this changes no emitted path on the current tree** — it closes the hole rather than fixing a live red. The collision space is already populated, though: six basenames are currently shared across the three backend roots, including `test_routes.py` (×4) and `test_security.py` (×2). One future entry in `windows-collect-ignore.txt` is all it takes, and the failure would land as missing coverage rather than as a failing job.

## What changed (motivation → approach → change)

- **Symptom:** the Windows branch of `collect()` filters emitted paths by basename, across all three backend roots.
- **Root cause:** the ignore list's entries are `test/`-relative by construction — `test/conftest.py` is what resolves them — and the filter dropped that scope when it reduced each path to its filename.
- **Change:** compare the emitted `as_posix()` path against `test/<name>` instead:

```python
excluded = {f"test/{name}" for name in _windows_collect_ignore(root)}
must_run = [rel for rel in must_run if rel not in excluded]
```

This is still a plain string join rather than `pathlib`, for the reason the original comment gives: `must_run` already holds `as_posix()` forms, so the separator is known and the filter stays independent of the host's `Path` flavour. It also handles a future sub-path entry (`sub/test_x.py`) correctly, which `collect_ignore` accepts and the basename form silently mismatched.

No behaviour changes on POSIX, and the ignore list itself is untouched.

## Tests

- **New regression pin** — `test_windows_filter_is_scoped_to_the_test_root` in `test/test_ci_surface_tests.py`. It builds a synthetic repo root holding `test/windows-collect-ignore.txt` with one entry plus two same-named cross-surface suites, one under `test/` and one under `src/kiro_crew/apps/builtins/**`, then asserts the first is filtered and the second survives.
- **Red-before, measured on pristine `origin/main` at `6ed29f5cb`** (the test added, the fix not): `AssertionError: ... got []` — both suites were dropped, including the one no conftest excludes. Green after the fix.
- The test loads its own selector instance via the file's existing `_load_selector()` rather than taking the module-scoped `selector` fixture, whose `collect` memo is keyed only on `(surface, _is_windows())` and would otherwise be shared with — and poisoned by — the synthetic root.
- **Whole file: 40 passed, 2 failed.** Both failures are **base-equal**, reproduced identically on a pristine `main` worktree with none of this branch applied: `test_backend_roots_cover_every_configured_testpath` (`UnicodeDecodeError: 'cp950' codec` — a locale-dependent read on a non-UTF-8 Windows console) and `test_explicit_cli_target_bypasses_collect_ignore` (nested-pytest plugin interaction on the same host). Neither is touched by this diff.
- The existing Windows guards still pass unchanged, including `test_windows_scope_names_nothing_on_the_ignore_list` and `test_posix_scope_is_unfiltered`.
- Gates at the scope CI uses: `flake8` and `isort --check-only` clean on both files. Both files were already outside the black baseline on `main`; the added lines are black-clean, and `black --diff` reports only the two pre-existing hunks this diff does not touch.

## Manual verification

N/A — unit coverage sufficient: the change is a pure path-comparison predicate inside `collect()`, and the new test drives it through the real `collect()` against a synthetic root rather than around it.

## Related Issues

No linked issue — found by reading the selector, not from a report, and small enough to land as the fix itself.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing contract or configuration changed
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
