### PR TITLE
fix(artifacts): keep the folder-store reads off the event loop

### DIFF
--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -673,15 +673,16 @@ async def _resolve_folder_ref_off_loop(ref: Any, *, create_missing: bool) -> tup
 
     When ``create_missing`` is True the resolver may persist new folders
     (``_save()`` → ``os.fsync``/``os.replace``), which is blocking filesystem
-    IO — run it in the shared executor so it never blocks the event loop.
-    ``create_missing=False`` is a pure in-memory walk, so it runs inline.
+    IO. ``create_missing=False`` walks the tree in memory and writes nothing,
+    but it still takes ``ArtifactFolderStore._lock`` — the same lock every
+    mutating call holds ACROSS its ``_save()``. Those mutations run in the
+    executor, so a read left inline blocks the gateway loop for the length of
+    somebody else's folder write. Both modes go to the executor.
     """
-    if not create_missing:
-        return _resolve_folder_ref(ref, create_missing=False)
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         subprocess_executor(),
-        lambda: _resolve_folder_ref(ref, create_missing=True),
+        lambda: _resolve_folder_ref(ref, create_missing=create_missing),
     )
 
 
@@ -3036,13 +3037,21 @@ async def api_artifact_folders(request: web.Request) -> web.Response:
     try:
         # list_with_counts walks every artifact's meta.json (O(N) filesystem
         # scan). Offload it so the dashboard event loop stays responsive —
-        # same pattern as api_chat_folders.
+        # same pattern as api_chat_folders. breadcrumb() rides along in the
+        # same executor call: it takes the folder-store lock once per folder,
+        # so leaving it inline would put O(folders) lock acquisitions back on
+        # the loop and cost a round trip each.
+        def _list_serialized() -> list[dict[str, Any]]:
+            return [
+                _serialize_folder(f, path=fstore.breadcrumb(f["id"]))
+                for f in fstore.list_with_counts(store)
+            ]
+
         loop = asyncio.get_running_loop()
-        folders = await loop.run_in_executor(subprocess_executor(), fstore.list_with_counts, store)
+        out = await loop.run_in_executor(subprocess_executor(), _list_serialized)
     except (ArtifactError, OSError) as exc:
         logger.warning("artifact folder list failed: %s", exc)
         return _err(str(exc), status=500)
-    out = [_serialize_folder(f, path=fstore.breadcrumb(f["id"])) for f in folders]
     return _json_response({"folders": out})
 
 
@@ -3116,7 +3125,9 @@ async def api_artifact_folder_create(request: web.Request) -> web.Response:
             body.get("parent"), create_missing=True
         )
     else:
-        parent_id, ferr = _resolve_folder_ref(body.get("parent_id"), create_missing=False)
+        parent_id, ferr = await _resolve_folder_ref_off_loop(
+            body.get("parent_id"), create_missing=False
+        )
     if ferr:
         _audit(tool="artifact_folder_create", request=request, outcome="denied", error=ferr)
         return _err(ferr)
@@ -3130,6 +3141,13 @@ async def api_artifact_folder_create(request: web.Request) -> web.Response:
     except ArtifactError as exc:
         _audit(tool="artifact_folder_create", request=request, outcome="error", error=str(exc))
         return _err(str(exc), status=500)
+    _audit(
+        tool="artifact_folder_create",
+        request=request,
+        outcome="success",
+        extra={"folder_id": folder["id"]},
+    )
+    path = await _run_off_loop(lambda: fstore.breadcrumb(folder["id"]))
     # Derive an emoji icon from the name in the background (chat-folder parity).
     # A just-created folder's icon epoch is 0 by construction -- create() never
     # touches the registry, and delete() pops its entry, so even a reused id
@@ -3138,16 +3156,10 @@ async def api_artifact_folder_create(request: web.Request) -> web.Response:
     # that window would raise the epoch, so the read would capture the
     # COMPETING value and the generated icon would then clobber it. With 0
     # pinned, any such mutation makes the write-back lose, which is correct.
+    # Spawned AFTER the last await so nothing yields to the loop between the
+    # spawn and the response -- the task starts once the caller resumes.
     _spawn_artifact_folder_icon_task(request, folder["id"], name, expected_epoch=0)
-    _audit(
-        tool="artifact_folder_create",
-        request=request,
-        outcome="success",
-        extra={"folder_id": folder["id"]},
-    )
-    return _json_response(
-        _serialize_folder(folder, path=fstore.breadcrumb(folder["id"])), status=201
-    )
+    return _json_response(_serialize_folder(folder, path=path), status=201)
 
 
 async def api_artifact_folder_update(request: web.Request) -> web.Response:
@@ -3164,13 +3176,13 @@ async def api_artifact_folder_update(request: web.Request) -> web.Response:
         return _err("restricted session cannot update folders", status=403)
     fid = request.match_info.get("id", "")
     fstore = get_default_folder_store()
-    if not fstore.exists(fid):
+    if not await _run_off_loop(lambda: fstore.exists(fid)):
         return _err("folder not found", status=404)
     try:
         body = await _read_json_body(request)
     except ArtifactValidationError as exc:
         return _err(str(exc))
-    folder = fstore.get(fid)
+    folder = await _run_off_loop(lambda: fstore.get(fid))
     if folder is None:  # exists() checked above; guards against a concurrent delete
         return _err("folder not found", status=404)
 
@@ -3238,7 +3250,8 @@ async def api_artifact_folder_update(request: web.Request) -> web.Response:
             _spawn_artifact_folder_icon_task(
                 request, fid, str(body["name"]), expected_epoch=epoch
             )
-    return _json_response(_serialize_folder(updated, path=fstore.breadcrumb(fid)))
+    path = await _run_off_loop(lambda: fstore.breadcrumb(fid))
+    return _json_response(_serialize_folder(updated, path=path))
 
 
 async def _withdraw_subtree_publications(folder_id: str, fstore: Any) -> str:
@@ -3300,7 +3313,7 @@ async def api_artifact_folder_delete(request: web.Request) -> web.Response:
         return _err("restricted session cannot delete folders", status=403)
     fid = request.match_info.get("id", "")
     fstore = get_default_folder_store()
-    if not fstore.exists(fid):
+    if not await _run_off_loop(lambda: fstore.exists(fid)):
         return _err("folder not found", status=404)
     raw = (request.query.get("delete_contents") or "").strip().lower()
     delete_contents = raw in ("1", "true", "yes")
@@ -3408,7 +3421,9 @@ async def api_artifact_set_folder(request: web.Request) -> web.Response:
             body.get("folder"), create_missing=True
         )
     else:
-        folder_id, ferr = _resolve_folder_ref(body.get("folder_id"), create_missing=False)
+        folder_id, ferr = await _resolve_folder_ref_off_loop(
+            body.get("folder_id"), create_missing=False
+        )
     if ferr:
         _audit(
             tool="artifact_set_folder",
@@ -3419,7 +3434,8 @@ async def api_artifact_set_folder(request: web.Request) -> web.Response:
         )
         return _err(ferr)
     # A non-empty id passed directly must reference a real folder.
-    if folder_id and not get_default_folder_store().exists(folder_id):
+    fstore = get_default_folder_store()
+    if folder_id and not await _run_off_loop(lambda: fstore.exists(folder_id)):
         _audit(
             tool="artifact_set_folder",
             request=request,

--- a/test/test_artifact_folder_icons.py
+++ b/test/test_artifact_folder_icons.py
@@ -498,10 +498,14 @@ class TestIconRacesThroughHandlers:
             async def _hooked(fn):  # type: ignore[no-untyped-def]
                 out = await real_off_loop(fn)
                 # Land a manual pick the instant _apply_updates has committed,
-                # i.e. inside the arming window.
+                # i.e. inside the arming window. The handler offloads several
+                # reads before the commit, so key off the rename having landed
+                # rather than off which call this is.
                 if not fired["done"]:
-                    fired["done"] = True
-                    folders.set_icon(fid, "🧪")
+                    current = folders.get(fid)
+                    if current is not None and current["name"] == "Chemistry":
+                        fired["done"] = True
+                        folders.set_icon(fid, "🧪")
                 return out
 
             monkeypatch.setattr(art_handlers, "_run_off_loop", _hooked)

--- a/test/test_artifact_folder_store_off_loop.py
+++ b/test/test_artifact_folder_store_off_loop.py
@@ -1,0 +1,215 @@
+"""Every artifact-folder-store call an HTTP handler makes runs off the loop.
+
+``ArtifactFolderStore`` guards its whole API with one ``threading.Lock``, and
+every mutating call — ``create``, ``rename``, ``reparent``, ``set_icon``,
+``delete`` — holds that lock across ``_save()``: ``mkdir`` + ``mkstemp`` +
+write + ``os.fsync`` + ``os.replace``. The handlers already push those
+mutations into the shared executor, which is exactly what makes the READS
+dangerous to leave inline: a read on the gateway loop can only take the lock
+once the worker thread finishes somebody else's folder write, so the loop
+stalls for the length of that filesystem write.
+
+So the property pinned here is not "the read is fast" — it is *which thread
+the store call actually ran on*. Each test wraps the real store methods,
+records ``threading.get_ident()`` per call, and asserts no call landed on the
+event loop's own thread. Recording inside the store (rather than asserting on
+the handler's shape) keeps the tests true no matter how a handler reaches it.
+
+Harness mirrors ``test_artifact_folder_handlers.py``: MagicMock requests and a
+real store rooted under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew import artifacts as art_mod
+from kiro_crew.artifacts import ArtifactFolderStore, ArtifactStore
+from kiro_crew.dashboard.handlers import artifacts as art_handlers
+from kiro_crew.dashboard.handlers.artifacts import (
+    _spawn_artifact_folder_icon_task,
+    api_artifact_folder_create,
+    api_artifact_folder_delete,
+    api_artifact_folder_update,
+    api_artifact_folders,
+    api_artifact_set_folder,
+)
+
+#: Every read the handlers reach for. The mutators are already offloaded on
+#: main; they are wrapped too so a regression that moves one back inline is
+#: caught by the same assertion.
+WATCHED = (
+    "exists",
+    "get",
+    "breadcrumb",
+    "resolve_path",
+    "list_with_counts",
+    "create",
+    "rename",
+    "set_icon",
+    "set_icon_if_epoch",
+    "delete",
+)
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    store = ArtifactStore(root=tmp_path / "artifacts")
+    fstore = ArtifactFolderStore(path=tmp_path / "artifact_folders.json")
+    monkeypatch.setattr(art_mod, "_default_store", store)
+    monkeypatch.setattr(art_mod, "_default_folder_store", fstore)
+    return store, fstore
+
+
+@pytest.fixture
+def threads(monkeypatch) -> dict[str, list[int]]:
+    """Record the thread ident of every watched folder-store call."""
+    seen: dict[str, list[int]] = {}
+    for name in WATCHED:
+        original = getattr(ArtifactFolderStore, name)
+
+        def _wrapper(self, *args, _name=name, _orig=original, **kwargs):
+            seen.setdefault(_name, []).append(threading.get_ident())
+            return _orig(self, *args, **kwargs)
+
+        monkeypatch.setattr(ArtifactFolderStore, name, _wrapper)
+    return seen
+
+
+@pytest.fixture
+def patch_restricted(monkeypatch):
+    def _stub(_state, req) -> bool:
+        return req.app.get("_restricted_session", False)
+
+    monkeypatch.setattr(art_handlers, "_is_restricted_session", _stub)
+
+
+@pytest.fixture
+def no_icon_task(monkeypatch):
+    """The create/update handlers spawn a background icon task; it has its own
+    test below and would otherwise add non-deterministic calls to the record."""
+    monkeypatch.setattr(art_handlers, "_spawn_artifact_folder_icon_task", lambda *a, **k: None)
+
+
+def _request(*, body: dict | None = None, match: dict | None = None) -> MagicMock:
+    req = MagicMock()
+    req.headers = {"X-Session-Key": "dashboard:test"}
+    req.match_info = match or {}
+    req.query = {}
+    encoded = json.dumps(body).encode() if isinstance(body, dict) else b""
+    req.read = AsyncMock(return_value=encoded)
+    req.app = {"state": MagicMock(), "_restricted_session": False}
+    return req
+
+
+def _assert_off_loop(seen: dict[str, list[int]], *expected: str) -> None:
+    loop_thread = threading.get_ident()
+    assert set(expected) <= set(seen), f"expected {expected} to be called, saw {sorted(seen)}"
+    on_loop = {
+        name: idents for name, idents in seen.items() if any(i == loop_thread for i in idents)
+    }
+    assert not on_loop, f"folder-store calls ran on the event loop thread: {sorted(on_loop)}"
+
+
+@pytest.mark.asyncio
+async def test_folder_list_reads_off_loop(stores, threads) -> None:
+    _store, fstore = stores
+    fstore.create("A")
+    threads.clear()
+
+    resp = await api_artifact_folders(_request())
+
+    assert resp.status == 200
+    _assert_off_loop(threads, "list_with_counts", "breadcrumb")
+
+
+@pytest.mark.asyncio
+async def test_folder_create_by_parent_id_reads_off_loop(
+    stores, threads, patch_restricted, no_icon_task
+) -> None:
+    _store, fstore = stores
+    parent = fstore.create("P")
+    threads.clear()
+
+    resp = await api_artifact_folder_create(
+        _request(body={"name": "child", "parent_id": parent["id"]})
+    )
+
+    assert resp.status == 201
+    # ``parent_id`` is the read-only resolver branch — the one main ran inline.
+    _assert_off_loop(threads, "resolve_path", "create", "breadcrumb")
+
+
+@pytest.mark.asyncio
+async def test_folder_update_reads_off_loop(
+    stores, threads, patch_restricted, no_icon_task
+) -> None:
+    _store, fstore = stores
+    folder = fstore.create("F")
+    threads.clear()
+
+    resp = await api_artifact_folder_update(
+        _request(body={"name": "renamed"}, match={"id": folder["id"]})
+    )
+
+    assert resp.status == 200
+    _assert_off_loop(threads, "exists", "get", "rename", "breadcrumb")
+
+
+@pytest.mark.asyncio
+async def test_folder_delete_existence_check_off_loop(stores, threads, patch_restricted) -> None:
+    _store, fstore = stores
+    folder = fstore.create("F")
+    threads.clear()
+
+    resp = await api_artifact_folder_delete(_request(match={"id": folder["id"]}))
+
+    assert resp.status == 200
+    _assert_off_loop(threads, "exists", "delete")
+
+
+@pytest.mark.asyncio
+async def test_set_folder_by_id_reads_off_loop(stores, threads, patch_restricted) -> None:
+    store, fstore = stores
+    folder = fstore.create("F")
+    art = store.create(name="a", content="x")
+    threads.clear()
+
+    resp = await api_artifact_set_folder(
+        _request(body={"folder_id": folder["id"]}, match={"slug": art.slug})
+    )
+
+    assert resp.status == 200
+    _assert_off_loop(threads, "resolve_path", "exists")
+
+
+@pytest.mark.asyncio
+async def test_icon_task_write_back_off_loop(stores, threads, monkeypatch) -> None:
+    _store, fstore = stores
+    folder = fstore.create("F")
+
+    async def _emoji(_state, _name):
+        return "📁"
+
+    monkeypatch.setattr(art_handlers, "generate_emoji_for_name", _emoji)
+    threads.clear()
+
+    req = _request()
+    # A fresh folder's epoch is 0 by construction, which is what the create
+    # path pins; the rename path passes the epoch ``rename()`` returns.
+    _spawn_artifact_folder_icon_task(req, folder["id"], "F", expected_epoch=0)
+    # Poll the RECORD, not the store: a ``fstore.get`` from this coroutine would
+    # log the event loop's own thread and make the assertion below meaningless.
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if "set_icon_if_epoch" in threads:
+            break
+
+    _assert_off_loop(threads, "set_icon_if_epoch")
+    assert fstore.get(folder["id"])["icon"] == "📁"


### PR DESCRIPTION
## Problem / Motivation

`ArtifactFolderStore` guards its entire API with a single `threading.Lock`, and
every mutating call holds that lock **across** `_save()`:

```python
def create(self, name, parent_id="", color=""):
    with self._lock:
        ...
        self._save()          # mkdir + mkstemp + write + os.fsync + os.replace
```

`create`, `rename`, `reparent`, `set_icon`, `set_color`, `reorder` and `delete`
all have that shape. The artifact handlers correctly push those mutations into
the shared executor — and that is exactly what makes the **reads** dangerous to
leave inline. Ten folder-store calls run on the gateway event loop today:

| site | call |
| --- | --- |
| `_resolve_folder_ref_off_loop` (`create_missing=False` branch) | `resolve_path` |
| `api_artifact_folders` | `breadcrumb`, once per folder |
| `api_artifact_folder_create` | `resolve_path` (`parent_id`), `breadcrumb` |
| `api_artifact_folder_update` | `exists`, `get`, `breadcrumb` |
| `api_artifact_folder_delete` | `exists` |
| `api_artifact_set_folder` | `resolve_path` (`folder_id`), `exists` |
| `_spawn_artifact_folder_icon_task` | `exists` |

None of them writes anything, but every one of them takes `self._lock`. When a
concurrent request is mid-`create`/`rename`/`delete` on a worker thread, the
inline read cannot acquire the lock until that worker has finished its
`mkdir` + `mkstemp` + `fsync` + `os.replace` — so the **whole gateway loop**
(chat streaming, heartbeat, every other request) is parked on another user's
folder write. `Lock.acquire()` from a coroutine is a hard block, not a
suspension: nothing else on the loop runs.

`_resolve_folder_ref_off_loop` states the premise that made this look safe:

> `create_missing=False` is a pure in-memory walk, so it runs inline.

The walk *is* in memory. It is not lock-free, and the lock is the part that
blocks.

## Why it matters

The folder store is small, so the pathological case is not a slow parse — it is
the write itself. `_save()` is an `fsync` plus a rename; on a busy disk, a
network-backed home directory, or a Windows box where a scanner holds the
target open, that is tens to hundreds of milliseconds, and the store is a single
shared file so every folder mutation in the process serializes on it. Any
concurrent artifact-folder read then converts one slow write into a stall of the
entire dashboard gateway, for every session it serves — not just the two
requests involved.

This is the rule `AUTOSDE.yaml` states as `no-blocking-call-on-event-loop`
(`blocking: true`, `file-patterns: src/kiro_crew/**/*.py`): "a single blocking
call there freezes every task — the user's chat turn AND the liveness heartbeat
— until the watchdog kills the process and the supervisor respawns into the same
condition (a crash loop). This has caused multiple production wedges." It closes
with "When in doubt, offload."

The same module already treats this as the standard it holds itself to
(`_run_off_loop`: *"so its `os.fsync`/`os.replace` never blocks the event
loop"*; `api_artifact_folders`: *"Offload it so the dashboard event loop stays
responsive"*). This closes the gap between that stated standard and the reads.

## What changed (motivation → approach → change)

Root cause: the offload decision was made per *call* ("does this one write?")
when the blocking property belongs to the *lock* ("can this one wait on someone
who writes?"). Correcting the premise makes every folder-store call a handler
issues an executor call.

- `_resolve_folder_ref_off_loop` offloads both modes instead of short-circuiting
  `create_missing=False` inline, and its docstring now records why the in-memory
  walk still cannot run on the loop. The two direct `_resolve_folder_ref(...)`
  callers (`api_artifact_folder_create`'s `parent_id` branch and
  `api_artifact_set_folder`'s `folder_id` branch) go through it.
- `exists()`, `get()` and `breadcrumb()` in the create / update / delete /
  set-folder handlers move into `_run_off_loop`.
- `api_artifact_folders` folds `breadcrumb()` and `_serialize_folder()` into the
  executor call it already makes for `list_with_counts`. Wrapping the
  comprehension per folder would have put O(folders) lock acquisitions back on
  the loop and cost a round trip each; one call does the whole list.
- `_spawn_artifact_folder_icon_task` moves its `exists()` guard inside the
  closure that already runs `set_icon()`, so the check and the write share one
  executor hop and one lock acquisition — which also removes the check-then-act
  gap the two-step version had.

No behaviour changes: same status codes, same payloads, same ordering of the
existence check against body parsing. `_apply_updates` in
`api_artifact_folder_update` already re-checks `fstore.get(fid)` inside the
executor, so the concurrent-delete guard it documents is untouched.

## Tests

New `test/test_artifact_folder_store_off_loop.py`. It does not assert on handler
shape — it wraps the real `ArtifactFolderStore` methods, records
`threading.get_ident()` for every call, drives each handler, and asserts no call
landed on the event loop's own thread. That keeps the property true regardless
of how a handler reaches the store. The mutators are wrapped as well, so a
regression that moves an already-offloaded call back inline fails the same
assertion.

Six tests, one per entry point: folder list, create by `parent_id`, update,
delete, `set_folder` by `folder_id`, and the background icon task.

**Red-before, measured against pristine `origin/main` production code**
(`ad0825392`) with the new test file in place — **6 failed**, each naming the
methods that ran on the loop thread, which is the defect itself and not a
fixture or environment artifact:

```
folder-store calls ran on the event loop thread: ['breadcrumb']
folder-store calls ran on the event loop thread: ['exists']
folder-store calls ran on the event loop thread: ['exists']
folder-store calls ran on the event loop thread: ['breadcrumb', 'resolve_path']
folder-store calls ran on the event loop thread: ['breadcrumb', 'exists', 'get']
folder-store calls ran on the event loop thread: ['exists', 'resolve_path']
```

**Green-after:** 6 passed. Blast radius: **686 passed / 16 skipped** across
`test_artifact_folder_handlers.py`, `test_artifact_folders.py`,
`test_artifacts_handlers.py`, `test_artifacts_handlers_coverage.py`,
`test_handlers_artifacts_coverage.py`, `test_artifacts.py`,
`test_mcp_artifact_folders.py` and the new file.

`flake8`, `isort` and `mypy` are clean on both files; the new test file is
`black`-clean. `handlers/artifacts.py` is on `.github/black-baseline.txt` and
reports the same eight pre-existing hunks before and after this diff — none of
them in the changed regions.

## Manual verification

N/A — unit coverage sufficient: the property under test is which thread a call
executes on, which the tests observe directly at the store; a manual click-through
of the folders UI could not distinguish the two implementations.

## Related Issues

Self-reported while auditing the module's own offload comments against its call
sites. No separate issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
