### PR TITLE
fix: detect Windows per-user Kiro CLI installs

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -560,9 +560,10 @@ unit-testable without mocking globals.
   contract instead of falling back to the Windows ANSI code page or an
   incompatible inherited POSIX encoding override.
 - Leaves the inherited child `PATH` unchanged. The gateway prerequisite service
-  probes supported Kiro CLI locations independently, so Finder-launched macOS
-  apps and Linux desktop launchers still find user-local installations without
-  mutating the shell environment.
+  probes supported Kiro CLI locations independently — including the Windows
+  per-user install at `%LOCALAPPDATA%\Kiro-Cli` — so desktop launches find
+  user-local installations without mutating the shell environment or requiring
+  the already-running gateway to inherit an installer-updated `PATH`.
 - On window close the app hides to the tray; quitting sends `SIGTERM` to the
   gateway process.
 

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -173,6 +173,11 @@ complete the device-code flow in the browser. The dashboard opens automatically
 after `kiro-cli whoami` succeeds. This setup runs on the gateway machine, which
 may be different from the computer running the browser.
 
+The per-user Kiro CLI install under `%LOCALAPPDATA%\Kiro-Cli` is discovered
+independently of the gateway's inherited `PATH`. Installing it while the desktop
+gateway is already running is therefore picked up by the setup page's next
+automatic check; neither a gateway restart nor a Windows reboot is required.
+
 `kirocrew` lands in `.venv\Scripts\`. If a launched (non-shell)
 gateway can't find the built-in `kirocrew-cron` / `kirocrew-core` MCP servers,
 that dir is appended to the MCP spawn `PATH` automatically

--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -17,6 +17,13 @@ fixed path — KiroCrew is not the authority on where Kiro CLI is installed, and
 Kiro CLI's own self-updater legitimately rewrites its bytes as the user, so an
 install-source/owner/path/codesign gate would strand real installs (toolbox,
 Homebrew, winget, a self-updated `/Applications` bundle) with no recovery path.
+On Windows the fixed candidates include the native per-user install at
+`%LOCALAPPDATA%\Kiro-Cli` before the machine-wide `Program Files\Kiro-Cli`
+location. After the inherited `PATH`, discovery also checks the shared set of
+standard user tool directories, preserving managed installations without
+hardcoding package-manager-specific paths. Discovery therefore sees a CLI
+installed after the desktop gateway started even though that process retains
+its old `PATH`.
 `snapshot_trusted_acp_executable` refuses only a non-runnable candidate and
 returns the resolved path; `TrustedAcpExecutableSnapshot` now carries just
 `launch_path`.

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -626,8 +626,11 @@ def git_build_info() -> tuple[str, str]:
     )
 
 
-def augmented_path(base_path: str = "") -> str:
+def augmented_path(base_path: str = "", *, home: str | None = None) -> str:
     """Return *base_path* prepended with well-known MCP binary directories.
+
+    ``home`` pins user-relative candidates for callers already resolving a
+    specific account instead of whichever account owns the current process.
 
     When KiroCrew runs under systemd or another non-login shell the
     inherited ``$PATH`` rarely includes directories like
@@ -655,8 +658,8 @@ def augmented_path(base_path: str = "") -> str:
     contributed directory. That contribution lives on :func:`mcp_search_path` —
     see the section comment near ``_registered_path_dirs``.
     """
-    home = os.path.expanduser("~")
-    mise_data = mise_data_dir(home)
+    resolved_home = home or os.path.expanduser("~")
+    mise_data = mise_data_dir(resolved_home)
     # Filter each formatted entry through the same absolute-only validation as
     # the other PATH sources (_validated_bin_dir): a relative MISE_DATA_DIR
     # would otherwise put a relative "{mise_data}/shims" entry on every spawned
@@ -665,9 +668,9 @@ def augmented_path(base_path: str = "") -> str:
     extra = [
         e
         for d in _EXTRA_PATH_DIRS
-        if (e := _validated_bin_dir(d.format(home=home, mise_data=mise_data)))
+        if (e := _validated_bin_dir(d.format(home=resolved_home, mise_data=mise_data)))
     ]
-    extra += node_all_bin_dirs()
+    extra += _node_all_bin_dirs(resolved_home, mise_data)
     parts = extra + ([base_path] if base_path else [])
     parts.append(str(Path(sys.executable).parent))
     return os.pathsep.join(parts)

--- a/src/kiro_crew/kiro_cli.py
+++ b/src/kiro_crew/kiro_cli.py
@@ -197,7 +197,11 @@ def known_kiro_cli_dirs(
     """Return fixed and inherited directories where Kiro CLI may be installed."""
 
     if platform_name == "win32":
-        dirs = [str(Path(_windows_program_files(environ)) / "Kiro-Cli")]
+        local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
+        dirs = [
+            str(local_app_data / "Kiro-Cli"),
+            str(Path(_windows_program_files(environ)) / "Kiro-Cli"),
+        ]
     else:
         dirs = [
             str(home / ".local" / "bin"),
@@ -214,10 +218,10 @@ def known_kiro_cli_dirs(
         )
     if include_inherited_path and platform_name == "win32":
         dirs.extend(part for part in environ.get("PATH", "").split(";") if part)
-        # A GUI-launched Windows gateway may omit its venv's Scripts directory
-        # from PATH. ACP launch still needs the console-script fallback that
-        # existed before setup and ACP adopted this shared resolver.
-        dirs.append(str(Path(sys.executable).parent))
+        # A GUI-launched Windows gateway can retain an old PATH after a user
+        # installs a CLI. Keep the inherited order, then add the shared set of
+        # standard user tool directories and the venv Scripts fallback.
+        dirs.extend(part for part in augmented_path("", home=str(home)).split(os.pathsep) if part)
     elif include_inherited_path:
         dirs.extend(
             part for part in augmented_path(environ.get("PATH", "")).split(os.pathsep) if part
@@ -251,6 +255,12 @@ def find_kiro_cli_candidates(
     result: list[str] = []
     for candidate in _unique(candidates):
         if platform_compat.is_executable_file(candidate, platform_name=platform_name):
+            if platform_name == "win32":
+                try:
+                    if os.path.getsize(candidate) == 0:
+                        continue
+                except OSError:
+                    continue
             result.append(os.path.realpath(candidate) if platform_name == "win32" else candidate)
     return result
 

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -512,7 +512,7 @@ class TestKiroPrerequisiteHelpers:
                 environ={},
             )
 
-    def test_windows_candidate_includes_official_msi_directory(self, tmp_path: Path) -> None:
+    def test_windows_candidate_includes_machine_wide_directory(self, tmp_path: Path) -> None:
         program_files = tmp_path / "Program Files"
         executable = program_files / "Kiro-Cli" / "kiro-cli.exe"
         _make_executable(executable)
@@ -524,6 +524,92 @@ class TestKiroPrerequisiteHelpers:
         )
 
         assert str(executable) in candidates
+
+    def test_windows_candidates_include_standard_user_tool_directory(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        home = tmp_path / "Users" / "new-user"
+        managed_bin = home / ".local" / "bin"
+        executable = managed_bin / "kiro-cli.exe"
+        _make_executable(executable)
+
+        candidates = find_kiro_cli_candidates(
+            "win32",
+            home,
+            {
+                "LOCALAPPDATA": str(tmp_path / "AppData" / "Local"),
+                "ProgramFiles": str(tmp_path / "Program Files"),
+                "PATH": "",
+            },
+        )
+
+        assert str(executable) in candidates
+
+    def test_windows_truncated_per_user_candidate_does_not_shadow_machine_wide(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        local_app_data = tmp_path / "AppData" / "Local"
+        truncated = local_app_data / "Kiro-Cli" / "kiro-cli.exe"
+        truncated.parent.mkdir(parents=True)
+        truncated.write_bytes(b"")
+        machine_wide = tmp_path / "Program Files" / "Kiro-Cli" / "kiro-cli.exe"
+        _make_executable(machine_wide)
+
+        candidates = find_kiro_cli_candidates(
+            "win32",
+            tmp_path / "Users" / "new-user",
+            {
+                "LOCALAPPDATA": str(local_app_data),
+                "ProgramFiles": str(tmp_path / "Program Files"),
+                "PATH": "",
+            },
+        )
+
+        assert candidates[0] == str(machine_wide)
+        assert str(truncated) not in candidates
+
+    @pytest.mark.asyncio
+    async def test_windows_refresh_discovers_per_user_install_without_new_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        local_app_data = tmp_path / "AppData" / "Local"
+        executable = local_app_data / "Kiro-Cli" / "kiro-cli.exe"
+        calls: list[tuple[str, list[str]]] = []
+
+        async def run(command: str, args: list[str], **_kwargs: Any) -> ProcessResult:
+            calls.append((command, args))
+            return ProcessResult(ok=True)
+
+        service = KiroPrerequisiteService(
+            platform_name="win32",
+            environ={
+                "LOCALAPPDATA": str(local_app_data),
+                "PATH": "",
+                "ProgramFiles": str(tmp_path / "Program Files"),
+            },
+            home=tmp_path / "Users" / "new-user",
+            data_home=tmp_path / "data-home",
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+        missing = await service.snapshot(force=True)
+        assert missing["installed"] is False
+
+        # The native installer updates the user's PATH, but a running desktop
+        # gateway keeps its old environment. A forced refresh must find the
+        # install at its fixed per-user location without a process restart.
+        _make_executable(executable)
+        refreshed = await service.snapshot(force=True)
+
+        assert refreshed["ready"] is True
+        assert calls == [
+            (str(executable), ["--version"]),
+            (str(executable), ["whoami"]),
+        ]
 
     def test_windows_candidates_include_inherited_path(
         self,


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

On Windows, installing Kiro CLI while the desktop gateway is already running can leave the setup page repeatedly reporting that the CLI is missing. The installer updates the user's `PATH`, but the long-lived gateway retains its previous environment until it is restarted or the computer is rebooted.

## Why it matters

Windows users can finish the required CLI installation and still be blocked from Kiro Crew, with a reboot appearing to be the only recovery. Managed and machine-wide installations must remain discoverable as well.

## What changed (motivation → approach → change)

Kiro Crew now resolves the native per-user Windows installation directly from `%LOCALAPPDATA%\Kiro-Cli`, independently of inherited `PATH`. It preserves the existing machine-wide candidate and reuses the shared standard user tool-directory search for managed installations without hardcoding package-manager-specific paths. Zero-byte Windows candidates are skipped so an interrupted per-user installation cannot shadow a valid machine-wide CLI.

The Windows setup and desktop documentation now state that the next automatic prerequisite refresh detects the per-user installation without restarting the gateway or rebooting Windows.

## Tests

- Added Windows resolver coverage for the per-user installation appearing after the gateway starts with an unchanged `PATH`.
- Added coverage for standard user tool directories, the existing machine-wide directory, and a truncated per-user executable falling back to a valid machine-wide CLI.
- `py -3.12 -m pytest test/test_kiro_prerequisite.py test/test_acp_client.py::TestResolveKiroBinEnvOverride -n0 -q` (`165 passed, 21 skipped`).
- Black, isort, flake8, mypy, documentation, brand, harness-parity, subprocess-encoding, loop-bound-lock, changelog-history, focus-cue, vendor-manifest, and structural push guards passed.
- `prove.py --base origin/main` passed: reverting the production fix while retaining the tests produces an assertion failure.
- Full repository suites are delegated to CI.

## Manual verification

On Windows, verified that resolution finds the installed `%LOCALAPPDATA%\Kiro-Cli\kiro-cli.exe` with the inherited `PATH` removed from the probe environment.

## Related Issues

no linked issue: this fixes a directly reported Windows onboarding failure.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
