### PR TITLE
feat(desktop): capture Chromium/V8 native output on every launch

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BaseWindow, BrowserWindow, WebContentsView, shell, dialog, Tray, Menu, nativeImage, nativeTheme, Notification, ipcMain, webContents, session, desktopCapturer, systemPreferences, screen } = require("electron");
+const { app, BaseWindow, BrowserWindow, WebContentsView, shell, dialog, Tray, Menu, nativeImage, nativeTheme, Notification, ipcMain, webContents, session, desktopCapturer, systemPreferences, screen, crashReporter } = require("electron");
 const Store = require("electron-store");
 const fs = require("fs");
 const os = require("os");
@@ -140,6 +140,8 @@ const { migrateRemoteHostConfig, getRemoteHostConfig, setRemoteHostConfig } = re
 const { seedRenamedStore } = require("./store-rename");
 
 const { isLocalGatewayEnabled, setLocalGatewayEnabled, classifyStartFailure } = require("./local-gateway");
+
+const { initNativeLogging } = require("./native-logging");
 
 // Carry settings across the npm `name` rename, by writing the new store's file
 // BEFORE electron-store opens it. Order is load-bearing: construction writes the
@@ -289,6 +291,28 @@ if (IS_WIN) {
 if (!app.requestSingleInstanceLock()) {
   app.exit(0);
 } else {
+  // Arm native diagnostic capture as the FIRST thing the winning instance does:
+  // early enough that Chromium still reads the logging switches (it reads them
+  // during initialization, so a call after app-ready is accepted and ignored),
+  // but strictly INSIDE the lock-won branch. A rejected second instance must not
+  // reach this: it would rotate `chromium.log` out from under the primary — the
+  // primary's open fd follows the renamed inode, and the genuine previous
+  // generation is destroyed — so double-clicking the icon of a running app would
+  // wipe exactly the retained evidence this capture exists to keep. `app.exit(0)`
+  // above is synchronous, so placing it here is what makes that unreachable
+  // rather than merely unlikely.
+  //
+  // `gatewayLogPath` is a hoisted function declaration needing only the modules
+  // required at the top of this file, so calling it here reuses its logs-dir
+  // resolution (including the tmpdir fallback) rather than duplicating it.
+  initNativeLogging({
+    logsDir: path.dirname(gatewayLogPath()),
+    appendSwitch: (name, value) => app.commandLine.appendSwitch(name, value),
+    startCrashReporter: (opts) => crashReporter.start(opts),
+    fs,
+    log: (m) => glog(m),
+  });
+
   app.on("second-instance", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       // Relaunching the app is a request for the window back; it must win over

--- a/website/electron/native-logging.js
+++ b/website/electron/native-logging.js
@@ -1,0 +1,242 @@
+"use strict";
+//
+// Always-on capture of the app's NATIVE diagnostic output (Chromium + V8 +
+// renderer), so a crash explains itself without the user having relaunched
+// under a debugger first.
+//
+// The problem this solves: everything Chromium and V8 print goes to the
+// process's raw stderr, and a GUI launch (Dock, Finder, Start menu) discards
+// stderr entirely. It is not in the macOS unified log either — verified against
+// a real renderer abort: `log show --last 12h` filtered to the Electron
+// framework returned zero fatal lines. So the single most useful sentence about
+// a renderer death — V8's own `Fatal error in ... / Reached heap limit /
+// invalid size` — was being thrown away, leaving only a `.ips` crash report
+// whose `asi` field is null and whose every frame symbol is a
+// nearest-neighbour mismatch. `renderer-recovery.js` could say THAT the
+// renderer died and reload it; nothing could say WHY.
+//
+// This is the same correction already applied to the gateway child process,
+// whose spawn used `stdio:"ignore"` until a silent Gatekeeper SIGKILL proved
+// that a discarded stream is a discarded bug report (see the comment above
+// `gatewayLogPath` in main.js). The app's own native output is the last stream
+// still going nowhere.
+//
+// Two channels, because they carry different things and neither subsumes the
+// other:
+//
+//   1. Chromium's log file (`--enable-logging=file --log-file=`). Carries
+//      Chromium's own `LOG()` output, renderer console errors, and GPU /
+//      network / sandbox failures. Set from here rather than asked of the user,
+//      because a switch the user must remember to pass is a switch that is
+//      never set on the launch that actually crashed.
+//   2. A local minidump via `crashReporter`. Carries the abort context for a
+//      renderer that dies without printing anything at all.
+//
+// Both are bounded by keeping exactly two generations of the log file (see
+// `rotateNativeLog`): the run being debugged is almost never the run that is
+// running, so the previous session has to survive the relaunch that
+// investigates it.
+//
+// Deliberately NOT attempted: redirecting the main process's own fd 2 to a
+// file. Node exposes no `dup2`, so the only ways to do it are a native addon or
+// re-spawning the app with `stdio` set — a double launch that would break the
+// single-instance lock, Dock activation, and the updater. A terminal launch
+// (`Contents/MacOS/<name> > log 2>&1`) remains the way to capture true raw
+// stderr, and that stays a deliberate debugging step rather than something the
+// app does to itself on every boot.
+//
+// Pure logic + injected dependencies: Electron main is not exercised by the
+// unit test runner, so the decisions have to be testable without a live `app`
+// (same pattern as renderer-recovery.js / perf-metrics.js).
+//
+
+const path = require("path");
+
+/** Log file name, alongside gateway-launch.log in the app's logs directory. */
+const NATIVE_LOG_BASENAME = "chromium.log";
+
+/** The retained previous session. Named, not numbered, so a user handing logs
+ *  over can tell which file is the run that went wrong. */
+const NATIVE_LOG_PREVIOUS_BASENAME = "chromium.previous.log";
+
+/**
+ * Absolute path of the Chromium log file inside `logsDir`.
+ */
+function nativeLogPath(logsDir) {
+  return path.join(String(logsDir || ""), NATIVE_LOG_BASENAME);
+}
+
+/**
+ * Absolute path of the retained previous-session log, beside `logPath`.
+ */
+function previousNativeLogPath(logPath) {
+  return path.join(path.dirname(String(logPath || "")), NATIVE_LOG_PREVIOUS_BASENAME);
+}
+
+/**
+ * The Chromium switches that route native logging to `logPath`.
+ *
+ * Returned as data rather than applied inline so a test can assert the exact
+ * switch names: these are Chromium's spelling, not Electron's, and a typo here
+ * fails silently (an unknown switch is ignored, logging simply stays off).
+ *
+ * @returns {Array<[string, string]>} `[name, value]` pairs for appendSwitch.
+ */
+function nativeLoggingSwitches(logPath) {
+  return [
+    // `=file` is what sends output to --log-file instead of stderr, which the
+    // GUI launch we are compensating for would throw away again.
+    ["enable-logging", "file"],
+    ["log-file", String(logPath)],
+  ];
+}
+
+/**
+ * Start-of-boot rotation, which is what bounds this file's size.
+ *
+ * Neither Chromium's log file nor this app's `glog` has any rotation (glog is a
+ * bare appendFileSync), so an always-on stream that only ever appends would
+ * grow without limit on a long-lived install. But truncating to nothing is the
+ * opposite mistake: it destroys the previous session at the exact moment a
+ * developer relaunches to investigate it. A main-process crash, a hard quit, or
+ * simply "change the code and restart to reproduce" all end the session that
+ * holds the evidence, and the next launch would wipe it before anyone read it.
+ * (Only a RENDERER death is healed in-process, and that is the narrow case —
+ * not the general one this capture exists for.)
+ *
+ * So: keep one generation. The current file becomes `chromium.previous.log` and
+ * Chromium creates a fresh one, leaving the last bad run readable from inside
+ * the run that is debugging it. Renaming rather than copying also means this
+ * works whether Chromium opens its log in append or truncate mode — the path it
+ * opens is simply absent, so it starts clean either way.
+ *
+ * The bound is therefore two sessions. A single session is not itself capped,
+ * because Chromium owns that file handle and nothing on this side can cap it;
+ * the size that matters in practice is one session's worth of Chromium logging,
+ * which is small unless something is looping — and something looping is the
+ * thing we want recorded.
+ *
+ * Returns which generations exist afterwards, and whether a rotation that was
+ * NEEDED could not be performed. A failure is reported, never thrown: losing
+ * rotation is worth a log line, not a failed launch. The caller distinguishes
+ * `blocked` from an ordinary first launch, because the two want opposite
+ * handling — nothing to preserve is safe, failing to preserve is not.
+ */
+function rotateNativeLog(logPath, { fs, log = () => {} } = {}) {
+  const previousPath = previousNativeLogPath(logPath);
+  try {
+    if (!fs.existsSync(logPath)) {
+      // First launch on this install, or the file was cleaned up. Nothing to
+      // preserve and nothing to do — Chromium will create it.
+      return { rotated: false, blocked: false, previousPath: null };
+    }
+    // Overwrites any older generation, which is the point: two files, not N.
+    // `renameSync` replaces an existing destination on Windows too (libuv
+    // passes MOVEFILE_REPLACE_EXISTING), which is what `perf-metrics.js`
+    // already relies on for its rolling artifact — so the destination existing
+    // is not itself a failure mode. What DOES fail on Windows is a sharing
+    // violation when any handle is open on either path (an AV or
+    // Search-indexer touch is enough); see `replace_with_retry` in
+    // `src/kiro_crew/atomic_write.py`.
+    fs.renameSync(logPath, previousPath);
+    return { rotated: true, blocked: false, previousPath };
+  } catch (e) {
+    // A read-only directory or a Windows sharing violation reaches here. The
+    // live log is still on disk and still holds the session we were trying to
+    // preserve, so this is `blocked`, not merely "not rotated".
+    log(`native log rotate failed at ${logPath}: ${e && e.message}`);
+    return { rotated: false, blocked: true, previousPath: null };
+  }
+}
+
+/**
+ * Arm both native-capture channels. Never throws.
+ *
+ * Must run BEFORE the app is ready: Chromium reads its logging switches during
+ * initialization, so appending them later is accepted and then ignored.
+ *
+ * @param {object} deps
+ * @param {string} deps.logsDir              Directory for the log file.
+ * @param {(name: string, value: string) => void} deps.appendSwitch
+ * @param {(opts: object) => void} [deps.startCrashReporter]
+ * @param {object} [deps.fs]                 Injected for the rotate step.
+ * @param {(msg: string) => void} [deps.log]
+ * @returns {{logPath: string, previousPath: string|null, rotated: boolean, blocked: boolean, switches: string[], crashReporter: boolean}}
+ */
+function initNativeLogging({
+  logsDir,
+  appendSwitch,
+  startCrashReporter,
+  fs,
+  log = () => {},
+} = {}) {
+  const logPath = nativeLogPath(logsDir);
+  const applied = [];
+  let rotated = false;
+  let blocked = false;
+  let previousPath = null;
+
+  // Before the switches: Chromium opens this path during initialization, so the
+  // previous generation has to be moved aside first or it is appended to (or
+  // clobbered) instead of preserved.
+  if (fs) ({ rotated, blocked, previousPath } = rotateNativeLog(logPath, { fs, log }));
+
+  // Fail SAFE, not fail open. A blocked rotation means the un-rotated live log
+  // still holds the session we were trying to preserve — and Chromium's own
+  // open mode for `--log-file` is not something this side can pin down, so
+  // arming the sink anyway risks it truncating exactly that evidence. Giving up
+  // this boot's logging is the cheap loss; destroying the retained crash log to
+  // start a fresh one is the expensive one. The minidump channel is unaffected
+  // and still armed below, so a crash this boot is not left undocumented.
+  if (blocked) {
+    log(
+      `native logging NOT armed: ${logPath} could not be rotated, so the file ` +
+        `sink is skipped this launch rather than risk overwriting it`
+    );
+  } else {
+    for (const [name, value] of nativeLoggingSwitches(logPath)) {
+      try {
+        appendSwitch(name, value);
+        applied.push(name);
+      } catch (e) {
+        // One rejected switch must not cost us the other, nor the boot.
+        log(`native logging switch --${name} failed: ${e && e.message}`);
+      }
+    }
+  }
+
+  let crashReporter = false;
+  if (typeof startCrashReporter === "function") {
+    try {
+      startCrashReporter({
+        // Mandatory, and the reason this is safe to ship on by default:
+        // Kiro Crew does not phone home (website/src/rum.ts is a no-op in the
+        // public build), so a dump that left the machine would be a new
+        // egress path, not a diagnostic. Dumps stay in the app's own
+        // crashDumps directory for the user to hand over deliberately.
+        uploadToServer: false,
+        compress: false,
+      });
+      crashReporter = true;
+    } catch (e) {
+      log(`crashReporter.start failed: ${e && e.message}`);
+    }
+  }
+
+  log(
+    `native logging armed: file=${blocked ? "skipped" : logPath} ` +
+      `previous=${previousPath || "none"} ` +
+      `switches=${applied.join(",") || "none"} minidumps=${crashReporter}`
+  );
+  return { logPath, previousPath, rotated, blocked, switches: applied, crashReporter };
+}
+
+module.exports = {
+  initNativeLogging,
+  nativeLogPath,
+  previousNativeLogPath,
+  nativeLoggingSwitches,
+  rotateNativeLog,
+  NATIVE_LOG_BASENAME,
+  NATIVE_LOG_PREVIOUS_BASENAME,
+};

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -165,6 +165,7 @@
       "gateway-liveness.js",
       "gateway-recovery.js",
       "renderer-recovery.js",
+      "native-logging.js",
     "pierre-perf-log.js",
       "pyspy-dump.js",
       "perf-metrics.js",

--- a/website/electron/test/native-logging.test.js
+++ b/website/electron/test/native-logging.test.js
@@ -1,0 +1,304 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+const fs = require("fs");
+const {
+  initNativeLogging,
+  nativeLogPath,
+  previousNativeLogPath,
+  nativeLoggingSwitches,
+  rotateNativeLog,
+  NATIVE_LOG_BASENAME,
+  NATIVE_LOG_PREVIOUS_BASENAME,
+} = require("../native-logging");
+
+const LIVE = path.join("/logs", NATIVE_LOG_BASENAME);
+const PREV = path.join("/logs", NATIVE_LOG_PREVIOUS_BASENAME);
+
+/**
+ * fs double over an in-memory file set, recording renames.
+ * `present` lists paths that exist; `throwOn` makes renameSync fail.
+ */
+function fakeFs({ present = [], throwOn = null } = {}) {
+  const files = new Set(present);
+  const renames = [];
+  return {
+    files,
+    renames,
+    existsSync: (p) => files.has(p),
+    renameSync(from, to) {
+      if (throwOn) throw new Error(throwOn);
+      renames.push({ from, to });
+      files.delete(from);
+      files.add(to);
+    },
+  };
+}
+
+describe("nativeLogPath / previousNativeLogPath", () => {
+  it("sits next to the other launch logs in the logs directory", () => {
+    assert.equal(nativeLogPath("/logs/Kiro Crew"), path.join("/logs/Kiro Crew", NATIVE_LOG_BASENAME));
+  });
+
+  it("keeps the previous generation beside the live file", () => {
+    assert.equal(previousNativeLogPath(LIVE), PREV);
+  });
+
+  it("does not throw on a missing directory", () => {
+    assert.equal(nativeLogPath(undefined), NATIVE_LOG_BASENAME);
+  });
+});
+
+describe("nativeLoggingSwitches", () => {
+  // These are Chromium's spellings, and an unknown switch is IGNORED rather
+  // than rejected — so a typo turns logging silently off and this assertion is
+  // the only thing standing between that and a shipped no-op.
+  it("uses the exact Chromium switch names", () => {
+    assert.deepEqual(nativeLoggingSwitches("/tmp/c.log"), [
+      ["enable-logging", "file"],
+      ["log-file", "/tmp/c.log"],
+    ]);
+  });
+
+  // `--enable-logging` without `=file` leaves output on stderr, which the GUI
+  // launch this module exists to compensate for discards again.
+  it("routes to the file sink, not stderr", () => {
+    const [[, value]] = nativeLoggingSwitches("/tmp/c.log");
+    assert.equal(value, "file");
+  });
+});
+
+describe("rotateNativeLog", () => {
+  // THE point of the whole rotation step: the run under investigation is not
+  // the run doing the investigating. A boot that destroyed the prior session
+  // would delete the evidence at the moment someone relaunched to read it.
+  it("preserves the previous session instead of discarding it", () => {
+    const fs = fakeFs({ present: [LIVE] });
+    const out = rotateNativeLog(LIVE, { fs });
+    assert.deepEqual(out, { rotated: true, blocked: false, previousPath: PREV });
+    assert.deepEqual(fs.renames, [{ from: LIVE, to: PREV }]);
+    assert.equal(fs.files.has(PREV), true);
+    // Left absent so Chromium starts clean whether it appends or truncates.
+    assert.equal(fs.files.has(LIVE), false);
+  });
+
+  // Two files, never N: the bound is one generation, so an older previous is
+  // replaced rather than accumulated. `renameSync` replaces an existing
+  // destination on Windows as well (libuv passes MOVEFILE_REPLACE_EXISTING),
+  // which `perf-metrics.js` already depends on for its rolling artifact.
+  it("overwrites an older generation instead of accumulating", () => {
+    const fs = fakeFs({ present: [LIVE, PREV] });
+    assert.equal(rotateNativeLog(LIVE, { fs }).rotated, true);
+    assert.deepEqual([...fs.files], [PREV]);
+  });
+
+  it("is a no-op on the first launch, when there is nothing to preserve", () => {
+    const fs = fakeFs({ present: [] });
+    assert.deepEqual(rotateNativeLog(LIVE, { fs }), {
+      rotated: false,
+      blocked: false,
+      previousPath: null,
+    });
+    assert.deepEqual(fs.renames, []);
+  });
+
+  // A Windows sharing violation (any open handle on either path) is the real
+  // failure mode, not the destination existing. It must report `blocked`, which
+  // is what separates it from the harmless first launch above.
+  it("reports blocked when the rename fails, never throwing", () => {
+    const fs = fakeFs({ present: [LIVE], throwOn: "EPERM" });
+    const lines = [];
+    const out = rotateNativeLog(LIVE, { fs, log: (m) => lines.push(m) });
+    assert.deepEqual(out, { rotated: false, blocked: true, previousPath: null });
+    assert.equal(fs.files.has(LIVE), true, "the live log must survive a failed rotate");
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /EPERM/);
+  });
+});
+
+describe("initNativeLogging", () => {
+  function harness(over = {}) {
+    const applied = [];
+    const started = [];
+    const lines = [];
+    const fs = over.fs === undefined ? fakeFs({ present: [LIVE] }) : over.fs;
+    const result = initNativeLogging({
+      logsDir: "/logs",
+      appendSwitch: (n, v) => applied.push([n, v]),
+      startCrashReporter: (o) => started.push(o),
+      log: (m) => lines.push(m),
+      ...over,
+      fs,
+    });
+    return { applied, started, lines, result, fs };
+  }
+
+  it("applies both switches and starts the crash reporter", () => {
+    const { applied, started, result } = harness();
+    assert.deepEqual(applied, [
+      ["enable-logging", "file"],
+      ["log-file", LIVE],
+    ]);
+    assert.equal(started.length, 1);
+    assert.equal(result.crashReporter, true);
+    assert.equal(result.rotated, true);
+    assert.equal(result.previousPath, PREV);
+    assert.deepEqual(result.switches, ["enable-logging", "log-file"]);
+  });
+
+  // The one non-negotiable option: this app does not phone home, so a minidump
+  // that left the machine would be a new egress path rather than a diagnostic.
+  it("never uploads crash dumps off the machine", () => {
+    const { started } = harness();
+    assert.equal(started[0].uploadToServer, false);
+  });
+
+  // Ordering is load-bearing: Chromium opens the log path during init, so a
+  // rotation that ran afterwards would preserve nothing.
+  it("rotates before arming the switches", () => {
+    const { fs } = harness();
+    assert.deepEqual(fs.renames, [{ from: LIVE, to: PREV }]);
+    assert.equal(fs.files.has(LIVE), false);
+  });
+
+  // A boot-path helper must never be the reason the app fails to start.
+  it("survives an appendSwitch that throws, keeping the other switch", () => {
+    const { result, lines } = harness({
+      appendSwitch: (n) => {
+        if (n === "enable-logging") throw new Error("refused");
+      },
+    });
+    assert.deepEqual(result.switches, ["log-file"]);
+    assert.ok(lines.some((l) => /refused/.test(l)));
+  });
+
+  it("survives a crashReporter that throws", () => {
+    const { result, lines } = harness({
+      startCrashReporter: () => {
+        throw new Error("no dump dir");
+      },
+    });
+    assert.equal(result.crashReporter, false);
+    assert.deepEqual(result.switches, ["enable-logging", "log-file"]);
+    assert.ok(lines.some((l) => /no dump dir/.test(l)));
+  });
+
+  it("still arms logging when no crash reporter is supplied", () => {
+    const { result, started } = harness({ startCrashReporter: undefined });
+    assert.equal(result.crashReporter, false);
+    assert.equal(started.length, 0);
+    assert.deepEqual(result.switches, ["enable-logging", "log-file"]);
+  });
+
+  it("skips rotation when no fs is supplied", () => {
+    const { result } = harness({ fs: null });
+    assert.equal(result.rotated, false);
+    assert.equal(result.blocked, false);
+    assert.equal(result.previousPath, null);
+    assert.deepEqual(result.switches, ["enable-logging", "log-file"]);
+  });
+
+  // THE fail-safe. A blocked rotation leaves the un-rotated live log holding the
+  // session we were trying to preserve, and Chromium's open mode for --log-file
+  // is not pinnable from here, so arming the sink could truncate exactly that
+  // evidence. Skipping this boot's file logging is the cheaper loss.
+  it("does NOT arm the file sink when a needed rotation failed", () => {
+    const fs = fakeFs({ present: [LIVE], throwOn: "EPERM" });
+    const { applied, result, lines } = harness({ fs });
+    assert.equal(result.blocked, true);
+    assert.deepEqual(applied, [], "no logging switch may point at an unrotated log");
+    assert.deepEqual(result.switches, []);
+    assert.equal(fs.files.has(LIVE), true, "the retained evidence must still be on disk");
+    assert.ok(lines.some((l) => /NOT armed/.test(l)));
+  });
+
+  // Minidumps go to their own directory and are unaffected by the log file, so a
+  // blocked rotation must not leave a crash this boot completely undocumented.
+  it("still arms minidumps when the file sink is skipped", () => {
+    const { started, result } = harness({ fs: fakeFs({ present: [LIVE], throwOn: "EPERM" }) });
+    assert.equal(result.blocked, true);
+    assert.equal(result.crashReporter, true);
+    assert.equal(started.length, 1);
+    assert.equal(started[0].uploadToServer, false);
+  });
+
+  it("names the skip in the verdict line rather than a file it did not arm", () => {
+    const { lines } = harness({ fs: fakeFs({ present: [LIVE], throwOn: "EPERM" }) });
+    const verdict = lines.find((l) => /native logging armed/.test(l));
+    assert.match(verdict, /file=skipped/);
+    assert.match(verdict, /switches=none/);
+    assert.match(verdict, /minidumps=true/);
+  });
+
+  it("logs a one-line verdict naming both generations", () => {
+    const { lines } = harness();
+    const verdict = lines.find((l) => /native logging armed/.test(l));
+    assert.ok(verdict, "expected an armed verdict line");
+    assert.match(verdict, /chromium\.log/);
+    assert.match(verdict, /chromium\.previous\.log/);
+    assert.match(verdict, /minidumps=true/);
+  });
+
+  it("names no previous generation on a first launch", () => {
+    const { lines, result } = harness({ fs: fakeFs({ present: [] }) });
+    assert.equal(result.previousPath, null);
+    assert.match(
+      lines.find((l) => /native logging armed/.test(l)),
+      /previous=none/
+    );
+  });
+});
+
+// main.js is not loadable under the unit runner (it requires `electron`), so the
+// call-site ORDER is asserted against its source. This is not a style check: the
+// order is the whole correctness of the rotation.
+describe("main.js call-site ordering", () => {
+  const mainSrc = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+
+  // A rejected second instance must never reach initNativeLogging. If it did, it
+  // would rename chromium.log out from under the RUNNING primary — whose open fd
+  // follows the renamed inode — and destroy the genuine previous generation, so
+  // double-clicking the icon of an already-running app would wipe exactly the
+  // evidence this capture exists to retain. `app.exit(0)` in the lock-lost branch
+  // is synchronous, so being inside the else-branch is what makes that
+  // unreachable.
+  it("arms logging only after the single-instance lock is won", () => {
+    const lock = mainSrc.indexOf("app.requestSingleInstanceLock()");
+    assert.ok(lock > 0, "expected a single-instance lock call in main.js");
+    // Anchoring on the lock CALL alone is not enough: `arm > lock` also holds
+    // when the arming sits INSIDE the lock-lost branch, which is precisely the
+    // defect. The branch boundary is the real constraint, so assert past the
+    // `} else {` that opens the lock-won branch.
+    const elseAt = mainSrc.indexOf("} else {", lock);
+    const exitAt = mainSrc.indexOf("app.exit(0)", lock);
+    const arm = mainSrc.indexOf("initNativeLogging({");
+    assert.ok(elseAt > lock, "expected a lock-won else branch after the lock call");
+    assert.ok(exitAt > lock && exitAt < elseAt, "expected app.exit(0) in the lock-lost branch");
+    assert.ok(arm > 0, "expected an initNativeLogging call in main.js");
+    assert.ok(
+      arm > elseAt,
+      "initNativeLogging must be called inside the lock-WON branch. After the " +
+        "lock call is not sufficient: from the lock-lost branch a rejected " +
+        "second instance still rotates the primary's live log"
+    );
+  });
+
+  // The other half of the same constraint: Chromium reads its logging switches
+  // during initialization, so arming after app-ready is accepted and then
+  // silently ignored — logging would simply never happen.
+  it("arms logging before the app becomes ready", () => {
+    const arm = mainSrc.indexOf("initNativeLogging({");
+    // `app.whenReady().then(` and not a bare `app.whenReady()`: the bare form
+    // also appears in prose comments, and matching one of those would let this
+    // assertion pass on an arming call that had moved after the real handler.
+    const ready = mainSrc.indexOf("app.whenReady().then(");
+    assert.ok(ready > 0, "expected an app.whenReady().then( call in main.js");
+    assert.ok(
+      arm < ready,
+      "initNativeLogging must be called BEFORE app.whenReady(), or Chromium " +
+        "ignores the logging switches"
+    );
+  });
+});


### PR DESCRIPTION
## Problem / Motivation

The desktop app's native diagnostic output goes nowhere. Chromium and V8 print to the process's raw stderr, and a GUI launch (Dock, Finder, Start menu) discards stderr entirely. It is not in the macOS unified log either — verified against a real renderer abort: `log show --last 12h` filtered to the Electron framework returned zero fatal lines.

So the single most useful sentence about a renderer death — V8's own `Fatal error in ... / Reached heap limit / invalid size` — was being thrown away. The only surviving artifact is a `KiroCrew Helper (Renderer)-*.ips` crash report, and it cannot substitute: its `asi` field is null and every frame symbol is a nearest-neighbour mismatch. Across 9 such reports the post-mortem could establish *that* the renderer died (`EXC_BREAKPOINT` on a Pierre highlight `DedicatedWorker` thread, 20 workers alive, 19 of them idle) and never *why*.

## Why it matters

`renderer-recovery.js` already heals these deaths by reloading the pane, so the user sees a brief black screen and keeps working — which means the crash is now *survivable but permanently unexplained*. Every recurrence spends the same diagnostic effort and reaches the same wall.

Asking the user to relaunch from a terminal with stderr redirected does work, but a switch someone must remember to set beforehand is a switch that is never set on the launch that actually crashed.

This is the same correction already applied to the gateway child process, whose spawn used `stdio:"ignore"` until a silent Gatekeeper SIGKILL proved that a discarded stream is a discarded bug report — see the comment above `gatewayLogPath` in `main.js`. The app's own native output is the last stream still going nowhere.

## What changed (motivation -> approach -> change)

New `website/electron/native-logging.js`, armed from `main.js` before the app is ready (Chromium reads its logging switches during initialization, so a later call is accepted and then ignored). Two channels, because neither subsumes the other:

1. **Chromium's log file** — `--enable-logging=file --log-file=<logs>/chromium.log`. Carries Chromium's `LOG()` output, renderer console errors, and GPU / network / sandbox failures.
2. **A local minidump** — `crashReporter.start({ uploadToServer: false })`, for a renderer that dies without printing anything at all.

Five decisions worth naming:

- **Bounded by rotation, not by truncation.** Neither Chromium's log file nor this app's `glog` has any rotation (`glog` is a bare `appendFileSync`), so an append-only always-on stream would grow without limit. But clearing the file at boot is the opposite mistake: **the run being debugged is almost never the run that is running.** A main-process crash, a hard quit, or simply "change the code and restart to reproduce" all end the session that holds the evidence, and a truncating boot would delete it at the exact moment someone relaunched to read it. (Only a *renderer* death is healed in-process — the narrow case, not the general one this capture exists for.) So boot renames the current log to `chromium.previous.log` and lets Chromium create a fresh one: two generations, and the last bad run stays readable from inside the run investigating it. Renaming rather than copying also makes this correct whether Chromium opens its log in append or truncate mode, since the path it opens is simply absent.

  The bound is therefore two sessions. A single session is not itself capped, because Chromium owns that file handle and nothing on this side can cap it; one session of Chromium logging is small unless something is looping — and something looping is the thing we want recorded.
- **Armed strictly inside the lock-won branch.** The arming call sits after `requestSingleInstanceLock()` succeeds, not merely early. Placed before it, a *rejected* second instance — double-clicking the icon of an already-running app — still reached the rotation and renamed `chromium.log` out from under the primary: the primary's open fd follows the renamed inode, and the genuine previous generation is destroyed. So the ordinary act of re-launching a running app would wipe exactly the evidence this capture exists to retain. `app.exit(0)` in the lock-lost branch is synchronous, so being inside the `else` is what makes that unreachable rather than merely unlikely. It is still before `app.whenReady().then(`, which is the opposite failure mode: arm after ready and Chromium silently ignores the switches, making the whole feature a no-op.
- **A blocked rotation skips the sink rather than risking the log.** The real Windows failure mode for the rename is a sharing violation — `PermissionError` when any handle is open on either path, which an AV or Search-indexer touch causes and which `src/kiro_crew/atomic_write.py` already documents. (Not the destination existing: `renameSync` is `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`, which `perf-metrics.js` already relies on for its rolling artifact.) When rotation is *needed and fails*, the un-rotated `chromium.log` still holds the session we were preserving, and Chromium's open mode for `--log-file` is not pinnable from this side — so arming the sink anyway could truncate exactly that evidence. `rotateNativeLog` therefore reports `blocked` distinctly from a first launch, and arming is skipped for that boot. Minidumps still arm, so a crash then is not undocumented. A bounded retry was deliberately not added: it buys logging *availability*, not evidence safety, and costs up to ~0.45s of synchronous boot latency.
- **`uploadToServer: false` is non-negotiable.** This app does not phone home (`website/src/rum.ts` is a no-op in the public build), so a dump that left the machine would be a new egress path rather than a diagnostic. Dumps stay in the app's own `crashDumps` directory for the user to hand over deliberately. A test pins this.
- **The main process's own fd 2 is deliberately NOT redirected.** Node exposes no `dup2`, so the only routes are a native addon or re-spawning the app with `stdio` set — a double launch that would break the single-instance lock, Dock activation, and the updater. A terminal launch stays the way to capture true raw stderr, as a deliberate debugging step rather than something the app does to itself every boot.

Neither log generation is added to the shareable diagnostics bundle: Chromium logs URLs, and the dashboard URL carries a query-string credential. They stay local files the user can choose to attach.

Module is pure logic + injected dependencies (same shape as `renderer-recovery.js` / `perf-metrics.js`), and every failure path reports rather than throws — a boot-path helper must never be the reason the app fails to start.

## Tests

`website/electron/test/native-logging.test.js`, 23 cases.

The **rotation contract** carries most of them: the previous session survives a boot, an older generation is replaced rather than accumulated (two files, never N), the live path is left *absent* so Chromium starts clean either way, a first launch is a no-op, and a failing rename reports `blocked` instead of throwing. Plus exact Chromium switch spellings (an unknown switch is *ignored*, so a typo would ship a silent no-op), file-sink routing, rotate-before-arm ordering, `uploadToServer: false`, and four degradation paths (`appendSwitch` throws and the other switch still lands; `crashReporter` throws; no reporter supplied; no `fs` supplied).

Three **fail-safe** cases cover the blocked-rotation path: no logging switch is applied when a needed rotation failed, the live log is asserted still on disk, and minidumps still arm so the boot is not left undocumented.

Two **call-site ordering** tests read `main.js` as source, because it is not loadable under the unit runner (it requires `electron`) and the ordering *is* the correctness of the rotation. Both were mutation-verified rather than assumed:

- moving the arming call above the lock fails the branch test;
- moving it *inside the lock-lost branch* — which an `arm > lock` assertion would wrongly pass — also fails it, because the assertion anchors on the `} else {` boundary;
- restoring the real ordering passes.

Gate results on this head:

- `npm --prefix website run test:electron` — **1354/1355 pass, 0 fail** (1 skipped)
- `npm --prefix website run build`, `npx tsc -b`, `npx eslint src/ --max-warnings 664`, `i18n:check`, `i18n:render`, `jscpd`, bundle-size — all clean
- frontend scoped tests — 1552 files / 24283 tests pass
- `check_brand_name`, `check_black_formatting`, `isort`, `flake8`, `mypy`, `docs-lint`, `scrub-lint`, `check_harness_parity`, `check_loop_bound_locks`, `check_changelog_history`, `check_focus_cue`, `verify_vendor_manifest`, `check_subprocess_encoding` — all clean
- backend full suite — 68922 pass, **49 pre-existing failures unrelated to this diff**. The diff touches zero Python files (`git diff origin/main...HEAD --name-only` is 4 files, all `website/electron/`), and the same failures reproduce on a clean `origin/main` checkout: missing `openpyxl`, and host-CPU/memory-dependent assertions in `test_xdist_host_budget.py`. Running the three largest of those files on a detached `origin/main` worktree gave an identical 27 failures.

## Manual verification

Not yet run against a rebuilt bundle: the installed `/Applications/KiroCrew.app` runs its frozen `app.asar`, so this needs `make desktop` before it takes effect. The check afterwards is two launches, not one — first launch creates `~/Library/Logs/Kiro Crew/chromium.log`, and the second must leave that content intact as `chromium.previous.log` while starting a fresh live file. `gateway-launch.log` carries the verdict line naming both generations (`native logging armed: file=... previous=... minidumps=true`). A third check covers the lock path: with the app already running, launching it again must leave `chromium.previous.log` untouched.

<!-- no-visual-delta -->
**Why no screenshot:** main-process only — no renderer, component, layout or i18n surface is touched, so there is no rendered delta a before/after frame could show.

no linked issue: found while diagnosing the recurring renderer aborts; no tracked issue was filed for the missing capture itself.
