### PR TITLE
fix: keep watching an app backend's health after startup

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -263,7 +263,7 @@ show the real product UI; the detail page renders both when both are declared.
 |-------|------|---------|-------------|
 | `backend.entryPoint` | string | | Script to run (relative to app root), or a dotted Python module path launched via `python -m` (used by built-in apps like `file-explorer`, e.g. `kiro_crew.apps.builtins.file_explorer.server`) |
 | `backend.port` | string | `"auto"` | Port number or `"auto"` for auto-assignment |
-| `backend.healthCheck` | string | `"/health"` | Health check endpoint path |
+| `backend.healthCheck` | string | `"/health"` | Health check endpoint path. Polled until it answers at startup, then re-polled for the life of the backend — keep the handler cheap and dependency-free. A backend that stops answering it is dropped from the reverse proxy and its MCP servers are deregistered until it answers again. |
 | `backend.routes` | string | | Base route path for the backend |
 | `backend.type` | string | `""` | Backend runtime: `"python"`, `"asgi"`, `"node"`, `"exec"` (execute the entry point file as-is), or `""` (auto-detect from `entryPoint` — a `.sh` file or an extensionless executable with a non-Python shebang is treated as a shell launcher) |
 

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -1036,3 +1036,53 @@ Writers: builtin `app.json` manifests, `apps/registry.py` (`_merge_manifest`),
 `website/src/components/appstore/appManifest.ts`,
 `website/src/pages/AppDetailPage.tsx`, and
 `website/scripts/check-app-manifest-sync.mjs`.
+
+## 17. A backend's health is a standing observation, not a startup verdict
+
+`healthy` on the `AppProcess` record is what the reverse proxy gates on
+(`get_app_backend_port` returns the port ONLY while the flag is set) and what
+`/api/apps` reports. Establishing it once at startup would make it a write-once
+cache: a backend that died an hour later would keep collecting proxied requests
+into a dead port, and the dashboard would keep calling it healthy, with no
+transition anywhere in the tree able to say otherwise.
+
+So the per-backend daemon thread that waits for the backend to come up does not
+exit when it does — it keeps watching, at the much coarser
+`_HEALTH_WATCH_INTERVAL`, for as long as the record stays tracked. The two phases
+are `_health_check_loop` (bounded startup poll) and `_watch_backend_health`
+(unbounded watch), joined by `_supervise_backend_health`.
+
+- **Liveness is cheapest-first, and only a dead process is decisive.** A backend
+  we spawned is judged first by `Popen.poll()`, which answers from an
+  already-reaped exit status without touching the app. An exited process cannot
+  recover on its own, so one observation demotes it and the watch stops. An
+  **adopted** backend has no `Popen` handle — it belongs to another supervisor —
+  and is judged by its health endpoint alone.
+- **An HTTP failure from a live process is not decisive.** A backend can be
+  briefly busy, so demotion needs `_HEALTH_WATCH_FAILURES` consecutive misses;
+  demoting on a single miss would let one slow response take a working app
+  offline.
+- **Demotion is reversible.** The watch keeps running after it demotes and
+  re-promotes on the next successful probe, which is what lets a backend that
+  wedged briefly heal with no operator action.
+- **Both directions move the MCP entry**, through the same
+  `_gate_mcp_registration` branches the startup phase uses: a demotion scrubs the
+  app's HTTP MCP url so kiro-cli does not dial a dead port on every session, and a
+  recovery re-registers it.
+- **The watch is bound to the RECORD, not the app name.** A stop/start installs a
+  new `AppProcess` under the same name with its own watch, so every transition is
+  guarded by `_processes.get(name) is ap`. Resolving by name instead would let a
+  retiring watch demote a successor it never observed. The same guard is how the
+  watch terminates — `stop_app_backend` pops the record — so it needs no separate
+  teardown, and a stale watcher exits before it can probe a port some other
+  backend has since taken.
+
+`backend_status.running` on `/api/apps` is likewise read off the record
+(`AppProcess.is_running`) rather than asserted from the record merely existing.
+For an adopted backend, where we hold no handle to poll, "we still track it"
+is the only honest answer and `healthy` is the load-bearing signal.
+
+Writers: `apps/backend.py` (`_health_check_loop`, `_watch_backend_health`,
+`_demote`, `_promote`, `_supervise_backend_health`, `_start_health_supervisor`,
+`_start_adopted_health_watch`, `AppProcess.is_running`), `apps/routes.py`
+(`handle_list_apps`).

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -1068,7 +1068,160 @@ are `_health_check_loop` (bounded startup poll) and `_watch_backend_health`
 - **Both directions move the MCP entry**, through the same
   `_gate_mcp_registration` branches the startup phase uses: a demotion scrubs the
   app's HTTP MCP url so kiro-cli does not dial a dead port on every session, and a
-  recovery re-registers it.
+  recovery re-registers it. The scrub goes through the **no-live-port registration**
+  path, not a blanket deregister: an app's stdio/command servers are launched by kiro-cli
+  itself and have no port to be dead, so removing them because an HTTP backend died would
+  take working tools away for a reason unrelated to them. That path pops each HTTP entry
+  and keeps the rest, and its port lookup is health-gated, so it cannot resurrect the
+  port it is removing. It calls `_register_mcp_servers` DIRECTLY rather than
+  `reregister_app_mcp_servers`, because the latter also re-materializes the app's agents
+  — an ungated write that would land before the caller's enablement check and make a
+  disabled app's agents dispatchable in the gap. The scrub owns the mcp.json half only;
+  the agent refresh belongs to the caller, which gates it. The admission gate is applied
+  explicitly here so a denied app still gets a FULL removal rather than the selective
+  keep-stdio treatment. It falls back to removing EVERY entry for the app when the
+  manifest cannot be resolved or declares no servers: that case cannot tell a
+  backend-dependent server from an independent one, and the dead url must not survive on
+  the strength of not knowing. The fallback **never deletes the app's materialized
+  agents**. Deleting them is unrecoverable — it takes the user-owned fields
+  `_preserve_user_agent_edits` carries across every refresh — whereas what it would
+  prevent, an agent naming a server that is gone, costs failed tool calls until the next
+  refresh with a readable manifest rewrites it. An unreadable manifest is frequently
+  TRANSIENT, so destroying data over it trades a temporary fault for a permanent one.
+  `deregister_app` is the path that legitimately owns removing those files.
+
+**An adopted backend registers through the serialized transition BEFORE its watch is
+armed.** Registering afterwards — from a caller that returns and leaves the work queued —
+lets the watch demote and scrub in between, after which the queued write restores the
+dead url and, having bypassed `_set_backend_health`, leaves `mcp_healthy` agreeing with a
+state that is no longer on disk, so nothing retries. **The scrub also re-materializes the app's agents**, because
+  an agent JSON COPIES the server's launch spec and the agent config is what kiro-cli
+  loads — clearing the global map alone leaves the dead url one file over. Registration
+  already refreshes agents for this reason; the scrub mirrors it by calling the SAME
+  `refresh_app_agents`, which carries the two guards this path must honour: an app with
+  `resources="app"` publishes its own agents and the gateway must not duplicate them, and
+  a denied app's agents are scrubbed rather than rewritten back into dispatchable
+  existence. Both return an empty list, which is "nothing to do" rather than a failure.
+  **Registration owes the same guarantee**: it writes the same agent JSONs, so an agent
+  write that failed there leaves the app's agent without the MCP tools the registration
+  was supposed to make reachable. Both directions collect I/O failures and report the
+  reconcile unlanded, so the watch retries either way. A FAILED refresh makes
+  the whole reconcile unlanded, so the watch retries it. Registration treats its own
+  refresh as non-fatal, but that path has no retry behind it — there, non-fatal means
+  "do not fail the registration". Here a re-scrub is idempotent and cheap, and the
+  alternative is a dead url left permanently in the file kiro-cli actually reads. An app
+  with no resolvable manifest has nothing materialized to correct and counts as
+  reconciled, since retrying that would never converge. The same distinction applies
+  WITHIN the refresh: `_register_agents` skips a failing agent and continues, so it
+  reports the agents it could not read or write for **I/O** reasons and only those make
+  the reconcile unlanded. Its other skips — a path escaping the app root, an unsafe agent
+  name, malformed JSON, an unresolved placeholder — are permanent refusals, and treating
+  "declared minus registered" as the retry signal would spin forever on an app that can
+  never converge.
+- **The probe treats a malformed HTTP response as a failed probe, not an error.**
+  `http.client.HTTPException` is NOT an `OSError` or `URLError` subclass (only
+  `RemoteDisconnected` is, via `ConnectionResetError`), and `urllib` re-raises
+  `getresponse()` failures unwrapped — so a `BadStatusLine` from a port answering with a
+  non-HTTP first line escapes a socket-errors-only catch. An app backend is arbitrary
+  third-party code, including `exec` backends and adopted processes, so that is a real
+  condition rather than a hypothetical one. Both probes catch it. The watch additionally
+  survives an unexpected fault in any single sweep, because the failure MODE is the bug
+  itself: a dead watch thread freezes `healthy` at its last value and silently restores
+  the write-once behaviour, with the proxy still routing to a port nothing serves.
+- **Every writer of an app's MCP and agent state shares one serialization.** Two
+  independent families write it: the lifecycle paths in `apps/bridges.py` (enable,
+  update, boot reconcile) and the backend's health watch. Unserialized they interleave
+  their DECISIONS — each performing a correct read-modify-write, with the stale one
+  landing last — so `_register_mcp_servers`, `_deregister_mcp_servers` and
+  `_register_agents` all acquire `health_reconcile_lock()`. It is an **RLock**, because
+  the health path already holds it before calling into those writers; a plain Lock
+  deadlocks the watch thread there. Agent materialization holds it across the READ as
+  well as the write, since an agent copies the ambient server spec and a read taken
+  before a scrub could otherwise be written after it. The order is always this lock
+  first, then `_lock` or `_mcp_lock` — never the reverse — which is what keeps the two
+  families from deadlocking against each other.
+- **A promotion requires a positively confirmed ENABLED app; a demotion never does.**
+  `kirocrew app disable` runs in its own process: it deregisters the app's resources and
+  never touches the gateway's tracking table, so the record survives and a later health
+  recovery would re-register the MCP servers and agents the operator just removed. The
+  check fails CLOSED — an unreadable enabled-state refuses the promotion rather than
+  guessing, because guessing wrong makes a disabled app dispatchable again. Demotion is
+  deliberately ungated: refusing a scrub because enablement could not be read would
+  strand the dead url this whole mechanism exists to remove.
+
+  The flag has to be flipped BEFORE the resources come down, or the check reads a stale
+  `enabled` while they are already gone. The gateway's own disable path has no such
+  window — `teardown_app_runtime` stops the backend first, which pops the record and ends
+  the watch — but `kirocrew app disable` runs in ANOTHER process and cannot pop it, so it
+  closes the window by ordering: `disable_app` then `deregister_app`.
+
+  Ordering closes one interleave; it cannot close the other, where the check passes and
+  the disable completes before the write lands. There is no lock to share across
+  processes, so the promotion is **verified after the write** and undone through
+  `deregister_app` when the app turns out to have been disabled meanwhile. Check-act-
+  verify is the convergence available here, and the undo is idempotent with the CLI's own
+  deregistration. `deregister_app` reports most problems SOFTLY, in
+  `RegistrationResult.errors` rather than by raising, so the undo reads that list and
+  moves `mcp_healthy` to False only on a complete removal — otherwise a failed cleanup
+  would read as done and a disabled app would stay dispatchable with nothing left to
+  retry. The refused-promotion path retries an unlanded undo on every sweep, because
+  nothing else revisits a disabled app.
+
+  A demotion's **scrub** is never gated or verified, for the same reason: removing a
+  disabled app's entry is the desired outcome, not something to roll back. Its **agent
+  refresh is**, and the distinction is the point — the scrub REMOVES, while the refresh
+  RE-MATERIALIZES, so for a disabled app it writes back the very files a concurrent
+  `deregister_app` just removed. That refresh is checked before and after and undone if
+  the disable wins, and the cleanup's OWN result is the reconcile's result, since
+  `deregister_app` reports softly and discarding it would record a removal that never
+  happened.
+
+  The identity guard runs BEFORE the enablement check, because the undo deregisters by
+  app NAME: an unreadable enabled state is exactly what would otherwise send a retired
+  watcher into deleting the SUCCESSOR's resources.
+
+  Enablement is **tri-state** — enabled, disabled, or unreadable — read through
+  `manager.app_enabled_state`, NOT `is_app_enabled`. That distinction is the whole
+  mechanism: `_read_installed` returns None for both a missing file and a caught read
+  error, so `is_app_enabled` collapses "unreadable" into False WITHOUT raising. Building
+  the tri-state on it left the unknown branch unreachable for precisely the transient
+  fault it exists to catch. The two callers want opposite defaults on that third state. Refusing to ADD when it is unknown is
+  safe: the app stays as it is. DELETING when it is unknown is not, since the cleanup
+  unlinks materialized agents and `installed.json` can fail to read transiently, so
+  collapsing "unknown" into "disabled" would destroy user edits over a temporary fault.
+  Unknown therefore refuses a promotion AND refuses a deletion, reporting unlanded so the
+  watch retries. That applies at **every** deletion site — the demotion path and both
+  undo calls in `_set_backend_health` — since all three reach the same
+  `deregister_app` → `_deregister_agents` → unlink. A demotion does not even read the
+  state: it is a file access with no bearing on a scrub.
+
+  A **transition always reconciles**, even when `healthy` and `mcp_healthy` agree. That
+  flag can be stale in the other direction after a partial reconcile — an MCP write that
+  landed followed by an agent write that did not leaves it unmoved while the entry is on
+  disk — so matching it across a flip would skip the scrub and strand the dead url. The
+  short-circuit is valid only when the verdict did not change, which is what keeps a
+  settled backend from rewriting `mcp.json` every sweep.
+
+  An **unreadable manifest leaves the scrub unlanded.** Keeping the agents there is
+  right, but it leaves them naming the server just removed, and `refresh_app_agents`
+  gives up on the same condition — so nothing else revisits those files. Reporting it
+  unlanded makes the watch retry until the manifest is readable and the refresh can
+  correct them, instead of recording a job that was only half done.
+- **Teardown participates in the same serialization.** `stop_app_backend` takes
+  `_health_reconcile_lock` across its pop, so it and a reconcile are mutually exclusive:
+  either the reconcile finishes and the pop follows it (the caller's subsequent
+  `deregister_app` then wins), or the pop lands first and the reconcile's identity check
+  fails. Without that, a watcher already past its identity check could still be inside
+  the MCP write when the caller scrubbed, and its write would land after — restoring the
+  dead url this gate exists to keep out of `mcp.json`.
+- **An ADOPTED recovery re-binds ownership before it promotes.** `adopted_pids` is what
+  `stop_app_backend` signals and what uninstall acts behind, and it was captured at
+  adoption. A recovery means the EXTERNAL supervisor put something back, possibly a
+  different process — so the owner set is re-captured through the same consistency
+  sandwich adoption uses, and the promotion is REFUSED when ownership cannot be
+  confirmed. Unhealthy-but-serving is recoverable on the next sweep; a record that claims
+  freshly-valid ownership of a process that is gone is not, because stop would then
+  signal the wrong PIDs while the live replacement keeps running.
 - **The watch is bound to the RECORD, not the app name.** A stop/start installs a
   new `AppProcess` under the same name with its own watch, so every transition is
   guarded by `_processes.get(name) is ap`. Resolving by name instead would let a
@@ -1076,6 +1229,54 @@ are `_health_check_loop` (bounded startup poll) and `_watch_backend_health`
   watch terminates — `stop_app_backend` pops the record — so it needs no separate
   teardown, and a stale watcher exits before it can probe a port some other
   backend has since taken.
+- **A reconcile that did not land is retried, not stranded.** The health flag moves
+  whether or not the mcp.json write succeeded, so gating the reconcile on the health
+  *transition* alone would leave a transient failure uncorrected until the next
+  transition — which for a backend that then stays put never arrives, leaving either a
+  dead URL kiro-cli dials every session or a live backend with no MCP entry.
+  `AppProcess.mcp_healthy` records the value last SUCCESSFULLY written — **tri-state**,
+  where `None` means *unknown* (no write has been confirmed) and only `False` means
+  confirmed-scrubbed, so it must never be read as a plain boolean. Each sweep
+  reconciles when the verdict changed **or** when that record is behind the verdict.
+  The terminal exited-process path consults it too, and does not return until the entry
+  is reconciled or the record is dropped. That path is the one place where giving up is
+  permanent — nothing revisits an exited backend — so returning on an unlanded scrub
+  would strand the dead URL for kiro-cli to dial on every session.
+- **The startup poll belongs to ONE generation, bound at the spawn.** The supervisor is
+  handed the `AppProcess` itself and derives both name and port from it; every attempt
+  re-checks that the record is still the tracked one. A name plus a port are two
+  independent inputs that can DISAGREE — a restart landing between the record's insertion
+  and the supervisor thread's first statement would give a name lookup the successor
+  while the port argument still named the predecessor, and the poll would then act on a
+  backend whose port it never probed. Re-resolving by name — even per attempt — lets a stop/start inside the ~30s
+  startup window hand a later attempt the successor, which the poll would then promote,
+  or on exhaustion scrub, on evidence gathered entirely about its predecessor, having
+  never probed the successor's port. The exhaustion scrub is identity-guarded for the
+  same reason: it deregisters by app NAME, and because a bypassing scrub never touches
+  the successor's record, its `mcp_healthy` would still read True and the retry above
+  would never fire to put the entry back.
+- **That identity guard has to stay effective THROUGH the MCP reconcile**, which is
+  why every health transition goes through `_set_backend_health`. The MCP writers key
+  on the app NAME, not on the record — `_deregister_mcp_servers` removes every
+  `<app>:` entry — so checking identity only alongside the flag write would leave a
+  window in which a retiring watcher scrubs the SUCCESSOR's live servers, or
+  republishes its own dead port. `_lock` cannot just be held across the reconcile: it
+  does manifest and config file I/O, so the reverse proxy's `get_app_backend_port`
+  would block behind it on every request, and the `bridges ↔ backend` import cycle
+  makes it a deadlock risk. The ordering is established with a separate
+  `_health_reconcile_lock` that every health-driven reconcile takes, including the
+  startup registration. That is what makes it sufficient: passing the identity check
+  proves the successor is not yet in `_processes` and so has not registered, and its
+  own registration must then queue behind the retiring one — so the last write always
+  belongs to the live record.
+
+**Teardown stops the backend before scrubbing its resources.** `stop_app_backend` pops
+the tracking record, and that pop is what ends the watch's authority to reconcile MCP for
+the app — so it has to happen BEFORE `deregister_app`. Scrubbing first leaves a window in
+which a backend that recovers re-registers the OLD manifest's servers, and entries the
+update removed survive it. Uninstall and the disable rollback already ordered it this
+way; the two update paths in `apps/routes.py` now match them, and
+`test_update_stops_the_backend_before_deregistering_resources` pins it.
 
 `backend_status.running` on `/api/apps` is likewise read off the record
 (`AppProcess.is_running`) rather than asserted from the record merely existing.

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -6,6 +6,7 @@ the backend process lifecycle: spawn on enable, health-check, stop on disable.
 from __future__ import annotations
 
 import concurrent.futures
+import http.client
 import json
 import logging
 import os
@@ -65,6 +66,15 @@ _HEALTH_WATCH_INTERVAL = 15.0
 # would take a working app offline; an exited process needs no threshold at all because
 # it cannot recover. See _watch_backend_health.
 _HEALTH_WATCH_FAILURES = 3
+# Serializes health-driven MCP reconciliation (see _set_backend_health). Deliberately
+# NOT `_lock`: the reconcile does manifest + config file I/O, and holding `_lock` across
+# it would block the reverse proxy's get_app_backend_port on every request and risk a
+# deadlock through the bridges <-> backend import cycle.
+# RE-ENTRANT: the health path acquires this and then calls into bridges, whose MCP and
+# agent writers acquire it too (see health_reconcile_lock). A plain Lock would deadlock
+# on that re-entry, and dropping it from either side would leave the two families of
+# writer unordered again.
+_health_reconcile_lock = threading.RLock()
 
 # Spawn survival check: poll the freshly-spawned child over a short grace window to
 # confirm it survived its initial bind (an immediate exit -> EADDRINUSE crash-loop must
@@ -206,7 +216,8 @@ def _probe_adoption_health(port: int, health_path: str) -> bool:
         )
         with urllib.request.urlopen(req, timeout=3) as resp:
             return bool(resp.status < 400)
-    except (urllib.error.URLError, OSError):
+    # HTTPException is not an OSError — see _health_probe for why that matters.
+    except (urllib.error.URLError, OSError, http.client.HTTPException):
         return False
 
 
@@ -365,6 +376,11 @@ class AppProcess:
     proc: subprocess.Popen | None = field(default=None, repr=False)
     log_fh: Any = field(default=None, repr=False)
     healthy: bool = False
+    # The `healthy` value last SUCCESSFULLY reconciled into mcp.json, or None if nothing
+    # has been written for this record yet. Distinct from `healthy` because the flag
+    # moves even when the mcp.json write fails; the gap between them is what the watch
+    # retries. Deliberately absent from to_dict(): internal bookkeeping, not API.
+    mcp_healthy: bool | None = None
     started_at: float = 0.0
     log_path: str = ""
     adopted_pids: list[int] = field(default_factory=list)
@@ -776,6 +792,13 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 with _lock:
                     _processes[app_name] = ap
                     _allocated_ports[app_name] = port
+                # Register through the SERIALIZED transition, before the watch is armed.
+                # Registering afterwards — from a caller that returns and queues the work
+                # — leaves a window in which the watch demotes and scrubs first and the
+                # queued registration lands after it, restoring the dead url. Going
+                # through _set_backend_health also records `mcp_healthy`, so the watch
+                # can tell whether what it believes matches what is on disk.
+                _set_backend_health(ap, healthy=True)
                 _start_adopted_health_watch(ap, manifest.backend.healthCheck)
                 return ap
             else:
@@ -1229,7 +1252,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
 
     # Health check in background, then a standing liveness watch for as long as the
     # backend is tracked — see _supervise_backend_health.
-    _start_health_supervisor(app_name, port, manifest.backend.healthCheck)
+    _start_health_supervisor(ap, manifest.backend.healthCheck)
 
     return ap
 
@@ -1262,9 +1285,18 @@ def _wait_for_pids(pids: list[int], timeout: float = 2.0) -> None:
 
 def stop_app_backend(app_name: str) -> bool:
     """Stop an app's backend process."""
-    with _lock:
-        ap = _processes.pop(app_name, None)
-        _allocated_ports.pop(app_name, None)
+    # Teardown participates in the health serialization, so the pop cannot land in the
+    # middle of a reconcile. Without this, a watcher that had already passed its identity
+    # check could still be inside `_gate_mcp_registration` when the caller's subsequent
+    # `deregister_app` scrubs — and its write would land AFTER, restoring the dead url
+    # this whole gate exists to keep out of mcp.json. Holding it across the pop makes the
+    # two mutually exclusive: either the reconcile completes and this pop follows it (the
+    # caller's scrub then wins), or this pop lands first and the reconcile's identity
+    # check fails. Lock order matches `_set_backend_health`: reconcile lock, then `_lock`.
+    with _health_reconcile_lock:
+        with _lock:
+            ap = _processes.pop(app_name, None)
+            _allocated_ports.pop(app_name, None)
 
     _forget_app_pid(app_name)
 
@@ -1531,7 +1563,21 @@ def unstopped_backend_port(app_name: str, *, port_hint: int | None = None) -> in
 # Health checking
 # ---------------------------------------------------------------------------
 
-def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> None:
+def health_reconcile_lock() -> Any:
+    """The serialization every writer of an app's MCP + agent state must hold.
+
+    Exported for ``apps/bridges.py``, which acquires it around its mcp.json and agent
+    materialization so a lifecycle registration and a health transition cannot interleave
+    their decisions. Held re-entrantly: the health path already owns it before it calls
+    into those writers.
+
+    Ordering is always this lock FIRST, then ``_lock`` or bridges' ``_mcp_lock`` — never
+    the reverse — so the two families of writer cannot deadlock against each other.
+    """
+    return _health_reconcile_lock
+
+
+def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> bool:
     """Register the app's MCP servers once its backend is healthy, or scrub them if not.
 
     Called from the health-check loop so the global mcp.json never carries an HTTP MCP url
@@ -1539,72 +1585,169 @@ def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> None:
     pre-health port would leave a dead url for an enabled app whose backend never
     became healthy, breaking every kiro-cli session). On
     health success we (re)register with the confirmed live port; on failure we deregister
-    so no dead entry survives. Never raises — registration must not crash the health loop."""
+    so no dead entry survives. Never raises — registration must not crash the health loop.
+
+    Returns whether the reconcile landed. The caller records that, because the health
+    FLAG moves whether or not mcp.json could be written: without a success signal a
+    transient write failure would strand a dead (or missing) entry until the next health
+    transition, which for a backend that then stays put never comes."""
     try:
         if healthy:
             # circular import: bridges imports backend.get_app_backend_port, so deferring
             # this import to call time breaks the backend ↔ bridges module cycle.
             from kiro_crew.apps.bridges import reregister_app_mcp_servers
 
-            reregister_app_mcp_servers(app_name, live_port=port)
+            # Symmetric with the scrub below: the agent JSONs carry the server spec, so a
+            # registration whose agent half failed has not made the tools reachable — and
+            # letting `mcp_healthy` advance on it would strand the app's agent without
+            # its MCP tools, with nothing left to retry.
+            register_io_failures: list[str] = []
+            reregister_app_mcp_servers(
+                app_name, live_port=port, io_failures=register_io_failures
+            )
+            if register_io_failures:
+                logger.warning(
+                    "App %s: %d agent(s) could not be rewritten after MCP registration "
+                    "(%s); reporting the reconcile unlanded so the watch retries",
+                    app_name, len(register_io_failures), ", ".join(register_io_failures),
+                )
+                return False
         else:
             # circular import: see above — bridges ↔ backend cycle, deferred to call time.
-            from kiro_crew.apps.bridges import _deregister_mcp_servers
+            from kiro_crew.apps.bridges import scrub_backend_mcp_url
 
-            removed = _deregister_mcp_servers(app_name)
-            if removed:
+            # NOT a blanket deregister. An app's stdio MCP servers are launched by
+            # kiro-cli itself and have no port to be dead, so dropping them because an
+            # HTTP backend died takes working tools away for a reason that has nothing to
+            # do with them. scrub_backend_mcp_url pops the HTTP entry and keeps the rest
+            # — falling back to removing everything when the manifest cannot say which is
+            # which, since the dead url must not survive on the strength of not knowing.
+            scrub_unreconciled: list[str] = []
+            kept = scrub_backend_mcp_url(app_name, unreconciled=scrub_unreconciled)
+            if scrub_unreconciled:
                 logger.warning(
-                    "Scrubbed %d MCP server(s) for app %s after backend failed health check",
-                    removed, app_name,
+                    "App %s: the scrub could not be completed (%s); reporting it "
+                    "unlanded so the watch retries",
+                    app_name, "; ".join(scrub_unreconciled),
                 )
+                return False
+            if kept:
+                logger.info(
+                    "App %s: kept %d backend-independent MCP server(s) after the scrub",
+                    app_name, len(kept),
+                )
+            # The scrub is only half the removal: an app's materialized agent JSONs COPY
+            # the server's launch spec, and the agent config is what kiro-cli loads. So
+            # clearing the global map alone leaves the agents still naming the dead url —
+            # the exact outage this gate exists to prevent, just one file over.
+            # Registration already refreshes agents for this reason; mirror it here.
+            #
+            # A failed refresh makes the whole reconcile UNLANDED rather than being
+            # swallowed. Registration treats its own refresh as non-fatal, but that path
+            # has no retry behind it, so non-fatal there means "do not fail the
+            # registration". Here the watch retries, an idempotent re-scrub is cheap, and
+            # the alternative is a dead url left permanently in the file kiro-cli reads.
+            from kiro_crew.apps.bridges import refresh_app_agents
+
+            # refresh_app_agents, NOT a hand-rolled re-materialization: it already
+            # carries the two guards this path must honour — a `resources="app"` app
+            # registers its own agents and the gateway must not publish duplicates, and
+            # a denied app's agents must be SCRUBBED rather than rewritten back into
+            # dispatchable existence. Both return an empty list, which is "nothing for us
+            # to do" rather than a failure; only the io_failures collector means retry.
+            # The agent refresh RE-MATERIALIZES this app's agent configs. Unlike the
+            # scrub above — always safe, and therefore never gated — that is a WRITE, and
+            # for an app the operator has disabled it puts back the very files a
+            # concurrent `deregister_app` just removed. Checked BEFORE and AFTER: the CLI
+            # runs in another process, so neither check can be atomic with the write, and
+            # only the pair converges.
+            # Deleting happens only on a CONFIRMED disable. `_drop_disabled_app_resources`
+            # unlinks materialized agents, taking user-owned fields with them, and
+            # `installed.json` can fail to read transiently — so an UNKNOWN state must
+            # not be collapsed into "disabled". It reports unlanded instead and the watch
+            # retries. The cleanup's own result is the reconcile's result, because
+            # deregister_app reports softly and discarding it would record a removal that
+            # never happened.
+            enabled = _app_enabled_state(app_name)
+            if enabled is False:
+                return _drop_disabled_app_resources(app_name)
+            if enabled is None:
+                return False  # unknown: neither refresh nor delete; try again next sweep
+            scrub_io_failures: list[str] = []
+            refresh_app_agents(app_name, io_failures=scrub_io_failures)
+            enabled = _app_enabled_state(app_name)
+            if enabled is False:
+                return _drop_disabled_app_resources(app_name)
+            if enabled is None:
+                return False
+            if scrub_io_failures:
+                logger.warning(
+                    "App %s: %d agent(s) could not be rewritten after the MCP scrub (%s); "
+                    "reporting the reconcile unlanded so the watch retries",
+                    app_name, len(scrub_io_failures), ", ".join(scrub_io_failures),
+                )
+                return False
+        return True
     except Exception as exc:  # noqa: BLE001 — health loop must never crash on reconcile
         logger.warning("Health-gated MCP registration failed for app %s: %s", app_name, exc)
+        return False
 
 
 def _health_probe(url: str) -> bool:
-    """Whether the health endpoint answers below 400. Never raises."""
+    """Whether the health endpoint answers below 400. Never raises.
+
+    `http.client.HTTPException` is caught alongside the socket errors because it is NOT
+    an `OSError` or `URLError` subclass (only `RemoteDisconnected` is, via
+    `ConnectionResetError`), and `urllib`'s `do_open` re-raises `getresponse()` failures
+    unwrapped. An app backend is arbitrary third-party code — an `exec` backend, or an
+    adopted process we do not own — so a non-HTTP first line on the port is a real
+    condition, and `BadStatusLine` escaping here would kill the standing watch thread
+    and freeze `healthy` at its last value: silently reinstating the write-once bug this
+    module's watch exists to prevent.
+    """
     try:
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=_HEALTH_CHECK_TIMEOUT) as resp:
             return bool(resp.status < 400)
-    except (urllib.error.URLError, OSError):
+    except (urllib.error.URLError, OSError, http.client.HTTPException):
         return False
 
 
-def _health_check_loop(app_name: str, port: int, health_path: str) -> AppProcess | None:
+def _health_check_loop(ap: AppProcess, health_path: str) -> AppProcess | None:
     """Poll the health endpoint until it responds or we give up.
 
-    Returns the tracking record this call promoted to healthy, or None if the backend
-    never answered (or stopped being tracked mid-check). The record — not the app name —
-    is what :func:`_watch_backend_health` needs to keep watching it: a later
-    stop/start replaces the entry under the same name, and a watch that re-resolved by
-    name could demote a NEWER generation it never observed.
+    Takes the RECORD rather than a name and a port, which is what binds the whole poll to
+    one generation. A name plus a port are two independent inputs that can disagree: a
+    stop/start landing between the spawn and this thread's first statement would hand a
+    name lookup the SUCCESSOR while the port argument still named the predecessor, and
+    the poll would then promote — or on exhaustion scrub — a backend whose port it never
+    probed. Deriving both from the record leaves nothing to disagree.
+
+    Returns the record if this call promoted it to healthy, else None (never answered, or
+    no longer the tracked entry).
     """
+    app_name = ap.app_name
+    port = ap.port
     url = f"http://127.0.0.1:{port}{health_path}"
     for attempt in range(_HEALTH_CHECK_RETRIES):
         time.sleep(_HEALTH_CHECK_INTERVAL)
         with _lock:
-            if app_name not in _processes:
-                return None  # stopped while we were checking
+            if _processes.get(app_name) is not ap:
+                return None  # replaced or stopped — this poll is a retired generation
         if _health_probe(url):
-            with _lock:
-                # Stopped/disabled between the health poll and here: do NOT
-                # register MCP for a backend that's no longer tracked — that would
-                # write the exact dead-URL entry this guard prevents.
-                # Mirror the top-of-loop guard.
-                ap = _processes.get(app_name)
-                if ap is None:
-                    return None
-                ap.healthy = True
-            logger.info(
-                "App %s backend healthy (port %d, attempt %d)",
-                app_name, port, attempt + 1,
-            )
             # Health-gated MCP registration: only now that the
             # backend has passed /health do we write its HTTP MCP url (live port) to
             # global mcp.json. Registering before this could leave a dead-but-enabled
             # url for an app whose backend never became healthy — the kiro-cli outage.
-            _gate_mcp_registration(app_name, port, healthy=True)
+            # Routed through the shared transition, which re-checks that `ap` is still
+            # the tracked record, so this is ordered against the watch's demotions
+            # rather than racing them.
+            if not _set_backend_health(ap, healthy=True):
+                return None
+            logger.info(
+                "App %s backend healthy (port %d, attempt %d)",
+                app_name, port, attempt + 1,
+            )
             return ap
 
     logger.warning(
@@ -1613,11 +1756,73 @@ def _health_check_loop(app_name: str, port: int, health_path: str) -> AppProcess
     )
     # Backend never became healthy: scrub any optimistic/stale MCP entry so kiro-cli does
     # not keep dialing a dead port on every session (the reverted-outage shape).
-    _gate_mcp_registration(app_name, port, healthy=False)
+    #
+    # Identity-guarded like every other transition, on the one record this loop probed.
+    # `_deregister_mcp_servers` removes by app NAME, so a restart during the startup
+    # window — whose successor may already have come up and registered — would otherwise
+    # have this retiring loop scrub the healthy successor's entry. That scrub also
+    # bypasses the record, so the successor's `mcp_healthy` would still read True and the
+    # watch's retry condition would never fire to put it back.
+    _set_backend_health(ap, healthy=False)
     return None
 
 
+def _rebind_adopted_owners(ap: AppProcess, health_path: str) -> bool:
+    """Re-capture an adopted backend's owning PIDs, or refuse to confirm ownership.
+
+    Reuses the adoption-time consistency sandwich (:func:`_capture_adopted_owners`), so a
+    responder that exits mid-capture cannot hand ownership to a bystander. Returns False
+    when ownership cannot be established, which the caller treats as "do not promote".
+    """
+    try:
+        captured = _capture_adopted_owners(ap.app_name, ap.port, health_path)
+    except Exception as exc:  # noqa: BLE001 — the watch must never die on a probe
+        logger.warning(
+            "App %s: could not re-capture adopted owners on port %d: %s",
+            ap.app_name, ap.port, exc,
+        )
+        return False
+    if captured is None:
+        logger.warning(
+            "App %s: adopted backend on port %d answered again but its ownership could "
+            "not be confirmed — leaving it unhealthy", ap.app_name, ap.port,
+        )
+        return False
+    pids, start_times = captured
+    with _lock:
+        if _processes.get(ap.app_name) is not ap:
+            return False
+        ap.adopted_pids = pids
+        ap.adopted_start_times = start_times
+    return True
+
+
 def _watch_backend_health(ap: AppProcess, health_path: str) -> None:
+    """Run the liveness watch, surviving an unexpected fault in any single sweep.
+
+    The whole point of the guard is the failure MODE: an exception escaping the sweep
+    kills this daemon thread, and a dead watch freezes ``healthy`` at its last value —
+    silently restoring the write-once behaviour this watch exists to remove, with the
+    proxy still routing to a port nothing serves. A logged fault that costs one sweep is
+    strictly better. Restarting resets the consecutive-failure counter, which is the
+    conservative direction (it delays a demotion rather than causing a spurious one), and
+    the inner loop sleeps before its first probe, so a persistent fault cannot spin.
+    """
+    while True:
+        try:
+            _watch_backend_health_sweeps(ap, health_path)
+            return
+        except Exception:  # noqa: BLE001 — see the docstring; a dying watch is the bug
+            logger.warning(
+                "App %s: health watch sweep failed on port %d; restarting the watch",
+                ap.app_name, ap.port, exc_info=True,
+            )
+            with _lock:
+                if _processes.get(ap.app_name) is not ap:
+                    return  # no longer tracked — nothing left to watch
+
+
+def _watch_backend_health_sweeps(ap: AppProcess, health_path: str) -> None:
     """Keep re-checking an already-healthy backend so ``healthy`` can go back to False.
 
     Without this the startup poll would leave ``healthy`` a write-once cache: a backend
@@ -1651,63 +1856,282 @@ def _watch_backend_health(ap: AppProcess, health_path: str) -> None:
             if _processes.get(ap.app_name) is not ap:
                 return
             was_healthy = ap.healthy
+            mcp_healthy = ap.mcp_healthy
             proc = ap.proc
 
         if proc is not None and proc.poll() is not None:
+            # A dead Popen never revives, so there is no health verdict left to reach —
+            # but the watch may not leave until the MCP entry is actually out. This is
+            # the one place where giving up strands the dead URL permanently: nothing
+            # else revisits an exited backend, so a scrub that did not land would stay
+            # unlanded and kiro-cli would keep dialing it every session. Keep sweeping
+            # (one attempt per interval) until the entry is reconciled or the record is
+            # dropped by stop_app_backend.
+            #
+            # `mcp_healthy` gates this as well as `healthy`: an entry that still says
+            # healthy has to come out even when the flag was moved without the write
+            # landing. It is TRI-STATE, and only `False` means "confirmed scrubbed" —
+            # `None` is *unknown*, which is what a failed startup reconcile leaves
+            # behind, and treating it as "nothing to unwind" would abandon exactly the
+            # entry that most needs removing.
             if was_healthy:
                 _demote(ap, reason=f"process exited (rc={proc.returncode})")
-            return  # decisive: a dead Popen never revives
+            elif mcp_healthy is not False:
+                _retry_mcp_reconcile(ap, healthy=False)
+            else:
+                return  # confirmed scrubbed — nothing to unwind
+            with _lock:
+                dropped = _processes.get(ap.app_name) is not ap
+                reconciled = ap.mcp_healthy is False
+            if dropped or reconciled:
+                return
+            continue
 
         if _health_probe(url):
             consecutive_failures = 0
-            if not was_healthy:
-                _promote(ap)
-            continue
+            healthy = True
+        else:
+            consecutive_failures += 1
+            healthy = was_healthy and consecutive_failures < _HEALTH_WATCH_FAILURES
 
-        consecutive_failures += 1
-        if was_healthy and consecutive_failures >= _HEALTH_WATCH_FAILURES:
-            _demote(ap, reason=f"{consecutive_failures} consecutive failed health probes")
+        if healthy != was_healthy:
+            if healthy:
+                # An ADOPTED record carries the PIDs `stop_app_backend` will signal and
+                # `uninstall` will act behind. Those were captured at adoption, and a
+                # recovery means the EXTERNAL supervisor put something back — quite
+                # possibly a different process. Promoting without re-binding ownership
+                # would mark the record freshly-valid while its identities name a process
+                # that is gone, so stop would signal the wrong PIDs (or none) and leave
+                # the live replacement running while its files are mutated or removed.
+                # Refuse the promotion instead: unhealthy-but-serving is recoverable on
+                # the next sweep, a mis-bound owner set is not.
+                if ap.proc is None and not _rebind_adopted_owners(ap, health_path):
+                    continue
+                _promote(ap)
+            else:
+                _demote(ap, reason=f"{consecutive_failures} consecutive failed health probes")
+        elif mcp_healthy != healthy:
+            # The verdict is unchanged but mcp.json never caught up — a previous
+            # reconcile failed. Retry it here rather than waiting for the next health
+            # transition, which for a backend that now stays put would never arrive.
+            _retry_mcp_reconcile(ap, healthy=healthy)
+
+
+def _app_enabled_state(app_name: str) -> bool | None:
+    """Tri-state enablement: True, False, or None when it could not be read.
+
+    The distinction is load-bearing, because the two callers want OPPOSITE defaults on an
+    unreadable state. Refusing to ADD resources when enablement is unknown is safe — the
+    app stays as it is. DELETING them when it is unknown is not: `_drop_disabled_app_resources`
+    unlinks materialized agents, taking the user-owned fields `_preserve_user_agent_edits`
+    carries, and `installed.json` can fail to read transiently. Collapsing "unknown" into
+    "disabled" would destroy data over a temporary fault.
+    """
+    try:
+        # circular import: manager imports from this module's package at call time.
+        #
+        # `app_enabled_state`, NOT `is_app_enabled`: the latter returns False for BOTH a
+        # deliberate disable and an unreadable metadata file, because `_read_installed`
+        # answers None to both. Trusting that collapsed False would make this whole
+        # tri-state a no-op for the transient fault it exists to catch — the read error
+        # never raises, so the `except` below would never see it.
+        from kiro_crew.apps.manager import app_enabled_state
+
+        return app_enabled_state(app_name)
+    except Exception as exc:  # noqa: BLE001 — unknown is a state, not a crash
+        logger.warning(
+            "App %s: could not read its enabled state: %s", app_name, exc,
+        )
+        return None
+
+
+def _drop_disabled_app_resources(app_name: str) -> bool:
+    """Remove everything registered for an app that turned out to be disabled.
+
+    Returns whether the removal COMPLETED. ``deregister_app`` reports most problems
+    softly, in ``RegistrationResult.errors`` rather than by raising, so a failed removal
+    looks identical to a clean one unless that list is read. Idempotent with the CLI's
+    own deregistration, so running it a second time costs nothing.
+    """
+    try:
+        # circular import: bridges ↔ backend, deferred to call time.
+        from kiro_crew.apps.bridges import deregister_app
+
+        result = deregister_app(app_name)
+    except Exception as exc:  # noqa: BLE001 — must not crash the watch
+        logger.warning("App %s: could not drop a disabled app's resources: %s", app_name, exc)
+        return False
+    errors = list(getattr(result, "errors", None) or [])
+    if errors:
+        logger.warning(
+            "App %s: dropping a disabled app's resources did not complete (%s)",
+            app_name, "; ".join(errors),
+        )
+        return False
+    return True
+
+
+def _undo_promotion_of_disabled_app(ap: AppProcess) -> bool:
+    """Remove what a promotion registered for an app disabled while it was being written.
+
+    The enabled check and the write CANNOT be atomic: ``kirocrew app disable`` runs in
+    another process, so there is no lock to share with it. Ordering closes the interleave
+    where the flag is read after the resources come down; this closes the other one,
+    where the check passes and the disable completes before the write lands. Verifying
+    afterwards and undoing is the convergence that is actually available.
+
+    ``deregister_app`` is idempotent and removes exactly what the promotion put back, so
+    running it a second time after the CLI's own call costs nothing.
+
+    Returns whether the removal COMPLETED. ``deregister_app`` reports most problems
+    softly, in ``RegistrationResult.errors`` rather than by raising, so a failed removal
+    looks identical to a clean one unless that list is read. ``mcp_healthy`` therefore
+    only moves to False on a complete success — leaving it otherwise is what makes the
+    next sweep try again, instead of recording a removal that did not happen and letting
+    a disabled app stay dispatchable.
+    """
+    with _lock:
+        if _processes.get(ap.app_name) is ap:
+            ap.healthy = False
+    if not _drop_disabled_app_resources(ap.app_name):
+        logger.warning(
+            "App %s: undoing the registration of a now-disabled app did not complete; "
+            "retrying on the next sweep", ap.app_name,
+        )
+        return False
+    with _lock:
+        if _processes.get(ap.app_name) is ap:
+            ap.mcp_healthy = False
+    logger.warning(
+        "App %s was disabled while its recovery was being registered; the registration "
+        "has been undone", ap.app_name,
+    )
+    return True
+
+
+def _set_backend_health(ap: AppProcess, *, healthy: bool) -> bool:
+    """Flip ``ap.healthy`` and move its MCP entry, only while ``ap`` is still tracked.
+
+    The identity re-check has to stay effective THROUGH the reconcile, not merely
+    alongside the flag write, because the MCP writers key on the app NAME rather than on
+    this record: `_deregister_mcp_servers` removes every ``<app>:`` entry, so a verdict
+    formed about a record that has since been replaced would scrub the SUCCESSOR's live
+    servers, and a stale re-register would publish the predecessor's dead port — the
+    dead-URL outage the health gating exists to prevent.
+
+    `_lock` cannot simply be held across the reconcile (it does manifest and config file
+    I/O, and the proxy's get_app_backend_port must not block behind it), so the ordering
+    is established with `_health_reconcile_lock` instead. That is sufficient because
+    every health-driven reconcile takes it: passing the identity check proves the
+    successor is not yet in `_processes`, hence has not registered, and its own
+    registration must then queue behind this one — so the last write is always the
+    live record's.
+
+    Returns True if the transition was applied.
+    """
+    with _health_reconcile_lock:
+        # IDENTITY FIRST. The undo below deregisters by app NAME, so running it for a
+        # record that is no longer the tracked one would delete the SUCCESSOR's
+        # resources — and an unreadable enabled state is exactly the case that would
+        # send a retired watcher down that path.
+        with _lock:
+            if _processes.get(ap.app_name) is not ap:
+                return False
+        # Only a promotion is gated; a demotion's scrub must never be blocked — and must
+        # not even READ the enabled state, which is a file access it has no use for.
+        enabled = _app_enabled_state(ap.app_name) if healthy else True
+        if enabled is not True:
+            # Undo ONLY on a CONFIRMED disable. The undo deregisters, which unlinks
+            # materialized agents and takes the user-owned fields with them, and
+            # `installed.json` can fail to read transiently — an unknown state must not
+            # be allowed to destroy data over a temporary fault. Unknown simply refuses
+            # the promotion and tries again next sweep.
+            #
+            # When it IS confirmed disabled and the record still believes something of
+            # ours is registered, an earlier undo did not land; this is where it is
+            # retried, because nothing else revisits a disabled app.
+            if enabled is False and ap.mcp_healthy is not False:
+                _undo_promotion_of_disabled_app(ap)
+            return False
+        with _lock:
+            if _processes.get(ap.app_name) is not ap:
+                return False
+            unchanged = ap.healthy == healthy
+            ap.healthy = healthy
+            # Short-circuit ONLY when the verdict did not change. `mcp_healthy` can be
+            # stale in the other direction after a partial reconcile — an MCP write that
+            # landed followed by an agent write that did not leaves it unmoved — so on a
+            # TRANSITION the reconcile has to run even when the two happen to agree, or
+            # a demotion would skip the scrub and leave the dead url registered.
+            if unchanged and ap.mcp_healthy == healthy:
+                return True  # already reconciled — nothing to rewrite
+        if _gate_mcp_registration(ap.app_name, ap.port, healthy=healthy):
+            with _lock:
+                # Only a reconcile that LANDED updates the record, so a transient
+                # failure leaves `mcp_healthy` out of step with `healthy` and the
+                # watch's next sweep tries again. Re-check identity: the write
+                # happened outside `_lock`.
+                if _processes.get(ap.app_name) is ap:
+                    ap.mcp_healthy = healthy
+        # VERIFY, because the check above could not be atomic with the write: a disable
+        # in the CLI's process can complete in between, and leaving the registration
+        # would keep a disabled app dispatchable.
+        # Same asymmetry on the verify: only a CONFIRMED disable undoes. An unknown
+        # state here leaves the registration standing — the pre-check had confirmed the
+        # app enabled, so the likely reading is a momentary read fault, and deleting on
+        # that basis is the unrecoverable direction.
+        if healthy and _app_enabled_state(ap.app_name) is False:
+            _undo_promotion_of_disabled_app(ap)
+            return False
+        return True
 
 
 def _demote(ap: AppProcess, *, reason: str) -> None:
     """Mark a backend unhealthy and scrub its MCP entry. Reversible — see _promote."""
-    with _lock:
-        if _processes.get(ap.app_name) is not ap:
-            return
-        ap.healthy = False
-    logger.warning(
-        "App %s backend went unhealthy on port %d — %s", ap.app_name, ap.port, reason,
-    )
-    # Same reason the startup failure path scrubs: an enabled app must not leave a dead
-    # HTTP MCP url behind for kiro-cli to dial on every session.
-    _gate_mcp_registration(ap.app_name, ap.port, healthy=False)
+    if _set_backend_health(ap, healthy=False):
+        logger.warning(
+            "App %s backend went unhealthy on port %d — %s", ap.app_name, ap.port, reason,
+        )
 
 
 def _promote(ap: AppProcess) -> None:
     """Mark a backend healthy again after a demotion and re-register its MCP servers."""
-    with _lock:
-        if _processes.get(ap.app_name) is not ap:
-            return
-        ap.healthy = True
-    logger.info("App %s backend recovered on port %d", ap.app_name, ap.port)
-    _gate_mcp_registration(ap.app_name, ap.port, healthy=True)
+    if _set_backend_health(ap, healthy=True):
+        logger.info("App %s backend recovered on port %d", ap.app_name, ap.port)
 
 
-def _supervise_backend_health(app_name: str, port: int, health_path: str) -> None:
+def _retry_mcp_reconcile(ap: AppProcess, *, healthy: bool) -> None:
+    """Re-attempt a reconcile that did not land, without re-announcing its transition.
+
+    The health verdict has not changed here — only mcp.json is behind — so this logs at
+    debug rather than repeating the demote/recover line every sweep until it succeeds.
+    """
+    if _set_backend_health(ap, healthy=healthy):
+        logger.debug(
+            "App %s: retried MCP reconcile (healthy=%s) on port %d",
+            ap.app_name, healthy, ap.port,
+        )
+
+
+def _supervise_backend_health(ap: AppProcess, health_path: str) -> None:
     """Thread target: wait for the backend to come up, then watch it for as long as it
     stays tracked."""
-    ap = _health_check_loop(app_name, port, health_path)
-    if ap is not None:
+    if _health_check_loop(ap, health_path) is not None:
         _watch_backend_health(ap, health_path)
 
 
-def _start_health_supervisor(app_name: str, port: int, health_path: str) -> None:
-    """Run :func:`_supervise_backend_health` on this backend's own daemon thread."""
+def _start_health_supervisor(ap: AppProcess, health_path: str) -> None:
+    """Run :func:`_supervise_backend_health` on this backend's own daemon thread.
+
+    The record is handed over directly, so the supervisor is bound to this generation
+    from the moment of the spawn — there is no window between inserting the record and
+    the thread resolving it in which a restart could substitute a different one.
+    """
     threading.Thread(
         target=_supervise_backend_health,
-        args=(app_name, port, health_path),
+        args=(ap, health_path),
         daemon=True,
-        name=f"app-health-{app_name}",
+        name=f"app-health-{ap.app_name}",
     ).start()
 
 
@@ -2266,6 +2690,9 @@ def _start_backends_concurrently(names: list[str]) -> list[str]:
                 # dead url for an enabled-but-never-healthy app and break every
                 # kiro-cli session. EXCEPTION: an adopted already-healthy instance
                 # runs no health loop, so register it synchronously now.
+                # Routed through the shared transition so this shares one order with
+                # the watch that _start_adopted_health_watch has by now armed on the
+                # same record — the two must not interleave their mcp.json writes.
                 if ap.healthy:
-                    _gate_mcp_registration(name, ap.port, healthy=True)
+                    _set_backend_health(ap, healthy=True)
     return started

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -52,6 +52,20 @@ _HEALTH_CHECK_TIMEOUT = 5
 _HEALTH_CHECK_RETRIES = 15
 _HEALTH_CHECK_INTERVAL = 2.0
 
+# Post-startup liveness watch (see _watch_backend_health). The startup poll above only
+# establishes that a backend CAME UP; without a standing watch `healthy` would be a
+# write-once cache and a backend that died later would keep the reverse proxy routing to
+# a dead port. The interval is far coarser than the startup one because it runs for the
+# whole life of every backend, and nothing is waiting on it — a demotion that lands one
+# interval late costs a few refused requests, whereas a tight poll costs one HTTP round
+# trip per backend forever.
+_HEALTH_WATCH_INTERVAL = 15.0
+# Consecutive failed probes of a process that is still ALIVE before it is demoted. A
+# backend can be briefly busy (a slow request, a GC pause), so demoting on a single miss
+# would take a working app offline; an exited process needs no threshold at all because
+# it cannot recover. See _watch_backend_health.
+_HEALTH_WATCH_FAILURES = 3
+
 # Spawn survival check: poll the freshly-spawned child over a short grace window to
 # confirm it survived its initial bind (an immediate exit -> EADDRINUSE crash-loop must
 # be caught, see _start_app_backend_body). The loop breaks as soon as the process exits,
@@ -365,12 +379,26 @@ class AppProcess:
     # popped on failure. Concurrent start_app_backend calls see it and skip duplicate spawn.
     starting: bool = False
 
+    def is_running(self) -> bool:
+        """Whether the tracked process is still alive.
+
+        A backend we spawned answers from its own already-reaped exit status, so this
+        costs no syscall to the app and cannot block. An ADOPTED backend belongs to
+        another supervisor and we hold no handle for it, so the only honest answer is
+        that we still track it — there, ``healthy`` (kept current by
+        :func:`_watch_backend_health`) is the load-bearing signal.
+        """
+        if self.proc is None:
+            return True
+        return self.proc.poll() is None
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "app_name": self.app_name,
             "port": self.port,
             "pid": self.pid,
             "healthy": self.healthy,
+            "running": self.is_running(),
             "started_at": self.started_at,
             "log_path": self.log_path,
         }
@@ -748,6 +776,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                 with _lock:
                     _processes[app_name] = ap
                     _allocated_ports[app_name] = port
+                _start_adopted_health_watch(ap, manifest.backend.healthCheck)
                 return ap
             else:
                 try:
@@ -1198,12 +1227,9 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     # Persist identity for the startup stale-reap (see _reap_stale_app_backends).
     _record_app_pid(app_name, proc.pid, port)
 
-    # Health check in background
-    threading.Thread(
-        target=_health_check_loop,
-        args=(app_name, port, manifest.backend.healthCheck),
-        daemon=True,
-    ).start()
+    # Health check in background, then a standing liveness watch for as long as the
+    # backend is tracked — see _supervise_backend_health.
+    _start_health_supervisor(app_name, port, manifest.backend.healthCheck)
 
     return ap
 
@@ -1535,38 +1561,51 @@ def _gate_mcp_registration(app_name: str, port: int, *, healthy: bool) -> None:
         logger.warning("Health-gated MCP registration failed for app %s: %s", app_name, exc)
 
 
-def _health_check_loop(app_name: str, port: int, health_path: str) -> None:
-    """Poll the health endpoint until it responds or we give up."""
+def _health_probe(url: str) -> bool:
+    """Whether the health endpoint answers below 400. Never raises."""
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=_HEALTH_CHECK_TIMEOUT) as resp:
+            return bool(resp.status < 400)
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def _health_check_loop(app_name: str, port: int, health_path: str) -> AppProcess | None:
+    """Poll the health endpoint until it responds or we give up.
+
+    Returns the tracking record this call promoted to healthy, or None if the backend
+    never answered (or stopped being tracked mid-check). The record — not the app name —
+    is what :func:`_watch_backend_health` needs to keep watching it: a later
+    stop/start replaces the entry under the same name, and a watch that re-resolved by
+    name could demote a NEWER generation it never observed.
+    """
     url = f"http://127.0.0.1:{port}{health_path}"
     for attempt in range(_HEALTH_CHECK_RETRIES):
         time.sleep(_HEALTH_CHECK_INTERVAL)
         with _lock:
             if app_name not in _processes:
-                return  # stopped while we were checking
-        try:
-            req = urllib.request.Request(url, method="GET")
-            with urllib.request.urlopen(req, timeout=_HEALTH_CHECK_TIMEOUT) as resp:
-                if resp.status < 400:
-                    with _lock:
-                        # Stopped/disabled between the health poll and here: do NOT
-                        # register MCP for a backend that's no longer tracked — that would
-                        # write the exact dead-URL entry this guard prevents.
-                        # Mirror the top-of-loop guard.
-                        if app_name not in _processes:
-                            return
-                        _processes[app_name].healthy = True
-                    logger.info(
-                        "App %s backend healthy (port %d, attempt %d)",
-                        app_name, port, attempt + 1,
-                    )
-                    # Health-gated MCP registration: only now that the
-                    # backend has passed /health do we write its HTTP MCP url (live port) to
-                    # global mcp.json. Registering before this could leave a dead-but-enabled
-                    # url for an app whose backend never became healthy — the kiro-cli outage.
-                    _gate_mcp_registration(app_name, port, healthy=True)
-                    return
-        except (urllib.error.URLError, OSError):
-            pass
+                return None  # stopped while we were checking
+        if _health_probe(url):
+            with _lock:
+                # Stopped/disabled between the health poll and here: do NOT
+                # register MCP for a backend that's no longer tracked — that would
+                # write the exact dead-URL entry this guard prevents.
+                # Mirror the top-of-loop guard.
+                ap = _processes.get(app_name)
+                if ap is None:
+                    return None
+                ap.healthy = True
+            logger.info(
+                "App %s backend healthy (port %d, attempt %d)",
+                app_name, port, attempt + 1,
+            )
+            # Health-gated MCP registration: only now that the
+            # backend has passed /health do we write its HTTP MCP url (live port) to
+            # global mcp.json. Registering before this could leave a dead-but-enabled
+            # url for an app whose backend never became healthy — the kiro-cli outage.
+            _gate_mcp_registration(app_name, port, healthy=True)
+            return ap
 
     logger.warning(
         "App %s backend failed health check after %d attempts",
@@ -1575,6 +1614,117 @@ def _health_check_loop(app_name: str, port: int, health_path: str) -> None:
     # Backend never became healthy: scrub any optimistic/stale MCP entry so kiro-cli does
     # not keep dialing a dead port on every session (the reverted-outage shape).
     _gate_mcp_registration(app_name, port, healthy=False)
+    return None
+
+
+def _watch_backend_health(ap: AppProcess, health_path: str) -> None:
+    """Keep re-checking an already-healthy backend so ``healthy`` can go back to False.
+
+    Without this the startup poll would leave ``healthy`` a write-once cache: a backend
+    that died an hour later would still be routed to by the reverse proxy
+    (:func:`get_app_backend_port` gates purely on the flag) and still reported
+    ``healthy`` by ``/api/apps``.
+
+    Liveness is checked cheapest-first. For a backend we spawned, ``Popen.poll()``
+    answers from an already-reaped exit status with no syscall to the app at all and is
+    DECISIVE — an exited process cannot come back on its own, so one observation demotes
+    it and the watch stops. An adopted backend has no ``Popen`` handle (it belongs to
+    another supervisor) and is judged by the health endpoint alone.
+
+    An HTTP failure from a process that is still alive is NOT decisive: it may be a slow
+    request or a GC pause, so demotion needs `_HEALTH_WATCH_FAILURES` consecutive misses
+    and stays REVERSIBLE — the watch keeps running and re-promotes on the next success,
+    which is what lets an app that wedged briefly heal without operator action.
+
+    Exits when the record is no longer the tracked one for its app: ``stop_app_backend``
+    pops it and a restart replaces it, so this needs no separate teardown — the same
+    "no longer tracked" guard the startup poll already uses.
+    """
+    url = f"http://127.0.0.1:{ap.port}{health_path}"
+    consecutive_failures = 0
+    while True:
+        time.sleep(_HEALTH_WATCH_INTERVAL)
+        with _lock:
+            # Identity, not name: a stop/start under the same name installs a NEW record
+            # with its own watch, and demoting that one from here would take a backend
+            # offline on evidence gathered about its predecessor.
+            if _processes.get(ap.app_name) is not ap:
+                return
+            was_healthy = ap.healthy
+            proc = ap.proc
+
+        if proc is not None and proc.poll() is not None:
+            if was_healthy:
+                _demote(ap, reason=f"process exited (rc={proc.returncode})")
+            return  # decisive: a dead Popen never revives
+
+        if _health_probe(url):
+            consecutive_failures = 0
+            if not was_healthy:
+                _promote(ap)
+            continue
+
+        consecutive_failures += 1
+        if was_healthy and consecutive_failures >= _HEALTH_WATCH_FAILURES:
+            _demote(ap, reason=f"{consecutive_failures} consecutive failed health probes")
+
+
+def _demote(ap: AppProcess, *, reason: str) -> None:
+    """Mark a backend unhealthy and scrub its MCP entry. Reversible — see _promote."""
+    with _lock:
+        if _processes.get(ap.app_name) is not ap:
+            return
+        ap.healthy = False
+    logger.warning(
+        "App %s backend went unhealthy on port %d — %s", ap.app_name, ap.port, reason,
+    )
+    # Same reason the startup failure path scrubs: an enabled app must not leave a dead
+    # HTTP MCP url behind for kiro-cli to dial on every session.
+    _gate_mcp_registration(ap.app_name, ap.port, healthy=False)
+
+
+def _promote(ap: AppProcess) -> None:
+    """Mark a backend healthy again after a demotion and re-register its MCP servers."""
+    with _lock:
+        if _processes.get(ap.app_name) is not ap:
+            return
+        ap.healthy = True
+    logger.info("App %s backend recovered on port %d", ap.app_name, ap.port)
+    _gate_mcp_registration(ap.app_name, ap.port, healthy=True)
+
+
+def _supervise_backend_health(app_name: str, port: int, health_path: str) -> None:
+    """Thread target: wait for the backend to come up, then watch it for as long as it
+    stays tracked."""
+    ap = _health_check_loop(app_name, port, health_path)
+    if ap is not None:
+        _watch_backend_health(ap, health_path)
+
+
+def _start_health_supervisor(app_name: str, port: int, health_path: str) -> None:
+    """Run :func:`_supervise_backend_health` on this backend's own daemon thread."""
+    threading.Thread(
+        target=_supervise_backend_health,
+        args=(app_name, port, health_path),
+        daemon=True,
+        name=f"app-health-{app_name}",
+    ).start()
+
+
+def _start_adopted_health_watch(ap: AppProcess, health_path: str) -> None:
+    """Watch an ADOPTED backend, which skipped the startup poll by already being healthy.
+
+    Adoption proves the instance is serving right now, so there is nothing to wait for —
+    but that made ``healthy`` write-once on this path too, and an external instance is
+    exactly the kind we do not control the lifetime of. It has no ``Popen`` handle, so
+    the watch judges it by its health endpoint alone.
+    """
+    threading.Thread(
+        target=_watch_backend_health,
+        args=(ap, health_path),
+        daemon=True,
+        name=f"app-health-{ap.app_name}",
+    ).start()
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -791,12 +791,20 @@ def _placeholder_values(app_name: str) -> dict[str, str]:
     }
 
 
-def _render_shipped_agent(app_name: str, agent_path: Path) -> Path | None:
+def _render_shipped_agent(
+    app_name: str, agent_path: Path, io_failures: list[str] | None = None
+) -> Path | None:
     """Render *agent_path*'s placeholders and return the gateway-written copy.
 
     Returns *agent_path* unchanged when the shipped file holds no placeholder, and
     ``None`` when it holds one that cannot be resolved (nothing is registered rather
     than registering a config with a literal ``{ENGINE_ROOT}`` in it).
+
+    ``io_failures`` collects ONLY the write failure. This returns ``None`` for three
+    different reasons and just one of them can succeed on a retry: an unresolved
+    placeholder and invalid rendered JSON are properties of the template and will fail
+    identically forever, so reporting them to a caller that retries would spin without
+    ever converging. The ``OSError`` arm is the transient one.
 
     **The gateway renders the template itself.** An earlier version of this took the
     app's own provisioned copy from its install dir and verified it was "the template
@@ -850,12 +858,26 @@ def _render_shipped_agent(app_name: str, agent_path: Path) -> Path | None:
         atomic_write(target, rendered)
     except OSError as exc:
         logger.warning("App %s: could not write rendered agent: %s", app_name, exc)
+        if io_failures is not None:
+            io_failures.append(str(agent_path))
         return None
     return target
 
 
-def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> list[str]:
+def _register_agents(
+    app_name: str,
+    manifest: AppManifest,
+    app_root: Path,
+    io_failures: list[str] | None = None,
+) -> list[str]:
     """Materialize app agent JSONs into ~/.kiro/agents/ with namespaced names.
+
+    ``io_failures``, when supplied, collects the agents skipped because of an OS-level
+    read or write error. That is deliberately NARROWER than "declared minus registered":
+    most skips here are PERMANENT refusals — a path escaping the app root, an unsafe
+    agent name, malformed JSON, an unresolved template placeholder — and retrying those
+    never converges. Only the I/O class can succeed on a later attempt, so only it is
+    worth reporting to a caller that retries.
 
     Written as a COPY, not a symlink, for two reasons:
 
@@ -870,152 +892,166 @@ def _register_agents(app_name: str, manifest: AppManifest, app_root: Path) -> li
     """
     registered: list[str] = []
     dispatchable: set[str] = set()
-    agents_dir = _kiro_agents_dir()
-    agents_dir.mkdir(parents=True, exist_ok=True)
-    policy = _agent_mcp_policy(app_name)
-    own_servers = _own_mcp_servers(app_name)
+    # Held across the whole materialization, not just the writes: each agent COPIES the
+    # ambient server spec, so a read taken before a health scrub and a write landing
+    # after it would leave the agent naming a server that no longer exists. The read and
+    # the write have to be inside the same critical section as the transition they race.
+    #
+    # Kept INLINE rather than delegated to a helper: the governed-auto-approve strip
+    # below is a write chokepoint that `test_both_config_writers_run_the_pass` asserts by
+    # inspecting THIS function's source. Moving the body elsewhere would keep the
+    # behaviour and silently retire the guarantee.
+    with _health_reconcile_guard():
+        agents_dir = _kiro_agents_dir()
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        policy = _agent_mcp_policy(app_name)
+        own_servers = _own_mcp_servers(app_name)
 
-    for agent_path_str in manifest.agents:
-        agent_path = app_root / agent_path_str
-        # Path containment check — reject paths that escape the app root
-        if not agent_path.resolve().is_relative_to(app_root.resolve()):
-            logger.warning("App %s: agent path escapes app root: %s", app_name, agent_path)
-            continue
-        if not agent_path.is_file():
-            logger.warning("App %s: agent file not found: %s", app_name, agent_path)
-            continue
-        # A shipped TEMPLATE is rendered BY THE GATEWAY, from values it computes
-        # itself, into a file under the data home. `None` means a placeholder could
-        # not be resolved, so nothing is registered for this agent rather than
-        # registering a config that names a literal `{ENGINE_ROOT}`.
-        resolved = _render_shipped_agent(app_name, agent_path)
-        if resolved is None:
-            continue
-        agent_path = resolved
+        for agent_path_str in manifest.agents:
+            agent_path = app_root / agent_path_str
+            # Path containment check — reject paths that escape the app root
+            if not agent_path.resolve().is_relative_to(app_root.resolve()):
+                logger.warning("App %s: agent path escapes app root: %s", app_name, agent_path)
+                continue
+            if not agent_path.is_file():
+                logger.warning("App %s: agent file not found: %s", app_name, agent_path)
+                continue
+            # A shipped TEMPLATE is rendered BY THE GATEWAY, from values it computes
+            # itself, into a file under the data home. `None` means a placeholder could
+            # not be resolved, so nothing is registered for this agent rather than
+            # registering a config that names a literal `{ENGINE_ROOT}`.
+            resolved = _render_shipped_agent(app_name, agent_path, io_failures=io_failures)
+            if resolved is None:
+                continue
+            agent_path = resolved
 
-        # Read agent JSON to get the agent name
-        try:
-            agent_data = json.loads(agent_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("App %s: unreadable agent %s: %s", app_name, agent_path, exc)
-            continue
-        if not isinstance(agent_data, dict):
-            # Valid JSON that is not an object (a list, a scalar, null) parses
-            # fine, but every `.get` below would raise. Same disposition as the
-            # unreadable case: skip this agent rather than register a config
-            # the spec never described.
-            logger.warning(
-                "App %s: agent spec %s is not a JSON object; skipping", app_name, agent_path
-            )
-            continue
-        agent_name = agent_data.get("name", agent_path.stem)
-
-        # The agent name is app-controlled (read from the agent JSON) and is
-        # about to become a filesystem path component. Reject any path separator
-        # or parent-dir token BEFORE constructing link_path: on Windows a name
-        # like "..\\..\\crew\\config" would otherwise traverse out of the agents
-        # dir (backslash is a separator there) and atomic_write would overwrite
-        # an arbitrary JSON file such as ~/.kiro/crew/config.json.
-        if (
-            not isinstance(agent_name, str)
-            or "/" in agent_name
-            or "\\" in agent_name
-            or "\x00" in agent_name
-            or agent_name in ("", ".", "..")
-        ):
-            logger.warning("App %s: refusing agent with unsafe name %r", app_name, agent_name)
-            continue
-
-        # Namespaced link name: app-name--agent-name.json
-        link_name = _safe_link_name(_namespace(app_name, agent_name)) + ".json"
-        link_path = agents_dir / link_name
-
-        # Snapshot the user's own edits BEFORE the unlink below — after it there
-        # is nothing left to read (see _preserve_user_agent_edits).
-        prior_on_disk = _read_agent_config(link_path)
-
-        # Drop a legacy SYMLINK from an older KiroCrew (which pointed at a file
-        # inside the app) so the write below lands a real file at this path.
-        #
-        # NOTHING is unlinked first — not even a legacy symlink. atomic_write does
-        # tmp+os.replace, which atomically swaps the destination NAME whether it is
-        # a regular file OR a symlink (rename operates on the path, not the
-        # symlink target), so the new real file replaces the old link in one step.
-        # Unlinking first (for either kind) opened a window where the working
-        # config was already gone and the replacement had not landed — a write
-        # that then failed (disk full, at startup reconciliation) made the agent
-        # DISAPPEAR. Leaving the old entry in place means a failed write leaves the
-        # last-good config untouched.
-        try:
-            # The app's own servers are always granted -- they are declared by
-            # the manifest, not chosen by the user, and the agent's `tools`
-            # already references them.
-            if own_servers:
-                agent_data["mcpServers"] = {
-                    **own_servers,
-                    **(agent_data.get("mcpServers") or {}),
-                }
-            # An app agent may also reference the host's managed servers
-            # (@kirocrew-cron / @kirocrew-core) in `tools`. Those specs live in
-            # the HOST agent's config, not the global mcp.json, so without this
-            # merge the reference dangles and the tool silently never mounts.
-            _materialize_managed_refs(agent_data)
-            merged = _apply_agent_mcp_policy(agent_data, agent_name, policy)
-            merged = _apply_agent_prompt(merged, agent_name, policy, app_name, app_root)
-            merged = _preserve_user_agent_edits(link_name, prior_on_disk, merged)
-            # LAST governance pass, on the map that is about to be written. By this
-            # point `autoApprove` could have come from the app's own manifest, the
-            # per-agent MCP policy, a materialized managed ref, or a preserved
-            # on-disk entry — filtering each of those separately is how earlier
-            # rounds kept leaving one open. The host agent's writer does the same
-            # thing at the same position (see agent.install_agent).
-            _servers = merged.get("mcpServers")
-            if isinstance(_servers, dict):
-                merged["mcpServers"] = _strip_ungoverned_auto_approve(_servers)
-            # The map above is FINAL — every source of servers has been merged —
-            # so this is the one point a dangling `@` grant is decidable. Warn,
-            # never reject: kiro-cli just skips the ref, so the agent works
-            # minus the tool, and the warning is the only signal that exists.
-            dangling = _unresolvable_tool_refs(merged)
-            if dangling:
+            # Read agent JSON to get the agent name
+            try:
+                agent_data = json.loads(agent_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("App %s: unreadable agent %s: %s", app_name, agent_path, exc)
+                if isinstance(exc, OSError) and io_failures is not None:
+                    io_failures.append(str(agent_path))  # transient; a malformed spec is not
+                continue
+            if not isinstance(agent_data, dict):
+                # Valid JSON that is not an object (a list, a scalar, null) parses
+                # fine, but every `.get` below would raise. Same disposition as the
+                # unreadable case: skip this agent rather than register a config
+                # the spec never described.
                 logger.warning(
-                    "App %s: agent %r grants MCP tool ref(s) not found in this "
-                    "agent's merged mcpServers or the global mcp.json; kiro-cli "
-                    "will silently never mount them: %s",
-                    app_name,
-                    agent_name,
-                    ", ".join(dangling),
+                    "App %s: agent spec %s is not a JSON object; skipping", app_name, agent_path
                 )
-            atomic_write(link_path, json.dumps(merged, indent=2) + "\n")
-            registered.append(_namespace(app_name, agent_name))
-            # The DECLARED name only — kiro-cli enumerates agents by their
-            # `name` field, so the namespaced filename stem is not a name it
-            # can resolve (see _scan_materialized_agents).
-            dispatchable.add(agent_name)
-            logger.info("Registered agent: %s (from %s)", link_name, agent_path)
-        except OSError as exc:
-            logger.warning("Failed to write agent %s: %s", link_name, exc)
+                continue
+            agent_name = agent_data.get("name", agent_path.stem)
 
-    if dispatchable:
-        # Publish the names just written BEFORE scheduling the rescan, and do it
-        # synchronously: publishing is a pure set union with no filesystem access,
-        # while the rescan can be delayed arbitrarily if the default executor is
-        # saturated. That window is not cosmetic — a slot created inside it would
-        # resolve to the default agent, so the app's first turn after being enabled
-        # would be answered by the wrong agent.
-        publish_materialized_agents(dispatchable)
-    # Reconcile the whole directory UNCONDITIONALLY, even when this call wrote
-    # nothing: a re-registration whose manifest no longer declares an agent (or
-    # that follows a prune) leaves the removed name in the snapshot, and only a
-    # rescan drops it. A name that is dispatchable in memory but gone from disk is
-    # the same invisible mismatch as the bug this change fixes — kiro-cli cannot
-    # load it and falls back to its own default. `_register_agents` runs ON the
-    # loop for the dashboard enable/update handlers (see the prune note in
-    # `register_app`), so the scan goes to an executor rather than walking every
-    # agent file inline.
-    schedule_materialized_agents_refresh()
+            # The agent name is app-controlled (read from the agent JSON) and is
+            # about to become a filesystem path component. Reject any path separator
+            # or parent-dir token BEFORE constructing link_path: on Windows a name
+            # like "..\\..\\crew\\config" would otherwise traverse out of the agents
+            # dir (backslash is a separator there) and atomic_write would overwrite
+            # an arbitrary JSON file such as ~/.kiro/crew/config.json.
+            if (
+                not isinstance(agent_name, str)
+                or "/" in agent_name
+                or "\\" in agent_name
+                or "\x00" in agent_name
+                or agent_name in ("", ".", "..")
+            ):
+                logger.warning("App %s: refusing agent with unsafe name %r", app_name, agent_name)
+                continue
 
-    return registered
+            # Namespaced link name: app-name--agent-name.json
+            link_name = _safe_link_name(_namespace(app_name, agent_name)) + ".json"
+            link_path = agents_dir / link_name
+
+            # Snapshot the user's own edits BEFORE the unlink below — after it there
+            # is nothing left to read (see _preserve_user_agent_edits).
+            prior_on_disk = _read_agent_config(link_path)
+
+            # Drop a legacy SYMLINK from an older Kiro Crew (which pointed at a file
+            # inside the app) so the write below lands a real file at this path.
+            #
+            # NOTHING is unlinked first — not even a legacy symlink. atomic_write does
+            # tmp+os.replace, which atomically swaps the destination NAME whether it is
+            # a regular file OR a symlink (rename operates on the path, not the
+            # symlink target), so the new real file replaces the old link in one step.
+            # Unlinking first (for either kind) opened a window where the working
+            # config was already gone and the replacement had not landed — a write
+            # that then failed (disk full, at startup reconciliation) made the agent
+            # DISAPPEAR. Leaving the old entry in place means a failed write leaves the
+            # last-good config untouched.
+            try:
+                # The app's own servers are always granted -- they are declared by
+                # the manifest, not chosen by the user, and the agent's `tools`
+                # already references them.
+                if own_servers:
+                    agent_data["mcpServers"] = {
+                        **own_servers,
+                        **(agent_data.get("mcpServers") or {}),
+                    }
+                # An app agent may also reference the host's managed servers
+                # (@kirocrew-cron / @kirocrew-core) in `tools`. Those specs live in
+                # the HOST agent's config, not the global mcp.json, so without this
+                # merge the reference dangles and the tool silently never mounts.
+                _materialize_managed_refs(agent_data)
+                merged = _apply_agent_mcp_policy(agent_data, agent_name, policy)
+                merged = _apply_agent_prompt(merged, agent_name, policy, app_name, app_root)
+                merged = _preserve_user_agent_edits(link_name, prior_on_disk, merged)
+                # LAST governance pass, on the map that is about to be written. By this
+                # point `autoApprove` could have come from the app's own manifest, the
+                # per-agent MCP policy, a materialized managed ref, or a preserved
+                # on-disk entry — filtering each of those separately is how earlier
+                # rounds kept leaving one open. The host agent's writer does the same
+                # thing at the same position (see agent.install_agent).
+                _servers = merged.get("mcpServers")
+                if isinstance(_servers, dict):
+                    merged["mcpServers"] = _strip_ungoverned_auto_approve(_servers)
+                # The map above is FINAL — every source of servers has been merged —
+                # so this is the one point a dangling `@` grant is decidable. Warn,
+                # never reject: kiro-cli just skips the ref, so the agent works
+                # minus the tool, and the warning is the only signal that exists.
+                dangling = _unresolvable_tool_refs(merged)
+                if dangling:
+                    logger.warning(
+                        "App %s: agent %r grants MCP tool ref(s) not found in this "
+                        "agent's merged mcpServers or the global mcp.json; kiro-cli "
+                        "will silently never mount them: %s",
+                        app_name,
+                        agent_name,
+                        ", ".join(dangling),
+                    )
+                atomic_write(link_path, json.dumps(merged, indent=2) + "\n")
+                registered.append(_namespace(app_name, agent_name))
+                # The DECLARED name only — kiro-cli enumerates agents by their
+                # `name` field, so the namespaced filename stem is not a name it
+                # can resolve (see _scan_materialized_agents).
+                dispatchable.add(agent_name)
+                logger.info("Registered agent: %s (from %s)", link_name, agent_path)
+            except OSError as exc:
+                logger.warning("Failed to write agent %s: %s", link_name, exc)
+                if io_failures is not None:
+                    io_failures.append(link_name)
+
+        if dispatchable:
+            # Publish the names just written BEFORE scheduling the rescan, and do it
+            # synchronously: publishing is a pure set union with no filesystem access,
+            # while the rescan can be delayed arbitrarily if the default executor is
+            # saturated. That window is not cosmetic — a slot created inside it would
+            # resolve to the default agent, so the app's first turn after being enabled
+            # would be answered by the wrong agent.
+            publish_materialized_agents(dispatchable)
+        # Reconcile the whole directory UNCONDITIONALLY, even when this call wrote
+        # nothing: a re-registration whose manifest no longer declares an agent (or
+        # that follows a prune) leaves the removed name in the snapshot, and only a
+        # rescan drops it. A name that is dispatchable in memory but gone from disk is
+        # the same invisible mismatch as the bug this change fixes — kiro-cli cannot
+        # load it and falls back to its own default. `_register_agents` runs ON the
+        # loop for the dashboard enable/update handlers (see the prune note in
+        # `register_app`), so the scan goes to an executor rather than walking every
+        # agent file inline.
+        schedule_materialized_agents_refresh()
+
+        return registered
 
 
 def _deregister_agents(app_name: str) -> int:
@@ -1862,6 +1898,22 @@ def _resolve_live_mcp_url(app_name: str, url: str, live_port: int | None = None)
         return url
 
 
+def _health_reconcile_guard() -> Any:
+    """Serialize this writer against backend health transitions.
+
+    An app's mcp.json entries and its materialized agent configs are written by two
+    independent families: the lifecycle paths here (enable, update, boot reconcile) and
+    the backend's health watch. Without a shared lock the two can interleave their
+    decisions — each doing a correct read-modify-write, with the STALE one landing last.
+
+    Deferred import: backend imports this module in its boot path, so resolving the lock
+    at call time is what keeps the bridges <-> backend cycle from closing at import.
+    """
+    from kiro_crew.apps.backend import health_reconcile_lock
+
+    return health_reconcile_lock()
+
+
 def _live_port_for(app_name: str, live_port: int | None) -> int | None:
     """The backend's actually-allocated port, or None if it isn't running yet.
 
@@ -2115,7 +2167,9 @@ def _register_mcp_servers(
     resolved_port = _live_port_for(app_name, live_port)
     registered: list[str] = []
     skipped: list[str] = []
-    with _mcp_lock():
+    # Reconcile guard OUTSIDE _mcp_lock: that order is fixed everywhere, so a health
+    # transition and a lifecycle registration can never deadlock against each other.
+    with _health_reconcile_guard(), _mcp_lock():
         mcp_data = _read_mcp_json_unlocked(strict=True)
         servers = mcp_data.setdefault("mcpServers", {})
         for server_name, server_config in manifest.mcpServers.items():
@@ -2193,7 +2247,9 @@ def registered_app_mcp_servers() -> dict[str, Any]:
     return dict(servers) if isinstance(servers, dict) else {}
 
 
-def reregister_app_mcp_servers(app_name: str, live_port: int | None = None) -> list[str]:
+def reregister_app_mcp_servers(
+    app_name: str, live_port: int | None = None, io_failures: list[str] | None = None
+) -> list[str]:
     """Re-register admitted MCP servers after an app backend has started.
 
     HTTP URLs are rewritten to the live allocated port. Shipped definitions are
@@ -2208,7 +2264,14 @@ def reregister_app_mcp_servers(app_name: str, live_port: int | None = None) -> l
     ):
         _deregister_mcp_servers(app_name)
         return []
-    if not manifest or not manifest.mcpServers:
+    if not manifest:
+        # UNREADABLE, not merely empty: nothing was registered, so reporting success
+        # would let the caller record a registration that never happened and leave a
+        # healthy backend with no MCP entry and nothing to retry it.
+        if io_failures is not None:
+            io_failures.append(f"{app_name}: manifest unreadable")
+        return []
+    if not manifest.mcpServers:
         return []
     registered = _register_mcp_servers(app_name, manifest, live_port=live_port)
     # Refresh the app's AGENTS after the live server lands. register_app runs
@@ -2219,12 +2282,79 @@ def reregister_app_mcp_servers(app_name: str, live_port: int | None = None) -> l
     # declared MCP tools until some unrelated rebuild happened to run.
     if registered:
         try:
-            _register_agents(app_name, manifest, app_root)
-        except Exception:  # noqa: BLE001 — a refresh failure must not fail health re-registration
+            _register_agents(app_name, manifest, app_root, io_failures=io_failures)
+        except Exception:  # noqa: BLE001 — reported via io_failures, never raised on
             logger.warning(
                 "Could not refresh agents for app %s after live MCP registration", app_name
             )
+            if io_failures is not None:
+                io_failures.append(f"{app_name}:<all agents>")
     return registered
+
+
+def scrub_backend_mcp_url(
+    app_name: str, unreconciled: list[str] | None = None
+) -> list[str]:
+    """Remove an app's backend-dependent MCP entry, keeping the servers that need no port.
+
+    Registering with no live port is the existing path for this: it pops each HTTP entry
+    and keeps stdio/command ones, which kiro-cli launches itself and which have no port
+    to be dead. Returns the servers that were kept.
+
+    Falls back to removing EVERY entry for the app when its manifest cannot be resolved
+    or declares no servers. That case cannot distinguish a backend-dependent server from
+    an independent one, and the dead url must not survive on the strength of not knowing
+    — the failure this whole gate exists to prevent.
+
+    The fallback never touches the app's materialized AGENT files. See the comment on
+    that branch: their deletion is unrecoverable, and only ``deregister_app`` owns it.
+
+    ``unreconciled`` collects a reason when the entry could not be brought into a
+    consistent state — today, an UNREADABLE manifest. Keeping the agents there is right,
+    but it leaves them naming the server just removed and nothing else revisits them, so
+    the caller must treat it as unlanded and retry rather than record it as done. A
+    manifest that simply declares no servers is fully reconciled: there is nothing stale
+    to correct.
+    """
+    manifest, app_root = _registration_source(app_name)
+    if not manifest and unreconciled is not None:
+        # Unreadable, not merely empty: the agents are kept (see below) and therefore
+        # still name the removed server, and `refresh_app_agents` gives up on the same
+        # condition — so nothing here can finish the job. Report it so the watch retries
+        # once the manifest is readable again.
+        unreconciled.append(f"{app_name}: manifest unreadable")
+    if not manifest or not manifest.mcpServers:
+        # Scrub the entry, but NEVER the materialized agents. Deleting them is
+        # unrecoverable — it takes the user-owned fields `_preserve_user_agent_edits`
+        # carries across every refresh — while the thing it would prevent, an agent
+        # naming a server that is gone, costs failed tool calls until the next
+        # successful refresh rewrites it. An unreadable manifest is also frequently
+        # TRANSIENT, so destroying data over it trades a temporary fault for a permanent
+        # one. Uninstall removes these files through `deregister_app`, which is the path
+        # that legitimately owns their deletion.
+        removed = _deregister_mcp_servers(app_name)
+        if removed:
+            logger.warning(
+                "Scrubbed %d MCP server(s) for app %s: its manifest declares none or "
+                "could not be read. Its materialized agents are KEPT and may still name "
+                "the removed server until a refresh with a readable manifest rewrites "
+                "them.",
+                removed, app_name,
+            )
+        return []
+    # `_register_mcp_servers` directly, NOT `reregister_app_mcp_servers`: the latter also
+    # calls `_register_agents`, which would re-materialize this app's agent configs here
+    # — before the caller's enablement check runs — making a disabled app's agents
+    # dispatchable in the gap. The scrub only needs the mcp.json half; the agent refresh
+    # is the caller's, and it is gated.
+    #
+    # The admission gate that `reregister_app_mcp_servers` applies is kept explicitly: a
+    # denied app gets a FULL removal rather than the selective keep-stdio treatment,
+    # because nothing of a denied app should stay reachable.
+    if _registration_denied(app_name, action="mcp_register", app_root=app_root):
+        _deregister_mcp_servers(app_name)
+        return []
+    return _register_mcp_servers(app_name, manifest, live_port=None)
 
 
 def _scrub_legacy_shared_mcp(app_name: str) -> int:
@@ -2265,7 +2395,7 @@ def _scrub_legacy_shared_mcp(app_name: str) -> int:
 def _deregister_mcp_servers(app_name: str) -> int:
     """Remove an app's MCP servers from the agent config (and the legacy shared file)."""
     prefix = f"{app_name}:"
-    with _mcp_lock():
+    with _health_reconcile_guard(), _mcp_lock():
         mcp_data = _read_mcp_json_unlocked(strict=True)
         servers = mcp_data.get("mcpServers", {})
         to_remove = [k for k in servers if k.startswith(prefix)]
@@ -2489,13 +2619,20 @@ def register_app(app_name: str) -> RegistrationResult:
     return result
 
 
-def refresh_app_agents(app_name: str) -> list[str]:
+def refresh_app_agents(
+    app_name: str, io_failures: list[str] | None = None
+) -> list[str]:
     """Re-materialize just this app's agent configs.
 
-    Called when something the agent config is derived from changes (today: the
-    app's MCP reach policy) so the change takes effect without a gateway
-    restart. Cheap and idempotent — it rewrites the same files registration
-    would.
+    Called when something the agent config is derived from changes (the app's MCP reach
+    policy, or a health scrub removing a server the agents copied) so the change takes
+    effect without a gateway restart. Cheap and idempotent — it rewrites the same files
+    registration would.
+
+    ``io_failures``, when supplied, collects the agents skipped for an OS-level read or
+    write error, so a caller that RETRIES can tell a transient failure from the several
+    permanent reasons this returns an empty list — a self-managed app, a denied one, or a
+    manifest declaring no agents are all "nothing for us to do", not failures.
     """
     manifest = get_app_manifest(app_name)
     if not manifest or not manifest.agents:
@@ -2511,7 +2648,7 @@ def refresh_app_agents(app_name: str) -> list[str]:
     if _registration_denied(app_name, action="resource_register", app_root=app_root):
         _deregister_agents(app_name)
         return []
-    return _register_agents(app_name, manifest, app_root)
+    return _register_agents(app_name, manifest, app_root, io_failures=io_failures)
 
 
 def reconcile_enabled_app_resources() -> dict[str, int]:

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -1624,6 +1624,32 @@ def get_app_manifest(name: str) -> AppManifest | None:
         return None
 
 
+def app_enabled_state(name: str) -> bool | None:
+    """Tri-state enablement: True, False, or None when the metadata cannot be READ.
+
+    :func:`is_app_enabled` collapses "not installed" and "unreadable" into a single
+    False, because :func:`_read_installed` returns None for both. That is the right
+    answer for a caller deciding whether to ACT on an app, and the wrong one for a caller
+    deciding whether to DELETE its files: a transient read fault (EMFILE, EIO, a Windows
+    AV lock) would be indistinguishable from a deliberate disable, and the deletion is
+    unrecoverable. This keeps the two apart.
+
+    A missing metadata file is a definite False — the app is not installed — not a
+    failure to read one.
+    """
+    meta_path = app_dir(name) / INSTALLED_META_FILENAME
+    try:
+        if not meta_path.is_file():
+            return False
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+        return bool(InstalledApp.from_dict(data).enabled)
+    # No `json.JSONDecodeError` member: it subclasses ValueError, so pairing the two is
+    # redundant and the repo ratchets against it (see #5287).
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        logger.warning("Could not determine enabled state from %s: %s", meta_path, exc)
+        return None
+
+
 def is_app_enabled(name: str) -> bool:
     """Read-only enablement check: True only for an installed, enabled app.
 

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -321,7 +321,10 @@ async def handle_list_apps(request: web.Request) -> web.Response:
         proc = procs.get(app["name"])
         if proc:
             app["backend_status"] = {
-                "running": True,
+                # Both flags come from the tracking record rather than being asserted
+                # from its mere presence: a tracked backend can have exited (running) or
+                # stopped answering its health endpoint (healthy) since it was started.
+                "running": proc["running"],
                 "port": proc["port"],
                 "healthy": proc["healthy"],
                 "pid": proc["pid"],

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -39,7 +39,6 @@ from kiro_crew.apps.bridges import (
     deregister_app,
     deregister_app_crons_from_service,
     register_app,
-    reregister_app_mcp_servers,
 )
 from kiro_crew.apps.builtins import BUILTIN_NAMES
 from kiro_crew.apps.dependencies import clean_dependencies
@@ -787,11 +786,16 @@ async def handle_update_app(request: web.Request) -> web.Response:
                     error=reg_install.get("error", ""),
                 )
                 return web.json_response(reg_install, status=400)
-            # Install succeeded — now safe to swap resources
-            await _deregister_app_off_loop(name)
+            # Install succeeded — now safe to swap resources. Stop the backend BEFORE
+            # deregistering, matching uninstall and the disable rollback: stopping pops
+            # the tracking record, which is what stops the health watch from
+            # re-registering the OLD manifest's MCP servers in the window between the
+            # two (see app-kit-platform §17). Deregistering first leaves that window
+            # open, and the entries the update removed would survive it.
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), stop_app_backend, name
             )
+            await _deregister_app_off_loop(name)
             if info.get("enabled"):
                 reg_result = await _register_app_off_loop(name)
                 await asyncio.get_running_loop().run_in_executor(
@@ -821,11 +825,14 @@ async def handle_update_app(request: web.Request) -> web.Response:
         if startup_refusal is not None:
             return startup_refusal
 
-        # Deregister old resources before update
-        await _deregister_app_off_loop(name)
+        # Stop the backend, then deregister old resources — same order as uninstall and
+        # the disable rollback. Stopping pops the tracking record, so the health watch
+        # can no longer re-register the OLD manifest's MCP servers after the scrub
+        # (see app-kit-platform §17).
         await asyncio.get_running_loop().run_in_executor(
             subprocess_executor(), stop_app_backend, name
         )
+        await _deregister_app_off_loop(name)
 
         # Off-loop: blocking filesystem copy (see handle_install_app).
         # expected_name makes update_app itself reject a source whose
@@ -1444,20 +1451,16 @@ async def handle_enable_app(request: web.Request) -> web.Response:
             backend = await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(), start_app_backend, name
             )
-            # MCP re-registration is HEALTH-GATED. register_app ran before
-            # the backend was up, so an HTTP MCP server with backend.port:"auto" carries the
-            # manifest's illustrative port. The backend's health-check loop calls
-            # _gate_mcp_registration once /health passes, rewriting the url to the real allocated
-            # port (and scrubbing it if the backend never becomes healthy — the dead-url shape
-            # that broke kiro-cli). EXCEPTION: an adopted already-healthy instance runs no health
-            # loop, so register it synchronously here.
-            if backend is not None and getattr(backend, "healthy", False):
-                try:
-                    reregister_app_mcp_servers(name, live_port=getattr(backend, "port", None))
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning(
-                        "MCP re-registration after backend start failed for %s: %s", name, exc
-                    )
+            # MCP re-registration is HEALTH-GATED and happens inside start_app_backend,
+            # not here. register_app ran before the backend was up, so an HTTP MCP server
+            # with backend.port:"auto" still carries the manifest's illustrative port; the
+            # health-check loop rewrites it to the real allocated port once /health passes
+            # (and scrubs it if the backend never becomes healthy — the dead-url shape
+            # that broke kiro-cli). An ADOPTED instance runs no health loop, so the
+            # adoption path registers it through the same serialized transition before
+            # arming its watch. Re-registering here instead would race that watch: the
+            # call is queued after this handler returns, so a demotion could scrub in
+            # between and the queued write would restore the dead url.
             resp["registration"] = reg.to_dict()
             if backend:
                 resp["backend"] = backend.to_dict()

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -682,8 +682,22 @@ def _handle_app(args: argparse.Namespace) -> None:
 
     elif action == "disable":
         _cleanup_app_crons_from_scheduler(args.name)
-        deregister_app(args.name)
+        # Flip the authoritative flag BEFORE tearing resources down. A running gateway
+        # is a DIFFERENT process: it watches this app's backend and re-registers its MCP
+        # servers and agents on a health recovery, gated on the enabled flag it reads
+        # from installed.json. Deregistering first leaves a window where that flag still
+        # says enabled and the resources are already gone — and a recovery landing there
+        # puts them back for an app the operator is disabling. The gateway's own disable
+        # path has no such window because it stops the backend first, which ends the
+        # watch; the CLI cannot do that from out here, so it closes the window by
+        # ordering instead.
+        #
+        # If the deregistration below then fails, the app is still correctly marked
+        # disabled and the failure is reported to an operator already at the terminal —
+        # which is the better of the two error shapes, because the alternative is a
+        # silent re-registration nobody sees.
         result = disable_app(args.name)
+        deregister_app(args.name)
         if result.ok:
             print(f"✅ {result.message}")
         else:

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -1643,3 +1644,239 @@ class TestTheCacheOnlyChildCanSeeTheCacheItMustBootFrom:
         bmod.start_app_backend("plain-app")
 
         assert seen.get("visible") == ()
+
+
+# =============================================================================
+# Post-startup liveness watch (#5726)
+# =============================================================================
+
+
+class _FakeProc:
+    """Popen stand-in for the watch's liveness check: alive until it is given an rc."""
+
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+class TestBackendLivenessWatch:
+    """``healthy`` must be able to go back to False (#5726).
+
+    Before the watch, the startup poll wrote ``healthy = True`` once and nothing ever
+    unwrote it, so a backend that died later kept the reverse proxy routing to its dead
+    port and kept ``/api/apps`` reporting it healthy.
+    """
+
+    @pytest.fixture
+    def watched(self, monkeypatch):
+        """A tracked, healthy backend plus the seams the watch runs through.
+
+        Yields ``(bmod, ap, probes, gate_calls)``. ``probes`` is the scripted probe
+        result list — the watch stops by untracking the record once the script runs out,
+        which is the same guard ``stop_app_backend`` exits it through in production.
+        """
+        import kiro_crew.apps.backend as bmod
+
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        gate_calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: gate_calls.append((name, port, healthy)),
+        )
+
+        ap = AppProcess(app_name="watched", port=9160, pid=4242,
+                        proc=_FakeProc(), healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["watched"] = ap
+
+        probes: list[bool] = []
+
+        def _scripted(_url):
+            if not probes:
+                # Script exhausted: untrack so the watch exits at its top-of-loop guard.
+                with bmod._lock:
+                    bmod._processes.pop("watched", None)
+                return False
+            return probes.pop(0)
+
+        monkeypatch.setattr(bmod, "_health_probe", _scripted)
+        try:
+            yield bmod, ap, probes, gate_calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_survives_transient_failures_below_the_threshold(self, watched):
+        # A backend that misses one probe and answers the next is briefly busy, not
+        # dead: demoting there would take a working app offline.
+        bmod, ap, probes, gate_calls = watched
+        probes.extend([False] * (bmod._HEALTH_WATCH_FAILURES - 1) + [True])
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is True
+        assert gate_calls == []  # never demoted, so the MCP entry was never scrubbed
+
+    def test_demotes_after_consecutive_failures_and_scrubs_mcp(self, watched):
+        bmod, ap, probes, gate_calls = watched
+        probes.extend([False] * bmod._HEALTH_WATCH_FAILURES)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is False
+        assert ("watched", 9160, False) in gate_calls
+
+    def test_a_demoted_backend_is_no_longer_routable(self, watched):
+        # The load-bearing consequence: get_app_backend_port gates the reverse proxy
+        # purely on this flag, so before the watch the proxy kept dialing a dead port.
+        bmod, ap, probes, gate_calls = watched
+        assert bmod.get_app_backend_port("watched") == 9160
+
+        probes.extend([False] * bmod._HEALTH_WATCH_FAILURES)
+        bmod._watch_backend_health(ap, "/health")
+
+        assert bmod.get_app_backend_port("watched") is None
+
+    def test_demotion_is_reversible(self, watched):
+        # An app that wedged briefly must heal without operator action.
+        bmod, ap, probes, gate_calls = watched
+        probes.extend([False] * bmod._HEALTH_WATCH_FAILURES + [True])
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is True
+        assert gate_calls == [("watched", 9160, False), ("watched", 9160, True)]
+
+    def test_an_exited_process_demotes_on_one_observation(self, watched):
+        # No threshold: a dead Popen cannot recover, so waiting for three misses would
+        # only keep routing to it for longer. The probe list stays untouched, pinning
+        # that liveness is answered from the exit status without an HTTP round trip.
+        bmod, ap, probes, gate_calls = watched
+        ap.proc = _FakeProc(returncode=1)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is False
+        assert gate_calls == [("watched", 9160, False)]
+        assert probes == []  # never consulted the health endpoint
+
+    def test_does_not_demote_a_newer_generation_under_the_same_name(self, watched):
+        # A stop/start replaces the record; the old watch must not carry its verdict
+        # over to a backend it never observed.
+        bmod, ap, probes, gate_calls = watched
+        replacement = AppProcess(app_name="watched", port=9161, pid=99,
+                                 proc=_FakeProc(), healthy=True)
+        with bmod._lock:
+            bmod._processes["watched"] = replacement
+        ap.proc = _FakeProc(returncode=1)  # the OLD generation is dead
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert replacement.healthy is True
+        assert gate_calls == []
+        assert bmod.get_app_backend_port("watched") == 9161
+
+    def test_an_untracked_record_is_never_probed(self, watched):
+        # stop_app_backend pops the record; the watch exits before touching the network,
+        # so a stale watcher can never probe a port another backend has since taken.
+        bmod, ap, probes, gate_calls = watched
+        probes.append(True)
+        with bmod._lock:
+            bmod._processes.pop("watched")
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert probes == [True]  # untouched
+        assert gate_calls == []
+
+
+class TestBackendRunningReflectsTheProcess:
+    """``/api/apps`` must not report an exited backend as running (#5726)."""
+
+    def test_running_is_false_once_the_process_exits(self):
+        ap = AppProcess(app_name="gone", port=9162, pid=7, proc=_FakeProc(returncode=0))
+        assert ap.to_dict()["running"] is False
+
+    def test_running_is_true_while_the_process_lives(self):
+        ap = AppProcess(app_name="live", port=9163, pid=7, proc=_FakeProc())
+        assert ap.to_dict()["running"] is True
+
+    def test_an_adopted_backend_has_no_handle_to_poll(self):
+        # proc=None is the adopted shape: the instance belongs to another supervisor, so
+        # "we still track it" is the only honest answer and `healthy` carries the signal.
+        ap = AppProcess(app_name="adopted", port=9164, pid=0, proc=None, healthy=True)
+        assert ap.to_dict()["running"] is True
+
+
+class TestHealthSupervisorHandoff:
+    """The startup poll must hand the watch its record, or the whole watch is dead wiring."""
+
+    def test_watch_runs_when_the_backend_came_up(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        ap = AppProcess(app_name="up", port=9170, healthy=True)
+        watched: list[tuple[AppProcess, str]] = []
+        monkeypatch.setattr(bmod, "_health_check_loop", lambda *_a, **_k: ap)
+        monkeypatch.setattr(bmod, "_watch_backend_health",
+                            lambda rec, path: watched.append((rec, path)))
+
+        bmod._supervise_backend_health("up", 9170, "/health")
+
+        assert watched == [(ap, "/health")]
+
+    def test_no_watch_when_the_backend_never_came_up(self, monkeypatch):
+        # Nothing to watch: the startup path already scrubbed the MCP entry and gave up.
+        import kiro_crew.apps.backend as bmod
+        watched: list[Any] = []
+        monkeypatch.setattr(bmod, "_health_check_loop", lambda *_a, **_k: None)
+        monkeypatch.setattr(bmod, "_watch_backend_health",
+                            lambda rec, path: watched.append(rec))
+
+        bmod._supervise_backend_health("down", 9171, "/health")
+
+        assert watched == []
+
+
+class TestHealthTransitionsRefuseAStaleRecord:
+    """stop_app_backend can land between a probe and its verdict.
+
+    Both transitions re-check identity under the lock, so a verdict formed about a
+    record that has since been popped or replaced cannot be written — and cannot move
+    the MCP entry of whatever holds the name now.
+    """
+
+    @pytest.fixture
+    def gate_calls(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: calls.append((name, port, healthy)),
+        )
+        with bmod._lock:
+            bmod._processes.clear()
+        try:
+            yield bmod, calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_demote_refuses_an_untracked_record(self, gate_calls):
+        bmod, calls = gate_calls
+        ap = AppProcess(app_name="stale", port=9172, healthy=True)  # never tracked
+
+        bmod._demote(ap, reason="test")
+
+        assert ap.healthy is True  # untouched
+        assert calls == []  # no scrub of a name this record no longer owns
+
+    def test_promote_refuses_an_untracked_record(self, gate_calls):
+        bmod, calls = gate_calls
+        ap = AppProcess(app_name="stale", port=9173, healthy=False)
+
+        bmod._promote(ap)
+
+        assert ap.healthy is False
+        assert calls == []

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -220,6 +220,11 @@ class TestFixedAndAutoPortIsolation:
         """
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         fixed = bmod._MIN_PORT + 3
         manifests = {
             "fixed-app": SimpleNamespace(
@@ -257,6 +262,11 @@ class TestFixedAndAutoPortIsolation:
         """Pre-claiming is best-effort: it must never itself fail boot."""
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         manifests = {
             "no-manifest": None,
             "bad-port": SimpleNamespace(backend=SimpleNamespace(port="not-a-number")),
@@ -282,6 +292,11 @@ class TestFixedAndAutoPortIsolation:
         already be reserved by the time the spawn body runs.
         """
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
 
         # Stub the OS sandbox: these tests are about PORT bookkeeping, and
         # wrap_argv() fail-closes before that code on hosts without a backend
@@ -326,6 +341,11 @@ class TestFixedAndAutoPortIsolation:
         that port — and a gateway retrying a broken app would leak one per attempt.
         """
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
 
         # Stub the OS sandbox: these tests are about PORT bookkeeping, and
         # wrap_argv() fail-closes before that code on hosts without a backend
@@ -437,6 +457,11 @@ class TestBootSpawnLatency:
 
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         # OUR child owns the listener — the very bind whose failure this guards.
         monkeypatch.setattr(bmod, "_port_is_listening", lambda port: True)
         monkeypatch.setattr(bmod, "_spawn_owns_listener", lambda port, pid: True)
@@ -463,6 +488,11 @@ class TestBootSpawnLatency:
         positive evidence that its own bind succeeded — may short-circuit.
         """
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
 
         monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
         monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
@@ -491,6 +521,11 @@ class TestBootSpawnLatency:
         """
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
         # Something is listening, but it is not our child (nor its descendant).
         monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
@@ -518,6 +553,11 @@ class TestBootSpawnLatency:
         is the launcher's child, not the pid Popen returned).
         """
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
 
         monkeypatch.setattr(bmod, "time", _frozen_spawn_time())
         monkeypatch.setattr(bmod.platform_compat, "listening_pid_tool_available", lambda: True)
@@ -598,6 +638,11 @@ class TestBootSpawnLatency:
 
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         monkeypatch.setattr(
             bmod.platform_compat, "listening_pid_tool_available", lambda: False
         )
@@ -628,6 +673,11 @@ class TestBootSpawnLatency:
 
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         names = [f"par-app-{i}" for i in range(4)]
         concurrent = threading.Barrier(len(names), timeout=10)
 
@@ -644,6 +694,11 @@ class TestBootSpawnLatency:
     def test_concurrent_boot_isolates_a_single_app_failure(self, monkeypatch):
         """One app's spawn failure must never take down the others (or boot)."""
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
 
         def _fake_start(app_name: str):
             if app_name == "bad-app":
@@ -995,6 +1050,11 @@ class TestBackendLifecycle:
         # verifies the child survived its bind; an immediate exit → None + cleared state.
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         # Widen the survival-check grace window for this test only. The boom.py child
         # exits immediately ONCE it runs, but under heavy pytest-xdist parallelism
         # (-n auto, ~32 workers) the sandboxed interpreter can take well over the default
@@ -1265,6 +1325,11 @@ class TestBootAdmissionRevet:
     def _boot_env(self, monkeypatch):
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         monkeypatch.setattr(bmod, "_reap_stale_app_backends", lambda: 0)
         started: list[str] = []
 
@@ -1313,6 +1378,11 @@ class TestBootAdmissionRevet:
         skips the failing app, and still boots the healthy one."""
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         monkeypatch.setattr(bmod, "_reap_stale_app_backends", lambda: 0)
         monkeypatch.setattr(bmod, "get_app_manifest", lambda name: None)
         started: list[str] = []
@@ -1341,6 +1411,30 @@ class TestBootAdmissionRevet:
         assert "boom-app" not in result
 
 
+def _reconcile_lock_held() -> bool:
+    """Whether the health reconcile lock is held right now.
+
+    Probed from a SEPARATE thread on purpose: the lock is an RLock, so a same-thread
+    acquire would succeed by re-entrancy and report False no matter who holds it.
+    """
+    import threading
+
+    import kiro_crew.apps.backend as bmod
+
+    result: list[bool] = []
+
+    def _probe() -> None:
+        got = bmod._health_reconcile_lock.acquire(blocking=False)
+        result.append(not got)
+        if got:
+            bmod._health_reconcile_lock.release()
+
+    t = threading.Thread(target=_probe)
+    t.start()
+    t.join()
+    return result[0]
+
+
 class _FakeHealthResp:
     """Minimal urlopen() stand-in: a 200 response usable as a context manager."""
 
@@ -1367,6 +1461,11 @@ class TestHealthGatedMcpRegistration:
 
     def test_registers_when_healthy_and_still_tracked(self, monkeypatch):
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         self._fast_health(bmod, monkeypatch)
         calls = []
         monkeypatch.setattr(bmod, "_gate_mcp_registration",
@@ -1377,7 +1476,7 @@ class TestHealthGatedMcpRegistration:
         with bmod._lock:
             bmod._processes["hg-app"] = AppProcess(app_name="hg-app", port=9150, healthy=False)
         try:
-            bmod._health_check_loop("hg-app", 9150, "/health")
+            bmod._health_check_loop(bmod._processes["hg-app"], "/health")
             assert calls == [("hg-app", 9150, True)]  # registered exactly once, healthy
             assert bmod._processes["hg-app"].healthy is True
         finally:
@@ -1388,6 +1487,11 @@ class TestHealthGatedMcpRegistration:
         # review-bot race finding: app removed from _processes between the poll and the lock →
         # must NOT register MCP for a now-dead backend.
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         self._fast_health(bmod, monkeypatch)
         calls = []
         monkeypatch.setattr(bmod, "_gate_mcp_registration",
@@ -1398,11 +1502,16 @@ class TestHealthGatedMcpRegistration:
         with bmod._lock:
             bmod._processes.clear()  # ensure absent
 
-        bmod._health_check_loop("gone-app", 9151, "/health")
+        bmod._health_check_loop(AppProcess(app_name="gone-app", port=9151), "/health")
         assert calls == []  # never registered — no dead-URL entry written
 
     def test_scrubs_when_never_healthy(self, monkeypatch):
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         self._fast_health(bmod, monkeypatch)
         calls = []
         monkeypatch.setattr(bmod, "_gate_mcp_registration",
@@ -1415,7 +1524,7 @@ class TestHealthGatedMcpRegistration:
         with bmod._lock:
             bmod._processes["sick-app"] = AppProcess(app_name="sick-app", port=9152, healthy=False)
         try:
-            bmod._health_check_loop("sick-app", 9152, "/health")
+            bmod._health_check_loop(bmod._processes["sick-app"], "/health")
             # Never healthy → scrub (healthy=False), never register.
             assert calls == [("sick-app", 9152, False)]
         finally:
@@ -1679,15 +1788,22 @@ class TestBackendLivenessWatch:
         """
         import kiro_crew.apps.backend as bmod
 
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
         monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
         gate_calls: list[tuple[str, int, bool]] = []
         monkeypatch.setattr(
             bmod, "_gate_mcp_registration",
-            lambda name, port, *, healthy: gate_calls.append((name, port, healthy)),
+            lambda name, port, *, healthy: (gate_calls.append((name, port, healthy)), True)[1],
         )
 
+        # mcp_healthy=True models the real precondition: a record only reaches the
+        # watch after a promotion has already reconciled mcp.json for it.
         ap = AppProcess(app_name="watched", port=9160, pid=4242,
-                        proc=_FakeProc(), healthy=True)
+                        proc=_FakeProc(), healthy=True, mcp_healthy=True)
         with bmod._lock:
             bmod._processes.clear()
             bmod._processes["watched"] = ap
@@ -1816,25 +1932,35 @@ class TestHealthSupervisorHandoff:
 
     def test_watch_runs_when_the_backend_came_up(self, monkeypatch):
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         ap = AppProcess(app_name="up", port=9170, healthy=True)
         watched: list[tuple[AppProcess, str]] = []
         monkeypatch.setattr(bmod, "_health_check_loop", lambda *_a, **_k: ap)
         monkeypatch.setattr(bmod, "_watch_backend_health",
                             lambda rec, path: watched.append((rec, path)))
 
-        bmod._supervise_backend_health("up", 9170, "/health")
+        bmod._supervise_backend_health(ap, "/health")
 
         assert watched == [(ap, "/health")]
 
     def test_no_watch_when_the_backend_never_came_up(self, monkeypatch):
         # Nothing to watch: the startup path already scrubbed the MCP entry and gave up.
         import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         watched: list[Any] = []
         monkeypatch.setattr(bmod, "_health_check_loop", lambda *_a, **_k: None)
         monkeypatch.setattr(bmod, "_watch_backend_health",
                             lambda rec, path: watched.append(rec))
 
-        bmod._supervise_backend_health("down", 9171, "/health")
+        bmod._supervise_backend_health(AppProcess(app_name="down", port=9171), "/health")
 
         assert watched == []
 
@@ -1853,7 +1979,7 @@ class TestHealthTransitionsRefuseAStaleRecord:
         calls: list[tuple[str, int, bool]] = []
         monkeypatch.setattr(
             bmod, "_gate_mcp_registration",
-            lambda name, port, *, healthy: calls.append((name, port, healthy)),
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
         )
         with bmod._lock:
             bmod._processes.clear()
@@ -1880,3 +2006,1530 @@ class TestHealthTransitionsRefuseAStaleRecord:
 
         assert ap.healthy is False
         assert calls == []
+
+
+class TestMcpReconcileHonoursRecordIdentity:
+    """A stale watcher must not move the SUCCESSOR's MCP entry (review finding).
+
+    The MCP writers key on the app NAME, not on the record: `_deregister_mcp_servers`
+    removes every `<app>:` entry. So the identity guard has to stay effective through
+    the reconcile, not merely alongside the flag write — otherwise a demotion decided
+    about a retired record scrubs the live successor's servers, and a stale promotion
+    republishes the predecessor's dead port.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
+        )
+        with bmod._lock:
+            bmod._processes.clear()
+        try:
+            yield bmod, calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_retired_record_cannot_scrub_the_successors_servers(self, wired):
+        bmod, calls = wired
+        old = AppProcess(app_name="app", port=9180, healthy=True)
+        new = AppProcess(app_name="app", port=9181, healthy=True)
+        with bmod._lock:
+            bmod._processes["app"] = new  # a stop/start already replaced `old`
+
+        bmod._demote(old, reason="its own process exited")
+
+        assert calls == []  # the successor's `app:` entries are untouched
+        assert new.healthy is True
+        assert bmod.get_app_backend_port("app") == 9181
+
+    def test_a_retired_record_cannot_republish_its_dead_port(self, wired):
+        bmod, calls = wired
+        old = AppProcess(app_name="app", port=9182, healthy=False)
+        new = AppProcess(app_name="app", port=9183, healthy=True)
+        with bmod._lock:
+            bmod._processes["app"] = new
+
+        bmod._promote(old)
+
+        assert calls == []  # never re-registers 9182, which nothing serves any more
+
+    def test_the_reconcile_runs_under_the_serialization_lock(self, wired):
+        # The ordering guarantee depends on the reconcile happening INSIDE
+        # _health_reconcile_lock, not merely after the identity check. Observe it from
+        # the reconcile itself, which is the only place the property is visible.
+        bmod, calls = wired
+        ap = AppProcess(app_name="app", port=9184, healthy=False)
+        with bmod._lock:
+            bmod._processes["app"] = ap
+        held: list[bool] = []
+
+        def _observe(name, port, *, healthy):
+            held.append(_reconcile_lock_held())
+            return True
+
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(bmod, "_gate_mcp_registration", _observe)
+        monkey.setattr(bmod, "_app_enabled_state", lambda name: True)
+        try:
+            bmod._promote(ap)
+        finally:
+            monkey.undo()
+
+        assert held == [True]
+
+    def test_startup_registration_takes_the_same_lock_as_the_watch(self, monkeypatch):
+        # Serializing only the watch would not be enough: the successor's own startup
+        # registration has to queue behind a retiring watcher's reconcile, or the two
+        # can still interleave and leave the dead port as the last write.
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 2)
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp())
+        held: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (held.append(_reconcile_lock_held()), True)[1],
+        )
+        ap = AppProcess(app_name="boot", port=9185, healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["boot"] = ap
+        try:
+            assert bmod._health_check_loop(ap, "/health") is ap
+            assert held == [True]
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestStartupProbeCannotPromoteAReplacement:
+    """The startup poll must promote only the record it actually probed (review finding).
+
+    Resolving the record by name AFTER the probe let a stop/start landing mid-probe hand
+    back the successor, which was then marked healthy — and therefore routed to, and MCP
+    registered — on evidence gathered about its predecessor, without ever having
+    answered a probe itself.
+    """
+
+    def test_a_successor_installed_mid_probe_is_not_promoted(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 2)
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
+        )
+
+        original = AppProcess(app_name="app", port=9190, healthy=False)
+        successor = AppProcess(app_name="app", port=9191, healthy=False)
+
+        def _probe_then_swap(_url):
+            # The stop/start lands while the probe is in flight.
+            with bmod._lock:
+                bmod._processes["app"] = successor
+            return True
+
+        monkeypatch.setattr(bmod, "_health_probe", _probe_then_swap)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = original
+        try:
+            result = bmod._health_check_loop(original, "/health")
+
+            assert result is None  # nothing promoted, so no watch is armed either
+            assert successor.healthy is False  # never answered a probe of its own
+            assert calls == []  # and its MCP entry was not written from a stale port
+            assert bmod.get_app_backend_port("app") is None
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestFailedMcpReconcileIsRetried:
+    """A reconcile that did not land must be retried (review finding).
+
+    The health FLAG moves whether or not mcp.json could be written. Gating the
+    reconcile on the health *transition* alone therefore stranded a failed write until
+    the next transition — which, for a backend that then stays put, never comes: a dead
+    URL kiro-cli dials on every session, or a live backend with no MCP entry at all.
+    """
+
+    @pytest.fixture
+    def watched(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        ap = AppProcess(app_name="w", port=9200, pid=1, proc=_FakeProc(),
+                        healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["w"] = ap
+        probes: list[bool] = []
+
+        def _scripted(_url):
+            if not probes:
+                with bmod._lock:
+                    bmod._processes.pop("w", None)
+                return False
+            return probes.pop(0)
+        monkeypatch.setattr(bmod, "_health_probe", _scripted)
+        try:
+            yield bmod, ap, probes
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_failed_scrub_is_reattempted_on_the_next_sweep(self, monkeypatch, watched):
+        bmod, ap, probes = watched
+        attempts: list[bool] = []
+
+        def _gate(name, port, *, healthy):
+            attempts.append(healthy)
+            return len(attempts) > 1  # the first write fails, the retry lands
+        monkeypatch.setattr(bmod, "_gate_mcp_registration", _gate)
+
+        # Demote on sweep 3, then two more sweeps with the verdict unchanged.
+        probes.extend([False] * (bmod._HEALTH_WATCH_FAILURES + 2))
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False, False]  # retried once, then stopped once it landed
+        assert ap.mcp_healthy is False  # record only advances on a write that landed
+
+    def test_a_landed_reconcile_is_not_rewritten_every_sweep(self, monkeypatch, watched):
+        bmod, ap, probes = watched
+        attempts: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
+        )
+
+        probes.extend([False] * (bmod._HEALTH_WATCH_FAILURES + 3))
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False]  # one scrub; the steady state writes nothing further
+
+    def test_an_exited_process_scrubs_an_entry_the_flag_had_already_left_behind(
+        self, monkeypatch, watched
+    ):
+        # healthy=False but mcp_healthy=True is exactly the state a failed scrub leaves.
+        # The terminal exit path has to consult the entry, not just the flag, or the
+        # dead URL survives the watch's own shutdown.
+        bmod, ap, probes = watched
+        attempts: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
+        )
+        ap.healthy = False
+        ap.mcp_healthy = True
+        ap.proc = _FakeProc(returncode=1)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False]
+        assert ap.mcp_healthy is False
+
+
+class TestStartupPollBelongsToOneGeneration:
+    """The whole startup poll is bound to the record it started on (design review).
+
+    Pinning per ATTEMPT is not enough: a stop/start between attempts hands a later
+    attempt the successor, and this poll then acts on it — promoting it, or on
+    exhaustion scrubbing it — on evidence gathered entirely about its predecessor,
+    having never probed the successor's port.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 4)
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
+        )
+        with bmod._lock:
+            bmod._processes.clear()
+        try:
+            yield bmod, calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_exhaustion_does_not_scrub_a_successor_that_replaced_it(
+        self, monkeypatch, wired
+    ):
+        # The harmful shape the design review named: the retiring poll's terminal scrub
+        # deregisters by app name, taking the healthy successor's entry with it — and
+        # because that bypasses the record, the successor's mcp_healthy still reads True,
+        # so the watch's retry never fires and the live backend stays MCP-less.
+        bmod, calls = wired
+        original = AppProcess(app_name="a", port=9210, healthy=False)
+        successor = AppProcess(app_name="a", port=9211, healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes["a"] = original
+
+        swapped = {"done": False}
+
+        def _never_answers(_url):
+            if not swapped["done"]:  # the restart lands between attempts
+                swapped["done"] = True
+                with bmod._lock:
+                    bmod._processes["a"] = successor
+            return False
+        monkeypatch.setattr(bmod, "_health_probe", _never_answers)
+
+        assert bmod._health_check_loop(original, "/health") is None
+        assert calls == []  # the successor's `a:` entries survive
+        assert successor.mcp_healthy is True
+        assert bmod.get_app_backend_port("a") == 9211
+
+    def test_a_successor_is_not_promoted_by_a_later_attempt(self, monkeypatch, wired):
+        bmod, calls = wired
+        original = AppProcess(app_name="a", port=9212, healthy=False)
+        successor = AppProcess(app_name="a", port=9213, healthy=False)
+        with bmod._lock:
+            bmod._processes["a"] = original
+
+        state = {"n": 0}
+
+        def _probe(_url):
+            state["n"] += 1
+            if state["n"] == 1:
+                with bmod._lock:
+                    bmod._processes["a"] = successor
+                return False
+            return True  # a later attempt would "succeed" against the OLD port
+        monkeypatch.setattr(bmod, "_health_probe", _probe)
+
+        assert bmod._health_check_loop(original, "/health") is None
+        assert successor.healthy is False  # never probed on its own port
+        assert calls == []
+
+
+class TestTerminalScrubIsRetriedUntilItLands:
+    """The exit path may not leave the dead URL behind (review finding).
+
+    This is the one place where giving up is permanent: nothing revisits an exited
+    backend, so a scrub that did not land stays unlanded and kiro-cli keeps dialing the
+    dead url every session. The retry the watch does elsewhere was useless here, because
+    the terminal path returned before it could run.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        ap = AppProcess(app_name="x", port=9220, pid=3,
+                        proc=_FakeProc(returncode=1), healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["x"] = ap
+        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+        try:
+            yield bmod, ap
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_failed_terminal_scrub_is_retried(self, monkeypatch, wired):
+        bmod, ap = wired
+        attempts: list[bool] = []
+
+        def _gate(name, port, *, healthy):
+            attempts.append(healthy)
+            return len(attempts) >= 3  # the first two writes fail
+        monkeypatch.setattr(bmod, "_gate_mcp_registration", _gate)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False, False, False]  # retried until it landed
+        assert ap.mcp_healthy is False
+
+    def test_it_stops_as_soon_as_the_scrub_lands(self, monkeypatch, wired):
+        bmod, ap = wired
+        attempts: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
+        )
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False]  # one scrub, then the watch is done
+
+    def test_it_gives_up_when_the_record_is_dropped_mid_retry(self, monkeypatch, wired):
+        # stop_app_backend popping the record ends the watch even with the scrub
+        # unlanded — that path owns the teardown from there, and a watch that spun on a
+        # record nobody tracks would never exit.
+        bmod, ap = wired
+        attempts: list[bool] = []
+
+        def _gate(name, port, *, healthy):
+            attempts.append(healthy)
+            with bmod._lock:
+                bmod._processes.pop("x", None)
+            return False  # never lands
+        monkeypatch.setattr(bmod, "_gate_mcp_registration", _gate)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == [False]  # did not spin
+
+    def test_nothing_registered_means_nothing_to_unwind(self, monkeypatch, wired):
+        bmod, ap = wired
+        ap.healthy = False
+        ap.mcp_healthy = False
+        attempts: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
+        )
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert attempts == []
+
+
+class TestTeardownParticipatesInTheReconcileSerialization:
+    """stop_app_backend takes the reconcile lock (review finding).
+
+    A watcher that had already passed its identity check could still be inside
+    `_gate_mcp_registration` when the caller's `deregister_app` scrubs — its write would
+    land after, restoring the dead url the gate exists to keep out of mcp.json.
+    """
+
+    def test_stop_holds_the_reconcile_lock_across_the_pop(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        ap = AppProcess(app_name="s", port=9230, healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["s"] = ap
+        held: list[bool] = []
+        real_lock = bmod._lock
+
+        class _SpyLock:
+            """Records whether the reconcile lock is held whenever `_lock` is entered.
+
+            Observing the nesting directly is the point: the guarantee is that the pop
+            happens INSIDE the serialization, and only the lock state at the moment
+            `_lock` is taken can show that.
+            """
+
+            def __enter__(self):
+                held.append(_reconcile_lock_held())
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc):
+                return real_lock.__exit__(*exc)
+
+        monkeypatch.setattr(bmod, "_lock", _SpyLock())
+        try:
+            bmod.stop_app_backend("s")
+        finally:
+            monkeypatch.setattr(bmod, "_lock", real_lock)
+            with bmod._lock:
+                bmod._processes.clear()
+
+        assert held and held[0] is True, held
+
+
+class TestAdoptedRecoveryRebindsOwnership:
+    """An adopted recovery must re-bind its owning PIDs (review finding).
+
+    `adopted_pids` is what `stop_app_backend` signals and what uninstall acts behind. A
+    recovery means the EXTERNAL supervisor put something back, possibly a different
+    process — so promoting on the adoption-time identities would mark the record
+    freshly-valid while naming a process that is gone.
+    """
+
+    @pytest.fixture
+    def watched(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration", lambda name, port, *, healthy: True
+        )
+        ap = AppProcess(app_name="ad", port=9240, pid=0, proc=None, healthy=False,
+                        mcp_healthy=False, adopted_pids=[111],
+                        adopted_start_times={111: "old"})
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["ad"] = ap
+        probes: list[bool] = []
+
+        def _scripted(_url):
+            if not probes:
+                with bmod._lock:
+                    bmod._processes.pop("ad", None)
+                return False
+            return probes.pop(0)
+        monkeypatch.setattr(bmod, "_health_probe", _scripted)
+        try:
+            yield bmod, ap, probes
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_recovery_recaptures_the_owner_set(self, monkeypatch, watched):
+        bmod, ap, probes = watched
+        monkeypatch.setattr(
+            bmod, "_capture_adopted_owners",
+            lambda name, port, path: ([222], {222: "new"}),
+        )
+        probes.append(True)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is True
+        assert ap.adopted_pids == [222]  # rebound to the replacement
+        assert ap.adopted_start_times == {222: "new"}
+
+    def test_unconfirmable_ownership_refuses_the_promotion(self, monkeypatch, watched):
+        # Unhealthy-but-serving is recoverable next sweep; a mis-bound owner set is not,
+        # because stop would signal the wrong PIDs while the replacement keeps running.
+        bmod, ap, probes = watched
+        monkeypatch.setattr(
+            bmod, "_capture_adopted_owners", lambda name, port, path: None
+        )
+        probes.append(True)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert ap.healthy is False  # refused
+        assert ap.adopted_pids == [111]  # untouched, not silently half-updated
+        assert bmod.get_app_backend_port("ad") is None
+
+    def test_a_spawned_backend_does_not_pay_the_recapture(self, monkeypatch, watched):
+        # Only the adopted shape has external ownership to re-bind; a spawned backend
+        # holds its own Popen and must not take this path.
+        bmod, ap, probes = watched
+        called: list[str] = []
+        monkeypatch.setattr(
+            bmod, "_capture_adopted_owners",
+            lambda name, port, path: called.append(name) or ([9], {9: "x"}),
+        )
+        ap.proc = _FakeProc()
+        probes.append(True)
+
+        bmod._watch_backend_health(ap, "/health")
+
+        assert called == []
+        assert ap.healthy is True
+
+
+class TestUnknownMcpStateStillGetsScrubbed:
+    """`mcp_healthy` is tri-state; only False means confirmed-scrubbed (review finding).
+
+    A startup reconcile that failed leaves `healthy=True, mcp_healthy=None` — the entry
+    may well be on disk, and None records only that we never confirmed a write. Treating
+    that as "nothing was ever registered" abandoned precisely the entry most in need of
+    removal, one sweep after the process exited.
+    """
+
+    def test_a_none_mcp_state_keeps_retrying_the_terminal_scrub(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        attempts: list[bool] = []
+
+        def _gate(name, port, *, healthy):
+            attempts.append(healthy)
+            return len(attempts) >= 3  # the first two scrubs fail
+        monkeypatch.setattr(bmod, "_gate_mcp_registration", _gate)
+        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+
+        # The state a failed startup reconcile leaves: promoted, never confirmed written.
+        ap = AppProcess(app_name="u", port=9250, pid=5,
+                        proc=_FakeProc(returncode=1), healthy=True, mcp_healthy=None)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["u"] = ap
+        try:
+            bmod._watch_backend_health(ap, "/health")
+            assert attempts == [False, False, False]  # kept going past sweep 2
+            assert ap.mcp_healthy is False
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_confirmed_scrub_still_ends_the_watch(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        attempts: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (attempts.append(healthy), True)[1],
+        )
+        monkeypatch.setattr(bmod, "_health_probe", lambda _u: False)
+
+        ap = AppProcess(app_name="u", port=9251, pid=5,
+                        proc=_FakeProc(returncode=0), healthy=False, mcp_healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["u"] = ap
+        try:
+            bmod._watch_backend_health(ap, "/health")
+            assert attempts == []  # nothing to unwind, and it does not spin
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestProbeSurvivesAMalformedHttpResponse:
+    """`http.client.HTTPException` is not an `OSError` (review finding).
+
+    An app backend is arbitrary third-party code — an `exec` backend, or an adopted
+    process we do not own — so a non-HTTP first line on the port is a real condition.
+    `BadStatusLine` escaping `_health_probe` would kill the standing daemon watch and
+    freeze `healthy` at its last value: the write-once behaviour this PR removes,
+    silently restored.
+    """
+
+    def _serve_garbage(self, payload: bytes) -> int:
+        import socket
+        import threading
+        srv = socket.socket()
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        port = srv.getsockname()[1]
+        srv.listen(1)
+
+        def _serve():
+            try:
+                conn, _ = srv.accept()
+                conn.recv(4096)
+                conn.sendall(payload)
+                conn.close()
+            except OSError:
+                pass
+            finally:
+                srv.close()
+
+        threading.Thread(target=_serve, daemon=True).start()
+        return port
+
+    def test_a_malformed_status_line_is_a_failed_probe_not_a_raise(self):
+        # Drives a REAL socket rather than a stubbed exception: the whole finding is
+        # about which concrete exception urllib lets through, so faking it would beg
+        # the question.
+        import kiro_crew.apps.backend as bmod
+        port = self._serve_garbage(b"NOT-HTTP garbage\r\n\r\n")
+
+        assert bmod._health_probe(f"http://127.0.0.1:{port}/health") is False
+
+    def test_the_adoption_probe_survives_it_too(self):
+        # Same class of bug in the sibling probe — fixed together so one does not sit
+        # next to the other still wrong.
+        import kiro_crew.apps.backend as bmod
+        port = self._serve_garbage(b"\x00\x01binary noise\r\n\r\n")
+
+        assert bmod._probe_adoption_health(port, "/health") is False
+
+
+class TestWatchSurvivesAnUnexpectedSweepFault:
+    """A dying watch silently restores write-once, so a sweep fault must not kill it."""
+
+    def test_the_watch_restarts_after_an_unexpected_exception(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration", lambda name, port, *, healthy: True
+        )
+        ap = AppProcess(app_name="w", port=9260, proc=_FakeProc(),
+                        healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["w"] = ap
+
+        calls = {"n": 0}
+
+        def _probe(_url):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("something nobody anticipated")
+            with bmod._lock:  # second sweep: end the watch cleanly
+                bmod._processes.pop("w", None)
+            return True
+        monkeypatch.setattr(bmod, "_health_probe", _probe)
+        try:
+            bmod._watch_backend_health(ap, "/health")
+            assert calls["n"] == 2  # survived the fault and swept again
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_it_does_not_restart_once_the_record_is_gone(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_WATCH_INTERVAL", 0)
+        ap = AppProcess(app_name="w", port=9261, proc=_FakeProc(),
+                        healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["w"] = ap
+
+        calls = {"n": 0}
+
+        def _probe(_url):
+            calls["n"] += 1
+            with bmod._lock:
+                bmod._processes.pop("w", None)
+            raise RuntimeError("faults while being torn down")
+        monkeypatch.setattr(bmod, "_health_probe", _probe)
+        try:
+            bmod._watch_backend_health(ap, "/health")
+            assert calls["n"] == 1  # did not spin on a record nobody tracks
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestScrubAlsoRefreshesMaterializedAgents:
+    """Removing a server from the global map is only half the removal (review finding).
+
+    An app's materialized agent JSONs COPY the server's launch spec, and the agent config
+    is what kiro-cli actually loads — so scrubbing `mcp.json` alone leaves the agents
+    still naming the dead url. The refresh goes through `bridges.refresh_app_agents`,
+    which already carries the guards this path must honour: a `resources="app"` app
+    publishes its own agents, and a denied app's are scrubbed rather than rewritten.
+    """
+
+    def test_an_unhealthy_reconcile_refreshes_the_apps_agents(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(
+            brmod, "refresh_app_agents",
+            lambda name, io_failures=None: (seen.append(name), [])[1],
+        )
+
+        # The demotion path's agent refresh is gated on the app still being
+        # enabled — it re-materializes files a disable would have removed. The
+        # gate itself is pinned by TestDemotionRefreshIsGatedOnEnablement.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        assert bmod._gate_mcp_registration("a", 9270, healthy=False) is True
+        assert seen == ["a"]
+
+    def test_a_healthy_reconcile_does_not_take_the_scrub_path(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        seen: list[str] = []
+        monkeypatch.setattr(brmod, "reregister_app_mcp_servers",
+                            lambda name, live_port=None, io_failures=None: [])
+        monkeypatch.setattr(
+            brmod, "refresh_app_agents",
+            lambda name, io_failures=None: (seen.append(name), [])[1],
+        )
+
+        assert bmod._gate_mcp_registration("a", 9271, healthy=True) is True
+        # reregister_app_mcp_servers does its own agent refresh; this must not double it.
+        assert seen == []
+
+    def test_an_agent_io_failure_makes_the_reconcile_unlanded(self, monkeypatch):
+        # The agent JSON is the file kiro-cli reads, so a scrub whose agent half failed
+        # has NOT achieved what the scrub exists for. Reporting it landed would let
+        # `mcp_healthy` advance and strand the dead url there permanently.
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+
+        def _refresh(name, io_failures=None):
+            if io_failures is not None:
+                io_failures.append("a--agent.json")
+            return []
+        monkeypatch.setattr(brmod, "refresh_app_agents", _refresh)
+
+        # The demotion path's agent refresh is gated on the app still being
+        # enabled — it re-materializes files a disable would have removed. The
+        # gate itself is pinned by TestDemotionRefreshIsGatedOnEnablement.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        assert bmod._gate_mcp_registration("a", 9272, healthy=False) is False
+
+    def test_nothing_to_refresh_is_not_a_failure(self, monkeypatch):
+        # A self-managed app, a denied one, and an app with no declared agents all return
+        # an empty list. None is a failed write, and retrying them never converges — only
+        # the io_failures collector means retry.
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(brmod, "refresh_app_agents", lambda name, io_failures=None: [])
+
+        # The demotion path's agent refresh is gated on the app still being
+        # enabled — it re-materializes files a disable would have removed. The
+        # gate itself is pinned by TestDemotionRefreshIsGatedOnEnablement.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        assert bmod._gate_mcp_registration("selfmanaged", 9273, healthy=False) is True
+
+
+class TestSupervisorIsBoundAtSpawn:
+    """The supervisor carries its record, not a name to re-resolve (review finding).
+
+    A name and a port are two independent inputs that can disagree. A stop/restart
+    landing between the spawn inserting the record and the supervisor thread's first
+    statement would hand a name lookup the SUCCESSOR while the port argument still named
+    the predecessor — and the poll would then promote, or on exhaustion scrub, a backend
+    whose port it never probed.
+    """
+
+    def test_the_starter_hands_over_the_record_itself(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        captured: list[object] = []
+        monkeypatch.setattr(
+            bmod.threading, "Thread",
+            lambda **kw: SimpleNamespace(start=lambda: captured.append(kw["args"])),
+        )
+        ap = AppProcess(app_name="s", port=9290)
+
+        bmod._start_health_supervisor(ap, "/health")
+
+        assert captured == [(ap, "/health")]  # the record, not ("s", 9290)
+
+    def test_a_restart_before_the_thread_runs_cannot_divert_the_poll(self, monkeypatch):
+        # Simulates the window: the successor is installed before the supervisor's first
+        # statement. Binding to the record means the poll retires instead of acting on a
+        # generation it never probed.
+        import kiro_crew.apps.backend as bmod
+
+        # These exercise promotion logic, not enablement: their app names are
+        # fabricated and so are not in installed.json. The real gate is pinned by
+        # TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 2)
+        gate: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (gate.append((name, port, healthy)), True)[1],
+        )
+        monkeypatch.setattr(bmod, "_health_probe", lambda _u: True)
+
+        original = AppProcess(app_name="s", port=9291, healthy=False)
+        successor = AppProcess(app_name="s", port=9292, healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["s"] = successor  # the restart already landed
+        try:
+            bmod._supervise_backend_health(original, "/health")
+            assert successor.healthy is False  # never promoted on the old port's evidence
+            assert gate == []
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestRegistrationReportsAgentIoFailuresToo:
+    """The healthy branch owes the same guarantee as the scrub (review finding).
+
+    Both directions write the agent JSONs, and both let `mcp_healthy` advance on success.
+    Reporting a failed agent write as landed on RECOVERY strands the app's agent without
+    its MCP tools exactly as reporting one on demotion stranded the dead url — the same
+    defect, mirrored, and fixing only one half was an oversight rather than a decision.
+    """
+
+    def test_a_failed_agent_write_on_recovery_is_unlanded(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        def _reregister(app_name, live_port=None, io_failures=None):
+            if io_failures is not None:
+                io_failures.append("a--agent.json")
+            return ["a:backend"]
+        monkeypatch.setattr(brmod, "reregister_app_mcp_servers", _reregister)
+
+        assert bmod._gate_mcp_registration("a", 9300, healthy=True) is False
+
+    def test_a_clean_registration_still_lands(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "reregister_app_mcp_servers",
+            lambda app_name, live_port=None, io_failures=None: ["a:backend"],
+        )
+
+        assert bmod._gate_mcp_registration("a", 9301, healthy=True) is True
+
+    def test_the_live_port_is_still_threaded_through(self, monkeypatch):
+        # The collector must not displace the argument that makes the url reachable.
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        seen: dict[str, object] = {}
+
+        def _reregister(app_name, live_port=None, io_failures=None):
+            seen["port"] = live_port
+            return []
+        monkeypatch.setattr(brmod, "reregister_app_mcp_servers", _reregister)
+
+        assert bmod._gate_mcp_registration("a", 9302, healthy=True) is True
+        assert seen == {"port": 9302}
+
+
+class TestPromotionRequiresAConfirmedEnabledApp:
+    """A disabled app must not be resurrected by a health recovery (#5726 review).
+
+    `kirocrew app disable` runs in its OWN process: it deregisters the app's resources
+    and never touches this process's tracking table. The record survives, so a later
+    recovery would re-register the MCP servers and agents the operator just removed.
+    Demotion is never gated — scrubbing is always safe.
+    """
+
+    @pytest.fixture
+    def tracked(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
+        )
+        ap = AppProcess(app_name="app", port=9310, healthy=False, mcp_healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            yield bmod, ap, calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_disabled_app_is_not_promoted(self, monkeypatch, tracked):
+        bmod, ap, calls = tracked
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert ap.healthy is False
+        assert calls == []  # nothing re-registered for an app the operator disabled
+
+    def test_an_enabled_app_is_promoted(self, monkeypatch, tracked):
+        bmod, ap, calls = tracked
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        assert bmod._set_backend_health(ap, healthy=True) is True
+        assert ap.healthy is True
+        assert calls == [("app", 9310, True)]
+
+    def test_demotion_is_never_gated(self, monkeypatch, tracked):
+        # Refusing a scrub because enablement cannot be confirmed would strand the dead
+        # url — the exact failure this whole gate exists to prevent.
+        bmod, ap, calls = tracked
+        ap.healthy = True
+        ap.mcp_healthy = True
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+
+        assert bmod._set_backend_health(ap, healthy=False) is True
+        assert ap.healthy is False
+        assert calls == [("app", 9310, False)]
+
+    # The unreadable-state case is covered by
+    # TestEnabledStateDistinguishesUnreadableFromDisabled, which drives REAL files. A
+    # stub of `is_app_enabled` cannot test it: the defect was that the reader collapses
+    # a read failure into False without raising, so stubbing it to raise would assert a
+    # path production never takes.
+
+
+class TestPromotionIsVerifiedAfterTheWrite:
+    """The enabled check cannot be atomic with the write (#5726 review).
+
+    `kirocrew app disable` runs in another process, so there is no lock to share. Ordering
+    closes the interleave where the flag is read after the resources come down; this
+    covers the other one — the check passes, the disable completes, and the write lands
+    afterwards, leaving a disabled app dispatchable.
+    """
+
+    @pytest.fixture
+    def tracked(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        calls: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append((name, port, healthy)), True)[1],
+        )
+        ap = AppProcess(app_name="app", port=9320, healthy=False, mcp_healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            yield bmod, ap, calls
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_disable_landing_mid_write_is_undone(self, monkeypatch, tracked):
+        bmod, ap, calls = tracked
+        # Enabled at the pre-check, disabled by the time the write has landed.
+        states = iter([True, False])
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: next(states))
+        undone: list[str] = []
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(brmod, "deregister_app", lambda n: undone.append(n))
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert undone == ["app"]  # what the promotion registered is removed again
+        assert ap.healthy is False
+        assert ap.mcp_healthy is False
+
+    def test_a_still_enabled_app_is_left_registered(self, monkeypatch, tracked):
+        bmod, ap, calls = tracked
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(
+            brmod, "deregister_app",
+            lambda n: pytest.fail("must not undo a promotion that is still valid"),
+        )
+
+        assert bmod._set_backend_health(ap, healthy=True) is True
+        assert ap.healthy is True
+        assert calls == [("app", 9320, True)]
+
+    def test_a_demotion_is_never_verified_or_undone(self, monkeypatch, tracked):
+        # Demotion is ungated going in and must stay ungated coming out: scrubbing a
+        # disabled app's entry is exactly what should happen.
+        bmod, ap, calls = tracked
+        ap.healthy = True
+        ap.mcp_healthy = True
+        monkeypatch.setattr(
+            bmod, "_app_enabled_state",
+            lambda name: pytest.fail("a demotion must not consult enablement"),
+        )
+
+        assert bmod._set_backend_health(ap, healthy=False) is True
+        assert calls == [("app", 9320, False)]
+
+
+class TestUndoIsRetriedUntilItCompletes:
+    """`deregister_app` reports softly, so a failed undo must not look clean (#5726 review).
+
+    It returns problems in `RegistrationResult.errors` rather than raising, so recording
+    the removal without reading that list leaves a disabled app's resources registered
+    while the record claims otherwise — and the retry condition then sees agreement and
+    never fires.
+    """
+
+    @pytest.fixture
+    def disabled(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration", lambda name, port, *, healthy: True
+        )
+        ap = AppProcess(app_name="app", port=9330, healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            yield bmod, ap
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_a_soft_failure_leaves_the_record_unreconciled(self, monkeypatch, disabled):
+        bmod, ap = disabled
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(
+            brmod, "deregister_app",
+            lambda n: SimpleNamespace(errors=["could not remove agent: ENOSPC"]),
+        )
+
+        assert bmod._undo_promotion_of_disabled_app(ap) is False
+        assert ap.healthy is False
+        assert ap.mcp_healthy is True, "a removal that failed must not read as done"
+
+    def test_a_clean_removal_is_recorded(self, monkeypatch, disabled):
+        bmod, ap = disabled
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(brmod, "deregister_app", lambda n: SimpleNamespace(errors=[]))
+
+        assert bmod._undo_promotion_of_disabled_app(ap) is True
+        assert ap.mcp_healthy is False
+
+    def test_a_raising_deregister_also_leaves_it_unreconciled(self, monkeypatch, disabled):
+        bmod, ap = disabled
+        import kiro_crew.apps.bridges as brmod
+
+        def _boom(n):
+            raise OSError("agents dir unwritable")
+        monkeypatch.setattr(brmod, "deregister_app", _boom)
+
+        assert bmod._undo_promotion_of_disabled_app(ap) is False
+        assert ap.mcp_healthy is True
+
+    def test_a_refused_promotion_retries_the_undo(self, monkeypatch, disabled):
+        # Nothing else revisits a disabled app and the watch will not promote it, so the
+        # refusal path is where an unlanded undo gets another attempt.
+        bmod, ap = disabled
+        attempts: list[str] = []
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(
+            brmod, "deregister_app",
+            lambda n: (attempts.append(n), SimpleNamespace(errors=["still failing"]))[1],
+        )
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert attempts == ["app", "app"]  # retried, not recorded and forgotten
+
+    def test_a_completed_undo_is_not_retried(self, monkeypatch, disabled):
+        bmod, ap = disabled
+        ap.mcp_healthy = False  # already reconciled
+        import kiro_crew.apps.bridges as brmod
+        monkeypatch.setattr(
+            brmod, "deregister_app",
+            lambda n: pytest.fail("nothing of ours is registered; nothing to undo"),
+        )
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+
+
+class TestDemotionRefreshIsGatedOnEnablement:
+    """The demotion's agent refresh must not restore a disabled app (#5726 review).
+
+    A demotion does two things: it scrubs the MCP entry — always safe, and deliberately
+    ungated — and it re-materializes the agent configs. The second is a WRITE, so for an
+    app the operator has disabled it puts back the very files a concurrent
+    `deregister_app` just removed.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        scrubbed: list[str] = []
+        refreshed: list[str] = []
+        dropped: list[str] = []
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url",
+            lambda name, unreconciled=None: (scrubbed.append(name), [])[1],
+        )
+        monkeypatch.setattr(
+            brmod, "refresh_app_agents",
+            lambda name, io_failures=None: (refreshed.append(name), [])[1],
+        )
+        monkeypatch.setattr(
+            bmod, "_drop_disabled_app_resources",
+            lambda name: (dropped.append(name), True)[1],
+        )
+        return bmod, scrubbed, refreshed, dropped
+
+    def test_a_disabled_app_is_scrubbed_but_never_refreshed(self, monkeypatch, wired):
+        bmod, scrubbed, refreshed, dropped = wired
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+
+        assert bmod._gate_mcp_registration("app", 9340, healthy=False) is True
+        assert scrubbed == ["app"]  # the scrub still happens — that is the desired outcome
+        assert refreshed == []  # ...but nothing is written back
+        assert dropped == ["app"]
+
+    def test_a_disable_landing_mid_refresh_is_dropped(self, monkeypatch, wired):
+        # Enabled at the pre-check, disabled by the time the refresh has landed. Neither
+        # check can be atomic with the write, so only the pair converges.
+        bmod, scrubbed, refreshed, dropped = wired
+        states = iter([True, False])
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: next(states))
+
+        assert bmod._gate_mcp_registration("app", 9341, healthy=False) is True
+        assert refreshed == ["app"]  # it did run
+        assert dropped == ["app"]  # ...and was undone
+
+    def test_an_enabled_app_is_refreshed_and_not_dropped(self, monkeypatch, wired):
+        bmod, scrubbed, refreshed, dropped = wired
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        assert bmod._gate_mcp_registration("app", 9342, healthy=False) is True
+        assert refreshed == ["app"]
+        assert dropped == []
+
+
+class TestDisabledCleanupResultIsTheReconcileResult:
+    """A failed disabled-app cleanup is not a completed reconcile (#5726 review)."""
+
+    def test_a_failed_cleanup_reports_unlanded(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+        monkeypatch.setattr(bmod, "_drop_disabled_app_resources", lambda name: False)
+
+        assert bmod._gate_mcp_registration("app", 9350, healthy=False) is False
+
+    def test_a_clean_cleanup_reports_landed(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+        monkeypatch.setattr(bmod, "_drop_disabled_app_resources", lambda name: True)
+
+        assert bmod._gate_mcp_registration("app", 9351, healthy=False) is True
+
+
+class TestTheUndoNeverTouchesASuccessor:
+    """Identity is checked BEFORE enablement (#5726 review).
+
+    The undo deregisters by app NAME, so running it for a record that is no longer the
+    tracked one deletes the SUCCESSOR's resources — and an unreadable enabled state is
+    precisely what would send a retired watcher down that path.
+    """
+
+    def test_a_retired_record_with_unreadable_enablement_undoes_nothing(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        old = AppProcess(app_name="app", port=9360, healthy=False, mcp_healthy=True)
+        successor = AppProcess(app_name="app", port=9361, healthy=True, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = successor
+        monkeypatch.setattr(
+            bmod, "_app_enabled_state",
+            lambda name: pytest.fail("identity must be checked first"),
+        )
+        monkeypatch.setattr(
+            bmod, "_undo_promotion_of_disabled_app",
+            lambda ap: pytest.fail("must never deregister on behalf of a retired record"),
+        )
+        try:
+            assert bmod._set_backend_health(old, healthy=True) is False
+            assert successor.mcp_healthy is True
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestUnreadableManifestKeepsTheScrubUnlanded:
+    """Keeping the agents is right, but it leaves them stale (#5726 review).
+
+    `refresh_app_agents` gives up on the same unreadable manifest, so nothing else
+    revisits those files. Recording the scrub as done would strand an agent config
+    dialing the dead url forever; reporting it unlanded makes the watch retry until the
+    manifest is readable and the refresh can correct them.
+    """
+
+    def test_an_unreadable_manifest_reports_unlanded(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        def _scrub(name, unreconciled=None):
+            if unreconciled is not None:
+                unreconciled.append(f"{name}: manifest unreadable")
+            return []
+        monkeypatch.setattr(brmod, "scrub_backend_mcp_url", _scrub)
+
+        assert bmod._gate_mcp_registration("app", 9370, healthy=False) is False
+
+    def test_a_readable_manifest_reports_landed(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+        monkeypatch.setattr(brmod, "refresh_app_agents", lambda name, io_failures=None: [])
+
+        assert bmod._gate_mcp_registration("app", 9371, healthy=False) is True
+
+
+class TestUnknownEnablementNeverDeletes:
+    """Fail-closed is right for ADDING and wrong for DELETING (#5726 review).
+
+    `installed.json` can fail to read transiently. Refusing to register when enablement
+    is unknown is safe — the app stays as it is. Deregistering when it is unknown unlinks
+    materialized agents and takes the user-owned fields `_preserve_user_agent_edits`
+    carries, permanently, over a temporary fault.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        dropped: list[str] = []
+        monkeypatch.setattr(
+            brmod, "scrub_backend_mcp_url", lambda name, unreconciled=None: []
+        )
+        monkeypatch.setattr(brmod, "refresh_app_agents", lambda name, io_failures=None: [])
+        monkeypatch.setattr(
+            bmod, "_drop_disabled_app_resources",
+            lambda name: (dropped.append(name), True)[1],
+        )
+        return bmod, dropped
+
+    def test_unknown_enablement_does_not_deregister(self, monkeypatch, wired):
+        bmod, dropped = wired
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: None)
+
+        assert bmod._gate_mcp_registration("app", 9380, healthy=False) is False
+        assert dropped == [], "an unreadable state must never destroy user-edited agents"
+
+    def test_a_confirmed_disable_does_deregister(self, monkeypatch, wired):
+        bmod, dropped = wired
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+
+        assert bmod._gate_mcp_registration("app", 9381, healthy=False) is True
+        assert dropped == ["app"]
+
+    def test_unknown_enablement_still_refuses_a_promotion(self, monkeypatch):
+        # The other direction is unchanged: not-confirmed means do not add. Asserted
+        # through the transition rather than a predicate, because what matters is that
+        # the promotion does not happen AND nothing is deleted on the way.
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: None)
+        monkeypatch.setattr(
+            brmod, "deregister_app",
+            lambda n: pytest.fail("an unknown state must never delete"),
+        )
+        ap = AppProcess(app_name="app", port=9382, healthy=False, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            assert bmod._set_backend_health(ap, healthy=True) is False
+            assert ap.healthy is False
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestATransitionAlwaysReconciles:
+    """`mcp_healthy` can be stale in the other direction (#5726 review).
+
+    An MCP write that landed followed by an agent write that did not leaves `mcp_healthy`
+    unmoved while the entry IS on disk. If the verdict then flips, matching that stale
+    value would skip the scrub and leave the dead url registered.
+    """
+
+    def test_a_demotion_reconciles_even_when_the_flags_agree(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: (calls.append(healthy), True)[1],
+        )
+        # healthy=True with mcp_healthy=False is exactly what a partial reconcile leaves.
+        ap = AppProcess(app_name="app", port=9390, healthy=True, mcp_healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            assert bmod._set_backend_health(ap, healthy=False) is True
+            assert calls == [False], "the transition must scrub, not trust the stale flag"
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_an_unchanged_verdict_still_short_circuits(self, monkeypatch):
+        # The fast path has to survive: without it a settled backend would rewrite
+        # mcp.json on every sweep.
+        import kiro_crew.apps.backend as bmod
+
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration",
+            lambda name, port, *, healthy: pytest.fail("nothing changed; nothing to write"),
+        )
+        ap = AppProcess(app_name="app", port=9391, healthy=False, mcp_healthy=False)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            assert bmod._set_backend_health(ap, healthy=False) is True
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+
+class TestTheUndoPathsAlsoRefuseAnUnknownState:
+    """The tri-state rule applies to ALL THREE deletion sites (#5726 review).
+
+    The demotion path was fixed first; the two undo calls inside `_set_backend_health`
+    were not, and they reach the same `deregister_app` → `_deregister_agents` → unlink.
+    A transient `installed.json` fault must not destroy user-edited agent configs from
+    any of them.
+    """
+
+    @pytest.fixture
+    def tracked(self, monkeypatch):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        deleted: list[str] = []
+        monkeypatch.setattr(brmod, "deregister_app", lambda n: deleted.append(n))
+        monkeypatch.setattr(
+            bmod, "_gate_mcp_registration", lambda name, port, *, healthy: True
+        )
+        ap = AppProcess(app_name="app", port=9400, healthy=False, mcp_healthy=True)
+        with bmod._lock:
+            bmod._processes.clear()
+            bmod._processes["app"] = ap
+        try:
+            yield bmod, ap, deleted
+        finally:
+            with bmod._lock:
+                bmod._processes.clear()
+
+    def test_the_pre_check_undo_refuses_an_unknown_state(self, monkeypatch, tracked):
+        bmod, ap, deleted = tracked
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: None)
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert deleted == [], "unknown must not delete user-edited agents"
+
+    def test_the_pre_check_undo_still_fires_on_a_confirmed_disable(self, monkeypatch, tracked):
+        bmod, ap, deleted = tracked
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: False)
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert deleted == ["app"]
+
+    def test_the_post_write_verify_refuses_an_unknown_state(self, monkeypatch, tracked):
+        # Enabled at the pre-check, unreadable by the verify: the registration stands,
+        # because the pre-check confirmed it and deleting is the unrecoverable direction.
+        bmod, ap, deleted = tracked
+        states = iter([True, None])
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: next(states))
+
+        assert bmod._set_backend_health(ap, healthy=True) is True
+        assert deleted == []
+        assert ap.healthy is True
+
+    def test_the_post_write_verify_still_fires_on_a_confirmed_disable(
+        self, monkeypatch, tracked
+    ):
+        bmod, ap, deleted = tracked
+        states = iter([True, False])
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: next(states))
+
+        assert bmod._set_backend_health(ap, healthy=True) is False
+        assert deleted == ["app"]
+
+
+class TestEnabledStateDistinguishesUnreadableFromDisabled:
+    """The tri-state has to be real, not nominal (#5726 review).
+
+    `is_app_enabled` returns False for BOTH a deliberate disable and an unreadable
+    metadata file, because `_read_installed` answers None to both and never raises. Built
+    on that, the "unknown" branch was unreachable for exactly the transient fault it
+    exists to catch — so a momentary read blip during a demotion still deleted a
+    still-enabled app's user-edited agents. Driven against REAL files, since the whole
+    defect was a collapsed return value that a stubbed reader would hide.
+    """
+
+    def _meta(self, monkeypatch, tmp_path):
+        import kiro_crew.apps.manager as mgr
+        app = tmp_path / "probe"
+        app.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(mgr, "app_dir", lambda name: app)
+        return mgr, app / mgr.INSTALLED_META_FILENAME
+
+    def test_an_unreadable_file_is_unknown_not_disabled(self, monkeypatch, tmp_path):
+        mgr, meta = self._meta(monkeypatch, tmp_path)
+        meta.write_text("{ not json", encoding="utf-8")
+
+        assert mgr.is_app_enabled("probe") is False  # the collapsed answer
+        assert mgr.app_enabled_state("probe") is None  # ...kept apart here
+
+    def test_a_deliberate_disable_is_false(self, monkeypatch, tmp_path):
+        mgr, meta = self._meta(monkeypatch, tmp_path)
+        meta.write_text(json.dumps({"name": "probe", "enabled": False}), encoding="utf-8")
+
+        assert mgr.app_enabled_state("probe") is False
+
+    def test_an_enabled_app_is_true(self, monkeypatch, tmp_path):
+        mgr, meta = self._meta(monkeypatch, tmp_path)
+        meta.write_text(json.dumps({"name": "probe", "enabled": True}), encoding="utf-8")
+
+        assert mgr.app_enabled_state("probe") is True
+
+    def test_a_missing_file_is_a_definite_false(self, monkeypatch, tmp_path):
+        # Not installed is an ANSWER, not a failure to read one — deleting an
+        # uninstalled app's leftovers is correct.
+        mgr, _meta = self._meta(monkeypatch, tmp_path)
+
+        assert mgr.app_enabled_state("probe") is False
+
+    def test_the_backend_predicate_reports_unknown_for_an_unreadable_file(
+        self, monkeypatch, tmp_path
+    ):
+        # The path that matters: backend must see None, or no deletion is ever refused.
+        import kiro_crew.apps.backend as bmod
+        mgr, meta = self._meta(monkeypatch, tmp_path)
+        meta.write_text("{ not json", encoding="utf-8")
+
+        assert bmod._app_enabled_state("probe") is None

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -3312,7 +3312,8 @@ class TestReregisterRefreshesAgents:
             bridges_mod, "_register_mcp_servers", lambda n, m, live_port=None: ["srv"]
         )
         monkeypatch.setattr(
-            bridges_mod, "_register_agents", lambda n, m, r: calls.append(f"agents:{n}")
+            bridges_mod, "_register_agents",
+            lambda n, m, r, io_failures=None: calls.append(f"agents:{n}"),
         )
         # give _registration_source a manifest with mcpServers
 
@@ -3703,3 +3704,448 @@ class TestRegisterAgentsSnapshotUpkeep:
         assert out == []
         # Nothing to publish, but the directory is still reconciled.
         assert calls == ["refresh"]
+
+
+class TestRefreshAppAgentsReportsIoFailures:
+    """A partial agent rewrite is not a reconciled one (#5726 review).
+
+    `_register_agents` skips a failing agent and continues, so a write that hit ENOSPC
+    left the agent JSON holding the dead MCP url while the caller was told the refresh
+    succeeded. Only the I/O class is collected: this function returns an empty list for
+    several PERMANENT reasons — a self-managed app, a denied one, no declared agents —
+    and a caller that retried on emptiness would spin forever on any of them.
+    """
+
+    def _wire(self, monkeypatch, brmod, tmp_path, *, agents=("a.json",)):
+        monkeypatch.setattr(
+            brmod, "get_app_manifest",
+            lambda name: SimpleNamespace(agents=list(agents)),
+        )
+        monkeypatch.setattr(brmod, "get_app", lambda name: {"resources": "gateway"})
+        monkeypatch.setattr(brmod, "_app_resource_root", lambda name: tmp_path)
+        monkeypatch.setattr(
+            brmod, "_registration_denied",
+            lambda name, action, app_root: None,
+        )
+
+    def test_an_io_failure_is_collected(self, monkeypatch, tmp_path):
+        import kiro_crew.apps.bridges as brmod
+        self._wire(monkeypatch, brmod, tmp_path)
+
+        def _fake(app_name, manifest, app_root, io_failures=None):
+            if io_failures is not None:
+                io_failures.append("app--agent.json")
+            return []
+        monkeypatch.setattr(brmod, "_register_agents", _fake)
+
+        collected: list[str] = []
+        brmod.refresh_app_agents("app", io_failures=collected)
+        assert collected == ["app--agent.json"]
+
+    def test_a_permanent_skip_collects_nothing(self, monkeypatch, tmp_path):
+        # An unsafe agent name or malformed spec registers nothing and never will.
+        import kiro_crew.apps.bridges as brmod
+        self._wire(monkeypatch, brmod, tmp_path)
+        monkeypatch.setattr(
+            brmod, "_register_agents",
+            lambda app_name, manifest, app_root, io_failures=None: [],
+        )
+
+        collected: list[str] = []
+        brmod.refresh_app_agents("app", io_failures=collected)
+        assert collected == []
+
+    def test_a_self_managed_app_is_never_materialized(self, monkeypatch, tmp_path):
+        # `resources="app"` means the app registers its own agents; the gateway
+        # publishing them too is duplicate dispatchable configuration.
+        import kiro_crew.apps.bridges as brmod
+        self._wire(monkeypatch, brmod, tmp_path)
+        monkeypatch.setattr(brmod, "get_app", lambda name: {"resources": "app"})
+        monkeypatch.setattr(
+            brmod, "_register_agents",
+            lambda *a, **k: pytest.fail("must not materialize a self-managed app"),
+        )
+
+        collected: list[str] = []
+        assert brmod.refresh_app_agents("app", io_failures=collected) == []
+        assert collected == []  # nothing to do is not a failure
+
+    def test_a_denied_app_has_its_agents_scrubbed_not_rewritten(self, monkeypatch, tmp_path):
+        # Rewriting a revoked app's agents would make them dispatchable again.
+        import kiro_crew.apps.bridges as brmod
+        self._wire(monkeypatch, brmod, tmp_path)
+        monkeypatch.setattr(
+            brmod, "_registration_denied", lambda name, action, app_root: "revoked"
+        )
+        scrubbed: list[str] = []
+        monkeypatch.setattr(
+            brmod, "_deregister_agents", lambda name: scrubbed.append(name)
+        )
+        monkeypatch.setattr(
+            brmod, "_register_agents",
+            lambda *a, **k: pytest.fail("must not re-register a denied app"),
+        )
+
+        collected: list[str] = []
+        assert brmod.refresh_app_agents("app", io_failures=collected) == []
+        assert scrubbed == ["app"]
+        assert collected == []
+
+
+class TestDemotionKeepsBackendIndependentServers:
+    """A dead HTTP backend must not take an app's stdio tools with it (#5726 review).
+
+    stdio/command servers are launched by kiro-cli itself and have no port to be dead.
+    Blanket-deregistering every `<app>:` entry on demotion removed working tools for a
+    reason that had nothing to do with them.
+    """
+
+    def test_the_unhealthy_reconcile_scrubs_http_and_keeps_stdio(
+        self, monkeypatch, tmp_path
+    ):
+        import kiro_crew.apps.backend as bmod
+        import kiro_crew.apps.bridges as brmod
+
+        calls: dict[str, object] = {}
+
+        # Fabricated app: not in installed.json, so the demotion path's enablement gate
+        # would otherwise divert into the disabled-app cleanup. The gate is pinned by
+        # TestDemotionRefreshIsGatedOnEnablement.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
+
+        def _scrub(app_name, unreconciled=None):
+            calls["app"] = app_name
+            return ["app:stdio-tool"]  # the stdio entry survives
+        monkeypatch.setattr(brmod, "scrub_backend_mcp_url", _scrub)
+        monkeypatch.setattr(brmod, "refresh_app_agents",
+                            lambda name, io_failures=None: [])
+
+        def _blanket(name):
+            raise AssertionError("must not blanket-deregister on a health demotion")
+        monkeypatch.setattr(brmod, "_deregister_mcp_servers", _blanket)
+
+        assert bmod._gate_mcp_registration("app", 9280, healthy=False) is True
+        assert calls == {"app": "app"}
+
+    def test_the_registration_path_pops_a_stale_http_entry(self):
+        # Pins the property the fix leans on, in the code that owns it: with no live
+        # port, an HTTP server is removed rather than merely left unwritten — otherwise
+        # the dead url would survive the demotion.
+        import inspect
+
+        import kiro_crew.apps.bridges as brmod
+        src = inspect.getsource(brmod._register_mcp_servers)
+        assert "servers.pop(namespaced, None)" in src
+        assert "if is_http and not resolved_port:" in src
+
+
+class TestScrubFallsBackWhenTheManifestCannotSay:
+    """No manifest → remove everything, rather than keep a dead url out of ignorance."""
+
+    def test_an_unresolvable_manifest_scrubs_every_entry(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
+        removed: list[str] = []
+        monkeypatch.setattr(
+            brmod, "_deregister_mcp_servers",
+            lambda n: (removed.append(n), 2)[1],
+        )
+        monkeypatch.setattr(
+            brmod, "reregister_app_mcp_servers",
+            lambda n, live_port=None: pytest.fail("cannot register without a manifest"),
+        )
+
+        assert brmod.scrub_backend_mcp_url("gone") == []
+        assert removed == ["gone"]
+
+    def test_a_manifest_declaring_no_servers_also_scrubs_everything(self, monkeypatch):
+        # A stale `<app>:` entry with nothing declaring it is exactly the shape that
+        # should not survive; there is no independent server to protect.
+        import kiro_crew.apps.bridges as brmod
+
+        empty = SimpleNamespace(mcpServers={})
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (empty, brmod.Path(".")))
+        removed: list[str] = []
+        monkeypatch.setattr(
+            brmod, "_deregister_mcp_servers",
+            lambda n: (removed.append(n), 1)[1],
+        )
+
+        assert brmod.scrub_backend_mcp_url("bare") == []
+        assert removed == ["bare"]
+
+
+class TestLifecycleWritersShareTheHealthSerialization:
+    """Both families of writer hold one lock (#5726 review).
+
+    An app's mcp.json entries and its materialized agents are written by the lifecycle
+    paths here AND by the backend's health watch. Unserialized, the two can interleave
+    their decisions — each doing a correct read-modify-write, with the STALE one landing
+    last. Closing that per call site is what this review kept re-finding; the writers now
+    share the guard instead.
+    """
+
+    def _lock_held(self):
+        # RLock has no public `locked()`; a non-blocking acquire from ANOTHER thread is
+        # the honest probe — it fails only while someone actually holds it.
+        import threading
+
+        import kiro_crew.apps.backend as bmod
+        result: list[bool] = []
+
+        def _probe():
+            got = bmod._health_reconcile_lock.acquire(blocking=False)
+            result.append(not got)
+            if got:
+                bmod._health_reconcile_lock.release()
+        t = threading.Thread(target=_probe)
+        t.start()
+        t.join()
+        return result[0]
+
+    def test_mcp_registration_runs_under_the_guard(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+        held: list[bool] = []
+        monkeypatch.setattr(
+            brmod, "_read_mcp_json_unlocked",
+            lambda strict=False: (held.append(self._lock_held()), {"mcpServers": {}})[1],
+        )
+        monkeypatch.setattr(brmod, "_write_mcp_json_unlocked", lambda data: None)
+
+        # A non-empty manifest: the function returns before the lock when there is
+        # nothing to register, so an empty one would pass this test vacuously.
+        monkeypatch.setattr(brmod, "strip_ungoverned_auto_approve", lambda m: m)
+        brmod._register_mcp_servers(
+            "app", SimpleNamespace(mcpServers={"srv": {"command": "x"}})
+        )
+        assert held == [True]
+
+    def test_mcp_deregistration_runs_under_the_guard(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+        held: list[bool] = []
+        monkeypatch.setattr(
+            brmod, "_read_mcp_json_unlocked",
+            lambda strict=False: (held.append(self._lock_held()), {"mcpServers": {}})[1],
+        )
+        monkeypatch.setattr(brmod, "_write_mcp_json_unlocked", lambda data: None)
+
+        brmod._deregister_mcp_servers("app")
+        assert held == [True]
+
+    def test_agent_materialization_runs_under_the_guard(self, monkeypatch, tmp_path):
+        # The READ is inside too, not just the write: an agent copies the ambient spec,
+        # so a read before a scrub and a write after it is the interleave that matters.
+        import kiro_crew.apps.bridges as brmod
+        held: list[bool] = []
+        monkeypatch.setattr(brmod, "_kiro_agents_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            brmod, "_agent_mcp_policy",
+            lambda name: (held.append(self._lock_held()), {})[1],
+        )
+
+        brmod._register_agents("app", SimpleNamespace(agents=[]), tmp_path)
+        assert held == [True]
+
+    def test_the_health_path_can_re_enter_it(self):
+        # The health transition holds the lock and then calls straight into these
+        # writers. A non-re-entrant lock would deadlock the watch thread here, which is
+        # why it is an RLock — pinned so nobody "simplifies" it back to Lock.
+        import kiro_crew.apps.backend as bmod
+
+        with bmod._health_reconcile_lock:
+            assert bmod._health_reconcile_lock.acquire(blocking=False)
+            bmod._health_reconcile_lock.release()
+
+
+class TestRenderFailureIsClassifiedByCause:
+    """`_render_shipped_agent` returns None for three reasons; one is retryable.
+
+    An unresolved placeholder and invalid rendered JSON are properties of the template
+    and fail identically forever — reporting them to a caller that retries would spin
+    without converging. Only the write failure can succeed later.
+    """
+
+    def _template(self, tmp_path, body: str):
+        src = tmp_path / "agent.json"
+        src.write_text(body, encoding="utf-8")
+        return src
+
+    def test_a_write_failure_is_collected(self, monkeypatch, tmp_path):
+        import kiro_crew.apps.bridges as brmod
+        src = self._template(tmp_path, '{"name": "a", "root": "{ENGINE_ROOT}"}')
+        monkeypatch.setattr(brmod, "_placeholder_values", lambda n: {"{ENGINE_ROOT}": "/x"})
+        monkeypatch.setattr(brmod, "_kiro_agents_dir", lambda: tmp_path / "agents")
+
+        def _boom(target, data):
+            raise OSError("ENOSPC")
+        monkeypatch.setattr(brmod, "atomic_write", _boom)
+
+        collected: list[str] = []
+        assert brmod._render_shipped_agent("app", src, io_failures=collected) is None
+        assert collected == [str(src)]
+
+    def test_an_unresolved_placeholder_is_not_collected(self, monkeypatch, tmp_path):
+        import kiro_crew.apps.bridges as brmod
+        src = self._template(tmp_path, '{"name": "a", "root": "{ENGINE_ROOT}"}')
+        monkeypatch.setattr(brmod, "_placeholder_values", lambda n: {})  # nothing resolves
+
+        collected: list[str] = []
+        assert brmod._render_shipped_agent("app", src, io_failures=collected) is None
+        assert collected == []  # permanent: retrying never converges
+
+    def test_invalid_rendered_json_is_not_collected(self, monkeypatch, tmp_path):
+        import kiro_crew.apps.bridges as brmod
+        src = self._template(tmp_path, '{"name": "a", "root": "{ENGINE_ROOT}"')  # unbalanced
+        monkeypatch.setattr(brmod, "_placeholder_values", lambda n: {"{ENGINE_ROOT}": "/x"})
+
+        collected: list[str] = []
+        assert brmod._render_shipped_agent("app", src, io_failures=collected) is None
+        assert collected == []
+
+
+class TestScrubNeverDeletesMaterializedAgents:
+    """The scrub fallback must not delete agent files (#5726 review).
+
+    Deleting them is unrecoverable — it takes the user-owned fields
+    `_preserve_user_agent_edits` carries across every refresh — while what it would
+    prevent, an agent naming a removed server, costs failed tool calls until the next
+    refresh rewrites it. An unreadable manifest is also frequently TRANSIENT, so
+    destroying data over it trades a temporary fault for a permanent one. Only
+    `deregister_app` owns deleting these files.
+    """
+
+    def test_an_unreadable_manifest_keeps_the_agents(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
+        monkeypatch.setattr(brmod, "_deregister_mcp_servers", lambda n: 1)
+        monkeypatch.setattr(
+            brmod, "_deregister_agents",
+            lambda n: pytest.fail("user-edited agent configs must survive a scrub"),
+        )
+
+        assert brmod.scrub_backend_mcp_url("unreadable") == []
+
+    def test_a_manifest_declaring_no_servers_keeps_them_too(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "_registration_source",
+            lambda n: (SimpleNamespace(mcpServers={}), brmod.Path(".")),
+        )
+        monkeypatch.setattr(brmod, "_deregister_mcp_servers", lambda n: 1)
+        monkeypatch.setattr(
+            brmod, "_deregister_agents",
+            lambda n: pytest.fail("nothing declared means nothing stale to remove"),
+        )
+
+        assert brmod.scrub_backend_mcp_url("bare") == []
+
+    def test_the_mcp_entry_is_still_scrubbed(self, monkeypatch):
+        # Keeping the agents must not turn into keeping the dead url as well.
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
+        removed: list[str] = []
+        monkeypatch.setattr(
+            brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1]
+        )
+        monkeypatch.setattr(brmod, "_deregister_agents", lambda n: 0)
+
+        brmod.scrub_backend_mcp_url("gone")
+        assert removed == ["gone"]
+
+
+class TestUnreadableManifestIsNotASilentRegistration:
+    """An unreadable manifest registered nothing, so it must not report success.
+
+    `reregister_app_mcp_servers` returns an empty list for several reasons. One of them —
+    the manifest could not be read — means nothing was written, and recording that as a
+    completed registration leaves a healthy backend with no MCP entry and nothing to
+    retry it.
+    """
+
+    def test_an_unreadable_manifest_is_collected(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(brmod, "_registration_source", lambda n: (None, brmod.Path(".")))
+        monkeypatch.setattr(
+            brmod, "_registration_denied", lambda name, action, app_root: None
+        )
+
+        collected: list[str] = []
+        assert brmod.reregister_app_mcp_servers("app", io_failures=collected) == []
+        assert collected == ["app: manifest unreadable"]
+
+    def test_a_manifest_declaring_no_servers_is_not_collected(self, monkeypatch):
+        # Readable and simply empty: nothing to register, and retrying never changes it.
+        import kiro_crew.apps.bridges as brmod
+
+        monkeypatch.setattr(
+            brmod, "_registration_source",
+            lambda n: (SimpleNamespace(mcpServers={}, agents=[]), brmod.Path(".")),
+        )
+        monkeypatch.setattr(
+            brmod, "_registration_denied", lambda name, action, app_root: None
+        )
+
+        collected: list[str] = []
+        assert brmod.reregister_app_mcp_servers("app", io_failures=collected) == []
+        assert collected == []
+
+
+class TestScrubDoesNotRematerializeAgents:
+    """The scrub must not write agents (#5726 review).
+
+    `reregister_app_mcp_servers` calls `_register_agents` internally, so routing the
+    scrub through it re-materialized this app's agent configs BEFORE the caller's
+    enablement check ran — making a disabled app's agents dispatchable in the gap. The
+    scrub needs only the mcp.json half; the agent refresh belongs to the caller, which
+    gates it.
+    """
+
+    def test_the_scrub_touches_mcp_only(self, monkeypatch):
+        import kiro_crew.apps.bridges as brmod
+
+        manifest = SimpleNamespace(mcpServers={"srv": {"command": "x"}}, agents=["a.json"])
+        monkeypatch.setattr(
+            brmod, "_registration_source", lambda n: (manifest, brmod.Path("."))
+        )
+        monkeypatch.setattr(
+            brmod, "_registration_denied", lambda name, action, app_root: None
+        )
+        monkeypatch.setattr(
+            brmod, "_register_mcp_servers",
+            lambda name, m, live_port=None: ["app:srv"],
+        )
+        monkeypatch.setattr(
+            brmod, "_register_agents",
+            lambda *a, **k: pytest.fail("the scrub must not re-materialize agents"),
+        )
+
+        assert brmod.scrub_backend_mcp_url("app") == ["app:srv"]
+
+    def test_a_denied_app_still_gets_a_full_removal(self, monkeypatch):
+        # The admission gate `reregister_app_mcp_servers` applied has to survive the
+        # switch: nothing of a denied app stays reachable, not even its stdio servers.
+        import kiro_crew.apps.bridges as brmod
+
+        manifest = SimpleNamespace(mcpServers={"srv": {"command": "x"}}, agents=[])
+        monkeypatch.setattr(
+            brmod, "_registration_source", lambda n: (manifest, brmod.Path("."))
+        )
+        monkeypatch.setattr(
+            brmod, "_registration_denied", lambda name, action, app_root: "revoked"
+        )
+        removed: list[str] = []
+        monkeypatch.setattr(
+            brmod, "_deregister_mcp_servers", lambda n: (removed.append(n), 1)[1]
+        )
+        monkeypatch.setattr(
+            brmod, "_register_mcp_servers",
+            lambda *a, **k: pytest.fail("a denied app must not keep any server"),
+        )
+
+        assert brmod.scrub_backend_mcp_url("app") == []
+        assert removed == ["app"]

--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -654,6 +654,11 @@ class TestAdoptExistingInstance:
         monkeypatch.setattr(
             bmod, "popen_limited", lambda *_a, **_k: pytest.fail("spawned onto a taken port")
         )
+        # The adoption path registers through the serialized transition, which is gated
+        # on the app being enabled. "adoptee" is fabricated and so is not in
+        # installed.json; in production start_app_backend only ever runs for an enabled
+        # app. The gate itself is pinned by TestPromotionRequiresAConfirmedEnabledApp.
+        monkeypatch.setattr(bmod, "_app_enabled_state", lambda name: True)
         return spawn_root
 
     def _run(self, port: int) -> AppProcess | None:
@@ -1538,7 +1543,7 @@ class TestGateMcpRegistration:
         seen: list[tuple[str, int]] = []
         monkeypatch.setattr(
             "kiro_crew.apps.bridges.reregister_app_mcp_servers",
-            lambda name, live_port: seen.append((name, live_port)),
+            lambda name, live_port, io_failures=None: seen.append((name, live_port)),
         )
         bmod._gate_mcp_registration("app", 9133, healthy=True)
         assert seen == [("app", 9133)]
@@ -1589,7 +1594,7 @@ class TestHealthCheckLoop:
         monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["sick"] = AppProcess(app_name="sick", port=9134)
-        bmod._health_check_loop("sick", 9134, "/health")
+        bmod._health_check_loop(bmod._processes.get("sick") or bmod.AppProcess(app_name="sick", port=9134), "/health")
         assert attempts["n"] == 2
         assert gate == [("sick", 9134, False)]
 
@@ -1614,7 +1619,7 @@ class TestHealthCheckLoop:
         monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
         with bmod._lock:
             bmod._processes["racy"] = AppProcess(app_name="racy", port=9135)
-        bmod._health_check_loop("racy", 9135, "/health")
+        bmod._health_check_loop(bmod._processes.get("racy") or bmod.AppProcess(app_name="racy", port=9135), "/health")
         assert gate == []
 
 

--- a/test/test_apps_routes_coverage.py
+++ b/test/test_apps_routes_coverage.py
@@ -1251,8 +1251,11 @@ class TestUpdateApp:
             data = await resp.json()
         assert data["ok"] is True
         assert "registration" in data
-        # Old resources are only swapped out AFTER the re-install succeeded.
-        assert calls == ["deregister", "stop", "start"]
+        # Old resources are only swapped out AFTER the re-install succeeded — and the
+        # backend is stopped BEFORE they are scrubbed, so the health watch has lost its
+        # tracking record and cannot re-register the old manifest's MCP servers in
+        # between (see app-kit-platform §17).
+        assert calls == ["stop", "deregister", "start"]
 
     @pytest.mark.asyncio
     async def test_local_update_failure_restores_registration(
@@ -4133,3 +4136,72 @@ def test_disable_route_normalizes_the_name_before_the_builtin_lookup():
     assert 'name.replace("-", "_")' in src, (
         "the disable handler must normalize the manifest name before testing "
         "membership in BUILTIN_NAMES / importing the package")
+
+
+@pytest.mark.asyncio
+async def test_update_stops_the_backend_before_deregistering_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Teardown order is load-bearing, not cosmetic (#5726 review).
+
+    `stop_app_backend` pops the tracking record, which is what stops the health watch
+    from reconciling MCP for the app. Deregistering first leaves a window in which a
+    recovering backend re-registers the OLD manifest's servers, so entries the update
+    removed survive it. Uninstall and the disable rollback already stop first; these are
+    the paths that did not.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    _install(tmp_path)
+    order: list[str] = []
+
+    async def _fake_deregister(name: str):
+        order.append("deregister")
+        return SimpleNamespace(to_dict=lambda: {})
+
+    monkeypatch.setattr(routes_mod, "_deregister_app_off_loop", _fake_deregister)
+    monkeypatch.setattr(
+        routes_mod, "stop_app_backend", lambda name: order.append("stop") or True
+    )
+    monkeypatch.setattr(
+        routes_mod, "update_app", lambda *a, **k: {"success": False, "error": "stop here"}
+    )
+
+    async with TestClient(TestServer(_make_app())) as client:
+        await client.post(f"/api/apps/{APP}/update", json={"source": str(tmp_path / "src")})
+
+    assert order[:2] == ["stop", "deregister"], (
+        f"backend must be stopped before its resources are scrubbed, got {order}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_does_not_re_register_after_the_backend_starts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Enable must not re-register MCP after start_app_backend returns (#5726 review).
+
+    A call made here is queued behind the handler, so the adopted backend's watch can
+    demote and scrub in between — and the queued write would then restore the dead url,
+    without updating `mcp_healthy`, so the watch would never notice the disagreement.
+    The adoption path registers through the serialized transition instead, before its
+    watch is armed.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    _install(tmp_path)
+    called: list[str] = []
+    import kiro_crew.apps.bridges as bridges_mod
+    monkeypatch.setattr(
+        bridges_mod, "reregister_app_mcp_servers",
+        lambda name, live_port=None, io_failures=None: called.append(name) or [],
+    )
+    monkeypatch.setattr(
+        routes_mod, "start_app_backend",
+        lambda name: SimpleNamespace(
+            healthy=True, port=7999, to_dict=lambda: {"port": 7999}
+        ),
+    )
+
+    async with TestClient(TestServer(_make_app())) as client:
+        await client.post(f"/api/apps/{APP}/enable", json={})
+
+    assert called == [], "enable re-registered after start; the adoption path owns that"

--- a/test/test_apps_routes_coverage.py
+++ b/test/test_apps_routes_coverage.py
@@ -308,8 +308,12 @@ async def test_list_apps_enriches_running_backend(
         routes_mod,
         "list_app_processes",
         lambda: [
-            {"app_name": APP, "port": 7999, "healthy": True, "pid": 4242},
-            {"app_name": "other-app", "port": 7998, "healthy": False, "pid": 1},
+            # Mirrors AppProcess.to_dict(): `running` is a real observation of the
+            # tracked process, not something the handler asserts from the row existing.
+            {"app_name": APP, "port": 7999, "healthy": True, "pid": 4242,
+             "running": True},
+            {"app_name": "other-app", "port": 7998, "healthy": False, "pid": 1,
+             "running": True},
         ],
     )
     async with TestClient(TestServer(_make_app())) as client:
@@ -503,6 +507,34 @@ async def test_get_app_keeps_genuinely_local_app_repositoryless(
         entry = await resp.json()
 
     assert "trustRepository" not in entry
+
+
+@pytest.mark.asyncio
+async def test_list_apps_reports_a_tracked_but_exited_backend_as_not_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A record outliving its process must not be reported as running (#5726).
+
+    The handler used to hardcode ``running: True`` for anything present in the process
+    table, so a backend that exited was reported as up until something popped its entry.
+    """
+    _setup_env(tmp_path, monkeypatch)
+    _install(tmp_path)
+    monkeypatch.setattr(
+        routes_mod,
+        "list_app_processes",
+        lambda: [
+            {"app_name": APP, "port": 7999, "healthy": False, "pid": 4242,
+             "running": False},
+        ],
+    )
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get("/api/apps")
+        assert resp.status == 200
+        rows = await resp.json()
+    entry = next(a for a in rows if a["name"] == APP)
+    assert entry["backend_status"]["running"] is False
+    assert entry["backend_status"]["healthy"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -395,6 +395,30 @@ class TestAppCli:
         dereg.assert_called_once_with("demo")
         assert "off" in capsys.readouterr().out
 
+    def test_disable_flips_the_flag_before_deregistering(self) -> None:
+        """Order is a security control, not cosmetics (#5726 review).
+
+        A running gateway is a DIFFERENT process: it watches this app's backend and
+        re-registers its MCP servers and agents on a health recovery, gated on the
+        enabled flag it reads from installed.json. Deregistering first leaves a window
+        where that flag still says enabled and the resources are already gone — a
+        recovery landing there puts them back for the app being disabled.
+        """
+        order: list[str] = []
+        with (
+            patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),
+            patch(
+                "kiro_crew.cli_commands.deregister_app",
+                side_effect=lambda n: order.append("deregister"),
+            ),
+            patch(
+                "kiro_crew.cli_commands.disable_app",
+                side_effect=lambda n: order.append("disable") or _result(True, message="off"),
+            ),
+        ):
+            cc._handle_app(_ns(app_action="disable", name="demo"))
+        assert order == ["disable", "deregister"], order
+
     def test_disable_failure_exits_1(self) -> None:
         with (
             patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),


### PR DESCRIPTION
## Problem / Motivation

An app backend was health-checked exactly once, at startup. `_health_check_loop` polled
`/health`, wrote `healthy = True`, and returned permanently — so the flag was a
write-once cache with no invalidation anywhere in the tree:

```
$ grep -rn "\.healthy\s*=" src/kiro_crew/
src/kiro_crew/apps/backend.py:1469:   _processes[app_name].healthy = True
```

One assignment, and it only ever wrote `True`. A backend that died an hour later stayed
`healthy` by default. Nothing re-armed the probe: the loop is spawned once per start,
`_survived_spawn` polls only inside the spawn grace window, and `_reap_stale_app_backends`
runs at gateway boot.

## Why it matters

Three surfaces read that stale flag, and all three were confidently wrong: the **reverse
proxy kept routing to a dead port** (`get_app_backend_port` gates purely on the flag), a
**dead HTTP MCP url stayed in `mcp.json`** for kiro-cli to dial every session, and
**`/api/apps` reported `running: true, healthy: true`** for an exited process.

## What changed (motivation → approach → change)

The supervisor already existed and gave up too early. Its per-backend daemon thread now
continues past the startup poll into a standing watch for as long as the record stays
tracked, so `healthy` is a current observation rather than a startup verdict. No new
lifecycle and no teardown change: the watch exits through the same "no longer tracked"
guard the startup phase already used.

**The core fix**

- **Liveness cheapest-first, and only a dead process is decisive.** A spawned backend is
  judged first by `Popen.poll()` — an already-reaped exit status, no syscall to the app.
  An exited process cannot recover, so one observation demotes it.
- **An HTTP failure from a live process is not decisive.** Demotion needs
  `_HEALTH_WATCH_FAILURES` consecutive misses and stays **reversible**, so a briefly
  wedged backend heals with no operator action.
- **Adopted backends** (`proc=None`) had the identical write-once defect and are watched
  too, judged by their health endpoint alone since we hold no handle.
- **`handle_list_apps` no longer hardcodes `"running": True`**; it reads a real
  observation off the record (`AppProcess.is_running`).

**The race-repair machinery the standing watch makes necessary.** A one-shot registration
could not race itself; a recurring one can. Each of these closes a race the watch itself
creates, each was found in review, and each is test-pinned:

- **`_health_reconcile_lock`** — the identity guard has to stay effective *through* the
  MCP reconcile, not just alongside the flag write, because the MCP writers key on the
  app **name** (`_deregister_mcp_servers` removes every `<app>:` entry). `_lock` cannot
  be held across it (manifest + config I/O would block the proxy's
  `get_app_backend_port`, and the `bridges ↔ backend` cycle risks deadlock), so every
  health-driven reconcile — including the startup registration — takes this lock and
  re-checks identity inside it.
- **`AppProcess.mcp_healthy`** (new field) — the health flag moves whether or not the
  `mcp.json` write succeeded. This records what was last *successfully* written, and each
  sweep reconciles when the verdict changed **or** when the record is behind it, so a
  transient failure is retried instead of stranded. The field is **tri-state** — `None`
  means *unknown*, and only `False` means confirmed-scrubbed. The terminal exited-process path does
  not return until the entry is reconciled or the record is dropped — that path is the one
  place where giving up is permanent.
- **Teardown participates in the same serialization** — `stop_app_backend` takes
  `_health_reconcile_lock` across its pop, so it and a reconcile are mutually exclusive.
  Otherwise a watcher already past its identity check could still be inside the MCP write
  when the caller's `deregister_app` scrubbed, and its write would land after.
- **An adopted recovery re-binds ownership before promoting** — `adopted_pids` is what
  `stop_app_backend` signals and what uninstall acts behind. A recovery means the
  external supervisor put something back, possibly a different process, so the owner set
  is re-captured through adoption's own consistency sandwich and the promotion is
  **refused** if ownership cannot be confirmed.
- **Probe robustness** — `http.client.HTTPException` is not an `OSError`/`URLError`
  subclass and `urllib` re-raises `getresponse()` failures unwrapped, so a
  `BadStatusLine` from a backend answering with a non-HTTP first line escaped the catch,
  killed the daemon watch, and froze `healthy` — silently restoring the very bug this PR
  removes. Both probes now catch it, and the watch survives an unexpected fault in any
  single sweep for the same reason.
- **Startup-poll generation pinning** — the poll pins its record once, before the first
  probe, and re-checks it every attempt. Re-resolving by name (even per attempt) let a
  stop/start inside the startup window hand a later attempt the successor, which the poll
  would then promote, or on exhaustion scrub, on evidence about its predecessor.

**Behavioral change to two endpoints, called out explicitly:** the two update paths in
`apps/routes.py` now **stop the backend before deregistering its resources**. Stopping
pops the tracking record, which is what ends the watch's authority to reconcile MCP;
scrubbing first left a window in which a recovering backend re-registered the *old*
manifest's servers. Uninstall (`routes.py:1142`) and the disable rollback
(`routes.py:1381`) already used this order, as does trust revocation in `teardown.py` —
these two were the outliers, and after this change no in-process path deregisters before
stopping.

## Tests

**43 new tests** across fifteen classes in `test/test_app_backend.py` and
`test/test_apps_routes_coverage.py`:

| class | locks in |
|---|---|
| `TestBackendLivenessWatch` | transient failures survive; demotion after N misses scrubs MCP; **a demoted backend is no longer routable**; demotion is reversible; an exited process demotes without consulting the endpoint; a successor is never demoted by its predecessor's watch; an untracked record is never probed |
| `TestBackendRunningReflectsTheProcess` | `running` follows the process; the adopted (`proc=None`) case |
| `TestHealthSupervisorHandoff` | the startup poll hands the watch its record (without this the watch is dead wiring) |
| `TestHealthTransitionsRefuseAStaleRecord` | both transitions refuse a record popped mid-verdict |
| `TestMcpReconcileHonoursRecordIdentity` | a retired record cannot scrub a successor's servers or republish its dead port; the reconcile runs under the lock; the startup registration takes the same lock |
| `TestStartupProbeCannotPromoteAReplacement` | a successor installed mid-probe is not promoted |
| `TestStartupPollBelongsToOneGeneration` | exhaustion does not scrub a successor; a later attempt cannot promote one |
| `TestFailedMcpReconcileIsRetried` | a failed scrub is retried; a landed one is not rewritten every sweep; an exited process scrubs an entry the flag had already left behind |
| `TestTerminalScrubIsRetriedUntilItLands` | retried until it lands; stops once it lands; gives up when the record is dropped; nothing registered means nothing to unwind |
| `TestTeardownParticipatesInTheReconcileSerialization` | `stop_app_backend` pops inside `_health_reconcile_lock` |
| `TestAdoptedRecoveryRebindsOwnership` | recovery re-captures the owner set; unconfirmable ownership refuses the promotion; a spawned backend does not pay the recapture |
| `TestUnknownMcpStateStillGetsScrubbed` | `mcp_healthy=None` (unknown) keeps retrying the terminal scrub; a confirmed scrub still ends the watch |
| `TestProbeSurvivesAMalformedHttpResponse` | a real socket answering a non-HTTP status line is a failed probe, not a raise (both probes) |
| `TestWatchSurvivesAnUnexpectedSweepFault` | the watch restarts after an unexpected fault; it does not restart once the record is gone |
| `TestScrubAlsoRefreshesMaterializedAgents` | an unhealthy reconcile re-materializes the app's agents; the healthy path does not double-refresh; a failed refresh makes the reconcile unlanded so the watch retries; nothing-to-refresh is not a failure |
| `test_update_stops_the_backend_before_deregistering_resources` | the teardown ordering above |

Two existing tests were updated, both flagged in-thread rather than left in the diff:
`test_list_apps_enriches_running_backend` (its `list_app_processes` stub had drifted from
the real `to_dict()` shape) and `test_registry_update_success_reregisters` (asserted the
now-changed relative order of stop/deregister; its documented intent — swap only after
install succeeds — is preserved).

## Manual verification

The issue's own reproduction, run against the real production wiring with only the poll
cadences shrunk:

```
alive : 64444   status: healthy=True  running=True
dead  : None    status: healthy=False running=False    <- was: the port, indefinitely
```

with the MCP registration scrubbed. Separately verified the adopted path end-to-end:
killed the external instance (demotes, unroutes), restarted it on the same port, and the
watch **re-promoted it with no operator action**.

Full gate passes: `check_black_formatting`, `check_subprocess_encoding`, `isort`,
`flake8`, `mypy --platform linux`, `docs-lint`, `check_harness_parity`,
`check_brand_name`. 11,983 app tests pass locally.

## Screenshots / video

N/A — no user-visible UI change. `/api/apps` returns accurate values for fields it
already returned; nothing in `website/src` reads `backend_status`.

## Related Issues

Fixes #5726

## Checklist

- [x] At most two commits, with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (spec **§17** + the `backend.healthCheck` manifest row, same commit)
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
