### PR TITLE
fix(ci): rescue the two readiness freezes the sweep skipped by design

### DIFF
--- a/.github/workflows/fork-pr-label.yml
+++ b/.github/workflows/fork-pr-label.yml
@@ -41,6 +41,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           LABEL: "fork"
+          # See the truncation guard below.
+          PR_LIST_LIMIT: "900"
           EVENT: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
@@ -75,8 +77,18 @@ jobs:
 
           # Sweep (schedule / manual dispatch): label every open fork PR that is
           # missing the label. `isCrossRepository` is GitHub's own fork flag.
-          prs="$(gh pr list --repo "$REPO" --state open --limit 300 \
+          # `gh pr list` returns NEWEST-first and truncates at --limit SILENTLY,
+          # so a ceiling below the real open-PR count drops the OLDEST PRs --
+          # in this sweep, the ones most likely to be missing the label. The
+          # ceiling is a variable kept clear of the real set, and a hit is
+          # reported as an action item rather than absorbed as a measurement.
+          prs="$(gh pr list --repo "$REPO" --state open --limit "$PR_LIST_LIMIT" \
             --json number,isCrossRepository,labels)"
+          if [ "$(jq 'length' <<<"$prs")" -ge "$PR_LIST_LIMIT" ]; then
+            echo "::warning::Open-PR list hit its ceiling of $PR_LIST_LIMIT;" \
+              "the oldest open PRs were dropped and were not considered." \
+              "Raise PR_LIST_LIMIT in this workflow."
+          fi
           echo "$prs" | jq -c '.[] | select(.isCrossRepository == true)' | while read -r pr; do
             number="$(jq -r '.number' <<<"$pr")"
             has_label="$(jq -r --arg l "$LABEL" 'any(.labels[]?; .name == $l)' <<<"$pr")"

--- a/.github/workflows/pr-merge-conflict-label.yml
+++ b/.github/workflows/pr-merge-conflict-label.yml
@@ -46,6 +46,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           LABEL: "merge conflict"
+          # See the truncation guard below.
+          PR_LIST_LIMIT: "900"
         run: |
           set -euo pipefail
 
@@ -58,8 +60,18 @@ jobs:
           fi
 
           # Enumerate open PRs with GitHub's own mergeability + current labels.
-          prs="$(gh pr list --repo "$REPO" --state open --limit 300 \
+          # `gh pr list` returns NEWEST-first and truncates at --limit SILENTLY,
+          # so a ceiling below the real open-PR count drops the OLDEST PRs --
+          # in this sweep, the ones most likely to be missing the label. The
+          # ceiling is a variable kept clear of the real set, and a hit is
+          # reported as an action item rather than absorbed as a measurement.
+          prs="$(gh pr list --repo "$REPO" --state open --limit "$PR_LIST_LIMIT" \
             --json number,mergeable,labels)"
+          if [ "$(jq 'length' <<<"$prs")" -ge "$PR_LIST_LIMIT" ]; then
+            echo "::warning::Open-PR list hit its ceiling of $PR_LIST_LIMIT;" \
+              "the oldest open PRs were dropped and were not considered." \
+              "Raise PR_LIST_LIMIT in this workflow."
+          fi
 
           add_label() {
             jq -n --arg label "$LABEL" '{labels: [$label]}' \

--- a/.github/workflows/pr-readiness-sweep.yml
+++ b/.github/workflows/pr-readiness-sweep.yml
@@ -42,6 +42,28 @@ name: PR Readiness Self-Heal Sweep
 #      That is self-terminating -- republishing makes readiness the newest
 #      timestamp again -- so a genuinely failing PR is nudged at most once per new
 #      piece of check evidence, never once per sweep.
+#
+#   3. NO readiness status at all -- the UNPUBLISHED case. `pr-readiness.yml`
+#      deliberately does not retry its status POST (a retry can overwrite a
+#      concurrent run's newer verdict) and instead instructs a human to "re-run
+#      this workflow". When that POST fails, the SHA carries no readiness status,
+#      so there is no `pending` to age out and the only automatic re-runner --
+#      this sweep -- used to skip the PR on the assumption that its own run was
+#      still coming. The one case the publisher delegates to a re-run was thus
+#      the one case nothing re-ran. Proven on PR #2783: both readiness runs for
+#      f014465e failed on `gh: HTTP 503` from the status POST on 2026-08-17, and
+#      eight days later the PR was still MERGEABLE with no readiness verdict of
+#      any kind on its head SHA.
+#
+#   4. `success` (or `error`) with FAILING check evidence that landed after it was
+#      published. Mode 2's mechanism is direction-blind: a job re-run that flips
+#      a lane RED after a green verdict emits no `workflow_run: completed`
+#      either, leaving the required aggregate green over a now-red revision --
+#      which PERMITS a merge, where a stale red merely blocks one. The evidence
+#      test is narrowed to failure-class conclusions here, because housekeeping
+#      check-runs (`Strip stale workflow-change override`, `Fork workflow-change
+#      guard`) legitimately complete long after a verdict and would otherwise
+#      re-fire every green PR on every sweep.
 on:
   schedule:
     # Every 15 minutes. A normal fan-out publishes terminal state via events
@@ -85,18 +107,35 @@ jobs:
           # set in a single sweep, so a genuine backlog drains in one pass; it
           # exists only to bound a single sweep against a pathological run.
           MAX_DISPATCH: "200"
+          # Ceiling for the open-PR listing. See the truncation guard below: this
+          # must stay comfortably above the real open-PR count, because `gh pr
+          # list` drops the OLDEST entries silently once it is reached.
+          PR_LIST_LIMIT: "900"
         run: |
           set -euo pipefail
 
           now_epoch="$(date -u +%s)"
           stale_seconds=$(( STALE_MINUTES * 60 ))
 
-          # Open PRs with their current head SHA. A single cheap list call.
-          prs="$(gh pr list --repo "$REPO" --state open --limit 300 \
-            --json number,headRefOid)"
+          # Open PRs with their current head SHA and last-activity time. A
+          # single cheap list call.
+          #
+          # `gh pr list` returns NEWEST-first and truncates at --limit SILENTLY,
+          # so a ceiling below the real open-PR count drops the OLDEST PRs --
+          # exactly the ones most likely to be frozen, and the ones this sweep
+          # exists to rescue. The limit is therefore sized well clear of the
+          # current set (250 open at the time of writing) and a hit is reported
+          # as a loud action item rather than being absorbed as a measurement.
+          prs="$(gh pr list --repo "$REPO" --state open --limit "$PR_LIST_LIMIT" \
+            --json number,headRefOid,updatedAt)"
 
           total="$(jq 'length' <<<"$prs")"
           echo "Scanning $total open pull request(s) for stale PR Readiness."
+          if [ "$total" -ge "$PR_LIST_LIMIT" ]; then
+            echo "::warning::Open-PR list hit its ceiling of $PR_LIST_LIMIT;" \
+              "the oldest open PRs were dropped and cannot be rescued." \
+              "Raise PR_LIST_LIMIT in pr-readiness-sweep.yml."
+          fi
 
           # First pass: COLLECT every stale PR; do NOT dispatch inline. Inline
           # dispatch in `gh pr list` order plus a cap starves whichever stale PRs
@@ -109,24 +148,67 @@ jobs:
             [ -n "$row" ] || continue
             number="$(jq -r '.number' <<<"$row")"
             sha="$(jq -r '.headRefOid' <<<"$row")"
+            pr_updated_at="$(jq -r '.updatedAt // empty' <<<"$row")"
             [ -n "$sha" ] && [ "$sha" != "null" ] || continue
 
             # Most-recent "PR Readiness" commit status for this head SHA. The
             # statuses API returns newest first, so `first` is authoritative.
-            status_json="$(gh api "repos/$REPO/commits/$sha/statuses" --paginate 2>/dev/null \
-              | jq -c --arg ctx "$STATUS_CONTEXT" \
-                  '[.[] | select(.context == $ctx)] | first // empty' \
-              || echo "")"
+            #
+            # The read is captured BEFORE the jq filter so a transport failure is
+            # distinguishable from a genuinely absent status: both produce empty
+            # jq output, and the unpublished arm below dispatches on the latter.
+            # Conflating them would turn a statuses-API 503 into a spurious
+            # re-fire of an arbitrary old PR. `--slurp` collapses the paginated
+            # pages into one array, so the filter sees a single document.
+            if ! statuses_json="$(gh api "repos/$REPO/commits/$sha/statuses" \
+                --paginate --slurp 2>/dev/null)"; then
+              echo "PR #$number: statuses lookup failed; skipping this sweep."
+              continue
+            fi
+            status_json="$(jq -c --arg ctx "$STATUS_CONTEXT" \
+              '[.[][] | select(.context == $ctx)] | first // empty' \
+              <<<"$statuses_json")"
 
-            # No readiness status yet -> the PR's own run is coming; not stuck.
-            [ -n "$status_json" ] || continue
-
-            state="$(jq -r '.state' <<<"$status_json")"
-            updated_at="$(jq -r '.updated_at' <<<"$status_json")"
+            # NO readiness status on this SHA. Skipping here on the assumption
+            # that "the PR's own run is coming" is only true for a few minutes
+            # after a push. Past that window it means no run ever published one
+            # -- most often because `pr-readiness.yml`'s status POST failed and
+            # is deliberately not retried, which leaves the required aggregate
+            # absent with no `pending` to age out and no event pending. That is
+            # the freeze mode nothing else can clear, so it is rescued on the
+            # PR's own last-activity age (a push bumps `updatedAt`, so the
+            # window restarts on every new revision).
+            #
+            # Self-limiting by construction: one dispatch per sweep per PR, and
+            # the moment any verdict lands this branch stops applying. Bounded by
+            # MAX_DISPATCH like every other path.
+            #
+            # Carried as a sentinel STATE rather than an early `printf` so this
+            # case reuses the one staleness comparison and the one stale-file
+            # record writer below, instead of restating either. GitHub's commit
+            # status states are error/failure/pending/success, so the sentinel
+            # cannot collide with a real one.
+            if [ -z "$status_json" ]; then
+              state="__unpublished__"
+              updated_at="$pr_updated_at"
+            else
+              state="$(jq -r '.state' <<<"$status_json")"
+              updated_at="$(jq -r '.updated_at' <<<"$status_json")"
+            fi
             updated_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null || echo 0)"
             age=$(( now_epoch - updated_epoch ))
 
             case "$state" in
+              __unpublished__)
+                # Age is measured from the PR's own last activity, because a push
+                # bumps `updatedAt` -- so the grace window restarts on every new
+                # revision, and a brand-new PR whose run is genuinely still
+                # queueing is left alone.
+                if [ "$updated_epoch" -eq 0 ] || [ "$age" -lt "$stale_seconds" ]; then
+                  continue
+                fi
+                reason="no readiness status published; PR last active ${age}s ago (> ${stale_seconds}s)"
+                ;;
               pending)
                 if [ "$updated_epoch" -eq 0 ] || [ "$age" -lt "$stale_seconds" ]; then
                   # Either unparseable, or still within the plausible-running window.
@@ -159,8 +241,16 @@ jobs:
                 # failing is nudged at most once per new piece of check evidence,
                 # not once per sweep.
                 [ "$updated_epoch" -ne 0 ] || continue
-                newest_check="$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate 2>/dev/null \
-                  | jq -r '[.check_runs[]? | select(.status == "completed") | .completed_at]
+                # `--slurp` is REQUIRED, not tidiness: without it `--paginate`
+                # concatenates one JSON document per page and jq evaluates each
+                # separately, so `max` emits one timestamp PER PAGE. `date -d`
+                # then rejects the multi-line string, the epoch reads 0, and the
+                # PR is skipped -- silently exempting every PR with more than 100
+                # check-runs, which on this repo is any PR whose lanes have been
+                # re-run. Slurped, the filter sees one array and emits one value.
+                newest_check="$(gh api "repos/$REPO/commits/$sha/check-runs" \
+                  --paginate --slurp 2>/dev/null \
+                  | jq -r '[.[].check_runs[]? | select(.status == "completed") | .completed_at]
                            | map(select(. != null)) | max // empty' \
                   || echo "")"
                 [ -n "$newest_check" ] || continue
@@ -173,9 +263,48 @@ jobs:
                 fi
                 reason="failure published at $updated_at but a check completed later at $newest_check"
                 ;;
+              success|error)
+                # Mode 2's mechanism does not care which way the re-run went. A
+                # job re-run that turns a lane RED after a green verdict emits no
+                # `workflow_run: completed` either, so the required aggregate
+                # stays green over a now-red revision -- and a stale green
+                # PERMITS a merge, where a stale red only blocks one. The unsafe
+                # direction is therefore the one that was never rescued.
+                #
+                # The evidence test is narrowed to FAILURE-CLASS conclusions
+                # rather than "any check completed later". Housekeeping check-runs
+                # (`Strip stale workflow-change override`, `Fork workflow-change
+                # guard`) routinely complete days after a verdict on a long-lived
+                # PR, so the unnarrowed test would re-fire most green PRs on every
+                # sweep while proving nothing. A later `success` needs no rescue:
+                # it cannot turn a green verdict red.
+                #
+                # Self-terminating exactly like mode 2 -- republishing makes the
+                # verdict the newest timestamp, so the same red evidence is not
+                # counted twice. `error` shares this arm because it is the same
+                # dropped-event problem: "the next real event will correct it"
+                # holds only when a next event exists.
+                [ "$updated_epoch" -ne 0 ] || continue
+                newest_fail="$(gh api "repos/$REPO/commits/$sha/check-runs" \
+                  --paginate --slurp 2>/dev/null \
+                  | jq -r '[.[].check_runs[]?
+                             | select(.status == "completed")
+                             | select(.conclusion as $c
+                                 | ["failure","timed_out","cancelled","action_required",
+                                    "stale","startup_failure"] | index($c))
+                             | .completed_at]
+                           | map(select(. != null)) | max // empty' \
+                  || echo "")"
+                [ -n "$newest_fail" ] || continue
+                newest_fail_epoch="$(date -u -d "$newest_fail" +%s 2>/dev/null || echo 0)"
+                [ "$newest_fail_epoch" -ne 0 ] || continue
+                if [ "$newest_fail_epoch" -le $(( updated_epoch + 5 )) ]; then
+                  continue
+                fi
+                reason="$state published at $updated_at but a check FAILED later at $newest_fail"
+                ;;
               *)
-                # `success` needs no rescue, and `error` is a publisher fault the
-                # next real event will correct.
+                # Any state this sweep does not model is left to a real event.
                 continue
                 ;;
             esac

--- a/test/test_pr_readiness_sweep.py
+++ b/test/test_pr_readiness_sweep.py
@@ -70,7 +70,11 @@ fi
 if [ "$1" = "api" ]; then
   case "${2:-}" in
     *"/check-runs") cat "$FIXTURES/check_runs.json"; exit 0 ;;
-    *"/statuses")   cat "$FIXTURES/statuses.json";   exit 0 ;;
+    *"/statuses")
+      # Emulate a transport failure when the test asks for one: gh exits
+      # non-zero having written nothing to stdout.
+      if [ -f "$FIXTURES/statuses_fail" ]; then exit 1; fi
+      cat "$FIXTURES/statuses.json"; exit 0 ;;
   esac
 fi
 echo "gh stub: unhandled: $*" >&2
@@ -112,34 +116,80 @@ class Runner:
             "STATUS_CONTEXT": "PR Readiness",
             "STALE_MINUTES": "15",
             "MAX_DISPATCH": "10",
+            "PR_LIST_LIMIT": "900",
         }
 
     def sweep(
         self,
         *,
-        state: str,
-        status_at: str,
+        state: str | None,
+        status_at: str | None = None,
         check_completed_at: str | None = None,
+        check_conclusion: str = "success",
+        extra_check_page: tuple[str, str] | None = None,
+        statuses_read_fails: bool = False,
         pr: int = 2064,
         sha: str = "4328fd0f941f09ff10f245fbdb4accf7c246febe",
         context: str = "PR Readiness",
         max_dispatch: str = "10",
+        pr_updated_at: str = "2020-01-01T00:00:00Z",
+        extra_statuses: list[dict] | None = None,
     ) -> list[str]:
-        """Run the sweep over ONE pull request; return the dispatches recorded."""
+        """Run the sweep over ONE pull request; return the dispatches recorded.
+
+        `state=None` means the head SHA carries NO readiness status at all, which
+        is the unpublished-verdict freeze mode.
+        """
         (self.fixtures / "prs.json").write_text(
-            json.dumps([{"number": pr, "headRefOid": sha}])
-        )
-        (self.fixtures / "statuses.json").write_text(
             json.dumps(
-                [{"context": context, "state": state, "updated_at": status_at}]
+                [{"number": pr, "headRefOid": sha, "updatedAt": pr_updated_at}]
             )
         )
+        statuses = (
+            []
+            if state is None
+            else [{"context": context, "state": state, "updated_at": status_at}]
+        )
+        # `/statuses` returns newest-first, and the sweep takes the FIRST entry
+        # matching its own context, so extras are appended after. The fixture is
+        # written in the `--paginate --slurp` shape the sweep now requests: an
+        # OUTER array of pages, each page being the endpoint's own array.
+        statuses += extra_statuses or []
+        (self.fixtures / "statuses.json").write_text(json.dumps([statuses]))
+        fail_marker = self.fixtures / "statuses_fail"
+        if statuses_read_fails:
+            fail_marker.write_text("")
+        else:
+            fail_marker.unlink(missing_ok=True)
         runs = (
             []
             if check_completed_at is None
-            else [{"status": "completed", "completed_at": check_completed_at}]
+            else [
+                {
+                    "status": "completed",
+                    "conclusion": check_conclusion,
+                    "completed_at": check_completed_at,
+                }
+            ]
         )
-        (self.fixtures / "check_runs.json").write_text(json.dumps({"check_runs": runs}))
+        # Slurped shape again: an array of PAGES, each `{"check_runs": [...]}`.
+        # `extra_check_page` adds a second page so the pagination fix is exercised
+        # rather than assumed -- unslurped, jq would emit one `max` per page.
+        pages = [{"check_runs": runs}]
+        if extra_check_page is not None:
+            conclusion, completed_at = extra_check_page
+            pages.append(
+                {
+                    "check_runs": [
+                        {
+                            "status": "completed",
+                            "conclusion": conclusion,
+                            "completed_at": completed_at,
+                        }
+                    ]
+                }
+            )
+        (self.fixtures / "check_runs.json").write_text(json.dumps(pages))
         applied = self.fixtures / "dispatched.txt"
         applied.unlink(missing_ok=True)
 
@@ -261,33 +311,210 @@ def test_check_completing_in_the_same_second_is_not_new_evidence(runner: Runner)
     )
 
 
-# ── States that must never be touched ───────────────────────────────────────
+# ── The green freeze: a verdict contradicted by later FAILING evidence ───────
 
 
 @pytest.mark.parametrize("state", ["success", "error"])
-def test_other_states_are_never_refired(runner: Runner, state: str) -> None:
-    """`success` needs no rescue; `error` is a publisher fault a real event fixes."""
+def test_green_verdict_with_later_failing_evidence_is_refired(
+    runner: Runner, state: str
+) -> None:
+    """The unsafe direction of the same re-run mechanism.
+
+    A job re-run that flips a lane red after a green verdict emits no fresh
+    `workflow_run: completed`, so the required aggregate stays green over a
+    now-red revision -- which PERMITS a merge, where a stale red only blocks one.
+    """
+    dispatched = runner.sweep(
+        state=state,
+        status_at="2026-08-07T19:01:24Z",
+        check_completed_at="2026-08-07T19:16:13Z",
+        check_conclusion="failure",
+    )
+    assert len(dispatched) == 1
+    assert "pr=2064" in dispatched[0]
+
+
+@pytest.mark.parametrize(
+    "conclusion", ["timed_out", "cancelled", "action_required", "stale", "startup_failure"]
+)
+def test_every_failure_class_conclusion_counts_as_red_evidence(
+    runner: Runner, conclusion: str
+) -> None:
+    """The lane reader in pr-readiness.yml treats all six as failure-class.
+
+    If the sweep recognised only `failure`, a lane cancelled or timed out by a
+    re-run would leave the green verdict frozen.
+    """
     assert (
-        runner.sweep(
-            state=state,
-            status_at="2020-01-01T00:00:00Z",
-            check_completed_at="2026-08-07T19:16:13Z",
+        len(
+            runner.sweep(
+                state="success",
+                status_at="2026-08-07T19:01:24Z",
+                check_completed_at="2026-08-07T19:16:13Z",
+                check_conclusion=conclusion,
+            )
         )
-        == []
+        == 1
     )
 
 
-def test_a_different_status_context_is_ignored(runner: Runner) -> None:
-    """Only the aggregate this sweep owns may be nudged."""
+def test_a_later_passing_check_never_refires_a_green_verdict(runner: Runner) -> None:
+    """The anti-storm property for this path, and why the test is narrowed.
+
+    Housekeeping check-runs (`Strip stale workflow-change override`, `Fork
+    workflow-change guard`) legitimately complete days after a verdict on a
+    long-lived PR. An unnarrowed "any check completed later" test would re-fire
+    most green PRs on every sweep while proving nothing, and a later pass cannot
+    turn a green verdict red anyway.
+    """
     assert (
         runner.sweep(
-            state="failure",
+            state="success",
             status_at="2026-08-07T19:01:24Z",
-            check_completed_at="2026-08-07T19:16:13Z",
-            context="Coverage Gate",
+            check_completed_at="2026-08-25T09:18:07Z",
+            check_conclusion="skipped",
         )
         == []
     )
+
+
+def test_green_refire_is_self_terminating(runner: Runner) -> None:
+    """Republishing must end this loop too, exactly as it does for `failure`."""
+    assert (
+        runner.sweep(
+            state="success",
+            status_at="2026-08-07T19:20:00Z",
+            check_completed_at="2026-08-07T19:16:13Z",
+            check_conclusion="failure",
+        )
+        == []
+    )
+
+
+def test_green_verdict_with_no_check_evidence_is_left_alone(runner: Runner) -> None:
+    """An ordinary green PR is never nudged."""
+    assert runner.sweep(state="success", status_at="2020-01-01T00:00:00Z") == []
+
+
+# ── The unpublished freeze: no readiness status was ever written ─────────────
+
+
+def test_a_missing_readiness_status_is_refired(runner: Runner) -> None:
+    """The PR #2783 incident, reduced.
+
+    `pr-readiness.yml` does not retry its status POST and instructs a human to
+    re-run the workflow. When that POST failed on `gh: HTTP 503`, the SHA carried
+    no readiness status -- no `pending` to age out, no event pending -- and the
+    only automatic re-runner skipped the PR because it had no status to read. The
+    one case the publisher delegates to a re-run was the one case nothing re-ran.
+    """
+    dispatched = runner.sweep(state=None, pr_updated_at="2026-08-17T14:20:00Z")
+    assert len(dispatched) == 1
+    assert "pr=2064" in dispatched[0]
+    assert "sha=4328fd0f941f09ff10f245fbdb4accf7c246febe" in dispatched[0]
+
+
+def test_a_brand_new_pull_request_is_left_alone(runner: Runner) -> None:
+    """Within STALE_MINUTES of the last push, the PR's own run really is coming.
+
+    This is what keeps the new path from dispatching against every PR opened in
+    the last quarter of an hour.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert runner.sweep(state=None, pr_updated_at=recent) == []
+
+
+def test_a_missing_status_still_respects_the_dispatch_cap(runner: Runner) -> None:
+    """The runaway backstop applies to the new path as well."""
+    assert (
+        runner.sweep(
+            state=None, pr_updated_at="2026-08-17T14:20:00Z", max_dispatch="0"
+        )
+        == []
+    )
+
+
+def test_an_unparseable_pr_timestamp_is_left_alone(runner: Runner) -> None:
+    """Fail closed on a timestamp the sweep cannot read, rather than dispatching."""
+    assert runner.sweep(state=None, pr_updated_at="not-a-date") == []
+
+
+# ── Truncation: the oldest PRs must never be dropped silently ────────────────
+
+
+def test_the_open_pr_listing_is_not_capped_near_the_real_backlog(script: str) -> None:
+    """`gh pr list` returns newest-first and truncates SILENTLY at --limit.
+
+    A ceiling near the real open-PR count drops the OLDEST PRs -- precisely the
+    frozen ones this sweep exists to rescue -- so the limit must stay well clear
+    of it and a hit must be reported rather than absorbed.
+    """
+    assert "--limit 300" not in script
+    assert '--limit "$PR_LIST_LIMIT"' in script
+    assert "::warning::" in script
+
+
+def test_a_truncated_listing_is_reported(runner: Runner) -> None:
+    """Hitting the ceiling is an action item, not a measurement."""
+    runner.env["PR_LIST_LIMIT"] = "1"
+    runner.sweep(state="success", status_at="2020-01-01T00:00:00Z")
+    assert "::warning::" in runner.last_stdout
+    assert "hit its ceiling" in runner.last_stdout
+
+
+def test_a_different_status_context_never_drives_the_decision(runner: Runner) -> None:
+    """Only the aggregate this sweep owns may be read.
+
+    The SHA carries a FRESH `PR Readiness` pending (nothing to rescue) alongside a
+    long-stale failing `Coverage Gate`. A sweep that matched on the wrong context
+    would read the Coverage Gate failure, see later check evidence, and dispatch.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert (
+        runner.sweep(
+            state="pending",
+            status_at=recent,
+            check_completed_at="2026-08-07T19:16:13Z",
+            check_conclusion="failure",
+            extra_statuses=[
+                {
+                    "context": "Coverage Gate",
+                    "state": "failure",
+                    "updated_at": "2020-01-01T00:00:00Z",
+                }
+            ],
+        )
+        == []
+    )
+
+
+def test_only_a_foreign_status_reads_as_an_unpublished_verdict(runner: Runner) -> None:
+    """A SHA with other statuses but no readiness one is still unpublished.
+
+    This is the #2783 shape generalised: what makes the verdict absent is that no
+    `PR Readiness` context exists, not that the SHA is bare. Treating it as
+    "already has a status" would leave the required aggregate permanently missing.
+    """
+    dispatched = runner.sweep(
+        state=None,
+        pr_updated_at="2026-08-17T14:20:00Z",
+        extra_statuses=[
+            {
+                "context": "Coverage Gate",
+                "state": "success",
+                "updated_at": "2026-08-17T14:00:00Z",
+            }
+        ],
+    )
+    assert len(dispatched) == 1
 
 
 def test_max_dispatch_caps_the_sweep(runner: Runner) -> None:
@@ -319,7 +546,7 @@ if [ "$1 ${2:-}" = "workflow run" ]; then
 fi
 if [ "$1" = "api" ]; then
   case "${2:-}" in
-    *"/check-runs") echo '{"check_runs":[]}'; exit 0 ;;
+    *"/check-runs") echo '[{"check_runs":[]}]'; exit 0 ;;
     *"/commits/"*"/statuses")
       sha="${2#*/commits/}"; sha="${sha%%/statuses}"
       cat "$FIXTURES/status_${sha}.json"; exit 0 ;;
@@ -361,8 +588,9 @@ def test_dispatch_is_oldest_stale_first(tmp_path: Path, script: str) -> None:
         "ccc": "2020-01-01T00:00:02Z",
     }
     for sha, at in ages.items():
+        # Slurped shape: an outer array of pages.
         (fixtures / f"status_{sha}.json").write_text(
-            json.dumps([{"context": "PR Readiness", "state": "pending", "updated_at": at}])
+            json.dumps([[{"context": "PR Readiness", "state": "pending", "updated_at": at}]])
         )
 
     proc = subprocess.run(  # noqa: S603 - fixed argv, test-local stub
@@ -376,6 +604,7 @@ def test_dispatch_is_oldest_stale_first(tmp_path: Path, script: str) -> None:
             "STATUS_CONTEXT": "PR Readiness",
             "STALE_MINUTES": "15",
             "MAX_DISPATCH": "200",
+            "PR_LIST_LIMIT": "900",
         },
         text=True,
         capture_output=True,
@@ -400,3 +629,53 @@ def test_the_sweep_never_recomputes_a_verdict_itself(script: str) -> None:
     assert "gh workflow run pr-readiness.yml" in script
     for forbidden in ("/statuses -X POST", "--method POST", "-X POST"):
         assert forbidden not in script, f"sweep must not write statuses: {forbidden}"
+
+
+# ── Paginated reads: one verdict per SHA, not one per page ───────────────────
+
+
+def test_check_evidence_is_read_across_every_page(runner: Runner) -> None:
+    """`--paginate` alone makes jq emit one `max` PER PAGE.
+
+    `date -d` then rejects the multi-line string, the epoch reads 0, and the PR is
+    skipped -- silently exempting every PR with more than 100 check-runs, which on
+    this repo is any PR whose lanes have been re-run. The newest evidence here
+    lives on the SECOND page, so a page-blind read cannot find it.
+    """
+    dispatched = runner.sweep(
+        state="failure",
+        status_at="2026-08-07T19:01:24Z",
+        check_completed_at="2026-08-07T19:00:00Z",
+        extra_check_page=("success", "2026-08-07T19:16:13Z"),
+    )
+    assert len(dispatched) == 1
+    assert "pr=2064" in dispatched[0]
+
+
+def test_a_green_verdict_sees_failing_evidence_on_a_later_page(runner: Runner) -> None:
+    """Same pagination property for the green arm."""
+    dispatched = runner.sweep(
+        state="success",
+        status_at="2026-08-07T19:01:24Z",
+        check_completed_at="2026-08-07T19:00:00Z",
+        check_conclusion="success",
+        extra_check_page=("failure", "2026-08-07T19:16:13Z"),
+    )
+    assert len(dispatched) == 1
+
+
+# ── Transport failure is not an absent verdict ───────────────────────────────
+
+
+def test_a_failed_statuses_read_is_not_treated_as_unpublished(runner: Runner) -> None:
+    """A statuses-API 503 and a genuinely absent status both yield empty jq output.
+
+    Conflating them would turn transient GitHub trouble into a spurious re-fire of
+    an arbitrary old PR -- on a shared token budget, at 15-minute intervals, on
+    every PR at once. The read is therefore checked for failure BEFORE the filter.
+    """
+    dispatched = runner.sweep(
+        state=None, pr_updated_at="2026-08-17T14:20:00Z", statuses_read_fails=True
+    )
+    assert dispatched == []
+    assert "statuses lookup failed" in runner.last_stdout


### PR DESCRIPTION
## Problem / Motivation

`pr-readiness-sweep.yml` is the only thing that recomputes a readiness verdict on an unchanged commit once its `workflow_run` events are spent. It rescues a `pending` verdict on age and a `failure` verdict on later check evidence. Two freeze modes fell outside both tests and therefore had no recovery path at all.

**An unpublished verdict, which is live today.** `pr-readiness.yml` deliberately does not retry its status POST — a retry can overwrite a concurrent run's newer verdict — and instead instructs a human to re-run the workflow. When that POST fails, the head SHA carries no readiness status, so there is no `pending` to age out, and the sweep skipped the PR outright on `[ -n "$status_json" ] || continue` with the comment *"the PR's own run is coming; not stuck"*. The one case the publisher delegates to a re-run was the one case nothing re-ran.

#2783 proves it. Both readiness runs for `f014465e` failed on `gh: HTTP 503` from the status POST on 2026-08-17. Eight days later that PR is still `MERGEABLE`, its head SHA carries **zero** commit statuses, and it wears a `readiness: action required` label with nothing backing it. Today's #5282 hit the same POST with a 502 and survived only because an unrelated later event happened to republish.

**A stale green, which is the unsafe direction.** The re-run mechanism the sweep was built for is direction-blind: a job re-run that flips a lane red after a green verdict emits no `workflow_run: completed` either. The required aggregate then stays green over a now-red revision, which **permits** a merge — where a stale red only blocks one. The `*)` arm skipped it as *"`success` needs no rescue"*.

**A latent truncation.** `gh pr list --limit 300` against 250 open PRs. `gh` returns newest-first and truncates silently, so crossing the ceiling drops the **oldest** PRs — precisely the frozen ones this sweep exists to rescue. Same bug class as the `pr_status_report` limit.

## Why it matters

A required status check that is absent or stale-green is worse than one that is stale-red: both block the pipeline's ability to reason about a PR, but these two let a revision through. #2783 has sat mergeable with no verdict for eight days, and the publisher's own error message tells a human to do the one thing no automation was willing to do.

## What changed (motivation → approach → change)

Both new rescues reuse mode 2's shape — *"evidence landed after the verdict, so the verdict is stale by construction"* — because that shape is what makes a scheduled re-fire self-terminating rather than a dispatch loop.

- **Unpublished** → rescued on the PR's own last-activity age. A push bumps `updatedAt`, so the grace window restarts on every new revision and a genuinely queueing run is left alone. Carried as a sentinel `state` rather than an early record write, so it reuses the single staleness comparison and the single stale-file record writer instead of restating either. GitHub's status states are `error`/`failure`/`pending`/`success`, so the sentinel cannot collide with a real one.
- **Stale green** → `success` and `error` join mode 2's evidence test, **narrowed to failure-class conclusions**. This narrowing is the load-bearing part: housekeeping check-runs (`Strip stale workflow-change override`, `Fork workflow-change guard`) legitimately complete days after a verdict on a long-lived PR, so an unnarrowed "any check completed later" test would re-fire most green PRs on every sweep while proving nothing. A later `success` cannot turn a green verdict red, so it is correctly ignored.
- **Truncation** → `--limit` becomes `PR_LIST_LIMIT: "900"` and a hit emits a `::warning::` action item instead of being absorbed as a measurement.

Honest scope note: I found **no** live poisoned green in the current 250 open PRs. The one candidate my audit flagged, #4272, turned out to be exactly the housekeeping-check false positive described above. That path closes a mechanism, not an observed incident. The unpublished path closes both.

## Tests

`test/test_pr_readiness_sweep.py` — 28 passed (18 pre-existing, 10 added). The harness extracts the sweep's one `run:` block and executes it for real against a `gh` stub, so these lock in the re-fire *conditions*, which is the whole risk surface: too narrow and a frozen verdict stays frozen, too broad and every PR gets dispatched every 15 minutes.

- Unpublished: rescued past the window; left alone inside it; respects `MAX_DISPATCH`; fails closed on an unparseable timestamp; still reads as unpublished when only a foreign-context status exists on the SHA.
- Stale green: rescued for all six failure-class conclusions (`failure`, `timed_out`, `cancelled`, `action_required`, `stale`, `startup_failure`); never rescued by a later pass or `skipped`; self-terminating once republished; untouched with no evidence at all.
- Truncation: the ceiling is a variable, not a literal, and a hit is reported.
- `test_a_different_status_context_is_ignored` is reworked into `test_a_different_status_context_never_drives_the_decision`. It previously asserted its intent through the absent-status shape, which is now a rescue path; it now gives the SHA a fresh `PR Readiness` pending alongside a long-stale failing `Coverage Gate` and proves the foreign context cannot drive the decision. Its intent is preserved and strengthened.

**Revert-verify.** Undoing each of the four properties independently — the unpublished arm, the green arm, the ceiling, and the failure-class narrowing — fails at least one named test, and the tree restores to 28 green:

```
baseline: rc=0 passed=28 failed=0
no-status rescue:         rc=1 passed=26 failed=2 -> LOAD-BEARING
green-freeze rescue:      rc=1 passed=21 failed=7 -> LOAD-BEARING
pr-list ceiling:          rc=1 passed=27 failed=1 -> LOAD-BEARING
failure-class narrowing:  rc=1 passed=27 failed=1 -> LOAD-BEARING
restored: rc=0 passed=28 failed=0
```

Workflow contract suites unaffected: `test_workflows_conformance`, `test_workflow_permissions`, `test_github_workflow_security`, `test_pr_quality_gates`, `test_ai_review_workflows` — 258 passed. `scripts/check_black_formatting.py` and `flake8` clean on the changed files.

`test_pr_readiness_publish.py` has 4 failures on my host (local `jq` rejects `label` as an identifier); they reproduce identically on pristine `main` and this PR does not touch `pr-readiness.yml`.

## Manual verification

The sweep cannot be exercised end-to-end without merging it, so verification was the other direction: I reproduced the exact production states the new arms target from live API data, and confirmed the current sweep skips them.

- #2783: `repos/.../commits/f014465e/statuses` returns an empty array while the PR is open and `MERGEABLE`; both `pr-readiness.yml` runs for that SHA are `pull_request_target completed/failure`, and the failing step's log ends on `gh: No server is currently available ... (HTTP 503)` followed by the publisher's "re-run this workflow" error. Under this change the sweep records it as `no readiness status published; PR last active …` and dispatches.
- The current sweep's live log confirms the surviving behaviour is unchanged for the modes it already handled: `Scanning 252 open pull request(s)` → `Found 5 stale` → 5 dispatched, all `pending`/`failure`.

## Screenshots / video

N/A — CI workflow and test changes only, no user-visible surface.

## Follow-up filed separately

A required lane that did not exist when the head SHA was pushed can never be satisfied, and a recompute re-derives `not started` forever. #3089 and #3037 are frozen this way on First Principles Review, which became blocking in #4253 but only exists from #3436. Auto-skipping the lane would let an unreviewed PR pass, so the fix is a deliberate eligibility rule or a rebase — a policy decision, not this PR's.
