### PR TITLE
fix(tls): honor macOS Keychain trust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ package_dir =
 packages = find:
 install_requires =
     aiohttp>=3.9,<4
+    # Security.framework-backed TLS validation for bundled macOS Python.
+    # File CA bundles cannot preserve Keychain trust policy or explicit deny.
+    truststore==0.10.4; sys_platform == "darwin"
     # Direct dependency, not just aiohttp's transitive one: the link-unfurl vet
     # derives the resolver-pin host with `yarl.URL.raw_host` so it matches the
     # exact key aiohttp asks its resolver with. Pinning on any other encoding of
@@ -415,6 +418,7 @@ per-file-ignores =
     # _ensure_ssl_certs() must run before any library caches its SSL context
     src/kiro_crew/cli.py: E402
     src/kiro_crew/__main__.py: E402
+    src/kiro_crew/mcp_gateway/gatewayd.py: E402
     # Builtin app backends use compact continuation indent style
     src/kiro_crew/apps/builtins/*: E128
 # Uncomment to enforce a maximum cyclomatic complexity - more info https://en.wikipedia.org/wiki/Cyclomatic_complexity

--- a/src/kiro_crew/_ssl_compat.py
+++ b/src/kiro_crew/_ssl_compat.py
@@ -1,43 +1,99 @@
-"""Ensure the system CA bundle is visible to OpenSSL before any HTTPS call.
+"""Make platform trust available before any HTTPS client caches an SSL context.
 
-Must run before any library (aiohttp, slack_sdk, requests) caches its
-default SSL context, otherwise every HTTPS call fails with
-CERTIFICATE_VERIFY_FAILED.
-
-Two distinct gaps, one fix: on Amazon Linux dev-desktops, mise-installed
-Python looks for certs at ``/etc/ssl/`` but Amazon Linux stores them at
-``/etc/pki/tls/`` (the ``_CA_CANDIDATES`` file paths below). On macOS, a
-python.org/Homebrew/pyenv-built CPython ships no bundled CA store at all and
-does not read the OS Keychain via any of these file paths — the standard
-fix there is ``certifi``'s bundled Mozilla root store, already present as a
-transitive dependency (``pip``, ``requests``, ``slack-sdk`` all pull it) but
-never installed as a direct one, so it is used only as a soft fallback: if
-it is not importable, this function is a no-op on that platform, matching
-prior behavior.
+macOS trust is policy-aware and cannot be represented faithfully as a static
+PEM bundle: the Keychain carries user/admin/system trust, explicit distrust,
+hostname policy, and validity decisions. Applications must therefore ask
+Security.framework to evaluate each connection. Other platforms keep the
+file-based bootstrap used for Linux distributions whose Python default points
+at the wrong CA location.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import ssl
+import sys
 from pathlib import Path
+
+try:  # macOS-only dependency (setup.cfg marker); absent on other platforms.
+    import truststore
+except ImportError:
+    truststore = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 _CA_CANDIDATES = (
     "/etc/pki/tls/cert.pem",
     "/etc/pki/tls/certs/ca-bundle.crt",
     "/etc/ssl/certs/ca-certificates.crt",
 )
+_TRUSTSTORE_INJECTED = False
+
+
+def _inject_macos_system_trust() -> bool:
+    """Install Security.framework-backed SSL contexts once per process.
+
+    ``truststore`` evaluates the real server chain through SecTrust instead of
+    flattening every certificate stored in a Keychain into an unconditional
+    OpenSSL trust anchor.  Return ``False`` on failure so startup can retain the
+    prior file-based behavior rather than losing all HTTPS capability.
+    """
+    global _TRUSTSTORE_INJECTED
+
+    if _TRUSTSTORE_INJECTED:
+        return True
+
+    if truststore is None:
+        logger.warning("truststore is not installed; falling back to file-based CA discovery")
+        return False
+
+    try:
+        truststore.inject_into_ssl()
+    except Exception as exc:
+        # A log line rather than warnings.warn: under a strict warnings filter
+        # a warning becomes an exception inside the startup prelude, turning
+        # the fallback this function promises into a startup crash.
+        logger.warning(
+            "Could not enable the macOS system trust store; falling back to "
+            "file-based CA discovery: %s",
+            exc,
+        )
+        return False
+
+    _TRUSTSTORE_INJECTED = True
+    return True
+
+
+def _ssl_context_has_ca_trust(context: ssl.SSLContext) -> bool:
+    """Return whether *context* has a usable CA trust source.
+
+    OpenSSL contexts expose a concrete CA count. Security.framework-backed
+    truststore contexts evaluate anchors dynamically and intentionally cannot
+    enumerate that count, so a successful process-level injection is their
+    equivalent trust-source signal.
+    """
+    try:
+        return context.cert_store_stats()["x509_ca"] > 0
+    except NotImplementedError:
+        return _TRUSTSTORE_INJECTED
 
 
 def _ensure_ssl_certs() -> None:
-    """Point OpenSSL at a working CA bundle before any library caches it.
+    """Configure platform trust before any HTTPS library caches its context.
 
-    Sets both ``SSL_CERT_FILE`` (used by OpenSSL / aiohttp) and
-    ``REQUESTS_CA_BUNDLE`` (used by the ``requests`` library / slack_sdk).
+    An explicit ``SSL_CERT_FILE`` remains the highest-precedence escape hatch.
+    macOS additionally installs Security.framework evaluation for this
+    process's own clients, but ``inject_into_ssl()`` is process-local, so the
+    file-based discovery below still runs to export ``SSL_CERT_FILE`` /
+    ``REQUESTS_CA_BUNDLE`` for child processes (kiro-cli, Node MCP servers)
+    that inherit this environment and cannot inherit a monkey-patch.
     """
     if os.environ.get("SSL_CERT_FILE"):
         return
 
-    import ssl
+    if sys.platform == "darwin":
+        _inject_macos_system_trust()
 
     defaults = ssl.get_default_verify_paths()
     if defaults.cafile and Path(defaults.cafile).exists():
@@ -49,8 +105,9 @@ def _ensure_ssl_certs() -> None:
             os.environ.setdefault("REQUESTS_CA_BUNDLE", candidate)
             return
 
-    # None of the Linux system paths exist (e.g. macOS) — fall back to
-    # certifi's bundle if it happens to be installed transitively.
+    # The file-based fallback keeps standalone/source installations usable when
+    # the OS-specific bootstrap is unavailable.  requests makes certifi part of
+    # Kiro Crew's installed dependency closure, including the desktop bundle.
     try:
         import certifi
 

--- a/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/tectonic.py
@@ -70,6 +70,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew._ssl_compat import _ssl_context_has_ca_trust
 from kiro_crew.apps.builtins.papyrus.backend import store
 from kiro_crew.sel import sel
 
@@ -564,7 +565,7 @@ def _make_ssl_context() -> ssl.SSLContext:
     ctx = ssl.create_default_context()
     try:
         ctx.load_default_certs()
-        if ctx.cert_store_stats()["x509_ca"] > 0:
+        if _ssl_context_has_ca_trust(ctx):
             return ctx
     except ssl.SSLError:
         pass

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/engine_source.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/engine_source.py
@@ -50,6 +50,7 @@ import urllib.request
 from pathlib import Path
 from typing import Callable
 
+from kiro_crew._ssl_compat import _ssl_context_has_ca_trust
 from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger("kirocrew.app.pptx-maker")
@@ -225,7 +226,7 @@ def _make_ssl_context() -> ssl.SSLContext:
     ctx = ssl.create_default_context()
     try:
         ctx.load_default_certs()
-        if ctx.cert_store_stats()["x509_ca"] > 0:
+        if _ssl_context_has_ca_trust(ctx):
             return ctx
     except ssl.SSLError:
         pass

--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -48,6 +48,7 @@ import urllib.request
 from pathlib import Path
 from typing import Callable, NamedTuple, Protocol
 
+from kiro_crew._ssl_compat import _ssl_context_has_ca_trust
 from kiro_crew.config.loader import config_path
 from kiro_crew.config.paths import config_dir
 from kiro_crew.metrics.provider import get_recorder
@@ -1711,9 +1712,7 @@ def _make_ssl_context() -> ssl.SSLContext:
     ctx = ssl.create_default_context()
     try:
         ctx.load_default_certs()
-        # Verify the defaults work by checking the cert store has entries
-        stats = ctx.cert_store_stats()
-        if stats["x509_ca"] > 0:
+        if _ssl_context_has_ca_trust(ctx):
             return ctx
     except ssl.SSLError:
         pass

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -27,6 +27,13 @@ installed by the caller should just forward into ``stop_event.set()``.
 
 from __future__ import annotations
 
+# System-trust injection is process-local and must run before imports below can
+# create or cache an SSLContext. Environment-only CA settings are inherited
+# from GatewayManager, but Security.framework-backed contexts are not.
+from kiro_crew._ssl_compat import _ensure_ssl_certs
+
+_ensure_ssl_certs()
+
 import argparse
 import asyncio
 import contextlib

--- a/test/test_ssl_certs.py
+++ b/test/test_ssl_certs.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import sys
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from kiro_crew import _ssl_compat
 from kiro_crew._ssl_compat import _CA_CANDIDATES, _ensure_ssl_certs
+
+
+@pytest.fixture(autouse=True)
+def _reset_ssl_bootstrap(monkeypatch):
+    """Keep tests independent and file-bootstrap cases platform-neutral."""
+    monkeypatch.setattr(_ssl_compat, "_TRUSTSTORE_INJECTED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
 
 
 class TestEnsureSslCerts:
@@ -173,3 +184,156 @@ class TestEnsureSslCerts:
 
             importlib.reload(kiro_crew.cli)
         mock_fn.assert_called()
+
+    def test_macos_injects_system_trust(self, monkeypatch, tmp_path):
+        """macOS should delegate TLS validation to Security.framework."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        inject = MagicMock()
+        mock_truststore = type("Truststore", (), {"inject_into_ssl": inject})()
+        ca_file = tmp_path / "system-ca.pem"
+        ca_file.write_text("fake cert bundle")
+        mock_paths = type("P", (), {"cafile": str(ca_file), "capath": None})()
+
+        with (
+            patch.object(_ssl_compat, "truststore", mock_truststore),
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+        ):
+            _ensure_ssl_certs()
+
+        inject.assert_called_once_with()
+        assert _ssl_compat._TRUSTSTORE_INJECTED is True
+
+    def test_macos_explicit_bundle_wins(self, monkeypatch):
+        """An operator-supplied SSL_CERT_FILE must bypass system injection."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setenv("SSL_CERT_FILE", "/operator/ca.pem")
+        inject = MagicMock()
+        mock_truststore = type("Truststore", (), {"inject_into_ssl": inject})()
+
+        with patch.object(_ssl_compat, "truststore", mock_truststore):
+            _ensure_ssl_certs()
+
+        inject.assert_not_called()
+        assert _ssl_compat._TRUSTSTORE_INJECTED is False
+
+    def test_macos_injection_is_idempotent(self, monkeypatch, tmp_path):
+        """Both application entry points may call the prelude in one process."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        inject = MagicMock()
+        mock_truststore = type("Truststore", (), {"inject_into_ssl": inject})()
+        ca_file = tmp_path / "system-ca.pem"
+        ca_file.write_text("fake cert bundle")
+        mock_paths = type("P", (), {"cafile": str(ca_file), "capath": None})()
+
+        with (
+            patch.object(_ssl_compat, "truststore", mock_truststore),
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+        ):
+            _ensure_ssl_certs()
+            _ensure_ssl_certs()
+
+        inject.assert_called_once_with()
+
+    def test_macos_injection_still_exports_child_env(self, monkeypatch, tmp_path):
+        """Injection covers this process only; children still need the env vars.
+
+        MCP subprocesses (kiro-cli, Node servers) inherit ``os.environ`` and
+        cannot inherit a process-local monkey-patch, so a successful macOS
+        injection must not short-circuit the file-based export they rely on.
+        """
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        inject = MagicMock()
+        mock_truststore = type("Truststore", (), {"inject_into_ssl": inject})()
+
+        mock_paths = type("P", (), {"cafile": None, "capath": None})()
+        fake_certifi_bundle = tmp_path / "certifi-cacert.pem"
+        fake_certifi_bundle.write_text("fake certifi bundle")
+        mock_certifi = type("M", (), {"where": staticmethod(lambda: str(fake_certifi_bundle))})()
+
+        with (
+            patch.object(_ssl_compat, "truststore", mock_truststore),
+            patch.dict(sys.modules, {"certifi": mock_certifi}),
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+            patch("kiro_crew._ssl_compat._CA_CANDIDATES", ("/nonexistent/a.pem",)),
+        ):
+            _ensure_ssl_certs()
+
+        import os
+
+        inject.assert_called_once_with()
+        assert os.environ["SSL_CERT_FILE"] == str(fake_certifi_bundle)
+        assert os.environ["REQUESTS_CA_BUNDLE"] == str(fake_certifi_bundle)
+
+    def test_macos_injection_failure_falls_back(self, monkeypatch, tmp_path, caplog):
+        """A system-trust failure must not prevent the prior CA bootstrap."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        ca_file = tmp_path / "fallback-ca.pem"
+        ca_file.write_text("fake cert bundle")
+        mock_paths = type("P", (), {"cafile": str(ca_file), "capath": None})()
+        inject = MagicMock(side_effect=RuntimeError("unavailable"))
+        mock_truststore = type("Truststore", (), {"inject_into_ssl": inject})()
+
+        with (
+            patch.object(_ssl_compat, "truststore", mock_truststore),
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+            caplog.at_level("WARNING", logger="kiro_crew._ssl_compat"),
+        ):
+            _ensure_ssl_certs()
+
+        inject.assert_called_once_with()
+        assert _ssl_compat._TRUSTSTORE_INJECTED is False
+        assert "falling back" in caplog.text
+
+        import os
+
+        assert os.environ.get("SSL_CERT_FILE") is None
+
+    def test_macos_missing_truststore_falls_back(self, monkeypatch, tmp_path, caplog):
+        """An absent truststore package degrades to file discovery, not a crash."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        ca_file = tmp_path / "fallback-ca.pem"
+        ca_file.write_text("fake cert bundle")
+        mock_paths = type("P", (), {"cafile": str(ca_file), "capath": None})()
+
+        with (
+            patch.object(_ssl_compat, "truststore", None),
+            patch("ssl.get_default_verify_paths", return_value=mock_paths),
+            caplog.at_level("WARNING", logger="kiro_crew._ssl_compat"),
+        ):
+            _ensure_ssl_certs()
+
+        assert _ssl_compat._TRUSTSTORE_INJECTED is False
+        assert "falling back" in caplog.text
+
+    def test_gatewayd_invokes_ensure_ssl_certs(self):
+        """The separate gateway process must install process-local trust."""
+        import importlib
+
+        mock_fn = MagicMock()
+        with patch("kiro_crew._ssl_compat._ensure_ssl_certs", mock_fn):
+            import kiro_crew.mcp_gateway.gatewayd
+
+            importlib.reload(kiro_crew.mcp_gateway.gatewayd)
+        mock_fn.assert_called()
+
+    def test_context_trust_uses_openssl_ca_count(self, monkeypatch):
+        """Regular OpenSSL contexts retain the concrete CA-count check."""
+        context = MagicMock()
+        context.cert_store_stats.return_value = {"x509_ca": 1}
+
+        assert _ssl_compat._ssl_context_has_ca_trust(context) is True
+        context.cert_store_stats.assert_called_once_with()
+
+    def test_context_trust_accepts_injected_dynamic_store(self, monkeypatch):
+        """Security.framework trust is valid even though it cannot list CAs."""
+        monkeypatch.setattr(_ssl_compat, "_TRUSTSTORE_INJECTED", True)
+        context = MagicMock()
+        context.cert_store_stats.side_effect = NotImplementedError
+
+        assert _ssl_compat._ssl_context_has_ca_trust(context) is True


### PR DESCRIPTION
## Problem / Motivation

Kiro Crew's bundled macOS Python validates TLS through OpenSSL's file store. `_ensure_ssl_certs()` returns as soon as `/etc/ssl/cert.pem` exists, so it never consults the macOS Keychain. A corporate root trusted by Security.framework (for example, a TLS-inspection root) is therefore invisible to Kiro Crew's `aiohttp` clients, even though native macOS clients accept it.

## Why it matters

Enterprise environments commonly install private roots through managed Keychain trust. The mismatch blocks Kiro Crew-owned HTTPS — including the remote Streamable HTTP MCP probe — and currently pushes users toward modifying `/etc/ssl/cert.pem` with `sudo`, a non-durable workaround that OS updates can erase.

Blindly exporting `security find-certificate -a -p` is not a safe substitute: it enumerates stored certificates, not effective TLS trust, and can flatten explicit distrust, policy constraints, expired certificates, and leaves/intermediates into unconditional OpenSSL anchors.

## What changed (motivation → approach → change)

- Add pinned, macOS-only `truststore==0.10.4` and inject it before HTTPS libraries cache an `SSLContext`. `truststore` delegates each real chain to Security.framework, preserving user/admin/system trust, explicit deny, hostname policy, and validity checks.
- Preserve an explicit `SSL_CERT_FILE` as the highest-precedence operator override. Keep the existing file-based Linux/certifi fallback unchanged; if truststore initialization fails, warn and fall back rather than blocking startup.
- **Injection does not short-circuit the environment export.** `inject_into_ssl()` is process-local, so after injecting, the prelude still runs the existing file/certifi discovery and exports `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` — child processes (kiro-cli, Node MCP servers) inherit the env exactly as before and cannot lose the CA bundle they previously received.
- Make injection process-idempotent because both `__main__.py` and `cli.py` may run the prelude.
- Restore the early gatewayd prelude. The earlier env-only version (#5831) was correctly closed as a no-op because env values are inherited. This version is different: `truststore.inject_into_ssl()` is a process-local monkey-patch, so the separate gateway Python runtime must install it for itself before TLS-touching imports.
- Centralize the CA-trust availability check used by embeddings, Papyrus, and PPTX downloads. A normal OpenSSL context exposes `cert_store_stats()`; a truststore context intentionally raises `NotImplementedError` because Security.framework evaluates anchors dynamically. The helper accepts the injected dynamic store without weakening the existing OpenSSL CA-count check. Because `inject_into_ssl()` replaces `ssl.SSLContext` process-wide, the full backend suite was run to confirm no other caller depends on an API the truststore context does not implement; these three `cert_store_stats()` sites were the only collisions.

## Tests

Added/updated SSL regression coverage for:

- macOS system-trust injection
- explicit `SSL_CERT_FILE` precedence
- idempotent injection
- **successful injection still exports the certifi env for child processes**
- warning + file-based fallback on injection failure
- gatewayd process-local prelude
- OpenSSL CA-count behavior
- truststore's dynamic, non-enumerable CA store

Local results:

- `test/test_ssl_certs.py`: **17 passed**; focused SSL/download set (embeddings, Papyrus, PPTX): **285 passed**
- `isort --check-only src/kiro_crew test`: clean
- `flake8 src/kiro_crew test`: clean
- `mypy src/kiro_crew/`: **1102 source files, no issues**
- Wheel build: metadata contains `Requires-Dist: truststore==0.10.4; sys_platform == "darwin"`
- Full backend: **68,264 passed**; 20 host/environment failures. The exact same 20 failures reproduce against a clean `origin/main` worktree (missing local AWS CLI, xdist host-budget assumptions, PTY timeouts, platform capability assertions, and existing test isolation issues), so none is introduced by this change.
- Frontend: TypeScript passed; Vitest **24,120 passed**, with one Hindi style ratchet failure. The same 120-vs-119 failure reproduces on clean `origin/main`.

## Manual verification

A public endpoint smoke test from this macOS host returned `TLS_OK 404` both before and after injection, so this host does not reproduce the managed-Keychain/private-CA condition. Validation on the affected environment is still required:

1. the Kiro Crew remote MCP probe succeeds with the Keychain-trusted corporate CA;
2. a real MCP tool call succeeds.

The first is directly fixed here. `truststore` does not propagate into unrelated external runtimes such as Node or a separately packaged kiro-cli process; those continue to receive the inherited `SSL_CERT_FILE` env (unchanged from before this PR). If the probe succeeds but the runtime call still fails, that external-runtime trust path remains a follow-up (upstream system-trust support or a supported CA-bundle bridge) rather than being hidden by this PR.

## Related Issues

Refs #5602. Do not auto-close until the affected environment confirms the probe/tool-call scope above.

## Checklist

- [x] At most two commits (one commit), with a Conventional Commits title
- [x] Existing affected tests pass and regression tests cover new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where behavior and security rationale changed
- [x] No secrets, credentials, certificate contents, or internal references in the diff

## Contribution License Agreement

N/A — the repository template currently provides no CLA wording for contributors.
