### PR TITLE
feat(chat-core): extract transport sendTurn and adopt it in ChatPane

### DIFF
--- a/website/src/chat-core/transport/sendTurn.ts
+++ b/website/src/chat-core/transport/sendTurn.ts
@@ -1,0 +1,117 @@
+import { api } from '../../api/client'
+import { confirmedDelivered, readSendReceipt, SendReceiptBody } from '../../utils/sendDelivery'
+
+/** Stop waiting on a send's response. Reaching this bound means the request
+ *  was received and only the reply is late: the turn is running and its output
+ *  arrives over the WebSocket, not through this promise. It is NOT a failure
+ *  signal, which is why the receipt below gives it its own status instead of
+ *  folding it into the error shapes. */
+export const SEND_ABORT_MS = 10_000
+
+/**
+ * Every outcome a send can have, normalized. This is the receipt contract that
+ * used to be re-derived (differently) at each hand-rolled call site. Parsing
+ * (`refused` vs `unknown` vs accepted) is `readSendReceipt`'s ruling; this
+ * layer adds the outcomes a parse cannot see -- the abort deadline and the
+ * transport reject -- and splits acceptance by what it means for
+ * an optimistic bubble:
+ *
+ * - `dispatched`      -- the server took custody of the message as an IMMEDIATE
+ *                        turn. This is the delivery receipt for an optimistic
+ *                        bubble: no `chat_message` echo is coming for a
+ *                        dashboard send, the HTTP response is all there is.
+ * - `queued`          -- the slot was busy and the server queued the message.
+ *                        The `queue_push` broadcast owns its on-screen card, so
+ *                        this is NOT a receipt for an optimistic bubble, and a
+ *                        queued message is still cancellable.
+ * - `refused`         -- the server said no: a non-2xx status, or a readable
+ *                        body with neither `ok` nor `queued`. Nothing was sent,
+ *                        so the payload is safe to hand back. `reason` is the
+ *                        server's own explanation when there is one.
+ * - `unknown`         -- a 2xx whose body could not be read. The request WAS
+ *                        accepted and only the answer is mangled, so the send
+ *                        may well have started a turn; reporting it as a
+ *                        failure would hand the payload back and invite a
+ *                        retry that duplicates a delivered turn. Callers must
+ *                        do NOTHING on this status.
+ * - `response-late`   -- the abort deadline fired before a receipt arrived.
+ *                        Delivery is indeterminate: a composer can keep its
+ *                        optimistic row pending to avoid a duplicate, while a
+ *                        caller that has already destroyed the only visible
+ *                        copy may choose to recover it.
+ * - `transport-error` -- the fetch itself rejected (offline, DNS, CORS). The
+ *                        send never left, so restore-and-report is safe.
+ */
+export type SendReceiptStatus =
+  | 'dispatched'
+  | 'queued'
+  | 'refused'
+  | 'unknown'
+  | 'response-late'
+  | 'transport-error'
+
+export interface SendReceipt {
+  status: SendReceiptStatus
+  /** The parsed acceptance body -- `{}` when no readable body exists. Passed
+   *  through so card/ask logic that reads the raw acceptance
+   *  (`resolveAskAfterSend`) keeps working unchanged. */
+  body: SendReceiptBody
+  /** Server-provided explanation, present only on `refused` with a readable
+   *  body. */
+  reason?: string
+}
+
+export interface SendTurnOptions {
+  /** Wire text, already serialized (dir tokens, file markers). The server
+   *  refuses an empty wire text above every dispatch branch, so an empty
+   *  message comes back as `refused`. */
+  message: string
+  slot?: string
+  meta?: Record<string, unknown>
+}
+
+/**
+ * The one send implementation (chat-core transport layer).
+ *
+ * Owns the whole receipt contract so call sites stop re-learning it:
+ * `POST /api/chat?ws=1` RESOLVES on HTTP failure (the fetch promise rejects
+ * only on transport-level errors or abort), the body's verdict is read through
+ * the shared `readSendReceipt` classifier, and a hung POST is bounded by
+ * `SEND_ABORT_MS`. Callers branch on `receipt.status`; how to REACT (error
+ * rows, composer restore, optimistic confirms, drafts) stays host policy at
+ * the surface.
+ *
+ * Never rejects: every outcome, including transport failure, is a receipt.
+ */
+export async function sendTurn(opts: SendTurnOptions): Promise<SendReceipt> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), SEND_ABORT_MS)
+  try {
+    const r = await api.sendChat(
+      opts.message,
+      opts.slot,
+      undefined,
+      controller.signal,
+      opts.meta,
+    )
+    const { body, outcome } = await readSendReceipt(r)
+    if (outcome === 'refused') return { status: 'refused', body, reason: typeof body.error === 'string' ? body.error : undefined }
+    // readSendReceipt deliberately converts an unreadable accepted body into
+    // `unknown`, including an AbortError raised while response.json() is still
+    // consuming a stalled body. Preserve the deadline signal here: callers
+    // recover input for `response-late`, while they correctly do nothing for a
+    // merely malformed 2xx receipt (which may already have delivered the turn).
+    if (outcome === 'unknown') {
+      return { status: controller.signal.aborted ? 'response-late' : 'unknown', body }
+    }
+    // Only an IMMEDIATE dispatch is a delivery receipt for an optimistic
+    // bubble: the busy branch sets BOTH flags, so `ok` alone proves nothing.
+    if (confirmedDelivered(body)) return { status: 'dispatched', body }
+    return { status: 'queued', body }
+  } catch (e: unknown) {
+    if (e instanceof DOMException && e.name === 'AbortError') return { status: 'response-late', body: {} }
+    return { status: 'transport-error', body: {} }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -32,8 +32,8 @@ import { PANE_HYDRATE_LIMIT, retireStatelessQuestion, captureStatelessCard, capt
 import { deriveFollowUpOptions } from '../app-sdk/protocol'
 import { CONTENT_WIDTH, loadChatConfig, type ChatConfig } from '../pages/chat/ChatSettings'
 import { tryQuickSend } from '../lib/quickSend'
-import { confirmedDelivered, readSendReceipt } from '../utils/sendDelivery'
 import { mergeRecoveredDraft } from '../utils/chatDrafts'
+import { sendTurn } from '../chat-core/transport/sendTurn'
 import { triggerRefresh, updateSlot } from '../store/dashboardSlice'
 import { performSlotSwitch } from '../lib/slotSwitch'
 import { performAgentSlotSwitch } from '../lib/agentSwitch'
@@ -45,11 +45,6 @@ import { displayModel } from '../lib/model'
 
 
 import { i18nT } from '../i18n/t'
-/** Stop waiting on a pane send's response. Mirrors the same bound in
- *  `ChatPage.send`, and carries its meaning too: reaching it means the request
- *  was received and only the reply is late, so the turn's output arrives over
- *  the socket rather than through this promise. It is NOT a failure signal. */
-const SEND_ABORT_MS = 10_000
 
 /**
  * ChatPane — one live chat session in the native session grid.
@@ -508,66 +503,37 @@ export default function ChatPane({
       // can re-click any time.
       if (!optionText) restoreIntoComposer(text, files)
     }
-    // Same 10s abort `ChatPage.send` uses. Without it a HUNG (not refused) POST
-    // settles neither way until the browser's own network timeout, so the
-    // message sits on screen looking sent for minutes with the composer already
-    // cleared — the exact window this change exists to close, and the one place
-    // the removed 30s notice used to speak sooner.
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), SEND_ABORT_MS)
-    api.sendChat(llm, slotKey, undefined, controller.signal, meta)
-      .then(async (r) => {
-        clearTimeout(timeout)
-        const { body, outcome } = await readSendReceipt(r)
-        // The server accepted neither `ok` nor `queued` (or refused with a status
-        // and no readable body), so nothing was sent. Reported before the card
-        // logic below, which only runs on acceptance.
-        if (outcome === 'refused') {
-          reportFailedSend(typeof body.error === 'string' ? body.error : undefined)
-          return
-        }
-        // NO READABLE RECEIPT on a 2xx: the request was accepted and only its
-        // ANSWER is mangled, so this send is in exactly the state an abort leaves
-        // one — it may well have started a turn, whose output arrives over the
-        // socket. The catch below already refuses to report an abort as a failure
-        // because handing the payload back invites a retry that duplicates a
-        // delivered turn, side effects included; the same is true here, so an
-        // unknown takes no action either way rather than claiming a refusal it
-        // cannot prove.
-        if (outcome === 'unknown') return
-        // A `queued` acceptance with no wire text is not an acceptance at all.
-        // `chat_handlers` queues `if message:` but returns `{ok, queued}`
-        // unconditionally, so an attachment-only send that raced the slot into
-        // the busy state was neither queued nor broadcast — nothing carries the
-        // attachment, and the composer has already cleared. Reported so the file
-        // comes back rather than vanishing. (The same request answers 400 when
-        // the slot is idle, which the branch above already handles.)
-        if (body.queued && !llm.trim()) { reportFailedSend(); return }
-        // The response is the delivery receipt for this pane's optimistic bubble
-        // (#4131) — see the same dispatch in ChatPage.send for why no `chat_message`
-        // echo is coming. Parsed unconditionally now: the previous early return on
-        // "no card and no ask" skipped the body entirely, which would have skipped
-        // this confirmation too. `confirmedDelivered` accepts only an IMMEDIATE
-        // dispatch: a queued acceptance is not a receipt for this bubble.
-        if (confirmedDelivered(body)) dispatch(confirmOptimisticSend({ slot: slotKey, sendId, mid: typeof body.mid === 'string' ? body.mid : undefined }))
-        if (!cardAtSend && !askAtSend) return
-        // `ok` only: a QUEUED acceptance is still cancellable — the queued
-        // path retires at its queue_pop instead (removeQueuedMessage).
-        if (body.ok && !body.queued && cardAtSend) dispatch(retireStatelessQuestion({ slot: slotKey, expected: cardAtSend }))
-        void resolveAskAfterSend(body, askAtSend, dispatch)
-      })
-      .catch((e: unknown) => {
-        clearTimeout(timeout)
-        // An abort means the request WAS received and only the RESPONSE is late,
-        // which is what `ChatPage` records at its own timeout ("message was
-        // received, WS will deliver response") — the turn is running and its
-        // output arrives over the socket. Reporting that as a failure would hand
-        // the payload back and invite a retry that duplicates a turn already in
-        // flight, side effects included. Only a rejection that is NOT an abort
-        // means the send never left.
-        if (e instanceof DOMException && e.name === 'AbortError') return
-        reportFailedSend()
-      })
+    // Receipt semantics live in the chat-core transport (sendTurn owns the
+    // abort deadline and the shared readSendReceipt classification). This
+    // pane only decides how to REACT
+    // per status: failures report on the pane that owns the message and hand
+    // the payload back. `unknown` proves a 2xx was received, while
+    // `response-late` proves no refusal either; restoring either one here could
+    // invite a retry that duplicates a turn already in flight, side effects
+    // included, so the optimistic composer row stays pending.
+    void sendTurn({ message: llm, slot: slotKey, meta }).then((receipt) => {
+      if (receipt.status === 'refused' || receipt.status === 'transport-error') {
+        reportFailedSend(receipt.reason)
+        return
+      }
+      if (receipt.status === 'unknown' || receipt.status === 'response-late') return
+      // The response is the delivery receipt for this pane's optimistic bubble
+      // because no `chat_message` echo is coming for a dashboard send. Only
+      // an IMMEDIATE dispatch counts: a queued acceptance is not a receipt for
+      // this bubble.
+      if (receipt.status === 'dispatched') {
+        dispatch(confirmOptimisticSend({
+          slot: slotKey,
+          sendId,
+          mid: typeof receipt.body.mid === 'string' ? receipt.body.mid : undefined,
+        }))
+      }
+      if (!cardAtSend && !askAtSend) return
+      // Immediate dispatch only: a QUEUED acceptance is still cancellable —
+      // the queued path retires at its queue_pop instead (removeQueuedMessage).
+      if (receipt.status === 'dispatched' && cardAtSend) dispatch(retireStatelessQuestion({ slot: slotKey, expected: cardAtSend }))
+      void resolveAskAfterSend(receipt.body, askAtSend, dispatch)
+    })
   }, [input, pendingFiles, busy, slotKey, dispatch, restoreIntoComposer, reportSendFailure])
 
   const onStop = useCallback(() => { dispatch(requestStop({ slotId: slotKey, force: false })) }, [dispatch, slotKey])
@@ -754,33 +720,26 @@ export default function ChatPane({
             full window. */}
         <PendingQuestionCard
           slotKey={slotKey}
-          /* doSend() reads the composer state, so the fallback sends directly,
-             and `sendChat` returns the raw Response — a refusal RESOLVES here
-             rather than rejecting, so the receipt has to be read. The card is
-             already cleared by the time this runs, which makes this the one send
-             in the pane whose payload nothing else carries: a failure it did not
-             report would destroy the user's answer outright AND leave the agent
-             waiting with nothing on screen saying so. Every refusal therefore
-             gets an error row and the answer back, through the same recovery
-             `doSend` uses. */
+          /* doSend() reads the composer state, so the fallback sends directly
+             through the chat-core transport. The card is already cleared by
+             the time this runs, so a swallowed failure would destroy the
+             user's answer outright; on refusal, transport failure, or
+             the abort deadline it goes back into the composer through the
+             same recovery `doSend` uses. `response-late` restores HERE unlike
+             the composer send: a deadline can fire before the POST ever
+             reached the gateway, and with the card gone a silently lost
+             answer has no other trace — the worst case is a duplicate answer,
+             which the user can see and delete. `unknown` stays silent — a 2xx
+             proves the request was accepted, so the answer may well have
+             landed, and handing it back would invite a second answer to a
+             question already gone. */
           onFallbackSend={(text) => {
             const fail = (reason?: string) => { reportSendFailure(reason); restoreIntoComposer(text) }
-            api
-              .sendChat(text, slotKey)
-              .then(async (res) => {
-                if (!res) { fail(); return }
-                // The RECEIPT, not the status alone: a 200 answering `{ok:false}`
-                // is a refusal too, and a status-only check let it pass as a
-                // success. An unreadable 2xx stays silent, as it always has here
-                // and as the composer's own send now does — the request was
-                // accepted, so the answer may well have landed, and handing it
-                // back would invite a second answer to a question already gone.
-                const { body, outcome } = await readSendReceipt(res)
-                if (outcome === 'refused') fail(typeof body.error === 'string' ? body.error : undefined)
-              })
-              // No body to quote on a transport reject, so the shared
-              // connectivity copy stands rather than a raw fetch message.
-              .catch(() => fail())
+            void sendTurn({ message: text, slot: slotKey }).then((receipt) => {
+              if (receipt.status === 'refused' || receipt.status === 'transport-error' || receipt.status === 'response-late') {
+                fail(receipt.reason)
+              }
+            })
           }}
         />
 

--- a/website/src/test/ChatPane.dirSend.test.tsx
+++ b/website/src/test/ChatPane.dirSend.test.tsx
@@ -140,6 +140,10 @@ describe('ChatPane send — the response confirms the optimistic bubble', () => 
     store.getState().chat.slotMessages[slot]?.find(m => m.role === 'user')
 
   it('retires the pending-confirmation flags when the server accepts', async () => {
+    ;(api.sendChat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, mid: 'm-server-confirmed' }),
+    })
     const { store } = renderPane('pane-confirm')
     const box = (await screen.findAllByRole('textbox'))[0]
     fireEvent.change(box, { target: { value: 'confirm me' } })
@@ -148,6 +152,7 @@ describe('ChatPane send — the response confirms the optimistic bubble', () => 
     await waitFor(() => expect(userRow(store, 'pane-confirm')?.meta?.optimistic).toBeUndefined())
     // The correlation id stays so a late echo updates this row in place.
     expect(userRow(store, 'pane-confirm')?.meta?.sendId).toMatch(/^s-/)
+    expect(userRow(store, 'pane-confirm')?.meta?.mid).toBe('m-server-confirmed')
   })
 
   it('leaves the bubble pending when the server rejects the send', async () => {
@@ -362,6 +367,29 @@ describe('ChatPane send — a failed send is reported on the pane', () => {
     await waitFor(() => expect(box.value).toBe('Public only'))
   })
 
+  it('recovers a cleared question-card answer when its receipt is late', async () => {
+    // The transport normalizes AbortError to response-late. Unlike the normal
+    // composer path, the card has already removed the only visible copy of the
+    // answer, so this caller deliberately restores it for the user to inspect.
+    ;(api.sendChat as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new DOMException('The operation was aborted.', 'AbortError'),
+    )
+    const { store } = renderPane('pane-ask-late')
+    act(() => {
+      store.dispatch(setQuestionCard({
+        slot: 'pane-ask-late',
+        card_id: 'delivery-late',
+        questions: [{ question: 'Pick a trust model', options: [{ label: 'Public only' }] }],
+      }))
+    })
+    fireEvent.click(await screen.findByText('Public only'))
+    fireEvent.click(screen.getByText('Submit'))
+
+    await waitFor(() => expect(errorsIn(store, 'pane-ask-late')).toHaveLength(1))
+    const box = (await screen.findAllByRole('textbox'))[0] as HTMLTextAreaElement
+    await waitFor(() => expect(box.value).toBe('Public only'))
+  })
+
   it('passes an abort signal so a hung send cannot sit silent', async () => {
     ;(api.sendChat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true, json: () => Promise.resolve({ ok: true }),
@@ -398,13 +426,13 @@ describe('ChatPane send — a failed send is reported on the pane', () => {
     expect((box as HTMLTextAreaElement).value).toBe('')
   })
 
-  it('reports an attachment-only send the backend claims it queued but dropped', async () => {
-    // `chat_handlers` queues `if message:` yet answers `{ok, queued}` either way,
-    // so a file-only send that raced the slot into the busy state is silently
-    // discarded. Nothing else carries the attachment once the composer clears.
+  it('reports an attachment-only send the backend refuses for its empty wire text', async () => {
+    // The server refuses an empty wire text above every dispatch branch, so a
+    // file-only send comes back 400 `message_required`. The pane must surface
+    // that refusal: nothing else carries the attachment once the composer clears.
     ;(api.uploadFiles as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ paths: ['/tmp/report.pdf'] })
     ;(api.sendChat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true, json: () => Promise.resolve({ ok: true, queued: true }),
+      ok: false, status: 400, json: () => Promise.resolve({ error: 'message is required', code: 'message_required' }),
     })
     const { store, container } = renderPane('pane-dropped')
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
@@ -417,8 +445,8 @@ describe('ChatPane send — a failed send is reported on the pane', () => {
     fireEvent.keyDown(box, { key: 'Enter', code: 'Enter' })
 
     await waitFor(() => expect(api.sendChat).toHaveBeenCalledTimes(1))
-    // Wire text is empty for a file-only send, which is exactly what the backend
-    // guard drops.
+    // Wire text is empty for a file-only send, which is exactly what the server
+    // refuses.
     expect((api.sendChat as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('')
     await waitFor(() => expect(errorsIn(store, 'pane-dropped')).toHaveLength(1))
   })

--- a/website/src/test/chatCoreTransport.contract.test.ts
+++ b/website/src/test/chatCoreTransport.contract.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Receipt-contract tests for the chat-core transport layer.
+ *
+ * These pin the semantics of `POST /api/chat?ws=1` that every hand-rolled send
+ * path had to re-learn -- and that were mis-learned at least once per surface:
+ *
+ * - The fetch promise RESOLVES on HTTP failure. Only transport-level errors
+ *   and the abort deadline reject. A caller that treats a resolved response as
+ *   success ships the "refused send silently reaches running state" defect.
+ * - An abort at the deadline means the request WAS received -- the response is
+ *   late, not lost -- so it must not be reported as a failure.
+ *
+ * The stubs sit at the real `fetch` seam (not at `api.sendChat`) so the tests
+ * exercise the same resolve/reject boundary production hits.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { sendTurn, SEND_ABORT_MS } from '../chat-core/transport/sendTurn'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('sendTurn receipt contract', () => {
+  it('normalizes an immediate dispatch: the HTTP response IS the delivery receipt', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('dispatched')
+    expect(receipt.body.ok).toBe(true)
+  })
+
+  it('normalizes a queued acceptance as NOT a delivery receipt', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, queued: true }))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('queued')
+  })
+
+  it('pins the resolves-not-rejects trap: an HTTP refusal RESOLVES and must be read from the body', async () => {
+    // The defect class this exists for: a 4xx/5xx does NOT reject the fetch
+    // promise. A caller that only catches rejections reports nothing while the
+    // message quietly went nowhere.
+    fetchMock.mockResolvedValue(jsonResponse(409, { ok: false, error: 'slot agent mismatch' }))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('refused')
+    expect(receipt.reason).toBe('slot agent mismatch')
+  })
+
+  it('treats a bodyless / unreadable NON-2XX as refused (the status line survives a mangled response)', async () => {
+    fetchMock.mockResolvedValue(new Response('gateway timeout', { status: 504 }))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('refused')
+    expect(receipt.reason).toBeUndefined()
+    expect(receipt.body).toEqual({})
+  })
+
+  it('classifies an unreadable 2XX as unknown, never as a refusal', async () => {
+    // The request WAS accepted and only the answer is mangled (truncated body,
+    // proxy cut-off). Reporting this as a failure hands the payload back and
+    // invites a retry that duplicates a delivered turn -- the exact defect
+    // readSendReceipt exists to prevent. Callers must act on nothing.
+    fetchMock.mockResolvedValue(new Response('{"ok": true, "run_', { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('unknown')
+    expect(receipt.body).toEqual({})
+  })
+
+  it('still queues a whitespace-free non-empty message', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true, queued: true }))
+    const receipt = await sendTurn({ message: '  spaced  ', slot: 'chat-1' })
+    expect(receipt.status).toBe('queued')
+  })
+
+  it('maps a transport rejection (never left the machine) to transport-error', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
+    const receipt = await sendTurn({ message: 'hi', slot: 'chat-1' })
+    expect(receipt.status).toBe('transport-error')
+    expect(receipt.body).toEqual({})
+  })
+
+  it('maps the abort deadline to response-late, NOT to a failure', async () => {
+    vi.useFakeTimers()
+    // A hung POST: resolve never comes; reject only when the signal aborts.
+    fetchMock.mockImplementation((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+      }))
+    const pending = sendTurn({ message: 'hi', slot: 'chat-1' })
+    await vi.advanceTimersByTimeAsync(SEND_ABORT_MS)
+    const receipt = await pending
+    expect(receipt.status).toBe('response-late')
+  })
+
+  it('maps a deadline while reading an accepted response body to response-late', async () => {
+    vi.useFakeTimers()
+    // Headers arrived with a 2xx, but the body never completes. Real fetch
+    // rejects response.json() when the request signal aborts; model that exact
+    // second phase so readSendReceipt's unreadable-body catch cannot erase the
+    // deadline signal and strand a caller's already-cleared input.
+    fetchMock.mockImplementation((_url: string, init: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        json: () => new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true },
+          )
+        }),
+      }))
+
+    const pending = sendTurn({ message: 'hi', slot: 'chat-1' })
+    await vi.advanceTimersByTimeAsync(SEND_ABORT_MS)
+    await expect(pending).resolves.toEqual({ status: 'response-late', body: {} })
+  })
+
+  it('does not fire the deadline before SEND_ABORT_MS', async () => {
+    vi.useFakeTimers()
+    let settled = false
+    fetchMock.mockImplementation((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+      }))
+    const pending = sendTurn({ message: 'hi', slot: 'chat-1' }).then((r) => { settled = true; return r })
+    await vi.advanceTimersByTimeAsync(SEND_ABORT_MS - 1)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    await pending
+    expect(settled).toBe(true)
+  })
+
+  it('carries slot and meta onto the wire and targets the streaming endpoint', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }))
+    await sendTurn({ message: 'hi', slot: 'chat-9', meta: { sendId: 's-1' } })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/chat?ws=1')
+    const wire = JSON.parse((init as RequestInit).body as string)
+    expect(wire.slot).toBe('chat-9')
+    expect(wire.meta).toEqual({ sendId: 's-1' })
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** This changes only transport receipt handling and deterministic tests; no rendered component, layout, style, motion, or interaction affordance changes.
## Problem / Motivation

ChatPane had two send sites that independently interpreted the same HTTP receipt. The composer and the question-card fallback could drift on refused, unreadable, queued, aborted, and transport-error outcomes; the fallback also had no bounded response contract.

## Why it matters

Receipt drift can silently lose a user's turn or recover an already-delivered turn and invite a duplicate. A shared transport seam makes delivery classification consistent while leaving each surface responsible for its own recovery policy.

## What changed (motivation → approach → change)

A new chat-core sendTurn transport wraps the existing readSendReceipt parser and normalizes dispatched, queued, refused, unknown, response-late, and transport-error outcomes. It owns the 10-second abort deadline and never rejects.

Both ChatPane send paths now consume that contract. The normal composer preserves current-main optimistic confirmation, including the server-provided message ID, follow-up options, pending questions, and queue behavior. It leaves unknown and response-late sends pending rather than restoring potentially delivered content. The question-card fallback deliberately restores on response-late because the card has already removed the only visible copy; a deterministic policy test now pins that caller-specific choice.

The server now rejects an empty wire message before every dispatch branch, so the obsolete client-side queued-but-dropped workaround is replaced by a refusal-path assertion.

The rebase preserves current-main behavior and does not import #6825's separate markSendFailed policy. #6825 is the explicit follow-up that must rebase its failure behavior onto this transport caller after this PR lands. #6823 follow-up options, #6307 ACP/rate-limit behavior, #5819 cross-session send, and #4904 fork-merge UI remain independently owned.

## Tests

- Eleven relevant transport, ChatPane, PendingQuestionCard, delivery, and ChatPage files: 155 passed in one run.
- Focused post-review transport and ChatPane policy run: 33 passed.
- npm typecheck passed.
- ESLint passed for all four changed files.
- Production build passed before the final comment/test-only review amendment.
- Fresh merge-tree against current main passed; git diff validation is clean.
- No retries, sleeps, real-time waits, increased timeouts, relaxed assertions, or warning filters were added. Deadline tests use fake timers; the new caller-policy test injects AbortError directly.

## Manual verification

N/A — pure transport and receipt-policy behavior with no rendered, layout, or styling delta; deterministic automated coverage exercises the fetch boundary and caller policy.

## Related Issues

Chat-core extraction phase P2. Follow-up semantic rebase point: #6825.

## Checklist

- [x] At most two commits; this PR has one Conventional Commits commit
- [x] Existing relevant tests pass and new deterministic tests cover the behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated if applicable; transport behavior is documented at the contract
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder only; no OSPO CLA text has been supplied.

## Body-read deadline follow-up

The GPT review found one valid residual path: a 2xx response can deliver its headers and then stall while `response.json()` reads the body. The abort is intentionally classified as unreadable by the shared parser, but the transport must preserve that the deadline fired. `sendTurn` now returns `response-late` when the parser reports `unknown` after its controller has aborted, so card/composer callers can recover their only visible input. A deterministic fake-timer test holds the body read open until abort and pins this contract.

Additional validation:
- `chatCoreTransport.contract.test.ts`: 11 passed
- transport + ChatPane focused suite: 34 passed
- changed-file ESLint: 0 errors
- `npm run typecheck`