### PR TITLE
test: unpin loser refusal code in concurrent case-alias create (#5917)

### DIFF
--- a/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py
@@ -16980,7 +16980,18 @@ async def test_create_refuses_a_macos_case_alias_for_the_same_directory(tmp_path
     statuses = [response.status for response in responses]
     assert sorted(statuses) == [201, 409], list(zip(statuses, bodies))
     refusal = bodies[statuses.index(409)]
-    assert refusal["code"] == "decision_directory_alias_conflict"
+    # The loser's refusal code depends on the filesystem, not on the race: the
+    # casefolded turn lock serializes both creates, and when the two spellings
+    # survive as distinct resolved paths (case-sensitive volumes) the loser hits
+    # the ``samefile`` alias probe and is refused as
+    # ``decision_directory_alias_conflict``. When the volume collapses the second
+    # spelling onto the winner's directory (case-insensitive volumes, as on the
+    # Windows CI shard), the resolved keys become lexically equal, the alias scan
+    # skips them, and the lexical duplicate check refuses as ``spec_dir_in_use``.
+    # Both refusals satisfy the invariant this test locks in — exactly one create
+    # succeeds and both spellings map to one directory — so either code is a
+    # correct outcome.
+    assert refusal["code"] in {"spec_dir_in_use", "decision_directory_alias_conflict"}
     assert len(routes._load_index()) == 1
     assert dispatched == ["x"]
 


### PR DESCRIPTION
## Problem / Motivation

`test_create_refuses_a_macos_case_alias_for_the_same_directory` (spec_builder, added by #3410) fails intermittently in CI: it fires two concurrent `POST /specs` for case-aliased spellings of the same directory and pins the loser's refusal to `decision_directory_alias_conflict`, but on the Windows shard the loser is refused as `spec_dir_in_use` instead. Observed red on PR #3514's merge-ref Windows shard while that PR does not touch spec_builder.

## Why it matters

Every PR pays for this: an unrelated red on a required shard forces authors and reviewers to triage a failure they did not cause, and re-runs waste CI capacity. Flaky required checks also erode trust in real reds.

## What changed (motivation -> approach -> change)

Symptom: the loser's refusal code differs across CI runs. Root cause: the code split is per-filesystem, not a race -- the casefolded turn lock (`_turn_key` with `_CASE_FOLD_TURN_KEYS`) serializes both creates, so on case-sensitive volumes the two spellings survive as distinct resolved paths and the `os.path.samefile` alias probe refuses the loser as `decision_directory_alias_conflict`, while on case-insensitive volumes (the Windows shard) `resolve()` collapses the second spelling onto the winner's directory, the resolved keys become lexically equal, the alias scan skips them, and the lexical duplicate check refuses as `spec_dir_in_use`. Both refusals deliver the behavior the test exists to lock in -- exactly one create succeeds and both spellings map to one directory -- so pinning a single code over-specifies the platform. The change relaxes only the loser-code assertion to set membership over the two valid codes and documents the mechanism in a comment; the load-bearing assertions (`sorted(statuses) == [201, 409]`, `len(routes._load_index()) == 1`, `dispatched == ["x"]`) are untouched, and production code is untouched. The relaxation does not weaken the probe's coverage: with `normcase` patched to identity in this test, both accepted codes are reachable only through `samefile` -- break the probe and both creates succeed, failing the surviving assertions. The sequential, non-racy pin on `decision_directory_alias_conflict` remains in `test_create_refuses_an_equivalent_orphan_ledger_before_inserting` and the detail/delete alias tests in the same file.

## Tests

Updated: the loser assertion in `test_create_refuses_a_macos_case_alias_for_the_same_directory` now accepts either valid refusal code. Ran the test 12x with the fix (all green) and 6x with the old pin on Linux (all green, confirming Linux deterministically takes the alias-probe arm -- the variance is cross-platform, not per-run on one platform). Full spec_builder route suite: 593 passed.

## Manual verification

N/A -- unit coverage sufficient; test-only change with no user-visible behavior.

## Related Issues

Closes #5917

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, test-only
- [x] No secrets, credentials, or internal references in the diff
