### PR TITLE
fix: launch the streaming speech helper with --fast (#5896)

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -800,8 +800,25 @@ class StreamingSession:
             return "streaming speech helper could not be built"
         try:
             try:
+                # `--fast` inserts `.frequentFinalization` into the transcriber's
+                # reporting options so the helper emits mid-stream FINAL segments
+                # while the audio stream is still open. Without it the default
+                # DictationTranscriber produces only volatile partials until the
+                # stream closes, so the dashboard's semantic endpointer — which
+                # schedules its utterance-complete judgment exclusively from
+                # note_final() — never fires and auto-submit is impossible. The
+                # one-shot batch path deliberately omits it: its final arrives
+                # when the stream closes, and frequent finalization can trade
+                # accuracy for latency it has no use for.
                 stream_argv, stream_env, self._sb_cleanup = await _sandboxed_off_loop(
-                    [helper, "--locale", self.locale, "--sample-rate", str(self.sample_rate)]
+                    [
+                        helper,
+                        "--locale",
+                        self.locale,
+                        "--sample-rate",
+                        str(self.sample_rate),
+                        "--fast",
+                    ]
                 )
             except sandbox.SandboxUnavailableError as exc:
                 return f"{_NO_SANDBOX_HINT}{exc}"

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -16,6 +16,7 @@ import platform
 import sys
 import threading
 from contextlib import ExitStack
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -770,6 +771,78 @@ class TestStreamingSession:
         session = apple_speech.StreamingSession()
         await session.close()
         await session.close()
+
+
+class TestHelperArgvPinsFast:
+    """Pin the ``--fast`` flag in the STREAMING helper argv (#5896).
+
+    ``--fast`` inserts ``.frequentFinalization`` into the transcriber's reporting
+    options; without it the helper emits only volatile partials for the whole open
+    stream and never a mid-stream final, so the endpointer's ``note_final()``-driven
+    auto-submit can never fire. The live helper is macOS-only with no CI runner
+    coverage, so the spawned argv IS the verifiable contract: these tests pin the
+    flag's presence on the streaming path and its deliberate absence on the one-shot
+    batch path (where the final arrives at stream close and frequent finalization
+    would only trade accuracy for unneeded latency).
+    """
+
+    @pytest.mark.asyncio
+    async def test_streaming_argv_includes_fast(self):
+        """StreamingSession.start() must pass --fast to the helper."""
+        session = apple_speech.StreamingSession(locale="en-US")
+        # Failing the spawn keeps the test on the argv contract alone: by the
+        # time create_subprocess_exec is called the argv is fully built, and no
+        # pump/ready plumbing needs to be faked.
+        spawn = Mock(side_effect=OSError("argv pin: no real spawn"))
+        with (
+            patch.object(
+                apple_speech, "availability", return_value=apple_speech.Availability(True)
+            ),
+            patch.object(apple_speech, "stream_helper_path", return_value="/fake/stream-helper"),
+            patch("asyncio.create_subprocess_exec", spawn),
+            _passthrough_sandbox(),
+        ):
+            problem = await session.start()
+        assert "could not start streaming helper" in problem
+        argv = list(spawn.call_args.args)
+        assert argv[0] == "/fake/stream-helper"
+        assert "--fast" in argv
+        # The helper's parser treats --fast as a bare switch; it must not have
+        # swallowed a neighbouring option's value.
+        assert argv[argv.index("--locale") + 1] == "en-US"
+        assert argv[argv.index("--sample-rate") + 1] == str(apple_speech.STREAM_SAMPLE_RATE_HZ)
+
+    @pytest.mark.asyncio
+    async def test_one_shot_argv_excludes_fast(self):
+        """The batch path must NOT opt into frequent finalization."""
+        spawn = Mock(side_effect=OSError("argv pin: no real spawn"))
+        with (
+            patch.object(
+                apple_speech, "availability", return_value=apple_speech.Availability(True)
+            ),
+            patch.object(apple_speech, "helper_path", return_value="/fake/helper"),
+            patch("asyncio.create_subprocess_exec", spawn),
+            _passthrough_sandbox(),
+        ):
+            text, meta = await apple_speech.transcribe("/tmp/x.wav")
+        assert text is None
+        assert "could not run speech helper" in meta["error"]
+        argv = list(spawn.call_args.args)
+        assert argv[0] == "/fake/helper"
+        assert "--fast" not in argv
+
+    def test_swift_helper_still_accepts_fast(self):
+        """Pin the OTHER side of the cross-process contract, by source inspection.
+
+        The helper is never compiled in CI (macOS-only), so the argv pins above
+        cannot see a Swift-side regression: renaming or dropping the ``--fast``
+        case would leave every Python test green while the helper dies at
+        startup with ``unexpected argument: --fast``. The helper source ships in
+        the same package directory ``_build_helper`` reads it from, so anchor on
+        the module rather than a CWD-relative path.
+        """
+        swift_src = Path(apple_speech.__file__).with_name("StreamTranscribe.swift")
+        assert 'case "--fast":' in swift_src.read_text(encoding="utf-8")
 
 
 class TestSandboxCleanupPathIsDropped:


### PR DESCRIPTION
## Summary

With Apple Speech (on-device) streaming and "Auto-submit when I finish speaking" enabled, partial transcripts render live but the utterance is never auto-submitted — recording stays active until manually stopped (#5896).

## Root cause

`StreamingSession.start()` built the streaming helper argv without `--fast`. The bundled `StreamTranscribe.swift` helper only inserts `.frequentFinalization` into the `DictationTranscriber` reporting options when `--fast` is passed; without it the transcriber emits only volatile partials while the audio stream is open and never produces mid-stream final segments. The dashboard's semantic endpointer (`_Endpointer` in `stt_stream.py`) schedules its utterance-complete judgment exclusively from `note_final()`, so with zero mid-stream finals auto-submit can never fire.

## Fix

Append `--fast` to the streaming helper argv (a bare switch — verified against the helper's own parser). The one-shot batch path at `transcribe()` deliberately keeps omitting the flag: its final arrives when the stream closes, and frequent finalization can trade accuracy for latency it has no use for.

Frequent finals are safe for the consumers: the `stt_stream` relay forwards each `final` and calls `note_final()` per event, and the frontend already accumulates multiple finals per session (the AWS Transcribe streaming path emits them the same way).

## Verification

This is a macOS-only code path with no CI runner coverage for the live helper, so **the spawned argv is the verifiable contract**:

- `test_streaming_argv_includes_fast` pins `--fast` in the streaming spawn argv (and that it did not swallow a neighbouring option's value).
- `test_one_shot_argv_excludes_fast` pins its absence on the batch path.
- `test_swift_helper_still_accepts_fast` pins the other side of the cross-process contract by source inspection: the Swift helper still parses `case "--fast":`, so a Swift-side rename cannot silently break every green Python test.
- Mutation-verified: removing the flag makes the streaming pin fail.

Behavioral evidence is the reporter's consistent repro on main `6ed29f5cb` (partials live, no finals, no auto-submit); the non-streaming one-shot path was confirmed unaffected.

Local gates: black/subprocess-encoding/isort/flake8/mypy clean; full pytest 68281 passed (17 failures reproduce identically on unmodified main or pass in isolation — host-env, none reachable from this diff). Pre-push reviews: GPT lane PASS (0 findings), Opus lane PASS (0 blocking, 2 advisories: Swift-side pin adopted; a `fast=` constructor escape hatch declined as speculative configurability for a single-caller path).

Closes #5896
