### PR TITLE
fix: keep windows gateway cold starts on the splash

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -92,6 +92,10 @@ Current status:
   open the existing native Electron menus from the left of that row, the command
   palette remains centered on the window, and native minimize/maximize/close
   controls remain on the right.
+- **Cold-start-aware gateway handoff** — a live bundled backend keeps the loading
+  screen and progress updates through the longer Windows import window instead of
+  presenting a false failure that succeeds on Retry. A child exit or spawn error
+  still fails immediately and includes the launch-log cause.
 
 The source install below remains the fully supported path.
 

--- a/docs/system-specs/common/error-handling.md
+++ b/docs/system-specs/common/error-handling.md
@@ -23,3 +23,4 @@ AcpError (base)
 | JSON-RPC read | Non-JSON lines silently skipped (kiro-cli debug output) |
 | Config load | Invalid JSON → log warning, return defaults |
 | Process spawn | `shutil.which` check before spawn; clear error if missing |
+| asyncio loop callback | A Windows Proactor reset repeated by its `connection_lost` close callback is warning-only; task-level connection resets and other exceptions remain ERRORs with crash breadcrumbs |

--- a/src/kiro_crew/crash_guard.py
+++ b/src/kiro_crew/crash_guard.py
@@ -9,7 +9,8 @@ Three layers of defense:
    stderr goes to /dev/null or a truncated pipe.
 3. ``asyncio`` loop exception handler — catches "Task exception was never
    retrieved" and task-internal exceptions that asyncio would otherwise swallow
-   at DEBUG level.  Writes to crash.log AND the normal logger at ERROR.
+   at DEBUG level. Writes real failures to crash.log and the normal logger at
+   ERROR; known connection-teardown noise is warning-only.
 
 Call ``install(loop)`` once at gateway startup.  Safe to call multiple times
 (idempotent via module-level flag).
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 _INSTALLED = False
 _CRASH_LOG: Path | None = None
+_PROACTOR_CONNECTION_LOST_CALLBACK = "_ProactorBasePipeTransport._call_connection_lost"
 
 
 def _crash_log_path() -> Path:
@@ -80,6 +82,22 @@ def _excepthook(exc_type, exc_value, exc_tb) -> None:
     sys.__excepthook__(exc_type, exc_value, exc_tb)
 
 
+def _is_transport_shutdown_noise(context: dict) -> bool:
+    """Return whether asyncio reported the expected Windows pipe-close race.
+
+    A Proactor transport can learn that its peer reset the connection, schedule
+    ``connection_lost``, and then receive the same reset again from ``shutdown``.
+    The connection is already gone at that point; the callback error does not
+    represent a failed task or a dying gateway.
+    """
+    exception = context.get("exception")
+    message = str(context.get("message", ""))
+    return (
+        isinstance(exception, ConnectionResetError)
+        and _PROACTOR_CONNECTION_LOST_CALLBACK in message
+    )
+
+
 def _asyncio_exception_handler(loop, context) -> None:  # noqa: no-blocking-call-on-event-loop
     """Catches exceptions swallowed by asyncio (task-never-retrieved, etc.).
 
@@ -90,6 +108,15 @@ def _asyncio_exception_handler(loop, context) -> None:  # noqa: no-blocking-call
     """
     exception = context.get("exception")
     message = context.get("message", "Unhandled asyncio exception")
+
+    if _is_transport_shutdown_noise(context):
+        logger.warning(
+            "asyncio unhandled (noise): %s — %s: %s",
+            message,
+            type(exception).__name__,
+            exception,
+        )
+        return
 
     # Log to the normal logger at ERROR (default asyncio only logs at DEBUG)
     if exception:

--- a/test/test_crash_guard.py
+++ b/test/test_crash_guard.py
@@ -142,6 +142,62 @@ class TestUnclosedConnectionDowngrade:
         assert "Some other problem" in crash_log.read_text()
 
 
+class TestWindowsProactorShutdownDowngrade:
+    """A reset repeated by Proactor's close callback is disconnect noise."""
+
+    def test_connection_lost_callback_reset_is_warning_only(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.crash_guard"):
+            crash_guard._asyncio_exception_handler(
+                loop,
+                {
+                    "message": (
+                        "Exception in callback "
+                        "_ProactorBasePipeTransport._call_connection_lost(None)"
+                    ),
+                    "exception": ConnectionResetError(10054, "peer reset"),
+                },
+            )
+
+        assert any("noise" in record.message for record in caplog.records)
+        assert all(record.levelno <= logging.WARNING for record in caplog.records)
+        assert not (tmp_path / "home" / "logs" / "crash.log").exists()
+
+    def test_other_connection_reset_stays_an_error(self, tmp_path, monkeypatch, caplog):
+        """A task-level reset may be a real defect and must retain crash evidence."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        crash_guard._CRASH_LOG = None
+        loop = asyncio.new_event_loop()
+        try:
+            crash_guard.install_loop_handler(loop)
+        finally:
+            loop.close()
+
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="kiro_crew.crash_guard"):
+            crash_guard._asyncio_exception_handler(
+                loop,
+                {
+                    "message": "Task exception was never retrieved",
+                    "exception": ConnectionResetError(10054, "peer reset"),
+                },
+            )
+
+        assert any(record.levelno == logging.ERROR for record in caplog.records)
+        crash_log = tmp_path / "home" / "logs" / "crash.log"
+        assert "Task exception was never retrieved" in crash_log.read_text()
+
+
 class TestInstallIdempotent:
     """``install()`` is documented "Idempotent." — pin the early-return contract.
 

--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -19,7 +19,9 @@ The app will:
    `/api/status`, so it is never adopted; the app waits for the port to clear
    and spawns fresh instead
 2. Launch `kirocrew gateway` when needed
-3. Show a loading screen while the backend boots
+3. Show a loading screen while the backend boots. A live bundled backend gets an
+   extended Windows cold-start window; a child that actually exits still fails
+   immediately with its launch-log cause.
 4. Load the dashboard
 5. Point the user at Kiro CLI installation and sign-in on the gateway host when
    either prerequisite is missing

--- a/website/electron/gateway-wait.js
+++ b/website/electron/gateway-wait.js
@@ -12,6 +12,28 @@
 // the launch log. The maxWaitMs timeout stays purely as the backstop for a
 // gateway that is alive but slow to bind its port.
 
+const DEFAULT_GATEWAY_WAIT_MS = 30_000;
+// Importing a freshly installed bundled Python tree can exceed the ordinary
+// connection deadline on Windows. Keep the splash responsive through that cold
+// start without weakening the fail-fast child-exit path above.
+const WINDOWS_LOCAL_GATEWAY_WAIT_MS = 120_000;
+
+/**
+ * Pick the readiness deadline for the connection being opened.
+ *
+ * Only the primary local gateway gets the extended Windows cold-start budget.
+ * Connection tabs still fail on the ordinary deadline, and every spawned child
+ * exit still wins immediately through `getFailure`.
+ *
+ * @param {{platform?: string, watchSpawn?: boolean}} [o]
+ * @returns {number}
+ */
+function gatewayWaitTimeoutMs({ platform = process.platform, watchSpawn = false } = {}) {
+  return platform === "win32" && watchSpawn
+    ? WINDOWS_LOCAL_GATEWAY_WAIT_MS
+    : DEFAULT_GATEWAY_WAIT_MS;
+}
+
 /**
  * Poll `checkBackend` until the gateway answers, the spawned child reports a
  * terminal failure, the window closes, or we hit maxWaitMs.
@@ -39,7 +61,7 @@ function waitForGateway({
   onStatus = () => {},
   now = Date.now,
   setTimeoutFn = setTimeout,
-  maxWaitMs = 30_000,
+  maxWaitMs = DEFAULT_GATEWAY_WAIT_MS,
   pollIntervalMs = 500,
 }) {
   const start = now();
@@ -142,4 +164,12 @@ function isPortInUse(text) {
   return /address already in use|already in use|EADDRINUSE/i.test(String(text));
 }
 
-module.exports = { waitForGateway, describeGatewayFailure, tailLines, isPortInUse };
+module.exports = {
+  DEFAULT_GATEWAY_WAIT_MS,
+  WINDOWS_LOCAL_GATEWAY_WAIT_MS,
+  gatewayWaitTimeoutMs,
+  waitForGateway,
+  describeGatewayFailure,
+  tailLines,
+  isPortInUse,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -53,7 +53,13 @@ const {
   windowsProcessCommand,
   windowsTaskkill,
 } = require("./windows-port");
-const { waitForGateway, describeGatewayFailure, tailLines, isPortInUse } = require("./gateway-wait");
+const {
+  gatewayWaitTimeoutMs,
+  waitForGateway,
+  describeGatewayFailure,
+  tailLines,
+  isPortInUse,
+} = require("./gateway-wait");
 const { describeSandboxProfileNeed } = require("./sandbox-profile");
 const { sanitizeWindowState, captureWindowState } = require("./window-state");
 const {
@@ -207,7 +213,6 @@ if (migrateRemoteHostConfig(store, PORT)) {
 }
 const HEALTH_URL = `${BACKEND_URL}/api/status`;
 const POLL_INTERVAL_MS = 500;
-const MAX_WAIT_MS = 30_000; // 30s max wait for backend
 const IS_MAC = process.platform === "darwin";
 const IS_WINDOWS = process.platform === "win32";
 const IS_WIN = IS_WINDOWS;
@@ -1246,7 +1251,13 @@ function waitForBackend(targetWin, healthUrl = HEALTH_URL, { watchSpawn = false 
     getFailure: watchSpawn ? (() => gatewayStartFailure) : (() => null),
     isWindowAlive: () => !targetWin?.isDestroyed(),
     onStatus: (msg) => { try { targetWin?.webContents?.send("status", msg); } catch { /* window gone */ } },
-    maxWaitMs: MAX_WAIT_MS,
+    // Windows may spend well past the ordinary deadline importing a newly
+    // installed bundled Python tree. Keep showing live splash progress only for
+    // the gateway child we spawned; exits still fail immediately via getFailure.
+    maxWaitMs: gatewayWaitTimeoutMs({
+      platform: process.platform,
+      watchSpawn: watchSpawn && gatewayOwnership === "spawned",
+    }),
     pollIntervalMs: POLL_INTERVAL_MS,
   });
 }

--- a/website/electron/test/gateway-wait.test.js
+++ b/website/electron/test/gateway-wait.test.js
@@ -1,6 +1,16 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { waitForGateway, describeGatewayFailure, tailLines, isPortInUse } = require("../gateway-wait");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  DEFAULT_GATEWAY_WAIT_MS,
+  WINDOWS_LOCAL_GATEWAY_WAIT_MS,
+  gatewayWaitTimeoutMs,
+  waitForGateway,
+  describeGatewayFailure,
+  tailLines,
+  isPortInUse,
+} = require("../gateway-wait");
 
 // Synchronous fake clock + timer so poll loops resolve instantly and
 // deterministically (no real waiting). setTimeoutFn advances the clock by the
@@ -42,6 +52,45 @@ test("waitForGateway resolves after a few unhealthy polls", async () => {
   });
   await p;
   assert.strictEqual(n, 3);
+});
+
+test("Windows local cold start stays on the splash past the ordinary deadline", async () => {
+  let polls = 0;
+  const maxWaitMs = gatewayWaitTimeoutMs({ platform: "win32", watchSpawn: true });
+  const { p } = harness({
+    // 110 failed 500ms polls model a 55-second packaged cold start.
+    checkBackend: () => (++polls <= 110
+      ? Promise.reject(new Error("not yet"))
+      : Promise.resolve()),
+    maxWaitMs,
+  });
+
+  await p;
+  assert.strictEqual(polls, 111);
+  assert.ok(maxWaitMs > DEFAULT_GATEWAY_WAIT_MS);
+});
+
+test("gateway wait policy extends only the primary Windows gateway", () => {
+  assert.strictEqual(
+    gatewayWaitTimeoutMs({ platform: "win32", watchSpawn: true }),
+    WINDOWS_LOCAL_GATEWAY_WAIT_MS,
+  );
+  assert.strictEqual(
+    gatewayWaitTimeoutMs({ platform: "win32", watchSpawn: false }),
+    DEFAULT_GATEWAY_WAIT_MS,
+  );
+  assert.strictEqual(
+    gatewayWaitTimeoutMs({ platform: "darwin", watchSpawn: true }),
+    DEFAULT_GATEWAY_WAIT_MS,
+  );
+});
+
+test("main extends the Windows deadline only for a gateway it spawned", () => {
+  const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+  assert.match(
+    main,
+    /watchSpawn: watchSpawn && gatewayOwnership === "spawned"/,
+  );
 });
 
 test("waitForGateway fails fast when the spawned gateway exited (no health polling)", async () => {


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

A freshly installed Windows Nightly can need about 55 seconds to import and
start its bundled Python gateway. The Electron shell stopped waiting after 30
seconds, showed a startup error even though the child was still alive, and then
succeeded when the user clicked Retry. During connection teardown, Windows can
also report the Proactor pipe-close race as `WinError 10054`, which the crash
guard presented as an ERROR and wrote to `crash.log`.

## Why it matters

The false startup failure makes a successful first launch look broken and asks
the user to recover from a timeout the application could have handled itself.
The teardown traceback then reinforces the impression that the gateway crashed,
even though the process remains healthy.

## What changed (motivation → approach → change)

- Give only the primary locally spawned Windows gateway a 120-second readiness
  deadline, which covers the observed cold start. Remote connection tabs and
  non-Windows launches retain the ordinary 30-second deadline, while a child
  exit or spawn error still fails immediately.
- Recognize only a `ConnectionResetError` reported from
  `_ProactorBasePipeTransport._call_connection_lost` as connection-teardown
  noise. That exact callback is warning-only and no longer creates a crash
  breadcrumb; task-level and unrelated connection resets remain ERRORs.
- Document the cold-start-aware desktop handoff and the asyncio teardown-noise
  boundary in the owning Windows, Electron, and error-handling docs.

## Tests

- Added deterministic Electron coverage for a 55-second Windows cold start,
  the platform/local-only timeout policy, and the `main.js` wiring.
- Added crash-guard coverage proving the exact Proactor callback reset is
  warning-only while an unrelated task-level reset still logs an ERROR and
  writes crash evidence.
- Ran the repository's scoped-test self-test, targeted backend and Electron
  suites, formatting, lint, type checking, and documentation lint locally.

## Manual verification

Inspected the installed Nightly launch log: the gateway child remained alive
and became healthy after roughly 55 seconds, beyond the old 30-second Electron
deadline. The same running gateway returned HTTP 200 after Retry.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** The splash rendering is unchanged; only how long it keeps waiting for a live Windows gateway changes.

## Related Issues

no linked issue: the failure was reported directly from an installed Nightly run.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
