### PR TITLE
test(skill-trust): deterministic distinct-inode precondition (#5932)

### DIFF
--- a/test/test_skill_trust.py
+++ b/test/test_skill_trust.py
@@ -503,11 +503,32 @@ class TestInstanceBinding:
         skill_trust.grant_project_trust(project)
         assert skill_trust.is_project_trusted(project) is True
 
-        # Replace the reviewed tree with a different directory at the same path.
+        # The identity the grant actually bound, captured before the delete.
+        granted_st = os.stat(project)
+        granted_instance = (granted_st.st_dev, granted_st.st_ino)
+
+        # Replace the reviewed tree with a different directory at the same
+        # path. On Linux ``_instance_identity`` is ``dev:ino`` alone (no birth
+        # time), so the replacement must land on a DIFFERENT inode for the
+        # untrusted outcome to be observable -- and recreating after the delete
+        # would leave that to the allocator, which is free to hand the
+        # just-freed inode straight back (the flake in #5932). Creating the
+        # replacement WHILE the granted directory still exists forces distinct
+        # inodes -- two live directories on one device cannot share one -- and
+        # the rename preserves the replacement's inode while giving it the
+        # granted path.
+        replacement = _real_dir(tmp_path, "replacement-instance")
         os.rmdir(project)
-        _real_dir(tmp_path, "an-intervening-inode")
-        recreated = _real_dir(tmp_path, "project")
+        os.rename(replacement, project)
+
+        recreated = os.path.realpath(project)
         assert recreated == project, "the path is unchanged; only the instance differs"
+        replacement_st = os.stat(project)
+        assert (replacement_st.st_dev, replacement_st.st_ino) != granted_instance, (
+            "precondition: inode reuse -- the replacement directory was handed "
+            "the granted directory's own (st_dev, st_ino) back, so the trust "
+            "assertions below could not distinguish the instances"
+        )
         skill_trust.reset_cache_for_tests()
 
         assert skill_trust.is_project_trusted(project) is False


### PR DESCRIPTION
## Problem

`test/test_skill_trust.py::TestInstanceBinding::test_a_different_directory_at_the_same_path_is_not_trusted` failed once on Backend Tests (3.12, 3) with an opaque `AssertionError: assert True is False`, on a PR with no overlap with skill trust. It passes locally on the same tree — a flake, not a regression.

## Why it matters

A security test that flakes trains people to re-run it, which is exactly the reflex that lets a real trust-binding regression slide through. It also reddens unrelated PRs and burns contributor CI rounds.

## Fix (symptoms -> root cause -> change)

**Symptom:** the "replacement directory at the granted path must not be trusted" assertion intermittently sees `True`.

**Root cause:** on Linux, `_instance_identity` is `st_dev:st_ino` only (CPython exposes no birth time there). The test deleted the granted directory and recreated one at the same path, relying on a single intervening `mkdir` to consume the freed inode — a hint to the allocator, not a guarantee. When the allocator hands the just-freed inode back, the identity compares equal and the untrusted-replacement assertion is a coin flip. This is flake class 1 in `docs/system-specs/common/testing-conventions.md` (nondeterministic input — the host is an input too). The defect is in the test's precondition, not the code under test.

**Change (one test file, production untouched):** make the distinct-inode precondition a guarantee instead of an allocator hint. Create the replacement directory **while the granted directory still exists** — two live directories on one device cannot share an inode — then `rmdir` the granted directory and `rename` the replacement onto its path, preserving its distinct inode. Capture the granted `(st_dev, st_ino)` before the delete and assert the distinctness precondition explicitly, so any future failure names inode reuse instead of surfacing as `assert True is False`. Both security assertions (`is_project_trusted(...) is False`, `is_key_trusted(...) is False`) are unchanged. No retry loop, no `pytest.skip` — the precondition holds unconditionally on every platform.

Two model-pinned pre-push reviewers ran on the diff; the first flagged that an earlier bounded-retry draft carried a terminal-skip coverage hole and both recommended the coexist-then-rename arrangement, which is what landed.

## Tests

- The changed test itself is the deliverable: deterministic precondition, explicit precondition assert with a message naming inode reuse, unchanged security assertions.
- Determinism: the targeted test was run **25 consecutive times** locally — all 25 passed.
- **Non-vacuity proven:** with `_instance_identity` temporarily mutated to return a path-only identity (simulating an unbound grant — the exact defect this test guards), the test **fails** with the original symptom (`assert True is False` at the trust assertion). The probe was reverted before committing.
- Full `test/test_skill_trust.py` suite: 30/30 pass, including the counterweight test `test_the_reviewed_directory_stays_trusted_across_ordinary_edits` (unchanged).
- Gates: isort, flake8, mypy (1104 files) all clean.

## Manual verification

N/A — unit coverage sufficient; this is a test-determinism change with no runtime surface.

## Screenshots

N/A — test-only change, no user-visible UI.

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no watched frontend paths touched and no rendered delta.

Closes #5932
