### PR TITLE
fix(cli): register mcp-<builtin> verbs only when the server module resolves (#5901)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -593,7 +593,6 @@ test/test_chat_turn_timeout_consistency.py
 test/test_chat_voice.py
 test/test_ci_surface_tests.py
 test/test_cli.py
-test/test_cli_commands_coverage.py
 test/test_cli_desktop.py
 test/test_cli_doctor.py
 test/test_cli_lazy_imports.py

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -29,6 +29,7 @@ import argparse
 import asyncio
 import faulthandler
 import importlib
+import importlib.machinery
 import logging
 import os
 import shutil
@@ -39,6 +40,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from kiro_crew import __version__, cli_help, platform_compat
+from kiro_crew.apps import builtins as _builtins_pkg
 from kiro_crew.apps.builtins import BUILTIN_NAMES as _BUILTIN_NAMES
 from kiro_crew.config import KiroCrewConfig, config_dir, ensure_data_home
 from kiro_crew.config.loader import (
@@ -873,6 +875,34 @@ def _setup_cli_logging(command: str | None, verbose: int) -> None:
     _LONG_LIVED_COMMANDS = {"serve", "gateway", "chat", None}
     if command in _LONG_LIVED_COMMANDS:
         install_log_redaction([])
+
+
+def _builtin_mcp_server_available(name: str) -> bool:
+    """True when ``kiro_crew.apps.builtins.<name>.mcp_server`` resolves.
+
+    ``_BUILTIN_NAMES`` answers two different questions: which builtins get HTTP
+    routes (all of them) and which get an ``mcp-<name>`` CLI verb (only those
+    that actually ship an ``mcp_server`` module). Gating the verb on this
+    predicate keeps the two decoupled — a builtin without the module is simply
+    not registered, instead of advertising a command that dies with a raw
+    ``ModuleNotFoundError`` traceback (#5901).
+
+    Resolution deliberately uses ``PathFinder`` rather than
+    ``importlib.util.find_spec``: ``find_spec`` IMPORTS the parent package as a
+    side effect, and every builtin's ``__init__`` pulls in its whole
+    ``backend.routes`` chain — which would execute all builtin apps at
+    parser-build time on every CLI invocation, including the gateway boot path.
+    ``PathFinder`` walks the same import machinery (source, bytecode, extension
+    loaders) without executing anything. Worst-case boot cost is bounded by
+    ``len(BUILTIN_NAMES)``: one directory listing per builtin package
+    (mtime-cached by the import system), independent of user data or profile
+    size.
+    """
+    finder = importlib.machinery.PathFinder
+    pkg_spec = finder.find_spec(name, list(_builtins_pkg.__path__))
+    if pkg_spec is None or not pkg_spec.submodule_search_locations:
+        return False
+    return finder.find_spec("mcp_server", list(pkg_spec.submodule_search_locations)) is not None
 
 
 def main() -> None:
@@ -1899,9 +1929,22 @@ Examples:
     # a session nothing: kiro-cli loads a server only when `tools` names it.
     sub.add_parser("mcp-dashboard")
 
-    # Builtin app MCP servers (spawned by the agent backend, not user-facing)
+    # Builtin app MCP servers (spawned by the agent backend, not user-facing).
+    # Only builtins that actually ship an ``mcp_server`` module get a verb —
+    # ``_BUILTIN_NAMES`` is load-bearing for HTTP route registration and lists
+    # every builtin, so registering unconditionally advertised commands that
+    # crashed with a raw ModuleNotFoundError traceback (#5901). A builtin that
+    # gains an ``mcp_server.py`` gains its verb automatically.
+    #
+    # The probe only runs when the invocation actually names an ``mcp-*``
+    # command: registration precision is unobservable otherwise (the verbs are
+    # hidden from help/choices by hide_internal_commands, and dispatch cannot
+    # reach them), so every other command — including the gateway boot path —
+    # pays nothing for it.
+    _probe_mcp_verbs = any(_a.startswith("mcp-") for _a in sys.argv[1:])
     for _bname in _BUILTIN_NAMES:
-        sub.add_parser(f"mcp-{_bname}")
+        if not _probe_mcp_verbs or _builtin_mcp_server_available(_bname):
+            sub.add_parser(f"mcp-{_bname}")
 
     # them in the ``kirocrew-computer`` MCP server instead.
     computer_parser = cli_help.add_command(
@@ -2422,8 +2465,15 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         # optional subsystem must not be imported to start it.
         importlib.import_module("kiro_crew.mcp_dashboard").run_mcp_server()
     elif args.command.startswith("mcp-") and args.command[4:] in _BUILTIN_NAMES:
-        _mod = importlib.import_module(f"kiro_crew.apps.builtins.{args.command[4:]}.mcp_server")
-        _mod.run_mcp_server()
+        # Registration gates this verb on _builtin_mcp_server_available, and
+        # _run_app_mcp_server is the ONE dispatch-time spelling of "import the
+        # builtin's mcp_server and run it or refuse cleanly" — the same helper
+        # the `kirocrew app mcp <name>` manifest path uses (clean stderr line +
+        # exit 1 on ImportError or a missing run_mcp_server entrypoint), so an
+        # unresolvable module cannot reach a raw traceback here (#5901).
+        from kiro_crew.cli_commands import _run_app_mcp_server
+
+        _run_app_mcp_server(args.command[4:])
     elif args.command == "computer":
         # Deferred import: ``computer_use.cli`` reaches the driver seam, and the
         # macOS driver loads native frameworks on first use. Keeping it out of

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -602,9 +602,15 @@ def _run_app_mcp_server(app_name: str) -> None:
     module_name = f"kiro_crew.apps.builtins.{app_name.replace('-', '_')}.mcp_server"
     try:
         mod = importlib.import_module(module_name)
-    except ImportError as exc:
-        print(f"App {app_name!r} has no MCP server ({module_name}): {exc}", file=sys.stderr)
-        sys.exit(1)
+    except ModuleNotFoundError as exc:
+        # Only the TARGET module (or one of its parent packages) missing means
+        # "this app has no MCP server". A missing dependency imported INSIDE
+        # mcp_server.py — or any other ImportError — is a real defect and must
+        # keep its traceback rather than exit with a misleading diagnosis.
+        if exc.name and (exc.name == module_name or module_name.startswith(exc.name + ".")):
+            print(f"App {app_name!r} has no MCP server ({module_name}): {exc}", file=sys.stderr)
+            sys.exit(1)
+        raise
     runner = getattr(mod, "run_mcp_server", None)
     if runner is None:
         print(f"{module_name} defines no run_mcp_server()", file=sys.stderr)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4380,6 +4380,9 @@ class TestMcpBuiltinDispatch:
         builtin_name = "fakebuiltin"
         # Patch the registry the CLI reads when building subparsers and dispatching.
         monkeypatch.setattr(cli_mod, "_BUILTIN_NAMES", [builtin_name])
+        # The verb is only registered (and dispatched) when the builtin's
+        # mcp_server module resolves (#5901) — make the synthetic one resolve.
+        monkeypatch.setattr(cli_mod, "_builtin_mcp_server_available", lambda _name: True)
         mock_module = MagicMock()
 
         monkeypatch.setattr(sys, "argv", ["kirocrew", f"mcp-{builtin_name}"])

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -41,7 +41,9 @@ def _ns(**kw: Any) -> argparse.Namespace:
     return argparse.Namespace(**kw)
 
 
-def _http_error(code: int, body: bytes | None = None, reason: str = "Boom") -> urllib.error.HTTPError:
+def _http_error(
+    code: int, body: bytes | None = None, reason: str = "Boom"
+) -> urllib.error.HTTPError:
     """Build an ``HTTPError`` whose ``.read()`` yields *body*."""
     fp = io.BytesIO(body if body is not None else b"")
     return urllib.error.HTTPError("http://localhost/x", code, reason, {}, fp)  # type: ignore[arg-type]
@@ -157,8 +159,12 @@ class TestWorkspaceDirGuard:
 
 
 class TestSpawnCli:
-    def test_list_prints_agents_with_status_glyphs(self, capsys: pytest.CaptureFixture[str]) -> None:
-        payload = {"agents": [{"id": "a1", "task": "do x", "done": True}, {"id": "a2", "task": "y"}]}
+    def test_list_prints_agents_with_status_glyphs(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        payload = {
+            "agents": [{"id": "a1", "task": "do x", "done": True}, {"id": "a2", "task": "y"}]
+        }
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value="s"),
             patch("kiro_crew.cli_commands.loopback_urlopen", return_value=_FakeResponse(payload)),
@@ -170,7 +176,10 @@ class TestSpawnCli:
     def test_list_empty_says_so(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("kiro_crew.cli_commands.loopback_urlopen", return_value=_FakeResponse({"agents": []})),
+            patch(
+                "kiro_crew.cli_commands.loopback_urlopen",
+                return_value=_FakeResponse({"agents": []}),
+            ),
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
         assert "No subagents." in capsys.readouterr().out
@@ -193,7 +202,9 @@ class TestSpawnCli:
     ) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=_http_error(503, b"<html>")),
+            patch(
+                "kiro_crew.cli_commands.loopback_urlopen", side_effect=_http_error(503, b"<html>")
+            ),
             pytest.raises(SystemExit),
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
@@ -204,7 +215,10 @@ class TestSpawnCli:
     ) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=urllib.error.URLError("refused")),
+            patch(
+                "kiro_crew.cli_commands.loopback_urlopen",
+                side_effect=urllib.error.URLError("refused"),
+            ),
             pytest.raises(SystemExit) as exc,
         ):
             cc._spawn(_ns(spawn_action="list", port=4321))
@@ -348,9 +362,7 @@ class TestAppCli:
         out = capsys.readouterr().out
         assert "one" in out and "enabled" in out and "two" in out and "disabled" in out
 
-    def test_enable_success_counts_registrations(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_enable_success_counts_registrations(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("kiro_crew.cli_commands.enable_app", return_value=_result(True, message="on")),
             patch(
@@ -402,9 +414,7 @@ class TestAppCli:
         with (
             patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),
             patch("kiro_crew.cli_commands.deregister_app"),
-            patch(
-                "kiro_crew.cli_commands.uninstall_app", return_value=_result(True)
-            ) as uninstall,
+            patch("kiro_crew.cli_commands.uninstall_app", return_value=_result(True)) as uninstall,
         ):
             cc._handle_app(_ns(app_action="uninstall", name="demo", purge_data=purge))
         uninstall.assert_called_once_with("demo", keep_data=expect_keep_data)
@@ -500,8 +510,12 @@ class TestAppCli:
 class TestRunAppMcpServer:
     def test_missing_module_exits_1_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
         """stdout is the JSON-RPC channel -- diagnostics must go to stderr."""
+        target = "kiro_crew.apps.builtins.my_app.mcp_server"
         with (
-            patch("importlib.import_module", side_effect=ImportError("nope")),
+            patch(
+                "importlib.import_module",
+                side_effect=ModuleNotFoundError(f"No module named {target!r}", name=target),
+            ),
             pytest.raises(SystemExit) as exc,
         ):
             cc._run_app_mcp_server("my-app")
@@ -509,6 +523,44 @@ class TestRunAppMcpServer:
         assert exc.value.code == 1
         assert captured.out == ""
         assert "my-app" in captured.err
+
+    def test_missing_parent_package_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A ModuleNotFoundError naming a PARENT package of the target is the
+        target being unimportable -- same clean refusal."""
+        parent = "kiro_crew.apps.builtins.my_app"
+        with (
+            patch(
+                "importlib.import_module",
+                side_effect=ModuleNotFoundError(f"No module named {parent!r}", name=parent),
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._run_app_mcp_server("my-app")
+        assert exc.value.code == 1
+        assert "my-app" in capsys.readouterr().err
+
+    def test_missing_dependency_inside_module_propagates(self) -> None:
+        """A dependency missing INSIDE mcp_server.py is a real defect: it must
+        keep its traceback, not exit with a misleading 'has no MCP server'."""
+        with (
+            patch(
+                "importlib.import_module",
+                side_effect=ModuleNotFoundError(
+                    "No module named 'some_missing_dep'", name="some_missing_dep"
+                ),
+            ),
+            pytest.raises(ModuleNotFoundError, match="some_missing_dep"),
+        ):
+            cc._run_app_mcp_server("my-app")
+
+    def test_nameless_import_error_propagates(self) -> None:
+        """An ImportError that names no module cannot be attributed to the
+        target -- it must propagate."""
+        with (
+            patch("importlib.import_module", side_effect=ModuleNotFoundError("boom")),
+            pytest.raises(ModuleNotFoundError, match="boom"),
+        ):
+            cc._run_app_mcp_server("my-app")
 
     def test_module_without_runner_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
@@ -1049,9 +1101,7 @@ class TestParseTimeSelector:
         Reading a bare date as local time would silently shift the window by the
         host's offset, so a window that looks right returns the wrong records.
         """
-        assert cc.parse_time_selector("2026-08-21") == datetime(
-            2026, 8, 21, tzinfo=timezone.utc
-        )
+        assert cc.parse_time_selector("2026-08-21") == datetime(2026, 8, 21, tzinfo=timezone.utc)
 
     def test_offset_is_normalized_to_utc(self) -> None:
         assert cc.parse_time_selector("2026-08-21T10:00:00+02:00") == datetime(
@@ -1124,9 +1174,7 @@ class TestPolicyCli:
             cc._policy(_ns(policy_action="show"))
         assert "commands.denied:" in capsys.readouterr().out
 
-    def test_show_ids_lists_rule_ids_per_category(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_show_ids_lists_rule_ids_per_category(self, capsys: pytest.CaptureFixture[str]) -> None:
         # Named --ids, not --verbose: the top-level parser already defines
         # --verbose/-v as an int `count` (log level); a same-named store_true
         # on this subparser would collide via argparse's parent/subparser
@@ -1192,9 +1240,7 @@ class TestPolicyCli:
         assert "bad.json: INVALID→deny-all" in out
         assert "some profiles failed validation" in out
 
-    def test_explain_unknown_scope_lists_catalog(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_explain_unknown_scope_lists_catalog(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch(
                 "kiro_crew.platform.context.current_context",
@@ -1218,9 +1264,7 @@ class TestPolicyCli:
         out = capsys.readouterr().out
         assert "Unknown scope" in out and "capabilities.telemetry" in out
 
-    def test_explain_known_scope_prints_verdicts(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_explain_known_scope_prints_verdicts(self, capsys: pytest.CaptureFixture[str]) -> None:
         decision = SimpleNamespace(
             permitted=False, rule="deny", layer="policy", reason="pinned off"
         )
@@ -1298,9 +1342,7 @@ class TestPolicyCli:
                 "kiro_crew.platform.context.current_context",
                 return_value=SimpleNamespace(governance=None),
             ),
-            patch(
-                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=None
-            ),
+            patch("kiro_crew.platform.governance_profiles.get_store_profile", return_value=None),
         ):
             cc._policy(_ns(policy_action="profile", name="ghost"))
         assert "No profile named 'ghost'" in capsys.readouterr().out
@@ -1317,9 +1359,7 @@ class TestPolicyCli:
                 "kiro_crew.platform.context.current_context",
                 return_value=SimpleNamespace(governance=None),
             ),
-            patch(
-                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof
-            ),
+            patch("kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof),
         ):
             cc._policy(_ns(policy_action="profile", name="team"))
         out = capsys.readouterr().out
@@ -1333,9 +1373,7 @@ class TestPolicyCli:
                 "kiro_crew.platform.context.current_context",
                 return_value=SimpleNamespace(governance=None),
             ),
-            patch(
-                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof
-            ),
+            patch("kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof),
         ):
             cc._policy(_ns(policy_action="profile", name="empty"))
         out = capsys.readouterr().out

--- a/test/test_cli_mcp_builtin_verbs.py
+++ b/test/test_cli_mcp_builtin_verbs.py
@@ -1,0 +1,161 @@
+"""Tests for the gated ``mcp-<builtin>`` CLI verbs (#5901).
+
+``_BUILTIN_NAMES`` is shared between HTTP route registration (every builtin)
+and MCP-verb registration (only builtins that ship an ``mcp_server`` module).
+The risk this file pins: a verb registered for a module-less builtin dies with
+a raw ``ModuleNotFoundError`` traceback when invoked, and every NEW builtin
+re-adds such a verb silently.
+"""
+
+import sys
+import types
+
+import pytest
+
+from kiro_crew import cli
+from kiro_crew.apps.builtins import BUILTIN_NAMES
+
+
+def _run_cli(monkeypatch, tmp_path, argv):
+    """Drive ``kirocrew <argv>`` through the real ``main()`` in isolation."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(cli, "boot_platform", lambda *_a, **_k: None)
+    # _setup_cli_logging attaches a file handler under tmp_path to the global
+    # logger; the retained open file blocks Windows cleanup and accumulates
+    # handlers across tests.
+    monkeypatch.setattr(cli, "_setup_cli_logging", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["kirocrew", *argv])
+    cli.main()
+
+
+def _moduleless_builtins() -> list[str]:
+    """Builtin names that do not resolve an ``mcp_server`` module."""
+    return [name for name in BUILTIN_NAMES if not cli._builtin_mcp_server_available(name)]
+
+
+class TestPredicate:
+    def test_mochi_resolves(self):
+        """mochi ships ``mcp_server.py`` — the one builtin whose verb must stay."""
+        assert cli._builtin_mcp_server_available("mochi") is True
+
+    def test_moduleless_builtins_exist_and_do_not_resolve(self):
+        """The defect class is live: some builtins have no ``mcp_server`` module."""
+        missing = _moduleless_builtins()
+        assert missing, "every builtin resolved an mcp_server module — gate is vacuous"
+        assert "mochi" not in missing
+
+    def test_missing_parent_package_returns_false_instead_of_raising(self):
+        """A name with no package under ``apps/builtins`` resolves to False."""
+        assert cli._builtin_mcp_server_available("no_such_builtin_xyz") is False
+
+    def test_probing_does_not_import_builtin_packages(self):
+        """Resolution must not EXECUTE app packages: each builtin's
+        ``__init__`` pulls in its backend routes, and the probe must stay a
+        pure filesystem walk even on the invocations that do run it."""
+        before = set(sys.modules)
+        for name in BUILTIN_NAMES:
+            cli._builtin_mcp_server_available(name)
+        assert set(sys.modules) == before
+
+    def test_non_mcp_invocations_do_not_probe(self, monkeypatch, tmp_path, capsys):
+        """A command that names no ``mcp-*`` verb must not pay the probe at
+        all — parser build on the gateway boot path stays free of filesystem
+        work (registration precision is unobservable there: the verbs are
+        hidden from help and dispatch cannot reach them)."""
+
+        def _fail(_name):  # pragma: no cover - failure path
+            raise AssertionError("probe ran on a non-mcp invocation")
+
+        monkeypatch.setattr(cli, "_builtin_mcp_server_available", _fail)
+        with pytest.raises(SystemExit) as excinfo:
+            _run_cli(monkeypatch, tmp_path, ["--help"])
+        assert excinfo.value.code == 0
+        assert "usage" in capsys.readouterr().out
+
+
+class TestParserRegistration:
+    def test_mochi_verb_is_registered(self, monkeypatch, tmp_path, capsys):
+        """``kirocrew mcp-mochi --help`` parses: the verb exists."""
+        with pytest.raises(SystemExit) as excinfo:
+            _run_cli(monkeypatch, tmp_path, ["mcp-mochi", "--help"])
+        assert excinfo.value.code == 0
+        assert "mcp-mochi" in capsys.readouterr().out
+
+    def test_moduleless_builtins_are_not_registered(self, monkeypatch, tmp_path, capsys):
+        """A module-less builtin's verb is rejected by argparse, not registered."""
+        name = _moduleless_builtins()[0]
+        with pytest.raises(SystemExit) as excinfo:
+            _run_cli(monkeypatch, tmp_path, [f"mcp-{name}"])
+        assert excinfo.value.code == 2
+        assert "invalid choice" in capsys.readouterr().err
+
+    def test_builtin_gaining_a_server_module_gains_the_verb(self, monkeypatch, tmp_path, capsys):
+        """Registration is driven by the predicate: a builtin that starts
+        resolving an ``mcp_server`` module is registered with no list edit."""
+        name = _moduleless_builtins()[0]
+        real = cli._builtin_mcp_server_available
+        monkeypatch.setattr(
+            cli,
+            "_builtin_mcp_server_available",
+            lambda bname: True if bname == name else real(bname),
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            _run_cli(monkeypatch, tmp_path, [f"mcp-{name}", "--help"])
+        assert excinfo.value.code == 0
+        assert f"mcp-{name}" in capsys.readouterr().out
+
+
+class TestDispatch:
+    def test_verb_delegates_to_the_shared_app_mcp_helper(self, monkeypatch, tmp_path):
+        """Dispatch is a delegation to ``_run_app_mcp_server`` — the ONE
+        spelling of "import the builtin's mcp_server and run it or refuse
+        cleanly", shared with the ``kirocrew app mcp <name>`` manifest path."""
+        from kiro_crew import cli_commands
+
+        calls: list[str] = []
+        monkeypatch.setattr(cli_commands, "_run_app_mcp_server", calls.append)
+        _run_cli(monkeypatch, tmp_path, ["mcp-mochi"])
+        assert calls == ["mochi"]
+
+    def test_moduleless_dispatch_exits_with_clean_message(self, monkeypatch, tmp_path, capsys):
+        """End-to-end pin of the #5901 contract: if a module-less verb ever
+        reaches dispatch (predicate stubbed True so the parser registers it),
+        the shared helper refuses with a one-line stderr message and exit 1 —
+        never a raw ModuleNotFoundError traceback.
+
+        Note: the real import attempt executes the builtin's parent package
+        (its ``__init__``), permanently populating ``sys.modules`` for this
+        worker — harmless for the probe test, which snapshots inside itself."""
+        name = _moduleless_builtins()[0]
+        monkeypatch.setattr(cli, "_builtin_mcp_server_available", lambda _bname: True)
+        with pytest.raises(SystemExit) as excinfo:
+            _run_cli(monkeypatch, tmp_path, [f"mcp-{name}"])
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "has no MCP server" in err
+        assert "Traceback" not in err
+
+    def test_resolvable_builtin_runs_its_mcp_server(self, monkeypatch, tmp_path):
+        """A registered verb reaches ``run_mcp_server()`` on the real module
+        resolution path (import stubbed at the module seam)."""
+        from kiro_crew import cli_commands
+
+        ran = {"hit": False}
+        stub = types.SimpleNamespace(run_mcp_server=lambda: ran.__setitem__("hit", True))
+        real_import = cli_commands.importlib.import_module
+
+        def stubbing_import(module, *a, **k):
+            if module == "kiro_crew.apps.builtins.mochi.mcp_server":
+                return stub
+            return real_import(module, *a, **k)
+
+        monkeypatch.setattr(
+            cli_commands,
+            "importlib",
+            types.SimpleNamespace(
+                **{**vars(cli_commands.importlib), "import_module": stubbing_import}
+            ),
+        )
+        _run_cli(monkeypatch, tmp_path, ["mcp-mochi"])
+        assert ran["hit"] is True


### PR DESCRIPTION
## Summary

`kirocrew mcp-<name>` was registered for every entry in `_BUILTIN_NAMES`, but only `mochi` ships `apps/builtins/<name>/mcp_server.py` — the other 11 advertised verbs exited with a raw `ModuleNotFoundError` traceback when invoked, and every new builtin silently re-added a broken verb (this triggered false review findings, e.g. on #5769).

Root cause: `_BUILTIN_NAMES` answers two different questions — which builtins get HTTP routes (all of them, list is load-bearing) and which get an MCP CLI verb (only those shipping the module). This change decouples the second question from the list without touching the list or route registration.

## Changes (single commit)

- New predicate `_builtin_mcp_server_available(name)` in `src/kiro_crew/cli.py`: resolves `kiro_crew.apps.builtins.<name>.mcp_server` via `importlib.machinery.PathFinder`.
  - **Deliberate deviation from the issue's suggested `importlib.util.find_spec`:** `find_spec` imports the parent package as a side effect, and every builtin `__init__` imports its `backend.routes` chain — that would execute all builtin apps at parser-build time, including the gateway boot path, which the AUTOSDE boot-path rule forbids. `PathFinder` walks the same import machinery without executing anything; cost is bounded by `len(BUILTIN_NAMES)` mtime-cached directory listings.
  - The probe additionally runs **only when argv names an `mcp-*` command**: registration precision is unobservable otherwise (the verbs are hidden from help by `hide_internal_commands` and dispatch cannot reach them), so `kirocrew gateway` and every other command pay zero filesystem work.
- Parser build registers `mcp-<name>` only when the predicate holds; a module-less name gets argparse's normal unknown-command rejection, and a builtin that gains an `mcp_server.py` gains its verb automatically, with no list edit.
- Dispatch **delegates to the existing shared helper `_run_app_mcp_server`** (`src/kiro_crew/cli_commands.py`) — the same path the manifests' `kirocrew app mcp <name>` uses — so there is exactly one dispatch-time spelling of "import the builtin's mcp_server and run it or refuse cleanly" (one-line stderr message + exit 1, stdout stays clean for JSON-RPC). The issue's suggested per-branch predicate re-check and `ModuleNotFoundError` backstop are satisfied by this delegation per the fix strategy's "(or a shared helper)" clause; a duplicate cli.py-local spelling was reviewed out (two lanes flagged it as divergent duplication).
- The shared helper's error scoping is **narrowed** from a bare `except ImportError` to `ModuleNotFoundError` attributed to the target module or one of its parent packages (`exc.name` check): a missing dependency *inside* an existing `mcp_server.py` now propagates with its real traceback instead of exiting with a misleading "has no MCP server". This fix benefits the `kirocrew app mcp <name>` path too.

## Tests

- `test/test_cli_mcp_builtin_verbs.py` (new, 11 tests): predicate resolution (mochi resolves, module-less names don't, missing package returns False without raising); probe executes no builtin package (`sys.modules` snapshot — the boot-path guarantee); non-`mcp-*` invocations never probe (fail-if-called stub); mochi verb registered; module-less verbs rejected by argparse; predicate-driven registration (stubbed resolve gains the verb); dispatch delegates to `_run_app_mcp_server`; end-to-end module-less dispatch exits 1 with the clean message and no traceback; resolvable verb reaches `run_mcp_server()`.
- `test/test_cli_commands_coverage.py::TestRunAppMcpServer` extended to pin the narrowed scoping: target-module missing → clean exit 1; parent-package missing → clean exit 1; dependency missing inside the module → propagates; nameless error → propagates.
- Pre-existing `test_cli.py::TestMcpBuiltinDispatch` synthetic-builtin test adapted by stubbing the predicate (its target is dispatch wiring, unchanged).
- Registration/probe guards mutation-verified (mutants injected and caught during development).

## Review

Pre-push model-pinned lanes: GPT (gpt-5.6-sol) PASS; Opus (claude-opus-5) PASS. In-CI rounds: GPT round-1 blockers (boot-path probe on every command; test logging-handler leak) fixed via the argv-conditional probe and a harness stub; First Principles round-1 BLOCK (duplicate dispatch-side hardening) resolved by the delegation subtraction above; Design/FP round-2 CONCERNS (description/code drift, helper's over-broad `except ImportError`) resolved by this description and the helper scoping fix.

## Follow-ups (out of scope per the issue)

- `auto_improvement/app.json` declares its MCP server at `backend.mcp_server`, a different path convention than the verb resolution — unifying the manifest convention is a separate design question.
- Whether the `mcp-<builtin>` verb family should exist at all (nothing in-tree invokes it; manifests use `kirocrew app mcp <name>`) is a maintainer decision.

no linked issue: n/a — Closes #5901
