### PR TITLE
fix(ci): fork first-principles sweep passes the computed verdict

### DIFF
--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -666,6 +666,10 @@ jobs:
           # on this head can belong to another PR that shares the commit, and
           # completing that one would publish a verdict computed from a different
           # diff -- the wedge is closed without ever touching a sibling's review.
+          # Completed with THIS run's computed verdict, not a hardcoded neutral:
+          # a genuine BLOCK whose own PATCH lost both attempts must not be
+          # swept into a verdict pr-readiness no longer gates on. With no
+          # verdict, $conclusion is already neutral/"review incomplete".
           if [ -n "${HEAD:-}" ] && [ -n "${PR:-}" ]; then
             enc="$(jq -rn '"First Principles Review" | @uri')"
             stranded="$(gh api --method GET \
@@ -676,6 +680,6 @@ jobs:
                     | .id" 2>/dev/null || true)"
             for id in $stranded; do
               echo "completing stranded check-run $id for $HEAD (PR #$PR)"
-              complete "$id" "neutral" "review incomplete (advisory)" || true
+              complete "$id" "$conclusion" "$title" || true
             done
           fi

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1281,6 +1281,12 @@ class TestAdvisoryVerdictRequiresCurrentHeadMarker:
 # (lane file, check-run name, external_id prefix, finalize step name)
 FORK_SWEEP_LANES = (
     ("fork-design-review.yml", "Design Review", "design", "Finalize check-run (advisory)"),
+    (
+        "fork-first-principles-review.yml",
+        "First Principles Review",
+        "first-principles",
+        "Finalize check-run (advisory)",
+    ),
     ("fork-gpt-review.yml", "GPT 5.6 Review", "gpt", "Finalize check-run (fail closed)"),
     ("fork-opus-review.yml", "Opus 4.8 Review", "opus", "Finalize check-run (fail closed)"),
     ("fork-ux-review.yml", "UX Review", "ux", "Finalize check-run (advisory)"),
@@ -1290,10 +1296,12 @@ FORK_SWEEP_LANES = (
 class TestForkLaneStrandedRunSweeps:
     """#3447 defect 1, second half: the retry alone still loses when BOTH
     attempts fail, and it cannot touch a run stranded by a PREVIOUS workflow
-    run. fork-first-principles-review.yml pairs the retry with a sweep that
-    lists still-incomplete check-runs of the lane's name on the head and
-    completes every one THIS pull request created; these tests port that pin
-    to the other four fork lanes.
+    run. fork-first-principles-review.yml introduced the sweep that lists
+    still-incomplete check-runs of the lane's name on the head and completes
+    every one THIS pull request created; the other four fork lanes ported it.
+    All five lanes are pinned here, including the reference lane itself --
+    #5949 fixed its sweep to pass the run's computed verdict instead of a
+    hardcoded neutral, the shape the ported lanes already had.
     """
 
     @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
@@ -1331,6 +1339,25 @@ class TestForkLaneStrandedRunSweeps:
         assert '[ -n "${PR:-}" ]' in script, f"{lane}: sweep runs without a resolved PR"
         assert 'select(.status != "completed") | .id' not in script, (
             f"{lane}: unscoped sweep must not come back"
+        )
+
+    @pytest.mark.parametrize(("lane", "check_name", "prefix", "finalize"), FORK_SWEEP_LANES)
+    def test_sweep_completes_with_the_computed_verdict(
+        self, lane: str, check_name: str, prefix: str, finalize: str
+    ) -> None:
+        # #5949: a hardcoded neutral at the sweep site either outvotes a
+        # genuine green re-run under pr-readiness's fail-precedence, or
+        # launders a genuine BLOCK whose own PATCH lost both attempts into an
+        # un-gated neutral. The sweep must pass the run's computed verdict --
+        # with no verdict, $conclusion already holds the lane's
+        # incomplete/advisory posture, so a genuinely-stranded run's behavior
+        # is unchanged.
+        script = _step_script(_workflow(lane), finalize)
+        assert 'complete "$id" "$conclusion" "$title"' in script, (
+            f"{lane}: sweep does not pass the computed verdict"
+        )
+        assert 'complete "$id" "neutral"' not in script, (
+            f"{lane}: hardcoded-neutral sweep must not come back"
         )
 
 


### PR DESCRIPTION
## Problem / Motivation

The four ported fork reviewer lanes (design/gpt/opus/ux) complete their stranded check-runs during the finalize sweep by passing the run's own computed verdict (`$conclusion` / `$title`). The reference lane, `fork-first-principles-review.yml`, still passed a hardcoded `neutral` / "review incomplete (advisory)" at its sweep call site -- the shape #5928 fixed in the four lanes it ported the sweep to, deferred there only because that PR's spec pinned the reference lane as unmodifiable.

## Why it matters

A hardcoded conclusion at the sweep site can do one of two bad things on a fork PR:

- **Outvote a genuine green re-run**: pr-readiness reads check-runs with fail-precedence, so a swept-to-neutral run sitting beside a real success degrades the lane's reported verdict.
- **Launder a genuine BLOCK**: a run whose own finalize PATCH lost both attempts falls through to the sweep, which would publish "review incomplete (advisory)" over a verdict that was actually a premise-concern BLOCK -- the one state the advisory lane exists to surface.

## What changed (motivation -> approach -> change)

The sweep's job is to close the stranded-run wedge, not to decide the verdict. The run already computes the correct verdict: the `case` statement earlier in the same step assigns `$conclusion` / `$title` on every path (unconditional `*)` arm), and with no verdict computed they already hold the neutral/"review incomplete" posture. So the fix is the same one-line shape the ported lanes carry: the sweep call passes `"$conclusion" "$title"` instead of the hardcoded pair, with the ported lanes' justifying comment mirrored above it. A genuinely-stranded run's advisory behavior is unchanged; only the case where a real verdict exists changes -- it now propagates.

The `TestForkLaneStrandedRunSweeps` ratchet (added by #5928) is extended: the reference lane joins `FORK_SWEEP_LANES` (all three existing pins -- PR-scoped `external_id` at creation, sweep presence, external_id-scoped selection -- hold on it unchanged), and a new `test_sweep_completes_with_the_computed_verdict` asserts all five lanes pass the computed verdict and the hardcoded-neutral sweep shape cannot come back.

## Tests

- New ratchet assertion is mutation-verified: red on the unfixed workflow (exactly the reference-lane param fails), green with the fix.
- `test/test_ai_review_workflows.py`: 168/168 pass; `TestForkLaneStrandedRunSweeps` 20/20 (4 tests x 5 lanes).
- `isort` / `flake8` clean; full backend pytest run -- the only failures are environment-owned (byte-identical failure set on pristine main in the same environment, A/B verified via stash).
- Both pre-push review lanes (GPT, Opus) returned NO BLOCKING FINDINGS; the Opus lane additionally executed the extracted step body under stubbed `gh`/`jq` across all `VERDICT` values (`BLOCK`/`PASS`/`CONCERNS`/`SKIPPED`/empty/`UNKNOWN`/`WITHHELD`) with `set -u`: no unbound variable on any path, and the negative assertion does not false-positive on the legitimate `POST` fallback's `-f conclusion="neutral"`.

## Manual verification

Verified all five lanes now carry the identical sweep call literal (`fork-design:644`, `fork-first-principles:683`, `fork-gpt:785`, `fork-opus:520`, `fork-ux:836`), and that `$conclusion` / `$title` are assigned on a flat path with no early exit between the `case` and the sweep.

## Screenshots / video

CI-workflow + backend-test change only; no visual surface.

## Related Issues

Closes #5949

## Checklist

- [x] Single conventional commit
- [x] Tests added/updated and mutation-verified
- [x] No user-facing strings, no spec-doc surface affected

## Contribution License Agreement

By submitting this pull request, I confirm my contribution is made under the terms of the repository's license.
