### PR TITLE
fix(channels): reject a non-string mention or thread_id instead of 500ing

### DIFF
--- a/src/kiro_crew/dashboard/handlers_channel.py
+++ b/src/kiro_crew/dashboard/handlers_channel.py
@@ -290,15 +290,32 @@ async def api_channel_post(request: web.Request) -> web.Response:
     content = raw_content.strip()[:10000]
     if not content:
         return web.json_response({"error": "content required"}, status=400)
-    # Validate mentions
+    # Validate mentions. Membership is a dict lookup, so an unhashable value
+    # here raises TypeError rather than simply failing to match.
     raw_mention = body.get("mention")
-    if raw_mention:
+    if raw_mention is not None:
         if isinstance(raw_mention, list):
-            raw_mention = [m for m in raw_mention if m in ch.members]
+            if not all(isinstance(name, str) for name in raw_mention):
+                return _agent_field_error(
+                    "mention entries must be strings",
+                    "channel_message_mention_type_invalid",
+                )
+            raw_mention = [name for name in raw_mention if name in ch.members]
+        elif not isinstance(raw_mention, str):
+            return _agent_field_error(
+                "mention must be a string or an array of strings",
+                "channel_message_mention_type_invalid",
+            )
         elif raw_mention not in ch.members:
             raw_mention = None
     # Validate thread_id
     thread_id = body.get("thread_id")
+    if thread_id is not None:
+        if not isinstance(thread_id, str):
+            return _agent_field_error(
+                "thread_id must be a string",
+                "channel_message_thread_id_type_invalid",
+            )
     if thread_id and thread_id not in ch._msg_index:
         thread_id = None
     msg = await ch.post(

--- a/test/test_channel_message_api_validation.py
+++ b/test/test_channel_message_api_validation.py
@@ -61,3 +61,70 @@ async def test_post_keeps_string_trim_and_length_limit(manager):
     assert response.status == 200
     assert _body(response)["message"]["content"] == "a" * 10000
     assert channel.messages[-1].content == "a" * 10000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mention",
+    [False, 7, {"id": "agent-1"}, ["ok", 7], ["ok", {"id": "agent-1"}], [["nested"]]],
+)
+async def test_post_rejects_non_string_mention_before_mutation(manager, monkeypatch, mention):
+    channel = manager.create("incident")
+    post_spy = AsyncMock(return_value=SimpleNamespace(to_dict=lambda: {}))
+    monkeypatch.setattr(channel, "post", post_spy)
+
+    response = await _invoke(_request(manager, {"content": "hi", "mention": mention}, channel.id))
+
+    assert response.status == 400
+    assert _body(response)["code"] == "channel_message_mention_type_invalid"
+    assert channel.messages == []
+    post_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("thread_id", [{"id": "m1"}, ["m1"], 7, True])
+async def test_post_rejects_non_string_thread_id_before_mutation(manager, monkeypatch, thread_id):
+    channel = manager.create("incident")
+    post_spy = AsyncMock(return_value=SimpleNamespace(to_dict=lambda: {}))
+    monkeypatch.setattr(channel, "post", post_spy)
+
+    response = await _invoke(
+        _request(manager, {"content": "hi", "thread_id": thread_id}, channel.id)
+    )
+
+    assert response.status == 400
+    assert _body(response)["code"] == "channel_message_thread_id_type_invalid"
+    assert channel.messages == []
+    post_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_still_drops_unknown_mention_and_thread_id(manager):
+    channel = manager.create("incident")
+
+    response = await _invoke(
+        _request(
+            manager,
+            {"content": "hi", "mention": "nobody", "thread_id": "no-such-message"},
+            channel.id,
+        )
+    )
+
+    assert response.status == 200
+    posted = channel.messages[-1]
+    assert posted.mention is None
+    assert posted.thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_post_accepts_empty_string_optional_fields(manager):
+    channel = manager.create("incident")
+
+    response = await _invoke(
+        _request(manager, {"content": "hi", "mention": "", "thread_id": ""}, channel.id)
+    )
+
+    assert response.status == 200
+    posted = channel.messages[-1]
+    assert posted.mention is None
+    assert posted.thread_id == ""


### PR DESCRIPTION
## Problem / Motivation

`POST /api/channels/{id}/messages` used raw JSON `mention` and `thread_id`
values in dictionary membership checks before validating their types. A dict or
nested list therefore raised `TypeError: unhashable type` and surfaced as a 500,
while hashable wrong types such as an integer or boolean could be silently
accepted.

This is the residual identified by the Design review on #5618, which fixed the
same class of defect for `content` in this handler.

## Why it matters

The endpoint is used by the dashboard, gateway, agents, and scripts. A malformed
client field should produce a stable coded 400, not an opaque server error or a
successful mutation with silently changed input. Inconsistent behavior also
makes client recovery and audit logs unreliable.

## What changed (motivation → approach → change)

- Validate `mention` before any member lookup. It must be a string or an array
  containing only strings; otherwise the handler returns coded 400
  `channel_message_mention_type_invalid`.
- Validate `thread_id` before any message lookup. A non-string returns coded 400
  `channel_message_thread_id_type_invalid`.
- Reuse the handler's existing `_agent_field_error` response helper instead of
  adding duplicate response sinks.
- Keep well-typed optional values compatible: an empty `mention` normalizes to
  `None`, an empty-string `thread_id` remains `""`, and an unknown non-empty
  member or message id is accepted and normalized to `None`. Only wrong-typed
  values are refused.

On base `bcf2efb732fe3f20f2691bd41b1dd3f1ce00b88d`, the committed
`error-code-baseline.json` totals are `missing_code=1262`, `opaque_body=18`,
`dynamic_status=43`, and `_compliant=1387`. A fresh generator run on both current
`main` and the final PR tree reports the same totals and `_compliant=1388`; that
one-site display-count drift already exists on `main` and is unchanged by this
diff. The generated baseline is therefore left untouched rather than mixing an
unrelated refresh into this contributor change.

Open-PR overlap was audited globally. #5248 touches the same handler in a
different, much larger logic area and is harder to merge; #5977 is the
easier-first change. Other intersecting PRs only share the generated baseline,
which this final diff no longer changes. No contributor hunk is replaced.

The related raw `source` membership issue in `handlers/taskrunner.py` belongs to
a different endpoint and provenance gate. It should be handled as a separate
small PR rather than expanding this contributor's scope.

## Tests

- Regression cases cover dict/list/int/bool `mention`, mixed and nested mention
  arrays, and dict/list/int/bool `thread_id`; all refuse before channel mutation.
- Compatibility cases cover unknown string ids plus both empty optional fields.
- Final strict suite: 123 passed, 1 platform-conditional skip, with
  RuntimeWarning and PytestUnraisableExceptionWarning promoted to errors.
- Focused final: 18/18 message validation tests and 24/24 with the error-code
  contract tests.
- isort, flake8, the Black ratchet, full mypy (1168 source files), and
  `git diff --check` pass.
- No retry, sleep, warning filter, timeout increase, or tolerance relaxation was
  used.

## Manual verification

N/A — the defect is a request-body contract exercised directly with the exact
JSON shapes that previously crashed or were silently accepted.

## Related Issues

Residual identified by the Design review on #5618. No separate issue was filed.

## Checklist

- [x] At most two commits (exactly one), with a Conventional Commits title
- [x] Existing affected tests pass and regression coverage is included
- [x] Self-review completed; repository style gates pass
- [x] Documentation updated (not applicable: existing API contract is enforced)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
