### PR TITLE
fix(ci): add the external_id-scoped stranded-run sweep to the 4 fork reviewer lanes

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -153,16 +153,24 @@ jobs:
       # Post the "Design Review" check-run as EARLY as possible, keyed to
       # head_sha, so the status always surfaces (advisory-neutral even if a later
       # step dies).
+      #
+      # `external_id` carries the PR number, which is what makes the finalize
+      # sweep safe: a check-run of this name on this head can belong to ANOTHER
+      # pull request (two PRs may share a commit), and completing that one would
+      # publish a verdict computed from a different diff. The sweep matches on
+      # this id, so it can only ever finish a run this pull request created.
       - name: Open check-run (in progress)
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Design Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="design-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -575,6 +583,7 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
+          PR: ${{ steps.pr.outputs.pr }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
         run: |
           set -uo pipefail
@@ -584,30 +593,54 @@ jobs:
             BLOCK)    conclusion="failure"; title="BLOCK — design concern (advisory)" ;;
             *)        conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
-          # complete <conclusion> <title> — one retry, because a single transient
-          # 5xx here is what strands the run: the check-run stays `in_progress`
-          # forever, and pr-readiness counts ANY non-completed run of this name as
-          # pending — including after a successful re-run — so the PR sits at
-          # `readiness: checking` with no event able to clear it.
+          summary="Advisory fork design review for $HEAD. See the PR comment for details."
+          # complete <check-run id> <conclusion> <title> — one retry, because a
+          # single transient 5xx here is what strands the run: the check-run stays
+          # `in_progress` forever, and pr-readiness counts ANY non-completed run of
+          # this name as pending — including after a successful re-run — so the PR
+          # sits at `readiness: checking` with no event able to clear it.
           complete() {
             for attempt in 1 2; do
-              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-                -f status="completed" -f conclusion="$1" \
-                -f "output[title]=Design Review — $2" \
-                -f "output[summary]=Advisory fork design review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=Design Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
                 return 0
               fi
               sleep 5
             done
-            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            echo "::warning::could not complete check-run $1 for $HEAD"
             return 1
           }
           if [ -n "${CHECK_ID:-}" ]; then
-            complete "$conclusion" "$title" || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Design Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="neutral" \
               -f "output[title]=Design Review — could not run (advisory)" \
               -f "output[summary]=The fork design review job failed before producing a verdict; re-run it. Advisory — does not block merge." >/dev/null || true
+          fi
+          # Sweep any still-incomplete run of this name that THIS pull request
+          # created (ours, if the PATCH above lost both attempts, or one stranded
+          # by a previous run). Scoped by `external_id`: a check-run of this name
+          # on this head can belong to another PR that shares the commit, and
+          # completing that one would publish a verdict computed from a different
+          # diff -- the wedge is closed without ever touching a sibling's review.
+          # Completed with THIS run's computed verdict, not a hardcoded neutral:
+          # a genuine BLOCK whose own PATCH lost both attempts must not be
+          # swept into a verdict pr-readiness no longer gates on. With no
+          # verdict, $conclusion is already neutral/"review incomplete".
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '"Design Review" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"design-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              echo "completing stranded check-run $id for $HEAD (PR #$PR)"
+              complete "$id" "$conclusion" "$title" || true
+            done
           fi

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -153,16 +153,24 @@ jobs:
 
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # branch protection always sees a result (fail-closed even if a later step dies).
+      #
+      # `external_id` carries the PR number, which is what makes the finalize
+      # sweep safe: a check-run of this name on this head can belong to ANOTHER
+      # pull request (two PRs may share a commit), and completing that one would
+      # publish a verdict computed from a different diff. The sweep matches on
+      # this id, so it can only ever finish a run this pull request created.
       - name: Open check-run (in progress)
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="GPT 5.6 Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="gpt-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -713,6 +721,7 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           conclusion="failure"; title="review incomplete"
@@ -723,30 +732,56 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
-          # complete <conclusion> <title> — one retry, because a single transient
-          # 5xx here is what strands the run: the check-run stays `in_progress`
-          # forever, and pr-readiness counts ANY non-completed run of this name as
-          # pending — including after a successful re-run — so the PR sits at
-          # `readiness: checking` with no event able to clear it.
+          summary="Fork AI review for $HEAD. See the PR comment for details."
+          # complete <check-run id> <conclusion> <title> — one retry, because a
+          # single transient 5xx here is what strands the run: the check-run stays
+          # `in_progress` forever, and pr-readiness counts ANY non-completed run of
+          # this name as pending — including after a successful re-run — so the PR
+          # sits at `readiness: checking` with no event able to clear it.
           complete() {
             for attempt in 1 2; do
-              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-                -f status="completed" -f conclusion="$1" \
-                -f "output[title]=GPT 5.6 Review — $2" \
-                -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=GPT 5.6 Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
                 return 0
               fi
               sleep 5
             done
-            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            echo "::warning::could not complete check-run $1 for $HEAD"
             return 1
           }
           if [ -n "${CHECK_ID:-}" ]; then
-            complete "$conclusion" "$title" || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="GPT 5.6 Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="failure" \
               -f "output[title]=GPT 5.6 Review — could not run" \
               -f "output[summary]=The fork GPT review job failed before producing a verdict; re-run it." >/dev/null || true
+          fi
+          # Sweep any still-incomplete run of this name that THIS pull request
+          # created (ours, if the PATCH above lost both attempts, or one stranded
+          # by a previous run). Scoped by `external_id`: a check-run of this name
+          # on this head can belong to another PR that shares the commit, and
+          # completing that one would publish a verdict computed from a different
+          # diff -- the wedge is closed without ever touching a sibling's review.
+          # Completed with THIS run's computed verdict: the current run is the
+          # authoritative review of this exact head, and pr-readiness collapses
+          # check-runs with fail-precedence, so stamping a hardcoded failure on
+          # the stranded run would permanently outvote a genuine green re-run.
+          # Fail-closed posture is preserved: with no verdict, $conclusion is
+          # already failure/"review incomplete".
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '"GPT 5.6 Review" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"gpt-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              echo "completing stranded check-run $id for $HEAD (PR #$PR)"
+              complete "$id" "$conclusion" "$title" || true
+            done
           fi

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -157,16 +157,24 @@ jobs:
 
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # branch protection always sees a result (fail-closed even if a later step dies).
+      #
+      # `external_id` carries the PR number, which is what makes the finalize
+      # sweep safe: a check-run of this name on this head can belong to ANOTHER
+      # pull request (two PRs may share a commit), and completing that one would
+      # publish a verdict computed from a different diff. The sweep matches on
+      # this id, so it can only ever finish a run this pull request created.
       - name: Open check-run (in progress)
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Opus 4.8 Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="opus-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -448,6 +456,7 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           conclusion="failure"; title="review incomplete"
@@ -458,30 +467,56 @@ jobs:
               conclusion="success"; title="no blocking findings"
             fi
           fi
-          # complete <conclusion> <title> — one retry, because a single transient
-          # 5xx here is what strands the run: the check-run stays `in_progress`
-          # forever, and pr-readiness counts ANY non-completed run of this name as
-          # pending — including after a successful re-run — so the PR sits at
-          # `readiness: checking` with no event able to clear it.
+          summary="Fork AI review for $HEAD. See the PR comment for details."
+          # complete <check-run id> <conclusion> <title> — one retry, because a
+          # single transient 5xx here is what strands the run: the check-run stays
+          # `in_progress` forever, and pr-readiness counts ANY non-completed run of
+          # this name as pending — including after a successful re-run — so the PR
+          # sits at `readiness: checking` with no event able to clear it.
           complete() {
             for attempt in 1 2; do
-              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-                -f status="completed" -f conclusion="$1" \
-                -f "output[title]=Opus 4.8 Review — $2" \
-                -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=Opus 4.8 Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
                 return 0
               fi
               sleep 5
             done
-            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            echo "::warning::could not complete check-run $1 for $HEAD"
             return 1
           }
           if [ -n "${CHECK_ID:-}" ]; then
-            complete "$conclusion" "$title" || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Opus 4.8 Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="failure" \
               -f "output[title]=Opus 4.8 Review — could not run" \
               -f "output[summary]=The fork Opus review job failed before producing a verdict; re-run it." >/dev/null || true
+          fi
+          # Sweep any still-incomplete run of this name that THIS pull request
+          # created (ours, if the PATCH above lost both attempts, or one stranded
+          # by a previous run). Scoped by `external_id`: a check-run of this name
+          # on this head can belong to another PR that shares the commit, and
+          # completing that one would publish a verdict computed from a different
+          # diff -- the wedge is closed without ever touching a sibling's review.
+          # Completed with THIS run's computed verdict: the current run is the
+          # authoritative review of this exact head, and pr-readiness collapses
+          # check-runs with fail-precedence, so stamping a hardcoded failure on
+          # the stranded run would permanently outvote a genuine green re-run.
+          # Fail-closed posture is preserved: with no verdict, $conclusion is
+          # already failure/"review incomplete".
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '"Opus 4.8 Review" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"opus-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              echo "completing stranded check-run $id for $HEAD (PR #$PR)"
+              complete "$id" "$conclusion" "$title" || true
+            done
           fi

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -152,16 +152,24 @@ jobs:
 
       # Post the required check-run as EARLY as possible, keyed to head_sha, so
       # the "UX Review" status always exists (finalized below regardless of path).
+      #
+      # `external_id` carries the PR number, which is what makes the finalize
+      # sweep safe: a check-run of this name on this head can belong to ANOTHER
+      # pull request (two PRs may share a commit), and completing that one would
+      # publish a verdict computed from a different diff. The sweep matches on
+      # this id, so it can only ever finish a run this pull request created.
       - name: Open check-run (in progress)
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          PR: ${{ steps.pr.outputs.pr }}
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="UX Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f external_id="ux-pr-$PR" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -761,6 +769,7 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
+          PR: ${{ steps.pr.outputs.pr }}
           VERDICT: ${{ steps.post.outputs.verdict }}
         run: |
           set -uo pipefail
@@ -776,30 +785,54 @@ jobs:
             *)
               conclusion="neutral"; title="review incomplete (advisory)" ;;
           esac
-          # complete <conclusion> <title> — one retry, because a single transient
-          # 5xx here is what strands the run: the check-run stays `in_progress`
-          # forever, and pr-readiness counts ANY non-completed run of this name as
-          # pending — including after a successful re-run — so the PR sits at
-          # `readiness: checking` with no event able to clear it.
+          summary="Advisory fork UX review for $HEAD. See the PR comment for details."
+          # complete <check-run id> <conclusion> <title> — one retry, because a
+          # single transient 5xx here is what strands the run: the check-run stays
+          # `in_progress` forever, and pr-readiness counts ANY non-completed run of
+          # this name as pending — including after a successful re-run — so the PR
+          # sits at `readiness: checking` with no event able to clear it.
           complete() {
             for attempt in 1 2; do
-              if gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
-                -f status="completed" -f conclusion="$1" \
-                -f "output[title]=UX Review — $2" \
-                -f "output[summary]=Advisory fork UX review for $HEAD. See the PR comment for details." >/dev/null 2>&1; then
+              if gh api --method PATCH "repos/$REPO/check-runs/$1" \
+                -f status="completed" -f conclusion="$2" \
+                -f "output[title]=UX Review — $3" \
+                -f "output[summary]=$summary" >/dev/null 2>&1; then
                 return 0
               fi
               sleep 5
             done
-            echo "::warning::could not complete check-run $CHECK_ID for $HEAD"
+            echo "::warning::could not complete check-run $1 for $HEAD"
             return 1
           }
           if [ -n "${CHECK_ID:-}" ]; then
-            complete "$conclusion" "$title" || true
+            complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="UX Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="neutral" \
               -f "output[title]=UX Review — could not run (advisory)" \
               -f "output[summary]=The fork UX review job failed before producing a verdict; advisory, does not block merge." >/dev/null || true
+          fi
+          # Sweep any still-incomplete run of this name that THIS pull request
+          # created (ours, if the PATCH above lost both attempts, or one stranded
+          # by a previous run). Scoped by `external_id`: a check-run of this name
+          # on this head can belong to another PR that shares the commit, and
+          # completing that one would publish a verdict computed from a different
+          # diff -- the wedge is closed without ever touching a sibling's review.
+          # Completed with THIS run's computed verdict, not a hardcoded neutral:
+          # a genuine BLOCK whose own PATCH lost both attempts must not be
+          # swept into a verdict pr-readiness no longer gates on. With no
+          # verdict, $conclusion is already neutral/"review incomplete".
+          if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
+            enc="$(jq -rn '"UX Review" | @uri')"
+            stranded="$(gh api --method GET \
+              "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+              --jq ".check_runs[]
+                    | select(.status != \"completed\")
+                    | select(.external_id == \"ux-pr-$PR\")
+                    | .id" 2>/dev/null || true)"
+            for id in $stranded; do
+              echo "completing stranded check-run $id for $HEAD (PR #$PR)"
+              complete "$id" "$conclusion" "$title" || true
+            done
           fi

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1278,6 +1278,62 @@ class TestAdvisoryVerdictRequiresCurrentHeadMarker:
             assert out.stdout.strip() == want, f"{summary!r} -> {out.stdout!r}"
 
 
+# (lane file, check-run name, external_id prefix, finalize step name)
+FORK_SWEEP_LANES = (
+    ("fork-design-review.yml", "Design Review", "design", "Finalize check-run (advisory)"),
+    ("fork-gpt-review.yml", "GPT 5.6 Review", "gpt", "Finalize check-run (fail closed)"),
+    ("fork-opus-review.yml", "Opus 4.8 Review", "opus", "Finalize check-run (fail closed)"),
+    ("fork-ux-review.yml", "UX Review", "ux", "Finalize check-run (advisory)"),
+)
+
+
+class TestForkLaneStrandedRunSweeps:
+    """#3447 defect 1, second half: the retry alone still loses when BOTH
+    attempts fail, and it cannot touch a run stranded by a PREVIOUS workflow
+    run. fork-first-principles-review.yml pairs the retry with a sweep that
+    lists still-incomplete check-runs of the lane's name on the head and
+    completes every one THIS pull request created; these tests port that pin
+    to the other four fork lanes.
+    """
+
+    @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
+    def test_check_run_is_created_with_a_pr_scoped_external_id(
+        self, lane: str, check_name: str, prefix: str, finalize: str
+    ) -> None:
+        # Without an external_id at CREATION the sweep has nothing safe to
+        # match on: a check-run of this name on this head can belong to a
+        # different PR that shares the commit.
+        opened = _step_script(_workflow(lane), "Open check-run (in progress)")
+        assert f'-f external_id="{prefix}-pr-$PR"' in opened, (
+            f"{lane}: check-run created without a PR-scoped external_id"
+        )
+
+    @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
+    def test_finalize_sweeps_stranded_check_runs(
+        self, lane: str, check_name: str, prefix: str, finalize: str
+    ) -> None:
+        script = _step_script(_workflow(lane), finalize)
+        assert "completing stranded check-run" in script, (
+            f"{lane}: no stranded-run sweep -- a doubly-failed finalize wedges the PR"
+        )
+        assert "check-runs?check_name=$enc&per_page=100" in script, lane
+
+    @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
+    def test_sweep_only_completes_check_runs_this_pr_created(
+        self, lane: str, check_name: str, prefix: str, finalize: str
+    ) -> None:
+        # Two open PRs can share a head commit; an unscoped sweep would publish
+        # a verdict computed from another PR's diff.
+        script = _step_script(_workflow(lane), finalize)
+        assert f'select(.external_id == \\"{prefix}-pr-$PR\\")' in script, (
+            f"{lane}: sweep is not scoped by external_id"
+        )
+        assert '[ -n "${PR:-}" ]' in script, f"{lane}: sweep runs without a resolved PR"
+        assert 'select(.status != "completed") | .id' not in script, (
+            f"{lane}: unscoped sweep must not come back"
+        )
+
+
 class TestPreparePrPreSubmitReview:
     def test_two_read_only_reviewers_run_before_the_first_push(self) -> None:
         skill = _prepare_pr_skill()


### PR DESCRIPTION
Fixes #3447

PR #3436 hardened three things inside the new first-principles lane only; the sibling reviewer lanes kept the un-hardened shape. Issue #3447 records the deferral. All three defects are now resolved: defect 3 landed via #3854 and defect 2 via #3855 (both mid-flight of this PR, adopted via rebase and dropped from this diff); this PR carries the remaining piece — defect 1's second half, stacking on the merged #3856.

## What this ships (defect 1, second half)

#3856 landed the `complete()` finalize retry in the 4 fork lanes; this adds the rest of the reference implementation from `fork-first-principles-review.yml`:

- **`external_id="<lane>-pr-$PR"` at check-run creation** (`design-pr-$PR`, `gpt-pr-$PR`, `opus-pr-$PR`, `ux-pr-$PR`). None of the four lanes set one before (the issue's "reuse each lane's existing external_id" was not executable as written — verified against the checkout).
- **`complete()` refactored to take the check-run id as `$1`** — byte-identical to the reference except the lane name in `output[title]` (per-lane `$summary` is assigned outside the helper).
- **The stranded-run sweep**: finalize lists still-incomplete check-runs of the lane's name on the head and completes only those with this PR's `external_id` — a run stranded by a previous workflow run (or by both PATCH attempts failing) can no longer wedge `pr-readiness` at `checking`, and a sibling PR sharing the head commit is never touched.
- **Sweep conclusions** (shaped by this PR's own review cycle — Design and GPT lane findings, both adopted): stranded runs complete with the CURRENT run's computed `$conclusion`/`$title`, not a hardcoded one. A hardcoded `failure` would permanently outvote a genuine green re-run under pr-readiness's fail-precedence; a hardcoded `neutral` would launder a genuine BLOCK whose own PATCH lost both attempts into a verdict pr-readiness no longer gates on. With no verdict, `$conclusion` already degrades to each lane's incomplete posture (failure for the fail-closed GPT/Opus lanes, neutral for the advisory Design/UX lanes). This deliberately diverges from the reference, which sweeps to hardcoded `neutral` and carries the same latent issue — tracked as #5949 (the dispatching spec pinned the reference lanes as unmodifiable for this change).
- Sweep guarded by `[ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]`, so the `workflow_run.head_sha` fallback path (where `steps.pr` never ran) skips it instead of tripping `set -u`.

## Tests

`TestForkLaneStrandedRunSweeps` in `test/test_ai_review_workflows.py` (red-before verified): external_id at creation, sweep presence, external_id scoping, `${PR:-}` guard, and unscoped-sweep absence, per lane.

## Verification

- YAML parse + `bash -n` of every `run:` block in all 4 touched workflows: clean.
- `complete()` diffed against the reference: only the lane name differs.
- Full backend suite (earlier heads): failure set byte-identical to an origin/main worktree baseline. Workflow test files: 212 passed on the final head. black gate (ratchet), isort, flake8: pass.

**What could not be verified without a real fork PR:** a PR modifying `.github/workflows/` does not exercise the modified workflows on its own runs — CI green here is NOT evidence the runtime behavior works. The sweep's live behavior (listing and completing a genuinely stranded check-run) is verified statically and by the ported reference's production record only.

## Relation to sibling PRs / out of scope

- #3856 (merged): defect 1's retry half; this PR stacks the deferred sweep on top.
- #3855 (merged mid-flight): defect 2 (marker verification) — adopted via rebase, my parallel implementation dropped in its favor.
- #3854 (merged mid-flight): defect 3 (here-string scope gates) — same.
- #5949 (filed from this PR's review cycle): the reference lane's own hardcoded-neutral sweep.
- `fork-pr-description.yml` carries a similar bare `PATCH … || true`, but is not a reviewer lane — observed, deliberately not widened into this diff (it already sets its own external_id).
