### PR TITLE
fix(chat): stop a voice round-trip inflating the mobile composer

### DIFF
--- a/website/scripts/capture-hold-to-talk.mjs
+++ b/website/scripts/capture-hold-to-talk.mjs
@@ -23,6 +23,10 @@
  *  - a draft hands the textarea back and leaves the mic an ENABLED record
  *    control, so dictating onto existing text still works
  *  - a sub-threshold tap discards and says so, leaving nothing running
+ *  - a voice round-trip leaves an EMPTY composer at its resting height (the
+ *    textarea is parked in a 1px `sr-only` box in voice mode, and measuring it
+ *    there pinned the composer at its 140px ceiling for good)
+ *  - no drag-resize handle exists under a finger
  *
  * Usage:
  *   npx vite --host 127.0.0.1 --port 6822 --strictPort   # in another shell
@@ -46,7 +50,7 @@ mkdirSync(OUT, { recursive: true })
 const FRAMES = [
   '01-keyboard-mode', '02-hold-mode', '03-holding', '04-armed-cancel', '05-after-discard',
   '06-holding-again', '07-transcript-in-composer', '08-after-tap', '09-draft-mic-records',
-  '10-draft-dictation-stoppable',
+  '10-draft-dictation-stoppable', '11-mode-roundtrip',
 ]
 const VIDEO_NAME = 'hold-to-talk.webm'
 
@@ -77,6 +81,8 @@ const VIEWPORT = { width: 390, height: 844 }
 const DRAG_UP_PX = 74
 /** Comfortably past the default holdMs (500) so the press resolves as a hold. */
 const HOLD_MS = 950
+/** ChatInput's INPUT_MIN_H — the collapsed one-line height of the textarea. */
+const INPUT_MIN_H = 44
 const TRANSCRIPT = 'Arm auto-merge on that PR and keep an eye on it'
 /** The isolated capture entry. Warm-up and the recorded run must load the same URL. */
 const CAPTURE_URL = `${BASE}/capture/hold-to-talk.html?theme=dark`
@@ -152,6 +158,8 @@ const composer = page.locator('textarea[data-composer-input]')
 const placeholder = await composer.getAttribute('placeholder')
 if (placeholder === 'Send a message, or tap the mic for voice') ok('keyboard mode promises only what the tap delivers')
 else fail(`placeholder was ${JSON.stringify(placeholder)}`)
+/** The empty composer's resting height, which section 8 requires it to return to. */
+const baselineWrapperH = Math.round((await page.locator('[data-testid="input-wrapper"]').boundingBox()).height)
 await shot('01-keyboard-mode')
 
 // ── 2. Switch to hold mode ──────────────────────────────────────────────────
@@ -304,6 +312,59 @@ if (await stopControl.count() >= 1 && !(await stopControl.first().isDisabled()))
 } else fail('draft-started dictation has no enabled control that can stop it')
 await shot('10-draft-dictation-stoppable')
 await page.waitForTimeout(700)
+
+// ── 8. The mode round-trip must not INFLATE the composer ─────────────────────
+// The textarea stays mounted through voice mode, clipped inside `sr-only` — a 1px
+// box. The auto-size pass measured it there anyway, read a `scrollHeight` of most
+// of a viewport, clamped it to the 140px ceiling and wrote that back as an inline
+// height that outlived the parking. So a voice round-trip handed the user back a
+// permanently tall empty composer, on the one surface with no way to shrink it
+// (the reset is a double-click, and the drag handle is gone under a finger).
+// Only observable over real layout: happy-dom computes no `scrollHeight`.
+await stopControl.first().click()
+await page.waitForTimeout(1200)
+await page.evaluate(() => {
+  const ta = document.querySelector('textarea[data-composer-input]')
+  const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set
+  setValue.call(ta, '')
+  ta.dispatchEvent(new Event('input', { bubbles: true }))
+})
+// Clearing the draft is what hands the surface back to hold mode, so the composer
+// is parked again — with the empty value whose height the bug measured.
+await holdBar.waitFor({ state: 'visible' })
+await page.waitForTimeout(400)
+await page.getByRole('button', { name: 'Switch to keyboard', exact: true }).click()
+await composer.waitFor({ state: 'visible' })
+await page.waitForTimeout(400)
+
+const roundTrip = await page.evaluate(() => {
+  const w = document.querySelector('[data-testid="input-wrapper"]')
+  const ta = document.querySelector('textarea[data-composer-input]')
+  return { wrapper: Math.round(w.getBoundingClientRect().height), inline: ta.style.height, value: ta.value }
+})
+if (roundTrip.value === '') ok('the round-trip left the composer empty')
+else fail(`composer was not empty: ${JSON.stringify(roundTrip.value)}`)
+if (roundTrip.wrapper === baselineWrapperH) {
+  ok(`an empty composer is back at its resting ${baselineWrapperH}px after a voice round-trip`)
+} else {
+  fail(`empty composer is ${roundTrip.wrapper}px after a voice round-trip, was ${baselineWrapperH}px at rest`
+    + ` (textarea inline height ${JSON.stringify(roundTrip.inline)})`)
+}
+// Named separately: the wrapper check above is the symptom, this is the mechanism,
+// and a future hider of the textarea would break this one first.
+if (roundTrip.inline === `${INPUT_MIN_H}px`) ok('the textarea was not measured while parked')
+else fail(`textarea inline height is ${JSON.stringify(roundTrip.inline)}, expected ${INPUT_MIN_H}px`)
+// Both forms, deliberately. The testid is this script's handle on the element; the
+// class is the affordance itself, and is what the element had BEFORE it carried a
+// testid — so a revert of the fix fails here rather than passing vacuously.
+const handleByTestId = await page.getByTestId('composer-resize-handle').count()
+const handleByClass = await page.locator('.input-area .cursor-row-resize').count()
+if (handleByTestId === 0 && handleByClass === 0) {
+  ok('no drag handle under a finger')
+} else fail(`the drag handle renders on a touch device (testid ${handleByTestId}, class ${handleByClass})`
+  + ' — a tap can pin the height with no way back')
+await shot('11-mode-roundtrip')
+await page.waitForTimeout(500)
 
 /*
  * Hold this run's own video handle. Playwright names the file by a random id, so

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -27,6 +27,7 @@ import TrustDropdown from './TrustDropdown'
 import AutoNudgePopover, { type AutoNudgeLoop } from './AutoNudgePopover'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { isTouchDevice } from '../utils/isTouchDevice'
+import { useIsTouchDevice } from '../hooks/useIsTouchDevice'
 import { Btn } from './ui'
 import { useTouchPushToTalk } from '../hooks/useTouchPushToTalk'
 import { consumeComposerRelease } from '../pages/chat/composerFocus'
@@ -222,12 +223,24 @@ function stripTrailingBlankLines(s: string): string {
 /** Auto-size textarea to fit content (only when not manually sized).
  *  Sets overflow:hidden during measurement so the parent flex container
  *  never sees the collapsed (height:0) intermediate state — prevents the
- *  Virtuoso message list above from reflowing and causing visible vibration. */
+ *  Virtuoso message list above from reflowing and causing visible vibration.
+ *
+ *  `parked` is a hard precondition, not an optimisation. Voice hold mode and the
+ *  dictation panel both keep the textarea mounted inside an `sr-only` box (value,
+ *  caret and IME state have to survive the swap), and `sr-only` is a 1px clip — a
+ *  textarea one pixel wide reports a `scrollHeight` of the better part of a
+ *  viewport, which this function would then clamp to `cap` and WRITE BACK as an
+ *  inline height. That height outlives the parking (nothing re-measures until
+ *  `value` changes again), so a single voice round-trip left the composer stuck
+ *  at the 140px ceiling with an empty box, on a surface whose only way to shrink
+ *  it — the drag handle's double-click — does not exist under a finger. */
 function applyHeight(
   el: HTMLTextAreaElement,
   manualHeight: number | null,
   prefillHint?: boolean,
+  parked?: boolean,
 ) {
+  if (parked) return // clipped out of layout — there is nothing valid to measure
   if (manualHeight !== null) return // manual height — wrapper controls size
   const cap = prefillHint ? INPUT_PREFILL_MAX_H : INPUT_DEFAULT_MAX_H
   const prev = el.style.height
@@ -1279,11 +1292,33 @@ function ChatInput({
     requestAnimationFrame(() => { const e2 = inputRef.current; if (e2) { e2.focus(); e2.setSelectionRange(next.caret, next.caret) } })
   }, [value, onChange])
   const chatMessages = useAppSelector(s => s.chat.messages)
-  const [manualHeight, setManualHeight] = useState<number | null>(() => {
+  /** The persisted drag-to-resize preference. Read `manualHeight` below instead —
+   *  this is the raw stored value and is not what the composer renders at. */
+  const [manualHeightPref, setManualHeight] = useState<number | null>(() => {
     const saved = localStorage.getItem(INPUT_HEIGHT_LS_KEY)
     const n = saved ? parseInt(saved, 10) : NaN
     return !isNaN(n) && n >= INPUT_MIN_H ? n : null
   })
+  /**
+   * Drag-to-resize is pointer-only, so on a touch device the composer always
+   * auto-sizes and the persisted preference is ignored outright.
+   *
+   * Nobody drags a phone's message box, and the affordance is not merely unused
+   * there — it is a trap. The handle is a 6px strip with `touch-action:none` and a
+   * zero-px drag threshold sitting directly above the input, so a thumb that lands
+   * short pins the height on the spot; and the only way back out is a
+   * double-click, which no finger can produce. One stray tap and the box was that
+   * size for good, across reloads.
+   *
+   * Derived rather than baked into the state's seed so a pointer-class change
+   * mid-session (a tablet gaining a trackpad) is honoured in both directions:
+   * the preference is never destroyed, only disregarded while there is no pointer
+   * to have set it. Every consumer below — the wrapper's height, the textarea's
+   * `flex-1`, the manual-resize floor, `applyHeight`'s bail — reads this and so
+   * follows automatically.
+   */
+  const isTouch = useIsTouchDevice()
+  const manualHeight = isTouch ? null : manualHeightPref
 
   // Drag-to-resize refs — resize wrapper div via direct DOM writes, commit on mouseup.
   // Resizing the wrapper (not the textarea) avoids layout thrashing: the textarea
@@ -1292,6 +1327,11 @@ function ChatInput({
   const dragging = useRef(false)
   const dragStartY = useRef(0)
   const dragStartH = useRef(0)
+  /** Mirrors `textareaParked` (defined with the voice-mode derivations, far below)
+   *  for the handlers declared above it. Assigned during render, like the other
+   *  prop/state mirrors in this file, so it is already current by the time any
+   *  effect or event handler reads it. */
+  const parkedRef = useRef(false)
 
   // Prompt history navigation: -1 = draft (not in history), else index into sentMessages.
   // Refs keep the handler stable across re-renders while preserving state between keystrokes.
@@ -1478,20 +1518,11 @@ function ChatInput({
     }
   }, [manualHeight, pendingFiles.length, pendingSessions.length])
 
-  // Auto-resize textarea to fit content
-  useEffect(() => {
-    if (inputRef.current && !dragging.current) applyHeight(inputRef.current, manualHeight, prefillHint)
-  }, [value, prefillHint, manualHeight])
-
-  // Keep the paste-highlight mirror's scroll aligned with the textarea after
-  // value/height changes (applyHeight mutates scrollTop programmatically, which
-  // doesn't fire the textarea's onScroll). rAF lets layout settle first.
-  useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      if (mirrorRef.current && inputRef.current) mirrorRef.current.scrollTop = inputRef.current.scrollTop
-    })
-    return () => cancelAnimationFrame(id)
-  }, [value, prefillHint, manualHeight])
+  // The two effects that MEASURE the textarea (auto-size, and the paste-mirror
+  // scroll sync that reads the scrollTop auto-size just wrote) are declared much
+  // further down, immediately below `textareaParked` — they must not run while the
+  // textarea is clipped out of layout, and a dep can only name a variable already
+  // in scope. Do not move them back up here.
 
   // Reset manual height when input is cleared (new message sent)
   const prevValueRef = useRef(value)
@@ -1593,7 +1624,7 @@ function ChatInput({
   }, [value, autoFocusKey])
 
   const handleInput = useCallback((e: React.FormEvent<HTMLTextAreaElement>) => {
-    if (!dragging.current) applyHeight(e.target as HTMLTextAreaElement, manualHeight, prefillHint)
+    if (!dragging.current) applyHeight(e.target as HTMLTextAreaElement, manualHeight, prefillHint, parkedRef.current)
   }, [manualHeight, prefillHint])
 
   const setTextUndoable = useCallback((text: string) => {
@@ -2427,6 +2458,34 @@ function ChatInput({
    * pointer events, so the gesture cannot start from a bar that is switched off.
    */
   const voiceSettling = voiceHoldMode && touchPtt.bar === 'settling'
+  /**
+   * The textarea is PARKED: still mounted, but clipped out of layout by the
+   * `sr-only` box the hold bar and the dictation panel both put it in.
+   *
+   * Anything that measures the textarea has to ask this first — see `applyHeight`
+   * for what a 1px-wide measurement did to the composer's height. It also has to
+   * be a dep of those effects, so the height is recomputed on the way BACK: the
+   * value that was streamed in while parked is exactly the value whose height was
+   * never measurable.
+   */
+  const textareaParked = !!showDictation || voiceHoldMode
+  parkedRef.current = textareaParked
+
+  // Auto-resize textarea to fit content. Moved down here from the other composer
+  // effects so it can name `textareaParked` — see the note at that site.
+  useEffect(() => {
+    if (inputRef.current && !dragging.current) applyHeight(inputRef.current, manualHeight, prefillHint, textareaParked)
+  }, [value, prefillHint, manualHeight, textareaParked])
+
+  // Keep the paste-highlight mirror's scroll aligned with the textarea after
+  // value/height changes (applyHeight mutates scrollTop programmatically, which
+  // doesn't fire the textarea's onScroll). rAF lets layout settle first.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      if (mirrorRef.current && inputRef.current) mirrorRef.current.scrollTop = inputRef.current.scrollTop
+    })
+    return () => cancelAnimationFrame(id)
+  }, [value, prefillHint, manualHeight, textareaParked])
   const toggleVoiceMode = useCallback(() => {
     setVoiceModePref(prev => {
       const next = !prev
@@ -2549,13 +2608,19 @@ function ChatInput({
           push it away from the box. */}
       {aboveComposer}
 
-      {/* Drag handle — always visible, sits above approval bar or input */}
+      {/* Drag handle — sits above approval bar or input, on pointer devices only */}
       {/* Pointer-drag resize handle for the message input (double-click resets).
           Resize is a pure visual enhancement — the textarea already auto-sizes to
           its content and there is no per-pixel keyboard resize gesture — so the
-          handle is aria-hidden and carries no interactive semantics. */}
-      {!showGhost && <div
+          handle is aria-hidden and carries no interactive semantics.
+
+          Absent under a finger, and its absence is the feature: the reset is a
+          double-click, so on touch the gesture could only ever pin the height, never
+          undo it. See `manualHeight` for why the persisted value is disregarded
+          there too. */}
+      {!showGhost && !isTouch && <div
         aria-hidden="true"
+        data-testid="composer-resize-handle"
         className="flex items-center justify-center h-[6px] cursor-row-resize group/drag"
         style={{ touchAction: 'none' }}
         {...inputResize}

--- a/website/src/test/ChatInput.resizeHandleTouch.test.tsx
+++ b/website/src/test/ChatInput.resizeHandleTouch.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+/**
+ * Drag-to-resize is a POINTER affordance, and on touch it was a one-way trap.
+ *
+ * The handle is a 6px strip with `touch-action:none` and a zero-px drag threshold
+ * sitting directly above the input, so a thumb that lands short pins the height on
+ * the spot — and the only way back out is a double-click, which no finger can
+ * produce. The pinned value is persisted, so one stray tap sized the composer for
+ * good, across reloads.
+ *
+ * Two halves, and both are needed: the handle must not RENDER on touch (nothing
+ * can pin a height), and a height already persisted must be DISREGARDED there
+ * (nothing stays pinned from before, or from a desktop session on the same
+ * origin). Neither half implies the other.
+ */
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+}
+
+/** Must match ChatInput's own constants. */
+const INPUT_DRAG_MIN_H = 93
+const MANUAL_H = 300
+
+const COARSE = '(pointer: coarse)'
+const NO_HOVER = '(hover: none)'
+
+/** Minimal flip-able matchMedia; the reactive path itself is covered by
+ *  src/test/useIsTouchDevice.test.ts, so this only needs a fixed answer. */
+function stubPointer(matches: Record<string, boolean>) {
+  const original = window.matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      get matches() { return matches[query] ?? false },
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+  return () => Object.defineProperty(window, 'matchMedia', { writable: true, configurable: true, value: original })
+}
+
+let restore: (() => void) | null = null
+
+beforeEach(() => {
+  localStorage.clear()
+})
+afterEach(() => { restore?.(); restore = null })
+
+const outer = () => screen.getByLabelText('Message input').closest('.input-area') as HTMLElement
+
+describe('ChatInput composer resize handle', () => {
+  it('renders no drag handle on a coarse pointer', () => {
+    restore = stubPointer({ [COARSE]: true, [NO_HOVER]: true })
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    expect(screen.queryByTestId('composer-resize-handle')).toBeNull()
+    // The affordance itself, not just this suite's handle on it: the element
+    // carried the class long before it carried a testid, so a revert of the gate
+    // fails here instead of passing on a selector that matches nothing either way.
+    expect(outer().querySelectorAll('.cursor-row-resize')).toHaveLength(0)
+  })
+
+  it('still renders the drag handle on a mouse pointer', () => {
+    restore = stubPointer({ [COARSE]: false, [NO_HOVER]: false })
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    expect(screen.getByTestId('composer-resize-handle')).toBeTruthy()
+    expect(outer().querySelectorAll('.cursor-row-resize')).toHaveLength(1)
+  })
+
+  it('disregards a persisted manual height on a coarse pointer', () => {
+    restore = stubPointer({ [COARSE]: true, [NO_HOVER]: true })
+    localStorage.setItem('mc-input-height', String(MANUAL_H))
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    // The manual-height floor is the observable side of the preference being live.
+    expect(outer().style.minHeight).toBe('')
+  })
+
+  it('honours a persisted manual height on a mouse pointer', () => {
+    restore = stubPointer({ [COARSE]: false, [NO_HOVER]: false })
+    localStorage.setItem('mc-input-height', String(MANUAL_H))
+    renderWithProviders(<ChatInput {...defaultProps} />)
+    expect(outer().style.minHeight).toBe(`${INPUT_DRAG_MIN_H}px`)
+  })
+})


### PR DESCRIPTION
## What

Two mobile composer defects, one symptom: the message box grew on its own and could not be shrunk back.

**1. A voice round-trip inflated the composer permanently.**

The textarea stays mounted through voice hold mode and the dictation panel, clipped inside an `sr-only` box — value, caret and IME state have to survive the swap. `sr-only` is a **1px clip**, and the auto-size pass measured the textarea there anyway: one pixel wide, it reports a `scrollHeight` of most of a viewport (835px at 390×844), which was clamped to the 140px ceiling and written back as an inline height.

Nothing re-measures until `value` changes, so that height outlived the parking. And because an empty composer re-enters hold mode, every clear re-inflated it — the box was 190px with nothing in it, indefinitely.

`applyHeight` now refuses to measure a parked textarea, and the two effects that measure it take `textareaParked` as a dep, so the height is computed on the way back **out**, when it is measurable. The value streamed in while parked is exactly the value whose height was never measurable, so the return trip is the only correct place to measure it.

**2. Drag-to-resize is removed on touch** — this is where "no way to shrink it" came from.

The handle is a 6px strip with `touch-action:none` and a zero-px drag threshold sitting directly above the input, so a thumb that lands short pins the height on the spot. The only reset is a double-click, which no finger can produce, and the pinned value is persisted — one stray tap sized the composer for good, across reloads. On a coarse pointer the handle is not rendered and the persisted height is disregarded outright, so the composer always auto-sizes. Pointer devices are unchanged, including a previously persisted height.

The two halves are independent and both are needed: fixing the measurement alone leaves the tap trap; removing the handle alone leaves the inflation.

## Before / after

An **empty** composer after tapping the mic to voice and back. Same harness, same gesture, same moment.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-composer-height/shots/before-empty-composer-inflated.png" width="330"> | <img src="https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-composer-height/shots/after-empty-composer-at-rest.png" width="330"> |
| wrapper 190px, textarea inline height `140px` | wrapper 94px, textarea inline height `44px` |

## Verification

Measured over real layout in the existing isolated capture entry (`website/capture/hold-to-talk.html`) at 390×844 with touch emulation, a real `MediaRecorder` and Chromium's fake microphone:

| step | before | after |
| --- | --- | --- |
| keyboard, empty | 94px / `44px` | 94px / `44px` |
| voice mode | 97px | 97px |
| transcript lands as draft | 94px / `44px` | 94px / `44px` |
| draft cleared (parks again) | 97px / **`140px`** | 97px / `44px` |
| back to keyboard, empty | **190px** / **`140px`** | 94px / `44px` |

A long transcript still sizes correctly on the way back (136px, under the 140 ceiling), so the fix does not simply pin the minimum.

New coverage, each verified to FAIL on the unfixed component:

- `website/src/test/ChatInput.resizeHandleTouch.test.tsx` — 4 specs: no handle on a coarse pointer, handle still present on a mouse pointer, persisted height disregarded on touch, honoured on a pointer. 3 of the 4 fail without the fix.
- `scripts/capture-hold-to-talk.mjs` sections 8 — the mode round-trip returns an empty composer to its resting height, the textarea was not measured while parked, and no handle exists under a finger. All 3 fail without the fix. Asserted on the `cursor-row-resize` class as well as the new testid, so a revert cannot pass vacuously on a selector that matches nothing either way.

Gates run locally: `tsc -b`, `eslint src/ --max-warnings 664` (644 warnings, 0 errors — matches the base), `i18n:check`, `jscpd` (0 clones), harness parity, changelog history, focus cue, brand. Frontend vitest: 1545 files / 24152 passed / 0 failed. The `test:electron` suite is red with an **identical 42-failure set on the base** (`MacUpdater`, gateway shutdown, mochi overlays, build-config schema) — inherited, and nothing in this diff touches that surface.

Still outstanding: real-device verification on an iPhone.


no linked issue: reported directly by the maintainer from a phone screenshot, not filed as an issue first.
