### PR TITLE
fix: backport desktop Gateway UTF-8 restarts to 0.4.0

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -551,6 +551,14 @@ unit-testable without mocking globals.
   validated to `1–65535`). `BACKEND_URL` / health checks target that port.
 - Sets `KIROCREW_PROJECT_DIR` to the Electron app's parent directory so the
   bundled `agents/` and `skills/` are discovered.
+- On every desktop platform, pins `PYTHONUTF8=1` and
+  `PYTHONIOENCODING=utf-8:backslashreplace` at the Electron-to-Gateway spawn
+  boundary. This applies before CPython constructs redirected stdout/stderr and
+  is inherited by the Gateway's `os.execv` successor plus its MCP/session
+  children. Consequently the initial launch, Tailnet/explicit restart, update
+  and stale-asset re-exec, and Electron liveness respawn all use the same UTF-8
+  contract instead of falling back to the Windows ANSI code page or an
+  incompatible inherited POSIX encoding override.
 - Leaves the inherited child `PATH` unchanged. The gateway prerequisite service
   probes supported Kiro CLI locations independently, so Finder-launched macOS
   apps and Linux desktop launchers still find user-local installations without

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -41,6 +41,27 @@ IS_LINUX: bool = sys.platform == "linux"
 IS_MACOS: bool = sys.platform == "darwin"
 
 
+_UTF8_PROCESS_ENV = {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8:backslashreplace",
+}
+
+
+def _ensure_utf8_process_environment() -> None:
+    """Pin UTF-8 for Python successors and child processes on every platform.
+
+    ``sys.stdout.reconfigure`` can repair the current process, but Windows
+    implements ``os.execv`` by creating a successor process.  Its standard
+    streams are constructed before Kiro Crew code runs, so the encoding must be
+    present in the environment at interpreter startup.  POSIX ``execv`` keeps
+    the current environment, where an inherited ``PYTHONIOENCODING`` can also
+    override the platform's normal UTF-8 defaults.  Overwrite inherited settings
+    deliberately: Kiro Crew's process tree emits Unicode as part of its normal
+    protocols and boot output.
+    """
+    os.environ.update(_UTF8_PROCESS_ENV)
+
+
 def reexec_python_module(module: str, args: Sequence[str]) -> None:
     """Replace this process with ``sys.executable -m module``.
 
@@ -50,6 +71,11 @@ def reexec_python_module(module: str, args: Sequence[str]) -> None:
     executable path passed separately to ``execv`` still selects the exact
     interpreter; only its display name needs to be space-free.
     """
+    # Publish UTF-8 before exec so in-app gateway restarts (Tailnet, update,
+    # stale-assets, explicit restart) cannot create a successor that inherits a
+    # Windows ANSI stream or a hostile POSIX PYTHONIOENCODING and crashes on the
+    # first emoji printed during boot.
+    _ensure_utf8_process_environment()
     executable = sys.executable
     argv0 = ntpath.basename(executable) if IS_WINDOWS else executable
     os.execv(executable, [argv0, "-m", module, *args])
@@ -339,20 +365,28 @@ def tcc_prune_walk_dirs(root: str, dirpath: str, dirnames: list[str]) -> list[st
 
 
 def ensure_utf8_console() -> None:
-    """Make stdout/stderr UTF-8 on Windows so KiroCrew's emoji output can't crash it.
+    """Keep Kiro Crew's process tree UTF-8 and repair current Windows streams.
 
     KiroCrew prints non-ASCII glyphs throughout its CLI/gateway output. On
     Windows the default console code page is cp1252, and when stdout is a pipe
     (e.g. the gateway launched detached with redirected output, or under the
     KiroCrewHub client) Python encodes prints as cp1252 — so the FIRST non-ASCII
     print raises ``UnicodeEncodeError: 'charmap' codec can't encode character``
-    and the process dies before the gateway binds. POSIX defaults to UTF-8, so
-    this is a no-op there. Best-effort: reconfigure (Python 3.7+) the streams to
-    UTF-8 with backslashreplace so a stray un-encodable char degrades to an
-    escape instead of crashing. Idempotent and safe to call once at startup.
+    and the process dies before the gateway binds.  On every platform, publish
+    the encoding contract for later re-exec and child processes; an inherited
+    ``PYTHONIOENCODING`` can otherwise override POSIX UTF-8 defaults too.  On
+    Windows, best-effort reconfigure (Python 3.7+) the current streams to UTF-8
+    with backslashreplace so a stray un-encodable char degrades to an escape
+    instead of crashing. Idempotent and safe to call once at startup.
     """
+    _ensure_utf8_process_environment()
     if not IS_WINDOWS:
         return
+    # Repair the current streams below, and separately make the invariant
+    # inheritable by MCP/session children and any later re-exec.  Environment
+    # variables affect the next interpreter at construction time; setting them
+    # here is intentional even though they cannot retroactively rebuild the
+    # current process's streams.
     for name in ("stdout", "stderr"):
         stream = getattr(sys, name, None)
         if stream is None:  # pythonw / fully detached — no stream to fix

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -70,6 +70,8 @@ class TestReexecPythonModule:
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc.sys, "executable", executable)
         monkeypatch.setattr(pc.os, "execv", lambda path, argv: calls.append((path, argv)))
+        monkeypatch.setenv("PYTHONUTF8", "0")
+        monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
 
         pc.reexec_python_module("kiro_crew", ["gateway", "--port", "5476"])
 
@@ -79,17 +81,63 @@ class TestReexecPythonModule:
                 ["python.exe", "-m", "kiro_crew", "gateway", "--port", "5476"],
             )
         ]
+        assert os.environ["PYTHONUTF8"] == "1"
+        assert os.environ["PYTHONIOENCODING"] == "utf-8:backslashreplace"
 
-    def test_posix_preserves_full_argv0(self, monkeypatch):
+    def test_posix_preserves_full_argv0_and_pins_utf8(self, monkeypatch):
         executable = "/opt/Kiro Crew/bin/python3"
         calls = []
         monkeypatch.setattr(pc, "IS_WINDOWS", False)
         monkeypatch.setattr(pc.sys, "executable", executable)
         monkeypatch.setattr(pc.os, "execv", lambda path, argv: calls.append((path, argv)))
+        monkeypatch.setenv("PYTHONUTF8", "0")
+        monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
 
         pc.reexec_python_module("kiro_crew", ["gateway"])
 
         assert calls == [(executable, [executable, "-m", "kiro_crew", "gateway"])]
+        assert os.environ["PYTHONUTF8"] == "1"
+        assert os.environ["PYTHONIOENCODING"] == "utf-8:backslashreplace"
+
+    def test_reexec_successor_survives_hostile_parent_encoding(self, tmp_path):
+        """Exercise the real failure shape behind desktop in-app restarts.
+
+        The first interpreter intentionally starts with cp1252 streams on every
+        OS.  It re-execs without calling ensure_utf8_console, so only the
+        environment published by reexec_python_module can make the successor's
+        first emoji print safe.
+        """
+        probe = tmp_path / "utf8_reexec_probe.py"
+        probe.write_text(
+            "import os\n"
+            "from kiro_crew.platform_compat import reexec_python_module\n"
+            "if os.environ.get('_KIROCREW_UTF8_REEXEC_PROBE') == '1':\n"
+            "    print('👻 restarted')\n"
+            "else:\n"
+            "    os.environ['_KIROCREW_UTF8_REEXEC_PROBE'] = '1'\n"
+            "    reexec_python_module('utf8_reexec_probe', [])\n",
+            encoding="utf-8",
+        )
+        source_root = str(Path(__file__).resolve().parents[1] / "src")
+        inherited_path = os.environ.get("PYTHONPATH", "")
+        env = {
+            **os.environ,
+            "PYTHONUTF8": "0",
+            "PYTHONIOENCODING": "cp1252",
+            "PYTHONPATH": os.pathsep.join(p for p in (source_root, inherited_path) if p),
+        }
+
+        result = subprocess.run(
+            [sys.executable, "-m", "utf8_reexec_probe"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+        assert "👻 restarted".encode() in result.stdout
 
 
 class TestFileLock:
@@ -491,10 +539,24 @@ class TestFindPythonInterpreter:
 
 
 class TestUtf8Console:
+    @pytest.mark.parametrize("is_windows", [False, True])
+    def test_call_publishes_utf8_for_children(self, monkeypatch, is_windows):
+        monkeypatch.setattr(pc, "IS_WINDOWS", is_windows)
+        monkeypatch.setattr(pc.sys, "stdout", None)
+        monkeypatch.setattr(pc.sys, "stderr", None)
+        monkeypatch.setenv("PYTHONUTF8", "0")
+        monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
+
+        pc.ensure_utf8_console()
+
+        assert os.environ["PYTHONUTF8"] == "1"
+        assert os.environ["PYTHONIOENCODING"] == "utf-8:backslashreplace"
+
     def test_ensure_utf8_console_is_safe_to_call(self):
-        # No-op on POSIX; reconfigures stdout/stderr on Windows. Either way it
-        # must never raise (it swallows non-reconfigurable streams), and must be
-        # idempotent (safe to call from both __main__ and cli.main).
+        # Publishes the child environment on every OS and reconfigures the
+        # current stdout/stderr only on Windows. Either way it must never raise
+        # (it swallows non-reconfigurable streams), and must be idempotent (safe
+        # to call from both __main__ and cli.main).
         pc.ensure_utf8_console()
         pc.ensure_utf8_console()
 
@@ -514,11 +576,10 @@ class TestUtf8Console:
         # crashed on the first non-ASCII log record. ensure_utf8_console() must
         # re-wrap the underlying buffer so the record emits cleanly.
         #
-        # This is a WINDOWS-only behavior: ensure_utf8_console() is a deliberate
-        # no-op on POSIX (which already defaults to UTF-8), so forcing a cp1252
-        # stderr here and asserting emoji survives only makes sense on Windows —
-        # on POSIX the function intentionally leaves the forced cp1252 stream
-        # alone, so the emoji would (correctly) fail to encode. Gate accordingly.
+        # This stream repair is WINDOWS-only behavior: on POSIX the function
+        # publishes the environment for children but leaves current streams
+        # alone. Forcing a cp1252 stderr and asserting emoji survives therefore
+        # only makes sense on Windows. Gate accordingly.
         if not pc.IS_WINDOWS:
             pytest.skip("ensure_utf8_console re-wrap is Windows-only (no-op on POSIX)")
 
@@ -3981,14 +4042,10 @@ class TestTrustedGitBin:
     """
 
     def test_uses_the_trusted_system_resolver(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            pc, "trusted_system_bin", lambda _n: "/usr/bin/git"
-        )
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/git")
         assert pc.trusted_git_bin() == "/usr/bin/git"
 
-    def test_windows_falls_back_to_the_git_for_windows_roots(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_windows_falls_back_to_the_git_for_windows_roots(self, monkeypatch, tmp_path) -> None:
         """Git for Windows installs under Program Files, never System32.
 
         Without the fallback every supported Windows source install resolves to
@@ -4014,9 +4071,7 @@ class TestTrustedGitBin:
         """
         monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
-        monkeypatch.setattr(
-            pc, "_WINDOWS_GIT_DIRS", (r"Z:\nonexistent\Git\cmd",)
-        )
+        monkeypatch.setattr(pc, "_WINDOWS_GIT_DIRS", (r"Z:\nonexistent\Git\cmd",))
         assert pc.trusted_git_bin() is None
 
     def test_posix_never_probes_the_windows_roots(self, monkeypatch) -> None:

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -266,11 +266,15 @@ class _StubbornStream:
 
 
 class TestEnsureUtf8Console:
-    def test_noop_off_windows(self, monkeypatch):
+    def test_off_windows_only_publishes_environment(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setenv("PYTHONUTF8", "0")
+        monkeypatch.setenv("PYTHONIOENCODING", "ascii")
         before = sys.stdout
         pc.ensure_utf8_console()
         assert sys.stdout is before
+        assert os.environ["PYTHONUTF8"] == "1"
+        assert os.environ["PYTHONIOENCODING"] == "utf-8:backslashreplace"
 
     def test_reconfigure_in_place_is_preferred(self, monkeypatch):
         monkeypatch.setattr(pc, "IS_WINDOWS", True)

--- a/website/electron/gateway-env.js
+++ b/website/electron/gateway-env.js
@@ -1,0 +1,40 @@
+"use strict";
+
+// Environment invariants for every gateway the desktop shell owns.
+//
+// CPython chooses the encoding for redirected stdout/stderr before any Kiro
+// Crew Python runs.  Reconfiguring sys.stdout later is therefore only a
+// best-effort repair.  Windows defaults redirected files/pipes to its ANSI code
+// page, while every platform permits PYTHONIOENCODING to override an otherwise
+// UTF-8 locale.  The gateway prints emoji during boot, so a hostile inherited
+// ascii/cp1252 value turns an ordinary in-app restart (Tailnet, update,
+// stale-assets, or the explicit restart API) into a fatal UnicodeEncodeError.
+//
+// Pinning the interpreter at this parent boundary covers both the first launch
+// and every Electron liveness respawn on Windows, macOS, and Linux.  The values
+// are inherited by the gateway's exec successor and Python children too,
+// including MCP/session processes.  platform_compat.py republishes the same
+// invariant for gateways started outside Electron.
+const GATEWAY_UTF8_ENV = Object.freeze({
+  PYTHONUTF8: "1",
+  PYTHONIOENCODING: "utf-8:backslashreplace",
+});
+
+/**
+ * Build a gateway child environment without mutating Electron's process.env.
+ *
+ * The desktop app owns this Python process tree, so the UTF-8 values
+ * deliberately override hostile inherited values such as PYTHONUTF8=0 or
+ * PYTHONIOENCODING=cp1252 on every supported desktop platform.
+ *
+ * @param {NodeJS.ProcessEnv} baseEnv
+ * @returns {NodeJS.ProcessEnv}
+ */
+function buildGatewayEnvironment(baseEnv) {
+  return {
+    ...baseEnv,
+    ...GATEWAY_UTF8_ENV,
+  };
+}
+
+module.exports = { buildGatewayEnvironment, GATEWAY_UTF8_ENV };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -7,6 +7,7 @@ const path = require("path");
 const http = require("http");
 
 const { findKirocrewBin } = require("./find-bin");
+const { buildGatewayEnvironment } = require("./gateway-env");
 const { resolveGatewayPath } = require("./mac-env");
 const {
   findMissingBundleParts,
@@ -982,7 +983,7 @@ function spawnGateway(resolve) {
           // without this every app launch opens a persistent console window
           // beside the Electron app. Ignored on POSIX.
           windowsHide: true,
-          env: {
+          env: buildGatewayEnvironment({
             ...cleanEnv,
             // Overrides the inherited PATH only when the launchd domain
             // actually contributed a directory (see resolveGatewayPath above);
@@ -1003,7 +1004,7 @@ function spawnGateway(resolve) {
             // gateway spawns (app servers run on the same interpreter), so
             // the whole process tree stays out of the bundle.
             PYTHONPYCACHEPREFIX: path.join(kirocrewDir, "cache", "pycache"),
-          },
+          }),
         });
         gatewayProcess = child;
         // We own this child — recovery may kill+respawn it. Ownership

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -139,6 +139,7 @@
       "instance-guard.js",
       "context-menu.js",
       "find-bin.js",
+      "gateway-env.js",
       "mac-env.js",
       "bundle-integrity.js",
       "data-home.js",

--- a/website/electron/test/gateway-env.test.js
+++ b/website/electron/test/gateway-env.test.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  buildGatewayEnvironment,
+  GATEWAY_UTF8_ENV,
+} = require("../gateway-env");
+
+for (const [platform, inheritedEncoding] of [
+  ["win32", "cp1252"],
+  ["darwin", "ascii"],
+  ["linux", "latin-1"],
+]) {
+  test(`${platform} gateway launches override hostile Python encoding`, () => {
+    const inherited = {
+      PATH: platform === "win32" ? String.raw`C:\Windows\System32` : "/usr/bin",
+      PYTHONUTF8: "0",
+      PYTHONIOENCODING: inheritedEncoding,
+    };
+
+    const env = buildGatewayEnvironment(inherited);
+
+    assert.deepStrictEqual(env, {
+      PATH: inherited.PATH,
+      PYTHONUTF8: "1",
+      PYTHONIOENCODING: "utf-8:backslashreplace",
+    });
+    assert.equal(
+      inherited.PYTHONUTF8,
+      "0",
+      "must not mutate Electron's environment",
+    );
+    assert.equal(inherited.PYTHONIOENCODING, inheritedEncoding);
+  });
+}
+
+test("the gateway UTF-8 contract is explicit and stable", () => {
+  assert.deepStrictEqual(GATEWAY_UTF8_ENV, {
+    PYTHONUTF8: "1",
+    PYTHONIOENCODING: "utf-8:backslashreplace",
+  });
+});
+
+test("the one desktop gateway spawn uses the hardened environment builder", () => {
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  const gatewaySpawns = [...main.matchAll(/spawn\(spawnBin, spawnArgs,/g)];
+
+  assert.equal(gatewaySpawns.length, 1, "expected one owned gateway spawn boundary");
+  assert.match(
+    main,
+    /env:\s*buildGatewayEnvironment\(\{[\s\S]*?PYTHONPYCACHEPREFIX:[\s\S]*?\}\),/,
+    "the owned gateway spawn must pass every initial launch and liveness respawn " +
+      "through buildGatewayEnvironment",
+  );
+});


### PR DESCRIPTION
## Problem / Motivation

Backport the merged UTF-8 Gateway restart hardening from #5919 to the 0.4.0 Insider release line.

A hostile or incorrectly inherited Python stream encoding can make an Electron-managed Gateway crash when it emits Unicode during an in-app restart. This affects restart paths shared by Tailnet, MCP, updates, and liveness recovery.

## What changed

- Force PYTHONUTF8=1 and PYTHONIOENCODING=utf-8:backslashreplace at the Electron Gateway spawn boundary on Windows, macOS, and Linux.
- Preserve those settings across Python module re-exec.
- Keep Windows stream reconfiguration while publishing the safe environment on every platform.
- Add hostile-environment tests for Electron spawn construction and Python re-exec.
- Document the Gateway encoding contract.

This is a minimal cherry-pick of merge commit 782851390fe8d4baf745a20cb8d0aa1aec57c953. The only conflict was resolved by excluding unrelated main-only count_open_fds code so release-specific behavior remains unchanged.

## Testing

- pytest test/test_platform_compat.py -q (226 passed, 38 skipped)
- Focused re-exec/UTF-8 tests (8 passed, 5 platform-inapplicable skipped)
- Real Windows native re-exec probe from a hostile cp1252 parent
- npm test --prefix website/electron (1327 passed, 2 skipped)
- node --test website/electron/test/gateway-env.test.js website/electron/test/shell-contract.test.js (10 passed)
- isort --check-only and flake8 on changed Python files
- scripts/check_subprocess_encoding.py --test and the actual gate
- scripts/check_black_formatting.py
- scripts/docs_lint.py --test and the actual docs lint

## Related

Backport of #5919.

<!-- no-visual-delta: process startup/restart environment only; no UI change. -->

## Checklist

- [x] Backport contains only the intended fix
- [x] Release-specific behavior is preserved
- [x] Relevant Python and Electron tests pass
- [x] No UI changes