### PR TITLE
fix(security): fold denial matrix, hint wrapped fragment (#5837)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -581,14 +581,45 @@ async def api_denied_command_user_add(request: web.Request) -> web.Response:
     # Reject catastrophic-backtracking (ReDoS) patterns before they can enter the
     # effective set: the gate runs user regexes synchronously on the event loop,
     # so an unsafe pattern like ``(a+)+$`` would freeze the gateway.
-    from kiro_crew.security import is_safe_user_regex
+    from kiro_crew.security import (
+        _DANGEROUS_AWS_FLAG_RUN,
+        _LINEARIZED_AWS_FLAG_RUN,
+        is_safe_user_regex,
+    )
 
     if not is_safe_user_regex(pattern):
-        _audit(request, operation=op, outcome="denied", resources="redos_unsafe")
-        return web.json_response(
-            {"error": "pattern rejected: unsafe (catastrophic-backtracking) regex"},
-            status=400,
+        error = "pattern rejected: unsafe (catastrophic-backtracking) regex"
+        # A user who copies a built-in pattern and tweaks it embeds the dangerous
+        # flag-run fragment verbatim and hits a dead end: the fragment is exempt
+        # from the backtracking check only as part of a COMPLETE built-in pattern
+        # (the scrub in ``is_safe_user_regex`` is builtin-gated), and a complete
+        # built-in never reaches this branch, so any pattern here is
+        # user-authored. Name the fragment so the trigger is self-explanatory --
+        # but only when it really is the trigger: the hint is emitted only if
+        # the pattern with both fragments scrubbed would pass, mirroring the
+        # builtin scrub (the linearized form is checked too for symmetry with
+        # it). ``is_safe_user_regex`` returns False on a non-compiling residue,
+        # so a misleading hint fails safe to the generic message.
+        embedded = next(
+            (
+                frag
+                for frag in (_DANGEROUS_AWS_FLAG_RUN, _LINEARIZED_AWS_FLAG_RUN)
+                if frag in pattern
+            ),
+            None,
         )
+        if embedded is not None:
+            scrubbed = pattern.replace(_DANGEROUS_AWS_FLAG_RUN, "").replace(
+                _LINEARIZED_AWS_FLAG_RUN, ""
+            )
+            if is_safe_user_regex(scrubbed):
+                error += (
+                    f"; the embedded built-in flag-run fragment '{embedded}' is"
+                    " the trigger. It is exempt only inside a complete built-in"
+                    " pattern, so remove or rewrite that fragment"
+                )
+        _audit(request, operation=op, outcome="denied", resources="redos_unsafe")
+        return web.json_response({"error": error}, status=400)
 
     # Optional operator note. Absent is the norm (and the pre-existing shape), so
     # a missing key is NOT an error — but a present-and-wrong-typed one is, to

--- a/test/test_denied_commands_api.py
+++ b/test/test_denied_commands_api.py
@@ -620,11 +620,67 @@ async def test_non_object_json_body_is_400_not_500(home: Path, mock_sel):
 async def test_user_add_redos_pattern_is_400(home: Path, mock_sel):
     # A catastrophic-backtracking regex must be rejected at add-time — it would
     # otherwise freeze the event loop when the gate runs it synchronously.
+    from kiro_crew.security import _DANGEROUS_AWS_FLAG_RUN, _LINEARIZED_AWS_FLAG_RUN
+
     async with _client() as client:
         resp = await client.post("/api/security/denied-commands/user", json={"pattern": "(a+)+$"})
         assert resp.status == 400
         body = await resp.json()
         assert "unsafe" in body["error"].lower()
+        # No flag-run fragment in the pattern, so no fragment hint either — the
+        # hint must name the actual trigger, not decorate every rejection.
+        assert _DANGEROUS_AWS_FLAG_RUN not in body["error"]
+        assert _LINEARIZED_AWS_FLAG_RUN not in body["error"]
+    assert mock_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_user_add_wrapped_builtin_fragment_rejection_names_the_trigger(
+    home: Path, mock_sel
+):
+    # A user who copies a built-in pattern and tweaks it embeds the flag-run
+    # fragment verbatim; the fragment is exempt from the backtracking check only
+    # as part of a complete built-in, so the tweaked copy is rejected. The
+    # rejection must name the fragment so the dead end is self-explanatory
+    # instead of a generic "unsafe regex" (#5837).
+    from kiro_crew.security import _DANGEROUS_AWS_FLAG_RUN, _LINEARIZED_AWS_FLAG_RUN
+
+    async with _client() as client:
+        for fragment in (_DANGEROUS_AWS_FLAG_RUN, _LINEARIZED_AWS_FLAG_RUN):
+            pattern = "aws s3" + fragment + r" rm .*my-bucket"
+            resp = await client.post(
+                "/api/security/denied-commands/user", json={"pattern": pattern}
+            )
+            assert resp.status == 400
+            body = await resp.json()
+            assert "unsafe" in body["error"].lower()
+            assert fragment in body["error"], body["error"]
+    assert mock_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_user_add_fragment_hint_withheld_when_not_the_trigger(home: Path, mock_sel):
+    # The hint says "remove or rewrite that fragment" — advice that must be
+    # TRUE before it is given. A pattern that embeds the fragment but also
+    # carries its own catastrophic quantifier stays rejected after the fragment
+    # is removed, so hinting at the fragment would send the user to an
+    # identical 400. The hint is gated on the fragment-scrubbed residue
+    # actually passing (#5837).
+    from kiro_crew.security import _DANGEROUS_AWS_FLAG_RUN, _LINEARIZED_AWS_FLAG_RUN
+
+    async with _client() as client:
+        for pattern in (
+            "(x+)+" + _DANGEROUS_AWS_FLAG_RUN,  # own nested quantifier
+            "a|b" + _DANGEROUS_AWS_FLAG_RUN,  # own top-level alternation
+        ):
+            resp = await client.post(
+                "/api/security/denied-commands/user", json={"pattern": pattern}
+            )
+            assert resp.status == 400
+            body = await resp.json()
+            assert "unsafe" in body["error"].lower()
+            assert _DANGEROUS_AWS_FLAG_RUN not in body["error"], body["error"]
+            assert _LINEARIZED_AWS_FLAG_RUN not in body["error"], body["error"]
     assert mock_sel.log_api_access.call_args.kwargs["outcome"] == "denied"
 
 

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -167,128 +167,6 @@ class TestCatalog:
                 allowed, denied_regexes=effective
             ), f"false positive on {allowed!r}"
 
-    def test_self_protection_commands_are_blocked_with_global_cli_options(self):
-        commands_by_id = {
-            "self-protection-restart": "restart",
-            "self-protection-update": "update",
-            "self-protection-cloud": "cloud destroy",
-            "self-protection-gateway-restart": "gateway restart",
-        }
-        rules = [rule for rule in BUILTIN_DENIED_RULES if rule.id in commands_by_id]
-        assert {rule.id for rule in rules} == set(commands_by_id)
-
-        for rule in rules:
-            for option in ("-v", "-vv", "--verbose", "--no-jail"):
-                command = f"kirocrew {option} {commands_by_id[rule.id]}"
-                reason = is_denied(command, denied_regexes=[rule.pattern])
-                assert reason is not None, command
-                assert reason.startswith(
-                    f"Blocked by security policy: {rule.pattern}"
-                ), command
-
-    def test_self_protection_commands_are_blocked_after_shell_quoting(self):
-        commands_by_id = {
-            "self-protection-restart": ("restart",),
-            "self-protection-update": ("update",),
-            "self-protection-cloud": ("cloud", "destroy"),
-            "self-protection-gateway-restart": ("gateway", "restart"),
-        }
-        rules = [rule for rule in BUILTIN_DENIED_RULES if rule.id in commands_by_id]
-        assert {rule.id for rule in rules} == set(commands_by_id)
-
-        for rule in rules:
-            words = commands_by_id[rule.id]
-            quoted_word_forms = [
-                " ".join(f"{quote}{word}{quote}" for word in words)
-                for quote in ('"', "'")
-            ]
-            commands = [f"kirocrew {form}" for form in quoted_word_forms]
-            commands.extend(f"kirocrew -v {form}" for form in quoted_word_forms)
-            for option in ("-v", "-vv", "--verbose", "--no-jail"):
-                for quote in ('"', "'"):
-                    commands.append(f"kirocrew {quote}{option}{quote} {' '.join(words)}")
-                    commands.extend(
-                        f"kirocrew {quote}{option}{quote} {form}"
-                        for form in quoted_word_forms
-                    )
-            for command in commands:
-                reason = is_denied(command, denied_regexes=[rule.pattern])
-                assert reason is not None, command
-                assert reason.startswith(
-                    f"Blocked by security policy: {rule.pattern}"
-                ), command
-
-    def test_self_protection_module_invocations_are_blocked(self):
-        commands_by_id = {
-            "self-protection-restart": ("restart",),
-            "self-protection-update": ("update",),
-            "self-protection-cloud": ("cloud", "destroy"),
-            "self-protection-gateway-restart": ("gateway", "restart"),
-        }
-        rules = [rule for rule in BUILTIN_DENIED_RULES if rule.id in commands_by_id]
-        assert {rule.id for rule in rules} == set(commands_by_id)
-
-        # These launcher spellings come from security._PYTHON_PROGRAM_RE and the
-        # documented ``python -m kiro_crew`` entrypoint.  ``py -3.12`` is the
-        # Windows launcher form; the version selector is an interpreter flag.
-        launchers = (
-            "python -m kiro_crew",
-            "python3 -B -m kiro_crew",
-            "python3.12 -X dev -m kiro_crew",
-            "py -3.12 -m kiro_crew",
-            "python -mkiro_crew",
-        )
-        global_options = ("", "-v", "-vv", "--verbose", "--no-jail")
-        for rule in rules:
-            for launcher in launchers:
-                for option in global_options:
-                    for quote in ('"', "'"):
-                        command = " ".join(
-                            part
-                            for part in (
-                                launcher,
-                                option,
-                                " ".join(
-                                    f"{quote}{word}{quote}"
-                                    for word in commands_by_id[rule.id]
-                                ),
-                            )
-                            if part
-                        )
-                        reason = is_denied(command, denied_regexes=[rule.pattern])
-                        assert reason is not None, command
-                        assert reason.startswith(
-                            f"Blocked by security policy: {rule.pattern}"
-                        ), command
-
-    def test_self_lifecycle_rules_do_not_over_match_nearby_subcommands(self):
-        """A lifecycle word AFTER an unrelated subcommand is not a lifecycle command.
-
-        Guards both halves of the union (regex tier and argv floor) through the
-        public gate: neither may scan past the first subcommand word.
-        """
-        rules = [
-            rule
-            for rule in BUILTIN_DENIED_RULES
-            if rule.id
-            in {
-                "self-protection-restart",
-                "self-protection-update",
-                "self-protection-cloud",
-                "self-protection-gateway-restart",
-            }
-        ]
-        patterns = [rule.pattern for rule in rules]
-        for command in (
-            "kirocrew doctor restart",
-            "kirocrew gateway status restart",
-            "kirocrew cloud status destroy",
-            "python -m kiro_crew doctor restart",
-            "python -m kiro_crew gateway status restart",
-            "python -m kiro_crew cloud status destroy",
-        ):
-            assert is_denied(command, denied_regexes=patterns) is None, command
-
     def test_rules_are_frozen_dataclass_with_four_fields(self):
         rule = BUILTIN_DENIED_RULES[0]
         assert isinstance(rule, DeniedCommandRule)
@@ -404,7 +282,9 @@ class TestSelfProtectionFlagInterposition:
         """Not over-broad: the flag run alone must never satisfy a rule.
 
         Benign invocations -- other subcommands behind the same flags, the flags
-        alone, and cloud subcommands outside the destructive list -- stay allowed.
+        alone, cloud subcommands outside the destructive list, and a lifecycle
+        word sitting AFTER an unrelated subcommand (direct or module form) --
+        stay allowed.
         """
         from kiro_crew import security
 
@@ -415,6 +295,15 @@ class TestSelfProtectionFlagInterposition:
             "kirocrew --no-jail doctor",
             "kirocrew -v status",
             "kirocrew -vv cloud status",
+            # A lifecycle word AFTER an unrelated subcommand is not a lifecycle
+            # command: neither tier may scan past the first subcommand word
+            # (#5837, folded from the retired TestCatalog matrix).
+            "kirocrew doctor restart",
+            "kirocrew gateway status restart",
+            "kirocrew cloud status destroy",
+            "python -m kiro_crew doctor restart",
+            "python -m kiro_crew gateway status restart",
+            "python -m kiro_crew cloud status destroy",
         ):
             assert not security.is_denied(
                 allowed, denied_regexes=effective
@@ -473,10 +362,19 @@ class TestSelfProtectionFlagInterposition:
 
     @staticmethod
     def _dressings(words):
-        """Shell spellings that all tokenize to argv ``[kirocrew, *words]``."""
+        """Shell spellings whose argv carries the plain flag/verb tokens.
+
+        Every entry reaches the shell as ``kirocrew [<flag>] <words...>`` after
+        the shell's own de-escaping and quote removal. The ``bare`` and
+        ``real-flag`` entries also match the regex tier directly; the escaped,
+        continued, and quoted entries split a token in the raw string the regex
+        tier matches, so only the floor catches those.
+        """
         rest = " ".join(words)
         first = words[0]
         tail = (" " + " ".join(words[1:])) if len(words) > 1 else ""
+        each_quoted = " ".join(f'"{w}"' for w in words)
+        each_single_quoted = " ".join(f"'{w}'" for w in words)
         return {
             "bare": f"kirocrew {rest}",
             "real-flag": f"kirocrew -v {rest}",
@@ -484,7 +382,16 @@ class TestSelfProtectionFlagInterposition:
             "escaped-verb-letter": f"kirocrew \\{first}{tail}",  # \restart -> restart
             "line-continuation-flag": f"kirocrew -\\\nv {rest}",
             "continuation-before-verb": f"kirocrew \\\n{first}{tail}",
-            "each-word-quoted": "kirocrew " + " ".join(f'"{w}"' for w in words),
+            "each-word-quoted": f"kirocrew {each_quoted}",
+            "each-word-single-quoted": f"kirocrew {each_single_quoted}",
+            # Quoted FLAGS (#5837, folded from the retired TestCatalog matrix):
+            # the quotes split the flag token in the raw text, but the shell
+            # strips them, so the interposed flag still lands in argv. The full
+            # flag-by-quote-style cross lives in
+            # ``test_self_protection_denied_under_the_full_quoting_cross``.
+            "double-quoted-flag": f'kirocrew "-v" {rest}',  # "-v" -> -v
+            "single-quoted-flag": f"kirocrew '-v' {rest}",
+            "quoted-flag-and-quoted-verb": f'kirocrew "-v" {each_quoted}',
         }
 
     def test_self_protection_subcommands_denied_under_every_shell_dressing(self):
@@ -497,19 +404,66 @@ class TestSelfProtectionFlagInterposition:
                     cmd, denied_regexes=effective
                 ), f"{rule_id} not denied under {label}: {cmd!r}"
 
-    def test_self_protection_floor_covers_the_four_subcommand_rules(self):
+    _QUOTES = ('"', "'")
+    # Single-token global options. ``-v --no-jail`` from ``_FLAGS`` is two
+    # tokens and cannot be quoted as one flag, so it has no quoted cell.
+    _SINGLE_TOKEN_FLAGS = ("-v", "-vv", "--verbose", "--no-jail")
+
+    @classmethod
+    def _quoting_cross(cls, prefix: str, words: "list[str]") -> "list[str]":
+        """Every quoting spelling of ``<prefix> [flag] <words...>``.
+
+        The full cross the retired TestCatalog matrix asserted (#5837): quoted
+        verbs, quoted flags, and both together, in each quote style, for every
+        single-token global option. The shell strips the quotes, so every cell
+        lands as the same argv and must stay denied.
+        """
+        rest = " ".join(words)
+        quoted_word_forms = [" ".join(f"{q}{w}{q}" for w in words) for q in cls._QUOTES]
+        cmds = [f"{prefix} {form}" for form in quoted_word_forms]
+        for flag in cls._SINGLE_TOKEN_FLAGS:
+            cmds.extend(f"{prefix} {flag} {form}" for form in quoted_word_forms)
+            for q in cls._QUOTES:
+                cmds.append(f"{prefix} {q}{flag}{q} {rest}")
+                cmds.extend(f"{prefix} {q}{flag}{q} {form}" for form in quoted_word_forms)
+        return cmds
+
+    def test_self_protection_denied_under_the_full_quoting_cross(self):
+        from kiro_crew import security
+
+        effective = self._effective()
+        for rule_id, words in self._SUBCOMMANDS.items():
+            for cmd in self._quoting_cross("kirocrew", list(words)):
+                assert security.is_denied(
+                    cmd, denied_regexes=effective
+                ), f"{rule_id} not denied in the quoting cross: {cmd!r}"
+
+    def test_self_protection_floor_covers_every_subcommand_rule(self):
         """The argv floor must cover every self-protection subcommand rule, so a
         regex-only rule cannot silently ship bypassable by shell de-escaping.
+
+        ``_SUBCOMMANDS`` (which feeds the dressing, quoting-cross, and launcher
+        walks) is tied to the LIVE floor set here, the way ``_TEMPLATES`` is
+        tied to the category by ``test_every_self_protection_rule_has_a_template``:
+        a floor-listed rule whose template names a ``kirocrew`` CLI subcommand
+        must appear in ``_SUBCOMMANDS`` (and vice versa), so a fifth subcommand
+        rule joining the floor cannot silently skip all three walks. The kill
+        rules key on a kill target, not a CLI subcommand, and the credential
+        mint rule is outside the self-protection category -- neither has a
+        ``kirocrew ...`` template, so the derivation excludes them.
         """
         from kiro_crew import security
 
-        expected = {
-            "self-protection-restart",
-            "self-protection-update",
-            "self-protection-gateway-restart",
-            "self-protection-cloud",
+        floor_subcommand_ids = {
+            rule_id
+            for rule_id in security._SELF_PROTECTION_FLOOR_RULE_IDS
+            if self._TEMPLATES.get(rule_id, "").startswith("kirocrew ")
         }
-        assert expected <= security._SELF_PROTECTION_FLOOR_RULE_IDS
+        assert set(self._SUBCOMMANDS) == floor_subcommand_ids, (
+            "every floor-listed kirocrew-subcommand rule must register its "
+            "words in _SUBCOMMANDS (and every _SUBCOMMANDS entry must be "
+            "floor-listed), or the shell-dressing walks silently skip it"
+        )
         # the predicate for each is wired and fires on a de-escaped argv
         assert security._is_self_restart("kirocrew -\\v restart")
         assert security._is_self_update("kirocrew \\update")
@@ -582,6 +536,49 @@ class TestSelfProtectionFlagInterposition:
         assert not security._is_self_restart("python -m kiro_crew status")
         assert not security._is_self_cloud_destructive("python -m kiro_crew cloud status")
         assert not security._is_self_restart("python -m pytest test/test_restart.py")
+
+    def test_self_protection_module_form_denied_under_version_launchers(self):
+        """Every interpreter launcher spelling of ``-m kiro_crew`` dispatches the
+        same self-action (#5837, folded from the retired TestCatalog matrix).
+
+        The spellings come from ``security._PYTHON_PROGRAM_RE``: version-suffixed
+        binaries, the Windows ``py`` launcher (its version selector is an
+        interpreter flag taking no operand), interpreter flags with separate
+        operands (``-X dev``), and the attached ``-mkiro_crew`` form. Each is
+        crossed with a bare and flag-interposed tail plus the full quoting
+        cross from ``_quoting_cross``, so every launcher cell the retired
+        TestCatalog matrix asserted survives here.
+        """
+        from kiro_crew import security
+
+        effective = self._effective()
+        launchers = (
+            "python -m kiro_crew",
+            "python3 -B -m kiro_crew",
+            "python3.12 -X dev -m kiro_crew",
+            "py -3.12 -m kiro_crew",
+            "python -mkiro_crew",
+        )
+        for launcher in launchers:
+            for rule_id, words in self._SUBCOMMANDS.items():
+                rest = " ".join(words)
+                cmds = [f"{launcher} {rest}"]
+                cmds.extend(f"{launcher} {flag} {rest}" for flag in self._SINGLE_TOKEN_FLAGS)
+                cmds.extend(self._quoting_cross(launcher, list(words)))
+                for cmd in cmds:
+                    assert security.is_denied(
+                        cmd, denied_regexes=effective
+                    ), f"{rule_id} not denied via version launcher: {cmd!r}"
+        # The same launchers running a benign subcommand (or another program
+        # entirely) stay allowed -- the launcher spelling is not the trigger.
+        for allowed in (
+            "py -3.12 -m kiro_crew status",
+            "python3.12 -X dev -m kiro_crew doctor",
+            "python3 -B -m pytest test/test_restart.py",
+        ):
+            assert not security.is_denied(
+                allowed, denied_regexes=effective
+            ), f"false positive on {allowed!r}"
 
     def test_self_protection_floor_is_not_over_broad(self):
         """The floor matches a real subcommand invocation, not a mention, a


### PR DESCRIPTION
## What is the problem?

PR #4823 landed four denial-matrix tests in `TestCatalog` that run parallel to `TestSelfProtectionFlagInterposition`, the class that carries the self-protection category-completeness invariant (`test_every_self_protection_rule_has_a_template`). Three of the four re-pin coverage the base class already holds, and the parallel matrix has no completeness guard, so the two matrices diverge silently when a self-protection rule is added. Separately, a user who copies a built-in deny pattern and tweaks it gets a generic "unsafe regex" rejection with no clue that the embedded flag-run fragment is the trigger (the fragment is exempt from the backtracking check only inside a complete built-in pattern).

## Why it matters

One matrix with one completeness guard is what keeps the self-protection walk honest: today a new rule fails the template invariant until it registers coverage, but the parallel matrix would simply not know about it. And the regex rejection is a dead end in the security settings UI: the built-in pattern is visible and copyable, so copy-and-tweak is the natural workflow, and the generic error gives the user nothing to act on.

## What changed

- Deleted the four parallel `TestCatalog` methods. Every retired cell survives inside `TestSelfProtectionFlagInterposition`: a `_quoting_cross` generator reproduces the full flag-by-quote-style cross (quoted verbs, quoted flags, both together, each quote style, every single-token global option) for the direct form and for the five version-launcher spellings (`python3 -B`, `python3.12 -X dev`, `py -3.12`, attached `-mkiro_crew`); quoted-flag shell dressings join the dressing walk; the nearby-subcommand false-positive guards (`kirocrew doctor restart` et al.) join the not-over-broad allowed list, asserted against the full effective set.
- `_SUBCOMMANDS` (which feeds the dressing, quoting-cross, and launcher walks) is tied to the live `_SELF_PROTECTION_FLOOR_RULE_IDS` by a derived-set equality, so a fifth subcommand rule joining the floor cannot silently skip the walks.
- The dashboard add handler names the embedded `_DANGEROUS_AWS_FLAG_RUN` / `_LINEARIZED_AWS_FLAG_RUN` fragment in its rejection error. The hint is gated on the fragment-scrubbed residue actually passing `is_safe_user_regex`, so the "remove or rewrite that fragment" advice is only given when following it would succeed; a pattern with its own catastrophic quantifier keeps the generic message.

Test-only consolidation plus error copy: enforcement behavior is unchanged. The `kiro_crew.security` import stays in-function per the blocking `no-new-work-on-gateway-boot-path` rule (clause 5) governing `dashboard/handlers/**`.

## Tests

- `test/test_denied_commands_security.py` + `test/test_denied_commands_api.py` + `test/test_security.py`: 1209 passed.
- Local gates: isort, flake8, black gate, mypy (only the two pre-existing `transcribe.py` errors, identical on main).
- Seven mutation probes, each caught by exactly the intended test: always-true floor predicate, leading-match widened to anywhere-match (caught by `kirocrew doctor restart`), `py` launcher dropped from `_PYTHON_PROGRAM_RE`, floor disabled (quoted-flag cells verified floor-dependent), hint branch disabled, hint gating forced unconditional, `gateway-restart` dropped from the floor frozenset (caught by the derived-set equality).
- Both pre-push review lanes ran (gpt-5.6-sol, claude-opus-5); all findings addressed: full quoting cross restored, derived floor invariant added, hint gated on the advice being true, negative assertions pinned to the fragment constants, docstring overclaims fixed. The top-level-import suggestion was declined per the boot-path rule above.

## Anything else

The retired cells asserted `is_denied` with a single-pattern effective set; the argv floor already fired there too (measured), so folding onto the effective-union path loses no regex-tier coverage, only per-rule attribution isolation, which the union walk's per-rule assertions retain.

Closes #5837
