### PR TITLE
fix: derive injection-timeout notice copy from the run's outcome (#5882)

### DIFF
--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -93,17 +93,30 @@ time-to-first-token distribution.
 
 ## Sub-agent delivery failure
 
-The sub-agent completed but injecting its result into the parent session timed out.
-`subagent.py` builds:
+A sub-agent reached a terminal state but injecting its report into the parent
+session failed (most commonly a delivery timeout). `subagent.py` builds:
 
 ```
 [Subagent completion event]
 Agent `<id>` ❌ <reason>
 Task: <first 100 chars of the task>
-The agent finished but result delivery timed out.
+<outcome line>
 Result saved at: <path> (<n> bytes)
 Use the read tool to retrieve it if needed.
 ```
+
+The outcome line reflects the run's actual terminal state instead of asserting
+completion — this path fires for every terminal state, including runs that
+never executed (the never-ran reading comes from the record's execution marker,
+never from its error wording):
+
+- completed: `The agent finished but result delivery timed out.`
+- failed after execution began: `The agent failed before a result could be delivered.`
+- failed before execution (approval or queued rejection, no output exists):
+  `The run failed before it started, so there is no result to deliver.`
+- stopped before execution began (no output exists):
+  `The run was stopped before it started, so there is no result to deliver.`
+- stopped mid-run: `The run was stopped before it completed.`
 
 The result-path lines are present only when a result file exists. **The result is
 on disk**, so use the `read` tool to retrieve it rather than re-running the work.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -260,6 +260,7 @@ from kiro_crew.subagent import (
     SubagentInfo,
     SubagentManager,
     ToolApprovalCallback,
+    _injection_notice_outcome,
     resolve_max_subagents,
 )
 from kiro_crew.subagent_completion_meta import (
@@ -7484,14 +7485,18 @@ class GatewayOrchestrator:
                     task_preview, _ = redact_credentials(task_preview)
                     error_text, _ = redact_exfiltration_urls(extra.get("error", "timed out"))
                     error_text, _ = redact_credentials(error_text)
+                    # The visible transcript card must state the run's real
+                    # outcome, same as the queued LLM copy: this event fires for
+                    # every terminal state whose report could not be injected,
+                    # not only successful completions.
+                    outcome_line = _injection_notice_outcome(info)
                     slot.append(
                         "assistant",
                         f"{SUBAGENT_COMPLETION_PREFIX}\n"
                         f"Agent `{info.id}` ❌\n"
                         f"Task: {task_preview}\n\n"
                         f"Error: {error_text}\n"
-                        f"⚠️ Result delivery timed out — the subagent finished but "
-                        f"its result could not be injected into this session.",
+                        f"⚠️ Result delivery failed — {outcome_line}",
                         "msg msg-a",
                         meta={
                             SUBAGENT_COMPLETION_META_KEY: single_completion_meta(

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1365,6 +1365,36 @@ class SubagentInfo:
 # Callback: (subagent_info) -> None
 AnnounceCallback = Callable[[SubagentInfo], Awaitable[None]]
 
+
+def _injection_notice_outcome(info: "SubagentInfo") -> str:
+    """One-sentence outcome line for the injection-failure fallback notice.
+
+    ``notify_injection_failed`` fires whenever a terminal report could not be
+    injected into the parent — for EVERY terminal state, not just successful
+    completion. Asserting "finished" for a run that was stopped or rejected
+    before it executed misdescribes the outcome, so the line branches on the
+    record's canonical :attr:`SubagentInfo.outcome` with one before-start
+    refinement per branch: ``_exec_started`` — the marker ``_run_inner`` sets
+    when execution actually begins — is ``None`` exactly when the run never
+    executed, which covers every spawn-rejection site (all of them construct
+    their record without it) with no wording contract between ``error``
+    strings and this notice. The "no result to deliver" phrasings are guarded
+    on the absence of any output so they can never contradict the result-path
+    recovery hint. Pure function of the record, unit-tested per branch.
+    """
+    never_ran = info._exec_started is None and not info.result and not info.result_path
+    outcome = info.outcome
+    if outcome == "stopped":
+        if never_ran:
+            return "The run was stopped before it started, so there is no result to deliver."
+        return "The run was stopped before it completed."
+    if outcome == "failed":
+        if never_ran:
+            return "The run failed before it started, so there is no result to deliver."
+        return "The agent failed before a result could be delivered."
+    return "The agent finished but result delivery timed out."
+
+
 # Event callback: (event_type, info, extra_data) -> None
 SubagentEventCallback = Callable[[str, "SubagentInfo", dict], Awaitable[None]]
 
@@ -2984,7 +3014,11 @@ class SubagentManager:
         Appends a synthetic error to the dashboard slot (UI) and queues a
         failure message into ``slot._pending_subagent_failures`` so the LLM
         learns about the failure on the next ``_run_chat`` turn and can read
-        the result from disk if needed.
+        the result from disk if needed. The notice's outcome line is derived
+        from the record (:func:`_injection_notice_outcome`) rather than
+        asserting completion: this path fires for every terminal state whose
+        report could not be injected, including runs cancelled or rejected
+        before they ever executed.
         """
         try:
             # Lazy: the dashboard layer must not be imported by a core module at
@@ -3017,7 +3051,7 @@ class SubagentManager:
                 f"{SUBAGENT_COMPLETION_PREFIX}\n"
                 f"Agent `{info.id}` ❌ {reason}\n"
                 f"Task: {task_preview}\n"
-                f"The agent finished but result delivery timed out.{result_hint}"
+                f"{_injection_notice_outcome(info)}{result_hint}"
             )
 
             # Queue for LLM context drain on next _run_chat

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -1289,6 +1289,134 @@ class TestNotifyInjectionFailed:
             mgr.notify_injection_failed(_info(parent_session_key="dash:1"))
 
 
+# ── Injection-failure notice: outcome-aware copy ──────────────────────────
+
+
+class TestInjectionNoticeOutcome:
+    """The pure helper maps a terminal record to a truthful outcome line."""
+
+    def test_completed_keeps_the_finished_copy(self) -> None:
+        info = _info(done=True, result="ok")
+        assert sa._injection_notice_outcome(info) == (
+            "The agent finished but result delivery timed out."
+        )
+
+    def test_failed_run_does_not_claim_finished(self) -> None:
+        info = _info(done=True, error="Timed out after 30 minutes", _exec_started=123.0)
+        line = sa._injection_notice_outcome(info)
+        assert line == "The agent failed before a result could be delivered."
+
+    def test_stopped_mid_run_reads_as_stopped(self) -> None:
+        info = _info(
+            done=True, user_stopped=True, _exec_started=123.0, tool_count=3, result="partial"
+        )
+        assert sa._injection_notice_outcome(info) == "The run was stopped before it completed."
+
+    def test_stopped_in_startup_window_is_not_before_start(self) -> None:
+        # Execution began (_exec_started set) but no turn, tool call, or output
+        # landed yet — the run DID start, so the before-start copy would lie.
+        info = _info(done=True, user_stopped=True, _exec_started=123.0)
+        assert sa._injection_notice_outcome(info) == "The run was stopped before it completed."
+
+    def test_stopped_before_execution_says_it_never_ran(self) -> None:
+        # A stop landing on a registered run before _run_inner ever executed:
+        # no _exec_started marker and no output of any kind.
+        info = _info(done=True, user_stopped=True)
+        assert sa._injection_notice_outcome(info) == (
+            "The run was stopped before it started, so there is no result to deliver."
+        )
+
+    def test_rejections_read_as_failed_before_start(self) -> None:
+        # Every spawn-rejection site constructs its record without
+        # _exec_started, so the never-ran refinement covers them all — the
+        # sentinel-worded ones AND the unknown-agent refusal, whose exact
+        # wording is consumed by _is_unknown_agent_refusal and cannot change.
+        for err in (
+            "spawn rejected",
+            "spawn refused: only 1.0 GB memory available (need 4 GB)",
+            "agent 'ghost' not found; available: scout, probe",
+        ):
+            info = _info(done=True, error=err)
+            assert sa._injection_notice_outcome(info) == (
+                "The run failed before it started, so there is no result to deliver."
+            ), err
+
+    def test_error_with_output_keeps_the_recovery_hint_honest(self) -> None:
+        # Defensive: a record carrying output must never be described as
+        # having no result to deliver — the generic failed copy stays truthful.
+        info = _info(done=True, error="spawn rejected", result_path="/tmp/r.txt")
+        assert sa._injection_notice_outcome(info) == (
+            "The agent failed before a result could be delivered."
+        )
+
+
+class TestNotifyInjectionFailedOutcomeCopy:
+    """End-to-end: the queued failure message carries the outcome-aware line.
+
+    Four regression paths: stop before execution, approval rejection, queued
+    rejection, and the ordinary post-run delivery timeout (whose copy is
+    unchanged).
+    """
+
+    async def _notice_for(self, info: SubagentInfo) -> str:
+        seen: list[dict] = []
+
+        async def _on_event(_etype: str, _info: SubagentInfo, extra: dict) -> None:
+            seen.append(extra)
+
+        mgr = _manager(on_event=_on_event)
+        with patch("kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value="slot-1"):
+            mgr.notify_injection_failed(info)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen, "expected a subagent_injection_failed event"
+        return str(seen[0]["failure_msg"])
+
+    @pytest.mark.asyncio
+    async def test_stop_before_execution_does_not_claim_the_agent_finished(self) -> None:
+        # A user stop landing on a registered run before execution began marks
+        # the record user_stopped with no _exec_started and no output: it never
+        # ran. (A cancel on a spawn still WAITING in the stagger queue is
+        # unqueued without a record and never reaches this notice at all.)
+        info = _info(parent_session_key="dash:1", done=True, user_stopped=True)
+        msg = await self._notice_for(info)
+        assert "The run was stopped before it started" in msg
+        assert "finished" not in msg
+
+    @pytest.mark.asyncio
+    async def test_approval_rejection_reads_as_never_started(self) -> None:
+        info = _info(parent_session_key="dash:1", done=True, error="spawn rejected")
+        msg = await self._notice_for(info)
+        assert "The run failed before it started" in msg
+        assert "finished" not in msg
+
+    @pytest.mark.asyncio
+    async def test_queued_rejection_reads_as_never_started_without_mechanism_detail(self) -> None:
+        info = _info(
+            parent_session_key="dash:1",
+            done=True,
+            error="spawn refused: only 1.0 GB memory available (need 4 GB)",
+        )
+        msg = await self._notice_for(info)
+        assert "The run failed before it started" in msg
+        # Mechanism details stay out of the user-facing notice.
+        assert "GB" not in msg
+        assert "finished" not in msg
+
+    @pytest.mark.asyncio
+    async def test_post_run_delivery_timeout_keeps_existing_copy_and_hint(
+        self, tmp_path: Path
+    ) -> None:
+        result = tmp_path / "result.txt"
+        result.write_text("hello", newline="\n")
+        info = _info(
+            parent_session_key="dash:1", done=True, result="hello", result_path=str(result)
+        )
+        msg = await self._notice_for(info)
+        assert "The agent finished but result delivery timed out." in msg
+        assert "Result saved at" in msg
+
+
 # ── Manager: continuable conversations ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`notify_injection_failed` hardcoded **"The agent finished but result delivery timed out."** for every terminal report whose injection into the parent session failed — including runs that never executed. A run stopped before execution began, an approval rejection, or a queued rejection all produced a transcript notice claiming the agent finished when it never ran. The visible dashboard card built by the gateway's `subagent_injection_failed` handler hardcoded the same claim. The terminal outcome itself was already durable; only the diagnostic copy misdescribed it (accepted UX Review follow-up on PR #5281).

## What changed

- **New pure helper `_injection_notice_outcome(info)`** (`src/kiro_crew/subagent.py`): the notice's outcome line branches on the record's canonical `SubagentInfo.outcome` (the documented single source of truth for terminal-state classification) with one structural before-start refinement: `_exec_started` — the marker `_run_inner` sets when execution actually begins — is `None` exactly when the run never executed. That covers every spawn-rejection site (all of them construct their record without it, including the unknown-agent refusal whose exact wording is consumed by `_is_unknown_agent_refusal` and cannot change) with **no wording contract between `error` strings and the notice**.
- **Both surfaces use it**: the queued LLM failure message in `notify_injection_failed` AND the visible transcript card in the gateway's `subagent_injection_failed` handler (previously a second hardcoded "the subagent finished" claim).
- **Copy per outcome** (mechanism details stay out of the user-facing text):
  - completed: `The agent finished but result delivery timed out.` (unchanged)
  - failed after execution began: `The agent failed before a result could be delivered.`
  - failed before execution (approval/queued rejection): `The run failed before it started, so there is no result to deliver.`
  - stopped before execution: `The run was stopped before it started, so there is no result to deliver.`
  - stopped mid-run: `The run was stopped before it completed.`
- The "no result to deliver" phrasings are guarded on the absence of any output (`result` and `result_path`), so they can never contradict the result-path recovery hint, which is preserved whenever output exists. A stop in the startup window (execution began, no output yet) deliberately reads as mid-run, not "before start".
- `docs/system-specs/common/injected-messages.md` updated in the same commit (documented message shape).

Note on the issue's "queued cancellation" path: a cancel on a spawn still **waiting in the stagger queue** is unqueued without a `SubagentInfo` record and never reaches this notice at all. The reachable variant — a user stop landing on a registered run before execution began — is what the before-start branch and its regression test cover.

## Testing

- 11 new tests in `test/test_subagent_coverage.py`: per-branch unit tests of the pure helper (completed / failed after start / stopped mid-run / stopped in startup window / stopped before execution / three rejection wordings including the unknown-agent refusal / output-guard honesty) plus four end-to-end regression paths through `notify_injection_failed` (stop before execution, approval rejection, queued rejection with mechanism detail kept out of the notice, and ordinary post-run delivery timeout whose copy and `Result saved at` hint are unchanged).
- **Mutation-verified**: short-circuiting the helper back to the fixed string fails 9 of the 11 new tests; the 2 that pass are the completed-copy pins, as expected.
- Full local gates: isort / flake8 / mypy clean; full `pytest` run: 68,290 passed — the 16 failures reproduce identically on a pristine `main` worktree on this host (host-env, zero overlap with this diff). Diff-scoped gates (black baseline, brand name, harness parity, subprocess encoding, docs-lint) all pass.
- Pre-push review lanes: GPT (gpt-5.6-sol) PASS with 2 Low advisories; Opus (claude-opus-5) PASS with 4 advisories — adopted (canonical `outcome` property, `_exec_started` marker, unreachable-trigger rewording). The First Principles lane's round-1 CONCERNS were both **adopted in full**: the sibling hardcoded "finished" claim in the gateway's visible card is fixed through the same helper, and its Subtraction replaced the rejection-sentinel string matching (`_SPAWN_REJECTION_PREFIXES`, now deleted along with the queue-capacity error-text edit) with the structural `_exec_started` check.

Known main-inherited CI reds at the base: Backend Tests shards 2/4 + Coverage Gate fail on `main` itself (issue #5846; unblocker PR #5880 in flight) — verified on a pristine main worktree and on main's own CI at the base SHA.

Closes #5882
