### PR TITLE
refactor(voice): extract the shared push-to-talk session-ownership core (#5719)

### DIFF
--- a/website/src/hooks/usePushToTalk.ts
+++ b/website/src/hooks/usePushToTalk.ts
@@ -25,7 +25,7 @@
  *
  * ONE session serves the whole gesture. It is opened before anyone knows what
  * the press will turn out to be, so ownership — not intent-at-open — decides its
- * fate (`ownerRef`):
+ * fate (the session core's `owner`):
  *
  * | the press turns out to be      | what happens to that session      |
  * |--------------------------------|-----------------------------------|
@@ -38,35 +38,47 @@
  * Nothing is transmitted for a discarded press: `useStreamingStt` buffers PCM
  * locally until the server's `ready` frame, which lands well after the threshold
  * has already resolved the gesture, so `cancel()` drops the buffer unsent.
+ *
+ * The ownership machinery itself — who owns the session, the in-flight-startup
+ * flag, the startup sequence, the hard-cap timer — lives in
+ * {@link createPttSession}, shared with the touch transport. This hook keeps
+ * only what is keyboard: key/chord matching, the latch, and the reconciliation
+ * paths a keyboard needs (a keyup that never arrives, a chord joining a held
+ * modifier, blur and visibility loss).
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   loadPttConfig,
   matchesBinding,
-  MAX_HOLD_MS,
   PTT_CHANGED_EVENT,
   type PttConfig,
   isBareModifier,
   stillHeld,
 } from '../lib/pushToTalk'
+import {
+  createPttSession,
+  type PttPhase,
+  type PttSession,
+  type VoiceControls,
+} from '../lib/pttSession'
 
-/** The slice of `useVoiceInput` this hook drives. */
-export interface VoiceControls {
-  recording: boolean
-  start: () => Promise<void> | void
-  stop: () => void
-  /**
-   * End capture WITHOUT transcribing, and release whatever was acquired.
-   *
-   * This is the discard for a press that never became a recording. On the
-   * streaming path it also drops the locally-buffered PCM, which is why a
-   * discarded press transmits nothing.
-   */
-  cancel: () => void
-}
+// The interface predates the shared core and every consumer (including both
+// hook test suites) imports it from here, so it stays part of this module's
+// public surface.
+export type { VoiceControls }
 
-type Phase = 'idle' | 'arming' | 'holding'
+type Phase = PttPhase
+
+/**
+ * The keyboard's owner kinds.
+ *
+ *   `'gesture'` — the key press that opened the session.
+ *   `'latch'`   — a deliberate tap-latch or toggle. Outlives the keypress, so
+ *                 an idle phase is expected and must not stop it — which is
+ *                 exactly what the `isLatched` predicate below tells the core.
+ */
+type KeyOwner = 'gesture' | 'latch'
 
 export interface UsePushToTalkOpts {
   /** Disable entirely (e.g. STT off, or a modal owns the keyboard). */
@@ -91,117 +103,6 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
   const setPhase = useCallback((p: Phase) => { phaseRef.current = p; setPhaseState(p) }, [])
 
   const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  /**
-   * The in-flight `start()`: what it was opened FOR, or null when none is
-   * pending. Set from just before the call until its promise settles.
-   *
-   *   `'hold'`  — a hold whose release must end the session.
-   *   `'latch'` — a deliberate toggle / tap-latch that must OUTLIVE the keypress.
-   *
-   * Load-bearing for the stuck-mic guarantee, because a startup can fail to
-   * settle AT ALL: the streaming path awaits a `ready` frame from the backend,
-   * and a socket that opens and then goes silent leaves that await pending
-   * forever. Any cleanup that runs only in the promise's own `.then()` therefore
-   * inherits its liveness, and the hard cap — the one mechanism that does not —
-   * has already been cleared by the time the key comes up. So every teardown in
-   * this window runs SYNCHRONOUSLY off this ref instead of awaiting anything.
-   *
-   * The KIND is what two decisions turn on, neither of which can read
-   * `voice.recording` (false for the whole `getUserMedia` + handshake window):
-   *
-   *   1. The settle handler telling an ORPHAN (a hold whose key is already up)
-   *      from a LATCH the user wants left running.
-   *   2. A second press cancelling a startup that has not gone live yet. Testing
-   *      `recording` alone let that press fall through and open a SECOND
-   *      `start()`, which `useVoiceInput`'s re-entrancy guard swallowed — so the
-   *      FIRST startup still went live and the mic stayed on with the user
-   *      believing they had just switched it off.
-   *
-   * Whether teardown commits or discards depends on the transport, not the kind:
-   * streaming has a live socket buffering real PCM, batch has no recorder yet.
-   * `cancel()` is the only call that aborts a batch startup — it releases the
-   * warm mic so `acquireWarm` rejects instead of handing back a stream — and it
-   * is also what releases the stream when startup REJECTS, since
-   * `useStreamingStt` builds its `AudioContext` and worklet after the handshake
-   * outside any `try` and `useVoiceInput` re-raises rather than catching.
-   */
-  /**
-   * Who owns the open session right now, or null when nobody does.
-   *
-   *   `'gesture'` — the key press that opened it. Owns it while `phase` is
-   *                 `arming` or `holding`; once `phase` returns to `idle` with
-   *                 this owner still set, the session is an ORPHAN.
-   *   `'latch'`   — a deliberate tap-latch or toggle. Outlives the keypress, so
-   *                 an idle phase is expected and must not stop it.
-   *
-   * The session is opened on keydown, BEFORE anyone knows whether the press is a
-   * tap, a hold, or a chord — so intent cannot be recorded at open time the way
-   * it could when `start()` waited for the threshold. Ownership is written when
-   * the gesture RESOLVES, and every teardown clears it, which is what lets the
-   * settle handler tell "still wanted" from "nothing is holding this any more".
-   */
-  const ownerRef = useRef<'gesture' | 'latch' | null>(null)
-  /**
-   * True while `start()`'s async startup is in flight.
-   *
-   * Load-bearing for the stuck-mic guarantee, because a startup can fail to
-   * settle AT ALL: the streaming path awaits a `ready` frame from the backend,
-   * and a socket that opens and then goes silent leaves that await pending
-   * forever. Any cleanup that runs only in the promise's own `.then()` therefore
-   * inherits its liveness, and the hard cap — the one mechanism that does not —
-   * may already have been cleared. So every teardown in this window runs
-   * SYNCHRONOUSLY off this ref instead of awaiting anything.
-   *
-   * It is also the only way to know a session exists at all before it goes live:
-   * `voice.recording` stays false for the whole `getUserMedia` + handshake
-   * window, so a second press that tested only `recording` fell through and
-   * opened a SECOND `start()` — which `useVoiceInput`'s re-entrancy guard
-   * swallowed, leaving the first startup to go live against a user who had just
-   * pressed to switch it off.
-   *
-   * Whether teardown commits or discards turns on `voice.recording` — "has
-   * capture actually begun" — NOT on which transport is in use. `useStreamingStt`
-   * flips recording true at the exact moment it has wired the worklet and PCM is
-   * buffering, and only THEN awaits the server's `ready` frame, so:
-   *
-   *   - `recording` true  → real audio exists (buffered, pre-`ready`). `stop()`
-   *     commits it; it sends the stop frame and arms its own force-cleanup.
-   *   - `recording` false → still inside `getUserMedia`/permission. Nothing was
-   *     captured and there is no socket, so `stop()` is a NO-OP and the startup
-   *     would run to completion and go live after the release. Only `cancel()`
-   *     aborts it.
-   *
-   * Keying this on `streamEnabled` instead was too coarse: it committed on the
-   * streaming transport even when the release beat the permission grant, which
-   * let a session open — and transmit post-release audio — for a press the user
-   * had already finished. `cancel()` is also what releases a half-acquired stream
-   * when startup REJECTS, since `useStreamingStt` builds its `AudioContext` and
-   * worklet after the handshake outside any `try` and `useVoiceInput` re-raises
-   * rather than catching.
-   */
-  const startPendingRef = useRef(false)
-  /**
-   * Monotonic per-`start()` sequence, bumped at EVERY call site AND by any
-   * teardown that supersedes a pending startup.
-   *
-   * Lets a late-resolving startup tell "the session I opened" from "a session
-   * someone else opened after me". Without it the settle handler's phase test is
-   * an unconditional "not mine" and stops whatever is live — so a user who
-   * releases and then immediately taps to latch (or clicks the mic button)
-   * inside the `getUserMedia` window gets their new session killed by the old
-   * hold's resolution. `useVoiceInput`'s own re-entrancy guard swallows that
-   * second `start()`, so the FIRST promise is the one that actually goes live,
-   * and leaving it running is what the user asked for.
-   */
-  const startSeqRef = useRef(0)
-  /**
-   * Bumped on every arm AND by `disarm`, so a timer armed by an earlier hold
-   * cannot fire against a later one. Deliberately NOT the guard for the async
-   * `start()` resolution -- `disarm` bumping it is exactly what made that guard
-   * dead; see `beginHold`.
-   */
-  const genRef = useRef(0)
   // Live refs for the voice controls: the document-level listeners are bound
   // once, so reading through refs avoids re-binding them whenever the parent
   // re-renders and hands over new callback identities.
@@ -211,6 +112,41 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
   cfgRef.current = cfg
   const disabledRef = useRef(disabled)
   disabledRef.current = disabled
+
+  /**
+   * Late-bound seams the session core calls back into. `disarm` and the reset
+   * path are defined below in terms of the core, so they cannot be closed over
+   * at construction time; the core reads whatever this ref holds at call time,
+   * and every render re-points it at the current callbacks.
+   */
+  const coreSeamsRef = useRef({ resetToIdle: () => {}, disarm: (_commit: boolean) => {} })
+
+  /**
+   * The shared session-ownership core. Constructed once — it holds the owner,
+   * the pending-startup flag, the startup sequence, the gesture generation and
+   * the hard-cap timer, all of which must survive re-renders the same way a
+   * ref does.
+   *
+   * The keyboard's parameterization:
+   *   - `isLatched` names the owner kind that outlives its gesture, feeding
+   *     the settle handler's latch branch.
+   *   - `disownPendingOnRelinquish` stays OFF: every teardown here clears the
+   *     owner but deliberately leaves the startup sequence alone, so a startup
+   *     that ignores the teardown and goes live anyway is still caught and
+   *     stopped by its settle handler.
+   */
+  const sessionRef = useRef<PttSession<KeyOwner> | null>(null)
+  if (!sessionRef.current) {
+    sessionRef.current = createPttSession<KeyOwner>({
+      voice: () => voiceRef.current,
+      phase: () => phaseRef.current,
+      setPhase,
+      resetToIdle: () => { coreSeamsRef.current.resetToIdle() },
+      disarm: (commit) => { coreSeamsRef.current.disarm(commit) },
+      isLatched: (owner) => owner === 'latch',
+    })
+  }
+  const session = sessionRef.current
 
   useEffect(() => {
     const onChange = () => setCfg(loadPttConfig())
@@ -226,14 +162,25 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
 
   const clearTimers = useCallback(() => {
     if (armTimerRef.current) { clearTimeout(armTimerRef.current); armTimerRef.current = null }
-    if (capTimerRef.current) { clearTimeout(capTimerRef.current); capTimerRef.current = null }
-  }, [])
+    session.clearCapTimer()
+  }, [session])
+
+  /**
+   * The reset the core runs on a FAILED startup: timers, generation, phase —
+   * the keyboard has no other per-gesture state to clear.
+   */
+  const resetToIdle = useCallback(() => {
+    clearTimers()
+    session.bumpGeneration()
+    if (phaseRef.current !== 'idle') setPhase('idle')
+  }, [clearTimers, session, setPhase])
+  coreSeamsRef.current.resetToIdle = resetToIdle
 
   /** Leave any armed/holding state, committing (`stop`) or discarding as told. */
   const disarm = useCallback((commit: boolean) => {
     const was = phaseRef.current
     clearTimers()
-    genRef.current++
+    session.bumpGeneration()
     setPhase('idle')
     if (was === 'holding') {
       // Startup still in flight. What that means depends on the path:
@@ -246,15 +193,15 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       //     force-cleanup either way, so the stuck-mic ceiling still holds.
       //   - BATCH has no recorder yet, so nothing was captured; `stop()` would
       //     do nothing at all, and only `cancel()` actually aborts the startup.
-      if (startPendingRef.current) {
+      if (session.startPending()) {
         // Clear the OWNER but leave the sequence alone: the settle handler is the
         // backstop for a startup that ignores this teardown and goes live
         // anyway, and bumping the sequence would make it read as stale and skip.
-        ownerRef.current = null
+        session.setOwner(null)
         if (voiceRef.current.recording) voiceRef.current.stop()
         else voiceRef.current.cancel()
       } else {
-        ownerRef.current = null
+        session.setOwner(null)
         // `recording`, not `startPending`, is the boundary that decides whether
         // `stop()` can reach anything — and this branch can be entered with a
         // startup STILL IN FLIGHT that we do not own. A mic-button start leaves
@@ -276,105 +223,11 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       // seconds later), so `cancel()` drops that buffer unsent instead of
       // shipping half a keystroke to the transcriber. Batch has no recorder yet,
       // and `cancel()` aborts its acquisition either way.
-      ownerRef.current = null
+      session.setOwner(null)
       voiceRef.current.cancel()
     }
-  }, [clearTimers, setPhase])
-
-  /**
-   * Startup SUCCEEDED — and is the LAST line of defence for a stuck mic, so it
-   * decides from the state that exists NOW rather than from the intent it was
-   * opened with:
-   *
-   *   - owner `'latch'` — a tap-latch or toggle. Meant to outlive the keypress,
-   *     so an idle phase is expected. Leave it running.
-   *   - owner `'gesture'` with a non-idle phase — the key is still down (arming
-   *     or holding). Leave it running; the release path owns the ending.
-   *   - anything else — the owner was cleared by a teardown, or the gesture ended
-   *     while startup was still in flight (no keyup coming, cap timer cleared) —
-   *     is an ORPHAN. Stop it.
-   *
-   * Every teardown in the startup window clears `ownerRef` and deliberately does
-   * NOT touch `seq`, so this handler still runs and can catch a startup that
-   * ignored that teardown and went live regardless.
-   *
-   * The liveness test is the PHASE, not the generation: `disarm` bumps `genRef`,
-   * so a generation comparison here is always false by the time a released hold
-   * resolves; it reads like a guard and is dead code. And it is scoped to `seq`
-   * so it only ever stops the session this call opened.
-   */
-  const settleStart = useCallback((seq: number) => {
-    if (startSeqRef.current !== seq) return
-    startPendingRef.current = false
-    const owner = ownerRef.current
-    if (owner === 'latch') return
-    if (owner === 'gesture' && phaseRef.current !== 'idle') return
-    ownerRef.current = null
-    voiceRef.current.stop()
-  }, [])
-
-  /**
-   * Startup FAILED. Nothing to commit, and a rejection can arrive with resources
-   * already half-acquired: `useStreamingStt` builds its `AudioContext` and worklet
-   * AFTER `getUserMedia` and the socket handshake, outside any `try`, and
-   * `useVoiceInput`'s streaming branch re-raises rather than catching. So a throw
-   * there leaves the mic stream open with no session to stop — `cancel()` is what
-   * tears it down.
-   *
-   * Scoped to `seq`, so a superseded startup's rejection cannot tear down the
-   * session that replaced it. Resets the phase directly rather than through
-   * `disarm`: with no session left there is nothing to commit on a later keyup,
-   * and leaving `phase` at `arming`/`holding` would let the release path try.
-   */
-  const failStart = useCallback((seq: number) => {
-    if (startSeqRef.current !== seq) return
-    startPendingRef.current = false
-    const owner = ownerRef.current
-    ownerRef.current = null
-    clearTimers()
-    genRef.current++
-    if (phaseRef.current !== 'idle') setPhase('idle')
-    if (owner !== null) voiceRef.current.cancel()
-  }, [clearTimers, setPhase])
-
-  /**
-   * Open a session for the press that just started, and track the pending startup
-   * so both a late resolution and a second press can reach it. EVERY `start()` in
-   * this hook goes through here — a call site that skipped it left no way to
-   * reach its own startup.
-   */
-  const launch = useCallback((owner: 'gesture' | 'latch') => {
-    ownerRef.current = owner
-    startPendingRef.current = true
-    const seq = ++startSeqRef.current
-    const started = voiceRef.current.start()
-    if (started && typeof (started as Promise<void>).then === 'function') {
-      void (started as Promise<void>).then(
-        () => { settleStart(seq) },
-        () => { failStart(seq) },
-      )
-    } else {
-      // Synchronous control (or one returning nothing): no startup window to
-      // guard, so leave the owner in place and nothing pending.
-      startPendingRef.current = false
-    }
-  }, [settleStart, failStart])
-
-  /**
-   * The threshold passed, so the press is a HOLD. Capture has been running since
-   * keydown — this only relabels the phase and arms the ceiling. There is no
-   * `start()` here: a second one would be swallowed by `useVoiceInput`'s
-   * re-entrancy guard, and the session opened on keydown is the one that already
-   * has the opening word in it.
-   */
-  const beginHold = useCallback(() => {
-    const gen = ++genRef.current
-    setPhase('holding')
-    // Hard ceiling: a release we never hear about must not hold the mic forever.
-    capTimerRef.current = setTimeout(() => {
-      if (genRef.current === gen && phaseRef.current === 'holding') disarm(true)
-    }, MAX_HOLD_MS)
-  }, [disarm, setPhase])
+  }, [clearTimers, session, setPhase])
+  coreSeamsRef.current.disarm = disarm
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -421,11 +274,11 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       // than "ending" a session nobody holds.
       if (phaseRef.current === 'idle'
           && (voiceRef.current.recording
-              || (startPendingRef.current && ownerRef.current !== null))) {
-        const pending = startPendingRef.current
+              || (session.startPending() && session.owner() !== null))) {
+        const pending = session.startPending()
         // Clear the owner so the settle handler stops the session if the startup
         // lands anyway, but leave the sequence alone so that handler still runs.
-        ownerRef.current = null
+        session.setOwner(null)
         if (pending) {
           // Startup still in flight: commit only if capture has actually begun
           // (`recording`), otherwise `stop()` is a no-op and the startup would
@@ -451,7 +304,7 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
         // hides the cutoff row for it), so the press simply stays `arming` until
         // it is released, joined by another key, or the window loses focus.
         setPhase('arming')
-        launch('gesture')
+        session.launch('gesture')
         return
       }
       setPhase('arming')
@@ -460,10 +313,10 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       // the threshold plus the mic (and, on streaming, the Transcribe
       // handshake). Whichever way the gesture resolves, THIS session is the one
       // that serves it — or gets discarded unsent.
-      launch('gesture')
+      session.launch('gesture')
       armTimerRef.current = setTimeout(() => {
         armTimerRef.current = null
-        if (phaseRef.current === 'arming') beginHold()
+        if (phaseRef.current === 'arming') session.beginHold()
       }, holdMs)
     }
 
@@ -480,7 +333,7 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       }
       // Released before the threshold — a TAP.
       clearTimers()
-      genRef.current++
+      session.bumpGeneration()
       setPhase('idle')
       if (mode === 'hybrid' || mode === 'toggle') {
         // Latch on by ADOPTING the session this press already opened — no second
@@ -488,11 +341,11 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
         // opened with) is already in it. Ownership moves from the gesture to the
         // latch, which is what tells a late-resolving startup to leave it alone.
         // Toggle mode arrives here for every release, since it never arms a hold.
-        ownerRef.current = 'latch'
+        session.setOwner('latch')
       } else {
         // Pure push-to-talk: a tap means nothing, so discard. `cancel()` drops
         // the streaming buffer before its `ready` frame — nothing was sent.
-        ownerRef.current = null
+        session.setOwner(null)
         voiceRef.current.cancel()
       }
     }
@@ -513,7 +366,7 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       window.removeEventListener('blur', onBlur)
       document.removeEventListener('visibilitychange', onVisibility)
     }
-  }, [beginHold, clearTimers, disarm, launch, setPhase])
+  }, [clearTimers, disarm, session, setPhase])
 
   // Unmounting mid-hold would orphan the timers AND the session. The key-up
   // listener goes away with this effect, so after unmount nothing is left that
@@ -526,9 +379,9 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
   // `disarm` calls setPhase, and this runs while the component is going away.
   useEffect(() => () => {
     clearTimers()
-    const pending = startPendingRef.current
-    const owner = ownerRef.current
-    ownerRef.current = null
+    const pending = session.startPending()
+    const owner = session.owner()
+    session.setOwner(null)
     if (pending) {
       // Startup still in flight: commit buffered audio only if capture began,
       // otherwise abort it — `stop()` cannot reach a socket that does not exist.
@@ -541,7 +394,7 @@ export function usePushToTalk(voice: VoiceControls, { disabled }: UsePushToTalkO
       if (phaseRef.current === 'arming') voiceRef.current.cancel()
       else voiceRef.current.stop()
     }
-  }, [clearTimers])
+  }, [clearTimers, session])
 
   return { config: cfg, phase, holding: phase === 'holding' }
 }

--- a/website/src/hooks/useTouchPushToTalk.ts
+++ b/website/src/hooks/useTouchPushToTalk.ts
@@ -15,10 +15,11 @@
  *    └─────────────────────┴──────────────────────────┘
  * ```
  *
- * Everything load-bearing is inherited from the keyboard hook and the reasons
+ * Everything load-bearing is shared with the keyboard hook through
+ * {@link createPttSession} — the ownership machinery itself — and the reasons
  * are recorded there rather than repeated here: capture opens on the DOWN (not
  * at the threshold) so the opening word is in the recording; ONE session serves
- * the whole gesture and `ownerRef` decides its fate when the gesture RESOLVES;
+ * the whole gesture and its owner decides its fate when the gesture RESOLVES;
  * `voice.recording` — not the transport, not `startPending` — is what decides
  * whether a teardown may commit.
  *
@@ -41,11 +42,15 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   loadPttConfig,
-  MAX_HOLD_MS,
   PTT_CHANGED_EVENT,
   type PttConfig,
 } from '../lib/pushToTalk'
-import { type VoiceControls } from './usePushToTalk'
+import {
+  createPttSession,
+  type PttPhase,
+  type PttSession,
+  type VoiceControls,
+} from '../lib/pttSession'
 
 /**
  * Upward travel, in CSS px, that arms the discard.
@@ -58,7 +63,7 @@ import { type VoiceControls } from './usePushToTalk'
  */
 export const CANCEL_THRESHOLD_PX = 56
 
-type Phase = 'idle' | 'arming' | 'holding'
+type Phase = PttPhase
 
 export interface UseTouchPushToTalkOpts {
   /**
@@ -99,11 +104,11 @@ export interface TouchPushToTalkState {
   /**
    * True while a live gesture owns the capture session: set at the pointerdown
    * that opens capture, relinquished when the gesture resolves — release,
-   * cancel, failed start, abandon. Exported from `ownerRef` itself so the
-   * consumer never has to infer ownership from a mounted DOM node or from a
-   * recording flag: both proxies also match captures opened elsewhere (the mic
-   * button, the keyboard binding on a device that has both inputs), which is the
-   * defect class this export closes (#5753).
+   * cancel, failed start, abandon. Exported from the session core's owner
+   * itself so the consumer never has to infer ownership from a mounted DOM
+   * node or from a recording flag: both proxies also match captures opened
+   * elsewhere (the mic button, the keyboard binding on a device that has both
+   * inputs), which is the defect class this export closes (#5753).
    *
    * Deliberately NOT true through the post-release drain — a commit relinquishes
    * ownership at the release, and `bar === 'settling'` is the name for what
@@ -147,30 +152,16 @@ export function useTouchPushToTalk(
   }, [])
 
   const armTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   /**
-   * Whether this gesture owns the capture session.
-   *
-   * A press owns its session from `pointerdown` to `pointerup`, so ownership and
-   * the gesture's own phase never disagree for long — but `ownerRef` is still the
-   * authority rather than `phase`, because a startup can be in flight while the
-   * phase has already moved on, and `setOwner(null)` is what invalidates it.
-   *
-   * Every write goes through `setOwner`. That is deliberate rather than tidy:
-   * state cleared on some exit paths and not others is the exact defect class
-   * this hook has already been fixed for twice.
-   */
-  const ownerRef = useRef<'gesture' | null>(null)
-  /**
-   * Render-visible mirror of `ownerRef`, exported as `owns`. Written ONLY by
-   * `setOwner`, so the ref keeps its sole-writer property and stays the
-   * synchronous authority the handlers read; this is the same fact at render
-   * time. A ref alone cannot be exported — reading it during render is
-   * unobservable, so a consumer's predicate would not recompute when ownership
-   * changes. Mirrored the same way `phase` is, and for the same reason.
+   * Render-visible mirror of the session core's owner, exported as `owns`.
+   * Written ONLY through the core's `onOwnerChange` seam, so the core keeps
+   * its sole-writer property and stays the synchronous authority the handlers
+   * read; this is the same fact at render time. The core's owner alone cannot
+   * be exported — reading it during render is unobservable, so a consumer's
+   * predicate would not recompute when ownership changes. Mirrored the same
+   * way `phase` is, and for the same reason.
    */
   const [owns, setOwns] = useState(false)
-  const startPendingRef = useRef(false)
   /**
    * This gesture committed and its capture has not finished draining yet.
    *
@@ -196,8 +187,6 @@ export function useTouchPushToTalk(
     setTapCue(true)
     cueTimerRef.current = setTimeout(() => { cueTimerRef.current = null; setTapCue(false) }, TAP_CUE_MS)
   }, [])
-  const startSeqRef = useRef(0)
-  const genRef = useRef(0)
   /** Y where the press began, in client coords — the origin the drag measures from. */
   const originYRef = useRef(0)
   /** The pointer this gesture owns. A second finger must not steer it. */
@@ -209,6 +198,46 @@ export function useTouchPushToTalk(
   cfgRef.current = cfg
   const disabledRef = useRef(disabled)
   disabledRef.current = disabled
+
+  /**
+   * Late-bound seams the session core calls back into. `disarm` and `toIdle`
+   * are defined below in terms of the core, so they cannot be closed over at
+   * construction time; the core reads whatever this ref holds at call time,
+   * and every render re-points it at the current callbacks.
+   */
+  const coreSeamsRef = useRef({ resetToIdle: () => {}, disarm: (_commit: boolean) => {} })
+
+  /**
+   * The shared session-ownership core. Constructed once — it holds the owner,
+   * the pending-startup flag, the startup sequence, the gesture generation and
+   * the hard-cap timer, all of which must survive re-renders the same way a
+   * ref does.
+   *
+   * The touch parameterization — the full argument for each policy lives on
+   * {@link PttSessionDeps}, the single place it is kept current:
+   *   - No `isLatched`: nothing here survives its own gesture. A tap does NOT
+   *     latch a running session — `VoiceControls` reports neither a refused
+   *     start nor a session end, so a latch invariant here has nothing sound
+   *     to stand on; tap-to-latch returns when the controls can report those
+   *     two facts.
+   *   - `disownPendingOnRelinquish` is ON: a replacement session on touch can
+   *     come from the mic button, a surface this hook never sees, so an
+   *     abandoned startup must be invalidated by sequence.
+   *   - `onOwnerChange` mirrors ownership into the render-visible `owns`.
+   */
+  const sessionRef = useRef<PttSession<'gesture'> | null>(null)
+  if (!sessionRef.current) {
+    sessionRef.current = createPttSession<'gesture'>({
+      voice: () => voiceRef.current,
+      phase: () => phaseRef.current,
+      setPhase,
+      resetToIdle: () => { coreSeamsRef.current.resetToIdle() },
+      disarm: (commit) => { coreSeamsRef.current.disarm(commit) },
+      disownPendingOnRelinquish: true,
+      onOwnerChange: (owner) => setOwns(owner !== null),
+    })
+  }
+  const session = sessionRef.current
 
   useEffect(() => {
     const onChange = () => setCfg(loadPttConfig())
@@ -222,8 +251,29 @@ export function useTouchPushToTalk(
 
   const clearTimers = useCallback(() => {
     if (armTimerRef.current) { clearTimeout(armTimerRef.current); armTimerRef.current = null }
-    if (capTimerRef.current) { clearTimeout(capTimerRef.current); capTimerRef.current = null }
-  }, [])
+    session.clearCapTimer()
+  }, [session])
+
+  /**
+   * Return the machine to idle, clearing EVERY piece of per-gesture state.
+   *
+   * A helper rather than four hand-written resets, because that is exactly what
+   * the misses looked like: a failed startup once cleared the phase and the
+   * cancel flag but left `pointerIdRef` set, and since `onPointerDown` refuses
+   * a press while that ref is non-null, ONE rejected streaming `start()` killed
+   * the hold target outright until the composer remounted. Ownership is
+   * deliberately NOT reset here: a startup can still be in flight when the
+   * phase resets, and only the call site knows whether that startup should be
+   * disowned, so it stays where the intent is visible.
+   */
+  const toIdle = useCallback(() => {
+    clearTimers()
+    session.bumpGeneration()
+    setPhase('idle')
+    setArmedCancel(false)
+    pointerIdRef.current = null
+  }, [clearTimers, session, setPhase, setArmedCancel])
+  coreSeamsRef.current.resetToIdle = toIdle
 
   /**
    * Leave any armed/holding state, committing (`stop`) or discarding as told.
@@ -234,59 +284,11 @@ export function useTouchPushToTalk(
    * live afterwards with nobody watching it — so only `cancel()` can end that
    * window. See `usePushToTalk.disarm` for the full argument.
    */
-  /**
-   * Return the machine to idle, clearing EVERY piece of per-gesture state.
-   *
-   * A helper rather than four hand-written resets, because that is exactly what
-   * the misses looked like: `failStart` cleared the phase and the cancel flag but
-   * left `pointerIdRef` set, and since `onPointerDown` refuses a press while that
-   * ref is non-null, ONE rejected streaming `start()` killed the hold target
-   * outright until the composer remounted. Ownership is deliberately NOT reset
-   * here: a startup can still be in flight when the phase resets, and only the
-   * call site knows whether that startup should be disowned, so it stays where
-   * the intent is visible.
-   */
-  const toIdle = useCallback(() => {
-    clearTimers()
-    genRef.current++
-    setPhase('idle')
-    setArmedCancel(false)
-    pointerIdRef.current = null
-  }, [clearTimers, setPhase, setArmedCancel])
-
-  /** The ONLY writer of `ownerRef`.
-   *
-   *  Relinquishing ownership (`null`) also DISOWNS any startup still in flight.
-   *  Without that, `settleStart`'s sequence guard stayed valid across a teardown:
-   *  a gesture abandoned during mic acquisition left `startSeqRef` unchanged, so
-   *  when its startup finally resolved — after the user had switched to the
-   *  keyboard and begun an ordinary dictation — `settleStart` found the sequence
-   *  still matching and ownership cleared, and called `stop()` on the REPLACEMENT
-   *  session, truncating speech it had nothing to do with.
-   *
-   *  The sibling keyboard hook leaves the sequence alone deliberately, so that a
-   *  startup which ignores teardown and goes live anyway still gets stopped. That
-   *  reasoning does not transfer here: a replacement session on touch can come
-   *  from the mic button (ChatPage's own `startVoice`), which this hook never sees
-   *  and whose sequence it therefore cannot distinguish from its own. The orphan
-   *  case is already covered without this: every teardown calls `cancel()` or
-   *  `stop()` on the transport synchronously, and `useVoiceInput.cancel()` bumps
-   *  its OWN generation so the abandoned `start()` returns early and never claims
-   *  anything. */
-  const setOwner = useCallback((owner: 'gesture' | null) => {
-    ownerRef.current = owner
-    setOwns(owner !== null)
-    if (owner === null) {
-      startSeqRef.current++
-      startPendingRef.current = false
-    }
-  }, [])
-
   const disarm = useCallback((commit: boolean) => {
     const was = phaseRef.current
     toIdle()
     if (was === 'idle') return
-    setOwner(null)
+    session.setOwner(null)
     // `arming` never commits: the press never became a hold, so there is at most
     // a locally-buffered fragment and `cancel()` drops it unsent.
     if (commit && was === 'holding' && voiceRef.current.recording) {
@@ -302,47 +304,8 @@ export function useTouchPushToTalk(
       setDraining(true)
       voiceRef.current.stop()
     } else voiceRef.current.cancel()
-  }, [toIdle, setOwner])
-
-  const settleStart = useCallback((seq: number) => {
-    if (startSeqRef.current !== seq) return
-    startPendingRef.current = false
-    if (ownerRef.current === 'gesture' && phaseRef.current !== 'idle') return
-    setOwner(null)
-    voiceRef.current.stop()
-  }, [setOwner])
-
-  const failStart = useCallback((seq: number) => {
-    if (startSeqRef.current !== seq) return
-    startPendingRef.current = false
-    const owner = ownerRef.current
-    setOwner(null)
-    toIdle()
-    if (owner !== null) voiceRef.current.cancel()
-  }, [toIdle, setOwner])
-
-  const launch = useCallback((owner: 'gesture') => {
-    setOwner(owner)
-    startPendingRef.current = true
-    const seq = ++startSeqRef.current
-    const started = voiceRef.current.start()
-    if (started && typeof (started as Promise<void>).then === 'function') {
-      void (started as Promise<void>).then(
-        () => { settleStart(seq) },
-        () => { failStart(seq) },
-      )
-    } else {
-      startPendingRef.current = false
-    }
-  }, [settleStart, failStart, setOwner])
-
-  const beginHold = useCallback(() => {
-    const gen = ++genRef.current
-    setPhase('holding')
-    capTimerRef.current = setTimeout(() => {
-      if (genRef.current === gen && phaseRef.current === 'holding') disarm(true)
-    }, MAX_HOLD_MS)
-  }, [disarm, setPhase])
+  }, [toIdle, session])
+  coreSeamsRef.current.disarm = disarm
 
   /**
    * Give up whatever this gesture owns because its TARGET is going away — hold
@@ -383,9 +346,9 @@ export function useTouchPushToTalk(
       // went live anyway, against a user who believed they had just stopped it.
       // Testing `recording` alone let a press inside the acquisition window fall
       // through, which is why the pending term is here.
-      if (voiceRef.current.recording || (startPendingRef.current && ownerRef.current !== null)) {
+      if (voiceRef.current.recording || (session.startPending() && session.owner() !== null)) {
         toIdle()
-        setOwner(null)
+        session.setOwner(null)
         if (voiceRef.current.recording) voiceRef.current.stop()
         else voiceRef.current.cancel()
         return
@@ -406,10 +369,10 @@ export function useTouchPushToTalk(
       }
       setArmedCancel(false)
       setPhase('arming')
-      launch('gesture')
-      const gen = genRef.current
+      session.launch('gesture')
+      const gen = session.generation()
       armTimerRef.current = setTimeout(() => {
-        if (genRef.current === gen && phaseRef.current === 'arming') beginHold()
+        if (session.generation() === gen && phaseRef.current === 'arming') session.beginHold()
       }, cfgRef.current.holdMs)
     }
 
@@ -439,13 +402,8 @@ export function useTouchPushToTalk(
        * opening word is never clipped, but a press that never became a hold is
        * not a recording the user asked for, and the fragment goes unsent.
        *
-       * A tap does NOT latch a running session. A latch survives its own gesture,
-       * which means the hook would have to keep an invariant over a session whose
-       * end it does not control -- and `VoiceControls` reports neither a refused
-       * start nor a session end, so every version of that invariant was built on
-       * a flag meaning something else. Four separate defects came out of it, all
-       * of them a bar claiming "Tap to stop" over a microphone that was not open.
-       * Tap-to-latch returns when the controls can report those two facts.
+       * A tap does NOT latch a running session — see the session construction
+       * comment above for why tap-to-latch is deliberately absent here.
        *
        * The discard is ACKNOWLEDGED rather than silent: capture opened on the
        * press, so a fragment really was dropped, and the most likely first gesture
@@ -492,7 +450,7 @@ export function useTouchPushToTalk(
     // Rebinds whenever the target appears, changes, or unmounts — which is the
     // whole reason this takes an element rather than a ref. Everything else is
     // read through refs, so a parent re-render does not re-bind.
-  }, [target, launch, disarm, beginHold, toIdle, abandon, setPhase, setArmedCancel, setOwner, showTapCue, clearTapCue])
+  }, [target, session, disarm, toIdle, abandon, setPhase, setArmedCancel, showTapCue, clearTapCue])
 
   /*
    * Close the drain the moment capture actually ends.

--- a/website/src/lib/pttSession.test.ts
+++ b/website/src/lib/pttSession.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createPttSession, type PttPhase, type PttSessionDeps, type VoiceControls } from './pttSession'
+import { MAX_HOLD_MS } from './pushToTalk'
+
+/**
+ * The transports' behavior is pinned end-to-end by the two hook suites
+ * (usePushToTalk.test.ts, useTouchPushToTalk.test.ts), which drive real DOM
+ * events. What is covered HERE is the core's own contract at its seams — the
+ * ownership/sequence/generation semantics both transports rely on, including
+ * the two policies that differ between them (`isLatched`,
+ * `disownPendingOnRelinquish`), exercised without a DOM or a gesture.
+ */
+
+/** A recording-state-tracking stand-in for useVoiceInput. */
+function makeVoice(overrides: Partial<VoiceControls> = {}) {
+  const calls: string[] = []
+  const v: VoiceControls & { calls: string[] } = {
+    calls,
+    recording: false,
+    start: vi.fn(() => { calls.push('start'); v.recording = true }),
+    stop: vi.fn(() => { calls.push('stop'); v.recording = false }),
+    cancel: vi.fn(() => { calls.push('cancel'); v.recording = false }),
+    ...overrides,
+  }
+  return v
+}
+
+/** A `start()` whose settlement the test controls. */
+function deferredStart(voice: ReturnType<typeof makeVoice>) {
+  let resolve!: () => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<void>((res, rej) => { resolve = res; reject = rej })
+  voice.start = vi.fn(() => { voice.calls.push('start'); return promise })
+  return { resolve, reject }
+}
+
+/** Drain the microtasks a settled `start()` promise schedules. */
+const flush = () => vi.advanceTimersByTimeAsync(0)
+
+type Owner = 'gesture' | 'latch'
+
+function makeHarness(overrides: Partial<PttSessionDeps<Owner>> = {}) {
+  const voice = makeVoice()
+  const state = { phase: 'idle' as PttPhase }
+  const setPhase = vi.fn((p: PttPhase) => { state.phase = p })
+  const resetToIdle = vi.fn(() => { state.phase = 'idle' })
+  const disarm = vi.fn()
+  const session = createPttSession<Owner>({
+    voice: () => voice,
+    phase: () => state.phase,
+    setPhase,
+    resetToIdle,
+    disarm,
+    ...overrides,
+  })
+  return { voice, state, setPhase, resetToIdle, disarm, session }
+}
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('launch', () => {
+  it('records the owner and the pending startup until the promise settles', async () => {
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    expect(h.session.owner()).toBe('gesture')
+    expect(h.session.startPending()).toBe(true)
+
+    start.resolve()
+    await flush()
+    expect(h.session.startPending()).toBe(false)
+  })
+
+  it('treats a synchronous start as having no startup window: nothing pending, owner kept', () => {
+    const h = makeHarness()
+    h.voice.start = vi.fn(() => { h.voice.calls.push('start') })
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    expect(h.session.startPending()).toBe(false)
+    expect(h.session.owner()).toBe('gesture')
+  })
+})
+
+describe('settle (startup succeeded)', () => {
+  it('leaves a still-owned gesture running while its phase is live', async () => {
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    start.resolve()
+    await flush()
+
+    expect(h.voice.stop).not.toHaveBeenCalled()
+    expect(h.session.owner()).toBe('gesture')
+  })
+
+  it('stops an ORPHAN: a gesture owner whose phase already returned to idle', async () => {
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    h.state.phase = 'idle'
+    start.resolve()
+    await flush()
+
+    expect(h.voice.stop).toHaveBeenCalledTimes(1)
+    expect(h.session.owner()).toBeNull()
+  })
+
+  it('leaves a LATCHED owner running even at idle phase — the latch outlives its gesture', async () => {
+    const h = makeHarness({ isLatched: (o) => o === 'latch' })
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    // The release adopted the session as a latch and returned the phase to idle.
+    h.session.setOwner('latch')
+    h.state.phase = 'idle'
+    start.resolve()
+    await flush()
+
+    expect(h.voice.stop).not.toHaveBeenCalled()
+    expect(h.session.owner()).toBe('latch')
+  })
+
+  it('is the backstop for a teardown that could not abort the startup: a disowned session is stopped', async () => {
+    // Without disownPendingOnRelinquish (the keyboard policy), clearing the
+    // owner leaves the sequence alone precisely so this handler still runs.
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'holding'
+    h.session.launch('gesture')
+    // Teardown cleared the owner while the startup was still in flight.
+    h.session.setOwner(null)
+    h.state.phase = 'idle'
+    start.resolve()
+    await flush()
+
+    expect(h.voice.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale settlement: a relaunch supersedes the sequence', async () => {
+    const h = makeHarness()
+    const first = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    // A second gesture opens its own startup before the first ever settles.
+    const second = deferredStart(h.voice)
+    h.session.launch('gesture')
+
+    h.state.phase = 'idle'
+    first.resolve()
+    await flush()
+    // The first settlement is "not mine any more" — it must not stop the
+    // replacement session, and must not clear the pending flag the second
+    // startup still owns.
+    expect(h.voice.stop).not.toHaveBeenCalled()
+    expect(h.session.startPending()).toBe(true)
+
+    second.resolve()
+    await flush()
+    expect(h.voice.stop).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('fail (startup rejected)', () => {
+  it('cancels the half-acquired session, resets the transport, and clears pending', async () => {
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    start.reject(new Error('mic denied'))
+    await flush()
+
+    expect(h.session.startPending()).toBe(false)
+    expect(h.session.owner()).toBeNull()
+    expect(h.resetToIdle).toHaveBeenCalledTimes(1)
+    expect(h.voice.cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('still resets the transport when the owner was already cleared, but has nothing to cancel', async () => {
+    const h = makeHarness()
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'holding'
+    h.session.launch('gesture')
+    h.session.setOwner(null)
+    start.reject(new Error('mic denied'))
+    await flush()
+
+    expect(h.resetToIdle).toHaveBeenCalledTimes(1)
+    expect(h.voice.cancel).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale rejection: a superseded startup cannot tear down its replacement', async () => {
+    const h = makeHarness()
+    const first = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    deferredStart(h.voice)
+    h.session.launch('gesture')
+
+    first.reject(new Error('mic denied'))
+    await flush()
+
+    expect(h.resetToIdle).not.toHaveBeenCalled()
+    expect(h.voice.cancel).not.toHaveBeenCalled()
+    expect(h.session.owner()).toBe('gesture')
+  })
+})
+
+describe('disownPendingOnRelinquish (the touch policy)', () => {
+  it('relinquishing ownership invalidates the in-flight startup: its settlement is a no-op', async () => {
+    const h = makeHarness({ disownPendingOnRelinquish: true })
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    // Teardown: the gesture was abandoned mid-acquisition.
+    h.session.setOwner(null)
+    expect(h.session.startPending()).toBe(false)
+
+    // A replacement session (the mic button) is now live; the abandoned
+    // startup's late resolution must not stop it.
+    h.state.phase = 'idle'
+    start.resolve()
+    await flush()
+    expect(h.voice.stop).not.toHaveBeenCalled()
+  })
+
+  it('relinquishing ownership also silences the startup rejection', async () => {
+    const h = makeHarness({ disownPendingOnRelinquish: true })
+    const start = deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    h.session.setOwner(null)
+    start.reject(new Error('mic denied'))
+    await flush()
+
+    expect(h.resetToIdle).not.toHaveBeenCalled()
+    expect(h.voice.cancel).not.toHaveBeenCalled()
+  })
+
+  it('handing ownership over (non-null) does NOT disown the startup', async () => {
+    const h = makeHarness({ disownPendingOnRelinquish: true })
+    deferredStart(h.voice)
+
+    h.state.phase = 'arming'
+    h.session.launch('gesture')
+    h.session.setOwner('gesture')
+    expect(h.session.startPending()).toBe(true)
+  })
+})
+
+describe('onOwnerChange', () => {
+  it('observes every ownership transition, from every writer', () => {
+    const seen: Array<Owner | null> = []
+    const h = makeHarness({ onOwnerChange: (o) => { seen.push(o) } })
+    h.voice.start = vi.fn(() => { h.voice.calls.push('start') })
+
+    h.session.launch('gesture')
+    h.session.setOwner('latch')
+    h.session.setOwner(null)
+    expect(seen).toEqual(['gesture', 'latch', null])
+  })
+})
+
+describe('beginHold and the hard cap', () => {
+  it('relabels the phase and commits the hold when the ceiling elapses', () => {
+    const h = makeHarness()
+
+    h.state.phase = 'arming'
+    h.session.beginHold()
+    expect(h.setPhase).toHaveBeenCalledWith('holding')
+
+    vi.advanceTimersByTime(MAX_HOLD_MS)
+    expect(h.disarm).toHaveBeenCalledWith(true)
+  })
+
+  it('does not fire against a hold that already ended: the phase moved on', () => {
+    const h = makeHarness()
+
+    h.state.phase = 'arming'
+    h.session.beginHold()
+    h.state.phase = 'idle'
+    vi.advanceTimersByTime(MAX_HOLD_MS)
+    expect(h.disarm).not.toHaveBeenCalled()
+  })
+
+  it('does not fire against a LATER hold: the generation moved on', () => {
+    const h = makeHarness()
+
+    h.state.phase = 'arming'
+    h.session.beginHold()
+    // A teardown bumps the generation, then a new hold begins — still 'holding'.
+    h.session.bumpGeneration()
+    h.state.phase = 'holding'
+    vi.advanceTimersByTime(MAX_HOLD_MS)
+    expect(h.disarm).not.toHaveBeenCalled()
+  })
+
+  it('clearCapTimer disarms the ceiling outright', () => {
+    const h = makeHarness()
+
+    h.state.phase = 'arming'
+    h.session.beginHold()
+    h.session.clearCapTimer()
+    vi.advanceTimersByTime(MAX_HOLD_MS)
+    expect(h.disarm).not.toHaveBeenCalled()
+  })
+
+  it('a fresh beginHold re-arms its own ceiling with its own generation', () => {
+    const h = makeHarness()
+
+    h.state.phase = 'arming'
+    h.session.beginHold()
+    h.session.bumpGeneration()
+    h.session.clearCapTimer()
+
+    h.session.beginHold()
+    vi.advanceTimersByTime(MAX_HOLD_MS)
+    expect(h.disarm).toHaveBeenCalledTimes(1)
+    expect(h.disarm).toHaveBeenCalledWith(true)
+  })
+})

--- a/website/src/lib/pttSession.ts
+++ b/website/src/lib/pttSession.ts
@@ -1,0 +1,296 @@
+/**
+ * The session-ownership core shared by the push-to-talk transports.
+ *
+ * `usePushToTalk` (keyboard) and `useTouchPushToTalk` (touch) drive the same
+ * contract: ONE capture session is opened the moment a gesture begins — before
+ * anyone knows whether the press will turn out to be a tap, a hold, or a chord
+ * — and ownership, not intent-at-open, decides that session's fate when the
+ * gesture RESOLVES. This module owns that machinery: who owns the session
+ * (`owner`), whether its async startup is still in flight (`startPending`), the
+ * per-startup sequence that lets a late resolution tell "the session I opened"
+ * from "a session someone else opened after me", and the gesture-generation
+ * counter plus the hard-cap timer behind `beginHold`.
+ *
+ * Each transport used to carry its own copy of this state machine, and the
+ * copies drifted: a fix applied to one silently missed the other. The
+ * transports differ only where keyboard and touch genuinely differ, and each
+ * difference is a construction-time parameter — see {@link PttSessionDeps}.
+ *
+ * Framework-free on purpose: the transports read and write it synchronously
+ * from DOM event handlers, and unit tests drive it without `renderHook` or a
+ * microphone.
+ */
+import { MAX_HOLD_MS } from './pushToTalk'
+
+/**
+ * The slice of `useVoiceInput` the push-to-talk transports drive.
+ *
+ * Injected rather than imported so the transports are testable without a
+ * microphone, and read through a getter at call time so a re-render's new
+ * callback identities are always the ones invoked.
+ */
+export interface VoiceControls {
+  recording: boolean
+  start: () => Promise<void> | void
+  stop: () => void
+  /**
+   * End capture WITHOUT transcribing, and release whatever was acquired.
+   *
+   * This is the discard for a press that never became a recording. On the
+   * streaming path it also drops the locally-buffered PCM, which is why a
+   * discarded press transmits nothing.
+   */
+  cancel: () => void
+}
+
+/** The gesture phase both transports share. */
+export type PttPhase = 'idle' | 'arming' | 'holding'
+
+/**
+ * What a transport provides the core — the seams where keyboard and touch
+ * genuinely differ, plus live reads of the state the transport still owns.
+ */
+export interface PttSessionDeps<Owner extends string> {
+  /** Live voice controls, read at call time, never captured. */
+  voice: () => VoiceControls
+  /** Current gesture phase — the settle handler's liveness test. */
+  phase: () => PttPhase
+  setPhase: (p: PttPhase) => void
+  /**
+   * Return the transport to idle after a FAILED startup: clear its timers,
+   * bump the generation, and reset per-transport gesture state (touch's
+   * cancel-zone flag and captured pointer id live here). The core resets the
+   * phase through this rather than through `disarm`: with no session left
+   * there is nothing to commit on a later release, and leaving the phase at
+   * `arming`/`holding` would let the release path try.
+   */
+  resetToIdle: () => void
+  /**
+   * Leave any armed/holding state, committing (`stop`) or discarding as told —
+   * the transport's own teardown. The hard-cap timer calls it when a release
+   * is never heard about, which must not hold the mic forever.
+   */
+  disarm: (commit: boolean) => void
+  /**
+   * True for an owner kind that must OUTLIVE its gesture — the keyboard's
+   * tap-latch / toggle. The settle handler leaves a latched session running
+   * even though the phase is back to idle. Absent: no owner outlives its
+   * gesture.
+   */
+  isLatched?: (owner: Owner) => boolean
+  /**
+   * When true, relinquishing ownership also DISOWNS any startup still in
+   * flight by invalidating its sequence, so a late settle or rejection is a
+   * no-op. Touch needs this: a replacement session there can come from the mic
+   * button (a surface the gesture machinery never sees), whose sequence it
+   * cannot distinguish from its own — without the disown, an abandoned
+   * gesture's late-resolving startup called `stop()` on the replacement and
+   * truncated speech it had nothing to do with. The orphan case stays covered
+   * even with the settle handler silenced: every teardown calls `cancel()` or
+   * `stop()` on the transport synchronously, and `useVoiceInput.cancel()`
+   * bumps its OWN generation so the abandoned `start()` returns early and
+   * never claims anything. The keyboard deliberately leaves the sequence
+   * alone, so a startup that ignores teardown and goes live anyway is still
+   * caught and stopped by its settle handler.
+   */
+  disownPendingOnRelinquish?: boolean
+  /**
+   * Observe every ownership change. Touch exports ownership to render
+   * (`owns`), and a plain field cannot be exported — reading it during render
+   * is unobservable — so the mirror is written here, by the sole writer.
+   */
+  onOwnerChange?: (owner: Owner | null) => void
+}
+
+/** The core's surface. One instance serves one transport for its whole life. */
+export interface PttSession<Owner extends string> {
+  /**
+   * Open a session for the gesture that just began, and track the pending
+   * startup so both a late resolution and a second press can reach it. EVERY
+   * `start()` in a transport goes through here — a call site that skips it
+   * leaves no way to reach its own startup.
+   */
+  launch(owner: Owner): void
+  /**
+   * The threshold passed, so the press is a HOLD. Capture has been running
+   * since the gesture began — this only relabels the phase and arms the
+   * ceiling. There is no `start()` here: a second one would be swallowed by
+   * `useVoiceInput`'s re-entrancy guard, and the session opened at the
+   * gesture's start is the one that already has the opening word in it.
+   */
+  beginHold(): void
+  /**
+   * Who owns the open session right now, or null when nobody does.
+   *
+   *   a gesture owner — the press that opened it. Owns it while the phase is
+   *   `arming` or `holding`; once the phase returns to `idle` with this owner
+   *   still set, the session is an ORPHAN.
+   *   a latched owner — deliberately outlives its gesture, so an idle phase is
+   *   expected and must not stop it.
+   *
+   * Ownership is written when the gesture RESOLVES, and every teardown clears
+   * it, which is what lets the settle handler tell "still wanted" from
+   * "nothing is holding this any more".
+   */
+  owner(): Owner | null
+  /**
+   * Hand ownership over (latch adoption) or relinquish it (teardown). The
+   * ONLY writer — state cleared on some exit paths and not others is the
+   * exact defect class the transports have already been fixed for.
+   */
+  setOwner(owner: Owner | null): void
+  /**
+   * True while `start()`'s async startup is in flight.
+   *
+   * Load-bearing for the stuck-mic guarantee, because a startup can fail to
+   * settle AT ALL: the streaming path awaits a `ready` frame from the backend,
+   * and a socket that opens and then goes silent leaves that await pending
+   * forever. Any cleanup that runs only in the promise's own `.then()`
+   * therefore inherits its liveness — so every teardown in this window runs
+   * SYNCHRONOUSLY off this flag instead of awaiting anything.
+   *
+   * It is also the only way to know a session exists at all before it goes
+   * live: `voice.recording` stays false for the whole `getUserMedia` +
+   * handshake window, so a second press that tested only `recording` fell
+   * through and opened a SECOND `start()` — which `useVoiceInput`'s
+   * re-entrancy guard swallowed, leaving the first startup to go live against
+   * a user who had just pressed to switch it off.
+   */
+  startPending(): boolean
+  /**
+   * Current gesture generation. Touch reads it to guard its arm timer, whose
+   * callback must not promote a LATER press's `arming` phase to a hold. The
+   * keyboard's arm timer needs no such guard — its handler nulls the timer
+   * ref and checks the phase, and every keyboard path that could start a new
+   * press first runs `clearTimers`, so a stale keyboard arm timer cannot
+   * exist.
+   */
+  generation(): number
+  /**
+   * Invalidate timers armed by an earlier gesture, so one cannot fire against
+   * a later one. Deliberately NOT the guard for the async `start()`
+   * resolution — teardown bumping it is exactly what made that guard dead;
+   * the settle handler's liveness test is the PHASE instead.
+   */
+  bumpGeneration(): number
+  /** Clear the hard-cap timer — part of the transport's own clearTimers. */
+  clearCapTimer(): void
+}
+
+export function createPttSession<Owner extends string>(
+  deps: PttSessionDeps<Owner>,
+): PttSession<Owner> {
+  let owner: Owner | null = null
+  let startPending = false
+  /**
+   * Monotonic per-`start()` sequence, bumped at every launch (and, under
+   * `disownPendingOnRelinquish`, by any teardown that supersedes a pending
+   * startup). Lets a late-resolving startup tell "the session I opened" from
+   * "a session someone else opened after me" — without it, the settle
+   * handler's phase test is an unconditional "not mine" and stops whatever is
+   * live, killing a session the user opened inside the `getUserMedia` window.
+   */
+  let startSeq = 0
+  let gen = 0
+  let capTimer: ReturnType<typeof setTimeout> | null = null
+
+  const writeOwner = (next: Owner | null): void => {
+    owner = next
+    deps.onOwnerChange?.(next)
+    if (next === null && deps.disownPendingOnRelinquish) {
+      startSeq++
+      startPending = false
+    }
+  }
+
+  /**
+   * Startup SUCCEEDED — and is the LAST line of defence for a stuck mic, so it
+   * decides from the state that exists NOW rather than from the intent it was
+   * opened with:
+   *
+   *   - a LATCHED owner is meant to outlive its gesture, so an idle phase is
+   *     expected. Leave it running.
+   *   - a gesture owner with a non-idle phase — the press is still down
+   *     (arming or holding). Leave it running; the release path owns the
+   *     ending.
+   *   - anything else — the owner was cleared by a teardown, or the gesture
+   *     ended while startup was still in flight (no release coming, cap timer
+   *     cleared) — is an ORPHAN. Stop it.
+   *
+   * The liveness test is the PHASE, not the generation: teardown bumps the
+   * generation, so a generation comparison here is always false by the time a
+   * released hold resolves; it reads like a guard and is dead code. And it is
+   * scoped to `seq` so it only ever stops the session this call opened.
+   */
+  const settleStart = (seq: number): void => {
+    if (startSeq !== seq) return
+    startPending = false
+    const current = owner
+    if (current !== null && deps.isLatched?.(current)) return
+    if (current !== null && deps.phase() !== 'idle') return
+    writeOwner(null)
+    deps.voice().stop()
+  }
+
+  /**
+   * Startup FAILED. Nothing to commit, and a rejection can arrive with
+   * resources already half-acquired: `useStreamingStt` builds its
+   * `AudioContext` and worklet AFTER `getUserMedia` and the socket handshake,
+   * outside any `try`, and `useVoiceInput`'s streaming branch re-raises rather
+   * than catching. So a throw there leaves the mic stream open with no session
+   * to stop — `cancel()` is what tears it down. Scoped to `seq`, so a
+   * superseded startup's rejection cannot tear down the session that replaced
+   * it.
+   */
+  const failStart = (seq: number): void => {
+    if (startSeq !== seq) return
+    startPending = false
+    const current = owner
+    writeOwner(null)
+    deps.resetToIdle()
+    if (current !== null) deps.voice().cancel()
+  }
+
+  return {
+    launch(next: Owner): void {
+      writeOwner(next)
+      startPending = true
+      const seq = ++startSeq
+      const started = deps.voice().start()
+      if (started && typeof (started as Promise<void>).then === 'function') {
+        void (started as Promise<void>).then(
+          () => { settleStart(seq) },
+          () => { failStart(seq) },
+        )
+      } else {
+        // Synchronous control (or one returning nothing): no startup window to
+        // guard, so leave the owner in place and nothing pending.
+        startPending = false
+      }
+    },
+
+    beginHold(): void {
+      const g = ++gen
+      deps.setPhase('holding')
+      // Hard ceiling: a release we never hear about must not hold the mic
+      // forever. Both transports clear the previous timer before re-entering
+      // `arming`, but this is a shared seam now — replace rather than leak a
+      // prior handle so the invariant holds for a transport that does not.
+      if (capTimer) clearTimeout(capTimer)
+      capTimer = setTimeout(() => {
+        capTimer = null
+        if (gen === g && deps.phase() === 'holding') deps.disarm(true)
+      }, MAX_HOLD_MS)
+    },
+
+    owner: (): Owner | null => owner,
+    setOwner: writeOwner,
+    startPending: (): boolean => startPending,
+    generation: (): number => gen,
+    bumpGeneration: (): number => ++gen,
+
+    clearCapTimer(): void {
+      if (capTimer) { clearTimeout(capTimer); capTimer = null }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

`usePushToTalk` (keyboard) and `useTouchPushToTalk` (touch) each carried a near-identical copy of the voice session-ownership state machine — `ownerRef`, `startPendingRef`, `startSeqRef`, the gesture generation and hard-cap timer, and the `launch` / `settleStart` / `failStart` / `beginHold` functions. Duplicated state machines drift: a fix applied to one copy silently misses the other.

This extracts the machine into `createPttSession<Owner extends string>` in `website/src/lib/pttSession.ts` and reduces both hooks to thin transports over it: keyboard keeps key/chord matching and latch handling; touch keeps pointer capture and cancel-zone geometry. `MAX_HOLD_MS` / `PttConfig` stay in `lib/pushToTalk.ts`; `VoiceControls` moves into the core and is re-exported from `usePushToTalk.ts` so every existing import site is untouched.

Each real divergence between the two copies is a construction-time parameter, not a fork of the core:

- **`isLatched`** — the keyboard's latch branch of the settle handler (an owner kind that outlives its gesture). Touch passes none.
- **`disownPendingOnRelinquish`** — touch invalidates an in-flight startup's sequence when ownership relinquishes (a replacement session there can come from the mic button, which the gesture machinery never sees); the keyboard deliberately leaves the sequence alone so its settle backstop still catches a startup that ignores teardown.
- **`onOwnerChange`** — feeds touch's render-visible `owns` export; the core stays the sole writer of ownership.
- **`resetToIdle`** — each transport's own gesture-state reset (touch clears its cancel flag and captured pointer id; keyboard clears its timers and bumps its generation).

Pure refactor: no user-visible behavior change, no i18n changes, no UI files beyond the hooks.

## Testing

- **Both existing hook suites pass UNCHANGED** (the regression net demanded by the issue): `usePushToTalk.test.ts` 47 tests, `useTouchPushToTalk.test.ts` 32 tests, plus `ChatInput.holdToTalk.test.tsx` 12 tests — zero edits to any of them.
- New focused unit tests for the extracted core (`pttSession.test.ts`, 19 tests): launch/settle/fail sequencing, the orphan backstop, latch survival, stale-settlement and stale-rejection guards, both relinquish policies, `onOwnerChange`, and the hard-cap generation/phase guards.
- `npx tsc -b` clean; full frontend vitest suite green (24191 passed); jscpd 0 clones; brand + i18n diff gates green.

Two pre-push model-pinned review lanes ran: GPT (gpt-5.6-sol) PASS with zero findings; Opus (claude-opus-5) PASS with zero blocking and four advisories, all four adopted (policy-rationale prose deduplicated onto `PttSessionDeps`, `beginHold` replaces a prior cap-timer handle, `generation()` readership documented, test flush rewritten with `advanceTimersByTimeAsync`).

Closes #5719
