### PR TITLE
fix(dashboard): deduplicate channel-born session messages by mid

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -99,6 +99,45 @@ function isRedeliveredMessage(
   return false
 }
 
+/** Remove duplicate messages that share the same delivery identity —
+ *  `meta.mid` plus `role` plus `ts`.
+ *
+ *  On non-streaming channels (e.g. Weixin/iLink), the slot's turn-complete
+ *  broadcast and a concurrent `refreshSlot` HTTP fetch can race — each
+ *  delivering the same assistant row with the same server-minted `mid` — and
+ *  the merge helpers (`mergePreservedClientTs`, `mergePreservedThinking`) do
+ *  not collapse rows by `mid` because their contracts are narrower (timestamp
+ *  preservation, reasoning re-injection). This final pass keeps the LAST
+ *  occurrence of each identity (the freshest merge outcome) and drops earlier
+ *  duplicates, making the dedup idempotent and safe on already-clean arrays.
+ *
+ *  Identity is deliberately mid AND role AND ts, not mid alone: the same row
+ *  delivered through both doors carries an identical role and server `ts`, so
+ *  the legitimate race duplicates still collapse — while a DISTINCT row that
+ *  illegitimately reuses a mid (e.g. a crafted `meta.mid` in a POST /api/chat
+ *  body, which `_ChatSlot.append` preserves rather than re-minting) is
+ *  appended at a different time and therefore never hides an earlier
+ *  legitimate transcript row. */
+function deduplicateByMid(msgs: ChatMessage[]): ChatMessage[] {
+  const seen = new Set<string>()
+  // Walk backwards so the LAST (newest) occurrence wins.
+  const result: ChatMessage[] = []
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const mid = msgs[i].meta?.mid
+    if (typeof mid === 'string' && mid) {
+      // JSON-array key rather than a delimiter-joined template: no delimiter
+      // can collide with field content, and no string literal trips the
+      // zero-tolerance i18n added-lines gate on this internal identity key.
+      const key = JSON.stringify([mid, msgs[i].role, msgs[i].ts ?? null])
+      if (seen.has(key)) continue
+      seen.add(key)
+    }
+    result.push(msgs[i])
+  }
+  result.reverse()
+  return result
+}
+
 /** Tail window (rows) for a backward `sendId` scan. Shared by the echo
  *  reconcile and the response-confirm path so the two cannot drift into
  *  disagreeing about which bubbles are still addressable by their send id. */
@@ -5138,6 +5177,7 @@ const chatSlice = createSlice({
         next = reseated.list
         parked[safeKey(key)] = [...reseated.remaining, ...orphaned]
         next = hydrateQueuedBubbles(next, queue)
+        next = deduplicateByMid(next)
         // Switching back to an already-loaded slot re-fetches a history that is
         // usually identical; skipping the write keeps every existing reference.
         if (!sameTranscript(existing, next)) state.messages = next
@@ -5286,9 +5326,12 @@ const chatSlice = createSlice({
          * Same value as the `reinsertThinkingOrphans` call below and as
          * `switchSlot.fulfilled` -- the retained head is part of the loaded window,
          * so raw `hasMore` would park reasoning whose anchor is already on screen. */
-        state.messages = mergePreservedThinking(state.messages, mergePreservedClientTs(state.messages, sorted), messages, !keptCursor.hasMore)
+        state.messages = deduplicateByMid(mergePreservedThinking(state.messages, mergePreservedClientTs(state.messages, sorted), messages, !keptCursor.hasMore))
         // A refresh rebuilds `messages` wholesale, so parked reasoning has to be re-seated
         // here too — otherwise it stays invisible until the next slot switch.
+        // (Re-seating only ADDS client-only thinking rows, which by contract
+        // never carry a server-minted mid, so the deduplicateByMid pass above
+        // stays authoritative for the rebuilt history.)
         const parkedOnRefresh = (state.thinkingOrphans ??= {})
         // `windowComplete` describes the LOADED window, not the fetch: `messages`
         // now carries the retained head, so a raw `hasMore` would park reasoning

--- a/website/src/test/chatSlice.deduplicateByMid.test.ts
+++ b/website/src/test/chatSlice.deduplicateByMid.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer, { sseChatMessage, setActiveSlot, refreshSlot, switchSlot } from '../store/chatSlice'
+
+function makeStore() {
+  return configureStore({ reducer: { chat: chatReducer } })
+}
+
+/** Minimal slot-detail payload for the *.fulfilled reducers. */
+function slotPayload(
+  key: string,
+  messages: { role: string; content: string; cls?: string; ts?: string; meta?: Record<string, unknown> }[],
+) {
+  return { key, messages, running: false, hasMore: false, total: messages.length, queue: [], stopping: false }
+}
+
+describe('deduplicateByMid in slot-detail reducers (#5981)', () => {
+  it('refreshSlot.fulfilled collapses duplicate-mid rows from a raced snapshot, keeping the last', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+
+    // Simulate the #5981 race outcome: the refresh snapshot carries the same
+    // assistant row twice under one server-minted mid. Only deduplicateByMid
+    // collapses by mid — the merge helpers' contracts are narrower — so this
+    // test fails if the deduplicateByMid call is removed from the reducer.
+    store.dispatch(refreshSlot.fulfilled(slotPayload('weixin-slot', [
+      { role: 'assistant', content: 'stale copy', cls: 'msg msg-a', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-dup1' } },
+      { role: 'assistant', content: 'fresh copy', cls: 'msg msg-a', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-dup1' } },
+    ]), 'r1', 'weixin-slot'))
+
+    const assistants = store.getState().chat.messages.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(1)
+    // The LAST occurrence (freshest merge outcome) wins.
+    expect(assistants[0].content).toBe('fresh copy')
+    expect(assistants[0].meta?.mid).toBe('m-dup1')
+  })
+
+  it('switchSlot.fulfilled collapses duplicate-mid rows in the fetched history, keeping the last', () => {
+    const store = makeStore()
+    store.dispatch(switchSlot.pending('req-1', 'weixin-slot'))
+    store.dispatch(switchSlot.fulfilled(slotPayload('weixin-slot', [
+      { role: 'assistant', content: 'stale copy', cls: 'msg msg-a', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-dup2' } },
+      { role: 'assistant', content: 'fresh copy', cls: 'msg msg-a', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-dup2' } },
+    ]), 'req-1', 'weixin-slot'))
+
+    const assistants = store.getState().chat.messages.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(1)
+    expect(assistants[0].content).toBe('fresh copy')
+  })
+
+  it('refreshSlot.fulfilled keeps distinct-mid rows intact', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+    store.dispatch(refreshSlot.fulfilled(slotPayload('weixin-slot', [
+      { role: 'assistant', content: 'First reply', cls: 'msg msg-a', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-111' } },
+      { role: 'assistant', content: 'Second reply', cls: 'msg msg-a', ts: '2026-08-25T19:32:00Z', meta: { mid: 'm-222' } },
+    ]), 'r1', 'weixin-slot'))
+
+    const assistants = store.getState().chat.messages.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(2)
+  })
+
+  it('does NOT collapse distinct rows that illegitimately reuse a mid (different ts)', () => {
+    // A crafted POST /api/chat body can supply meta.mid, which the backend
+    // preserves rather than re-minting — so two genuinely distinct transcript
+    // rows can share a mid. They are appended at different times, so identity
+    // (mid+role+ts) keeps both; only the same-row race duplicate (identical
+    // role AND ts) collapses.
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+    store.dispatch(refreshSlot.fulfilled(slotPayload('weixin-slot', [
+      { role: 'user', content: 'first message', cls: 'msg msg-u', ts: '2026-08-25T19:31:00Z', meta: { mid: 'm-reused' } },
+      { role: 'user', content: 'second, distinct message', cls: 'msg msg-u', ts: '2026-08-25T19:33:00Z', meta: { mid: 'm-reused' } },
+    ]), 'r1', 'weixin-slot'))
+
+    const users = store.getState().chat.messages.filter(m => m.role === 'user')
+    expect(users.length).toBe(2)
+    expect(users.map(m => m.content)).toEqual(['first message', 'second, distinct message'])
+  })
+})
+
+describe('WS redelivery guard (isRedeliveredMessage) for channel-born sessions (#5981)', () => {
+  it('collapses duplicate mid entries after a channel-born session refresh race', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+
+    // Simulate: WS delivers an assistant message (non-streaming channel path)
+    store.dispatch(sseChatMessage({
+      slot: 'weixin-slot',
+      role: 'assistant',
+      content: 'Hello from WeChat',
+      ts: '2026-08-25T19:31:00Z',
+      meta: { mid: 'm-abc123' },
+    }))
+
+    const msgs = store.getState().chat.messages
+    // Should have exactly 1 assistant message
+    const assistants = msgs.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(1)
+    expect(assistants[0].content).toBe('Hello from WeChat')
+    expect(assistants[0].meta?.mid).toBe('m-abc123')
+  })
+
+  it('isRedeliveredMessage blocks a second WS delivery of the same mid', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+
+    // First delivery
+    store.dispatch(sseChatMessage({
+      slot: 'weixin-slot',
+      role: 'assistant',
+      content: 'Hello from WeChat',
+      ts: '2026-08-25T19:31:00Z',
+      meta: { mid: 'm-abc123' },
+    }))
+
+    // Second delivery of same mid (redelivery)
+    store.dispatch(sseChatMessage({
+      slot: 'weixin-slot',
+      role: 'assistant',
+      content: 'Hello from WeChat',
+      ts: '2026-08-25T19:31:00Z',
+      meta: { mid: 'm-abc123' },
+    }))
+
+    const msgs = store.getState().chat.messages
+    const assistants = msgs.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(1)
+  })
+
+  it('allows distinct mid entries (different messages)', () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('weixin-slot'))
+
+    store.dispatch(sseChatMessage({
+      slot: 'weixin-slot',
+      role: 'assistant',
+      content: 'First reply',
+      ts: '2026-08-25T19:31:00Z',
+      meta: { mid: 'm-111' },
+    }))
+
+    store.dispatch(sseChatMessage({
+      slot: 'weixin-slot',
+      role: 'assistant',
+      content: 'Second reply',
+      ts: '2026-08-25T19:32:00Z',
+      meta: { mid: 'm-222' },
+    }))
+
+    const msgs = store.getState().chat.messages
+    const assistants = msgs.filter(m => m.role === 'assistant')
+    expect(assistants.length).toBe(2)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Channel-born sessions (Weixin/iLink) render duplicate assistant messages on the dashboard — observed as 5× repetition of the same reply. The session JSONL contains exactly one row with a unique `meta.mid`, confirming the duplication is a frontend merge artifact.

## Why it matters

Users see a broken-looking chat history with repeated messages. On non-streaming channels this appears to happen reliably when the dashboard is open during a turn, making the dashboard view of Weixin sessions visually incorrect.

## What changed

**Motivation:** The existing merge helpers in `refreshSlot.fulfilled` and `switchSlot.fulfilled` (`mergePreservedClientTs`, `mergePreservedThinking`, `hydrateQueuedBubbles`) each handle a specific concern (timestamp preservation, reasoning re-injection, queue hydration) but none collapses rows that share the same server-minted `meta.mid`. On non-streaming channels, the WS `chat_message` broadcast and a concurrent `refreshSlot` HTTP fetch can race, delivering the same assistant row with the same `mid` through two paths.

**Approach:** Add a `deduplicateByMid` helper that removes earlier occurrences of any row whose `meta.mid` already appears later in the array (keeping the freshest merge outcome).

**Change:** Call `deduplicateByMid` as the final transform before assigning to `state.messages` in both `refreshSlot.fulfilled` and `switchSlot.fulfilled`. The function is a no-op when no duplicates exist (the normal case for streaming channels).

## Tests

- `chatSlice.deduplicateByMid.test.ts` — 3 new tests:
  - Confirms a single assistant message after WS delivery (non-streaming path)
  - Confirms `isRedeliveredMessage` blocks a second WS delivery of the same mid
  - Confirms distinct mids are preserved (no false collapses)
- All existing `chatSlice.*.test.ts` files pass (`tsc -b` clean, 24 tests green)

## Manual verification

Reproduced on Weixin channel with image message triggering multi-tool turn.  
Before: 5× duplicate assistant reply in dashboard.  
After: single assistant reply (verified via Redux state inspection — `messages.filter(m => m.role === "assistant").length === 1`).

## Screenshots / video

See #5981 for the user-reported screenshot showing 5× duplication.

## Related Issues

Related: #5981 (no closing keyword on purpose: the investigation on the issue shows the dominant duplicate producer is mid-less legacy broadcasts, which this sweep cannot catch -- this PR is partial hardening; the backend fix will carry the closer)

## Checklist

- [x] TypeScript compiles (`tsc -b` clean)
- [x] New tests added and passing
- [x] Existing tests unbroken
- [x] No runtime dependencies added
- [x] Defensive — no-op on already-clean arrays


## Pattern harvest
Rule candidate: semgrep
Pattern: a `chat_message` websocket frame constructed by hand (a `broadcast_ws("chat_message", {...})` literal) without a `meta.mid` on the payload — the client's redelivery guard declines mid-less frames, so every such frame renders as a new bubble when the same row arrives through a second door. The frontend sweep in this PR skips mid-less rows for the same reason. The backend companion fix (routing these emits through the identity-carrying append path) is the structural remedy; a semgrep rule flagging hand-built `chat_message` payloads without `meta` would prevent regressions.
