### PR TITLE
fix: reap killed describe-voices child via communicate() not wait() (#5975)

### DIFF
--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -379,7 +379,11 @@ async def api_voice_voices(request: web.Request) -> web.Response:
     except asyncio.TimeoutError:
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
-        await proc.wait()
+        # Reap via communicate(), not wait(): wait_for cancelled the pipe
+        # readers before the kill landed, so a child blocked writing to a
+        # full stderr PIPE is never drained and wait() can hang the request
+        # handler indefinitely (#5975, same class as #5834).
+        await proc.communicate()
         return web.json_response({"error": "timeout"}, status=504)
     except FileNotFoundError:
         # Defense-in-depth behind the which() guard above: exec can still

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -506,15 +506,13 @@ class TestVoiceVoices:
 
         async def mock_exec(*args, **kwargs):
             proc = MagicMock()
-
-            async def comm():
-                raise asyncio.TimeoutError()
-            proc.communicate = comm
+            # First await (under wait_for) times out; the second (the reap
+            # after kill) drains the pipes and returns.
+            proc.communicate = AsyncMock(
+                side_effect=[asyncio.TimeoutError(), (b"", b"")]
+            )
             proc.kill = MagicMock()
-
-            async def _wait():
-                return 0
-            proc.wait = _wait
+            proc.wait = AsyncMock()
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
@@ -530,6 +528,52 @@ class TestVoiceVoices:
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/voice/voices")
             assert resp.status == 504
+
+    @pytest.mark.asyncio
+    async def test_voices_timeout_reaps_child_via_communicate_not_wait(
+        self, tmp_path, monkeypatch
+    ):
+        """After a timeout kills the describe-voices child, the cleanup must
+        call ``communicate()`` -- not ``wait()`` -- so that PIPE buffers are
+        drained. A child blocked writing to a full stderr PIPE would hang the
+        request handler if only ``wait()`` were used (#5975)."""
+        import asyncio
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(provider="polly", aws_profile="", region="")
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache", None)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache_ts", 0)
+
+        proc = MagicMock()
+        proc.communicate = AsyncMock(side_effect=[asyncio.TimeoutError(), (b"", b"")])
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+
+        async def mock_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_voice.resolve_polly_cli", lambda: "/usr/local/bin/aws"
+        )
+
+        from kiro_crew.dashboard.chat_voice import api_voice_voices
+        app = web.Application()
+        app["state"] = _make_state(tmp_path)
+        app.router.add_get("/api/voice/voices", api_voice_voices)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/voice/voices")
+            assert resp.status == 504
+
+        proc.kill.assert_called_once()
+        # The critical pin: reap via communicate(), not wait(). The handler
+        # awaits communicate once under wait_for; the reap must award a
+        # SECOND await, and wait() must never be touched. (A bare
+        # ``communicate.assert_awaited()`` would pass even against a
+        # wait()-based reap, so it must be this count/not_awaited shape.)
+        assert proc.communicate.await_count == 2
+        proc.wait.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_voices_aws_not_found(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

`GET /api/voice/voices` spawns `aws polly describe-voices` with `stdout=PIPE, stderr=PIPE`. When the 15s `asyncio.wait_for` fires, the handler kills the child and reaps it with a bare `await proc.wait()`. `wait_for` has already cancelled the pipe readers by then, so nothing drains the child's pipes: a child blocked writing to a full stderr PIPE (e.g. the AWS CLI dumping a long traceback or proxy/SSL diagnostics while wedged) never exits, and `wait()` awaits it forever. The request handler hangs indefinitely instead of returning the intended 504.

## Why it matters

The voices catalogue is fetched from the dashboard voice settings UI. A wedged `aws` CLI (network blackhole, misconfigured proxy) is exactly the case the timeout exists for -- and in that case the handler can hang an aiohttp request task forever, leaking the task and the child process. This is the same defect class already fixed on the ffmpeg stitch path (#5834, PR #5838) and the transcribe/synthesize paths (#5821, #5833); this call site was the remaining one in the family.

## What changed (motivation -> approach -> change)

Symptom: timeout path can hang -> root cause: `wait()` reaps without draining pipes that `wait_for`'s cancellation orphaned -> change: reap via `await proc.communicate()`, which re-attaches to the still-open stream readers, drains both pipes to EOF against the SIGKILLed child, and then reaps. One production line changed (plus a comment explaining why), identical to the substitution merged in #5838.

## Tests

- `TestVoiceVoices::test_voices_timeout_reaps_child_via_communicate_not_wait` (new): pins the reap shape with `communicate.await_count == 2` and `wait.assert_not_awaited()` -- a bare `communicate.assert_awaited()` would pass even against a `wait()`-based reap, so it must be this count/not-awaited shape (mirrors the #5838 pin in `test_voice_reply.py`). Mutation-verified: reverting the source line to `await proc.wait()` fails this test (`await_count 1 == 2`), and it passes with the fix.
- `TestVoiceVoices::test_voices_timeout` (updated): the mock's `communicate` now uses `side_effect=[TimeoutError(), (b"", b"")]` so the second (reap) await returns instead of re-raising; still asserts the 504 contract.

Local gates: isort/flake8 clean; mypy and full pytest failures A/B-verified identical on the clean base tree (environment-owned, none in the touched files); `test_chat_voice.py` + `test_voice_reply.py` 134/134 green.

Note: the test lives in `test/test_chat_voice.py` (the module's own test file), not `test/test_voice_reply.py` as the issue suggested -- the changed handler is `dashboard/chat_voice.py`, and `test_voice_reply.py` covers `voice_reply.py`.

## Manual verification

N/A -- unit coverage sufficient: the pin exercises the exact handler path over a real aiohttp TestClient request, and the defect/fix pair is deterministic under the mocked subprocess.

## Related Issues

Closes #5975

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no documented API or behavior contract changed
- [x] No secrets, credentials, or internal references in the diff
