### PR TITLE
feat(security): allowlist Superhuman MCP OAuth authorization endpoint

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -8122,6 +8122,7 @@ _OAUTH_AUTHORIZATION_ENDPOINTS: frozenset[tuple[str, str]] = frozenset(
         # MCP authorization server here too.
         ("access.stripe.com", "/mcp/oauth2/authorize"),
         ("gitlab.com", "/oauth/authorize"),
+        ("mcp.auth.mail.superhuman.com", "/oauth2/authorize"),
         ("mcp.linear.app", "/authorize"),
         ("mcp.notion.com", "/authorize"),
         ("vercel.com", "/oauth/authorize"),

--- a/test/oauth_url_corpus.py
+++ b/test/oauth_url_corpus.py
@@ -152,6 +152,22 @@ LEGIT_OAUTH_URLS: list[tuple[str, str]] = [
         "&code_challenge_method=S256"
         "&state=" + ("a1B2c3D4" * 16),  # 128-char opaque state
     ),
+    # Superhuman Mail MCP OAuth + PKCE. Endpoint taken from Superhuman's own
+    # RFC 8414 metadata (authorization_servers -> mcp.auth.mail.superhuman.com,
+    # authorization_endpoint /oauth2/authorize). kiro-cli generates the opaque
+    # state and S256 code_challenge, identical in shape to the other MCP-server
+    # providers already in the builtin set.
+    (
+        "superhuman-mail-mcp",
+        "https://mcp.auth.mail.superhuman.com/oauth2/authorize"
+        "?client_id=sh_mcp_client_0123456789"
+        "&response_type=code"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A33418%2Fcallback"
+        "&scope=mcp"
+        "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        "&code_challenge_method=S256"
+        "&state=" + ("Kp7mQ2xR" * 12),  # 96-char opaque state
+    ),
 ]
 
 # Consent URLs that the ACP banner-safety gate

--- a/test/test_mcp_oauth_banner.py
+++ b/test/test_mcp_oauth_banner.py
@@ -460,6 +460,58 @@ class TestOAuthParamCredentialScan:
         )
         assert oauth_url_contains_credential(url) is False
 
+    def test_superhuman_mcp_endpoint_high_entropy_state_allowed(self):
+        # Regression: Superhuman's MCP authorization endpoint
+        # (mcp.auth.mail.superhuman.com/oauth2/authorize) is in the builtin
+        # allowlist, so its opaque high-entropy state must NOT be flagged. This
+        # is the exact reconnect that failed with "URL contained credential or
+        # exfiltration pattern" before the endpoint was added.
+        url = (
+            "https://mcp.auth.mail.superhuman.com/oauth2/authorize"
+            "?client_id=sh_mcp_client_0123456789&response_type=code"
+            "&redirect_uri=http%3A%2F%2F127.0.0.1%3A33418%2Fcallback&scope=mcp"
+            "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+            "&code_challenge_method=S256"
+            "&state=" + ("Kp7mQ2xR" * 12)
+        )
+        assert oauth_url_contains_credential(url) is False
+
+    def test_superhuman_high_entropy_state_still_rejected_at_unlisted_host(self):
+        # The endpoint allowlist — not the params — is what grants the
+        # exemption: the SAME high-entropy state at a look-alike host that is
+        # not on the allowlist must still be rejected. Guards against a
+        # suffix-match or host-spoof regression.
+        url = (
+            "https://mcp.auth.mail.superhuman.com.attacker.example/oauth2/authorize"
+            "?client_id=sh_mcp_client_0123456789&response_type=code"
+            "&redirect_uri=http%3A%2F%2F127.0.0.1%3A33418%2Fcallback&scope=mcp"
+            "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+            "&code_challenge_method=S256"
+            "&state=" + ("Kp7mQ2xR" * 12)
+        )
+        assert oauth_url_contains_credential(url) is True
+
+    def test_superhuman_endpoint_does_not_waive_fixed_credentials(self):
+        # Adding an endpoint to the allowlist only exempts high-entropy OAuth
+        # entropy — a hard credential signature (AWS key) smuggled into a param
+        # must still be rejected even at the approved Superhuman endpoint.
+        url = (
+            "https://mcp.auth.mail.superhuman.com/oauth2/authorize"
+            "?client_id=x&state=AKIAIOSFODNN7EXAMPLE&response_type=code"
+        )
+        assert oauth_url_contains_credential(url) is True
+
+    def test_superhuman_endpoint_is_in_builtin_allowlist(self):
+        # Pins the fix at the data layer: the endpoint pair must be present
+        # exactly (host lowercase, path exact), so a rename/move in the set
+        # fails loudly rather than silently re-breaking reconnect.
+        from kiro_crew.security import _OAUTH_AUTHORIZATION_ENDPOINTS
+
+        assert (
+            "mcp.auth.mail.superhuman.com",
+            "/oauth2/authorize",
+        ) in _OAUTH_AUTHORIZATION_ENDPOINTS
+
 
 # ── Banner gate consolidation: one security predicate, no local copy (#2403) ──
 


### PR DESCRIPTION
## Problem / Motivation

Reconnecting the Superhuman Mail MCP server fails at the OAuth consent banner
with `superhuman-mail authentication failed: URL contained credential or
exfiltration pattern`. The connection worked while its token was valid, then
broke once the token expired and a fresh authorization was required.

## Why it matters

Superhuman is a shipped MCP integration. With this gate rejecting its consent
URL, the server cannot be (re-)authorized at all — every user whose Superhuman
token expires is locked out until a code change lands. It is the exact
regression class the consent-URL security gate documents: "A launch provider
missing from this set cannot be connected at all."

## What changed (motivation → approach → change)

- **Symptom:** the ACP OAuth banner is rejected for Superhuman.
- **Root cause:** `oauth_url_contains_credential()` only waives the generic
  credential/exfiltration heuristics for high-entropy OAuth `state`/PKCE values
  when the consent URL's exact `(host, path)` is in the code-owned allowlist
  `_OAUTH_AUTHORIZATION_ENDPOINTS`. Superhuman's MCP authorization server —
  `mcp.auth.mail.superhuman.com` + `/oauth2/authorize` (from its published
  RFC 8414 metadata) — is not in that set, so its opaque state is scanned as a
  credential and the URL is rejected.
- **Change:** add `("mcp.auth.mail.superhuman.com", "/oauth2/authorize")` to the
  builtin allowlist, matching the existing MCP-server authorization endpoints
  (Stripe, GitLab, Linear, Notion, Vercel). No change to the scan logic or the
  exemption's shape — the exemption stays bound to the exact host+path, and
  fixed-credential detection is unaffected.

## Tests

- `test/oauth_url_corpus.py`: added a `superhuman-mail-mcp` entry to
  `LEGIT_OAUTH_URLS`, so the existing corpus contract test asserts a realistic
  Superhuman consent URL is never flagged and renders as a live banner.
- `test/test_mcp_oauth_banner.py`: four targeted tests —
  the endpoint passes with high-entropy state; the SAME state at a look-alike
  host (`…superhuman.com.attacker.example`) is still rejected (no suffix/spoof
  match); a fixed AWS-key signature in a param is still rejected at the approved
  endpoint (the exemption covers entropy only, not fixed credentials); and the
  `(host, path)` pair is present in `_OAUTH_AUTHORIZATION_ENDPOINTS`.

## Manual verification

Verified against the real `security.oauth_url_contains_credential` by importing
the module directly: the endpoint is in the allowlist (True); a realistic
Superhuman consent URL is allowed (returns False); a look-alike host is rejected
(True); an AWS key in `state` is rejected (True). N/A for UI — backend-only.

## Related Issues

no linked issue: found while reconnecting Superhuman MCP; no tracked issue filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
