### PR TITLE
fix(memory): read the memory files off the gateway loop too

### DIFF
--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -97,6 +97,18 @@ def _redact_pip_stderr(raw: bytes) -> str:
     return redact_log_via_context(raw.decode(errors="replace"))[:_PIP_STDERR_LOG_CHARS]
 
 
+def _write_today_history(mem, content: str) -> None:
+    """Resolve today's history file, ensure its parent, and commit *content*.
+
+    One worker hop for the whole sequence: the ``mkdir`` is synchronous file
+    I/O just as much as the write it precedes, so leaving it on the loop would
+    keep exactly the stall the offload exists to remove.
+    """
+    today_path = mem._today_history_file()
+    today_path.parent.mkdir(parents=True, exist_ok=True)
+    mem._atomic_write_text(today_path, content)
+
+
 def _sel():
     """Late-binding sel() for test monkeypatch compatibility."""
     import kiro_crew.dashboard.handlers as _pkg  # noqa: F811
@@ -126,7 +138,9 @@ async def api_memory_preferences(request: web.Request) -> web.Response:
         async with _prefs_write_lock:
             await asyncio.to_thread(mem.write_preferences, content)
         return web.json_response({"ok": True})
-    return web.json_response({"content": mem.read_preferences()})
+    # The GET half reads the same file the PUT half writes — ``exists()`` plus
+    # ``read_text()`` is the same synchronous I/O, so it is offloaded too.
+    return web.json_response({"content": await asyncio.to_thread(mem.read_preferences)})
 
 
 async def api_memory_projects(request: web.Request) -> web.Response:
@@ -143,7 +157,8 @@ async def api_memory_projects(request: web.Request) -> web.Response:
         async with _projects_write_lock:
             await asyncio.to_thread(mem.write_projects, content)
         return web.json_response({"ok": True})
-    return web.json_response({"content": mem.read_projects()})
+    # Offloaded for the same reason as the GET half of api_memory_preferences.
+    return web.json_response({"content": await asyncio.to_thread(mem.read_projects)})
 
 
 async def api_memory_history(request: web.Request) -> web.Response:
@@ -162,12 +177,12 @@ async def api_memory_history(request: web.Request) -> web.Response:
         # write_text would follow a planted symlink at the dated name and
         # tear under concurrent PUTs; the atomic replace commits whole
         # versions and never traverses a link at the temp path.
-        today_path = mem._today_history_file()
-        today_path.parent.mkdir(parents=True, exist_ok=True)
         async with _history_write_lock:
-            await asyncio.to_thread(mem._atomic_write_text, today_path, content)
+            await asyncio.to_thread(_write_today_history, mem, content)
         return web.json_response({"ok": True})
-    return web.json_response({"content": mem.read_recent_history()})
+    # ``read_recent_history`` is TTL-cached, but a miss "stats + reads up to 181
+    # files synchronously" (its own docstring) — far too much to do on the loop.
+    return web.json_response({"content": await asyncio.to_thread(mem.read_recent_history)})
 
 
 async def api_memory_settings(request: web.Request) -> web.Response:
@@ -736,7 +751,9 @@ async def api_memory_embedding_model(request: web.Request) -> web.Response:
                 {"ok": False, "error": error, "code": code}, status=400
             )
         try:
-            size_bytes = path.stat().st_size
+            # ``path`` is operator-supplied and may live on a removable or
+            # network volume, where a stat blocks for the mount's timeout.
+            size_bytes = (await asyncio.to_thread(path.stat)).st_size
         except OSError:
             size_bytes = 0
     if validate_only:

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -263,6 +263,90 @@ class TestPreferencesProjectsHistory:
         assert target.read_text(encoding="utf-8") == "entry"
 
     @pytest.mark.asyncio
+    async def test_preferences_get_read_runs_off_the_event_loop_thread(self) -> None:
+        """The GET half reads the same file the PUT half writes.
+
+        ``read_preferences`` is ``exists()`` + ``read_text()`` — the same
+        synchronous file I/O the PUT test above pins off the loop. Offloading
+        only the write leaves the read stalling every other gateway task on a
+        slow or network-backed filesystem.
+        """
+        loop_thread = threading.get_ident()
+        read_threads: list[int] = []
+        mem = MagicMock()
+
+        def _read() -> str:
+            read_threads.append(threading.get_ident())
+            return "- dark mode"
+
+        mem.read_preferences.side_effect = _read
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_preferences(_make_request(state))
+        assert _body(resp) == {"content": "- dark mode"}
+        assert read_threads and read_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_projects_get_read_runs_off_the_event_loop_thread(self) -> None:
+        loop_thread = threading.get_ident()
+        read_threads: list[int] = []
+        mem = MagicMock()
+
+        def _read() -> str:
+            read_threads.append(threading.get_ident())
+            return "## Proj"
+
+        mem.read_projects.side_effect = _read
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_projects(_make_request(state))
+        assert _body(resp) == {"content": "## Proj"}
+        assert read_threads and read_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_history_get_read_runs_off_the_event_loop_thread(self) -> None:
+        """``read_recent_history`` is TTL-cached, but a miss "stats + reads up
+        to 181 files synchronously" (its own docstring) — the worst of the
+        three to leave on the loop."""
+        loop_thread = threading.get_ident()
+        read_threads: list[int] = []
+        mem = MagicMock()
+
+        def _read() -> str:
+            read_threads.append(threading.get_ident())
+            return "# 2026-01-01"
+
+        mem.read_recent_history.side_effect = _read
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_history(_make_request(state))
+        assert _body(resp) == {"content": "# 2026-01-01"}
+        assert read_threads and read_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_history_put_parent_mkdir_runs_off_the_event_loop_thread(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``mkdir`` is file I/O too, and it sat outside the offload the write
+        already had — so the PUT still touched the filesystem on the loop."""
+        loop_thread = threading.get_ident()
+        mkdir_threads: list[int] = []
+        target = tmp_path / "history" / "2026-01-01.md"
+        real_mkdir = Path.mkdir
+
+        def _spy_mkdir(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if self == target.parent:
+                mkdir_threads.append(threading.get_ident())
+            return real_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", _spy_mkdir)
+        mem = MagicMock()
+        mem._today_history_file.return_value = target
+        mem._atomic_write_text.side_effect = lambda p, c: p.write_text(c, encoding="utf-8")
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "entry"})
+        assert (await mem_mod.api_memory_history(req)).status == 200
+        assert target.read_text(encoding="utf-8") == "entry"
+        assert mkdir_threads and all(t != loop_thread for t in mkdir_threads)
+
+    @pytest.mark.asyncio
     async def test_history_put_rejects_invalid_json(self, tmp_path: Path) -> None:
         mem = MagicMock()
         mem._today_history_file.return_value = tmp_path / "h.md"
@@ -271,6 +355,39 @@ class TestPreferencesProjectsHistory:
         resp = await mem_mod.api_memory_history(req)
         assert resp.status == 400
         assert not (tmp_path / "h.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# embedding model — validation stat
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingModelValidationStat:
+    @pytest.mark.asyncio
+    async def test_size_stat_runs_off_the_event_loop_thread(self, monkeypatch) -> None:
+        """The model path is operator-supplied and may sit on a removable or
+        network volume, where ``stat`` blocks for the mount's timeout."""
+        loop_thread = threading.get_ident()
+        stat_threads: list[int] = []
+
+        class _Path:
+            def stat(self) -> Any:
+                stat_threads.append(threading.get_ident())
+                return SimpleNamespace(st_size=4096)
+
+        monkeypatch.setattr(
+            mem_mod, "validate_custom_model_path", lambda _raw, _label: (_Path(), None, None)
+        )
+        state = _make_state()
+        req = _make_request(
+            state,
+            method="POST",
+            json_body={"path": "/mnt/models/custom.gguf", "validate_only": True},
+        )
+        resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 200
+        assert _body(resp) == {"ok": True, "size_bytes": 4096}
+        assert stat_threads and stat_threads[0] != loop_thread
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

Three memory handlers are GET/PUT pairs over the same file, and each one
offloads only half of itself. `api_memory_preferences` carries the reasoning
explicitly:

```python
# Offloaded to a worker thread: write_preferences does synchronous
# atomic file I/O plus an FTS index update, and this handler runs on
# the gateway event loop — inline, a slow filesystem stalls every
# other gateway task.
async with _prefs_write_lock:
    await asyncio.to_thread(mem.write_preferences, content)
return web.json_response({"ok": True})
return web.json_response({"content": mem.read_preferences()})   # ← on the loop
```

`read_preferences()` is `exists()` + `read_text()` on the file
`write_preferences` just wrote. `api_memory_projects` has the identical pair.
`api_memory_history` is the sharpest of the three, because
`read_recent_history` says so itself:

> TTL-cached … because this runs on every message turn and otherwise **stats +
> reads up to 181 files synchronously**.

A cache miss — first read after boot, first read of a new day, or any read
after a write invalidates it — does that whole walk on the gateway loop.

Two smaller sites have the same gap:

- the history PUT resolves `mem._today_history_file()` and runs
  `today_path.parent.mkdir(parents=True, exist_ok=True)` *before* entering the
  offload, so the handler still touches the filesystem on the loop immediately
  under a comment saying it does not;
- `api_memory_embedding_model` calls `path.stat().st_size` on an
  operator-supplied `.gguf` path, straight from the request body.

## Why it matters

These are not background passes; they are the Memory tab's ordinary reads, and
the loop they run on is the one serving chat streaming, WebSocket fan-out and
the heartbeat for every session in the process. `read_text` on a home directory
that lives on a network share, or under a Windows scanner holding the file open,
parks all of that — and the history read multiplies it by up to 181 files.

The embedding-model stat is the nastiest failure mode of the five, because the
path is chosen by the caller: point it at a disconnected SMB share or an ejected
removable volume and `stat` blocks for the mount's timeout, tens of seconds,
with the whole gateway behind it. Nothing about that path is trusted to be
local.

This is the rule `AUTOSDE.yaml` states as `no-blocking-call-on-event-loop`
(`blocking: true`, `file-patterns: src/kiro_crew/**/*.py`): "a single blocking
call there freezes every task — the user's chat turn AND the liveness heartbeat
— until the watchdog kills the process and the supervisor respawns into the same
condition (a crash loop). This has caused multiple production wedges." It closes
with "When in doubt, offload."

The module already treats the loop as something to protect — it uses
`asyncio.to_thread` / `run_in_executor` in 24 places. This closes the read side
of that same standard.

## What changed (motivation → approach → change)

Root cause: the offload was applied per *direction* (writes are slow) rather
than per *operation* (filesystem calls block). Every one of the five is a
filesystem call.

- `mem.read_preferences`, `mem.read_projects` and `mem.read_recent_history` are
  awaited through `asyncio.to_thread`. Only the GET expression changes; the
  response bodies and status codes are identical.
- A new module-level `_write_today_history(mem, content)` resolves today's
  history path, creates its parent, and calls `mem._atomic_write_text` — so the
  `mkdir` rides in the same worker hop as the write instead of preceding it on
  the loop. It runs under `_history_write_lock` exactly as the write did, which
  also brings the `mkdir` inside the ordering the lock exists to give.
- `path.stat()` in `api_memory_embedding_model` is awaited through
  `asyncio.to_thread`. The `except OSError → size_bytes = 0` fallback is
  unchanged.

The reads are deliberately *not* given endpoint locks: the write locks exist to
keep rapid successive saves committing in request order, and a read has no
order to preserve.

Left alone on purpose: the two `os.unlink(cleanup)` calls in `finally` blocks in
`_ensure_pip_available` and `api_memory_enable_embeddings`. They are a
single-file unlink on a cleanup path, and adding a suspension point to a
`finally` after a subprocess failure is a different change with a different
argument — it does not belong in this diff.

## Tests

Added to `test/test_handlers_memory_coverage.py`, beside the PUT-side
off-loop tests that already live there and use the same technique — record
`threading.get_ident()` inside the mocked store call, compare it against the
test coroutine's own thread:

- `test_preferences_get_read_runs_off_the_event_loop_thread`
- `test_projects_get_read_runs_off_the_event_loop_thread`
- `test_history_get_read_runs_off_the_event_loop_thread`
- `test_history_put_parent_mkdir_runs_off_the_event_loop_thread` — spies on
  `Path.mkdir`, filtered to the target's parent so an unrelated `mkdir` cannot
  make it pass or fail
- `TestEmbeddingModelValidationStat::test_size_stat_runs_off_the_event_loop_thread`
  — drives the `validate_only` path with a stub path object whose `stat()`
  records its thread

Each also keeps asserting the response body, so an offload that lost the value
fails too.

**Red-before, measured against pristine `origin/main` production code**
(`ad0825392`) with the new tests in place — **5 failed / 125 passed**, and every
failure is the ident comparison, i.e. the defect itself:

```
assert ([36104] and 36104 != 36104)     # preferences GET
assert ([2968]  and 2968  != 2968)      # projects GET
assert ([34936] and 34936 != 34936)     # history GET
assert ([33972] and False)              # history PUT mkdir
assert ([47348] and 47348 != 47348)     # embedding-model stat
```

**Green-after:** 130 passed in that module. Blast radius: 258 passed across
`test_handlers_memory_coverage.py`, `test_embedding_model_apply.py`,
`test_memory_graph.py` and `test_handler_error_no_exception_leak.py`; and
**1102 passed / 69 skipped** across the whole `-k memory` selection.

That wider run also reports 34 collection errors in
`test_bench_download_fd.py` and `test_discord_doctor.py` (`KeyError: 'file'`).
Those are pre-existing on this machine and unrelated to this diff — verified by
stashing the change and re-running the two files on pristine main, which
produces the same 59 passed / 34 errors.

`flake8`, `isort` and `mypy` are clean on both files. Both are on
`.github/black-baseline.txt` and report the same pre-existing hunks before and
after this diff; none of them fall in the added lines.

## Manual verification

N/A — unit coverage sufficient: the property is which thread a call runs on,
which the tests observe directly at the store; clicking through the Memory tab
cannot distinguish the two implementations without a deliberately slow volume.

## Related Issues

Residual sites in the module converted by #5059 (`fix(memory): run the config
read-modify-write off the gateway loop`). No separate issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
