### PR TITLE
chore(executors): name the asyncio default executor threads

### DIFF
--- a/src/kiro_crew/executors.py
+++ b/src/kiro_crew/executors.py
@@ -7,8 +7,10 @@ agent-overlay rewrites) piles onto that default pool it can saturate it and
 starve the loop's own DNS resolution -- which is exactly the failure mode that
 turns a brief network blip into a multi-second event-loop stall.
 
-This module provides *separate*, bounded pools for that blocking work so it
-can never contend with the loop's default executor.
+This module provides *separate*, bounded pools for that blocking work and also
+names the loop's default executor's threads ``mc-default`` (Python's default
+names them anonymously), so profilers like py-spy can attribute blocking work
+to this gateway.
 
 Three pools, deliberately split:
 
@@ -76,6 +78,7 @@ _T = TypeVar("_T")
 
 __all__ = [
     "CronQueueTimeout",
+    "configure_default_executor",
     "maintenance_executor",
     "subprocess_executor",
     "cron_executor",
@@ -94,9 +97,16 @@ __all__ = [
     "shutdown_maintenance_executor",
 ]
 
+# ── Default executor naming ──
+# asyncio.to_thread and run_in_executor(None, ...) route onto the loop's default
+# executor.  The loop itself uses that same pool for getaddrinfo (DNS).  Python
+# caps it at min(32, cpu_count + 4) and names threads anonymously.  This module
+# keeps that cap but names threads ``mc-default`` so profilers like py-spy can
+# attribute blocking work to this gateway.
+
 # Bounded so a burst of maintenance work cannot spawn unbounded threads.  Four
-# is enough for the periodic sweeps + agent-overlay rewrites while leaving the
-# default executor entirely free for the loop's own I/O.
+# is enough for the periodic sweeps + agent-overlay rewrites while keeping them
+# isolated from the default executor's own bounded pool.
 _MAX_MAINT_WORKERS = 4
 
 # Subprocess/PTY teardown can block on a wedged kernel resource and a single
@@ -244,6 +254,31 @@ _image_pool: ThreadPoolExecutor | None = None
 _stt_pool: ThreadPoolExecutor | None = None
 _governance_pool: ThreadPoolExecutor | None = None
 _cron_gate_pool: ThreadPoolExecutor | None = None
+
+
+def configure_default_executor() -> None:
+    """Name the event loop's default executor threads.
+
+    Call once per event loop at startup, BEFORE any ``asyncio.to_thread`` or
+    ``run_in_executor(None, ...)`` runs.  Creates a fresh pool for the current
+    loop; the loop owns the pool and shuts it down when it closes.
+
+    Effects:
+
+    * Keeps Python's default cap (``min(32, cpu_count + 4)``).
+    * Names threads ``mc-default`` so they appear labeled in profilers like
+      py-spy, instead of the anonymous ``ThreadPoolExecutor-N_M``.
+
+    Does NOT make the documented "default executor free for the loop's own I/O"
+    invariant literally true -- 1700+ call sites still route onto it.  That
+    migration is tracked separately; this function names the pool until then.
+    """
+    loop = asyncio.get_running_loop()
+    pool = ThreadPoolExecutor(
+        max_workers=None,  # keep Python's default: min(32, cpu_count + 4)
+        thread_name_prefix="mc-default",
+    )
+    loop.set_default_executor(pool)
 
 
 def maintenance_executor() -> ThreadPoolExecutor:
@@ -726,7 +761,11 @@ async def run_in_embed_pool(func: Callable[..., _T], /, *args: Any, **kwargs: An
 
 
 def shutdown_maintenance_executor() -> None:
-    """Shut down all maintenance pools if they were created.  Idempotent."""
+    """Shut down all maintenance pools if they were created.  Idempotent.
+
+    The default executor pool is NOT included here -- it is owned by each event
+    loop and shut down by asyncio when the loop closes.
+    """
     global _pool, _subprocess_pool, _cron_pool, _discovery_pool, _embed_pool
     global _governance_pool, _image_pool, _cron_gate_pool, _stt_pool
     with _lock:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -50,7 +50,11 @@ from typing import Any, Callable, Collection, Iterator, Optional
 
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.loader import config_dir as _config_dir
-from kiro_crew.executors import maintenance_executor, subprocess_executor
+from kiro_crew.executors import (
+    configure_default_executor,
+    maintenance_executor,
+    subprocess_executor,
+)
 from kiro_crew.mcp_caller import CallerContext
 from kiro_crew.mcp_caller import _parent_pid as _ppid_fn
 from kiro_crew.mcp_gateway import credwatch, hazards, socketsec, transport
@@ -3713,6 +3717,13 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
     stop_event = asyncio.Event()
 
     loop = asyncio.get_running_loop()
+
+    # ── Name the default executor ──
+    # asyncio.to_thread and run_in_executor(None, ...) route onto the loop's
+    # default executor, which Python names threads anonymously.  This names
+    # them ``mc-default`` so profilers like py-spy can attribute blocking work
+    # to this gateway.  Must run BEFORE any to_thread offload.
+    configure_default_executor()
 
     # Catch exceptions that slip past per-task handlers — e.g. a
     # fire-and-forget coroutine that blows up without ``await``. Without

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from kiro_crew import platform_compat
-from kiro_crew.executors import subprocess_executor
+from kiro_crew.executors import configure_default_executor, subprocess_executor
 from kiro_crew.jsonl_util import rotate_jsonl_at
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
@@ -1697,6 +1697,13 @@ async def _recaller_loop(
 
 
 async def _amain(argv: Optional[list[str]] = None) -> int:
+    # ── Name the default executor ──
+    # asyncio.to_thread and run_in_executor(None, ...) route onto the loop's
+    # default executor, which Python names threads anonymously.  This names
+    # them ``mc-default`` so profilers like py-spy can attribute blocking work
+    # to this stub.  Must run BEFORE any to_thread offload.
+    configure_default_executor()
+
     # An invalid MC_MCP_LOG (e.g. "verbose") would make basicConfig raise
     # "Unknown level" and kill the stub BEFORE its fallback-to-per-session-exec
     # path can run. Fall back to WARNING on any unrecognised level.

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -147,6 +147,7 @@ from kiro_crew.embeddings import (
 )
 from kiro_crew.executors import (
     CronQueueTimeout,
+    configure_default_executor,
     cron_gate_budget,
     maintenance_executor,
     run_in_cron_gate_pool,
@@ -10582,6 +10583,13 @@ async def run_gateway(
     all services (chat, cron, subagents, task runner) are available via
     the web dashboard, but Slack connectivity is disabled.
     """
+    # ── Name the default executor ──
+    # asyncio.to_thread and run_in_executor(None, ...) route onto the loop's
+    # default executor, which Python names threads anonymously.  This names
+    # them ``mc-default`` so profilers like py-spy can attribute blocking work
+    # to this gateway.  Must run BEFORE any to_thread offload.
+    configure_default_executor()
+
     # ── Platform context boot (CPP seam) ──
     # Resolve + install the PlatformContext ONCE before any service spins up.
     # Idempotent: a no-op when ``cli.main`` already booted in this process.

--- a/test/test_executors.py
+++ b/test/test_executors.py
@@ -619,3 +619,82 @@ async def test_the_gate_keeps_most_of_its_budget_for_a_claimed_call() -> None:
     finally:
         release.set()
         ex.shutdown_maintenance_executor()
+
+
+# --- configure_default_executor: naming ----------------------------------------
+#
+# The default executor is the pool asyncio.to_thread and run_in_executor(None, ...)
+# route onto.  The loop itself uses it for getaddrinfo (DNS).  These tests cover
+# the thread naming (`mc-default-*`) -- sizing is left to Python's default.
+
+
+@pytest.mark.asyncio
+async def test_configure_default_executor_installs_named_pool() -> None:
+    """configure_default_executor installs a pool with mc-default-* threads."""
+    ex.configure_default_executor()
+
+    loop = asyncio.get_running_loop()
+    thread_name = await loop.run_in_executor(None, lambda: threading.current_thread().name)
+
+    assert thread_name.startswith(
+        "mc-default"
+    ), f"Expected thread name starting with 'mc-default', got {thread_name!r}"
+
+
+@pytest.mark.asyncio
+async def test_configure_default_executor_creates_fresh_pool_per_call() -> None:
+    """Each call to configure_default_executor creates a fresh pool for the loop.
+
+    The per-loop design means the loop owns the pool and shuts it down on close,
+    removing the need for process-global tracking and private-attribute probes.
+    """
+    ex.configure_default_executor()
+    loop = asyncio.get_running_loop()
+    first_executor = loop._default_executor
+
+    ex.configure_default_executor()
+    second_executor = loop._default_executor
+
+    # Each call creates a fresh pool
+    assert first_executor is not second_executor
+
+
+def test_second_loop_gets_configured_executor() -> None:
+    """A second event loop gets a configured mc-default executor, not anonymous.
+
+    Uses explicit loop management (new_event_loop + run_until_complete + close)
+    rather than asyncio.run to avoid a false positive from test_spawn_audit's
+    subprocess-spawn detector, which matches asyncio.run as base=asyncio attr=run.
+
+    This test pins the per-loop design: configure_default_executor creates a
+    fresh pool for each loop, and each loop gets mc-default threads.
+    """
+    results: list[str] = []
+
+    async def capture_thread_name() -> None:
+        ex.configure_default_executor()
+        loop = asyncio.get_running_loop()
+        thread_name = await loop.run_in_executor(None, lambda: threading.current_thread().name)
+        results.append(thread_name)
+
+    # First event loop
+    loop1 = asyncio.new_event_loop()
+    try:
+        loop1.run_until_complete(capture_thread_name())
+    finally:
+        loop1.close()
+
+    # Second event loop -- the per-loop design gives it its own fresh pool
+    loop2 = asyncio.new_event_loop()
+    try:
+        loop2.run_until_complete(capture_thread_name())
+    finally:
+        loop2.close()
+
+    assert len(results) == 2
+    assert results[0].startswith(
+        "mc-default"
+    ), f"First loop: expected 'mc-default*', got {results[0]!r}"
+    assert results[1].startswith(
+        "mc-default"
+    ), f"Second loop: expected 'mc-default*', got {results[1]!r}"


### PR DESCRIPTION
## Summary

Name the asyncio default executor threads at gateway startup.

## Problem / Motivation

`src/kiro_crew/executors.py` documents a deliberate architecture (lines 3-11):

> The asyncio event loop's *default* executor is also used by the loop itself
> for `getaddrinfo` (DNS) and by every `run_in_executor(None, ...)` caller.
> When long-running maintenance work [...] piles onto that default pool it can
> saturate it and starve the loop's own DNS resolution -- which is exactly the
> failure mode that turns a brief network blip into a multi-second event-loop
> stall.

Python caps the default pool at `min(32, cpu_count + 4)` and names its threads
anonymously (`ThreadPoolExecutor-N_M`). The anonymous names make saturation hard
to attribute in profilers like py-spy.

## Why it matters

When diagnosing event-loop stalls, py-spy is a primary tool for sampling thread
activity. With anonymous thread names (`ThreadPoolExecutor-N_M`), nothing in the
profile distinguishes work this gateway offloaded from unrelated threads in the
same process, so a stall caused by default-pool saturation cannot be attributed
directly -- it has to be inferred.

Naming the pool `mc-default-*` makes that attribution direct in py-spy profiles.
The severity is moderate and strictly diagnostic: pool size, scheduling and all
1,784 existing call sites are unchanged, so this closes an observability gap
rather than the starvation risk described above.

## What changed

Call `loop.set_default_executor(...)` with a **named** pool at gateway startup,
before any offload runs. This affects all three long-lived gateway loops:

1. **`slack/gateway.py:run_gateway`** — the Slack/dashboard gateway
2. **`mcp_gateway/gatewayd.py:_amain`** — the MCP gateway daemon
3. **`mcp_gateway/stub.py:_amain`** — the MCP stub (per-server child process)

Effects:

1. **Keeps Python's cap** — `min(32, cpu_count + 4)`, unchanged.
2. **Named threads** — `mc-default-*` appears in profilers like py-spy instead
   of the anonymous `ThreadPoolExecutor-N_M`.
3. **Per-loop pool** — each call creates a fresh pool for the current loop; the
   loop owns the pool and shuts it down when it closes.

## What this PR does NOT do

This PR does **not** make the documented invariant ("default executor free for
the loop's own I/O") literally true — 1,784 call sites still route onto the
default pool. Migrating them to a dedicated `io_executor()` would be a larger
change and is tracked separately. This PR names the pool that exists.

## Related issues

Both may be downstream symptoms of unbounded pool usage:

- #4707 — Gateway v0.2.0 sustains ~3250% CPU (32/40 cores) while idle on WSL2
- #5033 — KiroCrew uses 5+ GB RAM for one chat

## Tests

- 3 unit tests in `test/test_executors.py`:
  - `test_configure_default_executor_installs_named_pool` — verifies threads are named `mc-default-*`
  - `test_configure_default_executor_creates_fresh_pool_per_call` — verifies per-loop pool creation
  - `test_second_loop_gets_configured_executor` — verifies per-loop assignment
- All existing tests pass.
