### PR TITLE
fix(test): accept endpoint kwarg in the missed fake_post stub (#5879)

### DIFF
--- a/test/test_kiro_usage_api.py
+++ b/test/test_kiro_usage_api.py
@@ -502,7 +502,7 @@ class TestWindowsCliStore:
         usage_body = {"usageBreakdownList": [
             {"resourceType": "CREDIT", "currentUsage": 3.0, "usageLimit": 100.0}]}
 
-        def fake_post(token, target, payload):
+        def fake_post(token, target, payload, **_kwargs):
             if target == api._TARGET_LIST_PROFILES:
                 return _resp(200, {"profiles": []})
             return _resp(200, usage_body)


### PR DESCRIPTION
## Problem / Motivation

main CI is red on Backend Tests shard 2 (3.10, 3.12, Windows): `test/test_kiro_usage_api.py::TestWindowsCliStore::test_local_appdata_store_token_is_trusted_without_arn` fails with `assert None is not None`. Red since commit 6ed29f5cb landed (the eu-central-1 RTS endpoint change, #4545). Tracked by #5879 and #5888.

## Why it matters

Every open PR inherits the red on the same three shards, dragging Coverage Gate and PR Readiness with it -- nothing can go green until main is fixed.

## What changed

Commit 6ed29f5cb added an `endpoint=` keyword to `_post` and updated 7 of the 8 `fake_post` test stubs to accept `**_kwargs` -- but missed the one in `test_local_appdata_store_token_is_trusted_without_arn` (line 505). The production code now calls the stub with `endpoint=...`, the stub TypeErrors, the deliberate blanket `except Exception` in the candidate loop swallows it as "unexpected error", and `fetch_usage_limits` returns None. One line: the missed stub now takes `**_kwargs`, matching its 7 siblings byte-for-byte.

## Tests

- The failing test flips red-to-green with only this change.
- Full `test/test_kiro_usage_api.py`: 88/88 pass.
- isort/flake8 clean; no production code touched.

## Any other suggestions

The swallow-as-"unexpected error" path made a plain TypeError invisible in CI output; the log line only appears at DEBUG. Not expanded here to keep the fix one line.

Closes #5879
Refs #5888
