### PR TITLE
fix(test): accept endpoint kwarg in local-appdata trust test stub (#5879)

### DIFF
--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -502,7 +502,7 @@ class TestWindowsCliStore:
         usage_body = {"usageBreakdownList": [
             {"resourceType": "CREDIT", "currentUsage": 3.0, "usageLimit": 100.0}]}
 
-        def fake_post(token, target, payload):
+        def fake_post(token, target, payload, **_kwargs):
             if target == api._TARGET_LIST_PROFILES:
                 return _resp(200, {"profiles": []})
             return _resp(200, usage_body)


### PR DESCRIPTION
# Summary

Main unblocker: one-line test fix. `TestWindowsCliStore::test_local_appdata_store_token_is_trusted_without_arn` fails on all backend shards of main's own CI (and on every PR merge ref) with `assert None is not None`.

Closes #5879

## Root cause

PR #4545 changed `_post` in `src/kiro_crew/dashboard/handlers/kiro_usage_api.py` to take a keyword-only parameter:

```python
def _post(token: str, target: str, payload: dict, *, endpoint: str | None = None) -> _Resp:
```

Both production call sites (`:598`, `:901`) now pass `endpoint=`. The failing test's stub at `test/test_kiro_usage_api.py:505` was declared `def fake_post(token, target, payload)` without `**_kwargs`, so the `side_effect` raises `TypeError` inside `fetch_usage_limits`, which degrades to returning `None` — hence the assertion failure.

## Fix

Add `**_kwargs` to the stub's signature, byte-matching the passing sibling stub at `:466`. Grep confirms every other `_post` stub in the file (`fake_post` × 7, `recording_post` × 3) already accepts `**_kwargs`; line 505 was the only miss.

Deliberately minimal diff (1 line): this unblocks PR Readiness repo-wide. The Frontend Tests shard 3 red on main is a separate issue (#5529) and is not touched here.

## Verification

- Red→green proven locally on main head `6ed29f5cb`: the test fails before the change (`assert None is not None`) and passes after; full `test/test_kiro_usage_api.py` = 88 passed.
- Local gates: `isort` / `flake8` / `mypy` clean; black diff-gate passed; full `pytest` = 68281 passed, 15 failures all in files untouched by this diff (host-env classes: `test_xdist_host_budget`, `test_artifact_source`, `test_host_isolation_floor`, `test_trust_reads` — byte-identical to main).
- Pre-push model-pinned reviews: GPT lane (gpt-5.6-sol) PASS, zero findings. Opus lane (claude-opus-5) PASS, zero blocking; one advisory noted below.

## Advisory disposition

Opus advisory: the stub swallows `endpoint` into `**_kwargs`, so the test cannot observe whether the regional endpoint is threaded to `_TARGET_GET_USAGE`. Capturing and asserting it is real coverage of #4545's behavior but widens the diff beyond a one-line main unblocker — deferred, not adopted here.
