### PR TITLE
fix(test): stop a leaked logger level from emptying caplog

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -959,6 +959,92 @@ def _restore_log_record_factory():
         logging.setLogRecordFactory(before)
 
 
+# ── logger levels go back after every test ──────────────────────────
+
+
+#: What a logger nobody has configured looks like. ``logging.getLogger(name)`` builds
+#: exactly this, so a name MISSING from the "before" snapshot restores to it rather than
+#: being passed over -- otherwise a test that creates a logger and configures it leaks
+#: through the one gap a snapshot cannot see.
+_PRISTINE_LOGGER: tuple[int, bool] = (logging.NOTSET, False)
+
+
+def _logger_levels() -> dict[str, tuple[int, bool]]:
+    """``(level, disabled)`` for the root logger and every logger by name.
+
+    ``loggerDict`` also holds ``PlaceHolder`` entries for the un-instantiated middle of a
+    dotted name; those carry no level and are skipped. The root logger is not in it at
+    all, so it is added under ``""`` -- the name ``logging.getLogger`` maps back to it.
+    """
+    snapshot: dict[str, tuple[int, bool]] = {
+        name: (obj.level, obj.disabled)
+        for name, obj in list(logging.Logger.manager.loggerDict.items())
+        if isinstance(obj, logging.Logger)
+    }
+    root = logging.getLogger()
+    snapshot[""] = (root.level, root.disabled)
+    return snapshot
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_levels():
+    """Put every logger's level and ``disabled`` flag back after each test.
+
+    A level is PROCESS-GLOBAL and HIERARCHICAL, which together are what make a leak here
+    so hard to attribute: ``Logger.debug`` checks the EFFECTIVE level, so an explicit
+    level left on ``kiro_crew`` decides what every ``kiro_crew.*`` logger in the worker
+    may emit, and it outranks the root level ``caplog.at_level()`` sets. The victim then
+    sees ``caplog.text == ""`` -- not the wrong text, NOTHING -- from a test that passes
+    alone, in a file that has nothing to do with the cause.
+
+    Measured: ``test_slack_gateway_more_coverage.py::TestDeliverCronResponse::
+    test_options_post_failure_still_delivers_text`` asserts on a ``logger.debug`` line and
+    reds whenever ``test_cli.py::TestCronCli::test_cli_argparse_cron_add_agent_flag``
+    shares its worker -- an ARGPARSE test, in a file with no connection to Slack. It
+    drives the real ``cli.main()``, whose ``_setup_cli_logging`` pins ``kiro_crew`` at
+    WARNING, exactly as production does once per process and never undoes. Test modules
+    across the suite drive ``main()`` that way.
+
+    Restoring rather than blaming, for the same reason as ``_restore_log_record_factory``
+    above: configuring logging is what the entry point under test is FOR, so demanding
+    per-module bookkeeping from every test that reaches it buys no coverage and is one
+    forgotten fixture away from reappearing. The damage is to OTHER tests, so stopping it
+    propagating is the whole job.
+
+    **HANDLERS are deliberately not restored, and the boundary is not squeamishness.** A
+    handler is routinely paired with a module-global that records it as installed --
+    ``dashboard.handlers.updates._log_ring_handler_installed`` is the live example -- and
+    a floor can detach the handler but cannot know to clear the flag. That leaves the
+    module in a state neither a test nor production can otherwise reach: the singleton
+    reports installed while nothing is attached, so the next caller is handed a handler
+    that receives nothing. Restoring the ROOT logger's handler list is unsafe for a
+    second, independent reason: pytest's ``catching_logs`` adds one per test PHASE and
+    removes it at the phase boundary, so a list snapshotted during setup would be written
+    back during teardown, re-attaching the setup phase's handler and dropping the one the
+    teardown phase is capturing through.
+
+    The handlers ``_setup_cli_logging`` leaves on ``kiro_crew`` do accumulate -- each open
+    on a ``gateway.log`` under a ``tmp_path`` the next test deletes -- but that is a
+    separate defect from this one, and it is not what empties ``caplog``.
+    ``test_cli_logging.py``'s own ``_pristine_logging`` fixture is what absorbs it today,
+    by clearing both handler lists at setup rather than by trusting its inheritance.
+
+    Measured cost: ~30us per snapshot at ~450 live loggers, so ~60us per test.
+    """
+    before_disable = logging.Logger.manager.disable
+    before = _logger_levels()
+    yield
+    for name, after in _logger_levels().items():
+        level, disabled = before.get(name, _PRISTINE_LOGGER)
+        if after == (level, disabled):
+            continue
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+        logger.disabled = disabled
+    if logging.Logger.manager.disable != before_disable:
+        logging.disable(before_disable)
+
+
 # ── the sandbox probe cache is warm for every test, in every testpath ──
 
 

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -125,7 +125,7 @@ It also pins the other real host paths a test must not reach: the subagent regis
 running gateway sweeps stray entries there as orphans), the 610MB embedding-model
 download, and the agent-state sidecar.
 
-Three members are there for a different reason — a **process-global** that any testpath
+Five members are there for a different reason — a **process-global** that any testpath
 can poison for every test after it, which is the same failure shape as host mutation
 one scope down:
 
@@ -151,6 +151,21 @@ one scope down:
   undoes it, so a test driving that code cannot avoid it.
   `log_redaction.uninstall_log_redaction()` exists for a test that wants to assert on
   the uninstalled state itself.
+* `_restore_logger_levels` puts every logger's level and `disabled` flag back. A level is
+  process-global AND hierarchical, so an explicit one left on `kiro_crew` decides what
+  every `kiro_crew.*` logger in the worker may emit and it outranks the root level
+  `caplog.at_level()` sets — the victim's `caplog.text` comes back **empty**, not wrong,
+  which reads as "the code stopped logging" rather than as pollution.
+  `cli._setup_cli_logging` pins `kiro_crew` at WARNING, and test modules across the suite
+  run it for real by driving `cli.main()` in process. Restored rather than blamed, for the
+  same reason the CWD restore is. **Handlers are deliberately not restored**: one is
+  routinely paired with a module-global recording it as installed
+  (`dashboard.handlers.updates._log_ring_handler_installed`), and a floor can detach the
+  handler but cannot know to clear the flag, which leaves the singleton reporting
+  installed with nothing attached. The root logger's handler list is doubly excluded —
+  pytest's own `catching_logs` adds one per test phase and removes it at the phase
+  boundary, so writing back a setup-phase snapshot during teardown would drop the handler
+  the teardown phase is capturing through.
 * `_restore_autonudge_singleton` puts `autonudge._INSTANCE` back to whatever the test
   inherited. `AutoNudgeService.start()` publishes itself there and `stop()` clears it, so
   a test that starts the service — or drives a dashboard handler that does — leaves a live

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -833,6 +833,72 @@ class TestTheLogRecordFactoryIsRestored:
         )
 
 
+# ── logger levels ──────────────────────────────────────────────────────────
+
+
+#: Written by the leaking test and read by the one after it, for the same reason as
+#: ``_FACTORY_ORDER``: the restore this pins runs in teardown, after every finalizer the
+#: leaking test itself could own.
+_LOGGER_ORDER: dict[str, object] = {}
+
+
+@pytest.mark.xdist_group(name="logger_level_floor")
+class TestLoggerLevelsAreRestored:
+    """A logger's level is PROCESS-GLOBAL, per worker, and HIERARCHICAL.
+
+    Together those are what make this leak class so hard to attribute. ``Logger.debug``
+    gates on the EFFECTIVE level, so an explicit level left on ``kiro_crew`` decides what
+    every ``kiro_crew.*`` logger in the worker may emit, and it outranks the root level
+    ``caplog.at_level()`` sets -- the victim gets ``caplog.text == ""``, nothing at all
+    rather than the wrong text, from a test that passes alone. The suite reaches this
+    through ``cli._setup_cli_logging``, which pins ``kiro_crew`` at WARNING, and which
+    test modules across the suite run for real by driving ``cli.main()`` in process.
+
+    ``conftest._restore_logger_levels`` is what removes the class; without a test, an edit
+    to it reverts silently and the failures reappear in files that have nothing to do with
+    the cause.
+
+    Grouped with ``xdist_group`` so the leaker and the observer stay on ONE worker:
+    ``--dist loadgroup`` honours that, and without it the two are distributed
+    independently and the observation passes vacuously.
+    """
+
+    def test_this_test_starts_with_an_unconfigured_kiro_crew_logger(self) -> None:
+        """Which is only true if no earlier test on this worker left a level on it."""
+        assert logging.getLogger("kiro_crew").level == logging.NOTSET
+
+    def test_a_leaked_level_does_not_reach_the_next_test(self) -> None:
+        """Leaks one and deliberately restores nothing -- the floor's job, not ours."""
+        logging.getLogger("kiro_crew").setLevel(logging.WARNING)
+        _LOGGER_ORDER["leaked"] = True
+        assert logging.getLogger("kiro_crew").level == logging.WARNING
+
+    def test_the_next_test_sees_the_level_gone(self) -> None:
+        """Reads what the previous test recorded. Ordered by definition order in the file."""
+        assert _LOGGER_ORDER.get("leaked"), (
+            "the leaking test did not run on this worker, so this assertion proves "
+            "nothing -- the xdist_group mark on the class is what keeps them together"
+        )
+        level = logging.getLogger("kiro_crew").level
+        assert level == logging.NOTSET, (
+            f"kiro_crew is still pinned at {logging.getLevelName(level)} -- every "
+            "kiro_crew.* record below that level is now dropped before it reaches the "
+            "root handler caplog captures through"
+        )
+
+    def test_a_debug_record_from_a_kiro_crew_logger_still_reaches_caplog(self, caplog) -> None:
+        """The capability the level restore exists to protect, asserted directly.
+
+        The level assertion above pins the mechanism; this pins the OUTCOME, in the exact
+        shape the victim test uses -- ``at_level`` on the root logger, a ``debug`` call on
+        a ``kiro_crew.*`` child -- so a future floor that restores something subtly
+        different still has to keep this working.
+        """
+        with caplog.at_level("DEBUG"):
+            logging.getLogger("kiro_crew.slack.gateway").debug("floor canary")
+        assert "floor canary" in caplog.text
+
+
 # ── the worker budget ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## The flake

`test/test_slack_gateway_more_coverage.py::TestDeliverCronResponse::test_options_post_failure_still_delivers_text` fails with `assert 'failed to post OPTIONS blocks' in ''` — nothing captured at all, rather than the wrong text captured. It passes alone and passes most full runs.

The culprit is `test/test_cli.py::TestCronCli::test_cli_argparse_cron_add_agent_flag`, an **argparse** test in a file with no connection to Slack. It drives the real `cli.main()` to check that `--agent` lands on the namespace, and `main()` calls `_setup_cli_logging`, which does:

```python
logging.getLogger("kiro_crew").setLevel(level)   # WARNING at verbose=0
```

Nothing puts it back, and that level is process-global per xdist worker.

**Why an empty `caplog.text` rather than a wrong one:** the assertion is on a `logger.debug` line in `slack/gateway.py`. `caplog.at_level("DEBUG")` with no `logger=` argument sets the level of the **root** logger only, but `Logger.debug` gates on the *effective* level — which stops at the first ancestor carrying an explicit one. That is now `kiro_crew`, pinned at WARNING, so the record is never created and never reaches caplog's handler. The sibling test `test_unresolvable_channel_returns_false` survives because it asserts at WARNING.

Ten test modules drive `cli.main()` in process this way.

## The fix

`_restore_logger_levels` in the rootdir `conftest.py`, beside the existing `_restore_log_record_factory` floor: snapshot `(level, disabled)` per logger at setup, restore what the test changed at teardown, plus `logging.disable`.

Placed at the floor rather than in `TestCronCli` because configuring logging is what `main()` is *for* — ten modules reach it, so per-module bookkeeping buys no coverage and is one forgotten fixture away from the flake returning. That is the same argument `_restore_log_record_factory` already makes in its docstring, for the same helper.

**Handlers are deliberately not restored.** An earlier revision of this PR did restore them, and @GPT's review was right to block it: a handler is routinely paired with a module-global recording it as installed — `dashboard.handlers.updates._log_ring_handler_installed` is the live example — and a floor can detach the handler but cannot know to clear the flag, leaving the singleton reporting installed with nothing attached. The root logger's list is doubly excluded, since pytest's `catching_logs` adds one per test *phase* and removes it at the phase boundary.

The handlers `_setup_cli_logging` leaves on `kiro_crew` do accumulate — each open on a `gateway.log` under a `tmp_path` the next test deletes — but that is a separate defect from this one, it is not what empties `caplog`, and `test_cli_logging.py`'s own `_pristine_logging` fixture is what absorbs it today.

Also adds `TestLoggerLevelsAreRestored` to `test/test_host_isolation_floor.py` — a leaker/observer pair on one `xdist_group`, matching the record-factory pin, plus a canary that asserts the *outcome* directly (`at_level` on root, `debug` on a `kiro_crew.*` child, record must reach `caplog`) so a future floor that restores something subtly different still has to keep this working. Floor entry added to `testing-conventions.md`.

## Verification

- **Reported repro** (`pytest test/ -k "variables or cron or apps_cron"` under `-n auto --dist loadgroup`): 1919 passed, 6 skipped.
- **Same selection serially in one process**: 1919 passed. This was a *deterministic* failure before the fix, which is how the culprit was isolated, and it is the check that confirms the level alone was the whole cause.
- **Full suite**: green apart from host-specific failures that reproduce identically on a reverted tree (symlink / `dir_fd` / collect-ignore assumptions, plus one timing-sensitive pty test).
- **Repo-wide leak sweep**: the full suite under a per-test global-`logging`-state differ reports zero leaks across ~67,800 tests.
- The pin fails without the floor (`kiro_crew is still pinned at WARNING`) and passes with it.
- `black` / `flake8` / `isort` / `docs-lint.sh` / brand + subprocess-encoding gates clean.

Measured cost of the floor: ~30us per snapshot at ~450 live loggers, so ~60us per test — the same order as the record-factory floor's ~50us.

> [!NOTE]
> All local runs used a Python **3.13** venv, since no interpreter on the dev machine had pytest or the project installed. The pre-existing host failures above may not reproduce on CI's 3.10/3.12 shards and were not checked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
