### PR TITLE
fix(dashboard): re-assert queued prompt containment at drain (#5911)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -212,7 +212,6 @@ src/kiro_crew/dashboard/chat_folder_suggest.py
 src/kiro_crew/dashboard/chat_folders.py
 src/kiro_crew/dashboard/chat_fork.py
 src/kiro_crew/dashboard/chat_nav.py
-src/kiro_crew/dashboard/chat_orchestrator.py
 src/kiro_crew/dashboard/chat_persistence.py
 src/kiro_crew/dashboard/chat_slack.py
 src/kiro_crew/dashboard/chat_title.py
@@ -799,7 +798,6 @@ test/test_governance_chokepoints.py
 test/test_governance_policy.py
 test/test_governance_policy_viewer.py
 test/test_handler_cron_list.py
-test/test_handler_link_intercept.py
 test/test_handlers_channel_clear_context.py
 test/test_handlers_channel_presets.py
 test/test_handlers_files_upload.py
@@ -1155,9 +1153,7 @@ test/test_slack_dashboard_live_sync.py
 test/test_slack_events_coverage.py
 test/test_slack_gateway.py
 test/test_slack_gateway_coverage.py
-test/test_slack_handler_coverage.py
 test/test_slack_handler_coverage_branches.py
-test/test_slack_handler_more_coverage.py
 test/test_slack_home_tab.py
 test/test_slack_inline_stop.py
 test/test_slack_interactions_coverage.py

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
@@ -5059,8 +5059,16 @@ def _dispatch_turn(
     """Relay a turn into the spec's agent slot with its structural provenance."""
     if getattr(slot, "running", False):
         try:
+            # circular import (deferred), and load-bearing (#5911): a spec slot
+            # is app-scoped, so an UNMARKED plain entry would fail the drain's
+            # closed-world re-check.
+            # The stamp records app=True at admission, which the drain treats as
+            # designed behaviour rather than a containment change.
+            from kiro_crew.dashboard.session_control import containment_meta
+
             slot.queue_append(
                 message,
+                meta=containment_meta(state, slot),
                 directive_user_origin=directive_user_origin,
             )
         except Exception:

--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -322,8 +322,12 @@ def queue_for_next_turn(
     The running turn's teardown drains the queue, so this is how a message
     reaches a busy slot when steering is unavailable or not asked for.
     """
+    # circular import: session_control imports this module at module level.
+    from kiro_crew.dashboard.session_control import containment_meta
+
     qid = slot.queue_append(
         message,
+        meta=containment_meta(state, slot),
         directive_user_origin=directive_user_origin,
     )
     state.broadcast_ws(

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -412,8 +412,12 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         and state.subagents is not None
         and state.subagents.running_agents_for(f"dashboard:{slot.key}")
     ):
+        # circular import: session_control imports this package's modules at module level.
+        from kiro_crew.dashboard.session_control import containment_meta
+
         qid = slot.queue_append(
             message,
+            meta=containment_meta(state, slot),
             directive_user_origin=not bool(request_app),
         )
         _c, _ = redact_exfiltration_urls(message)
@@ -2657,7 +2661,21 @@ async def api_chat_slot_continue(request: web.Request) -> web.Response:
         # cleanly that it was "interrupted before it finished" sends it looking
         # for half-done work that does not exist.
         resume = _MANUAL_RESUME_MSG if _is_interrupted(slot) else _MANUAL_CONTINUE_MSG
-        slot.queue_insert(0, resume, kind=SYNTHETIC_RECOVERY_KIND)
+        # circular import: session_control imports this package's modules at module level.
+        from kiro_crew.dashboard.session_control import containment_meta
+
+        # Admission stamp + provenance (#5911): recovery-kind entries are subject
+        # to drain re-validation like any other externally admitted content, and
+        # provenance follows the CALLER — the same request-identity split as
+        # api_chat. An app hitting Continue on its own slot must not gain the
+        # authenticated-human flag that gates session-mutating effects.
+        slot.queue_insert(
+            0,
+            resume,
+            kind=SYNTHETIC_RECOVERY_KIND,
+            meta=containment_meta(state, slot),
+            directive_user_origin=not bool(request.get("app", "")),
+        )
 
     sel().log_tool_invocation(
         session_key=_history_key_for(name),

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -232,7 +232,11 @@ async def _stage_loop(
 
     logger.info(
         "Stage loop start: slot=%s total=%d start_idx=%d auto_run=%s titles=%s",
-        slot.key, total, start_idx, auto_run, titles,
+        slot.key,
+        total,
+        start_idx,
+        auto_run,
+        titles,
     )
 
     _paused = False
@@ -265,7 +269,9 @@ async def _stage_loop(
             if stage_idx >= slot._plan_stage_count:
                 logger.warning(
                     "Stage loop clamp for slot %s: stage_idx=%d >= plan_stage_count=%d; stopping",
-                    slot.key, stage_idx, slot._plan_stage_count,
+                    slot.key,
+                    stage_idx,
+                    slot._plan_stage_count,
                 )
                 break
 
@@ -330,7 +336,10 @@ async def _stage_loop(
             # Inject as hidden user message and run LLM turn
             logger.info(
                 "Stage %d/%d: context=%d chars, messages=%d",
-                stage_num, total, len(context), len(slot.messages),
+                stage_num,
+                total,
+                len(context),
+                len(slot.messages),
             )
             # NOT flushed here: a stage turn is automatic (`auto-go`), and a held
             # note is owed to the next USER turn, so feeding it to a stage would
@@ -377,7 +386,9 @@ async def _stage_loop(
                 # convention already used by _run_pending_synthesis).
                 logger.error(
                     "Stage %d exceeded its %ds ceiling for slot %s",
-                    stage_num, tracker.stage_timeout_seconds, slot.key,
+                    stage_num,
+                    tracker.stage_timeout_seconds,
+                    slot.key,
                 )
                 _timeout_msg = (
                     f"⏱️ Stage {stage_num} timed out after {tracker.timeout_human}. "
@@ -404,8 +415,12 @@ async def _stage_loop(
                 )
                 break
             except Exception:
-                logger.exception("_run_chat failed during stage %d for slot %s", stage_num, slot.key)
-                _err_msg = f"❌ Stage {stage_num} failed due to an internal error. Auto-run stopped."
+                logger.exception(
+                    "_run_chat failed during stage %d for slot %s", stage_num, slot.key
+                )
+                _err_msg = (
+                    f"❌ Stage {stage_num} failed due to an internal error. Auto-run stopped."
+                )
                 slot._auto_run = False
                 slot.append("assistant", _err_msg, "msg msg-a")
                 state.broadcast_ws(
@@ -451,11 +466,11 @@ async def _stage_loop(
                 logger.warning(
                     "Stage %d: subagents manager is None for slot %s"
                     " — stopping auto-run (fail-closed)",
-                    stage_num, slot.key,
+                    stage_num,
+                    slot.key,
                 )
                 _fc_msg = (
-                    f"⚠️ Stage {stage_num}: subagent manager unavailable. "
-                    "Auto-run stopped."
+                    f"⚠️ Stage {stage_num}: subagent manager unavailable. " "Auto-run stopped."
                 )
                 slot._auto_run = False
                 slot.append("assistant", _fc_msg, "msg msg-a")
@@ -485,12 +500,10 @@ async def _stage_loop(
                     logger.warning(
                         "Stage %d: running_agents_for returned None for slot %s"
                         " — stopping auto-run (fail-closed)",
-                        stage_num, slot.key,
+                        stage_num,
+                        slot.key,
                     )
-                    _fc_msg = (
-                        f"⚠️ Stage {stage_num}: subagent check failed. "
-                        "Auto-run stopped."
-                    )
+                    _fc_msg = f"⚠️ Stage {stage_num}: subagent check failed. " "Auto-run stopped."
                     slot._auto_run = False
                     slot.append("assistant", _fc_msg, "msg msg-a")
                     state.broadcast_ws(
@@ -528,13 +541,17 @@ async def _stage_loop(
                     if _pending and _sa_rounds % 10 == 0:
                         state.broadcast_ws(
                             "chat_status",
-                            {"slot": slot.key, "status": f"Waiting for {len(_pending)} subagent(s)..."},
+                            {
+                                "slot": slot.key,
+                                "status": f"Waiting for {len(_pending)} subagent(s)...",
+                            },
                         )
                     if _pending is None:
                         logger.warning(
                             "Stage %d: running_agents_for returned None during"
                             " polling for slot %s — stopping auto-run",
-                            stage_num, slot.key,
+                            stage_num,
+                            slot.key,
                         )
                         slot._auto_run = False
                         break
@@ -567,7 +584,11 @@ async def _stage_loop(
                 _wait_secs = _sa_rounds * 2
                 logger.warning(
                     "Stage %d: subagent wait exhausted after %ds (%d rounds, cap %d) for slot %s",
-                    stage_num, _wait_secs, _sa_rounds, _sa_max_rounds, slot.key,
+                    stage_num,
+                    _wait_secs,
+                    _sa_rounds,
+                    _sa_max_rounds,
+                    slot.key,
                 )
                 slot._auto_run = False
                 _sa_msg = (
@@ -603,14 +624,20 @@ async def _stage_loop(
                 result_path = _capture_stage_result(slot, stage_num)
                 tracker.record_stage_result(stage_num, result_path)
             except OSError:
-                logger.warning("Failed to capture stage %d result to disk", stage_num, exc_info=True)
+                logger.warning(
+                    "Failed to capture stage %d result to disk", stage_num, exc_info=True
+                )
 
             # Gate: if not auto_run, wait for user approval
             if not auto_run:
                 # Emit completion message — user must click Go for next stage
                 if stage_idx + 1 < total:
                     next_title = titles[stage_idx + 1] if stage_idx + 1 < len(titles) else ""
-                    next_label = f"Stage {stage_idx + 2}: {next_title}" if next_title else f"Stage {stage_idx + 2}"
+                    next_label = (
+                        f"Stage {stage_idx + 2}: {next_title}"
+                        if next_title
+                        else f"Stage {stage_idx + 2}"
+                    )
                     done_msg = (
                         f"✅ Stage {stage_num} complete. Click **Go** to proceed to {next_label}."
                         "\n\n[OPTION: Go | Go All | Cancel]"
@@ -686,7 +713,11 @@ async def _stage_loop(
         slot._in_stage_execution = False
         logger.info(
             "Stage loop end: slot=%s current_stage=%s/%s stopping=%s auto_run=%s",
-            slot.key, tracker.current_stage, total, slot._stopping, slot._auto_run,
+            slot.key,
+            tracker.current_stage,
+            total,
+            slot._stopping,
+            slot._auto_run,
         )
         # Hand off any messages the user queued while the plan ran (held via the
         # _in_stage_execution gate in _start_next_queued_turn — now cleared above).
@@ -785,7 +816,7 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
         slot._auto_run = False
         if state.subagents:
             session_key = f"dashboard:{slot.key}"
-            for a in (state.subagents.running_agents_for(session_key) or []):
+            for a in state.subagents.running_agents_for(session_key) or []:
                 t = state.subagents._tasks.get(a["id"])
                 if t and not t.done():
                     t.cancel()
@@ -799,7 +830,19 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
 
     # Go or Go All — use Python-controlled stage loop
     if slot.running:
-        slot.queue_append("Go")
+        # circular import: session_control imports this package's modules at module level.
+        from kiro_crew.dashboard.session_control import containment_meta
+
+        # Provenance follows the CALLER — the same request-identity split as
+        # api_chat and the manual continue. A human clicking Go on their own
+        # busy session must not lose the approval if they link the session
+        # before the drain; an app relaying a plan action never gains the
+        # authenticated-human flag.
+        slot.queue_append(
+            "Go",
+            meta=containment_meta(state, slot),
+            directive_user_origin=not bool(request.get("app", "")),
+        )
         return web.json_response({"ok": True, "queued": True})
 
     is_auto = action == "go all"

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -246,6 +246,7 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     _POSTTOKEN_RECOVER_MSG,
     _PROMISE_ONLY_CONTINUE_MSG,
     _SYNTHETIC_RECOVERY_MSGS,
+    CRON_NOTIFICATION_KIND,
     SUBAGENT_COMPLETION_KIND,
     SYNTHETIC_RECOVERY_KIND,
     RecoveryPayload,
@@ -4175,6 +4176,9 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
     """
     if not slot._pending_steers:
         return
+    # circular import: session_control imports this package's modules at module level.
+    from kiro_crew.dashboard.session_control import containment_meta
+
     requeued = slot._pending_steers[:]
     slot._pending_steers.clear()
     for steer_msg in reversed(requeued):
@@ -4191,11 +4195,29 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
         # when several queued items are merged into one — which is the only way the
         # steer's caller can tell "already persisted by the drain" from "consumed by
         # the turn" after both bookkeeping lists have emptied.
-        _meta: dict | None = None
+        #
+        # Stamp the containment snapshot too (#5911): a requeued steer is plain
+        # user speech re-entering the queue, and this requeue is the last moment
+        # its admission is re-affirmed — a link appearing between here and the
+        # drain must drop it like any other queued prompt, while a session that
+        # was ALREADY channel-born keeps its steers.
+        _meta: dict = containment_meta(state, slot)
         _did = getattr(slot, "_steer_delivery_ids", {}).pop(steer_msg, "")
         if _did:
-            _meta = {"steer_delivery_id": _did}
-        qid = slot.queue_insert(0, steer_msg, meta=_meta)
+            _meta["steer_delivery_id"] = _did
+        # Provenance is derivable, not guessed: `steer_into_running_turn` has
+        # exactly one caller (the api_chat composer branch), and app isolation
+        # confines app-surface requests to app-scoped slots — so every steer
+        # into a NON-app slot came from the authenticated human composer. That
+        # provenance is what exempts the requeued card from the LINKED drop,
+        # exactly as the composer's own queued
+        # fallback is exempt; an app slot's steers stay unexempted (False).
+        qid = slot.queue_insert(
+            0,
+            steer_msg,
+            meta=_meta,
+            directive_user_origin=not bool(getattr(slot, "_app", "")),
+        )
         try:
             content, _ = redact_exfiltration_urls(steer_msg)
             content, _ = redact_credentials(content)
@@ -4364,8 +4386,115 @@ def _has_user_queued_followup(slot: "_ChatSlot") -> bool:
     return any(not _queue_entry_is_orchestration(q) for q in getattr(slot, "_queue", []))
 
 
+def _drop_stale_admissions(state: DashboardState, slot: _ChatSlot) -> None:
+    """Drop queued entries whose admission-time containment no longer holds (#5911).
+
+    Authorization is decided when a prompt is ADMITTED (`authorize_target` for
+    `session_send`, the authenticated composer for a human typing into a busy
+    session), but delivery happens later, at this drain — and the target-side
+    containment those decisions rest on can change in between: a target
+    authorized while unlinked can be given a channel or mirror link before its
+    queue drains, and the queued prompt would then execute and republish to an
+    audience its admission never contemplated.
+
+    Producers of plain (user-speech) entries stamp the containment snapshot at
+    enqueue (`session_control.containment_meta`); this sweep recomputes the same
+    constraints and drops any entry for which a constraint holds NOW that did
+    not hold at admission — including a WORKSPACE change, which swaps the
+    memory/lessons/project context under a waiting prompt. An unmarked plain
+    entry fails closed against the boolean constraint set, so an untagged
+    producer can never ride a queued prompt past a boundary the tagged paths
+    respect.
+
+    Entries carrying `_directive_user_origin` (authenticated-human provenance)
+    are exempt from the LINKED constraint only: the author typed into the
+    session's own surface and linking it is that owner's deliberate act, so
+    composer input into a just-linked session is designed behaviour. A NEW
+    outbound mirror still drops them — the author does not control mirror
+    links — as do all other constraints (see
+    `session_control.newly_held_constraints`).
+
+    Structural exemption is narrow: cron notifications and sub-agent
+    completions only (`CRON_NOTIFICATION_KIND` / `SUBAGENT_COMPLETION_KIND`) —
+    runner machinery minted fresh by trusted internal producers, which
+    channel-born sessions receive by design. Synthetic-recovery entries are
+    NOT exempt: a recovery replays externally admitted content verbatim, so it
+    is re-validated like any plain entry against the admission stamp its
+    requeue recorded (`_queue_recovery`), failing closed when unmarked.
+
+    Runs at the top of the drain with no suspension point between the snapshot
+    and the dequeue (everything below is synchronous on the event loop), so the
+    decision cannot go stale before the surviving entry becomes a turn. A drop
+    is never silent: the queue card is retracted, a visible notice naming the
+    changed constraint lands in the transcript, and the drop is written to the
+    SEL.
+    """
+    if not slot._queue:
+        return
+    # circular import: session_control imports this package's modules at module level.
+    from kiro_crew.dashboard import session_control as _sc
+
+    now = _sc.containment_snapshot(state, slot, on_probe_failure=True)
+    _mirror_unverified = bool(now.get("mirror_unverified"))
+    doomed: list[tuple[dict, list[str]]] = []
+    for q in slot._queue:
+        # Exempt ONLY cron notifications and sub-agent completions: both are
+        # minted fresh by trusted internal producers for THIS slot's own turn
+        # lifecycle, and channel-born sessions receive them by design. A
+        # synthetic-recovery entry is deliberately NOT exempt — it replays
+        # externally admitted content verbatim under a fresh queue id, so an
+        # exemption would let the retry ride past a link that appeared during
+        # the recovery window. Every recovery producer stamps admission context
+        # at requeue (`_queue_recovery`, the manual continue), so a recovery in
+        # a channel-born session still drains: its stamp records linked=True.
+        if q.get("kind") in (CRON_NOTIFICATION_KIND, SUBAGENT_COMPLETION_KIND):
+            continue
+        changed = _sc.newly_held_constraints(
+            now,
+            q.get("meta"),
+            directive_user_origin=q.get("_directive_user_origin") is True,
+        )
+        if changed:
+            doomed.append((q, changed))
+    for q, changed in doomed:
+        slot.queue_remove_by_id(q["id"])
+        # The broadcast is unconditional: the frontend's queue card was created
+        # by the producer's queue_push, not by a transcript placeholder row, so
+        # gating retraction on the (rare) placeholder existing would leave a
+        # card on screen for a message the server discarded. The placeholder
+        # removal is the separate, best-effort half.
+        _remove_queued_by_id(slot.messages, q["id"])
+        state.broadcast_ws("queue_pop", {"slot": slot.key, "content": "", "queue_id": q["id"]})
+        slot.append(
+            "notice",
+            "⚠️ Queued message dropped: "
+            + _sc.describe_containment_change(changed, mirror_unverified=_mirror_unverified)
+            + " after it was queued, so the authorization that admitted it no longer holds.",
+            "msg msg-info",
+        )
+        _sc.audit_queued_drop(slot, q["id"], changed)
+        _log = logger.warning if _mirror_unverified and "mirrored" in changed else logger.info
+        _log(
+            "Dropped queued entry %s for slot %s at drain re-validation " "(newly held: %s%s)",
+            q["id"],
+            slot.key,
+            ",".join(changed),
+            (
+                "; mirror probe FAILED — refusal is fail-closed, not an observed link"
+                if _mirror_unverified and "mirrored" in changed
+                else ""
+            ),
+        )
+
+
 async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> bool:
     """Dequeue and start one ready Kiro turn, preserving queue semantics."""
+
+    # FIRST, before anything reads the queue: re-assert each entry's
+    # admission-time containment and drop what no longer qualifies (#5911).
+    # Everything below — the note flush peeking at queue[0], the user-intervention
+    # purge, the dequeue itself — must see only entries that may still deliver.
+    _drop_stale_admissions(state, slot)
 
     # Above the dequeue, so a held note's visible line lands before this turn's
     # user row: its context half drains inside _run_chat via drain_pending_context.
@@ -4562,6 +4691,25 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # completion never merges (it drains alone and breaks any user-message
     # merge), so a merged row cannot carry them in the first place.
     _drained_ids: list[str] = []
+    # circular import: session_control imports this package's modules at module level.
+    from kiro_crew.dashboard.session_control import (
+        QUEUED_CONTAINMENT_META_KEY,
+        audit_queued_allow,
+    )
+
+    # The ALLOW side of the drain's permission decision (#5911): these entries
+    # passed re-validation and are now becoming a turn. Audited at consumption —
+    # not per sweep pass — so an entry that waits across several drains yields
+    # one row when it actually executes. Exempt kinds were never subject to the
+    # decision, so they are not counted as one.
+    _revalidated_ids = [
+        item["id"]
+        for item in consumed
+        if item.get("kind") not in (CRON_NOTIFICATION_KIND, SUBAGENT_COMPLETION_KIND)
+    ]
+    if _revalidated_ids:
+        audit_queued_allow(slot, _revalidated_ids)
+
     for item in consumed:
         _item_meta = item.get("meta")
         if isinstance(_item_meta, dict):
@@ -4571,7 +4719,12 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
             _many = _item_meta.get("steer_delivery_ids")
             if isinstance(_many, list):
                 _drained_ids.extend(x for x in _many if isinstance(x, str) and x)
-            _drained_meta.update(_item_meta)
+            # The admission-time containment snapshot (#5911) is queue plumbing,
+            # consumed by _drop_stale_admissions above; it says nothing about the
+            # ROW, so it must not ride into the persisted transcript meta.
+            _drained_meta.update(
+                (k, v) for k, v in _item_meta.items() if k != QUEUED_CONTAINMENT_META_KEY
+            )
     if _drained_ids:
         _drained_meta.pop("steer_delivery_id", None)
         _drained_meta["steer_delivery_ids"] = _drained_ids
@@ -5140,13 +5293,25 @@ async def _run_chat(
         kind: str,
         payload: str = "",
     ) -> str:
-        """Queue a retry without losing a producer's consumption settlement."""
+        """Queue a retry without losing a producer's consumption settlement.
+
+        Stamps FRESH admission context (#5911): a recovery entry replays
+        externally admitted content verbatim under a new queue id, so without
+        its own stamp the drain would either wave it past a link that appeared
+        during the retry window (exemption) or destroy every recovery in a
+        channel-born session (fail-closed). The requeue is the moment its
+        admission is re-affirmed, and the turn's directive provenance rides
+        along so the audience exemption follows the original author.
+        """
+        # circular import: session_control imports this package's modules at module level.
+        from kiro_crew.dashboard.session_control import containment_meta
 
         return slot.queue_insert(
             index,
             content,
             kind=kind,
             payload=payload,
+            meta=containment_meta(state, slot),
             on_consumed=_on_consumed if not _consumed_reported else None,
             on_irreversibly_consumed=(
                 _on_irreversibly_consumed if not _irreversible_consumption_reported else None
@@ -9406,7 +9571,12 @@ async def _run_chat(
                 slot._fallback_candidate_idx = 0
                 slot._fallback_walked = []
             else:
-                slot.queue_insert(
+                # Through _queue_recovery like every other retry (#5911): a direct
+                # queue_insert carries no admission stamp, so the drain's
+                # fail-closed re-check would destroy this fallback-model retry in
+                # every channel-linked or unattended session — exactly the
+                # long-running jobs most likely to hit throttle fallback.
+                _queue_recovery(
                     0,
                     message,
                     kind=SYNTHETIC_RECOVERY_KIND,

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -13,8 +13,12 @@ delivers a message the target runs as its next turn, redacted through
 ``sanitize_outbound`` and prefixed with a ``[sent by session … via session_send]``
 envelope so it can never render as something the person typed. An IDLE target runs
 it under the authorization that admitted it; a BUSY target queues it, and the
-generic drain re-runs no check — an accepted window, not an oversight, because a
-human-typed queued message shares it (see the spec, and issue #5911).
+generic drain re-asserts the target-side containment before the entry becomes a
+turn (issue #5911): producers stamp the constraints that held at admission
+(:func:`containment_meta`), and ``chat_runner``'s drain drops — with a visible
+notice and an SEL record — any entry for which a constraint holds at delivery
+that did not hold at admission. A human-typed queued message shares the same
+window and the same re-check.
 
 Authorization is deny-by-default and checked in one place
 (:func:`authorize_target`) for the two operations that take a target, so a guard
@@ -37,7 +41,7 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.dashboard.chat_delivery import sanitize_outbound
 from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
-from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, SlotOrigin
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
@@ -166,8 +170,49 @@ def caller_slot_key(state: "DashboardState", session_key: str) -> str:
     return ""
 
 
-def _has_channel_mirror(state: "DashboardState", slot: "_ChatSlot") -> bool:
-    """Whether *slot*'s conversation is mirrored out to a channel.
+def _probe_channel_mirror(state: "DashboardState", slot: "_ChatSlot") -> str | None:
+    """The identity of *slot*'s outbound channel mirror, ``""`` when the
+    conversation is not mirrored, or ``None`` when the session store could not
+    answer.
+
+    The tri-state exists because the two consumers need OPPOSITE fail-closed
+    treatments of an unreadable store, and a collapsed boolean forces one of
+    them to lie: the refusal paths must treat unknown as mirrored (refuse rather
+    than open the boundary), while the queue-drain notice must not claim "the
+    session gained a mirror" for a state change that is merely unverifiable.
+
+    The identity (channel type + channel + thread) rather than a bare boolean,
+    because a mirror can be RETARGETED while a queue waits: rebinding session
+    mirror A to channel B keeps the boolean true from admission to drain while
+    substituting the audience — exactly the republication change the drain
+    re-check exists to catch (#5911).
+
+    Read on the EFFECTIVE session key, because that is the key the mirror is
+    registered under -- the slot key would miss a mirror on a session whose turns
+    run under a different identity.
+    """
+    sessions = getattr(state, "sessions", None)
+    getter = getattr(sessions, "get_mirror_link", None)
+    if getter is None:
+        return ""
+    try:
+        link = getter(slot_history_key(slot))
+    except Exception:
+        logger.debug("mirror-link probe failed", exc_info=True)
+        return None
+    if not link:
+        return ""
+    return (
+        f"{getattr(link, 'channel_type', '')}"
+        f":{getattr(link, 'channel_id', '') or ''}"
+        f":{getattr(link, 'thread_id', '') or ''}"
+    )
+
+
+def _has_channel_mirror(
+    state: "DashboardState", slot: "_ChatSlot", *, on_probe_failure: bool = True
+) -> bool:
+    """Boolean view of :func:`_probe_channel_mirror` for the refusal paths.
 
     `linked_session_key` catches a channel-BORN slot. It does not catch a
     dashboard-born slot that was later given an OUTBOUND mirror link, which
@@ -175,22 +220,273 @@ def _has_channel_mirror(state: "DashboardState", slot: "_ChatSlot") -> bool:
     on the slot, so a slot with an empty `linked_session_key` can still be
     republishing every turn to Slack or Telegram.
 
-    Read on the EFFECTIVE session key, because that is the key the mirror is
-    registered under -- the slot key would miss a mirror on a session whose turns
-    run under a different identity.
-
-    Best-effort by design: a store that cannot answer is treated as mirrored, so
-    an unreadable link fails closed rather than opening the boundary.
+    Best-effort by design: a store that cannot answer returns *on_probe_failure*,
+    and the default (``True``) keeps the refusal paths failing closed -- an
+    unreadable link is treated as mirrored rather than opening the boundary.
+    The enqueue-time containment snapshot passes ``False`` because ITS fail-closed
+    direction is inverted: recording "not mirrored" for an unreadable link is the
+    least-authorized admission state, so the drain-side re-check re-validates the
+    entry instead of waving it through (see :func:`containment_snapshot`).
     """
-    sessions = getattr(state, "sessions", None)
-    getter = getattr(sessions, "get_mirror_link", None)
-    if getter is None:
-        return False
-    try:
-        return bool(getter(slot_history_key(slot)))
-    except Exception:
-        logger.debug("mirror-link probe failed; treating as mirrored", exc_info=True)
-        return True
+    probed = _probe_channel_mirror(state, slot)
+    return on_probe_failure if probed is None else bool(probed)
+
+
+# ── Drain-time re-validation of queued prompts (issue #5911) ──
+#
+# Authorization is decided when a prompt is ADMITTED — `authorize_target` for
+# `session_send`, the authenticated composer for a human — but a busy target
+# QUEUES the prompt and delivers it later, and the containment those decisions
+# rest on can change in between: a target authorized while unlinked can gain a
+# channel or mirror link before its queue drains, and the queued prompt would
+# then execute and republish to an audience its admission never contemplated.
+# Producers stamp the constraints that held at admission on the queue entry
+# (`containment_meta`); `chat_runner`'s drain recomputes them and drops any
+# entry for which a constraint holds at delivery that did not hold at admission.
+
+# Queue-entry meta key carrying the admission-time containment snapshot.
+QUEUED_CONTAINMENT_META_KEY = "queued_containment"
+
+# Transcript-notice phrasing per snapshot field, for the drop notice a reader
+# of the session must be able to understand without knowing this module.
+_CONTAINMENT_CHANGE_LABELS = {
+    "linked": "the session was linked to a channel",
+    "mirrored": "the session gained an outbound channel mirror",
+    "mirror_retarget": "the session's outbound mirror was retargeted to a different channel",
+    "crew": "the session was switched to crew mode",
+    "ephemeral": "the session became incognito/temporary",
+    "app": "the session became app-scoped",
+    "unattended": "the session became unattended",
+    "workspace": "the session moved to a different workspace",
+}
+
+
+# Snapshot keys that are NOT constraints: carried for notice wording and
+# telemetry only, never compared by :func:`newly_held_constraints`.
+_NON_CONSTRAINT_KEYS = frozenset({"mirror_unverified"})
+
+# The one constraint a directive user-origin entry is exempt from at the drain:
+# a channel LINK on the entry's own session. The author of a directive entry is
+# an authenticated human typing into that session's own surface, and linking it
+# is that surface owner's deliberate act — dropping their already-typed messages
+# when they link would destroy user speech on a supported flow (`api_chat`
+# applies no linked refusal to composer input). `mirrored` is deliberately NOT
+# exempt: directive content can be authored by any allowed human in a linked
+# thread while only the session owner adds outbound mirror links, so a NEW
+# mirror widens the audience beyond anything the message's author controlled —
+# the exact republication issue #5911 closes. `session_send` and automation
+# entries never carry the flag and stay fully enforced.
+_AUDIENCE_CONSTRAINTS = frozenset({"linked"})
+
+
+def containment_snapshot(
+    state: "DashboardState", slot: "_ChatSlot", *, on_probe_failure: bool
+) -> dict[str, Any]:
+    """The target-side containment constraints of :func:`authorize_target`, as
+    they hold for *slot* right now.
+
+    Two call sites with OPPOSITE fail-closed directions, hence the mandatory
+    ``on_probe_failure``: the enqueue-time snapshot passes ``False`` so an
+    unreadable mirror link records the least-authorized admission state (the
+    drain then re-validates the entry), while the drain-time snapshot passes
+    ``True`` so an unreadable link refuses delivery rather than opening the
+    boundary. When the drain-side probe fails, ``mirror_unverified`` is set so
+    the drop notice can say the state could not be verified instead of claiming
+    a mirror appeared — the refusal is the same, the wording must not lie.
+    Every other field is a plain slot attribute read that cannot fail.
+
+    ``workspace`` is the seventh refusal (:func:`authorize_target`'s
+    ``workspace_mismatch``), an identity rather than a boolean: a CHANGE — the
+    slot moving to another workspace while the entry waited — invalidates the
+    admission, because the prompt would run with memory, lessons and project
+    context its admission never saw. It is compared only when the entry
+    recorded one; the unmarked fail-closed baseline stays the boolean set,
+    since there is no least-authorized workspace to assume.
+
+    ``unattended`` keys on the slot-key prefix exactly as ``authorize_target``
+    does. A slot key is immutable, so this field can never flip between enqueue
+    and drain for a TAGGED entry — it is carried for the unmarked fail-closed
+    path, where the baseline is all-False and any held constraint must count.
+    """
+    probed = _probe_channel_mirror(state, slot)
+    snap: dict[str, Any] = {
+        "linked": bool(getattr(slot, "linked_session_key", "")),
+        "mirrored": on_probe_failure if probed is None else bool(probed),
+        "crew": getattr(slot, "mode", "") == "crew",
+        "ephemeral": getattr(slot, "memory_mode", "persistent") != "persistent",
+        "app": bool(getattr(slot, "_app", "")),
+        "unattended": str(getattr(slot, "key", "")).startswith(UNATTENDED_SLOT_PREFIXES),
+        "workspace": str(getattr(slot, "workspace", "default") or "default"),
+    }
+    if probed is not None:
+        # The mirror's identity, compared like ``workspace``: a RETARGETED
+        # mirror (A -> B) keeps the boolean true across the wait while
+        # substituting the audience, so identity is what the drain must compare.
+        # Omitted on probe failure — there is no identity to compare then, and
+        # the drain fails closed on the unverifiable boolean instead
+        # (:func:`newly_held_constraints` treats ``mirror_unverified`` as a
+        # mirror change regardless of the admission snapshot).
+        snap["mirror_identity"] = probed
+    if probed is None and on_probe_failure:
+        snap["mirror_unverified"] = True
+    return snap
+
+
+def containment_meta(state: "DashboardState", slot: "_ChatSlot") -> dict[str, Any]:
+    """Queue-entry ``meta`` recording the containment that held at admission.
+
+    Every producer of a plain (user-speech) queue entry stamps this at enqueue;
+    the drain compares it against the constraints holding at delivery and drops
+    the entry when one is newly held (:func:`newly_held_constraints`). An entry
+    without the stamp fails closed — it is checked against the full
+    current-constraint set — so an untagged producer can never ride a queued
+    prompt past a boundary the tagged paths respect.
+    """
+    return {QUEUED_CONTAINMENT_META_KEY: containment_snapshot(state, slot, on_probe_failure=False)}
+
+
+def newly_held_constraints(
+    now: dict[str, Any], entry_meta: Any, *, directive_user_origin: bool = False
+) -> list[str]:
+    """Containment constraints in *now* that the entry's admission never saw.
+
+    *now* is the drain-time :func:`containment_snapshot`; *entry_meta* is the
+    queue entry's ``meta`` (any shape — untrusted plumbing, so a missing or
+    malformed snapshot degrades to the all-False baseline and the entry is
+    checked against every currently-held boolean constraint, failing closed).
+
+    A constraint recorded ``True`` at admission is not a change: the prompt was
+    knowingly admitted under it (a human typing into a channel-born session, an
+    app relaying into its own slot), and dropping it would refuse designed
+    behaviour rather than close a window.
+
+    ``workspace`` compares by identity and only when the entry recorded one —
+    an unmarked entry has no least-authorized workspace to assume, so its
+    fail-closed floor stays the boolean set. ``mirror_identity`` compares the
+    same way: a mirror retargeted to a different channel while the entry waited
+    is an audience substitution the boolean cannot see, reported as
+    ``mirror_retarget``.
+
+    *directive_user_origin* exempts the LINKED constraint only, for entries
+    carrying the authenticated-human provenance flag: the author typed into the
+    session's own surface and linking it is that owner's deliberate act, so
+    dropping their already-typed messages when they link the session would
+    destroy user speech on a supported flow (``api_chat`` applies no linked
+    refusal to composer input). A NEW outbound mirror is never exempt — the
+    message's author does not control mirror links, so it still drops. Every
+    other constraint — crew, ephemeral, app, unattended, workspace — applies
+    to directive entries too.
+    """
+    recorded: dict[str, Any] = {}
+    if isinstance(entry_meta, dict):
+        raw = entry_meta.get(QUEUED_CONTAINMENT_META_KEY)
+        if isinstance(raw, dict):
+            recorded = raw
+    changed: list[str] = []
+    for name, value in now.items():
+        if name in _NON_CONSTRAINT_KEYS:
+            continue
+        if name == "workspace":
+            admitted_ws = recorded.get("workspace")
+            if isinstance(admitted_ws, str) and admitted_ws != value:
+                changed.append(name)
+            continue
+        if name == "mirrored":
+            # Fail closed on an unverifiable drain-side probe REGARDLESS of the
+            # admission snapshot: an entry admitted under mirror A cannot be
+            # delivered when the store no longer answers, because the audience
+            # may have been retargeted since admission and there is no identity
+            # to compare (the probe-failure snapshot omits ``mirror_identity``).
+            # Matching ``authorize_target``'s posture — unreadable state refuses
+            # rather than opens the boundary; the notice wording says the state
+            # could not be verified (``mirror_unverified``), never that a mirror
+            # appeared.
+            if value and (now.get("mirror_unverified") or not bool(recorded.get(name, False))):
+                changed.append(name)
+            continue
+        if name == "mirror_identity":
+            # Identity comparison, like workspace: a mirror RETARGETED while the
+            # entry waited (A -> B) keeps ``mirrored`` true at both ends while
+            # substituting the audience, so the boolean can never see it. Fires
+            # only when both sides carry a verified, non-empty identity — a
+            # newly GAINED mirror is the boolean's job, and an unverifiable side
+            # omits the key. Never exempt for directive entries: the message's
+            # author does not control mirror links.
+            admitted_id = recorded.get("mirror_identity")
+            if value and isinstance(admitted_id, str) and admitted_id and admitted_id != value:
+                changed.append("mirror_retarget")
+            continue
+        if directive_user_origin and name in _AUDIENCE_CONSTRAINTS:
+            continue
+        if value and not bool(recorded.get(name, False)):
+            changed.append(name)
+    return changed
+
+
+def describe_containment_change(constraints: list[str], *, mirror_unverified: bool = False) -> str:
+    """One transcript-ready phrase naming what changed, for the drop notice.
+
+    *mirror_unverified* swaps the mirrored wording: when the drain-side probe
+    failed, the refusal stands (fail closed) but the notice must describe an
+    unverifiable state, not assert a mirror appeared.
+    """
+    labels = dict(_CONTAINMENT_CHANGE_LABELS)
+    if mirror_unverified:
+        labels["mirrored"] = "the session's channel-mirror state could not be verified"
+    return "; ".join(labels.get(c, c) for c in constraints)
+
+
+def audit_queued_drop(slot: "_ChatSlot", queue_id: str, constraints: list[str]) -> None:
+    """Record one drain-time drop in the SEL, best-effort and off the loop.
+
+    Logged as a denied tool invocation on the TARGET's EFFECTIVE session — a
+    linked slot's turns run under ``linked_session_key``, so filing under the
+    slot key would hide exactly the drops this feature exists to record. The
+    slot key stays in ``resources``/``metadata``. The admission-time caller may
+    be long gone, so there is no caller identity to attribute the drop to.
+    """
+    _audit_queue_drain(slot, outcome="denied", queue_ids=[queue_id], newly_held=constraints)
+
+
+def audit_queued_allow(slot: "_ChatSlot", queue_ids: list[str]) -> None:
+    """Record that re-validated queued entries were AUTHORIZED to become a turn.
+
+    The allow side of the same permission decision :func:`audit_queued_drop`
+    records the deny side of — both outcomes are auditable, matching
+    ``authorize_target``'s convention of logging ``allowed`` operations and not
+    only refusals. Emitted at CONSUMPTION (the moment the drain hands the
+    entries to a turn), not per sweep pass, so an entry that waits across
+    several drains produces one row when it actually executes rather than one
+    per re-check. One row covers the whole consumed batch.
+    """
+    _audit_queue_drain(slot, outcome="allowed", queue_ids=queue_ids, newly_held=None)
+
+
+def _audit_queue_drain(
+    slot: "_ChatSlot", *, outcome: str, queue_ids: list[str], newly_held: list[str] | None
+) -> None:
+    slot_key = str(getattr(slot, "key", ""))
+    session_key = effective_session_key(slot)
+    metadata: dict[str, Any] = {
+        "target": slot_key,
+        "queue_ids": ",".join(queue_ids),
+    }
+    if newly_held is not None:
+        metadata["newly_held"] = ",".join(newly_held)
+
+    def _do() -> None:
+        sel().log_tool_invocation(
+            session_key=session_key,
+            agent="",
+            source="dashboard",
+            tool_name="queue_drain_revalidation",
+            tool_kind="command",
+            outcome=outcome,
+            resources=f"target={slot_key}",
+            metadata=metadata,
+        )
+
+    _sel_off_loop(_do, "queue-drain revalidation audit")
 
 
 def _refuse_ineligible_creator(state: "DashboardState", caller_slot: "_ChatSlot") -> None:
@@ -885,6 +1181,10 @@ async def send_to_target(
     a busy one queues the message for its next turn. Both outcomes are reported
     distinctly — ``started`` says which happened — because "it ran" and "it will
     run later" must not look the same to a caller coordinating several sessions.
+    A queued delivery is re-validated at the drain (issue #5911): the entry
+    carries the containment that held here, and a constraint newly held at
+    delivery time drops it with a visible notice instead of executing it under
+    the weaker authorization that admitted it.
 
     The turn is NOT charged against the background-turn cap, and deliberately so:
     that cap only binds unattended (app-owned) slots, and every target this

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4473,7 +4473,14 @@ class _ChatSlot:
         ``running == False`` within a single loop iteration.
         """
         if self.running:
-            self.queue_append(prompt)
+            # circular import: session_control imports this module at module level.
+            from kiro_crew.dashboard.session_control import containment_meta
+
+            # Stamp the containment constraints holding at ADMISSION, so the
+            # queue drain can re-assert them at delivery (issue #5911): a target
+            # that gains a channel/mirror link while this prompt waits must not
+            # execute it under the weaker constraints that admitted it.
+            self.queue_append(prompt, meta=containment_meta(state, self))
             return False
         self.append("user", prompt, "msg msg-u")
         task = asyncio.create_task(run_chat_coro(state, self, prompt))

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -2540,7 +2540,17 @@ async def maybe_route_linked_thread(
         _dashboard_state._background_tasks.add(_chat_task)  # type: ignore[attr-defined]
         _chat_task.add_done_callback(_dashboard_state._background_tasks.discard)  # type: ignore[attr-defined]
     else:
-        _linked_slot.queue_append(text, directive_user_origin=True)
+        # circular import: session_control pulls in dashboard modules at module level.
+        from kiro_crew.dashboard.session_control import containment_meta
+
+        # Stamp the admission-time containment (#5911). A linked slot records
+        # linked=True here, so its own channel's queued messages keep draining;
+        # only a constraint that appears AFTER this enqueue drops the entry.
+        _linked_slot.queue_append(
+            text,
+            meta=containment_meta(_dashboard_state, _linked_slot),  # type: ignore[arg-type]
+            directive_user_origin=True,
+        )
     _dashboard_state.push_slots_update()  # type: ignore[attr-defined]
     sel().log_tool_invocation(
         session_key=session_key,

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import ConversationLog
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
+from kiro_crew.messaging.link import ChannelLink
 
 #: Draining is a LOOP because a drained task may register another -- not because any
 #: current one does (``chat_slack`` has a single ``create_task``, and the backfill
@@ -129,12 +130,16 @@ def _make_state(tmp_path, **kwargs):
     # and a bare MagicMock is unconditionally truthy, so every session reads as
     # mirrored to a channel. A guard that refuses mirrored sessions then refuses
     # ALL of them, which looks like a broken guard rather than a missing double.
-    # Parity with SessionStore: absent -> None.
-    _mirror_links: dict[str, tuple[str, str]] = {}
+    # Parity with SessionStore: absent -> None, present -> ChannelLink (the
+    # drain's mirror-retarget comparison reads the link's identity fields, so a
+    # bare tuple would make every mirror identical).
+    _mirror_links: dict[str, ChannelLink] = {}
 
     def _set_mirror_link(key, channel_id, thread_ts):
         if channel_id or thread_ts:
-            _mirror_links[key] = (channel_id, thread_ts)
+            _mirror_links[key] = ChannelLink(
+                channel_type="slack", channel_id=channel_id, thread_id=thread_ts
+            )
         else:
             _mirror_links.pop(key, None)
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -8440,6 +8440,33 @@ class TestPlanAction:
             assert resp.status == 200
         assert slot._auto_run is False
 
+    @pytest.mark.asyncio
+    async def test_busy_go_queues_with_stamp_and_human_provenance(self, tmp_path, monkeypatch):
+        """A Go clicked on a BUSY slot queues, and the entry carries both the
+        admission-time containment stamp and authenticated-human provenance —
+        without the flag, a human linking their own session before the drain
+        would silently destroy the approval they already gave (the same
+        request-identity split as api_chat and the manual continue)."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard import session_control as sc
+
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("plan-busy", mode="orchestrator")
+        task = MagicMock()
+        task.done.return_value = False
+        slot.task = task  # running -> the Go must queue, not start a stage loop
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/plan-busy/plan-action",
+                json={"action": "go"},
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+        entry = slot._queue[0]
+        assert entry["content"] == "Go"
+        assert entry.get("_directive_user_origin") is True  # no app identity on the request
+        assert sc.QUEUED_CONTAINMENT_META_KEY in entry.get("meta", {})
+
 
 class TestPlanValidationStuck:
     """Tests for has_plan=False after strip_plan_markers on invalid plans."""
@@ -13489,6 +13516,9 @@ class TestAcpProcessDiedRecovery:
                 # A continuation, not the user's request: the turn had emitted, so
                 # this text is the runner's and must not mirror as user speech.
                 "payload": RecoveryPayload.CONTINUATION,
+                # Admission stamp (#5911): recovery requeues record the containment
+                # that held at requeue so the drain can re-validate the retry.
+                "meta": slot._queue[0]["meta"],
             }
         ]
 
@@ -13536,6 +13566,9 @@ class TestAcpProcessDiedRecovery:
                 # A continuation, not the user's request: the turn had emitted, so
                 # this text is the runner's and must not mirror as user speech.
                 "payload": RecoveryPayload.CONTINUATION,
+                # Admission stamp (#5911): recovery requeues record the containment
+                # that held at requeue so the drain can re-validate the retry.
+                "meta": slot._queue[0]["meta"],
             }
         ]
         # The status card and the queued marker describe the same event to two
@@ -13579,6 +13612,9 @@ class TestAcpProcessDiedRecovery:
                 "content": _CONN_RECOVER_MSG,
                 "kind": SYNTHETIC_RECOVERY_KIND,
                 "payload": RecoveryPayload.CONTINUATION,
+                # Admission stamp (#5911): recovery requeues record the containment
+                # that held at requeue so the drain can re-validate the retry.
+                "meta": slot._queue[0]["meta"],
             }
         ]
 

--- a/test/test_handler_link_intercept.py
+++ b/test/test_handler_link_intercept.py
@@ -31,7 +31,14 @@ class TestLinkToDashboardCommand:
             patch.object(handler, "is_allowed_user", return_value=True),
         ):
             result = await handler._handle_slash_command(
-                "!link-to-dashboard", slack, MagicMock(), "C1", "t1", "msg1", "t1", "U1",
+                "!link-to-dashboard",
+                slack,
+                MagicMock(),
+                "C1",
+                "t1",
+                "msg1",
+                "t1",
+                "U1",
             )
         assert result == ""
         assert any("not available" in str(c).lower() for c in slack.post_message.call_args_list)
@@ -48,7 +55,14 @@ class TestLinkToDashboardCommand:
             patch.object(handler, "is_allowed_user", return_value=True),
         ):
             result = await handler._handle_slash_command(
-                "!link-to-dashboard", slack, MagicMock(), "C1", "msg1", "msg1", "msg1", "U1",
+                "!link-to-dashboard",
+                slack,
+                MagicMock(),
+                "C1",
+                "msg1",
+                "msg1",
+                "msg1",
+                "U1",
             )
         assert result == ""
         assert any("thread" in str(c).lower() for c in slack.post_message.call_args_list)
@@ -69,7 +83,14 @@ class TestLinkToDashboardCommand:
             ),
         ):
             result = await handler._handle_slash_command(
-                "!link-to-dashboard", slack, MagicMock(), "C1", "t1", "msg1", "t1", "U1",
+                "!link-to-dashboard",
+                slack,
+                MagicMock(),
+                "C1",
+                "t1",
+                "msg1",
+                "t1",
+                "U1",
             )
         assert result == ""
         assert any("could not" in str(c).lower() for c in slack.post_message.call_args_list)
@@ -81,7 +102,14 @@ class TestLinkToDashboardCommand:
         slack = _make_slack()
         with patch.object(handler, "is_allowed_user", return_value=False):
             result = await handler._handle_slash_command(
-                "!link-to-dashboard", slack, MagicMock(), "C1", "t1", "msg1", "t1", "UBAD",
+                "!link-to-dashboard",
+                slack,
+                MagicMock(),
+                "C1",
+                "t1",
+                "msg1",
+                "t1",
+                "UBAD",
             )
         assert result == ""
         assert any("not authorized" in str(c).lower() for c in slack.post_message.call_args_list)
@@ -109,7 +137,14 @@ class TestLinkToDashboardCommand:
                 ),
             ):
                 result = await handler._handle_slash_command(
-                    "!link-to-dashboard", slack, MagicMock(), "C1", "t1", "msg1", "t1", "U1",
+                    "!link-to-dashboard",
+                    slack,
+                    MagicMock(),
+                    "C1",
+                    "t1",
+                    "msg1",
+                    "t1",
+                    "U1",
                 )
         finally:
             handler.sel = orig_sel
@@ -144,7 +179,13 @@ class TestLinkedThreadIntercept:
                 patch.object(handler, "is_allowed_user", return_value=False),
             ):
                 await handler.handle_message(
-                    slack, MagicMock(), "C1", "hello", "t1", "msg1", "UBAD",
+                    slack,
+                    MagicMock(),
+                    "C1",
+                    "hello",
+                    "t1",
+                    "msg1",
+                    "UBAD",
                 )
                 mock_sel_inst.log_tool_invocation.assert_called_once()
                 kw = mock_sel_inst.log_tool_invocation.call_args[1]
@@ -174,7 +215,13 @@ class TestLinkedThreadIntercept:
             patch("kiro_crew.dashboard.chat._run_chat", new_callable=AsyncMock) as mock_run_chat,
         ):
             await handler.handle_message(
-                slack, MagicMock(), "C1", "hello", "t1", "msg1", "U1",
+                slack,
+                MagicMock(),
+                "C1",
+                "hello",
+                "t1",
+                "msg1",
+                "U1",
             )
             slot.append.assert_called_once()
             mock_run_chat.assert_called_once()
@@ -201,11 +248,19 @@ class TestLinkedThreadIntercept:
             patch.object(handler, "_dashboard_state", ds),
             patch.object(handler, "is_allowed_user", return_value=True),
             patch("kiro_crew.dashboard.chat._run_chat", new_callable=AsyncMock) as mock_run_chat,
-            patch.object(handler, "redact_exfiltration_urls", return_value=("[REDACTED-URL]", True)),
+            patch.object(
+                handler, "redact_exfiltration_urls", return_value=("[REDACTED-URL]", True)
+            ),
             patch.object(handler, "redact_credentials", return_value=("[REDACTED]", True)),
         ):
             await handler.handle_message(
-                slack, MagicMock(), "C1", "hello http://evil.com", "t1", "msg1", "U1",
+                slack,
+                MagicMock(),
+                "C1",
+                "hello http://evil.com",
+                "t1",
+                "msg1",
+                "U1",
             )
             # UI gets redacted text
             slot.append.assert_called_once_with("user", "[REDACTED]", "msg msg-u")
@@ -222,8 +277,13 @@ class TestLinkedThreadIntercept:
         slot.key = "slot1"
         slot._queue = []
 
-        def queue_append(content, *, directive_user_origin):
+        def queue_append(content, *, meta=None, directive_user_origin):
             assert directive_user_origin is True
+            # The linked-thread enqueue stamps the admission-time containment
+            # snapshot (#5911) so the drain can re-assert it at delivery.
+            from kiro_crew.dashboard.session_control import QUEUED_CONTAINMENT_META_KEY
+
+            assert isinstance(meta, dict) and QUEUED_CONTAINMENT_META_KEY in meta
             slot._queue.append({"id": "test", "content": content})
             return "test"
 
@@ -239,7 +299,13 @@ class TestLinkedThreadIntercept:
             patch("kiro_crew.dashboard.chat._run_chat", new_callable=AsyncMock) as mock_run_chat,
         ):
             await handler.handle_message(
-                slack, MagicMock(), "C1", "hello", "t1", "msg1", "U1",
+                slack,
+                MagicMock(),
+                "C1",
+                "hello",
+                "t1",
+                "msg1",
+                "U1",
             )
             assert len(slot._queue) == 1
             mock_run_chat.assert_not_called()
@@ -278,7 +344,13 @@ class TestTransportLinkedThreadIntercept:
             patch("kiro_crew.dashboard.chat._run_chat", new_callable=AsyncMock) as mock_run_chat,
         ):
             await transport_dispatch.handle_message_transport(
-                slack, sessions, "C1", "hello", "t1", "msg1", "U1",
+                slack,
+                sessions,
+                "C1",
+                "hello",
+                "t1",
+                "msg1",
+                "U1",
             )
             slot.append.assert_called_once()
             mock_run_chat.assert_called_once()
@@ -305,14 +377,19 @@ class TestTransportLinkedThreadIntercept:
                 patch.object(handler, "is_allowed_user", return_value=False),
             ):
                 await transport_dispatch.handle_message_transport(
-                    slack, sessions, "C1", "hello", "t1", "msg1", "UBAD",
+                    slack,
+                    sessions,
+                    "C1",
+                    "hello",
+                    "t1",
+                    "msg1",
+                    "UBAD",
                 )
                 # Denied with SEL audit; no session acquired.
                 mock_sel_inst.log_tool_invocation.assert_called_once()
                 assert mock_sel_inst.log_tool_invocation.call_args[1]["outcome"] == "denied"
                 assert any(
-                    "not authorized" in str(c).lower()
-                    for c in slack.post_message.call_args_list
+                    "not authorized" in str(c).lower() for c in slack.post_message.call_args_list
                 )
                 sessions.get_or_create.assert_not_called()
         finally:

--- a/test/test_queue_drain_revalidation.py
+++ b/test/test_queue_drain_revalidation.py
@@ -1,0 +1,598 @@
+"""Drain-time re-validation of queued prompts (issue #5911).
+
+Authorization is decided at ADMISSION — ``authorize_target`` for
+``session_send``, the authenticated composer for a human typing into a busy
+session — but a busy target QUEUES the prompt and delivers it later, and the
+containment those decisions rest on can change in between: a target authorized
+while unlinked can gain a channel or mirror link before its queue drains.
+
+These tests pin the three-part fix end to end: producers stamp the
+admission-time containment on the queue entry (``containment_meta``), the drain
+re-asserts the same constraints and drops what no longer qualifies, and a drop
+is loud (queue card retracted, visible transcript notice, SEL record) — never a
+silent vanish. They also pin the two designed non-drops: a constraint already
+held at admission is not a change (channel-born sessions keep draining), and
+structural orchestration entries are the runner's own machinery, exempt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import chat_runner as cr
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.chat_utils import (
+    CRON_NOTIFICATION_KIND,
+    SUBAGENT_COMPLETION_KIND,
+    SYNTHETIC_RECOVERY_KIND,
+    slot_history_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    """Run in the shipped (enabled) session-control state without reading config."""
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+@pytest.fixture(autouse=True)
+def _inline_audit(monkeypatch):
+    """Route SEL writes inline to a mock: assertable, and no executor thread
+    outlives the test."""
+    fake = MagicMock()
+    monkeypatch.setattr(sc, "sel", lambda: fake)
+    monkeypatch.setattr(sc, "_sel_off_loop", lambda write, what: write())
+    return fake
+
+
+def _busy(slot):
+    """``running`` is derived (``task is not None and not task.done()``)."""
+    task = MagicMock()
+    task.done.return_value = False
+    slot.task = task
+    return slot
+
+
+def _link(slot):
+    slot.linked_session_key = "C0LINKED|1700000000.000100"
+    return slot
+
+
+async def _never_runs(state, slot, prompt):  # pragma: no cover - queued, not run
+    raise AssertionError("a queued prompt must not start a turn at enqueue")
+
+
+def _snapshot_of(entry):
+    return entry.get("meta", {}).get(sc.QUEUED_CONTAINMENT_META_KEY)
+
+
+# ── Producers stamp the admission-time snapshot ──────────────────────────────
+
+
+def test_human_typed_enqueue_stamps_admission_snapshot(tmp_path):
+    """The composer path: ``enqueue_or_run_prompt`` on a busy slot records the
+    constraints that held at admission on the entry it queues."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+
+    started = slot.enqueue_or_run_prompt("hello there", _never_runs, state)
+
+    assert started is False
+    snap = _snapshot_of(slot._queue[0])
+    assert snap == {
+        "linked": False,
+        "mirrored": False,
+        "mirror_identity": "",
+        "crew": False,
+        "ephemeral": False,
+        "app": False,
+        "unattended": False,
+        "workspace": "default",
+    }
+
+
+def test_session_send_enqueue_stamps_admission_snapshot(tmp_path):
+    """The ``session_send`` path shares the same seam and the same stamp."""
+    state = _make_state(tmp_path)
+    caller = state.get_or_create_slot("chat-1")
+    target = _busy(state.get_or_create_slot("chat-2"))
+
+    out = asyncio.run(
+        sc.send_to_target(
+            state,
+            caller_session_key=slot_history_key(caller),
+            target="chat-2",
+            message="queued message",
+        )
+    )
+
+    assert out["started"] is False
+    snap = _snapshot_of(target._queue[0])
+    assert snap is not None
+    assert not any(v for k, v in snap.items() if k != "workspace")
+    assert isinstance(snap["workspace"], str) and snap["workspace"]
+
+
+def test_channel_born_enqueue_records_linked_true(tmp_path):
+    """A slot that is ALREADY channel-linked at admission records that fact, so
+    its own channel's queued messages keep draining (designed behaviour)."""
+    state = _make_state(tmp_path)
+    slot = _busy(_link(state.get_or_create_slot("chat-1")))
+
+    slot.queue_append("from the thread", meta=sc.containment_meta(state, slot))
+
+    assert _snapshot_of(slot._queue[0])["linked"] is True
+
+
+def test_requeued_steer_is_stamped(tmp_path):
+    """A steer degraded to a queue card is plain user speech re-entering the
+    queue; the requeue stamps it like any other plain producer."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._pending_steers = ["steer me"]
+
+    cr._requeue_unconsumed_steers(state, slot)
+
+    assert _snapshot_of(slot._queue[0]) is not None
+
+
+# ── The drain drops what no longer qualifies, loudly ─────────────────────────
+
+
+def test_linked_after_enqueue_drops_with_visible_notice(tmp_path, _inline_audit):
+    """The issue's core scenario: authorized while unlinked, linked before the
+    drain. The entry is dropped, the transcript says why, and the SEL records it."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+
+    _link(slot)
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "linked to a channel" in notices[-1]["content"]
+    assert "dropped" in notices[-1]["content"].lower()
+    call = _inline_audit.log_tool_invocation.call_args
+    assert call.kwargs["outcome"] == "denied"
+    assert "linked" in call.kwargs["metadata"]["newly_held"]
+
+
+def test_mirror_added_after_enqueue_drops(tmp_path):
+    """The other mechanism the issue names: an OUTBOUND mirror link appearing
+    between enqueue and drain (the ``_has_channel_mirror`` gap)."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0MIRROR", "1700000000.000200")
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "outbound channel mirror" in notices[-1]["content"]
+
+
+def test_mirror_retargeted_while_queued_drops(tmp_path, _inline_audit):
+    """A mirror RETARGETED between enqueue and drain (A -> B) keeps the boolean
+    true at both ends while substituting the audience — the identity comparison
+    must catch what the boolean cannot. Directive provenance does not exempt it:
+    the message's author does not control mirror links."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0AUDIENCE_A", "1700000000.000400")
+    slot.enqueue_or_run_prompt("meant for audience A", _never_runs, state)
+    slot._queue[0]["_directive_user_origin"] = True
+
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0AUDIENCE_B", "1700000000.000500")
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "retargeted" in notices[-1]["content"]
+    call = _inline_audit.log_tool_invocation.call_args
+    assert call.kwargs["outcome"] == "denied"
+    assert "mirror_retarget" in call.kwargs["metadata"]["newly_held"]
+
+
+def test_mirror_unchanged_identity_still_drains(tmp_path):
+    """The identity comparison must not turn an UNCHANGED admitted mirror into a
+    drop: a session mirrored to the same channel at both ends keeps its queue."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0AUDIENCE_A", "1700000000.000400")
+    slot.enqueue_or_run_prompt("same audience", _never_runs, state)
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert [q["content"] for q in slot._queue] == ["same audience"]
+
+
+def test_unchanged_containment_drains(tmp_path):
+    """No containment change, no drop — including a constraint that already
+    held at admission (a channel-born session keeps its queue)."""
+    state = _make_state(tmp_path)
+    plain = _busy(state.get_or_create_slot("chat-1"))
+    plain.enqueue_or_run_prompt("still fine", _never_runs, state)
+    born_linked = _busy(_link(state.get_or_create_slot("chat-2")))
+    born_linked.queue_append("thread msg", meta=sc.containment_meta(state, born_linked))
+
+    cr._drop_stale_admissions(state, plain)
+    cr._drop_stale_admissions(state, born_linked)
+
+    assert [q["content"] for q in plain._queue] == ["still fine"]
+    assert [q["content"] for q in born_linked._queue] == ["thread msg"]
+
+
+def test_unmarked_legacy_entry_fails_closed(tmp_path):
+    """An entry with no snapshot is checked against the FULL current-constraint
+    set: an untagged producer can never ride a queued prompt past a boundary
+    the tagged paths respect."""
+    state = _make_state(tmp_path)
+    slot = _link(state.get_or_create_slot("chat-1"))
+    slot._queue = [{"id": "legacy1", "content": "hi"}]
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+
+
+def test_unmarked_entry_in_unconstrained_slot_survives(tmp_path):
+    """Fail-closed is about constraints that HOLD: with none holding, an
+    unmarked entry drains exactly as before this change."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._queue = [{"id": "legacy1", "content": "hi"}]
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert [q["content"] for q in slot._queue] == ["hi"]
+
+
+def test_cron_and_subagent_entries_are_exempt(tmp_path):
+    """Cron notifications and sub-agent completions are minted fresh by trusted
+    internal producers for THIS slot's own turn lifecycle — channel-born
+    sessions receive them by design, so the sweep must not touch them even
+    unmarked."""
+    state = _make_state(tmp_path)
+    slot = _link(state.get_or_create_slot("chat-1"))
+    slot.queue_append("[cron] tick", kind=CRON_NOTIFICATION_KIND)
+    slot.queue_append("[Subagent completion event] done", kind=SUBAGENT_COMPLETION_KIND)
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert len(slot._queue) == 2
+
+
+def test_unmarked_recovery_entry_fails_closed(tmp_path):
+    """A synthetic-recovery entry replays externally admitted content verbatim
+    under a fresh queue id, so it is NOT exempt: unmarked, it is checked
+    against the full boolean constraint set like any untagged producer — the
+    retry window must not ride past a link the original admission never saw."""
+    state = _make_state(tmp_path)
+    slot = _link(state.get_or_create_slot("chat-1"))
+    slot.queue_append("continue", kind=SYNTHETIC_RECOVERY_KIND)
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+
+
+def test_stamped_recovery_entry_follows_its_admission(tmp_path):
+    """A recovery requeue stamps admission context at requeue time: linked
+    recorded True keeps draining (channel-born recovery machinery survives),
+    while a link appearing AFTER the requeue drops the retry."""
+    state = _make_state(tmp_path)
+    born_linked = _link(state.get_or_create_slot("chat-1"))
+    born_linked.queue_append(
+        "continue",
+        kind=SYNTHETIC_RECOVERY_KIND,
+        meta=sc.containment_meta(state, born_linked),
+    )
+    cr._drop_stale_admissions(state, born_linked)
+    assert [q["content"] for q in born_linked._queue] == ["continue"]
+
+    plain = state.get_or_create_slot("chat-2")
+    plain.queue_append(
+        "replayed send prompt",
+        kind=SYNTHETIC_RECOVERY_KIND,
+        meta=sc.containment_meta(state, plain),
+    )
+    _link(plain)
+    cr._drop_stale_admissions(state, plain)
+    assert plain._queue == []
+
+
+# ── Helper semantics ─────────────────────────────────────────────────────────
+
+
+def test_snapshot_probe_failure_directions(tmp_path):
+    """The mirror probe fails closed in BOTH directions: at enqueue an
+    unreadable link records not-mirrored (least-authorized admission, so the
+    drain re-validates), at drain it reads as mirrored (refuse delivery) and
+    carries the ``mirror_unverified`` marker so the notice can say the state
+    could not be verified instead of asserting a mirror appeared."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    state.sessions.get_mirror_link = MagicMock(side_effect=RuntimeError("store down"))
+
+    at_enqueue = sc.containment_snapshot(state, slot, on_probe_failure=False)
+    at_drain = sc.containment_snapshot(state, slot, on_probe_failure=True)
+
+    assert at_enqueue["mirrored"] is False
+    assert "mirror_unverified" not in at_enqueue
+    assert at_drain["mirrored"] is True
+    assert at_drain["mirror_unverified"] is True
+    # The marker is wording/telemetry, never a constraint to compare.
+    assert "mirror_unverified" not in sc.newly_held_constraints(
+        at_drain, {sc.QUEUED_CONTAINMENT_META_KEY: dict(at_drain)}
+    )
+    # An unverifiable drain-side probe fails closed EVEN for an entry admitted
+    # under a mirror: the audience may have been retargeted since admission and
+    # there is no identity to compare, so "mirrored at both ends" is not
+    # positive authorization.
+    assert "mirrored" in sc.newly_held_constraints(
+        at_drain,
+        {sc.QUEUED_CONTAINMENT_META_KEY: {"mirrored": True, "mirror_identity": "slack:C0A:1"}},
+    )
+
+
+def test_admitted_mirrored_entry_drops_on_drain_probe_failure(tmp_path):
+    """End to end: a session mirrored at admission whose store stops answering
+    by drain time REFUSES delivery — an unverifiable mirror state may hide a
+    retarget, and `authorize_target`'s posture is refuse-not-open. The notice
+    says the state could not be verified."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0AUDIENCE_A", "1700000000.000600")
+    slot.enqueue_or_run_prompt("admitted under mirror A", _never_runs, state)
+
+    state.sessions.get_mirror_link = MagicMock(side_effect=RuntimeError("store down"))
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "could not be verified" in notices[-1]["content"]
+
+
+def test_malformed_snapshot_fails_closed():
+    """Queue meta is untrusted plumbing: any shape other than a dict snapshot
+    degrades to the all-False baseline."""
+    now = {"linked": True, "mirrored": False}
+    assert sc.newly_held_constraints(now, None) == ["linked"]
+    assert sc.newly_held_constraints(now, {"other": 1}) == ["linked"]
+    assert sc.newly_held_constraints(now, {sc.QUEUED_CONTAINMENT_META_KEY: "junk"}) == ["linked"]
+    assert sc.newly_held_constraints(now, {sc.QUEUED_CONTAINMENT_META_KEY: {"linked": True}}) == []
+
+
+def test_workspace_change_invalidates_admission(tmp_path):
+    """`authorize_target`'s seventh refusal is `workspace_mismatch`, and
+    `slot.workspace` is mutable while a queue waits (the agent-switch endpoint
+    re-derives it): a prompt admitted under workspace A must not run with
+    workspace B's memory, lessons and project context."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.workspace = "team-a"
+    slot.enqueue_or_run_prompt("workspace-a prompt", _never_runs, state)
+
+    slot.workspace = "team-b"
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "different workspace" in notices[-1]["content"]
+
+
+def test_workspace_not_compared_for_unmarked_entries(tmp_path):
+    """An unmarked entry has no least-authorized workspace to assume, so its
+    fail-closed floor stays the boolean set — it drains in any workspace when
+    no boolean constraint holds."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot.workspace = "team-b"
+    slot._queue = [{"id": "legacy1", "content": "hi"}]
+
+    cr._drop_stale_admissions(state, slot)
+
+    assert [q["content"] for q in slot._queue] == ["hi"]
+
+
+def test_directive_user_origin_exempts_linked_only(tmp_path):
+    """A human linking their OWN busy session must not destroy the messages
+    they already typed (`api_chat` applies no linked refusal to composer
+    input) — but the exemption covers ONLY the link: a NEW outbound mirror
+    (which the message's author does not control) and a workspace change both
+    still drop a directive entry."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.workspace = "team-a"
+    slot.queue_append(
+        "typed by the owner",
+        meta=sc.containment_meta(state, slot),
+        directive_user_origin=True,
+    )
+
+    _link(slot)
+    cr._drop_stale_admissions(state, slot)
+    assert [q["content"] for q in slot._queue] == ["typed by the owner"]
+
+    state.sessions.set_mirror_link(slot_history_key(slot), "C0MIRROR", "1700000000.000300")
+    cr._drop_stale_admissions(state, slot)
+    assert slot._queue == []
+
+    slot2 = _busy(state.get_or_create_slot("chat-2"))
+    slot2.workspace = "team-a"
+    slot2.queue_append(
+        "typed by the owner",
+        meta=sc.containment_meta(state, slot2),
+        directive_user_origin=True,
+    )
+    slot2.workspace = "team-b"
+    cr._drop_stale_admissions(state, slot2)
+    assert slot2._queue == []
+
+
+def test_drop_retracts_the_queue_card_unconditionally(tmp_path):
+    """The frontend's queue card comes from the producer's queue_push, not a
+    transcript placeholder row, so the retraction broadcast must not be gated
+    on a placeholder existing."""
+    state = _make_state(tmp_path)
+    state.broadcast_ws = MagicMock()
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+    qid = slot._queue[0]["id"]
+
+    _link(slot)
+    cr._drop_stale_admissions(state, slot)
+
+    pops = [c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "queue_pop"]
+    assert pops and pops[-1].args[1]["queue_id"] == qid
+
+
+def test_probe_failure_drop_says_unverified_not_gained(tmp_path):
+    """When the drain-side mirror probe fails, the refusal stands (fail closed)
+    but the notice must describe an unverifiable state, not assert a mirror
+    appeared."""
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+
+    state.sessions.get_mirror_link = MagicMock(side_effect=RuntimeError("store down"))
+    cr._drop_stale_admissions(state, slot)
+
+    assert slot._queue == []
+    notices = [m for m in slot.messages if m.get("role") == "notice"]
+    assert notices and "could not be verified" in notices[-1]["content"]
+    assert "gained an outbound channel mirror" not in notices[-1]["content"]
+
+
+def test_drop_audit_uses_the_effective_session_key(tmp_path, _inline_audit):
+    """A linked slot's turns run under `linked_session_key`; filing the drop
+    under the slot key would hide exactly the drops this feature records."""
+    from kiro_crew.dashboard.chat_utils import effective_session_key
+
+    state = _make_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+
+    _link(slot)
+    cr._drop_stale_admissions(state, slot)
+
+    call = _inline_audit.log_tool_invocation.call_args
+    assert call.kwargs["session_key"] == effective_session_key(slot)
+    assert call.kwargs["metadata"]["target"] == slot.key
+
+
+@pytest.mark.asyncio
+async def test_consumed_entry_emits_an_allowed_audit(tmp_path, monkeypatch, _inline_audit):
+    """The ALLOW side of the drain's permission decision is audited too,
+    matching `authorize_target`'s convention: an entry that passes
+    re-validation and becomes a turn leaves an `allowed` SEL row naming its
+    queue id — emitted at consumption, so waiting across sweeps does not
+    multiply rows."""
+    state = _make_state(tmp_path)
+    state.subagents = None
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("still fine", _never_runs, state)
+    qid = slot._queue[0]["id"]
+    slot.task = None
+
+    async def _stub_run_chat(_state, _slot, _prompt, **_kwargs):
+        return None
+
+    def _fake_spawn(_state, _slot, coro):
+        coro.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    monkeypatch.setattr(cr, "_run_chat", _stub_run_chat)
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _fake_spawn)
+
+    assert await cr._start_next_queued_turn(state, slot) is True
+
+    allowed = [
+        c
+        for c in _inline_audit.log_tool_invocation.call_args_list
+        if c.kwargs.get("outcome") == "allowed"
+        and c.kwargs.get("tool_name") == "queue_drain_revalidation"
+    ]
+    assert allowed and qid in allowed[-1].kwargs["metadata"]["queue_ids"]
+
+
+def test_requeued_steer_in_a_plain_slot_carries_human_provenance(tmp_path):
+    """The only steer producer is the api_chat composer branch, and app
+    isolation confines app requests to app slots — so a non-app slot's
+    requeued steer is human speech and keeps the audience exemption."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._pending_steers = ["steer me"]
+
+    cr._requeue_unconsumed_steers(state, slot)
+
+    assert slot._queue[0].get("_directive_user_origin") is True
+
+
+# ── The full drain path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drain_drops_stale_entry_and_starts_nothing(tmp_path, monkeypatch):
+    """Through ``_start_next_queued_turn``: a stale entry is dropped before the
+    dequeue ever sees it, and no turn is spawned for it."""
+    state = _make_state(tmp_path)
+    state.subagents = None
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("exfil me", _never_runs, state)
+    slot.task = None  # the turn ended; the tail-drain runs
+    _link(slot)
+
+    spawned = MagicMock()
+
+    def _no_spawn(_state, _slot, coro):  # pragma: no cover - must not be reached
+        coro.close()
+        spawned()
+        return MagicMock()
+
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _no_spawn)
+    started = await cr._start_next_queued_turn(state, slot)
+
+    assert started is False
+    assert not spawned.called
+    assert slot._queue == []
+    assert any(m.get("role") == "notice" for m in slot.messages)
+
+
+@pytest.mark.asyncio
+async def test_drain_strips_snapshot_from_the_persisted_row(tmp_path, monkeypatch):
+    """A surviving entry's snapshot is queue plumbing, consumed at the drain —
+    it must not ride into the transcript row's persisted meta."""
+    state = _make_state(tmp_path)
+    state.subagents = None
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("still fine", _never_runs, state)
+    slot.task = None
+
+    async def _stub_run_chat(_state, _slot, _prompt, **_kwargs):
+        return None
+
+    def _fake_spawn(_state, _slot, coro):
+        coro.close()
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    monkeypatch.setattr(cr, "_run_chat", _stub_run_chat)
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _fake_spawn)
+
+    started = await cr._start_next_queued_turn(state, slot)
+
+    assert started is True
+    user_rows = [m for m in slot.messages if m.get("role") == "user"]
+    assert user_rows, "the drained entry must land as a user row"
+    row_meta = user_rows[-1].get("meta") or {}
+    assert sc.QUEUED_CONTAINMENT_META_KEY not in row_meta

--- a/test/test_slack_handler_coverage.py
+++ b/test/test_slack_handler_coverage.py
@@ -17,7 +17,7 @@ import asyncio
 import json
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -348,7 +348,9 @@ class TestAgentCommand:
         assert "Reset to default agent." in _texts(slack)
 
     @pytest.mark.asyncio
-    async def test_write_failure_surfaces_error(self, slack, sessions, owner, agents_dir, monkeypatch):
+    async def test_write_failure_surfaces_error(
+        self, slack, sessions, owner, agents_dir, monkeypatch
+    ):
         def _boom(_name):
             raise ValueError("read-only config")
 
@@ -574,9 +576,12 @@ class TestChannelCommand:
         from kiro_crew.config.loader import config_path
 
         await _slash("!channel agent demo", slack, sessions)
-        assert json.loads(config_path().read_text(encoding="utf-8"))["slack"]["channels"]["C1"][
-            "agent"
-        ] == "demo"
+        assert (
+            json.loads(config_path().read_text(encoding="utf-8"))["slack"]["channels"]["C1"][
+                "agent"
+            ]
+            == "demo"
+        )
         slack.actions.clear()
         await _slash("!channel agent off", slack, sessions)
         assert "default" in _texts(slack)
@@ -645,7 +650,9 @@ class TestKeywordCommands:
         saver.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_spawn_keyword_skips_log_when_incognito(self, slack, sessions, owner, monkeypatch):
+    async def test_spawn_keyword_skips_log_when_incognito(
+        self, slack, sessions, owner, monkeypatch
+    ):
         saver = AsyncMock()
         monkeypatch.setattr(h, "save_conversation_turn_off_loop", saver)
         h._mark_incognito("t1")
@@ -800,7 +807,9 @@ class TestCronHelpers:
     async def test_remove_found_and_missing(self):
         svc = MagicMock()
         svc.remove_job_async = AsyncMock(return_value=True)
-        assert "Removed cron job" in _reply(await h._handle_cron_command("cron remove j1", svc, "C", "t"))
+        assert "Removed cron job" in _reply(
+            await h._handle_cron_command("cron remove j1", svc, "C", "t")
+        )
         svc.remove_job_async = AsyncMock(return_value=False)
         assert "not found" in _reply(await h._handle_cron_command("cron remove j1", svc, "C", "t"))
 
@@ -896,14 +905,18 @@ class TestRunHelper:
             "No task running."
         )
         busy = MagicMock(running=True)
-        assert "cancelled" in _reply(await h._handle_run_command("task run cancel", busy, slack, "C", "t"))
+        assert "cancelled" in _reply(
+            await h._handle_run_command("task run cancel", busy, slack, "C", "t")
+        )
         busy.cancel.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_missing_spec_file(self, slack, tmp_path):
         runner = MagicMock(running=False)
         out = _reply(
-            await h._handle_run_command(f"task run {tmp_path / 'absent.md'}", runner, slack, "C", "t")
+            await h._handle_run_command(
+                f"task run {tmp_path / 'absent.md'}", runner, slack, "C", "t"
+            )
         )
         assert "Spec file not found" in out
 
@@ -1383,9 +1396,7 @@ class TestHandleInteractionGuards:
         provider = MagicMock()
         provider.approve_tool = AsyncMock()
         h._pending_approvals["C1:m1"] = h._PendingApproval(provider, "r1", "sess-9")
-        out = await h.handle_interaction(
-            "C1", "m1", h._ACTION_TRUST, "U1", sessions=sessions
-        )
+        out = await h.handle_interaction("C1", "m1", h._ACTION_TRUST, "U1", sessions=sessions)
         assert out == h._ACTION_TRUST
         assert h.is_slack_session_trusted("sess-9")
         sessions.set_approval_policy.assert_called_once_with("sess-9", "auto")
@@ -1436,9 +1447,7 @@ class TestLinkedApprovals:
         state = MagicMock()
         state.resolve_approval.return_value = False
         monkeypatch.setattr(h, "_dashboard_state", state)
-        ts = _reply(
-            await h.post_linked_approval(slack, "C1", "t1", "r9", "slot-1", "Delete prod")
-        )
+        ts = _reply(await h.post_linked_approval(slack, "C1", "t1", "r9", "slot-1", "Delete prod"))
         out = await h.handle_interaction("C1", ts, h._ACTION_REJECT, "U1")
         assert out == h._ACTION_REJECT
         state.resolve_approval.assert_called_once_with("r9", False)
@@ -1489,7 +1498,8 @@ class TestRouteLinkedThread:
         state.get_linked_slot.return_value = slot
         monkeypatch.setattr(h, "_dashboard_state", state)
         assert await h.maybe_route_linked_thread("do it", "t1", "U1", "C1", slack, "t1") is True
-        slot.queue_append.assert_called_once_with("do it", directive_user_origin=True)
+        # meta carries the admission-time containment snapshot (#5911).
+        slot.queue_append.assert_called_once_with("do it", meta=ANY, directive_user_origin=True)
         slot.append.assert_called_once()
         state.push_slots_update.assert_called_once()
 
@@ -1780,9 +1790,7 @@ class TestPureHelpers:
         _, text = h.build_timing_footer(125.0)
         assert text == "Finished in 2m 5s"
 
-    @pytest.mark.parametrize(
-        ("pct", "icon"), [(80, "🔴"), (60, "🟠"), (40, "🟡"), (5, "🟢")]
-    )
+    @pytest.mark.parametrize(("pct", "icon"), [(80, "🔴"), (60, "🟠"), (40, "🟡"), (5, "🟢")])
     def test_timing_footer_context_icon(self, pct, icon):
         client = MagicMock()
         client.context_usage_pct.return_value = pct

--- a/test/test_slack_handler_more_coverage.py
+++ b/test/test_slack_handler_more_coverage.py
@@ -513,9 +513,7 @@ class TestRunCommand:
         spec.write_text("# task\n", encoding="utf-8", newline="\n")
 
         runner = _FakeRunner()
-        out = await h._handle_run_command(
-            f"task run {spec}", runner, MockSlackClient(), "C1", "t1"
-        )
+        out = await h._handle_run_command(f"task run {spec}", runner, MockSlackClient(), "C1", "t1")
         assert "Task started" in out and runner.started == [spec]
 
         class _Boom(_FakeRunner):
@@ -798,9 +796,7 @@ class TestHandleInteractionAuthReChecks:
     @pytest.mark.asyncio
     async def test_trust_with_session_key_propagates_policy_to_subagents(self, owner):
         provider = FakeProvider()
-        h._pending_approvals["C1:m1"] = h._PendingApproval(
-            provider, "rq9", session_key="slack:t1"
-        )
+        h._pending_approvals["C1:m1"] = h._PendingApproval(provider, "rq9", session_key="slack:t1")
         sessions = FakeSessions()
         out = await handle_interaction(
             "C1", "m1", h._ACTION_TRUST, owner, thread_ts="t1", sessions=sessions
@@ -1215,8 +1211,11 @@ class _Slot:
     def append(self, role, text, cls):
         self.appended.append((role, text))
 
-    def queue_append(self, text, *, directive_user_origin):
+    def queue_append(self, text, *, meta=None, directive_user_origin):
         assert directive_user_origin is True
+        # The linked-thread enqueue stamps the admission-time containment
+        # snapshot (#5911) so the drain can re-assert it at delivery.
+        assert isinstance(meta, dict)
         self.queued.append(text)
 
 

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -1854,8 +1854,11 @@ class _Slot:
         self._pending_synthesis = False
         self.queued: list[str] = []
 
-    def queue_append(self, message: str, *, directive_user_origin: bool) -> None:
+    def queue_append(self, message: str, *, meta=None, directive_user_origin: bool) -> None:
         assert directive_user_origin is False
+        # The relay stamps the admission-time containment snapshot (#5911); an
+        # app slot records app=True so its own queued turns keep draining.
+        assert isinstance(meta, dict)
         self._queue.append(message)
 
     def append(self, role: str, content: str) -> None:

--- a/test/test_stop_hook_continuation.py
+++ b/test/test_stop_hook_continuation.py
@@ -68,12 +68,14 @@ class TestParseHookContinuations:
 
     def test_deeply_nested_json_does_not_error_the_turn(self) -> None:
         """``json.loads`` raises RecursionError -- a RuntimeError, not a ValueError."""
-        assert parse_hook_continuations(["[" * 20000] + ['{"decision": "block", "reason": "ok"}']) == [
-            "ok"
-        ]
+        assert parse_hook_continuations(
+            ["[" * 20000] + ['{"decision": "block", "reason": "ok"}']
+        ) == ["ok"]
 
     def test_a_valid_decision_survives_a_malformed_sibling(self) -> None:
-        out = parse_hook_continuations(["not json at all", '{"decision": "block", "reason": "go on"}'])
+        out = parse_hook_continuations(
+            ["not json at all", '{"decision": "block", "reason": "go on"}']
+        )
 
         assert out == ["go on"]
 
@@ -207,6 +209,9 @@ class TestRunnerWiring:
                 "content": f"{HOOK_CONTINUATION_RECOVERY_PREFIX}\nRead the log first.",
                 "kind": SYNTHETIC_RECOVERY_KIND,
                 "payload": "",
+                # Admission stamp (#5911): recovery requeues record the containment
+                # that held at requeue so the drain can re-validate the retry.
+                "meta": slot._queue[0]["meta"],
             }
         ]
         assert is_synthetic_recovery_item(slot._queue[0])
@@ -229,18 +234,14 @@ class TestRunnerWiring:
         assert slot._queue == []
 
     @pytest.mark.asyncio
-    async def test_a_stop_during_the_hook_fire_suppresses_the_continuation(
-        self, tmp_path
-    ) -> None:
+    async def test_a_stop_during_the_hook_fire_suppresses_the_continuation(self, tmp_path) -> None:
         """A user Stop that lands WHILE the Stop hook runs must cancel the
         continuation. The stop handler bumps the stop-request counter, and
         stop_turn() reporting "idle" (no active provider turn during the hook)
         resets _stop_state to idle before the guard reads _stopping — so
         _stopping alone misses it and the counter is the durable signal.
         """
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "go on"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "go on"}')
         real_fire = state._hook_store.fire
 
         async def _fire_with_concurrent_stop(event, *args, **kwargs):
@@ -259,13 +260,9 @@ class TestRunnerWiring:
         assert slot._queue == []
 
     @pytest.mark.asyncio
-    async def test_a_stop_during_pre_turn_await_suppresses_the_continuation(
-        self, tmp_path
-    ) -> None:
+    async def test_a_stop_during_pre_turn_await_suppresses_the_continuation(self, tmp_path) -> None:
         """The generation snapshot must precede the first await in _run_chat."""
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "go on"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "go on"}')
 
         async def _expire_options_then_stop(*args, **kwargs):
             slot._stop_state = "soft_pending"
@@ -280,17 +277,13 @@ class TestRunnerWiring:
         assert slot._queue == []
 
     @pytest.mark.asyncio
-    async def test_a_stop_during_turn_body_suppresses_the_continuation(
-        self, tmp_path
-    ) -> None:
+    async def test_a_stop_during_turn_body_suppresses_the_continuation(self, tmp_path) -> None:
         """A stop initiated mid-turn (during streaming / completion persistence,
         before the Stop hook fires) must also cancel the continuation. Snapshot-
         ting the stop generation just before the hook _fire misses it — the
         generation must be captured at turn entry.
         """
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "go on"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "go on"}')
         from kiro_crew.providers.base import EVENT_TEXT_CHUNK, LLMEvent
 
         client = state.sessions.get_or_create.return_value[0]
@@ -395,9 +388,7 @@ class TestRealHookProcess:
         assert parse_hook_continuations([r.stdout for r in second if r.exit_code == 0]) == []
 
     @pytest.mark.asyncio
-    async def test_a_real_hook_that_only_logs_yields_no_continuation(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_real_hook_that_only_logs_yields_no_continuation(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         store = ScriptHookStore(tmp_path)
         script = tmp_path / "noisy.py"
@@ -525,9 +516,7 @@ class TestStopHookContinuationCount:
         assert self._stop_counts(state) == [1, 0]
 
     @pytest.mark.asyncio
-    async def test_a_user_typed_marker_is_not_counted_as_a_continuation(
-        self, tmp_path
-    ) -> None:
+    async def test_a_user_typed_marker_is_not_counted_as_a_continuation(self, tmp_path) -> None:
         """A user whose message literally starts with the marker is ordinary
         user speech (``_synthetic_payload`` False), not a runner-injected
         continuation: it must not inflate the depth the Stop hook is told, or a
@@ -579,9 +568,7 @@ class TestStopHookNudgeCap:
 
     async def _run_blocking_turn(self, tmp_path, cap: int, start_depth: int):
         """One turn whose Stop hook blocks, at ``start_depth`` under ``cap``."""
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "go on"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "go on"}')
         slot._hook_continuation_depth = start_depth
         with (
             patch(
@@ -598,9 +585,7 @@ class TestStopHookNudgeCap:
         return slot
 
     def _halt_rows(self, slot) -> list:
-        return [
-            m for m in slot.messages if m["content"].startswith(HOOK_HALTED_RECOVERY_PREFIX)
-        ]
+        return [m for m in slot.messages if m["content"].startswith(HOOK_HALTED_RECOVERY_PREFIX)]
 
     @pytest.mark.asyncio
     async def test_below_cap_queues_the_continuation(self, tmp_path) -> None:
@@ -613,9 +598,7 @@ class TestStopHookNudgeCap:
     @pytest.mark.asyncio
     async def test_stop_during_cap_load_suppresses_the_continuation(self, tmp_path) -> None:
         """The off-thread config load must not reopen a checked Stop boundary."""
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "go on"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "go on"}')
         capped_load = self._capped_load(5)
 
         def _load_then_stop():
@@ -662,9 +645,7 @@ class TestStopHookNudgeCap:
         would overrun the cap. With room for one, exactly one queues and the
         overflow surfaces a halt card.
         """
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "first"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "first"}')
         state._hook_store.fire = AsyncMock(
             return_value=[
                 _hook_result('{"decision": "block", "reason": "first"}'),
@@ -689,9 +670,7 @@ class TestStopHookNudgeCap:
         assert len(self._halt_rows(slot)) == 1
 
     @pytest.mark.asyncio
-    async def test_pending_queued_continuations_count_against_the_cap(
-        self, tmp_path
-    ) -> None:
+    async def test_pending_queued_continuations_count_against_the_cap(self, tmp_path) -> None:
         """The cap bounds the whole in-flight run, so continuations already
         queued from an earlier multi-reason event must be subtracted from the
         budget. Otherwise each event recomputes room from depth alone (which
@@ -699,9 +678,7 @@ class TestStopHookNudgeCap:
         """
         from kiro_crew.dashboard.chat_utils import SYNTHETIC_RECOVERY_KIND
 
-        state, slot, run_chat = _harness(
-            tmp_path, '{"decision": "block", "reason": "a"}'
-        )
+        state, slot, run_chat = _harness(tmp_path, '{"decision": "block", "reason": "a"}')
         state._hook_store.fire = AsyncMock(
             return_value=[
                 _hook_result('{"decision": "block", "reason": "a"}'),
@@ -738,9 +715,7 @@ class TestStopHookNudgeCap:
         assert len(self._halt_rows(slot)) == 1
 
     @pytest.mark.asyncio
-    async def test_user_marker_in_queue_does_not_count_against_the_cap(
-        self, tmp_path
-    ) -> None:
+    async def test_user_marker_in_queue_does_not_count_against_the_cap(self, tmp_path) -> None:
         """Only machine-authored continuation entries consume the cap budget."""
         state, slot, run_chat = _harness(
             tmp_path, '{"decision": "block", "reason": "new continuation"}'


### PR DESCRIPTION
## Problem / Motivation

A message queued for a busy chat session is delivered later **without re-checking the authorization that admitted it**. The window is between enqueue and drain: a target authorized while unlinked can be given a channel or outbound mirror link before its queue drains, and the queued prompt then executes and republishes to that channel. `_has_channel_mirror` (`session_control.py`) documents the mechanism; issue #5911 records it as the maintainer-approved follow-up from the PR #5650 `needs-a-decision` override.

The gap is caller-independent: `session_send` and a human typing into a busy session share the same `enqueue_or_run_prompt` → `queue_append` → `chat_runner` drain path, so any fix scoped to one caller leaves the others open.

## Why it matters

The containment `authorize_target` enforces at decision time (`linked_session_target` / `mirrored_target` are both refusals) is a promise the drain did not keep: a prompt admitted under private-session constraints could surface in front of a Slack/Telegram audience its admission never contemplated. This is a TOCTOU authorization bypass on a security boundary the module itself calls deny-by-default.

## What changed (motivation → approach → change)

Symptom → root cause: authorization is checked at enqueue but never re-asserted at drain, while the constraints it rests on (channel link, outbound mirror, crew mode, memory mode, workspace) are mutable while the entry waits. The issue explicitly declines the 409-refuse-busy-targets shape — the queue is not the defect; the missing re-validation is. So the fix closes the gap **at the drain, once, for every caller**, using the seams the issue names:

1. **Tag at enqueue.** Every producer of plain (user-speech) queue entries stamps the admission-time containment snapshot on the entry via `session_control.containment_meta` (`queue_append`'s existing `meta` channel — classification by metadata, never content). Producers: `enqueue_or_run_prompt` (composer, `session_send`, Slack gateway, workflow injection, crew runtime), the composer hold-queue, `queue_for_next_turn`, the Slack linked-thread enqueue, requeued steers, the plan-mode "Go", and the spec-builder relay.
2. **Re-validate at drain.** `_start_next_queued_turn` sweeps the queue before anything reads it (`_drop_stale_admissions`), recomputes the same constraints — `authorize_target`'s own set: linked, mirrored, crew, ephemeral, app, unattended, **and workspace** (its seventh refusal, `workspace_mismatch`; `slot.workspace` is mutable under a waiting queue via the agent-switch endpoint) — and drops any entry for which a constraint holds at delivery that did not hold at admission. The mirror is compared by **identity** (channel type + channel + thread), not just presence: a mirror **retargeted** to a different channel while the entry waited keeps the boolean true at both ends while substituting the audience, so the sweep drops that too (`mirror_retarget`). No suspension point sits between the sweep and the dequeue.
3. **Loud refusal, audited both ways.** A drop retracts the frontend queue card (unconditional `queue_pop` broadcast), appends a visible transcript notice naming the changed constraint, and writes a **denied** SEL record under the slot's **effective** session key (a linked slot's turns run under `linked_session_key`). The drain decision is a session-control authorization, and SEL records both outcomes of every other authorization in this module — so entries that pass re-validation and are consumed write an **allowed** SEL record too (`audit_queued_allow`, one row per drained batch), keeping the drain auditable rather than inferable-by-absence.

Boundaries that keep designed behaviour working:

- **Unmarked plain entries fail closed** against the boolean constraint set, so an untagged producer can never ride a queued prompt past a boundary the tagged paths respect. Workspace is compared only when the entry recorded one — there is no least-authorized workspace to assume.
- **Structural exemption is narrow: cron notifications and sub-agent completions only** — runner machinery minted fresh by trusted internal producers, which channel-born sessions receive by design. **Synthetic-recovery entries are NOT exempt**: a recovery replays externally admitted content verbatim under a fresh queue id, so every recovery producer (`_queue_recovery` — the single funnel for all in-turn retries, including the fallback-model retry — and the manual continue) stamps fresh admission context at requeue time and the drain re-validates it like any plain entry — a link appearing during the retry window drops the replay, while channel-born recovery machinery keeps working because its stamp records the link as pre-existing.
- **A constraint already held at admission is not a change**: channel-born sessions keep draining their own thread's messages.
- **Authenticated-human entries are exempt from the LINKED constraint only** (`_directive_user_origin`, the fail-closed provenance the queue already tracks — the manual continue and the queued plan-mode "Go" both derive it from the request identity, so app surfaces never gain it): a user linking their own busy session must not destroy the messages they already typed — `api_chat` applies no linked refusal to composer input. A NEW outbound mirror is never exempt (the message's author does not control mirror links), and a RETARGETED mirror is never exempt for the same reason; crew/ephemeral/app/unattended/workspace all still apply. Requeued steers derive the same provenance (the sole steer producer is the composer branch; app isolation confines app requests to app slots).
- **A drain-side mirror-probe failure refuses delivery unconditionally** — even for an entry admitted under a mirror, because the audience may have been retargeted since admission and an unreadable store leaves no identity to compare (fail closed, matching `authorize_target`'s posture). The probe is tri-state so the notice says the state *could not be verified* rather than asserting a mirror appeared, and the drop logs at WARNING.

The enqueue-side probe failure records *not mirrored* — the least-authorized admission state — so the two sides fail closed in opposite, correct directions.

## Tests

`test/test_queue_drain_revalidation.py` (27 tests, red-before verified against unpatched source):

- Human-typed (`enqueue_or_run_prompt`) and `session_send` (`send_to_target`) paths both stamp the admission snapshot; channel-born enqueue records `linked: True`; requeued steers are stamped and carry human provenance on non-app slots.
- Queued-then-linked and queued-then-mirrored drop with a visible notice and a denied SEL record filed under the effective session key; a mirror **retargeted** to a different channel while queued drops (directive provenance does not exempt it) while an unchanged admitted mirror still drains; queued-then-unchanged drains normally (including linked-from-birth).
- Workspace change drops a marked entry; unmarked entries skip the workspace comparison; unmarked entries fail closed on held boolean constraints and survive in unconstrained slots; cron and sub-agent kinds are exempt; an unmarked recovery entry fails closed, and a stamped recovery entry follows its own admission (channel-born recovery survives, link-during-retry drops).
- Directive-origin entries survive linking but still drop on a workspace change; the card-retraction broadcast fires without a placeholder row; probe failure records opposite fail-closed directions per side and produces the "could not be verified" wording; malformed snapshots degrade to the fail-closed baseline; a surviving entry's snapshot is stripped from the persisted transcript row; a consumed (re-validated) batch emits exactly one allowed SEL record.

`test/test_dashboard_chat.py::TestPlanAction` adds a busy-Go test: a plan approval clicked while the slot runs queues with BOTH the admission stamp and authenticated-human provenance, so a human linking their own session before the drain does not lose the approval (apps never gain the flag — same request-identity split as `api_chat`).

Four existing test doubles updated to the new `queue_append(meta=...)` contract, and the shared helper's in-memory mirror store now returns a `ChannelLink` (SessionStore parity — required for identity comparison). Full backend suite: 68,769 passed; the 16 failures + 2 errors reproduce on pristine main in this environment (AF_UNIX path length, xdist host budget, py-spy absence, etc.).

## Manual verification

N/A — unit coverage sufficient: the drain sweep, both enqueue paths, and the refusal surface are exercised end-to-end in-process, and the change adds no new external integration.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend files touched. The only user-visible artifact is a transcript notice row rendered through the existing `notice` role machinery.

## Related Issues

Closes #5911

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module docstrings updated where behaviour changed
- [x] No secrets, credentials, or internal references in the diff

