### PR TITLE
perf(sidebar): narrow subagent subscriptions to derived counts

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -16,7 +16,7 @@ import { useConnected } from '../hooks/useConnected'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent } from '../components/ui/dropdown-menu'
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from '../components/ui/context-menu'
 import { offlineProps } from '../utils/offline'
-import { switchSlot, createSlot, deleteSlot, fetchHistory, resumeFromHistory, deleteHistorySession, clearSlotReveal } from '../store/chatSlice'
+import { switchSlot, createSlot, deleteSlot, fetchHistory, resumeFromHistory, deleteHistorySession, clearSlotReveal, selectSidebarSubagentCounts, selectSidebarApprovalCounts } from '../store/chatSlice'
 import { sseSlotTitle, setSidebarOrder } from '../store/dashboardSlice'
 import { useDigitModifierHeld, jumpLabelFor } from '../hooks/useKeyboardShortcuts'
 import { api, SEARCH_MIN_CHARS } from '../api/client'
@@ -59,7 +59,7 @@ import { DndDraggable, DndDroppable, pointerWithinDeepest, closestEdge } from '.
 import { collectFolderSubtreeIds } from '../utils/folderTree'
 import { runBelongsToSlot } from '../apps/workflows/runModel'
 import { sanitizeLlmOutput } from '../utils/sanitize'
-import type { ChatFolder, ChatTag, TagColumn, TagColumnMode, SubagentActivity, SessionLink } from '../types'
+import type { ChatFolder, ChatTag, TagColumn, TagColumnMode, SessionLink } from '../types'
 import { SESSION_LANES, inferLane } from './chat/sessionLane'
 import { decideUnreadDrain } from './unreadDrain'
 import {
@@ -1630,75 +1630,12 @@ function ChatSidebar({
   const uiLang = useLanguage().resolved
   // Presence in this map means "this session is in an active goal loop".
   const goalLoops = useAppSelector(s => s.chat.goalLoops)
-  // Live subagent activity per slot, for the sidebar row's "N agents running"
-  // subtitle. Mirrors SubagentProgressBar's source of truth: chatSlice.subagents
-  // for the store's active slot, slotActivity[slot].subagents for background
-  // slots (both populated by the globally-subscribed subagent_spawn/tool/done WS
-  // events). We deliberately do NOT use dashboardSlice.subagentRunning — that
-  // count is only broadcast on the subagent_status "done" event
-  // (gateway._broadcast_subagent_status), never on spawn, so it under-reports
-  // while agents are still running.
-  const storeActiveSlot = useAppSelector(s => s.chat.activeSlot)
-  const activeSlotSubagents = useAppSelector(s => s.chat.subagents)
-  const slotActivity = useAppSelector(s => s.chat.slotActivity)
-  // Queued-but-not-started agents have no entry in the per-slot subagents map,
-  // so a slot whose whole wave is still behind the concurrency cap counted 0
-  // and showed no subtitle at all — the window in which a user is most likely
-  // to wonder whether their spawn did anything. Fold the queue depth in.
+  // NOT dashboardSlice.subagentRunning — that only broadcasts on "done", not spawn.
+  const subagentCounts = useAppSelector(selectSidebarSubagentCounts, shallowEqual)
+  // Spawn approvals (pending + approval_id) — surfaced here since background chats have no inline prompt.
+  const subagentApprovalCounts = useAppSelector(selectSidebarApprovalCounts, shallowEqual)
+  // Queued agents (behind concurrency cap) — ensures subtitle shows even when no agents started yet.
   const subagentQueued = useAppSelector(s => s.chat.subagentQueued)
-  const subagentCounts = useMemo(() => {
-    const countActive = (m?: Record<string, SubagentActivity>) => {
-      if (!m) return 0
-      let n = 0
-      for (const a of Object.values(m)) {
-        if (a.status === 'running' || a.status === 'tool' || a.status === 'pending') n++
-      }
-      return n
-    }
-    const counts: Record<string, number> = {}
-    if (storeActiveSlot) { const n = countActive(activeSlotSubagents); if (n > 0) counts[storeActiveSlot] = n }
-    for (const [slot, act] of Object.entries(slotActivity ?? {})) {
-      // Load-bearing: on switchSlot the active slot's subagents map is aliased
-      // into BOTH state.subagents and slotActivity[active].subagents (same
-      // object reference), so skipping the active slot here is what prevents
-      // double-counting it. Do not drop this guard.
-      if (slot === storeActiveSlot) continue
-      const n = countActive(act.subagents)
-      if (n > 0) counts[slot] = n
-    }
-    for (const [slot, q] of Object.entries(subagentQueued ?? {})) {
-      if (q > 0) counts[slot] = (counts[slot] || 0) + q
-    }
-    return counts
-  }, [storeActiveSlot, activeSlotSubagents, slotActivity, subagentQueued])
-  // Sub-agents blocked on a SPAWN approval, per slot. Mirrors
-  // selectSlotPendingSpawnApprovals (status 'pending' + an approval_id), but
-  // across every slot rather than the viewed one: a spawn approval raised by a
-  // background chat has no inline prompt and no notification, so without this
-  // the sidebar was the only place it could have surfaced and it showed
-  // "N agents running" instead — an owed decision rendered as work in
-  // progress. Counted separately from `subagentCounts` so the running subtitle
-  // can subtract them (an agent waiting on approval is not running).
-  const subagentApprovalCounts = useMemo(() => {
-    const countPending = (m?: Record<string, SubagentActivity>) => {
-      if (!m) return 0
-      let n = 0
-      for (const a of Object.values(m)) {
-        if (a.status === 'pending' && a.approval_id) n++
-      }
-      return n
-    }
-    const counts: Record<string, number> = {}
-    if (storeActiveSlot) { const n = countPending(activeSlotSubagents); if (n > 0) counts[storeActiveSlot] = n }
-    for (const [slot, act] of Object.entries(slotActivity ?? {})) {
-      // Same aliasing guard as countActive above: the active slot's map is the
-      // same object in both places, so skipping it here avoids double-counting.
-      if (slot === storeActiveSlot) continue
-      const n = countPending(act.subagents)
-      if (n > 0) counts[slot] = n
-    }
-    return counts
-  }, [storeActiveSlot, activeSlotSubagents, slotActivity])
   // Live dynamic-workflow runs per slot, for the sidebar row's "workflow
   // running" subtitle. Mirrors WorkflowProgressBar's source of truth:
   // chatSlice.workflowRuns (populated by the globally-subscribed

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -2153,6 +2153,32 @@ export const selectSlotSubagentsActive = (state: RootState, slot: string): boole
   return false
 }
 
+// Shared subagent-counting helpers — single implementations for both sidebar and aggregate selectors.
+
+/** Counts active subagents (running + tool + pending) in a subagent map. */
+const countActiveSubagents = (m?: Record<string, SubagentActivity>) => {
+  if (!m) return 0
+  let n = 0
+  for (const a of Object.values(m)) {
+    if (a.status === 'running' || a.status === 'tool' || a.status === 'pending') n++
+  }
+  return n
+}
+
+/** Predicate: subagent is blocked awaiting a spawn approval. */
+const isAwaitingSpawnApproval = (a: SubagentActivity) =>
+  a.status === 'pending' && !!a.approval_id
+
+/** Counts subagents pending spawn approval in a subagent map. */
+const countPendingApprovals = (m?: Record<string, SubagentActivity>) => {
+  if (!m) return 0
+  let n = 0
+  for (const a of Object.values(m)) {
+    if (isAwaitingSpawnApproval(a)) n++
+  }
+  return n
+}
+
 // Stable empty result so the selector is referentially stable (with shallowEqual)
 // when a slot has no pending spawn approvals — avoids needless re-renders.
 const _EMPTY_PENDING_SPAWNS: SubagentActivity[] = []
@@ -2173,7 +2199,7 @@ export const selectSlotPendingSpawnApprovals = (state: RootState, slot: string |
   if (!slot) return _EMPTY_PENDING_SPAWNS
   const subs = getSlotSubs(state.chat, slot)
   if (!subs) return _EMPTY_PENDING_SPAWNS
-  const out = Object.values(subs).filter(a => a.status === 'pending' && !!a.approval_id)
+  const out = Object.values(subs).filter(isAwaitingSpawnApproval)
   return out.length ? out : _EMPTY_PENDING_SPAWNS
 }
 
@@ -2195,24 +2221,70 @@ export const selectSubagentActivityCount = createSelector(
     (state: RootState) => state.chat.subagentQueued,
   ],
   (activeSlot, activeSubs, slotActivity, queued) => {
-    const countActive = (m?: Record<string, SubagentActivity>) => {
-      if (!m) return 0
-      let n = 0
-      for (const a of Object.values(m)) {
-        if (a.status === 'running' || a.status === 'tool' || a.status === 'pending') n++
-      }
-      return n
-    }
-    let total = activeSlot ? countActive(activeSubs) : 0
+    let total = activeSlot ? countActiveSubagents(activeSubs) : 0
     for (const [slot, act] of Object.entries(slotActivity ?? {})) {
       // On switchSlot the active slot's map is aliased into both
       // state.subagents and slotActivity[active].subagents (same reference),
       // so this guard is what prevents double-counting it.
       if (slot === activeSlot) continue
-      total += countActive(act.subagents)
+      total += countActiveSubagents(act.subagents)
     }
     for (const q of Object.values(queued ?? {})) total += q > 0 ? q : 0
     return total
+  },
+)
+
+/** Per-slot subagent counts for sidebar. Reuses shared counting helpers above. */
+
+/** Total active subagents per slot (running + tool + pending). */
+export const selectSidebarSubagentCounts = createSelector(
+  [
+    (state: RootState) => state.chat.activeSlot,
+    (state: RootState) => state.chat.subagents,
+    (state: RootState) => state.chat.slotActivity,
+    (state: RootState) => state.chat.subagentQueued,
+  ],
+  (activeSlot, activeSubs, slotActivity, queued) => {
+    const counts: Record<string, number> = {}
+    if (activeSlot) {
+      const n = countActiveSubagents(activeSubs)
+      if (n > 0) counts[activeSlot] = n
+    }
+    for (const [slot, act] of Object.entries(slotActivity ?? {})) {
+      // Load-bearing: active slot's map is aliased in both places; skip to avoid double-count.
+      if (slot === activeSlot) continue
+      const n = countActiveSubagents(act.subagents)
+      if (n > 0) counts[slot] = n
+    }
+    // Fold in queued counts.
+    for (const [slot, q] of Object.entries(queued ?? {})) {
+      if (q > 0) counts[slot] = (counts[slot] || 0) + q
+    }
+    return counts
+  },
+)
+
+/** Subagents pending approval per slot (status=pending + has approval_id). */
+export const selectSidebarApprovalCounts = createSelector(
+  [
+    (state: RootState) => state.chat.activeSlot,
+    (state: RootState) => state.chat.subagents,
+    (state: RootState) => state.chat.slotActivity,
+  ],
+  (activeSlot, activeSubs, slotActivity) => {
+    const approvalCounts: Record<string, number> = {}
+    if (activeSlot) {
+      const p = countPendingApprovals(activeSubs)
+      if (p > 0) approvalCounts[activeSlot] = p
+    }
+    for (const [slot, act] of Object.entries(slotActivity ?? {})) {
+      // Same aliasing guard as countActive above: the active slot's map is the
+      // same object in both places, so skipping it here avoids double-counting.
+      if (slot === activeSlot) continue
+      const p = countPendingApprovals(act.subagents)
+      if (p > 0) approvalCounts[slot] = p
+    }
+    return approvalCounts
   },
 )
 

--- a/website/src/test/ChatSidebar.selectorScope.test.tsx
+++ b/website/src/test/ChatSidebar.selectorScope.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Verifies the sidebar's subagent selectors re-render only when counts change,
+ * not on every streaming token. Uses a hoisted render counter on the component.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { sseSubagentChunk, sseSubagentSpawn } from '../store/chatSlice'
+
+// Counts renders of ChatSidebar.
+const { sidebarRenders } = vi.hoisted(() => ({ sidebarRenders: { n: 0 } }))
+
+// Mock framer-motion to avoid jsdom projection issues.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: any, ref: any) => {
+      const clean: any = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    LayoutGroup: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ tagColumnsEnabled: false, confirmCloseSession: false }),
+  saveChatConfig: vi.fn(),
+}))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: () => vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+// The actual sidebar, but with a render counter injected via a hook mock.
+// We mock useSimplifiedToolNames since it's called unconditionally at render.
+vi.mock('../hooks/useSimplifiedToolNames', () => ({
+  useSimplifiedToolNames: () => {
+    sidebarRenders.n++
+    return false
+  },
+}))
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+function mountSidebar(slots: any[], chat: Record<string, unknown>, activeSlotProp: string | null = null) {
+  const store = createTestStore({
+    dashboard: {
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as any,
+    chat: {
+      activeSlot: chat.activeSlot ?? null,
+      slotStatusDetail: {},
+      subagents: {},
+      slotActivity: {},
+      subagentQueued: {},
+      goalLoops: {},
+      messages: [],
+      slotMessages: {},
+      ...chat,
+    } as any,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], [])
+  const result = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots} activeSlot={activeSlotProp} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { store, ...result }
+}
+
+/** Runs `body`, lets React flush, and returns how many times the sidebar rendered. */
+async function rendersDuring(body: () => void) {
+  const before = sidebarRenders.n
+  await act(async () => {
+    body()
+    await new Promise(r => setTimeout(r, 50))
+  })
+  return sidebarRenders.n - before
+}
+
+describe('ChatSidebar store subscription scope', () => {
+  beforeEach(() => { sidebarRenders.n = 0; localStorage.clear() })
+  afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+  it('does not re-render on a subagent chunk for a DIFFERENT (background) slot', async () => {
+    const slots = [
+      { key: 'slot-a', title: 'A', running: false, messages: 1 },
+      { key: 'slot-b', title: 'B', running: false, messages: 1 },
+    ]
+    const { store } = mountSidebar(
+      slots,
+      {
+        activeSlot: 'slot-a',
+        slotActivity: {
+          'slot-b': { toolLog: [], subagents: { 'sub-1': { id: 'sub-1', status: 'running', streaming: '' } } },
+        },
+      },
+      'slot-a',
+    )
+
+    await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+    sidebarRenders.n = 0
+
+    expect(await rendersDuring(() => {})).toBe(0) // Control: no dispatch → no render
+
+    // Cross-slot: chunk for slot-b should not re-render when slot-a is active.
+    const delta = await rendersDuring(() => {
+      store.dispatch(sseSubagentChunk({ slot: 'slot-b', id: 'sub-1', text: 'token' }))
+    })
+
+    expect(delta).toBe(0)
+  })
+
+  it('does not re-render on a subagent chunk for the ACTIVE slot when count unchanged', async () => {
+    const slots = [{ key: 'slot-a', title: 'A', running: false, messages: 1 }]
+    const { store } = mountSidebar(
+      slots,
+      {
+        activeSlot: 'slot-a',
+        subagents: { 'sub-1': { id: 'sub-1', status: 'running', streaming: '' } },
+      },
+      'slot-a',
+    )
+
+    await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+    sidebarRenders.n = 0
+
+    // Same-slot streaming: count unchanged so derived selector should not re-render.
+    const delta = await rendersDuring(() => {
+      store.dispatch(sseSubagentChunk({ slot: 'slot-a', id: 'sub-1', text: 'token' }))
+    })
+
+    expect(delta).toBe(0)
+  })
+
+  it('DOES re-render when a new subagent spawns (count changes)', async () => {
+    const slots = [{ key: 'slot-a', title: 'A', running: false, messages: 1 }]
+    const { store } = mountSidebar(
+      slots,
+      {
+        activeSlot: 'slot-a',
+        subagents: { 'sub-1': { id: 'sub-1', status: 'running', streaming: '' } },
+      },
+      'slot-a',
+    )
+
+    await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+    sidebarRenders.n = 0
+
+    const delta = await rendersDuring(() => {
+      store.dispatch(sseSubagentSpawn({ slot: 'slot-a', id: 'sub-2', name: 'agent2' }))
+    })
+
+    expect(delta).toBeGreaterThan(0) // Count changed: re-render expected
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`ChatSidebar` subscribed to whole nested maps (`state.chat.subagents`, `slotActivity`) with plain reference equality. A `sseSubagentChunk` that only mutated `a.streaming` still triggered a re-render because Immer gives every ancestor of a mutated draft a new identity.

## Why it matters

The re-render fired on chunks that changed nothing the sidebar displays. `sseSubagentChunk` arrives at streaming frequency, so the wasted render work scaled with token throughput rather than with anything the user could see — and it fired for slots the user was not viewing, not just the active one. Both of those paths measured 2 renders before and 0 after (table below).

## What changed

This PR replaces the raw whole-map subscriptions + useMemo with two derived-count selectors that compute per-slot counts:
- `selectSidebarSubagentCounts` — total active subagents (running + tool + pending + queued)
- `selectSidebarApprovalCounts` — subagents pending approval

Each selector returns `Record<string, number>` and is consumed via `useAppSelector(..., shallowEqual)`.

### Why two selectors instead of one returning an object?

`createSelector` always returns a fresh object even when values inside have not changed. `shallowEqual` on that object still triggers a re-render because `newObj.counts !== oldObj.counts` (they are new objects too). By returning a plain `Record<string, number>` from each selector, `shallowEqual` compares the map values directly — and when only `a.streaming` changes (same count), no re-render happens.

## Measurement

| Scenario | Before | After |
|----------|--------|-------|
| Cross-slot: chunk for slot-b while slot-a active | 2 renders | **0 renders** |
| Same-slot streaming: chunk for active slot | 2 renders | **0 renders** |
| Count change (spawn new subagent) | re-renders | re-renders (correct) |

## Precedent

PRs #2752 and #2886 applied this exact fix shape to the app root and keyboard shortcuts but missed the sidebar. This closes that gap.

## Tests

Added `ChatSidebar.selectorScope.test.tsx` following the established pattern from `App.rootSelectorScope.test.tsx`.

Refs: #2752, #2886

<!-- no-visual-delta -->
**Why no screenshot:** This is a selector/performance optimization — the sidebar renders identically before and after; only the re-render frequency changes (measured via React Profiler, not visible to users).