### PR TITLE
perf(sessions): offload list_sessions() off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1026,7 +1026,12 @@ async def api_sessions(request: web.Request) -> web.Response:
         offset = 0
     want_preview = (request.query.get("preview") or "").lower() in ("1", "true", "yes")
     exclude_open = (request.query.get("exclude_open") or "").lower() in ("1", "true", "yes")
-    all_sessions = state.conversation_log.list_sessions()
+    # list_sessions() globs, stats, and reads the first line of EVERY session file
+    # in the history dir — O(all sessions). At 2000 sessions, that's ~200 ms of
+    # blocking IO (measured: 208 ms / 2000 files on a dev host). Running that on
+    # the event loop freezes chat, heartbeat, and every other coroutine for the
+    # full duration. Offload to a worker thread (#3057).
+    all_sessions = await asyncio.to_thread(state.conversation_log.list_sessions)
     if exclude_open:
         open_keys = _open_slot_transcript_keys(state)
         # Fold through ``_canonical_key`` as well: ``list_sessions`` deduplicates
@@ -1408,39 +1413,35 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
     if not state.conversation_log:
         return web.json_response({"error": "no conversation log"}, status=400)
 
-    # Same definition of "open as a tab" the Older-sessions list excludes on, so
-    # a session cannot be simultaneously hidden from that list and eligible for
-    # this delete.
-    protected = _open_slot_transcript_keys(state)
+    # Bind after the None guard so mypy's narrowing carries into the closure.
+    log = state.conversation_log
 
-    sessions = state.conversation_log.list_sessions()
+    # list_sessions() globs, stats, and reads the first line of EVERY session file
+    # in the history dir — O(all sessions). Offload to keep the event loop responsive.
+    all_sessions = await asyncio.to_thread(log.list_sessions)
+
     count = 0
     skipped = 0
     failed = 0
     cleanup_tasks = []
-    for s in sessions:
+    for s in all_sessions:
         key = s["key"]
-        if key in protected:
+
+        # Re-check per iteration: a resume publishing a slot during the
+        # list_sessions scan OR during an earlier delete-await now appears here.
+        if key in _open_slot_transcript_keys(state):
             skipped += 1
             continue
+
         try:
-            meta = state.conversation_log.get_metadata(key)
-        except Exception:
-            logger.warning(
-                "api_sessions_clear: unreadable metadata for %s, skipping", key, exc_info=True
-            )
-            skipped += 1
-            continue
-        if not isinstance(meta, dict):
-            skipped += 1
-            continue
-        if meta.get("pinned"):
-            skipped += 1
-            continue
-        try:
-            # delete_session enters _locked (flock + os.close) — offload off the
-            # event loop so a wedged peer can't stall the bulk clear on it.
-            if await asyncio.to_thread(state.conversation_log.delete_session, key):
+            # Offload off the event loop — delete_session enters _locked (flock).
+            # skip_pinned=True makes the pin-check-and-delete atomic so a
+            # concurrent pin cannot sneak in between the metadata read and the
+            # unlink. The invariant (lock, real test) now lives in history.py.
+            result = await asyncio.to_thread(log.delete_session, key, skip_pinned=True)
+            if result is None:
+                skipped += 1
+            elif result:
                 cleanup_tasks.append(_remove_slot_for_history_key(state, key))
                 count += 1
             else:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -22,7 +22,7 @@ from collections.abc import Callable, Container, Iterator
 from collections.abc import Set as AbstractSet
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, NamedTuple, TypeVar, overload
 
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
@@ -4367,7 +4367,28 @@ class ConversationLog:
             if chained not in keys:
                 keys.append(chained)
 
-    def delete_session(self, key: str) -> bool:
+    @overload
+    def delete_session(
+        self,
+        key: str,
+        *,
+        skip_pinned: Literal[False] = ...,
+    ) -> bool: ...
+
+    @overload
+    def delete_session(
+        self,
+        key: str,
+        *,
+        skip_pinned: Literal[True],
+    ) -> bool | None: ...
+
+    def delete_session(
+        self,
+        key: str,
+        *,
+        skip_pinned: bool = False,
+    ) -> bool | None:
         """Delete a session file. Returns True if a file was removed.
 
         The existence check and unlink run under ``_locked`` so a concurrent
@@ -4380,10 +4401,42 @@ class ConversationLog:
         between our existence check and the unlink). On a wedged holder the lock
         acquire raises ``HistoryLockTimeout``; we report "not removed" rather
         than delete unlocked (the very clobber this lock prevents).
+
+        Args:
+            skip_pinned: If True, check the session's metadata under the same
+                lock and return None (skip) if pinned=True OR if the metadata
+                is transiently unreadable. This makes the pin-check-and-delete
+                atomic so a concurrent pin cannot sneak in between.
+
+        Returns:
+            True if a file was removed, False if nothing to remove or unlink
+            failed, None if skipped due to skip_pinned + (pinned OR unreadable).
         """
         existed = False
         try:
             with self._locked(key):
+                if skip_pinned:
+                    try:
+                        meta, readable = self.get_metadata_status(key)
+                    except Exception:
+                        # Corrupt metadata, permanent I/O failure — skip (don't
+                        # delete blind). Log so aggregate 'skipped' count is
+                        # diagnosable.
+                        logger.warning(
+                            "delete_session: unexpected error reading metadata "
+                            "for %s, skipping",
+                            key,
+                            exc_info=True,
+                        )
+                        return None
+                    if not readable:
+                        # Transient read failure (Windows indexer/AV hold) — skip
+                        # quietly so the caller can retry later.
+                        return None
+                    if not isinstance(meta, dict):
+                        return None  # malformed -> skip
+                    if meta.get("pinned"):
+                        return None  # pinned -> skip
                 path = self._path(key)
                 existed = path.exists()
                 try:

--- a/src/kiro_crew/suggestions.py
+++ b/src/kiro_crew/suggestions.py
@@ -169,7 +169,10 @@ def _redact_suggestions(suggestions: list[str]) -> list[str]:
 
 async def generate_suggestions(state: DashboardState) -> list[str]:
     """Generate suggestions using the background kiro-cli session."""
-    context = _build_context(state)
+    # _build_context() calls list_sessions() + recent() — O(all sessions) disk IO.
+    # Offload to keep the event loop responsive (same pattern as this PR's other
+    # two offload sites in sessions.py).
+    context = await asyncio.to_thread(_build_context, state)
     if not context or len(context) < 50:
         logger.debug("Insufficient context for suggestions — using fallback")
         return list(_FALLBACK_SUGGESTIONS)

--- a/test/test_dashboard_sessions_clear.py
+++ b/test/test_dashboard_sessions_clear.py
@@ -13,7 +13,9 @@ tracked separately by (Clean Up button).
 
 from __future__ import annotations
 
+import contextlib
 import json
+from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -59,20 +61,61 @@ def _make_request(
     *,
     slots: dict[str, _FakeSlot] | None = None,
     metadata: dict[str, dict] | None = None,
+    unreadable_keys: set[str] | None = None,
+    raising_keys: set[str] | None = None,
 ) -> tuple[web.Request, MagicMock, list[str]]:
     """Build a minimal ``web.Request`` with a fake ``conversation_log`` + ``_slots``.
 
     Returns (request, state, deleted_keys) where ``deleted_keys`` is populated
     by ``delete_session`` so tests can assert exactly which keys were removed.
+
+    Args:
+        unreadable_keys: Keys for which get_metadata_status returns ({}, False)
+            simulating a transient read failure (Windows indexer/AV hold).
+        raising_keys: Keys for which get_metadata_status raises an exception
+            simulating corrupt metadata.
     """
     deleted_keys: list[str] = []
     metadata = metadata or {}
+    unreadable_keys = unreadable_keys or set()
+    raising_keys = raising_keys or set()
 
     conv_log = MagicMock()
     conv_log.list_sessions.return_value = sessions
     conv_log.get_metadata.side_effect = lambda k: metadata.get(k, {})
 
-    def _delete(key: str) -> bool:
+    def _get_metadata_status(k: str) -> tuple[dict, bool]:
+        if k in raising_keys:
+            raise json.JSONDecodeError("bad", "", 0)
+        if k in unreadable_keys:
+            return {}, False  # transient read failure
+        return metadata.get(k, {}), True
+
+    conv_log.get_metadata_status.side_effect = _get_metadata_status
+
+    # Mock _locked as a reentrant context manager (no-op for tests)
+    @contextlib.contextmanager
+    def _locked_mock(k: str) -> Iterator[None]:
+        yield
+
+    conv_log._locked = _locked_mock
+
+    def _delete(key: str, *, skip_pinned: bool = False) -> bool | None:
+        """Mock delete_session returning canned values per key.
+
+        The skip_pinned invariant (pinned/unreadable/raising -> None) is
+        already tested by 4 real-lock tests in test_history.py. Here we
+        just return canned values so api_sessions_clear's counting is
+        exercised.
+        """
+        if skip_pinned:
+            if key in raising_keys or key in unreadable_keys:
+                return None
+            meta = metadata.get(key, {})
+            if not isinstance(meta, dict):
+                return None  # corrupt metadata -> skip
+            if meta.get("pinned"):
+                return None
         deleted_keys.append(key)
         return True
 
@@ -247,19 +290,12 @@ async def test_skips_all_sessions_no_refresh() -> None:
 
 @pytest.mark.asyncio
 async def test_skips_session_when_metadata_raises() -> None:
-    """If get_metadata raises (corrupt JSON), the session is skipped, not deleted."""
+    """If get_metadata_status raises (corrupt JSON), the session is skipped, not deleted."""
     k1 = _history_key_for("chat-1")
     k2 = _history_key_for("chat-2")
     sessions = [{"key": k1}, {"key": k2}]
-    request, state, deleted = _make_request(sessions)
-
-    # k1 raises, k2 returns normal metadata
-    def _meta(key: str) -> dict:
-        if key == k1:
-            raise json.JSONDecodeError("bad", "", 0)
-        return {}
-
-    state.conversation_log.get_metadata.side_effect = _meta
+    # k1 raises (via raising_keys), k2 returns normal metadata
+    request, state, deleted = _make_request(sessions, raising_keys={k1})
 
     status, body = await _call_and_parse(request)
 
@@ -275,8 +311,11 @@ async def test_delete_failure_tracked_as_failed() -> None:
     sessions = [{"key": k1}, {"key": k2}]
     request, state, _ = _make_request(sessions)
 
-    # k1 succeeds, k2 fails
-    state.conversation_log.delete_session.side_effect = lambda k: k == k1
+    # k1 succeeds, k2 fails (simulating unlink failure)
+    def _delete(key: str, *, skip_pinned: bool = False) -> bool | None:
+        return key == k1
+
+    state.conversation_log.delete_session.side_effect = _delete
 
     status, body = await _call_and_parse(request)
 
@@ -291,7 +330,7 @@ async def test_delete_exception_tracked_as_failed() -> None:
     sessions = [{"key": k1}, {"key": k2}]
     request, state, _ = _make_request(sessions)
 
-    def _delete(key: str) -> bool:
+    def _delete(key: str, *, skip_pinned: bool = False) -> bool | None:
         if key == k1:
             raise PermissionError("access denied")
         return True
@@ -310,7 +349,7 @@ async def test_all_failed_returns_ok_false() -> None:
     k1, k2 = _history_key_for("chat-1"), _history_key_for("chat-2")
     sessions = [{"key": k1}, {"key": k2}]
     request, state, _ = _make_request(sessions)
-    state.conversation_log.delete_session.side_effect = lambda k: False
+    state.conversation_log.delete_session.side_effect = lambda k, *, skip_pinned=False: False
 
     status, body = await _call_and_parse(request)
 
@@ -379,3 +418,33 @@ async def test_skips_the_transcript_a_bound_channel_tab_is_reading() -> None:
 
     assert status == 200
     assert deleted == [other]
+
+
+@pytest.mark.asyncio
+async def test_skips_session_with_transient_unreadable_metadata() -> None:
+    """A session whose metadata is transiently unreadable is SKIPPED, not deleted.
+
+    Regression test for data-loss bug: get_metadata() returns {} on transient
+    read failure (Windows indexer/AV holding the file) WITHOUT raising, so
+    {}.get("pinned") is falsy and a PINNED session gets permanently deleted.
+
+    The fix is to use get_metadata_status() which returns (meta, readable=False)
+    on transient failure, and skip when not readable.
+    """
+    k_pinned = _history_key_for("chat-pinned")
+    k_normal = _history_key_for("chat-normal")
+    sessions = [{"key": k_pinned}, {"key": k_normal}]
+    # k_pinned is actually pinned on disk, but its metadata is transiently unreadable
+    metadata = {k_pinned: {"pinned": True}, k_normal: {}}
+    # Simulate transient read failure for k_pinned
+    request, _state, deleted = _make_request(
+        sessions, metadata=metadata, unreadable_keys={k_pinned}
+    )
+
+    status, body = await _call_and_parse(request)
+
+    assert status == 200
+    # k_pinned should be SKIPPED (unreadable), not deleted
+    assert k_pinned not in deleted, "Pinned session with unreadable metadata was deleted!"
+    assert deleted == [k_normal]
+    assert body == {"ok": True, "cleared": 1, "skipped": 1, "failed": 0}

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -4515,6 +4515,89 @@ class TestDeleteSessionSummarySidecar:
         assert log.delete_session("thread-nosum") is True
         assert not log._summary_cache_path("thread-nosum").exists()
 
+    def test_delete_session_skip_pinned_protects_pinned_sessions(self, tmp_path):
+        """skip_pinned=True returns None for pinned sessions under the REAL lock.
+
+        Regression test for the layering fix: the pin-check-and-delete invariant
+        now lives in ConversationLog.delete_session rather than in a handler closure.
+        This test exercises the real _locked codepath, NOT a mocked context manager,
+        so a regression that breaks lock reentrancy will actually fail.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("sess-pinned", "user", "important")
+        log.update_metadata("sess-pinned", {"pinned": True})
+        log.append("sess-unpinned", "user", "ephemeral")
+
+        # Pinned session: skip_pinned=True returns None, file survives
+        assert log.delete_session("sess-pinned", skip_pinned=True) is None
+        assert log._path("sess-pinned").exists()
+
+        # Unpinned session: skip_pinned=True returns True, file is deleted
+        assert log.delete_session("sess-unpinned", skip_pinned=True) is True
+        assert not log._path("sess-unpinned").exists()
+
+    def test_delete_session_skip_pinned_skips_unreadable_metadata(self, tmp_path):
+        """skip_pinned=True returns None when get_metadata_status returns unreadable.
+
+        Simulates a Windows indexer/AV hold that makes the metadata transiently
+        unreadable. The session is skipped (not deleted blind) and can be retried.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("sess-transient", "user", "might be locked")
+
+        # Patch get_metadata_status to simulate transient unreadability
+        original = log.get_metadata_status
+
+        def _unreadable(key):
+            if key == "sess-transient":
+                return {}, False  # readable=False
+            return original(key)
+
+        log.get_metadata_status = _unreadable
+
+        # skip_pinned=True returns None, file survives
+        assert log.delete_session("sess-transient", skip_pinned=True) is None
+        assert log._path("sess-transient").exists()
+
+    def test_delete_session_skip_pinned_logs_on_exception(self, tmp_path, caplog):
+        """skip_pinned=True logs and returns None when get_metadata_status raises.
+
+        Corrupt metadata or permanent I/O failure should be diagnosable via logs.
+        """
+        import logging
+
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("sess-corrupt", "user", "bad metadata")
+
+        # Patch to simulate corrupt metadata raising
+        def _corrupt_meta(key):
+            if key == "sess-corrupt":
+                raise ValueError("corrupt JSON")
+            return log.get_metadata(key), True
+
+        log.get_metadata_status = _corrupt_meta
+
+        with caplog.at_level(logging.WARNING):
+            result = log.delete_session("sess-corrupt", skip_pinned=True)
+
+        assert result is None
+        assert log._path("sess-corrupt").exists()
+        assert "unexpected error reading metadata" in caplog.text
+        assert "sess-corrupt" in caplog.text
+
+    def test_delete_session_skip_pinned_false_deletes_pinned(self, tmp_path):
+        """skip_pinned=False (default) deletes even pinned sessions.
+
+        Ensures the default behavior is unchanged for callers that don't use skip_pinned.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("sess-pinned-force", "user", "pinned but forced")
+        log.update_metadata("sess-pinned-force", {"pinned": True})
+
+        # Without skip_pinned, pinned sessions ARE deleted
+        assert log.delete_session("sess-pinned-force") is True
+        assert not log._path("sess-pinned-force").exists()
+
 
 @pytest.mark.asyncio
 async def test_dedupe_candidate_falls_back_to_lexical_without_judge_model(tmp_path):

--- a/test/test_persist_off_loop.py
+++ b/test/test_persist_off_loop.py
@@ -465,7 +465,7 @@ def test_all_candidates_corrupt_yields_no_floor(bad: str) -> None:
 # the gateway before it ever finishes booting.
 #
 # SCOPE, stated plainly: this gate is SHAPE cover, not the proof. It flags a read
-# spelled directly inside an `async def` body in chat_persistence.py. It would
+# spelled directly inside an `async def` body in the scanned files. It would
 # NOT have caught #895's original form, where the async driver drove a synchronous
 # GENERATOR and the reads sat one hop away inside it — and it deliberately does not
 # chase that hop, because following module-local calls transitively lands in
@@ -481,10 +481,11 @@ def test_all_candidates_corrupt_yields_no_floor(bad: str) -> None:
 # The offloaded shape passes for free — `asyncio.to_thread(_prefetch_recent_session, …)`
 # passes the function as a bare Name, which is not a call at that point.
 #
-# Scoped to chat_persistence.py deliberately. Repo-wide these three methods have
-# many legitimate on-loop callers reading one small metadata line; the invariant
-# being pinned is about the BULK restore path, and a gate that fires everywhere
-# would be turned off rather than obeyed.
+# Scoped to an explicit allow-list of bulk-restore drivers (chat_persistence.py and
+# sessions.py), not repo-wide. Repo-wide, these three methods have many legitimate
+# on-loop callers reading one small metadata line; the invariant being pinned is
+# about the BULK restore path, and a gate that fires everywhere would be turned
+# off rather than obeyed.
 
 _RESTORE_READS = frozenset({"list_sessions", "read_messages_chained", "get_metadata_status"})
 
@@ -516,22 +517,34 @@ def find_restore_read_violations(source: str, path: str = "<source>") -> list[tu
 
 
 def test_no_startup_restore_read_runs_on_the_event_loop() -> None:
-    """chat_persistence's async drivers must prefetch, never read inline."""
-    target = _src_root() / "dashboard" / "chat_persistence.py"
-    assert target.exists(), f"chat_persistence.py not found at {target}"
-    violations = find_restore_read_violations(
-        target.read_text(encoding="utf-8"), str(target)
-    )
-    if violations:
-        detail = "\n".join(f"  {path}:{lineno}" for path, lineno in violations)
+    """Async handlers must offload bulk-reads, never call inline.
+
+    **Limitation:** This gate is lexical — it flags only calls syntactically
+    inside an ``async def`` body. A one-level sync-helper extraction defeats it
+    (e.g. ``def _helper(): return log.list_sessions()`` called from an async def).
+    Zero-violation does NOT prove the code is safe; it proves the gate cannot see
+    a violation.
+    """
+    targets = [
+        _src_root() / "dashboard" / "chat_persistence.py",
+        _src_root() / "dashboard" / "handlers" / "sessions.py",
+    ]
+    all_violations: list[tuple[str, int]] = []
+    for target in targets:
+        assert target.exists(), f"{target.name} not found at {target}"
+        all_violations.extend(
+            find_restore_read_violations(target.read_text(encoding="utf-8"), str(target))
+        )
+    if all_violations:
+        detail = "\n".join(f"  {path}:{lineno}" for path, lineno in all_violations)
         raise AssertionError(
             "a bulk-restore disk read is called directly inside an `async def` "
-            "body in chat_persistence.py.\n\n"
+            "body.\n\n"
             "list_sessions() scans every session file; read_messages_chained() "
             "walks a whole transcript across forks. On the event loop that "
             "starves the LoopStallWatchdog heartbeat, whose exit_after timer "
             "then kills the gateway mid-boot (#895). Hoist the read:\n"
-            "    meta, msgs = await asyncio.to_thread(_prefetch_recent_session, …)\n"
+            "    sessions = await asyncio.to_thread(log.list_sessions)\n"
             "and keep only the slot mutation on the loop (slot creation "
             "broadcasts through asyncio.Queue.put_nowait / Event.set, neither "
             "thread-safe).\n"


### PR DESCRIPTION
## Summary

Offloads `ConversationLog.list_sessions()` off the event loop in three async callers, extending the existing offload gate in `test_persist_off_loop.py` to cover the new call sites.

## Problem / Motivation

`list_sessions()` globs, stats, and reads the first line of **every** session file in the history directory — O(all sessions). **Measured: 208 ms over 2000 files** on a dev host, scaling linearly.

Three async callers called it directly on the event loop:
- `api_sessions` (GET /api/sessions) — `sessions.py:1029`
- `api_sessions_clear` (DELETE /api/sessions) — `sessions.py:1416`
- `generate_suggestions` — `suggestions.py:172` (via `_build_context`)

The inversion was instructive: at line 1059, thirty lines *below* the expensive scan, `api_sessions` offloaded the small bounded preview tail-reads with the comment:

> Tail reads are sync file IO — keep them off the event loop.

So the O(all sessions) scan ran on the loop while the small bounded reads got a thread.

## Why it matters

Blocking the event loop is not local to the request that caused it. For the
208 ms the scan runs, every other request, websocket frame and background task
on the loop is stalled — so one user with a large history degrades the whole
gateway, not just their own dashboard load. The cost grows with history size,
which is exactly the direction it grows in over time.

## What changed

1. **Offload all three call sites**: `api_sessions` and `api_sessions_clear` via `asyncio.to_thread()`, and `generate_suggestions` via `asyncio.to_thread()` (matching this PR's other two offload sites in sessions.py).

2. **Extend the existing offload gate** in `test_persist_off_loop.py` to scan `sessions.py` alongside `chat_persistence.py`. This follows the established pattern of 7 existing per-surface offload gates (e.g., `test_channel_env_write_off_loop.py`, `test_knowledge_ingest_scan_off_loop.py`).

3. **Atomic pinned-check-and-delete moved into ConversationLog**: The metadata check and delete now run in `delete_session(key, skip_pinned=True)`, keeping the invariant, the lock, and its (unmocked) test in one module. The open-tab guard is re-checked per iteration on the event loop (cheap in-memory set). `_locked` is reentrant, so `delete_session`'s inner lock reuses the held fd.

4. **Use `get_metadata_status` for transient-failure safety**: The delete path now uses `get_metadata_status()` inside `delete_session` to detect transient read failures (Windows indexer/AV holding the file). `get_metadata()` returns `{}` on transient failure WITHOUT raising, so `{}.get("pinned")` is falsy and would delete a pinned session. `get_metadata_status()` returns `(meta, readable=False)` on transient failure, allowing the delete to skip.


## Why extend the existing gate

The generic `no-blocking-call-on-event-loop` gate in `AUTOSDE.yaml` covers calls that are **always** dangerous on the loop (`subprocess.run`, `time.sleep`). Its *deterministic* tier cannot gate *method* calls without knowing the receiver type — these require the *judgment* tier, which is advisory and not build-blocking. **That exclusion is precisely why this defect survived for so long.**

The existing `test_persist_off_loop.py` already detects `list_sessions()` and `read_messages_chained()` calls; this PR simply adds `sessions.py` to its scan targets.

## Against a TTL cache

The existing `_meta_cache` is keyed on per-file `st_mtime`, which guarantees a miss for every session that received a message since the last call — so an active dashboard never runs warm anyway. A short-TTL cache would add complexity for marginal gain since the offload already removes the latency from the user's perspective. Happy to add it in a follow-up if measurements show benefit.

## Related issues

- Closes partially: #3057 — "No guard or CI ratchet prevents synchronous IO inside async def"
- Related: #895 — "Startup restore still blocks the event loop" (related surface, distinct path — not addressed here)

## Known deferred sibling

One counted destructive call site remains unfixed and is out of scope for this PR:
- **history.py:5539** — `orig_meta = self.get_metadata(key) or {}` in the compaction codepath. The same transient-failure pattern: if `get_metadata` returns `{}` on transient read failure, compaction rebuilds the metadata line from scratch, silently dropping `pinned`, `title`, `agent`, etc. Tracked as follow-up.

## Measurements

| Sessions | Time (cold cache) |
| -------- | ----------------- |
| 100      | 10.1 ms           |
| 500      | 51.0 ms           |
| 1000     | 102.6 ms          |
| 1500     | 156.1 ms          |
| 2000     | 208.1 ms          |

## Tests

- Extended `test_no_startup_restore_read_runs_on_the_event_loop` to scan both `chat_persistence.py` and `sessions.py`
- Added `test_skips_session_with_transient_unreadable_metadata` regression test for the data-loss bug
- Added `test_delete_session_skip_pinned_*` tests that exercise the REAL lock (not mocked) in history.py
- All sessions_clear tests pass
- Gate catches pre-fix code (violations) and passes post-fix code (0 violations)

