### PR TITLE
refactor(dashboard): split _open_checked so all four file sites share one security prefix (#5742)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -22,7 +22,7 @@ import urllib.parse
 import uuid
 import zipfile
 from pathlib import Path
-from typing import NamedTuple
+from typing import BinaryIO, NamedTuple
 
 from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
@@ -1393,8 +1393,8 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
                 {"error": "Cannot use config root as workspace directory"}, status=400
             )
         if src_path.is_dir():
-            # Use is_sensitive_path to filter entries instead of hardcoded names
-            from kiro_crew.security import is_sensitive_path  # noqa: F811
+            # Use the module-level is_sensitive_path alias to filter entries
+            # instead of hardcoded names -- one binding for one guard.
 
             def _ignore_sensitive(directory: str, entries: list[str]) -> set[str]:
                 from pathlib import Path as _Path  # noqa: F811
@@ -1417,8 +1417,6 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
     else:
         ws_dir = body.get("dir", f"workspace-{name}")
     # Guard against path traversal for relative paths; absolute paths are allowed
-    from kiro_crew.security import is_sensitive_path as _isp  # noqa: F811
-
     _abs = Path(ws_dir).expanduser().is_absolute()
     # Path constructed for validation only (never opened/read/written); the
     # is_relative_to + is_sensitive_path guards below reject traversals before
@@ -1439,7 +1437,7 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
             {"error": f"Directory '{ws_dir}' is already used by another workspace"},
             status=409,
         )
-    if _isp(str(final_path.resolve())):
+    if is_sensitive_path(str(final_path.resolve())):
         _sel().log_api_access(
             caller=request.get("user", "dashboard"),
             operation="workspace.create",
@@ -1493,8 +1491,6 @@ async def api_workspaces_update(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid JSON body"}, status=400)
     if "dir" in body:
         new_dir = body["dir"]
-        from kiro_crew.security import is_sensitive_path as _isp  # noqa: F811
-
         _abs = Path(new_dir).expanduser().is_absolute()
         # Resolved for validation only; is_relative_to + is_sensitive_path guard
         # below reject traversals before the value is stored in config.
@@ -1502,7 +1498,7 @@ async def api_workspaces_update(request: web.Request) -> web.Response:
             Path(new_dir).expanduser().resolve() if _abs
             else (data_home() / new_dir).resolve()
         )
-        if _isp(str(resolved)):
+        if is_sensitive_path(str(resolved)):
             _sel().log_api_access(
                 caller=request.get("user", "dashboard"),
                 operation="workspace.update",
@@ -1799,6 +1795,121 @@ async def api_file_read(request: web.Request) -> web.Response:
         return web.json_response({"error": "failed to read file"}, status=500)
 
 
+class _OpenDenied(NamedTuple):
+    """A refusal from :func:`_open_checked_file`: why, and the path to log.
+
+    ``code`` uses the machine vocabulary the streaming endpoint already
+    exposes (``invalid_path`` / ``sensitive_path`` / ``not_found`` /
+    ``symlink_refused`` / ``file_too_large`` / ``read_failed``); each adopter
+    maps it onto its own SEL outcome and response body, which is where the
+    endpoints legitimately differ. ``path`` is the raw input for
+    ``invalid_path`` (validation produced nothing) and the validated path
+    otherwise -- exactly what each adopter logs today.
+    """
+
+    code: str
+    path: str
+
+
+class _CheckedFile(NamedTuple):
+    """A successful :func:`_open_checked_file`: the checked open file.
+
+    ``size`` is the fstat size of THIS fd -- authoritative for a streaming
+    caller that must announce a length, advisory for whole-read callers
+    whose bounded read is their own size guard.
+    """
+
+    path: str
+    file: BinaryIO
+    size: int
+
+
+def _open_checked_file(
+    raw_path: str,
+    *,
+    tool_name: str,
+    fstat_cap: int | None = None,
+    log_open_failure: bool = True,
+) -> _CheckedFile | _OpenDenied:
+    """The open-and-check half of the file-serving security prefix.
+
+    validate -> sensitive-path check -> is-file -> ``_open_rb_nofollow`` ->
+    fstat (cap enforced only when *fstat_cap* is passed), then RETURNS the
+    checked open file object. What happens to the bytes afterwards is
+    per-endpoint POLICY and stays with the caller: the whole-read envelope
+    (:func:`_open_checked`) reads and closes it, the streaming endpoint
+    sniffs and serves ranges from it, the sheet endpoint hands it to the
+    workbook parser. The split exists because the streaming and sheet
+    endpoints must keep the open file object, so they cannot use the
+    whole-read envelope -- sharing the prefix keeps ONE copy of this
+    boundary for every endpoint.
+
+    The sensitive-path gate runs through this module's import-time
+    ``is_sensitive_path`` alias -- ONE binding for one guard, so a test
+    override (or a future hardening change) applied to
+    ``files.is_sensitive_path`` is observed by every adopter instead of
+    landing on whichever binding an endpoint happened to import.
+
+    *fstat_cap* is the streaming endpoint's size policy: its fd stays open
+    for range reads, so the announced size must be authoritative up front.
+    Whole-read adopters pass no cap here -- an fstat pre-check races a
+    concurrent writer (the file can grow between the stat and the read),
+    while their bounded read caps memory unconditionally.
+
+    *log_open_failure* keeps log volume a per-endpoint decision: a
+    caller-reachable open failure (mode-000 file, EACCES on a parent) writes
+    a full traceback per request when True. The whole-read envelope wants
+    that traceback (its 500 is the only signal); the streaming and sheet
+    endpoints answer a coded refusal instead and pass False, so a request
+    loop against a known-unreadable path cannot amplify into the log.
+
+    Synchronous by design -- callers run it on a worker thread. Refusals are
+    returned as typed codes, not responses: SEL logging and the HTTP body
+    vocabulary belong to each endpoint.
+    """
+    import kiro_crew.dashboard.handlers as _h  # noqa: F811  # circular import
+
+    try:
+        path = _h._validate_dashboard_path(raw_path)
+    except ValueError:
+        # A malformed path (an embedded NUL makes realpath raise) is an
+        # invalid path, not a crash.
+        path = None
+    if not path:
+        return _OpenDenied("invalid_path", raw_path)
+    if is_sensitive_path(path):
+        return _OpenDenied("sensitive_path", path)
+    if not os.path.isfile(path):
+        return _OpenDenied("not_found", path)
+    # Symlinks rejected atomically (O_NOFOLLOW on POSIX; lstat guard +
+    # O_BINARY on Windows -- see _open_rb_nofollow).
+    try:
+        fd = _open_rb_nofollow(path)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:  # symlink with O_NOFOLLOW
+            return _OpenDenied("symlink_refused", path)
+        if log_open_failure:
+            # The only traceback for a failed open: adopters map the code
+            # onto an outcome, and SEL records outcome, not cause.
+            logger.exception("%s open failed for %s", tool_name, path)
+        return _OpenDenied("read_failed", path)
+    fobj = os.fdopen(fd, "rb")
+    try:
+        # fstat is authoritative for THIS fd; a file that grows afterwards
+        # only extends past the size announced here, never past the cap.
+        size = os.fstat(fobj.fileno()).st_size
+    except OSError:
+        with contextlib.suppress(Exception):
+            fobj.close()
+        if log_open_failure:
+            logger.exception("%s fstat failed for %s", tool_name, path)
+        return _OpenDenied("read_failed", path)
+    if fstat_cap is not None and size > fstat_cap:
+        fobj.close()
+        return _OpenDenied("file_too_large", path)
+    return _CheckedFile(path=path, file=fobj, size=size)
+
+
 class _OpenRefusal(NamedTuple):
     """A refusal from :func:`_open_checked`: the response to return, already audited."""
 
@@ -1818,19 +1929,19 @@ def _open_checked(
     tool_name: str,
     max_bytes: int,
 ) -> _OpenedFile | _OpenRefusal:
-    """The dashboard file endpoints' shared open-and-check envelope.
+    """The dashboard file endpoints' shared WHOLE-READ envelope.
 
-    validate -> sensitive-path check -> is-file -> ``_open_rb_nofollow`` ->
-    bounded read (cap enforced on the bytes actually read, so a concurrent
-    writer cannot outgrow it), with every refusal SEL-audited under
-    *tool_name*.
+    The open-and-check half lives in :func:`_open_checked_file` (the prefix
+    shared with the streaming and sheet endpoints); this layer is the
+    whole-read policy on top: bounded read (cap enforced on the bytes
+    actually read, so a concurrent writer cannot outgrow it), close, and the
+    mapping of every refusal onto this envelope's SEL vocabulary and
+    response bodies.
 
-    This is a SECURITY boundary, and it was spelled out independently by each
-    endpoint that needed it, with small divergences in cap values and error
-    vocabularies. Three (now two) hand-rolled copies of a boundary means a
-    future hardening fix — a new TOCTOU guard, a tightened sniff, a cap change —
-    lands in some and silently leaves the others on the old posture. The same
-    shape already bit the zip-vetting surfaces (#3908, #4031).
+    This is a SECURITY boundary: hand-rolled copies of one mean a future
+    hardening fix — a new TOCTOU guard, a tightened sniff, a cap change —
+    lands in some and silently leaves the others on the old posture (the
+    same shape the zip-vetting surfaces guard against).
 
     Per-endpoint POLICY stays with the endpoint and is passed in rather than
     copied: which cap applies, and what the endpoint does with the bytes
@@ -1841,12 +1952,10 @@ def _open_checked(
     a typed either, so a caller cannot accidentally use the data on a refusal
     path the way an ``(data, error)`` tuple invites.
 
-    Synchronous by design — callers offload it via ``asyncio.to_thread`` (the
-    same shape as ``api_file_stream``'s ``_open_media``): everything here is
-    blocking file I/O and must not run on the event loop. SEL audit writes are
-    thread-safe (locked appends).
+    Synchronous by design — callers offload it via ``asyncio.to_thread``:
+    everything here is blocking file I/O and must not run on the event loop.
+    SEL audit writes are thread-safe (locked appends).
     """
-    import kiro_crew.dashboard.handlers as _h  # noqa: F811  # circular import
 
     def _log(outcome: str, res: str, error: str = "") -> None:
         kw = {"error": error} if error else {}
@@ -1855,46 +1964,52 @@ def _open_checked(
             outcome=outcome, resources=res, **kw,
         )
 
-    path = _h._validate_dashboard_path(raw_path)
-    if not path:
-        _log("denied", raw_path)
-        return _OpenRefusal(
-            web.json_response({"error": "invalid or forbidden path"}, status=400)
-        )
-    # One seam for the sensitive-path check. The two copies this replaces called
-    # DIFFERENT bindings of the same function -- api_file_raw re-imported it from
-    # ``kiro_crew.security`` per call, api_file_download used this module's
-    # import-time alias -- so an override applied to one was invisible to the
-    # other. Identical in production; the divergence only showed up as the two
-    # endpoints' tests patching different names, which is precisely the kind of
-    # drift a shared envelope exists to make impossible.
-    if is_sensitive_path(path):
-        _log("denied", path, "sensitive_path")
-        return _OpenRefusal(
-            web.json_response({"error": "sensitive path blocked"}, status=403)
-        )
-    if not os.path.isfile(path):
-        _log("not_found", path)
-        return _OpenRefusal(web.json_response({"error": "not found"}, status=404))
-
-    # Symlinks rejected atomically (O_NOFOLLOW on POSIX; lstat guard +
-    # O_BINARY on Windows -- see _open_rb_nofollow). Bounded read IS the size
-    # guard: an fstat pre-check races a concurrent writer (the file can grow
-    # between the stat and the read, e.g. an agent still generating it), while
-    # reading at most cap+1 bytes bounds memory unconditionally -- the same
-    # shape as _load_sheet_payload's guard.
-    try:
-        fd = _open_rb_nofollow(path)
-        with os.fdopen(fd, "rb") as f:
-            data = f.read(max_bytes + 1)
-    except OSError as exc:
-        if exc.errno == errno.ELOOP:  # symlink with O_NOFOLLOW
-            _log("denied", path, "symlink_rejected")
+    checked = _open_checked_file(raw_path, tool_name=tool_name)
+    if isinstance(checked, _OpenDenied):
+        code, res = checked.code, checked.path
+        if code == "invalid_path":
+            _log("denied", res)
+            return _OpenRefusal(
+                web.json_response({"error": "invalid or forbidden path"}, status=400)
+            )
+        if code == "sensitive_path":
+            _log("denied", res, "sensitive_path")
+            return _OpenRefusal(
+                web.json_response({"error": "sensitive path blocked"}, status=403)
+            )
+        if code == "not_found":
+            _log("not_found", res)
+            return _OpenRefusal(web.json_response({"error": "not found"}, status=404))
+        if code == "symlink_refused":
+            _log("denied", res, "symlink_rejected")
             return _OpenRefusal(
                 web.json_response({"error": "symlinks not allowed"}, status=403)
             )
-        # Keep the traceback main's per-endpoint copies wrote here: this 500 is
-        # the only signal for a failed read, and SEL records outcome, not cause.
+        if code == "file_too_large":
+            # Reachable only through a caller that passes fstat_cap; mapped so
+            # a policy refusal can never masquerade as the 500 below.
+            _log("denied", res, "file_too_large")
+            return _OpenRefusal(
+                web.json_response(
+                    {"error": "file too large", "code": "file_too_large"}, status=413
+                )
+            )
+        # read_failed: the residual code. (This envelope's own size guard is
+        # the bounded read below, because an fstat pre-check races a
+        # concurrent writer while reading at most cap+1 bytes bounds memory
+        # unconditionally -- the same shape as _load_sheet_payload's guard.)
+        _log("failure", res)
+        return _OpenRefusal(
+            web.json_response({"error": "cannot read file", "code": "read_failed"}, status=500)
+        )
+
+    path = checked.path
+    try:
+        with checked.file as f:
+            data = f.read(max_bytes + 1)
+    except OSError:
+        # Keep the traceback for a failed read: this 500 is the only signal,
+        # and SEL records outcome, not cause.
         logger.exception("%s read failed for %s", tool_name, path)
         _log("failure", path)
         return _OpenRefusal(web.json_response({"error": "cannot read file"}, status=500))
@@ -2185,7 +2300,6 @@ async def api_file_stream(request: web.Request) -> web.StreamResponse:
     (file-raw) performs no content scan at all. The probe exists to catch
     the honest-mistake shape: a text file wearing a forged media magic.
     """
-    import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
     def _log(outcome: str, res: str) -> None:
         _sel().log_tool_invocation(
@@ -2198,44 +2312,32 @@ async def api_file_stream(request: web.Request) -> web.StreamResponse:
     def _open_media(raw: str) -> tuple:
         """Validate, open, and sniff the media file. Runs on a worker thread.
 
-        Everything filesystem-touching lives here: relative-path resolution
-        against the project dir (the resolve=1 contract shared with
-        file-read/file-download), realpath resolution inside the validator,
-        the sensitive-path check, existence probe, the symlink-refusing open,
-        fstat, and the header read. Returns either
+        The open-and-check prefix is the shared :func:`_open_checked_file`
+        (validate -> sensitive-path -> nofollow open -> fstat cap), with this
+        endpoint's stream cap passed in as policy; what stays here is the
+        endpoint's own policy: relative-path resolution against the project
+        dir (the resolve=1 contract shared with file-read/file-download), the
+        media sniff, and the text probe. Returns either
         ("ok", file_object, size, content_type, path) or a refusal tuple
-        ("refused", code, path_for_log). A malformed path (embedded NUL
-        makes realpath raise ValueError) is an invalid path, not a crash.
+        ("refused", code, path_for_log).
         """
-        try:
-            if resolve_requested:
+        if resolve_requested:
+            try:
                 raw, resolve_err = _resolve_project_relative(raw)
-                if resolve_err:
-                    return ("refused", resolve_err, raw)
-            validated = _h._validate_dashboard_path(raw)
-        except ValueError:
-            validated = None
-        if not validated:
-            return ("refused", "invalid_path", raw)
-        from kiro_crew.security import is_sensitive_path as _isp  # noqa: F811
-        if _isp(validated):
-            return ("refused", "sensitive_path", validated)
-        if not os.path.isfile(validated):
-            return ("refused", "not_found", validated)
+            except ValueError:
+                # A malformed path (embedded NUL) is an invalid path, not a
+                # crash -- same verdict the shared prefix gives one.
+                return ("refused", "invalid_path", raw)
+            if resolve_err:
+                return ("refused", resolve_err, raw)
+        checked = _open_checked_file(
+            raw, tool_name="file_stream", fstat_cap=_STREAM_MAX_BYTES,
+            log_open_failure=False,
+        )
+        if isinstance(checked, _OpenDenied):
+            return ("refused", checked.code, checked.path)
+        fobj, size, validated = checked.file, checked.size, checked.path
         try:
-            fd = _open_rb_nofollow(validated)
-        except OSError as exc:
-            if exc.errno == errno.ELOOP:
-                return ("refused", "symlink_refused", validated)
-            return ("refused", "read_failed", validated)
-        fobj = os.fdopen(fd, "rb")
-        try:
-            size = os.fstat(fobj.fileno()).st_size
-            # fstat is authoritative for THIS fd; a file that grows afterwards
-            # only extends past the size we announce, never past the cap check.
-            if size > _STREAM_MAX_BYTES:
-                fobj.close()
-                return ("refused", "file_too_large", validated)
             header = fobj.read(16)
             content_type = _sniff_media_type(header)
             if not content_type:
@@ -2865,8 +2967,6 @@ def _browse_files_sync(base: str, skip: set[str]) -> tuple[list[dict], list[dict
 
 async def api_browse_dirs(request: web.Request) -> web.Response:
     """GET /api/browse-dirs?path=... — list subdirectories for directory browser."""
-    from kiro_crew.security import is_sensitive_path  # noqa: F811
-
     caller = request.get("user", "dashboard")
     raw = request.query.get("path", "").strip()
     base = os.path.realpath(os.path.expanduser(raw)) if raw else os.path.realpath(os.path.expanduser("~"))
@@ -3530,28 +3630,30 @@ def _sheet_formula_text(value: object) -> str | None:
     return None
 
 
-def _load_sheet_payload(path: str) -> dict:
-    """Open, vet, and parse the workbook into the sheet-grid payload.
+def _load_sheet_payload(f: BinaryIO, *, max_bytes: int) -> dict:
+    """Read, vet, and parse the workbook into the sheet-grid payload.
 
     Runs ENTIRELY on a worker thread (via asyncio.to_thread) so filesystem
     latency, the first (heavy) openpyxl import, and parse time never stall the
-    gateway event loop. The open goes through _open_rb_nofollow: atomic
-    O_NOFOLLOW on POSIX, and the lstat-based symlink/reparse guard on Windows,
-    where os.O_NOFOLLOW does not exist. openpyxl is a soft import: absence
-    surfaces as ImportError from this thread and the handler maps it to 501.
+    gateway event loop. Receives the checked-open file object from
+    :func:`_open_checked_file` (the shared open-and-check prefix, which owns
+    path validation, the sensitive-path gate, and the symlink-refusing open)
+    and takes ownership: the file is closed on every path. The bounded-read
+    cap is this endpoint's size policy, passed in as *max_bytes*. openpyxl is
+    a soft import: absence surfaces as ImportError from this thread and the
+    handler maps it to 501.
     """
     import io
 
-    import openpyxl  # noqa: F401  (probe here, off-loop; parse imports lazily too)
+    with f:
+        import openpyxl  # noqa: F401  (probe here, off-loop; parse imports lazily too)
 
-    fd = _open_rb_nofollow(path)
-    with os.fdopen(fd, "rb") as f:
         # Bounded read is the size guard: a pre-check via fstat would race a
         # concurrent writer (the file can grow between the stat and the read,
         # e.g. an agent still generating the workbook), while reading at most
         # cap+1 bytes bounds memory unconditionally.
-        data = f.read(_MAX_UPLOAD_BYTES + 1)
-    if len(data) > _MAX_UPLOAD_BYTES:
+        data = f.read(max_bytes + 1)
+    if len(data) > max_bytes:
         raise _SheetRefusal(413, "file too large", "file_too_large")
     header = data[:4]
     # OOXML spreadsheets are ZIP containers; refuse anything else before
@@ -3708,17 +3810,17 @@ def _parse_workbook_grid(data: bytes) -> dict:
 async def api_file_sheet(request: web.Request) -> web.Response:
     """GET /api/file-sheet?path=… — parse an OOXML spreadsheet into a JSON cell grid.
 
-    Powers the file viewer's inline xlsx preview. Follows the api_file_raw
-    security pattern: dashboard path validation, sensitive-path block, a
-    symlink-refusing open (_open_rb_nofollow: atomic O_NOFOLLOW on POSIX,
-    lstat guard on Windows), size and zip-expansion caps, and a ZIP magic-byte
-    check before openpyxl touches the bytes. All file IO and parsing runs on a
-    worker thread so a large workbook cannot stall the event loop, and cell
-    text is credential-redacted like every other dashboard egress. openpyxl is
-    soft-imported: without it the endpoint answers 501 and the frontend
-    degrades to the download card.
+    Powers the file viewer's inline xlsx preview. The security prefix is the
+    shared :func:`_open_checked_file` (dashboard path validation,
+    sensitive-path block, a symlink-refusing open — _open_rb_nofollow: atomic
+    O_NOFOLLOW on POSIX, lstat guard on Windows); this endpoint's own policy
+    on top is the bounded-read size cap, the zip-expansion caps, and a ZIP
+    magic-byte check before openpyxl touches the bytes. All file IO and
+    parsing runs on a worker thread so a large workbook cannot stall the
+    event loop, and cell text is credential-redacted like every other
+    dashboard egress. openpyxl is soft-imported: without it the endpoint
+    answers 501 and the frontend degrades to the download card.
     """
-    import kiro_crew.dashboard.handlers as _h  # noqa: F811
 
     def _log(outcome: str, res: str) -> None:
         _sel().log_tool_invocation(
@@ -3726,33 +3828,43 @@ async def api_file_sheet(request: web.Request) -> web.Response:
         )
 
     raw_path = request.query.get("path", "")
-    path = _h._validate_dashboard_path(raw_path)
-    if not path:
-        _log("denied", raw_path)
-        return web.json_response(
-            {"error": "invalid or forbidden path", "code": "invalid_path"}, status=400
+    # The validated path once the prefix produces one -- exported by the
+    # worker callback so the exception handlers log the same SEL resource
+    # the success path does.
+    res_path = raw_path
+
+    def _open_and_load() -> dict | _OpenDenied:
+        """Open-and-check plus parse, in ONE worker-thread hop.
+
+        The checked open file object never crosses back to the event loop:
+        every path that opens it also closes it on THIS thread (refusals
+        close inside the prefix; the parser's ``with f:`` covers the rest).
+        A cancellation of the awaiting task therefore cannot strand an open
+        file in a discarded future or finalize one on the loop -- the
+        future's result is only ever a payload dict or a typed refusal.
+        """
+        nonlocal res_path
+        checked = _open_checked_file(
+            raw_path, tool_name="file_sheet", log_open_failure=False,
         )
-    from kiro_crew.security import is_sensitive_path as _isp  # noqa: F811
-    if _isp(path):
-        _log("denied", path)
-        return web.json_response(
-            {"error": "sensitive path blocked", "code": "sensitive_path"}, status=403
-        )
-    if not os.path.isfile(path):
-        _log("not_found", path)
-        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+        if isinstance(checked, _OpenDenied):
+            return checked
+        res_path = checked.path
+        return _load_sheet_payload(checked.file, max_bytes=_MAX_UPLOAD_BYTES)
+
     try:
-        payload = await asyncio.to_thread(_load_sheet_payload, path)
+        result = await asyncio.to_thread(_open_and_load)
     except asyncio.CancelledError:
-        # Shutdown or client disconnect mid-parse: the file was already
-        # opened, so the access must not vanish from the audit trail.
-        _log("cancelled", path)
+        # Shutdown or client disconnect: the access attempt must not vanish
+        # from the audit trail. No resource handling here -- the worker
+        # callback owns the file's whole lifetime.
+        _log("cancelled", res_path)
         raise
     except ImportError:
         # openpyxl absent: the preview is unavailable, not broken. The probe
         # runs inside the worker thread so even the first heavy import never
         # touches the event loop.
-        _log("failure", path)
+        _log("failure", res_path)
         return web.json_response(
             {"error": "spreadsheet preview unavailable", "code": "preview_unavailable"},
             status=501,
@@ -3760,29 +3872,58 @@ async def api_file_sheet(request: web.Request) -> web.Response:
     except _SheetRefusal as refusal:
         # Both refusal kinds map to literal statuses so the response shape
         # stays statically checkable; the carried code names the exact cause.
-        _log("denied", path)
+        _log("denied", res_path)
         if refusal.status == 415:
             return web.json_response({"error": str(refusal), "code": refusal.code}, status=415)
         return web.json_response({"error": str(refusal), "code": refusal.code}, status=413)
-    except OSError as exc:
-        if exc.errno == errno.ELOOP:  # symlink, from _open_rb_nofollow on any OS
-            _log("denied", path)
-            return web.json_response(
-                {"error": "symlinks not allowed", "code": "symlink_refused"}, status=403
-            )
-        _log("failure", path)
+    except OSError:
+        # Read failure on the already-checked fd. (A symlink never reaches
+        # here: the shared prefix refuses it as _OpenDenied("symlink_refused")
+        # before the parser sees a file object.)
+        _log("failure", res_path)
         return web.json_response({"error": "cannot read file", "code": "read_failed"}, status=500)
     except Exception:
         # openpyxl's failure surface is wide (bad zip members, malformed XML,
         # unexpected workbook parts). Every parse failure degrades to the same
         # client answer, and the frontend falls back to the download card.
-        logger.warning("file-sheet: cannot parse workbook %s", path, exc_info=True)
-        _log("failure", path)
+        logger.warning("file-sheet: cannot parse workbook %s", res_path, exc_info=True)
+        _log("failure", res_path)
         return web.json_response(
             {"error": "cannot parse workbook", "code": "parse_failed"}, status=422
         )
-    _log("success", path)
-    return web.json_response(payload)
+    if isinstance(result, _OpenDenied):
+        code, res = result.code, result.path
+        if code == "invalid_path":
+            _log("denied", res)
+            return web.json_response(
+                {"error": "invalid or forbidden path", "code": "invalid_path"}, status=400
+            )
+        if code == "sensitive_path":
+            _log("denied", res)
+            return web.json_response(
+                {"error": "sensitive path blocked", "code": "sensitive_path"}, status=403
+            )
+        if code == "not_found":
+            _log("not_found", res)
+            return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+        if code == "symlink_refused":
+            _log("denied", res)
+            return web.json_response(
+                {"error": "symlinks not allowed", "code": "symlink_refused"}, status=403
+            )
+        if code == "file_too_large":
+            # Reachable only if this endpoint ever passes fstat_cap; mapped so
+            # a policy refusal can never masquerade as the 500 below. (Its
+            # size guard today is the bounded read inside _load_sheet_payload.)
+            _log("denied", res)
+            return web.json_response(
+                {"error": "file too large", "code": "file_too_large"}, status=413
+            )
+        # read_failed: the residual code.
+        _log("failure", res)
+        return web.json_response({"error": "cannot read file", "code": "read_failed"}, status=500)
+    _log("success", res_path)
+    return web.json_response(result)
 
 
 # ── Git status & log endpoints ──────────────────────────────────────────────

--- a/test/test_file_raw.py
+++ b/test/test_file_raw.py
@@ -191,27 +191,61 @@ class TestOpenRbNofollow:
 
 
 def test_both_endpoints_route_through_the_shared_envelope():
-    """api_file_raw and api_file_download must not re-grow private copies.
+    """Every file-serving site must route through the shared security prefix.
 
-    The envelope (validate -> sensitive-path -> O_NOFOLLOW open -> bounded-read size
-    cap -> read) is a security boundary. It used to be spelled out per endpoint,
-    and the copies had already drifted -- they called different bindings of
-    is_sensitive_path, so an override applied to one was invisible to the other.
-    Three divergent copies mean a future hardening fix lands in some and leaves
-    the rest on the old posture.
+    The prefix (validate -> sensitive-path -> O_NOFOLLOW open -> size cap) is
+    a security boundary, and a hand-rolled copy of one drifts: separate
+    bindings of is_sensitive_path mean an override applied to one is
+    invisible to the other, and a future hardening fix lands in some copies
+    and leaves the rest on the old posture.
+
+    Pins all four adopters -- the two whole-read endpoints (via _open_checked),
+    the streaming endpoint, and the sheet endpoint (via _open_checked_file
+    directly) -- plus the whole-read envelope itself and the sheet parser, so
+    a fifth hand-rolled copy of the prefix fails here before it can drift.
 
     Asserted on the source because the property is structural: what matters is
-    that neither endpoint opens files itself, not what a given call returns.
+    that no endpoint opens files or re-checks the sensitive path itself, not
+    what a given call returns.
     """
+    import ast
     import inspect
+    import textwrap
 
     from kiro_crew.dashboard.handlers import files as mod
 
-    for fn in (mod.api_file_raw, mod.api_file_download):
-        src = inspect.getsource(fn)
-        body = "\n".join(
-            line for line in src.splitlines() if not line.lstrip().startswith("#")
+    def _body(fn):
+        """The function's source minus every docstring and comment.
+
+        The docstrings must go -- including NESTED ones (api_file_stream's
+        _open_media carries its own): they legitimately NAME the shared
+        helpers, so a positive assertion against raw source would pass on
+        prose alone and the mutation check (remove an adopter, the test must
+        fail) would go vacuous.
+        """
+        src = textwrap.dedent(inspect.getsource(fn))
+        tree = ast.parse(src)
+        spans = []
+        for node in ast.walk(tree):
+            body = getattr(node, "body", None)
+            if (
+                isinstance(body, list)
+                and body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                spans.append((body[0].lineno, body[0].end_lineno))
+        lines = src.splitlines()
+        for start, end in sorted(spans, reverse=True):
+            del lines[start - 1:end]
+        return "\n".join(
+            line for line in lines if not line.lstrip().startswith("#")
         )
+
+    # Whole-read endpoints: the shared _open_checked envelope, offloaded.
+    for fn in (mod.api_file_raw, mod.api_file_download):
+        body = _body(fn)
         assert "_open_checked" in body, f"{fn.__name__} must use the shared envelope"
         assert "asyncio.to_thread" in body, (
             f"{fn.__name__} must offload the envelope to a worker thread -- the "
@@ -224,6 +258,51 @@ def test_both_endpoints_route_through_the_shared_envelope():
         assert "is_sensitive_path" not in body, (
             f"{fn.__name__} re-checks the sensitive path itself; the envelope owns it"
         )
+
+    # The whole-read envelope itself is a bounded read over the shared prefix:
+    # it must not re-grow a private copy of the open-and-check half.
+    body = _body(mod._open_checked)
+    assert "_open_checked_file(" in body, (
+        "_open_checked must route through the shared open-and-check prefix"
+    )
+    assert "_open_rb_nofollow(" not in body, (
+        "_open_checked re-opened a file itself; _open_checked_file owns the open"
+    )
+    assert "is_sensitive_path" not in body, (
+        "_open_checked re-checks the sensitive path itself; the prefix owns the gate"
+    )
+
+    # Streaming + sheet endpoints: the same prefix, their caps passed in as
+    # policy (fstat cap for the stream, bounded read for the sheet parser).
+    # No paren in the positive assertion: the sheet endpoint hands the helper
+    # to asyncio.to_thread as an argument rather than calling it inline.
+    for fn in (mod.api_file_stream, mod.api_file_sheet):
+        body = _body(fn)
+        assert "_open_checked_file" in body, (
+            f"{fn.__name__} must use the shared open-and-check prefix"
+        )
+        assert "asyncio.to_thread" in body, (
+            f"{fn.__name__} must offload the prefix to a worker thread -- it is "
+            "synchronous file I/O and must not run on the event loop"
+        )
+        assert "_open_rb_nofollow(" not in body, (
+            f"{fn.__name__} re-opened a file itself instead of going through "
+            "_open_checked_file -- that is how the copies drifted apart"
+        )
+        assert "is_sensitive_path" not in body, (
+            f"{fn.__name__} re-checks the sensitive path itself; the prefix owns it"
+        )
+
+    # The sheet parser receives the checked-open file object; it must not
+    # re-grow an open or a sensitive-path check of its own.
+    body = _body(mod._load_sheet_payload)
+    assert "_open_rb_nofollow(" not in body, (
+        "_load_sheet_payload re-opened a file itself; it must receive the "
+        "checked-open file from _open_checked_file"
+    )
+    assert "is_sensitive_path" not in body, (
+        "_load_sheet_payload re-checks the sensitive path itself; the prefix owns it"
+    )
 
 
 @pytest.mark.asyncio
@@ -254,3 +333,22 @@ async def test_the_envelope_still_rejects_a_symlink_for_both(tmp_path):
             async with TestClient(TestServer(app)) as client:
                 resp = await client.get(f"/api/{route}?path={link}")
                 assert resp.status == 403, route
+
+
+@pytest.mark.asyncio
+async def test_a_nul_bearing_path_is_a_400_with_a_sel_denied(mock_sel):
+    """A malformed path (embedded NUL makes realpath raise ValueError) is an
+    invalid path, not a crash: the shared prefix answers 400 and the refusal
+    is SEL-audited as denied. Pinned because /api/file-raw has no
+    validate_tool_args guard ahead of the envelope, so the prefix's
+    ValueError handling is the only thing between this input and an
+    unaudited 500."""
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get("/api/file-raw?path=%00x")
+        assert resp.status == 400
+        assert (await resp.json())["error"] == "invalid or forbidden path"
+    outcomes = [
+        call.kwargs.get("outcome")
+        for call in mock_sel.log_tool_invocation.call_args_list
+    ]
+    assert "denied" in outcomes

--- a/test/test_file_sheet.py
+++ b/test/test_file_sheet.py
@@ -12,6 +12,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.handlers import api_file_sheet
 from kiro_crew.dashboard.handlers.files import (
+    _MAX_UPLOAD_BYTES,
     _SHEET_MAX_COLS,
     _SHEET_MAX_ROWS,
     _load_sheet_payload,
@@ -30,7 +31,7 @@ def _make_app() -> web.Application:
 @pytest.fixture
 def mock_sel():
     with patch("kiro_crew.sel.sel") as m, \
-         patch("kiro_crew.security.is_sensitive_path", return_value=False):
+         patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=False):
         instance = MagicMock()
         m.return_value = instance
         yield instance
@@ -218,7 +219,10 @@ def test_zip_expansion_cap_refuses_before_parse(tmp_path):
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("kiro_crew.dashboard.handlers.files._SHEET_MAX_EXPANDED_BYTES", 1024)
         with pytest.raises(_SheetRefusal) as exc:
-            _load_sheet_payload(str(f))
+            # The parser receives the checked-open file object (ownership
+            # transfers: it closes on every path) and the bounded-read cap as
+            # passed-in policy -- the same shape the endpoint uses.
+            _load_sheet_payload(open(f, "rb"), max_bytes=_MAX_UPLOAD_BYTES)
     assert exc.value.status == 413
     assert "expands" in str(exc.value)
 
@@ -233,7 +237,7 @@ def test_zip_member_count_cap_refuses_before_parse(tmp_path):
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("kiro_crew.dashboard.handlers.files._SHEET_MAX_MEMBERS", 10)
         with pytest.raises(_SheetRefusal) as exc:
-            _load_sheet_payload(str(f))
+            _load_sheet_payload(open(f, "rb"), max_bytes=_MAX_UPLOAD_BYTES)
     assert exc.value.status == 413
 
 
@@ -373,7 +377,7 @@ async def test_rejects_sensitive_path(tmp_path):
     f = tmp_path / "creds.xlsx"
     f.write_bytes(b"PK\x03\x04junk")
     with patch("kiro_crew.sel.sel", return_value=MagicMock()), \
-         patch("kiro_crew.security.is_sensitive_path", return_value=True), \
+         patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True), \
          patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)):
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(f"/api/file-sheet?path={f}")

--- a/test/test_file_stream.py
+++ b/test/test_file_stream.py
@@ -281,10 +281,11 @@ async def test_binary_media_is_not_affected_by_the_probe(tmp_path, mock_sel):
 async def test_sensitive_path_403(tmp_path, mock_sel):
     f = tmp_path / "demo.mp4"
     f.write_bytes(_MP4_BYTES)
-    # The endpoint imports is_sensitive_path from kiro_crew.security at call
-    # time, so the patch must target the source module, not the files module.
+    # The shared open-and-check prefix reads this module's import-time
+    # is_sensitive_path alias -- one binding for one guard -- so the patch
+    # targets the files module, the same seam every other endpoint's tests use.
     with patch("kiro_crew.dashboard.handlers._validate_dashboard_path", return_value=str(f)), \
-         patch("kiro_crew.security.is_sensitive_path", return_value=True):
+         patch("kiro_crew.dashboard.handlers.files.is_sensitive_path", return_value=True):
         async with TestClient(TestServer(_make_app())) as client:
             resp = await client.get(f"/api/file-stream?path={f}")
             assert resp.status == 403


### PR DESCRIPTION
## Problem / Motivation

The open-and-check envelope PR #4070 introduced (`_open_checked`) only covers the two whole-read file endpoints. `api_file_stream`'s `_open_media` and `api_file_sheet` + `_load_sheet_payload` each carry a hand-rolled copy of the identical security prefix — validate → sensitive-path gate → `_open_rb_nofollow` → size cap — because the envelope whole-reads while they must keep the open file object. On top of that, `files.py` carries several per-call `from kiro_crew.security import is_sensitive_path` re-imports, so one guard has two patch seams: a test override (or a hardening change) applied to one binding is invisible to sites using the other. `test_file_stream`'s `mock_sel` fixture already exhibits this drift — it patches `files.is_sensitive_path`, which the stream endpoint's per-call re-import silently ignored.

## Why it matters

A security prefix spelled out in three places means a future hardening fix — a new TOCTOU guard, a tightened check, a cap change — lands in one copy and silently leaves the others on the old posture. That is the exact drift class #4070 set out to retire; this finishes the job.

## What changed (motivation → approach → change)

Following the Design Review direction from PR #4070: split `_open_checked` at the open-and-check boundary.

- **`_open_checked_file`** (new) is the shared prefix: path validation, the sensitive-path gate through the module-level `is_sensitive_path` alias, the `O_NOFOLLOW` open, fstat, and an optional `fstat_cap`. It RETURNS the checked open file object, with refusals as typed codes (the streaming endpoint's existing `code` vocabulary) so each adopter keeps its own SEL outcomes and response bodies.
- **`_open_checked`** becomes the whole-read policy on top: bounded read (`max_bytes + 1`, the cap the fstat race cannot beat), close, and the same SEL/response mapping as before.
- **`_open_media`** adopts the prefix with its stream cap passed in (`fstat_cap=_STREAM_MAX_BYTES`); the media sniff and text probe stay as endpoint policy.
- **`_load_sheet_payload`** now receives the checked-open file object and the bounded-read cap as passed-in policy (`max_bytes`); `api_file_sheet` runs the prefix via `asyncio.to_thread`, which also moves its validate/sensitive/isfile work off the event loop (it previously ran inline in the async handler).
- **`is_sensitive_path` seam unification:** the per-call re-imports in the workspace create/update/copy handlers and `api_browse_dirs` are removed in favor of the module-level alias. `api_file_search`'s documented deliberate late-binding is preserved with its comment.
- **Review-round hardening** (from the pre-push review lanes): no `close()` runs on the event loop on the sheet cancellation path (the parser's `with f:` owns the close on the worker thread); the helper takes `log_open_failure` so the streaming/sheet endpoints keep their no-traceback log posture (preventing per-request log amplification on caller-reachable open failures); `file_too_large` is explicitly mapped in both whole-read and sheet adopters so a policy refusal can never surface as a 500.

Behavior is unchanged for every endpoint — same status codes, same caps, same refusal bodies, same SEL vocabulary — with two deliberate, additive exceptions: (1) a NUL-bearing path to `/api/file-raw` now answers a SEL-audited 400 `invalid or forbidden path` instead of an unhandled, unaudited 500 (the shared prefix treats a malformed path as an invalid path, matching the streaming endpoint's existing contract; pinned by a new test); (2) the whole-read envelope's two NEW response sites (the open-failure 500 and the fstat-cap 413) carry a machine-readable `code` field, as the error-code contract ratchet (`test_error_code_contract.py`) requires of every new error-response site — additive to the body, `error` prose unchanged.

## Tests

- `test_both_endpoints_route_through_the_shared_envelope` extended to pin **all four adopters** plus the whole-read envelope and the sheet parser: each must route through the shared prefix, must not call `_open_rb_nofollow` itself, and must not re-check `is_sensitive_path`. The helper now strips **all** docstrings (including nested ones) before asserting, so prose naming the helpers cannot satisfy the check — mutation-verified: aliasing the prefix call away makes the test fail.
- New `test_a_nul_bearing_path_is_a_400_with_a_sel_denied` pins the one deliberate behavior change.
- `test_file_stream` / `test_file_sheet` sensitive-path patches retargeted onto the now-single `files.is_sensitive_path` seam; the two direct `_load_sheet_payload` tests updated to the new signature (checked-open file + passed-in cap).
- Full files-handler suites (file_raw / file_stream / file_sheet / browse_dirs / browse_files / file_search / file_search_dirs / file_download: 147 tests) and the workspace CRUD suites (64 tests) pass; isort / flake8 / mypy / black-gate clean.

## Manual verification

N/A — unit coverage sufficient: every endpoint's status-code, cap, and refusal surface is exercised by the existing endpoint suites, and the structural test pins the seam itself.

## Related Issues

Closes #5742

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor of dashboard file handlers; no frontend file is touched and no rendered pixel changes.
