### PR TITLE
feat(conductor): one code owner for the ledger item entry (#5912)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4403,8 +4403,9 @@ a build run, or a fix made, it is a work item for a child session — your four
 jobs are decomposition, dispatch, verification, and the next-round decision.
 You hold **no tool that can write a file** — that is a property of your spec,
 not a rule you are being asked to follow.
-Shell access exists solely to run the bundled acceptance evaluator
-(`goal-conductor` skill, `scripts/accept_eval.py`); acceptance is its
+Shell access exists solely to run the `goal-conductor` skill's bundled scripts
+(`scripts/accept_eval.py` for acceptance verdicts, `scripts/ledger_entry.py`
+for the durable ledger item-entry format); acceptance is the evaluator's
 deterministic verdict, never your reading of a child session's transcript.
 
 Your session-control tools are DEFERRED: `session_create`, `session_send`,
@@ -4427,7 +4428,8 @@ def _install_conductor_agent() -> None:
 
     Derives from the kirocrew agent (resolved MCP invocations, security hooks)
     but narrows to the conductor's charter: session control + core tools +
-    shell for the bundled acceptance evaluator, and **no tool that can write a
+    shell for the bundled skill scripts (acceptance evaluator + ledger entry
+    codec), and **no tool that can write a
     file** — not ``fs_write``, and not ``code`` either, which governance classes
     under ``filesystem.write`` because it writes files and can shell out. That
     is what makes "never does a work item's work itself" a property of the spec

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -16,10 +16,11 @@ Your four jobs, none of which can be delegated to a work item:
 
 Everything else belongs in a work item. This spec has **no `fs_write`** — that
 is deliberate. If a task needs a file written, it is a work item, not something
-you do. `execute_bash` IS granted, for exactly one purpose: running the bundled
-acceptance evaluator (`scripts/accept_eval.py`). It is deliberately kept out of
-`allowedTools`, so every call prompts for approval — see "Known limits" for what
-that costs per patrol cycle.
+you do. `execute_bash` IS granted, for exactly one purpose: running this
+skill's bundled scripts — the acceptance evaluator (`scripts/accept_eval.py`)
+and the ledger entry codec (`scripts/ledger_entry.py`). Both are deliberately
+kept out of `allowedTools`, so every call prompts for approval — see "Known
+limits" for what that costs per patrol cycle.
 
 ## What is a work item
 
@@ -97,10 +98,16 @@ For each item in the round:
    acceptance condition, and where to report. The seed is the item's whole
    contract: the child session gets no other context from you.
 5. `session_ledger_record` the item: its goal text, the round number, and — in
-   `artifacts`, under an `item-<n>` key, as a JSON-serialized STRING — the durable
-   item entry carrying its acceptance spec, session key, round, status and read
-   cursor (see "What goes where" below for the encoding, its string requirement,
-   and its bounds). That entry is the ONLY place the acceptance spec survives
+   `artifacts`, under an `item-<n>` key — the durable item entry carrying its
+   acceptance spec, session key, round, status and read cursor. **Never
+   hand-write the entry value: encode it with the bundled codec**
+   (`scripts/ledger_entry.py`, same directory as the evaluator — see "The
+   ledger item-entry codec" below). **Before any dispatch write that would
+   push the map past the entry cap, `rotate` the combined current-plus-new
+   map and write THAT back** — the ledger's own cap handling blindly ages out
+   the oldest entry, active or not, so the codec must be the thing that
+   decides what drops (and a `cap_exceeded_all_active` error means do not
+   dispatch). That entry is the ONLY place the acceptance spec survives
    compaction; `next` carries the resumable intent.
 
 Send the seed BEFORE recording the ledger row as dispatched — a ledger row that
@@ -131,9 +138,10 @@ Each cycle:
    skills root, so on such an install that path does not exist and every
    evaluator call would fail before patrol ever ran.
 
-   Build the items JSON from the `item-*` entries in your ledger's `artifacts`,
-   and evaluate **every open item in ONE call** — each invocation costs one
-   approval prompt.
+   Build the items JSON from the `item-*` entries in your ledger's `artifacts`
+   — decode each stored value with the codec (`ledger_entry.py decode`), never
+   by eyeballing the string — and evaluate **every open item in ONE call** —
+   each invocation costs one approval prompt.
 
    Verdicts: `pass` / `fail` are final for this cycle. `pending` means keep
    waiting. `refused` means the spec asked for something the evaluator will not
@@ -158,18 +166,20 @@ Each cycle:
 3. For items still running, `session_read_message` with the `since` cursor you
    stored last cycle — this answers "is it moving / did it ask a question",
    never "did it succeed". Store the returned `next_since` back into that item's
-   `artifacts` entry — held only in context it is lost on compaction, and the
-   next cycle then re-reads the transcript from the top.
+   `artifacts` entry (a fresh `ledger_entry.py encode` with the new cursor) —
+   held only in context it is lost on compaction, and the next cycle then
+   re-reads the transcript from the top.
 4. `session_ledger_record` only what changed — but an item's `artifacts` entry is
    rewritten whole, so include the fields you are not changing.
 5. **Say nothing unless there is a real signal.** An item passing acceptance,
    failing it, asking a question, or stalling. Never post "nothing changed".
 
-**Shell exists for the evaluator, not for work.** `execute_bash` is granted so
-this patrol step can run `accept_eval.py`. Running a work item's build, test,
-or fix yourself through it is the boundary violation this skill exists to
-prevent — if you need a command run to MAKE something true, that is a work
-item; the evaluator only CHECKS what is already true.
+**Shell exists for the bundled scripts, not for work.** `execute_bash` is
+granted so patrol can run `accept_eval.py` and `ledger_entry.py`. Running a
+work item's build, test, or fix yourself through it is the boundary violation
+this skill exists to prevent — if you need a command run to MAKE something
+true, that is a work item; the bundled scripts only CHECK and ENCODE what is
+already true.
 
 ### Close the round
 
@@ -231,36 +241,77 @@ What goes where:
 - `next` — a resumable intent, not a status. "round 2: A awaiting acceptance,
   B still running" beats "monitoring".
 - `artifacts` — **the durable home for every active work item.** One entry per
-  item, and the entry must carry everything patrol needs to run a cycle without
-  the conversation: the acceptance spec, the session key, the round, the status,
-  and the read cursor. Nothing else is durable — the transcript is gone after
-  compaction, and judging an item from its transcript is forbidden anyway — so an
-  acceptance spec that lives only in your context is a spec patrol cannot rebuild.
+  item, keyed `item-<n>`, and the entry must carry everything patrol needs to
+  run a cycle without the conversation: the acceptance spec, the session key,
+  the round, the status, and the read cursor. Nothing else is durable — the
+  transcript is gone after compaction, and judging an item from its transcript
+  is forbidden anyway — so an acceptance spec that lives only in your context is
+  a spec patrol cannot rebuild.
 
-  **`artifacts` is a map of string to STRING.** The value must be a
-  JSON-*serialized* string, not a nested object: a non-string value is rejected
-  outright with `artifacts_not_string_map` (HTTP 400), so an entry sent as a real
-  object does not persist at all — which loses exactly the state this entry
-  exists to keep. Key it `item-<n>`, and serialize the object into one line:
-
-  ```
-  item-1 -> "{\"accept\":{\"kind\":\"pr_checks\",\"pr\":123,\"repo\":\"o/r\"},\"session\":\"<session key>\",\"round\":2,\"status\":\"running\",\"since\":\"<next_since cursor>\"}"
-  ```
-
-  Parse it back with a JSON decode when you read the ledger, and treat a value
-  that fails to decode as a lost item — re-derive it from the child session
-  rather than guessing.
-
-  The field's real bounds make this fit and also bound it: **32 entries, key
-  ≤128 chars, value ≤2000 chars** — ample for one item's serialized spec, far too
-  small for prose or a transcript excerpt. So keep values to this encoding, and
-  **rotate**: when an item reaches a terminal verdict, collapse its entry to a
-  one-line outcome (`"{\"status\":\"pass\",\"round\":2}"`) or drop it, so a long
-  goal's finished items cannot age an ACTIVE item out of the 32-entry cap. Record
-  the entry in the same `session_ledger_record` call that marks the item
-  dispatched, and rewrite it whenever the spec concretizes (the two-phase TBD
-  case) or the cursor advances.
+  **The entry format is owned by the bundled codec, `scripts/ledger_entry.py`
+  — never hand-write or hand-parse a value.** See "The ledger item-entry
+  codec" below for the four operations. Record the entry in the same
+  `session_ledger_record` call that marks the item dispatched, and rewrite it
+  (a fresh `encode`) whenever the spec concretizes (the two-phase TBD case) or
+  the cursor advances — an entry is rewritten whole, never patched.
 - `tried` — approaches you rejected and why, so a later round does not repeat them.
+
+## The ledger item-entry codec
+
+`scripts/ledger_entry.py` (same directory as the evaluator — resolve it the
+same way) is the single owner of the item-entry format. It exists because the
+two failure modes it prevents are silent: the ledger's `artifacts` field is a
+map of string to STRING — a nested object is rejected with
+`artifacts_not_string_map` and **nothing persists** — and an oversized value is
+silently TRUNCATED at the ledger's cap, corrupting the stored JSON. The codec
+knows the ledger's real bounds and refuses before the write instead.
+
+Every mode reads JSON on stdin and writes JSON on stdout; domain problems come
+back as `{"ok": false, "error": {...}}`, never a crash:
+
+- **encode** — fields in, the single-line string value out:
+
+  ```bash
+  printf '%s' '{"accept":{"kind":"pr_checks","pr":123,"repo":"o/r"},"session":"<session key>","round":2,"status":"running","since":"<next_since cursor>"}' \
+    | python3 <this skill's dir>/scripts/ledger_entry.py encode
+  ```
+
+  Put the returned `value` under the `item-<n>` key. `since` is optional.
+  `status` must be one of `running`, `waiting`, `pass`, `fail` — the codec
+  rejects anything else. **A failed acceptance CHECK is not `fail`:** your
+  stop condition allows three failures, so on a failed check re-encode with
+  `status` still `running` and the optional `fails` counter incremented (that
+  count is what survives compaction and feeds the three-strikes stop). Write
+  `fail` only when the item is finally given up — `pass` and `fail` are the
+  terminal statuses rotation collapses.
+- **decode** — a stored value in, structured fields out, plus `terminal` and
+  `complete` flags. A failed decode means a lost item: re-derive it from the
+  child session rather than guessing.
+- **validate** — the whole artifacts map you are about to write in, violations
+  out. Run it before `session_ledger_record` when in doubt; a violation the
+  ledger would enforce silently (truncation, age-out, whole-write rejection)
+  comes back as a named violation instead.
+- **rotate** — the artifacts map in, a rotated map out: terminal entries are
+  collapsed to their one-line outcome, then dropped oldest-first ONLY if the
+  map still exceeds the entry cap. An active item is never dropped; when the
+  cap cannot be met without dropping one, you get a structured error to
+  surface. Run it at BOTH trigger points: when an item reaches a terminal
+  verdict, and **before any dispatch write that would push the map past the
+  entry cap — on the combined current-plus-new map, including the entries you
+  are about to add**. Rotate trims down TO the cap, never below it, so a map
+  at the cap plus a new item would otherwise be capped by the LEDGER, whose
+  age-out is blind to status and evicts the oldest entry even when it is an
+  active item's only surviving state. A `cap_exceeded_all_active` error at
+  dispatch time means the goal has no capacity: do not dispatch.
+  **Write the returned map back WHOLE, in one `session_ledger_record` call.**
+  The ledger merges rather than replaces — an omitted key is not deleted, and
+  every key you send becomes newest — so a partial write-back would leave the
+  untouched active entries oldest in the age-out order and make `dropped`
+  meaningless. This is the one place "write only deltas" does not apply.
+
+Batch your codec calls like evaluator calls — each invocation costs one
+approval prompt, so one `rotate` (or one `validate` of the whole map) per
+cycle beats one call per item.
 
 ## Cost discipline
 
@@ -278,16 +329,17 @@ watches, and that cost grows with the loop's own history.
   defaults to OFF and fails closed — every session tool answers
   `session_control_disabled` until the user sets it to `true` in config.json.
   If you see that error, say which switch to flip; do not retry.
-- **Every dashboard tool call prompts for approval, and so does every evaluator
-  run.** That is deliberate: both `@kirocrew-dashboard` and `execute_bash` are
-  withheld from auto-approve so their calls still pass through the tool-call hook
-  where the deny floor and governance ceiling apply. The steady-state cost is
+- **Every dashboard tool call prompts for approval, and so does every bundled
+  script run.** That is deliberate: both `@kirocrew-dashboard` and `execute_bash`
+  are withheld from auto-approve so their calls still pass through the tool-call
+  hook where the deny floor and governance ceiling apply. The steady-state cost is
   concrete and worth planning for: **each patrol cycle blocks on one approval for
-  the `accept_eval.py` invocation**, plus one per session-control call in a
-  dispatch round. Patrol is therefore attended-unattended — the loop wakes itself,
-  but a cycle that finds nobody at the keyboard waits rather than proceeding. Size
-  the nudge interval for that, and prefer one evaluator call per cycle carrying
-  every open item over one call per item.
+  the `accept_eval.py` invocation** plus one per codec call, and one per
+  session-control call in a dispatch round. Patrol is therefore
+  attended-unattended — the loop wakes itself, but a cycle that finds nobody at
+  the keyboard waits rather than proceeding. Size the nudge interval for that,
+  and prefer batched calls — one evaluator call per cycle carrying every open
+  item, one codec call per map-wide operation — over one call per item.
 - **`session_send` reports delivery, not completion.** `started: true` means the
   target began a turn on your message; `started: false` means it queued. Neither
   says the work succeeded — acceptance is still the domain assertion's job.
@@ -295,15 +347,17 @@ watches, and that cost grows with the loop's own history.
   app-scoped sessions, channel-linked or mirrored sessions, crew-mode sessions,
   and sessions in another workspace are all refused by the shared guard. Plan
   work items onto plain persistent dashboard sessions only.
-- **Shell is for the evaluator only, and the evaluator runs no command you
-  name.** `execute_bash` exists so patrol can run `accept_eval.py`; every call is
-  audit-logged and every call prompts. The evaluator accepts **no command,
-  argv array, or shell string from a spec** — it builds every argv it runs from a
-  fixed template, so `pr_checks` becomes `gh pr checks <n>` and nothing else
-  executes. That is deliberate and load-bearing: this script is invoked as an
-  approved wrapper, so a spec that could name a command would turn it into a
-  general way to run one, and Kiro Crew's denied-command floor cannot see inside
-  it (the floor reads the `execute_bash` string, which says `python3
-  accept_eval.py`). Widening happens by adding a purpose-built kind that
-  constructs its own argv — never by accepting one. A `refused` verdict is a
-  spec to re-express, never a list to route around.
+- **Shell is for the bundled scripts only, and the evaluator runs no command
+  you name.** `execute_bash` exists so patrol can run `accept_eval.py` and
+  `ledger_entry.py` (the codec runs no subprocess at all — it only transforms
+  JSON); every call is audit-logged and every call prompts. The evaluator
+  accepts **no command, argv array, or shell string from a spec** — it builds
+  every argv it runs from a fixed template, so `pr_checks` becomes `gh pr
+  checks <n>` and nothing else executes. That is deliberate and load-bearing:
+  this script is invoked as an approved wrapper, so a spec that could name a
+  command would turn it into a general way to run one, and Kiro Crew's
+  denied-command floor cannot see inside it (the floor reads the
+  `execute_bash` string, which says `python3 accept_eval.py`). Widening
+  happens by adding a purpose-built kind that constructs its own argv — never
+  by accepting one. A `refused` verdict is a spec to re-express, never a list
+  to route around.

--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/ledger_entry.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/ledger_entry.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Ledger item-entry codec - the one code owner of the conductor's entry format.
+
+The goal-conductor's only compaction-surviving state is the per-work-item entry
+it writes into the session ledger's ``artifacts`` map. Before this script, that
+format existed only as prose plus a worked example in SKILL.md, and the model
+re-derived it every patrol cycle - which produced two real defects during
+review of PR #5652: an acceptance spec that lived only in model context (lost
+on compaction), and an entry written as a nested JSON object, which the ledger
+rejects with ``artifacts_not_string_map`` so nothing persisted at all.
+
+This script owns the format. The conductor calls it; it never hand-rolls the
+encoding again.
+
+Usage:
+    python3 ledger_entry.py {encode|decode|validate|rotate} < input.json
+
+Every mode reads one JSON document on stdin and writes one on stdout. Domain
+problems (a value too long, a malformed stored entry) are structured
+``{"ok": false, "error": {...}}`` results, never crashes - the conductor must
+be able to read WHY and re-derive, not lose the sibling results. Exit code 0
+means the operation ran; 2 means stdin was not the JSON the mode needs or the
+mode name is unknown.
+
+Modes:
+
+``encode``  fields -> the single-line JSON STRING the ledger accepts.
+    stdin:  {"accept": {...}, "session": "<key>", "round": 2,
+             "status": "running", "since": "<cursor>"}
+    stdout: {"ok": true, "value": "<compact json string>", "chars": 123}
+    The value is a STRING (the ledger's artifacts map is string->string; a
+    nested object is rejected outright). ``since`` is optional. Output is
+    deterministic (sorted keys, compact separators) so rewriting an unchanged
+    entry produces an identical value.
+
+``decode``  stored value -> structured fields.
+    stdin:  {"value": <the stored artifacts value>}
+    stdout: {"ok": true, "entry": {...}, "terminal": bool, "complete": bool}
+            or {"ok": false, "error": {"code": ..., "detail": ...}}
+    ``terminal`` means the status is a finished verdict; ``complete`` means the
+    entry still carries the full patrol contract (accept + session). A decode
+    failure means a lost item: re-derive it from the child session, never guess.
+
+``validate``  enforce the ledger's REAL bounds before a write is attempted.
+    stdin:  {"artifacts": {"item-1": "...", ...}}   (the map about to be written)
+    stdout: {"ok": bool, "violations": [{"key": ..., "code": ..., "detail": ...}]}
+    The bounds mirror the ledger's own (see the constants below). Validating
+    first matters because the ledger does not reject an oversized write - it
+    silently TRUNCATES the value at the cap, which corrupts the JSON payload,
+    and silently ages out the oldest entries past the entry cap.
+
+``rotate``  collapse or drop terminal entries so finished items cannot age an
+    ACTIVE item out of the entry cap.
+    stdin:  {"artifacts": {...}}
+    stdout: {"ok": true, "artifacts": {...}, "collapsed": [...], "dropped": [...]}
+            or {"ok": false, "error": {"code": "cap_exceeded_all_active", ...}}
+    Deterministic rule: terminal entries are first collapsed to their one-line
+    outcome ({"round": N, "status": "pass"}), then - only if the map still
+    exceeds the cap - dropped oldest-first. An active item is NEVER dropped;
+    if the cap cannot be met without dropping one, that is a structured error
+    for the conductor to surface, not a silent loss.
+
+Stdlib-only, Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# The ledger's real bounds, mirrored from kiro_crew/session_ledger.py
+# (_MAX_TEXT, key clamp in record(), _MAX_ARTIFACTS). Do NOT tune these here:
+# test_conductor_ledger_entry.py asserts they equal the ledger's own constants,
+# so a ledger-side change fails that test instead of silently drifting.
+# The ledger CLAMPS rather than rejects (a long value is truncated, a full map
+# ages out its oldest entries), which is exactly why validation must happen on
+# this side, before the write.
+# ---------------------------------------------------------------------------
+MAX_VALUE_CHARS = 2000
+MAX_KEY_CHARS = 128
+MAX_ENTRIES = 32
+
+#: The full status vocabulary. ``encode`` REJECTS anything else: a synonym like
+#: "passed" or "done" would decode as non-terminal, so rotation would treat the
+#: finished item as active forever and the map would fill to an unresolvable
+#: cap_exceeded_all_active. Failing at authoring time is the cheap failure.
+#:
+#: Retry semantics are part of the contract: a cycle-level acceptance failure
+#: is NOT terminal — the skill's stop condition allows three failures — so on a
+#: failed check the entry stays "running" with ``fails`` incremented, and
+#: "fail" is written only when the item is finally given up (retries exhausted
+#: or the item abandoned). Collapsing on the first failed check would destroy
+#: the acceptance spec, session key and cursor that the retry needs.
+ALLOWED_STATUSES = frozenset({"running", "waiting", "pass", "fail"})
+
+#: Statuses that mean the item is FINISHED (see the retry semantics above).
+#: Rotation never collapses or drops an entry it is not certain is terminal,
+#: so an unknown status can cost capacity but never state.
+TERMINAL_STATUSES = frozenset({"pass", "fail"})
+
+#: The full entry contract patrol needs to run a cycle without the
+#: conversation. ``since`` (read cursor) and ``fails`` (acceptance-failure
+#: count) are optional; a collapsed terminal entry keeps only ``round`` and
+#: ``status``.
+_FIELD_TYPES = {
+    "accept": dict,
+    "session": str,
+    "round": int,
+    "status": str,
+    "since": str,
+    "fails": int,
+}
+_REQUIRED_FOR_ENCODE = ("accept", "session", "round", "status")
+
+
+def _error(code: str, detail: str) -> Dict[str, Any]:
+    return {"ok": False, "error": {"code": code, "detail": detail}}
+
+
+def _check_field(name: str, value: Any) -> Optional[str]:
+    """Return a problem description when ``value`` has the wrong type."""
+    want = _FIELD_TYPES[name]
+    # bool is an int subclass; {"round": true} must not encode as round=True.
+    if want is int and (not isinstance(value, int) or isinstance(value, bool)):
+        return f"{name!r} must be an integer"
+    if want is not int and not isinstance(value, want):
+        return f"{name!r} must be a {want.__name__}"
+    return None
+
+
+def _encode_value(entry: Dict[str, Any]) -> str:
+    """The one serialization: compact, key-sorted, single line."""
+    return json.dumps(entry, sort_keys=True, separators=(",", ":"))
+
+
+def mode_encode(payload: Dict[str, Any]) -> Dict[str, Any]:
+    for name in _REQUIRED_FOR_ENCODE:
+        if name not in payload:
+            return _error("missing_field", f"encode needs {name!r}")
+    unknown = sorted(set(payload) - set(_FIELD_TYPES))
+    if unknown:
+        # Strict on the authoring side: a typo'd field must not silently
+        # vanish from the durable entry. (decode stays tolerant of unknown
+        # fields so an older helper can read a newer entry.)
+        return _error("unknown_field", f"unknown field(s): {', '.join(unknown)}")
+    entry: Dict[str, Any] = {}
+    for name in _FIELD_TYPES:
+        if name not in payload:
+            continue
+        problem = _check_field(name, payload[name])
+        if problem:
+            return _error("bad_field_type", problem)
+        entry[name] = payload[name]
+    if entry["status"] not in ALLOWED_STATUSES:
+        return _error(
+            "unknown_status",
+            f"status {entry['status']!r} is not one of {sorted(ALLOWED_STATUSES)}. "
+            "A synonym would silently read as active and never rotate; note that "
+            "a failed acceptance CHECK keeps status 'running' with 'fails' "
+            "incremented — 'fail' means finally given up.",
+        )
+    value = _encode_value(entry)
+    if len(value) > MAX_VALUE_CHARS:
+        return _error(
+            "value_too_long",
+            f"encoded entry is {len(value)} chars; the ledger truncates past "
+            f"{MAX_VALUE_CHARS}, which would corrupt the JSON. Shrink the "
+            "acceptance spec (it is a machine condition, not prose).",
+        )
+    return {"ok": True, "value": value, "chars": len(value)}
+
+
+def decode_value(value: Any) -> Dict[str, Any]:
+    """Decode one stored artifacts value; structured error on malformed input."""
+    if not isinstance(value, str):
+        return _error(
+            "value_not_string",
+            f"stored value must be a string, got {type(value).__name__} - the "
+            "ledger rejects non-string values (artifacts_not_string_map), so "
+            "this entry was never persisted",
+        )
+    try:
+        entry = json.loads(value)
+    except json.JSONDecodeError as exc:
+        return _error("not_json", f"stored value is not JSON: {exc}")
+    except RecursionError:
+        # Deeply-nested JSON within the 2000-char bound can exceed the parser's
+        # recursion limit; a damaged entry must come back as a structured error
+        # ("re-derive the item"), never a traceback.
+        return _error("not_json", "stored value is JSON nested too deeply to parse")
+    if not isinstance(entry, dict):
+        return _error(
+            "not_an_object", f"stored value must decode to an object, got {type(entry).__name__}"
+        )
+    for name in _FIELD_TYPES:
+        if name in entry:
+            problem = _check_field(name, entry[name])
+            if problem:
+                return _error("bad_field_type", problem)
+    if "status" not in entry:
+        return _error("missing_field", "entry has no 'status'")
+    terminal = entry["status"] in TERMINAL_STATUSES
+    complete = isinstance(entry.get("accept"), dict) and isinstance(entry.get("session"), str)
+    return {"ok": True, "entry": entry, "terminal": terminal, "complete": complete}
+
+
+def mode_decode(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if "value" not in payload:
+        return _error("missing_field", "decode needs 'value'")
+    return decode_value(payload["value"])
+
+
+def validate_artifacts(artifacts: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Every bound the ledger would silently enforce, reported instead."""
+    violations: List[Dict[str, str]] = []
+    for key, value in artifacts.items():
+        if len(key) > MAX_KEY_CHARS:
+            violations.append(
+                {
+                    "key": key,
+                    "code": "key_too_long",
+                    "detail": f"key is {len(key)} chars; the ledger truncates keys past "
+                    f"{MAX_KEY_CHARS}, which can silently collide two items",
+                }
+            )
+        if not isinstance(value, str):
+            violations.append(
+                {
+                    "key": key,
+                    "code": "value_not_string",
+                    "detail": f"value is {type(value).__name__}, not a string; the ledger "
+                    "rejects the whole write with artifacts_not_string_map and "
+                    "nothing persists",
+                }
+            )
+        elif len(value) > MAX_VALUE_CHARS:
+            violations.append(
+                {
+                    "key": key,
+                    "code": "value_too_long",
+                    "detail": f"value is {len(value)} chars; the ledger truncates past "
+                    f"{MAX_VALUE_CHARS}, corrupting the stored JSON",
+                }
+            )
+    if len(artifacts) > MAX_ENTRIES:
+        violations.append(
+            {
+                "key": "",
+                "code": "too_many_entries",
+                "detail": f"{len(artifacts)} entries; the ledger keeps only the newest "
+                f"{MAX_ENTRIES} and silently ages out the oldest - rotate first",
+            }
+        )
+    return violations
+
+
+def mode_validate(payload: Dict[str, Any]) -> Dict[str, Any]:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return _error("bad_field_type", "validate needs 'artifacts' as an object")
+    violations = validate_artifacts(artifacts)
+    return {"ok": not violations, "violations": violations}
+
+
+def _collapse(entry: Dict[str, Any]) -> Tuple[str, bool]:
+    """Terminal entry -> its one-line outcome. Returns (value, changed)."""
+    kept = {k: entry[k] for k in ("round", "status") if k in entry}
+    collapsed = _encode_value(kept)
+    return collapsed, kept != entry
+
+
+def mode_rotate(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Collapse/drop terminal entries; the result must be written back WHOLE.
+
+    Two trigger points, and the second is load-bearing: on a terminal verdict,
+    and BEFORE any dispatch write that would push the map past the cap — run
+    on the COMBINED current-plus-new map, because rotate trims down TO the cap
+    (never below), so a map already at the cap plus a new entry would
+    otherwise be capped by the ledger itself, whose age-out is blind to status
+    and evicts the oldest entry even when it is an active item's only
+    surviving state. A cap_exceeded_all_active error at dispatch time means
+    there is no capacity: do not dispatch.
+
+    The ledger MERGES artifacts rather than replacing them: a key omitted from
+    a ``session_ledger_record`` call is never removed, and every key present is
+    re-inserted as newest. So writing back only the changed entries would move
+    the collapsed TERMINAL entries to the newest positions and leave the
+    untouched ACTIVE entries oldest — inverting the age-out order rotation
+    exists to protect, and making ``dropped`` a no-op. Always write the entire
+    returned ``artifacts`` map in one call.
+    """
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return _error("bad_field_type", "rotate needs 'artifacts' as an object")
+    rotated: Dict[str, Any] = {}
+    terminal_keys: List[str] = []
+    collapsed: List[str] = []
+    # Pass 1: collapse every terminal entry to its outcome. Insertion order is
+    # preserved throughout - it is the ledger's own age-out order, so "oldest"
+    # here means the same entry the ledger itself would age out first.
+    for key, value in artifacts.items():
+        decoded = decode_value(value)
+        if decoded["ok"] and decoded["terminal"]:
+            terminal_keys.append(key)
+            new_value, changed = _collapse(decoded["entry"])
+            rotated[key] = new_value
+            if changed:
+                collapsed.append(key)
+        else:
+            # Active, opaque, or malformed: rotation must never destroy what it
+            # cannot prove is finished.
+            rotated[key] = value
+    # Pass 2: only when over the cap, drop terminal entries oldest-first.
+    dropped: List[str] = []
+    if len(rotated) > MAX_ENTRIES:
+        for key in terminal_keys:
+            if len(rotated) <= MAX_ENTRIES:
+                break
+            del rotated[key]
+            dropped.append(key)
+    if len(rotated) > MAX_ENTRIES:
+        return _error(
+            "cap_exceeded_all_active",
+            f"{len(rotated)} entries remain after dropping every terminal one; "
+            f"the ledger caps at {MAX_ENTRIES} and an active item must never be "
+            "dropped. Finish or stop items before dispatching more.",
+        )
+    return {"ok": True, "artifacts": rotated, "collapsed": collapsed, "dropped": dropped}
+
+
+_MODES = {
+    "encode": mode_encode,
+    "decode": mode_decode,
+    "validate": mode_validate,
+    "rotate": mode_rotate,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in _MODES:
+        # stdout, like the malformed-stdin error below and accept_eval.py: the
+        # conductor reads one stream, and a wrong mode name is the likeliest
+        # invocation error, so its cause must be where the caller looks.
+        print(
+            json.dumps(
+                {"error": f"usage: ledger_entry.py {{{'|'.join(sorted(_MODES))}}} < input.json"}
+            )
+        )
+        return 2
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        print(json.dumps({"error": "stdin must be a JSON object"}))
+        return 2
+    if not isinstance(payload, dict):
+        # An explicit check, not an assert: asserts vanish under `python -O`,
+        # and a JSON array on stdin would then crash inside the mode handler
+        # instead of returning the documented structured exit-2.
+        print(json.dumps({"error": "stdin must be a JSON object"}))
+        return 2
+    print(json.dumps(_MODES[sys.argv[1]](payload), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -11,11 +11,12 @@ bare interpreters are NOT on the evaluator's allowlist (a spec could otherwise
 name ``python -c <payload>``), and pinning that is one of the tests below.
 """
 
-import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+
+from skill_script_helpers import load_skill_script
 
 from kiro_crew import agent
 from kiro_crew.agent_files import CONDUCTOR_AGENT_FILENAME, OWNED_KIRO_AGENT_FILES
@@ -234,13 +235,22 @@ class TestConductorInstaller:
         conductor to send a nested object would lose every dispatched item's
         state — the exact durability this entry exists to provide. Pinned as a
         doc ratchet because the instruction, not the code, is what would drift.
+
+        The format is owned by ``scripts/ledger_entry.py`` (issue #5912), so
+        the skill must route encoding through the codec rather than carrying a
+        hand-written byte-format example for models to re-derive — the worked
+        example was the specification once, and produced real defects on
+        PR #5652.
         """
         text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
         assert "artifacts_not_string_map" in text
         assert "map of string to STRING" in text
-        # The worked example must show an escaped-quote string value, never a
-        # bare `item-1 -> {` object literal.
-        assert 'item-1 -> "{\\"accept\\"' in text
+        # The codec is the format's one code owner: the skill must direct the
+        # conductor to it for encode/decode/validate/rotate...
+        assert "scripts/ledger_entry.py" in text
+        assert "ledger_entry.py encode" in text
+        # ...and must never show a bare `item-1 -> {` object literal, which is
+        # exactly the value shape the ledger rejects.
         assert "item-1 -> {" not in text
 
     def test_spec_is_registered_as_kirocrew_owned(self):
@@ -268,17 +278,15 @@ class TestConductorInstaller:
 
 
 def _load_evaluator():
-    """Import the bundled script as a module so its internals are addressable.
+    """Load accept_eval.py by file location, via the shared no-bytecode helper.
 
-    It ships inside a skill directory rather than the package, so there is no
-    import path to it; loading it by file location is what lets a test assert the
-    argv a handler BUILDS without executing anything.
+    The script lives inside the checked-in skill dir (no package import path);
+    loading it by file location is what lets a test assert on its internals.
+    ``load_skill_script`` is the residue-guarded loader — a hand-rolled
+    ``exec_module`` here would drop ``__pycache__`` beside the checked-in
+    script, the exact side effect ``no-test-side-effects`` forbids.
     """
-    spec = importlib.util.spec_from_file_location("_accept_eval_under_test", SCRIPT)
-    assert spec and spec.loader
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    return load_skill_script("_accept_eval_under_test", SCRIPT)
 
 
 class TestAcceptEvaluatorInvariant:

--- a/test/test_conductor_ledger_entry.py
+++ b/test/test_conductor_ledger_entry.py
@@ -1,0 +1,451 @@
+"""The conductor's ledger item-entry codec (``scripts/ledger_entry.py``).
+
+The codec is the ONE code owner of the entry format the conductor persists in
+the session ledger's ``artifacts`` map. Two properties are load-bearing and
+each has a dedicated test class:
+
+- **Its bounds are the ledger's bounds.** The constants are asserted equal to
+  ``session_ledger``'s own, so a ledger-side change fails here instead of
+  silently drifting (the ledger CLAMPS rather than rejects, so drift would be
+  invisible at runtime — a too-long value is truncated into corrupt JSON).
+- **Rotation never destroys active state.** Terminal entries collapse then
+  drop oldest-first; anything the codec cannot PROVE terminal (active, opaque,
+  malformed) survives every rotation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from skill_script_helpers import load_skill_script
+
+from kiro_crew import session_ledger
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "goal-conductor"
+    / "scripts"
+    / "ledger_entry.py"
+)
+
+
+def _mod():
+    return load_skill_script("_ledger_entry_under_test", SCRIPT)
+
+
+def _fields(**overrides):
+    fields = {
+        "accept": {"kind": "pr_checks", "pr": 123, "repo": "o/r"},
+        "session": "dashboard:slot-1",
+        "round": 2,
+        "status": "running",
+        "since": "cursor-17",
+    }
+    fields.update(overrides)
+    return fields
+
+
+class TestBoundsMirrorTheLedger:
+    """The codec's constants ARE the ledger's — drift fails loudly."""
+
+    def test_value_bound_is_the_ledger_text_clamp(self):
+        assert _mod().MAX_VALUE_CHARS == session_ledger._MAX_TEXT
+
+    def test_key_bound_is_the_ledger_key_clamp(self):
+        # record() clamps artifact keys with _clamp(k, 128); the literal is the
+        # contract (session_ledger has no named constant for it).
+        assert _mod().MAX_KEY_CHARS == 128
+
+    def test_entry_cap_is_the_ledger_artifacts_cap(self):
+        assert _mod().MAX_ENTRIES == session_ledger._MAX_ARTIFACTS
+
+
+class TestEncodeDecode:
+    def test_round_trip(self):
+        mod = _mod()
+        encoded = mod.mode_encode(_fields())
+        assert encoded["ok"] is True
+        assert isinstance(encoded["value"], str)
+        assert "\n" not in encoded["value"]
+        decoded = mod.mode_decode({"value": encoded["value"]})
+        assert decoded["ok"] is True
+        assert decoded["entry"] == _fields()
+        assert decoded["terminal"] is False
+        assert decoded["complete"] is True
+
+    def test_encode_is_deterministic(self):
+        mod = _mod()
+        a = mod.mode_encode(_fields())["value"]
+        b = mod.mode_encode(_fields())["value"]
+        assert a == b
+
+    def test_encode_since_is_optional(self):
+        mod = _mod()
+        fields = _fields()
+        del fields["since"]
+        out = mod.mode_encode(fields)
+        assert out["ok"] is True
+        assert "since" not in json.loads(out["value"])
+
+    def test_encode_rejects_missing_required_field(self):
+        mod = _mod()
+        for name in ("accept", "session", "round", "status"):
+            fields = _fields()
+            del fields[name]
+            out = mod.mode_encode(fields)
+            assert out["ok"] is False, name
+            assert out["error"]["code"] == "missing_field"
+
+    def test_encode_rejects_unknown_field(self):
+        """A typo'd field must not silently vanish from the durable entry."""
+        out = _mod().mode_encode(_fields(sesion_key="oops"))
+        assert out["ok"] is False
+        assert out["error"]["code"] == "unknown_field"
+        assert "sesion_key" in out["error"]["detail"]
+
+    def test_encode_rejects_bool_round(self):
+        """bool is an int subclass; round=true must not encode."""
+        out = _mod().mode_encode(_fields(round=True))
+        assert out["ok"] is False
+        assert out["error"]["code"] == "bad_field_type"
+
+    def test_encode_rejects_unknown_status(self):
+        """A synonym would decode as non-terminal and never rotate, filling the
+        map toward an unresolvable cap error — refuse it at authoring time."""
+        mod = _mod()
+        for synonym in ("passed", "done", "complete", "refused", "error"):
+            out = mod.mode_encode(_fields(status=synonym))
+            assert out["ok"] is False, synonym
+            assert out["error"]["code"] == "unknown_status"
+
+    def test_encode_accepts_fails_counter(self):
+        """A failed acceptance CHECK keeps the item running with `fails`
+        incremented — the count is retry state and must survive round-trips."""
+        mod = _mod()
+        encoded = mod.mode_encode(_fields(fails=2))
+        assert encoded["ok"] is True
+        decoded = mod.mode_decode({"value": encoded["value"]})
+        assert decoded["ok"] is True
+        assert decoded["entry"]["fails"] == 2
+        assert decoded["terminal"] is False
+
+    def test_decode_deeply_nested_json_is_a_structured_error(self):
+        """Nesting can exceed the parser's recursion limit well inside the
+        2000-char bound; a damaged entry must never crash decode."""
+        depth = 100_000
+        out = _mod().mode_decode({"value": "[" * depth + "]" * depth})
+        assert out["ok"] is False
+        assert out["error"]["code"] in ("not_json", "not_an_object")
+
+    def test_encode_rejects_wrong_types(self):
+        mod = _mod()
+        for bad in (
+            _fields(accept="not-a-dict"),
+            _fields(session=7),
+            _fields(round="2"),
+            _fields(status=None),
+            _fields(since=3),
+        ):
+            out = mod.mode_encode(bad)
+            assert out["ok"] is False
+            assert out["error"]["code"] == "bad_field_type"
+
+    def test_encode_refuses_a_value_the_ledger_would_truncate(self):
+        """The ledger silently clamps at the cap, corrupting the stored JSON;
+        the codec must refuse BEFORE the write instead."""
+        mod = _mod()
+        out = mod.mode_encode(_fields(accept={"kind": "file", "path": "x" * 2100}))
+        assert out["ok"] is False
+        assert out["error"]["code"] == "value_too_long"
+
+    def test_decode_rejects_non_string_value(self):
+        """The exact constraint behind artifacts_not_string_map."""
+        out = _mod().mode_decode({"value": {"accept": {}, "status": "running"}})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "value_not_string"
+
+    def test_decode_rejects_non_json(self):
+        out = _mod().mode_decode({"value": "{not json"})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "not_json"
+
+    def test_decode_rejects_non_object_json(self):
+        out = _mod().mode_decode({"value": "[1, 2]"})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "not_an_object"
+
+    def test_decode_requires_status(self):
+        out = _mod().mode_decode({"value": json.dumps({"round": 2})})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "missing_field"
+
+    def test_decode_flags_terminal(self):
+        mod = _mod()
+        for status, terminal in (("pass", True), ("fail", True), ("running", False)):
+            out = mod.mode_decode({"value": json.dumps({"round": 1, "status": status})})
+            assert out["ok"] is True
+            assert out["terminal"] is terminal, status
+
+    def test_decode_collapsed_entry_is_incomplete(self):
+        """A rotated one-line outcome decodes fine but is not a full contract."""
+        out = _mod().mode_decode({"value": json.dumps({"round": 2, "status": "pass"})})
+        assert out["ok"] is True
+        assert out["terminal"] is True
+        assert out["complete"] is False
+
+    def test_decode_preserves_unknown_fields(self):
+        """Forward compatibility: an older codec must not drop a newer field."""
+        value = json.dumps({"status": "running", "round": 1, "note": "new-field"})
+        out = _mod().mode_decode({"value": value})
+        assert out["ok"] is True
+        assert out["entry"]["note"] == "new-field"
+
+
+class TestValidate:
+    def test_clean_map_passes(self):
+        mod = _mod()
+        value = mod.mode_encode(_fields())["value"]
+        out = mod.mode_validate({"artifacts": {"item-1": value}})
+        assert out == {"ok": True, "violations": []}
+
+    def test_key_too_long(self):
+        out = _mod().mode_validate({"artifacts": {"k" * 129: "v"}})
+        assert out["ok"] is False
+        assert [v["code"] for v in out["violations"]] == ["key_too_long"]
+
+    def test_key_at_the_bound_passes(self):
+        out = _mod().mode_validate({"artifacts": {"k" * 128: "v"}})
+        assert out["ok"] is True
+
+    def test_value_not_a_string(self):
+        out = _mod().mode_validate({"artifacts": {"item-1": {"nested": "object"}}})
+        assert out["ok"] is False
+        assert [v["code"] for v in out["violations"]] == ["value_not_string"]
+
+    def test_value_too_long(self):
+        out = _mod().mode_validate({"artifacts": {"item-1": "x" * 2001}})
+        assert out["ok"] is False
+        assert [v["code"] for v in out["violations"]] == ["value_too_long"]
+
+    def test_value_at_the_bound_passes(self):
+        out = _mod().mode_validate({"artifacts": {"item-1": "x" * 2000}})
+        assert out["ok"] is True
+
+    def test_too_many_entries(self):
+        arts = {f"item-{i}": "v" for i in range(33)}
+        out = _mod().mode_validate({"artifacts": arts})
+        assert out["ok"] is False
+        assert [v["code"] for v in out["violations"]] == ["too_many_entries"]
+
+    def test_exactly_at_the_entry_cap_passes(self):
+        arts = {f"item-{i}": "v" for i in range(32)}
+        out = _mod().mode_validate({"artifacts": arts})
+        assert out["ok"] is True
+
+    def test_rejects_non_object_artifacts(self):
+        out = _mod().mode_validate({"artifacts": ["not", "a", "map"]})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "bad_field_type"
+
+
+class TestRotate:
+    def _entry(self, mod, status, n):
+        return mod.mode_encode(
+            {
+                "accept": {"kind": "pr_checks", "pr": n},
+                "session": f"s-{n}",
+                "round": 1,
+                "status": status,
+            }
+        )["value"]
+
+    def test_collapses_terminal_entries(self):
+        mod = _mod()
+        arts = {
+            "item-1": self._entry(mod, "pass", 1),
+            "item-2": self._entry(mod, "running", 2),
+        }
+        out = mod.mode_rotate({"artifacts": arts})
+        assert out["ok"] is True
+        assert out["collapsed"] == ["item-1"]
+        assert out["dropped"] == []
+        assert json.loads(out["artifacts"]["item-1"]) == {"round": 1, "status": "pass"}
+        # The active entry is untouched, byte for byte.
+        assert out["artifacts"]["item-2"] == arts["item-2"]
+
+    def test_rotate_is_idempotent(self):
+        mod = _mod()
+        arts = {"item-1": self._entry(mod, "fail", 1)}
+        once = mod.mode_rotate({"artifacts": arts})
+        twice = mod.mode_rotate({"artifacts": once["artifacts"]})
+        assert twice["artifacts"] == once["artifacts"]
+        assert twice["collapsed"] == []
+
+    def test_drops_oldest_terminal_first_under_the_cap(self):
+        mod = _mod()
+        arts = {}
+        # 3 terminal (oldest) then 31 active = 34 entries, 2 over the cap.
+        for i in range(3):
+            arts[f"done-{i}"] = self._entry(mod, "pass", i)
+        for i in range(31):
+            arts[f"live-{i}"] = self._entry(mod, "running", 100 + i)
+        out = mod.mode_rotate({"artifacts": arts})
+        assert out["ok"] is True
+        assert out["dropped"] == ["done-0", "done-1"]
+        assert len(out["artifacts"]) == 32
+        assert "done-2" in out["artifacts"]
+        assert all(f"live-{i}" in out["artifacts"] for i in range(31))
+
+    def test_never_drops_an_active_item(self):
+        mod = _mod()
+        arts = {f"live-{i}": self._entry(mod, "running", i) for i in range(33)}
+        out = mod.mode_rotate({"artifacts": arts})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "cap_exceeded_all_active"
+
+    def test_preserves_opaque_and_malformed_entries(self):
+        """Rotation must never destroy what it cannot prove is finished."""
+        mod = _mod()
+        arts = {
+            "opaque": "not json at all",
+            "item-1": self._entry(mod, "pass", 1),
+        }
+        out = mod.mode_rotate({"artifacts": arts})
+        assert out["ok"] is True
+        assert out["artifacts"]["opaque"] == "not json at all"
+
+    def test_rotation_preserves_a_failing_but_retrying_item(self):
+        """status=running with fails>0 is retry state, not a terminal verdict:
+        rotation must keep the full entry (spec, session, cursor) intact."""
+        mod = _mod()
+        value = mod.mode_encode(
+            {
+                "accept": {"kind": "pr_checks", "pr": 9},
+                "session": "s-9",
+                "round": 2,
+                "status": "running",
+                "fails": 2,
+            }
+        )["value"]
+        out = mod.mode_rotate({"artifacts": {"item-9": value}})
+        assert out["ok"] is True
+        assert out["collapsed"] == []
+        assert out["artifacts"]["item-9"] == value
+
+    def test_pre_dispatch_rotation_of_combined_map_protects_active_items(self):
+        """The dispatch-time invariant: rotate the CURRENT map plus the entries
+        about to be written, so the codec — not the ledger's status-blind
+        age-out — decides what drops. A full map (31 active + 1 old terminal)
+        plus one new dispatch must drop the terminal entry, never an active
+        one; the result fits the cap so the ledger's own eviction never runs."""
+        mod = _mod()
+        combined = {"done-old": self._entry(mod, "pass", 0)}
+        for i in range(31):
+            combined[f"live-{i}"] = self._entry(mod, "running", i)
+        combined["item-new"] = self._entry(mod, "running", 99)  # the new dispatch
+        assert len(combined) == 33
+        out = mod.mode_rotate({"artifacts": combined})
+        assert out["ok"] is True
+        assert out["dropped"] == ["done-old"]
+        assert len(out["artifacts"]) == 32
+        assert "item-new" in out["artifacts"]
+        assert all(f"live-{i}" in out["artifacts"] for i in range(31))
+
+    def test_malformed_entries_count_as_active_for_the_cap(self):
+        mod = _mod()
+        arts = {f"opaque-{i}": "not json" for i in range(33)}
+        out = mod.mode_rotate({"artifacts": arts})
+        assert out["ok"] is False
+        assert out["error"]["code"] == "cap_exceeded_all_active"
+
+
+class TestCli:
+    """The script is invoked as ``python3 ledger_entry.py <mode>`` by the
+    conductor; the process contract (stdin/stdout/exit codes) is the API."""
+
+    def _run(self, mode, payload):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), mode],
+            input=json.dumps(payload) if payload is not None else "",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def test_encode_decode_round_trip_via_cli(self):
+        proc = self._run("encode", _fields())
+        assert proc.returncode == 0, proc.stderr
+        value = json.loads(proc.stdout)["value"]
+        proc = self._run("decode", {"value": value})
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout)["entry"] == _fields()
+
+    def test_domain_errors_exit_zero(self):
+        """A domain problem is a structured result the conductor reads, never a
+        nonzero exit that hides it."""
+        proc = self._run("decode", {"value": "{broken"})
+        assert proc.returncode == 0
+        assert json.loads(proc.stdout)["error"]["code"] == "not_json"
+
+    def test_unknown_mode_exits_2(self):
+        proc = self._run("frobnicate", {})
+        assert proc.returncode == 2
+        # The cause must land on stdout — the stream the conductor reads —
+        # matching the malformed-stdin error and accept_eval.py.
+        assert "usage" in proc.stdout
+
+    def test_json_array_stdin_exits_2_without_traceback(self):
+        """A JSON array parses fine but is not an object; the contract is a
+        structured exit-2, never a crash inside a mode handler."""
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "rotate"],
+            input='["not", "an", "object"]',
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert proc.returncode == 2
+        assert "Traceback" not in proc.stderr
+        assert json.loads(proc.stdout)["error"] == "stdin must be a JSON object"
+
+    def test_malformed_stdin_exits_2(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "encode"],
+            input="not json",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert proc.returncode == 2
+
+    def test_missing_mode_exits_2(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert proc.returncode == 2
+
+
+class TestLedgerAcceptsWhatTheCodecEmits:
+    """End-to-end against the real store: an encoded entry survives a real
+    ``session_ledger.record`` write and reads back byte-identical."""
+
+    def test_encoded_entry_round_trips_through_the_ledger(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        mod = _mod()
+        value = mod.mode_encode(_fields())["value"]
+        session_ledger.record("slot-a", artifacts={"item-1": value})
+        state = session_ledger.read_state("slot-a")
+        assert state["artifacts"]["item-1"] == value
+        decoded = mod.mode_decode({"value": state["artifacts"]["item-1"]})
+        assert decoded["ok"] is True
+        assert decoded["entry"] == _fields()


### PR DESCRIPTION
## Problem / Motivation

The goal-conductor's only compaction-surviving state is the per-work-item entry it writes into the session ledger's `artifacts` map — and that entry format had no code owner. SKILL.md specified it as prose plus a worked example, and the model re-derived the encoding every patrol cycle. Review of PR #5652 caught two real defects this produced: an acceptance spec that lived only in model context (lost on compaction), and an entry documented as a nested JSON object, which `dashboard/handlers/session_ledger.py` rejects with `artifacts_not_string_map` — so nothing persisted, silently.

## Why it matters

A conductor that loses an item's acceptance spec cannot evaluate, steer, or resume that item after compaction — the goal silently degrades into orphaned child sessions. Both observed failure modes are silent: the ledger *truncates* an oversized value (corrupting the stored JSON) rather than rejecting it, and a non-string value never persists at all. A format only enforced by prose will keep regressing.

## What changed (motivation → approach → change)

The prose example was the specification, and models drift from prose — so the format needs one code owner the conductor calls instead of re-deriving bytes. Added as a sibling script (not an `accept_eval.py` mode) to keep the evaluator single-purpose:

- **`src/kiro_crew/builtin_skills/goal-conductor/scripts/ledger_entry.py`** — stdlib-only CLI codec, JSON on stdin/stdout, structured errors (never a crash), exit 2 only for malformed invocation:
  - `encode`: fields → the single-line JSON *string* the ledger accepts; rejects unknown fields, an unknown `status` (a synonym like `"done"` would silently read as active and never rotate), and a value the ledger would truncate.
  - `decode`: stored value → structured fields + `terminal`/`complete` flags; structured error on malformed input, including `RecursionError` on pathologically nested JSON.
  - `validate`: enforces the ledger's real bounds before a write (value ≤ 2000, key ≤ 128, ≤ 32 entries, value-is-a-string) — mirrored from `session_ledger.py` and drift-guarded by test against the ledger's own constants.
  - `rotate`: collapses terminal entries to a one-line outcome, drops oldest-terminal-first only when over the entry cap, never drops an active item; docstring pins the whole-map write-back contract (the ledger merges, so a partial write-back would invert age-out order).
  - Retry semantics in the status vocabulary: a failed acceptance *check* keeps `status: running` with a `fails` counter (the three-strikes stop's durable state); `fail` means finally given up. This prevents rotation from destroying the spec/session/cursor an item still being retried needs.
- **SKILL.md** — the worked byte-format example is gone; a new "ledger item-entry codec" section routes encode/decode/validate/rotate through the script. The WHEN-to-write prose stays; the HOW is now helper invocations.
- **`agent.py`** — the conductor system prompt and installer docstring now name both bundled scripts as the shell grant's purpose.
- **`test/test_conductor_agent.py`** — the doc-ratchet test now pins the codec-owned contract instead of the removed worked example, and `_load_evaluator` uses the shared `load_skill_script` helper (the hand-rolled `exec_module` was leaving `__pycache__` residue beside the checked-in script).

## Tests

`test/test_conductor_ledger_entry.py` (46 tests):
- Bounds drift-guard: codec constants asserted equal to `session_ledger._MAX_TEXT` / `_MAX_ARTIFACTS` (and the key clamp literal), so a ledger-side change fails this test instead of silently drifting.
- encode/decode round-trip, determinism, optional fields; rejection of missing/unknown fields, bool-as-int `round`, unknown `status`, and values the ledger would truncate.
- decode structured errors: non-string value (the `artifacts_not_string_map` shape), non-JSON, non-object, missing status, deep-nesting `RecursionError`; unknown fields preserved for forward compatibility.
- validate: every bound at and past its edge.
- rotate: terminal collapse, idempotence, oldest-terminal-first drops under the cap, never-drop-active (structured `cap_exceeded_all_active`), opaque/malformed entries preserved, and a `running`+`fails` retrying item surviving rotation whole.
- CLI process contract: round-trip, domain errors exit 0, usage/malformed-stdin/JSON-array exit 2 with the cause on stdout, no traceback.
- End-to-end: an encoded entry survives a real `session_ledger.record` write and reads back byte-identical.

## Manual verification

N/A — unit coverage sufficient: the codec is a pure JSON transform with a subprocess CLI contract, both exercised directly; the end-to-end test writes through the real ledger store.

## Related Issues

Fixes #5912

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend skill script + SKILL.md prose only; nothing renders in the browser.
