### PR TITLE
fix(knowledge): make a source's ignore_patterns mean the same on every host

### DIFF
--- a/src/kiro_crew/knowledge/doc_filter.py
+++ b/src/kiro_crew/knowledge/doc_filter.py
@@ -31,7 +31,7 @@ because a handful of large documents dominate the chunk count.
 from __future__ import annotations
 
 import os
-from fnmatch import fnmatch
+from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
 
 from .folder_watcher import DEFAULT_IGNORE_GLOBS, HARD_SKIP_DIRS
@@ -141,6 +141,10 @@ def should_ingest_doc(rel_path: str, size: int) -> bool:
         return False
     if Path(name).suffix.lower() not in DOC_EXTENSIONS:
         return False
-    if any(fnmatch(norm, pat) for pat in IGNORE_PATTERNS):
+    # `fnmatchcase`, so the verdict cannot depend on the host: `fnmatch`
+    # normcases both operands, which folds case on Windows only, and
+    # `IGNORE_PATTERNS` is the same list handed to the scan by
+    # `project_doc_properties()` -- the two must agree on every platform.
+    if any(fnmatchcase(norm, pat) for pat in IGNORE_PATTERNS):
         return False
     return size >= MIN_DOC_BYTES

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -9,7 +9,7 @@ import logging
 import math
 import os
 from datetime import datetime
-from fnmatch import fnmatch
+from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
 from typing import Callable
 
@@ -629,7 +629,17 @@ class FolderWatcher:
                 # Patterns are written with "/" separators, so the path has to be
                 # normalized before matching or every pattern containing a
                 # separator silently never matches on Windows.
-                if any(fnmatch(rel_path.replace(os.sep, "/"), pat) for pat in ignore_patterns):
+                #
+                # `fnmatchcase`, NOT `fnmatch`: `fnmatch` runs both operands
+                # through `os.path.normcase`, which folds case on Windows and is
+                # the identity on POSIX. These patterns are persisted source
+                # configuration, so that made one stored property select
+                # different files depending on which supported host ran the scan
+                # -- `SECURITY.md` also swallowed `security.md`, but only on
+                # Windows. The pattern is authoritative on every host instead.
+                # (The line above is what keeps separators working: `normcase`
+                # used to fold "/" to a backslash on both sides, and no longer does.)
+                if any(fnmatchcase(rel_path.replace(os.sep, "/"), pat) for pat in ignore_patterns):
                     continue
                 if kiroignore is not None and kiroignore.is_ignored(
                         _rel_posix(rel_dir, fname), is_dir=False):

--- a/test/test_knowledge_doc_filter.py
+++ b/test/test_knowledge_doc_filter.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
+from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
 
+import pytest
 from test_folder_watcher import LOCK_FILES
 
 from kiro_crew.knowledge.doc_filter import (
@@ -218,3 +221,76 @@ class TestWalkEquivalence:
         predicted = {rel for rel, size in files.items() if should_ingest_doc(rel, size)}
         assert walked == predicted
         assert walked == {"README.md", "docs/design.md", "docs/modules/security.md"}
+
+
+class TestHostIndependentPatternMatching:
+    """A persisted ``ignore_patterns`` must select the same files on every host.
+
+    ``fnmatch.fnmatch`` runs both operands through ``os.path.normcase``, which
+    folds case on Windows and is the identity on POSIX. The patterns are source
+    *configuration* that outlives the machine that wrote it, so that made one
+    stored property mean two different things: root-anchored ``SECURITY.md``
+    also swallowed a root ``security.md``, but only on a Windows scan.
+
+    These tests substitute ``ntpath``'s ``normcase`` on any host, so the trap is
+    reproducible on the POSIX shards too -- a ``skipif(os.name != "nt")`` guard
+    would hide the regression from every reviewer not on Windows.
+    """
+
+    @staticmethod
+    def _windows_normcase(value: str) -> str:
+        """What ``ntpath.normcase`` does: lowercase, and "/" folded to "\\"."""
+        return value.replace("/", "\\").lower()
+
+    @pytest.fixture
+    def windows_host(self, monkeypatch):
+        monkeypatch.setattr(os.path, "normcase", self._windows_normcase)
+
+    def test_the_trap_is_actually_armed(self, windows_host) -> None:
+        """Guard the guard: if this stops folding, the two tests below are vacuous."""
+        assert fnmatch("security.md", "SECURITY.md") is True
+        assert fnmatchcase("security.md", "SECURITY.md") is False
+
+    def test_predicate_does_not_fold_case_on_a_windows_style_host(self, windows_host) -> None:
+        # `SECURITY.md` is root-anchored boilerplate; a root `security.md` is a
+        # different document and is taken, on Windows exactly as on POSIX.
+        assert should_ingest_doc("security.md", BIG) is True
+        assert should_ingest_doc("SECURITY.md", BIG) is False
+        # Separator patterns are unaffected: the `os.sep` normalisation above the
+        # match is what carries them now that normcase no longer folds "/".
+        assert should_ingest_doc("x.egg-info/PKG-INFO.md", BIG) is False
+
+    def test_walk_matches_the_predicate_on_a_windows_style_host(
+        self, tmp_path, windows_host
+    ) -> None:
+        """The scan and the predicate must agree, and both must take the file.
+
+        Only one casing of the name is created: a same-directory `security.md`
+        AND `SECURITY.md` cannot coexist on a case-insensitive filesystem, so a
+        two-file fixture would not survive the Windows or macOS shards.
+        """
+        files = {
+            "security.md": BIG,  # NOT the root-anchored `SECURITY.md` pattern
+            "CHANGELOG.md": BIG,  # exact-case root boilerplate, dropped
+            "docs/design.md": BIG,  # ordinary document
+        }
+        for rel, size in files.items():
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x" * size)
+
+        props = project_doc_properties()
+        fw = FolderWatcher(store=None, pipeline=None)
+        walked = {
+            Path(fp).relative_to(tmp_path).as_posix()
+            for fp, _ in fw._walk(
+                str(tmp_path),
+                props["ignore_patterns"],
+                set(props["extra_skip_dirs"]),
+                set(props["include_extensions"]),
+                props["min_file_bytes"],
+            )
+        }
+        predicted = {rel for rel, size in files.items() if should_ingest_doc(rel, size)}
+        assert walked == predicted
+        assert walked == {"security.md", "docs/design.md"}


### PR DESCRIPTION
## Problem / Motivation

A folder source's `ignore_patterns` is persisted configuration. **The same stored property selects different files depending on which supported host performs the scan.**

`fnmatch.fnmatch` is not a pure glob match — it runs both operands through `os.path.normcase` first, which folds case on Windows and is the identity on POSIX:

```python
# fnmatch.fnmatch, CPython
name = os.path.normcase(name)
pat = os.path.normcase(pat)
return fnmatchcase(name, pat)
```

Measured, with a pattern of `SECURITY.md`:

| path | Windows (`fnmatch`) | POSIX (`fnmatch`) |
| --- | --- | --- |
| `SECURITY.md` | ignored | ignored |
| `security.md` | **ignored** | taken |

The same reaches `should_ingest_doc`, which `doc_filter`'s module docstring calls "the same rule" that `project_doc_properties()` hands to the scan, and which `TestWalkEquivalence` pins against `FolderWatcher._walk`. Both sides normcase identically, so the predicate and the scan agreed with each other while both disagreed with the other platform — the drift guard cannot see this class of bug.

## Why it matters

A source registered on one machine and scanned on another indexes a different set of documents, with no error and nothing in the logs. Every extra file taken is an LLM extraction call, and every file wrongly dropped is a document missing from the Library.

It also silently widens root-anchoring, which `doc_filter` names as the property that matters most about this list — its own comment records that an unanchored `security.md` matched two nested documents in this repository. On Windows the root-anchored `SECURITY.md` entry stops meaning one exact file.

The repository has already decided that pattern semantics must not depend on the host: the line directly above the match normalizes `os.sep` to `/` precisely so that "every pattern containing a separator" does not "silently never match on Windows". Case folding is the same class of host dependency, arriving accidentally through `fnmatch` rather than by choice.

## What changed (motivation → approach → change)

- **Symptom:** an `ignore_patterns` entry matches case-insensitively on Windows and case-sensitively on POSIX.
- **Root cause:** `fnmatch` applies `os.path.normcase` to both operands; that is a platform-dependent transform applied to platform-independent, persisted configuration.
- **Change:** use `fnmatchcase` for per-source patterns at both call sites, so the pattern itself is authoritative on every host.

```python
# src/kiro_crew/knowledge/folder_watcher.py — the production scan
if any(fnmatchcase(rel_path.replace(os.sep, "/"), pat) for pat in ignore_patterns):

# src/kiro_crew/knowledge/doc_filter.py — the predicate that must not drift from it
if any(fnmatchcase(norm, pat) for pat in IGNORE_PATTERNS):
```

Case-sensitive rather than lowercasing both sides, because the codebase already distinguishes the two policies and only one of them is opt-in:

- `DEFAULT_IGNORE_GLOBS` is **explicitly** case-insensitive — it is matched as `fnmatch(fname.lower(), pat)` against an all-lowercase list, and is commented as such. Left exactly as it is.
- Per-source `ignore_patterns` are raw user patterns with no such contract. If they were meant to be case-insensitive too, the explicit lowercasing above them would be redundant.

Deliberately **not** touched: `.kiroignore` (its own matcher and its own gitignore-subset contract), `DEFAULT_IGNORE_GLOBS`, the pattern lists themselves. No configuration knob, no case-sensitivity option, no shared glob abstraction — the defect is one implicit transform, and the fix removes it.

The `os.sep` normalization above the match becomes load-bearing rather than redundant: `normcase` used to fold `/` on both sides, so separator patterns survived either way. `fnmatchcase` does not, which is exactly what that line was written for. Verified: `x.egg-info/PKG-INFO.md` is still dropped by `*.egg-info/*`.

## Tests

New class `TestHostIndependentPatternMatching` in `test/test_knowledge_doc_filter.py`, three cases:

- `test_the_trap_is_actually_armed` — guards the guard: asserts `fnmatch` folds and `fnmatchcase` does not under the substituted `normcase`. Without it the other two could pass vacuously if the substitution ever stopped taking effect.
- `test_predicate_does_not_fold_case_on_a_windows_style_host` — `should_ingest_doc("security.md", BIG)` is taken, `"SECURITY.md"` is dropped, and `"x.egg-info/PKG-INFO.md"` is still dropped by its separator pattern.
- `test_walk_matches_the_predicate_on_a_windows_style_host` — drives the real `FolderWatcher._walk` over a synthetic tree with the real `project_doc_properties()`, asserting both that the scan matches the predicate **and** the exact set taken.

**The trap is reproduced on every host, not skipped off Windows.** The tests substitute `ntpath`'s `normcase` (`value.replace("/", "\\").lower()`) for the duration of the test, so the POSIX shards run the regression too — a `skipif(os.name != "nt")` guard would hide it from every reviewer not on Windows.

The equivalence assertion alone is **not** sufficient and this is worth stating: under the old code the predicate and the walk both dropped `security.md`, so `walked == predicted` still held. The exact-set assertion is what fails.

**Red-before, measured on pristine `origin/main` production code at `6ed29f5cb`** (tests added, both source files reverted):

```
FAILED ...::test_predicate_does_not_fold_case_on_a_windows_style_host - assert False is True
FAILED ...::test_walk_matches_the_predicate_on_a_windows_style_host
        - assert {'docs/design.md'} == {'docs/design.md', 'security.md'}
2 failed, 1 passed
```

Green after, and the blast radius is clean: every test file referencing `ignore_patterns`, `folder_watcher`, `should_ingest_doc` or `project_doc_properties` — 13 files including `test_knowledge_kiroignore.py` and `test_knowledge_project_docs.py` — **423 passed, 11 skipped, 1 xfailed, 0 failed**.

Gates at the scope CI uses: `flake8`, `isort --check-only`, and `mypy` (`Success: no issues found in 2 source files`) all clean; the added lines are black-clean, with `black --diff` reporting only pre-existing hunks this change does not touch.

## Manual verification

N/A — unit coverage sufficient: the change is one matcher call on each of the two code paths, and the new walk test exercises the real `FolderWatcher._walk` against a real tree rather than mocking it.

## Related Issues

No linked issue — found by reading the filter, and small enough to land as the fix itself.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing contract or configuration changed
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
