### PR TITLE
fix(gateway): finish process-group + bounded-reap sweep across remaining spawns

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2332,6 +2332,12 @@ class GatewayOrchestrator:
                 "--version",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                # Own process group (POSIX; no-op on Windows) so the tree kill
+                # in `_kill_startup_child` below reaches any descendants, not
+                # just the direct child — the kill+reap arms were already here,
+                # but without a session of its own the group signal had nothing
+                # to address beyond the child's PID.
+                start_new_session=platform_compat.IS_POSIX,
             )
         except Exception:
             return  # binary missing/unspawnable — same silence as before
@@ -8782,6 +8788,13 @@ class GatewayOrchestrator:
         proj = os.environ.get("KIROCREW_PROJECT_DIR", "")
         if not proj:
             return
+        # Timeout/cancel discipline for every spawn below. Function-local like
+        # the wheel path's import further down this file: the helper owns the
+        # kill-the-tree + bounded-reap contract, and there is exactly one
+        # implementation of it (issue #4210 exists to close the two-conventions
+        # gap, not to add a second helper).
+        from kiro_crew.platform.update_provider import _kill_and_reap
+
         try:
             # Every git call below reads a tree an agent can write, and several of
             # them (`status`, `diff`, `reset`) will EXEC a program the repository
@@ -8832,8 +8845,20 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
+                # Own process group (POSIX; no-op on Windows) so a timeout or
+                # cancellation kill reaches the whole tree, not just the direct
+                # child. Every spawn in this method carries the same discipline
+                # (issue #4210): on TimeoutError/CancelledError, kill the tree
+                # and reap under a bound via the shared `_kill_and_reap`, then
+                # re-raise so the outer handler keeps its current behaviour —
+                # without this the child is ABANDONED on timeout, not stopped.
+                start_new_session=platform_compat.IS_POSIX,
             )
-            branch_out, _ = await asyncio.wait_for(branch_proc.communicate(), timeout=10)
+            try:
+                branch_out, _ = await asyncio.wait_for(branch_proc.communicate(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(branch_proc)
+                raise
             if branch_proc.returncode != 0:
                 logger.error("Auto-update: could not determine current branch")
                 return
@@ -8917,8 +8942,13 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            await asyncio.wait_for(fetch.communicate(), timeout=60)
+            try:
+                await asyncio.wait_for(fetch.communicate(), timeout=60)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(fetch)
+                raise
 
             if fetch.returncode != 0:
                 if self.dashboard_state:
@@ -8949,8 +8979,13 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            target_out, _ = await asyncio.wait_for(target_proc.communicate(), timeout=10)
+            try:
+                target_out, _ = await asyncio.wait_for(target_proc.communicate(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(target_proc)
+                raise
             target = (target_out or b"").strip().decode()
             if target_proc.returncode != 0 or not target:
                 logger.warning(
@@ -8972,8 +9007,13 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            await asyncio.wait_for(diff_proc.wait(), timeout=10)
+            try:
+                await asyncio.wait_for(diff_proc.wait(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(diff_proc)
+                raise
             if diff_proc.returncode == 0:
                 # No diff — already up to date
                 if self.dashboard_state:
@@ -9049,8 +9089,13 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            status_out, _ = await asyncio.wait_for(status_proc.communicate(), timeout=10)
+            try:
+                status_out, _ = await asyncio.wait_for(status_proc.communicate(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(status_proc)
+                raise
             if status_proc.returncode != 0:
                 # Cannot prove the tree is clean, and the next step is
                 # irreversible — treat an unreadable status as dirty.
@@ -9136,8 +9181,13 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            added_out, _ = await asyncio.wait_for(added_proc.communicate(), timeout=10)
+            try:
+                added_out, _ = await asyncio.wait_for(added_proc.communicate(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                await _kill_and_reap(added_proc)
+                raise
             if added_proc.returncode != 0:
                 logger.warning(
                     "Auto-update: skipping — could not list the paths %s would add; "
@@ -9232,8 +9282,15 @@ class GatewayOrchestrator:
                 env=_git_env,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
             )
-            await asyncio.wait_for(reset.wait(), timeout=10)
+            try:
+                await asyncio.wait_for(reset.wait(), timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                # This child is a MUTATION, not a query: abandoned, it is a
+                # hard reset still running against the operator's checkout.
+                await _kill_and_reap(reset)
+                raise
             if reset.returncode != 0:
                 logger.error("Auto-update: git reset --hard failed (rc=%d)", reset.returncode)
                 if self.dashboard_state:
@@ -9243,14 +9300,34 @@ class GatewayOrchestrator:
 
             # Update the optional kiro-cli backend if present.
             if shutil.which("kiro-cli"):
+                kiro_update: asyncio.subprocess.Process | None = None
                 try:
                     kiro_update = await asyncio.create_subprocess_exec(
                         "kiro-cli",
                         "update",
                         stdout=asyncio.subprocess.DEVNULL,
                         stderr=asyncio.subprocess.DEVNULL,
+                        # Own process group (POSIX; no-op on Windows) so the
+                        # kill in the arms below reaches the whole tree.
+                        start_new_session=platform_compat.IS_POSIX,
                     )
                     await asyncio.wait_for(kiro_update.wait(), timeout=120)
+                except (TimeoutError, asyncio.TimeoutError):
+                    # Kill the tree BEFORE falling through: this step is
+                    # non-fatal, but the code below rebuilds the frontend and
+                    # reinstalls the Python deps, and an abandoned
+                    # `kiro-cli update` would keep mutating the installation
+                    # concurrently — the same half-replaced-install race the
+                    # wheel path's CancelledError branch exists to prevent.
+                    if kiro_update is not None:
+                        await _kill_and_reap(kiro_update)
+                    logger.debug("Auto-update: kiro-cli update timed out (non-fatal)")
+                except asyncio.CancelledError:
+                    # Shutdown cancels the update task; without this the child
+                    # keeps mutating the installation unsupervised.
+                    if kiro_update is not None:
+                        await _kill_and_reap(kiro_update)
+                    raise
                 except Exception:
                     logger.debug("Auto-update: kiro-cli update failed (non-fatal)")
 
@@ -9334,8 +9411,15 @@ class GatewayOrchestrator:
                     cwd=proj,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    # Own process group (POSIX; no-op on Windows) so the kill
+                    # below reaches pip's build-backend grandchildren too.
+                    start_new_session=platform_compat.IS_POSIX,
                 )
-                _fb_out, fb_err = await asyncio.wait_for(fallback.communicate(), timeout=300)
+                try:
+                    _fb_out, fb_err = await asyncio.wait_for(fallback.communicate(), timeout=300)
+                except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                    await _kill_and_reap(fallback)
+                    raise
                 if fallback.returncode == 0:
                     logger.info(
                         "Auto-update: core deps repaired after pip failure (%s)",

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -3436,6 +3436,83 @@ class TestAutoApplyUpdateVenvPath:
         ds.push_update_progress.assert_any_call("pulling", "Fetching latest changes…")
         ds.push_update_progress.assert_any_call("building", "Building frontend…")
 
+    @pytest.mark.asyncio
+    async def test_kiro_cli_update_timeout_kills_child_and_stays_nonfatal(self):
+        """A hung `kiro-cli update` is tree-killed AND the update stays non-fatal.
+
+        Both halves matter (issue #4210). Before the fix, the 120s timeout was
+        swallowed by the bare ``except Exception`` → DEBUG, so the run fell
+        through to the frontend build and dep reinstall while the ABANDONED
+        `kiro-cli update` kept mutating the installation concurrently — the
+        same half-replaced-install race the wheel path's CancelledError branch
+        exists to prevent. A kill-only assertion would pass on a fix that
+        turned the timeout fatal; the non-fatal half pins that the surrounding
+        contract (log at DEBUG, continue the update) is unchanged.
+        """
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+        orch.sessions = _mock_sessions()
+
+        _git_fake = _git_exec_fake()
+        kiro_procs: list = []
+
+        async def _fake_exec(*args, **kwargs):
+            argv = [a for a in args if isinstance(a, str)]
+            if argv and argv[0] == "kiro-cli":
+                proc = AsyncMock()
+                proc.kill = MagicMock()
+                proc.returncode = None
+                # The wait never completes inside its 120s budget; raising the
+                # timeout from the awaited side is this file's precedent for
+                # an expired `asyncio.wait_for` (the arm under test catches
+                # the same exception either way).
+                proc.wait = AsyncMock(side_effect=asyncio.TimeoutError())
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                kiro_procs.append(proc)
+                return proc
+            return await _git_fake(*args, **kwargs)
+
+        killed: list = []
+
+        async def _fake_kill_and_reap(proc):
+            killed.append(proc)
+
+        with patch("kiro_crew.env.is_toolbox_install", return_value=False):
+            with patch.dict("os.environ", {"KIROCREW_PROJECT_DIR": "/tmp/proj"}):
+                with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                    with patch(
+                        "kiro_crew.dep_sync.sync_or_reinstall", return_value=0
+                    ) as mock_install:
+                        with patch.object(
+                            GatewayOrchestrator, "_is_brazil_install", return_value=False
+                        ):
+                            with patch(
+                                "kiro_crew.slack.gateway.build_frontend_async",
+                                new_callable=AsyncMock,
+                            ) as mock_build:
+                                with patch("os.execv", side_effect=OSError("test")):
+                                    # Truthy: the optional kiro-cli step runs.
+                                    with patch(
+                                        "shutil.which", return_value="/usr/bin/kiro-cli"
+                                    ):
+                                        # The gateway resolves _kill_and_reap
+                                        # function-locally on every call, so
+                                        # patching the source module reaches it.
+                                        with patch(
+                                            "kiro_crew.platform.update_provider._kill_and_reap",
+                                            side_effect=_fake_kill_and_reap,
+                                        ):
+                                            await orch._auto_apply_update()
+
+        # Half 1: the hung child was killed (tree kill + bounded reap).
+        assert kiro_procs, "the kiro-cli update spawn never happened"
+        assert killed == kiro_procs
+        # Half 2: the timeout stayed NON-FATAL — the update continued into the
+        # frontend build and the dependency install exactly as before.
+        mock_build.assert_awaited_once()
+        assert mock_install.call_count == 1
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Tests: Subagent Slack injection timeout

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1552,3 +1552,191 @@ def test_bundled_skill_assets_are_not_imported():
         "shared logic into a real module under src/kiro_crew (where the spawn "
         "audit reviews it), or drop the import."
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Gateway spawn timeout discipline — issue #4210
+#
+# `slack/gateway.py` spawns children on the boot and auto-update paths. PR
+# #4049 established the discipline for a spawn that can time out: own process
+# group (`start_new_session` on POSIX), tree-kill + bounded reap on
+# TimeoutError AND on CancelledError. These two ratchets make the discipline
+# structural: the NEXT spawn added to the file cannot silently regress to an
+# abandoned-child-on-timeout, because the audit below fails until it carries
+# the same treatment.
+# ═══════════════════════════════════════════════════════════════════════════
+
+_GATEWAY_REL = "slack/gateway.py"
+
+#: Functions that own the kill-the-tree + bounded-reap contract. The module
+#: helper lives in `platform/update_provider.py`; the two `_startup_child`
+#: methods are the boot-path equivalent (kill and reap split in two).
+_TREE_KILL_FUNCS = frozenset({"_kill_and_reap", "_kill_startup_child"})
+
+
+@functools.cache
+def _gateway_tree() -> ast.Module:
+    path = _SRC_ROOT / "slack" / "gateway.py"
+    return ast.parse(path.read_text(encoding="utf-8"), str(path))
+
+
+def _is_spawn_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr.startswith("create_subprocess_")
+    )
+
+
+def _handler_catches(handler: ast.ExceptHandler, name: str) -> bool:
+    """Whether *handler* names *name* (bare or attribute-qualified) explicitly.
+
+    A blanket ``except Exception`` deliberately does NOT count: the discipline
+    requires the timeout/cancel arm to be explicit so the kill is visibly tied
+    to the abandonment hazard, and `_auto_apply_update`'s outer
+    ``except Exception`` (which does not kill) must not satisfy this audit.
+    """
+    types = handler.type
+    if types is None:
+        return False
+    parts = types.elts if isinstance(types, ast.Tuple) else [types]
+    for part in parts:
+        if isinstance(part, ast.Name) and part.id == name:
+            return True
+        if isinstance(part, ast.Attribute) and part.attr == name:
+            return True
+    return False
+
+
+def _handler_kills(handler: ast.ExceptHandler, proc_name: str) -> bool:
+    """Whether *handler*'s body calls a tree-kill helper on *proc_name*."""
+    for node in ast.walk(handler):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        fname = (
+            fn.id if isinstance(fn, ast.Name) else fn.attr if isinstance(fn, ast.Attribute) else ""
+        )
+        if fname not in _TREE_KILL_FUNCS:
+            continue
+        if any(isinstance(a, ast.Name) and a.id == proc_name for a in node.args):
+            return True
+    return False
+
+
+def test_gateway_spawns_all_own_session():
+    """Every subprocess spawn in slack/gateway.py starts its own session.
+
+    `proc.kill()` signals only the direct child; without
+    ``start_new_session`` the process-group tree kill in the timeout/cancel
+    arms has no group of its own to address, so grandchildren survive the
+    kill and keep running (issue #4210).
+    """
+    missing: list[str] = []
+    spawns = 0
+    for node in ast.walk(_gateway_tree()):
+        if not _is_spawn_call(node):
+            continue
+        spawns += 1
+        if not any(kw.arg == "start_new_session" for kw in node.keywords):
+            missing.append(f"{_GATEWAY_REL}:{node.lineno}")
+    assert spawns >= 10, (
+        f"only {spawns} spawn sites found in {_GATEWAY_REL} — the audit's "
+        "spawn matcher no longer matches the file's spawn idiom; fix the "
+        "matcher rather than deleting the ratchet"
+    )
+    assert not missing, (
+        "Spawn(s) in slack/gateway.py without start_new_session — a timeout "
+        "kill would reach only the direct child, abandoning its descendants "
+        "(issue #4210):\n  " + "\n  ".join(missing) + "\n\nAdd "
+        "start_new_session=platform_compat.IS_POSIX to the spawn."
+    )
+
+
+def test_gateway_proc_waits_all_kill_on_timeout_and_cancel():
+    """Every ``wait_for(<proc>.communicate()|.wait())`` in slack/gateway.py
+    sits under explicit TimeoutError AND CancelledError arms that tree-kill
+    that proc.
+
+    Without the arm, the child is ABANDONED on timeout — the exception
+    propagates (or is swallowed) while the process keeps running with no
+    supervisor, which on the auto-update path means a `git reset` or
+    `kiro-cli update` still mutating the installation (issue #4210).
+    """
+    offenders: list[str] = []
+    audited = 0
+    for func in ast.walk(_gateway_tree()):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        # Names assigned from a spawn IN THIS function. A proc received as a
+        # parameter (the reap helpers) is that caller's site, audited there.
+        proc_names = {
+            t.id
+            for stmt in ast.walk(func)
+            if isinstance(stmt, ast.Assign)
+            and isinstance(stmt.value, ast.Await)
+            and _is_spawn_call(stmt.value.value)
+            for t in stmt.targets
+            if isinstance(t, ast.Name)
+        }
+        if not proc_names:
+            continue
+        # Map each wait_for-on-a-proc to the Trys enclosing it in their body.
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(func):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        for node in ast.walk(func):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "wait_for"
+                and node.args
+                and isinstance(node.args[0], ast.Call)
+                and isinstance(node.args[0].func, ast.Attribute)
+                and node.args[0].func.attr in ("communicate", "wait")
+                and isinstance(node.args[0].func.value, ast.Name)
+                and node.args[0].func.value.id in proc_names
+            ):
+                continue
+            audited += 1
+            proc_name = node.args[0].func.value.id
+            timeout_ok = cancel_ok = False
+            cursor: ast.AST | None = node
+            while cursor is not None and cursor is not func:
+                parent = parents.get(cursor)
+                if isinstance(parent, ast.Try) and cursor in ast.walk(parent):
+                    # Only count Trys where the wait sits in the BODY (an
+                    # already-handling arm re-waiting is the reap, not a site).
+                    in_body = any(
+                        cursor is stmt or cursor in ast.walk(stmt) for stmt in parent.body
+                    )
+                    if in_body:
+                        for handler in parent.handlers:
+                            if _handler_kills(handler, proc_name):
+                                if _handler_catches(handler, "TimeoutError"):
+                                    timeout_ok = True
+                                if _handler_catches(handler, "CancelledError"):
+                                    cancel_ok = True
+                cursor = parent
+            if not (timeout_ok and cancel_ok):
+                lacking = " and ".join(
+                    what
+                    for what, ok in (("TimeoutError", timeout_ok), ("CancelledError", cancel_ok))
+                    if not ok
+                )
+                offenders.append(
+                    f"{_GATEWAY_REL}:{node.lineno} ({func.name}: {proc_name}) lacks a "
+                    f"{lacking} arm that tree-kills the proc"
+                )
+    assert audited >= 10, (
+        f"only {audited} proc wait sites found in {_GATEWAY_REL} — the audit's "
+        "wait matcher no longer matches the file's idiom; fix the matcher "
+        "rather than deleting the ratchet"
+    )
+    assert not offenders, (
+        "wait_for on a spawned proc without kill+reap discipline (issue "
+        "#4210):\n  " + "\n  ".join(offenders) + "\n\nWrap the wait in explicit "
+        "TimeoutError and CancelledError arms that call _kill_and_reap (or the "
+        "startup-child kill/reap pair) on the proc before returning/re-raising."
+    )


### PR DESCRIPTION
Fixes #4210

## What

PR #4049 converted three `slack/gateway.py` spawns to the timeout-surviving discipline (own process group, tree-kill, bounded reap, same treatment on `CancelledError`). This finishes the sweep across every remaining spawn in the file:

- **`_auto_apply_update` — 9 sites** (git branch probe, fetch, target rev-parse, diff, status, added-files listing, hard reset, `kiro-cli update`, fallback core-dep pip): each spawn now passes `start_new_session=platform_compat.IS_POSIX`, and each `asyncio.wait_for` is wrapped in explicit `TimeoutError`/`CancelledError` arms that route through the **existing** `update_provider._kill_and_reap` (tree-kill + bounded reap) before re-raising. Control flow and log levels are otherwise unchanged — the timeout still reaches the outer `except Exception` → "Auto-update failed", and cancellation still propagates.
- **`kiro-cli update` (highest-risk site):** the 120s timeout was previously swallowed by the bare `except Exception` → DEBUG while execution fell through to the frontend rebuild and pip reinstall — with the abandoned `kiro-cli update` still mutating the installation concurrently (the same half-replaced-install race the wheel path's `CancelledError` branch exists to prevent). It now gets an explicit timeout arm that tree-kills before falling through, and a `CancelledError` arm that kills and re-raises. The bare `except Exception` → DEBUG non-fatal contract is **kept** for every other exception.
- **`_warn_if_kiro_cli_outdated` (version probe):** kill+reap arms were already present; only `start_new_session` was missing — added.
- **git `reset --hard` site:** called out specifically because an abandoned child there is a *mutation* still running against the operator's checkout, not a read-only query.

## The ratchet (the deliverable)

Two static AST tests in `test/test_spawn_audit.py` make the discipline structural, so the next spawn added to the file cannot silently regress:

- `test_gateway_spawns_all_own_session` — every `create_subprocess_*` in `slack/gateway.py` must pass `start_new_session`.
- `test_gateway_proc_waits_all_kill_on_timeout_and_cancel` — every `wait_for(<proc>.communicate()|.wait())` on a spawned proc must sit under **explicit** `TimeoutError` AND `CancelledError` arms that tree-kill that proc. A blanket `except Exception` deliberately does not satisfy the audit. Both tests carry non-vacuity floors so a drifting matcher fails loudly instead of passing on an empty set.

Plus a per-site behavioural test (`test_kiro_cli_update_timeout_kills_child_and_stays_nonfatal`) asserting **both halves**: the hung `kiro-cli update` is killed, AND the update still completes non-fatally (a kill-only check would pass on a fix that turned the timeout fatal).

## Two corrections to the issue body (pre-dispositioned)

1. **The issue's shell-pipeline hazard framing no longer applies.** It argues `proc.kill()` orphans shell-pipeline members and blocks `communicate()` forever. There are **zero** `create_subprocess_shell` calls in the file (`grep -c create_subprocess_shell src/kiro_crew/slack/gateway.py` → 0), and the only spawn running a shell string (the wheel installer) was already converted. The actual residual this PR fixes is the unkilled/unreaped child abandoned on timeout.
2. **The issue's "write one small helper" suggestion is already implemented** — `update_provider._read_bounded_output` / `_kill_and_reap` / `_REAP_TIMEOUT_SECS` exist and the wheel path already imports them. This PR **reuses** `_kill_and_reap` (function-local import, matching the existing convention; no import cycle — `update_provider` does not import `gateway`) rather than inventing a second helper, which would recreate the two-conventions problem this issue exists to close.

Also: the file has **12** spawn sites, not the issue's ~20 (its count was stale).

## Deliberate choice: no new `_read_bounded_output` call sites

`_read_bounded_output` caps captured output at 64 KiB. For the git sites this would be a behaviour change that *weakens* safety guards, not a hardening: the `status --porcelain` and added-files outputs feed the pre-reset data-loss refusal checks, and truncating them could hide a tracked edit past the cap and let the reset destroy it. Outputs at these sites are git plumbing bounded by repo state, not attacker-inflatable streams, so the existing `communicate()` is kept.

## Verification

- All 3 new tests red on unfixed code, green after (stash-verified).
- 4 mutants killed: session flag removed → own-session ratchet red; kill removed from an arm → timeout ratchet red; kill removed at the kiro-cli site → behavioural half 1 red; timeout made fatal → behavioural half 2 red.
- `scripts/local-gate.py --base origin/main`: full backend suite 68,508 passed; 95 failed + 2 errors, **byte-identical** to an `origin/main` git-worktree baseline run of the same failing files (`comm -23`/`comm -13` both empty = zero regressions; all pre-existing environmental).
- black 26.3.1 (CI pin), isort, flake8, mypy clean on touched files. `test_slack_gateway.py` stays in the black baseline (not reformatted wholesale, to keep this diff reviewable).
- Frontend cross-surface guards not runnable locally (node 16 host); CI's node lanes are the backstop.
