### PR TITLE
fix(taskrunner): move the spec and plan-directory I/O off the gateway loop

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1137,
+    "missing_code": 1135,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1722,
+  "_compliant": 1767,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -135,7 +135,7 @@
       "missing_code": 20
     },
     "dashboard/handlers/taskrunner.py": {
-      "missing_code": 43
+      "missing_code": 41
     },
     "dashboard/handlers/themes.py": {
       "dynamic_status": 4,

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -127,14 +127,19 @@ async def api_taskrunner_status(request: web.Request) -> web.Response:
     return web.json_response(data)
 
 
-def _validate_spec_path(raw: str) -> tuple[str | None, str, int]:
-    """Resolve and validate a caller-supplied spec path off the event loop."""
+def _validate_spec_path(raw: str) -> tuple[str | None, str]:
+    """Resolve and validate a caller-supplied spec path off the event loop.
+
+    Returns ``(resolved_path, "")`` on success, or ``(None, code)`` where
+    ``code`` is the machine-readable failure identifier the handler maps to
+    its error response (``invalid_spec_path`` or ``access_denied``).
+    """
     resolved = Path(raw).resolve()
     if ".." in Path(raw).parts or not resolved.is_file():
-        return None, "invalid spec path", 400
+        return None, "invalid_spec_path"
     if is_sensitive_path(str(resolved)):
-        return None, "access denied", 403
-    return str(resolved), "", 0
+        return None, "access_denied"
+    return str(resolved), ""
 
 
 def _write_inline_spec(work_dir: str | Path, content: str) -> Path:
@@ -206,6 +211,22 @@ async def _materialize_inline_spec(work_dir: str | Path, content: str) -> Path:
         raise cancelled
 
 
+def _spec_retained_by_run(state: DashboardState, spec_path: Path) -> bool:
+    """True when a registered run still references *spec_path* as its spec.
+
+    ``start_background`` can be cancelled AFTER it registered the run
+    placeholder (its internal rollback covers only the persistence hop), in
+    which case the run — and the dashboard surface reading it — legitimately
+    owns the spec file now: deleting it would corrupt a retained run. Ownership
+    of a handler-created spec transfers the moment any run records its path.
+    """
+    runner = state.task_runner
+    if runner is None:
+        return False
+    target = str(spec_path)
+    return any(run.spec_path == target for run in runner._runs.values())
+
+
 async def _claim_plan_dir(work_dir: Path) -> tuple[str, Path]:
     """Claim a plan directory without letting cancellation orphan the result."""
     worker = asyncio.create_task(asyncio.to_thread(_make_plan_dir, work_dir))
@@ -253,9 +274,15 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
     # use share one value — no gap where spec_path could differ from what was
     # checked, and the containment guard is visible to static analysis.
     if not spec_path.startswith("__inline__:"):
-        validated, error, status = await asyncio.to_thread(_validate_spec_path, spec_path)
+        validated, failure = await asyncio.to_thread(_validate_spec_path, spec_path)
         if validated is None:
-            return web.json_response({"error": error}, status=status)
+            if failure == "access_denied":
+                return web.json_response(
+                    {"error": "access denied", "code": "access_denied"}, status=403
+                )
+            return web.json_response(
+                {"error": "invalid spec path", "code": "invalid_spec_path"}, status=400
+            )
         spec_path = validated
 
     # Handle inline spec content
@@ -287,21 +314,34 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
             workspace_dir=workspace_dir,
             auto_approve=auto_approve,
         )
-    except Exception as exc:
-        # The handler owns the temp file ONLY when it created it: a rejected
-        # start must not strand TASK_*.md orphans in the work dir, and an
-        # external spec the caller passed by path must never be deleted.
+    except BaseException as exc:
+        # The handler owns the temp file ONLY when it created it AND no run
+        # retains it: a rejected start must not strand TASK_*.md orphans in
+        # the work dir, an external spec the caller passed by path must never
+        # be deleted, and a spec a registered run still references must never
+        # be deleted either — ``start_background`` cancelled after admission
+        # retains the run placeholder (its rollback covers only the
+        # persistence hop), so ownership has transferred to the run.
+        # ``BaseException`` (mirroring the from_chat rollback below) so a
+        # request cancelled during ``start_background`` also cleans up — the
+        # spec-write hop is shielded, but the very next await used to leak.
         # Cleanup is best-effort — its failure must not replace the startup
         # error the client is about to receive.
-        if created_spec is not None:
+        if created_spec is not None and not _spec_retained_by_run(state, created_spec):
             try:
                 await _remove_owned_path(created_spec)
+            except asyncio.CancelledError:
+                # The removal worker was drained to completion; the pending
+                # cancellation is re-delivered by the raise below / next await.
+                pass
             except OSError:
                 logger.warning(
                     "failed to remove inline spec %s after a rejected start",
                     created_spec,
                     exc_info=True,
                 )
+        if not isinstance(exc, Exception):
+            raise  # CancelledError and friends: propagate after cleanup.
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response({"ok": True, "spec": spec_path, "task_id": task_id})
 

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -127,6 +127,110 @@ async def api_taskrunner_status(request: web.Request) -> web.Response:
     return web.json_response(data)
 
 
+def _validate_spec_path(raw: str) -> tuple[str | None, str, int]:
+    """Resolve and validate a caller-supplied spec path off the event loop."""
+    resolved = Path(raw).resolve()
+    if ".." in Path(raw).parts or not resolved.is_file():
+        return None, "invalid spec path", 400
+    if is_sensitive_path(str(resolved)):
+        return None, "access denied", 403
+    return str(resolved), "", 0
+
+
+def _write_inline_spec(work_dir: str | Path, content: str) -> Path:
+    """Materialize an inline spec. Blocking; call from a worker thread."""
+    fpath = Path(work_dir) / f"TASK_{uuid.uuid4().hex[:8]}.md"
+    fpath.parent.mkdir(parents=True, exist_ok=True)
+    fpath.write_text(content, encoding="utf-8")
+    return fpath
+
+
+def _make_plan_dir(work_dir: Path) -> tuple[str, Path]:
+    """Claim a fresh plan directory. Blocking; call from a worker thread."""
+    while True:
+        new_id = f"plan_{uuid.uuid4().hex[:8]}"
+        task_dir = work_dir / new_id
+        try:
+            task_dir.mkdir(parents=True, exist_ok=False)
+            return new_id, task_dir
+        except FileExistsError:
+            continue
+
+
+async def _drain_worker(worker: asyncio.Task) -> None:
+    """Wait for an already-dispatched worker across repeated cancellation.
+
+    Cancelling ``asyncio.to_thread`` never stops its thread.  An owned file or
+    directory could otherwise appear after the handler has lost the path needed
+    to remove it.  Callers drain first, inspect the worker result, clean up, and
+    only then propagate cancellation.
+    """
+    while not worker.done():
+        try:
+            await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            continue
+        except Exception:
+            break
+
+
+async def _remove_owned_path(path: Path, *, directory: bool = False) -> None:
+    """Remove a handler-owned path off-loop and settle the worker on cancel."""
+    operation = path.rmdir if directory else lambda: path.unlink(missing_ok=True)
+    worker = asyncio.create_task(asyncio.to_thread(operation))
+    try:
+        await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        await _drain_worker(worker)
+        raise
+
+
+async def _materialize_inline_spec(work_dir: str | Path, content: str) -> Path:
+    """Write an inline spec without letting cancellation orphan the result."""
+    worker = asyncio.create_task(asyncio.to_thread(_write_inline_spec, work_dir, content))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError as cancelled:
+        await _drain_worker(worker)
+        try:
+            fpath = worker.result()
+        except Exception:
+            pass
+        else:
+            try:
+                await _remove_owned_path(fpath)
+            except asyncio.CancelledError:
+                pass
+            except OSError:
+                logger.warning("failed to remove cancelled inline spec %s", fpath, exc_info=True)
+        raise cancelled
+
+
+async def _claim_plan_dir(work_dir: Path) -> tuple[str, Path]:
+    """Claim a plan directory without letting cancellation orphan the result."""
+    worker = asyncio.create_task(asyncio.to_thread(_make_plan_dir, work_dir))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError as cancelled:
+        await _drain_worker(worker)
+        try:
+            _new_id, task_dir = worker.result()
+        except Exception:
+            pass
+        else:
+            try:
+                await _remove_owned_path(task_dir, directory=True)
+            except asyncio.CancelledError:
+                pass
+            except OSError:
+                logger.warning(
+                    "failed to remove cancelled chat plan directory %s",
+                    task_dir,
+                    exc_info=True,
+                )
+        raise cancelled
+
+
 async def api_taskrunner_start(request: web.Request) -> web.Response:
     """POST /api/taskrunner — start a task from a spec file path or inline content.
 
@@ -149,12 +253,10 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
     # use share one value — no gap where spec_path could differ from what was
     # checked, and the containment guard is visible to static analysis.
     if not spec_path.startswith("__inline__:"):
-        resolved = Path(spec_path).resolve()
-        if ".." in Path(spec_path).parts or not resolved.is_file():
-            return web.json_response({"error": "invalid spec path"}, status=400)
-        if is_sensitive_path(str(resolved)):
-            return web.json_response({"error": "access denied"}, status=403)
-        spec_path = str(resolved)
+        validated, error, status = await asyncio.to_thread(_validate_spec_path, spec_path)
+        if validated is None:
+            return web.json_response({"error": error}, status=status)
+        spec_path = validated
 
     # Handle inline spec content
     created_spec: Path | None = None
@@ -162,11 +264,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         content = spec_path[len("__inline__:") :]
         if not content.strip():
             return web.json_response({"error": "empty spec content"}, status=400)
-        work_dir = state.task_runner._work_dir
-        fname = f"TASK_{uuid.uuid4().hex[:8]}.md"
-        fpath = Path(work_dir) / fname
-        fpath.parent.mkdir(parents=True, exist_ok=True)
-        fpath.write_text(content, encoding="utf-8")
+        fpath = await _materialize_inline_spec(state.task_runner._work_dir, content)
         created_spec = fpath
         spec_path = str(fpath)
 
@@ -197,7 +295,7 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
         # error the client is about to receive.
         if created_spec is not None:
             try:
-                created_spec.unlink(missing_ok=True)
+                await _remove_owned_path(created_spec)
             except OSError:
                 logger.warning(
                     "failed to remove inline spec %s after a rejected start",
@@ -671,14 +769,7 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
         if task_id:
             run = await state.task_runner.update_plan(task_id, steps)
         else:
-            while True:
-                new_id = f"plan_{uuid.uuid4().hex[:8]}"
-                task_dir = state.task_runner._work_dir / new_id
-                try:
-                    task_dir.mkdir(parents=True, exist_ok=False)
-                    break
-                except FileExistsError:
-                    continue
+            new_id, task_dir = await _claim_plan_dir(state.task_runner._work_dir)
             original_input = str(body.get("original_input", ""))
             run = Project(
                 spec_path="",
@@ -702,7 +793,7 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
                     await asyncio.shield(cleanup_task)
                 finally:
                     try:
-                        task_dir.rmdir()
+                        await _remove_owned_path(task_dir, directory=True)
                     except OSError:
                         logger.warning("Failed to remove rejected chat plan directory %s", task_dir)
                 raise

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -1544,6 +1544,72 @@ class TestSpecIoRunsOffTheEventLoop:
         assert list(runner._work_dir.glob("TASK_*.md")) == []
 
     @pytest.mark.asyncio
+    async def test_cancelled_start_backgrounding_does_not_orphan_spec(self, tmp_path: Path) -> None:
+        """A cancel AFTER the shielded write, during ``start_background``, cleans up too."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _blocked_start(*args: Any, **kwargs: Any) -> str:
+            started.set()
+            await release.wait()
+            return "t1"
+
+        runner = _runner(tmp_path)
+        runner.start_background = _blocked_start
+        request_task = asyncio.create_task(
+            api_taskrunner_start(
+                _request(_state(runner), json_body={"spec": "__inline__:# cancel late"})
+            )
+        )
+        await started.wait()
+        assert list(runner._work_dir.glob("TASK_*.md")) != []  # spec exists mid-flight
+        request_task.cancel()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        assert list(runner._work_dir.glob("TASK_*.md")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_start_never_unlinks_a_spec_a_registered_run_retains(
+        self, tmp_path: Path
+    ) -> None:
+        """Cancel after ``start_background`` registered the run: the spec survives.
+
+        ``start_background``'s internal rollback covers only its persistence
+        hop; a cancel landing after run registration retains the placeholder,
+        and deleting the spec it references would corrupt that run.
+        """
+        started = asyncio.Event()
+        release = asyncio.Event()
+        runner = _runner(tmp_path)
+
+        async def _registering_start(spec_path: str, **kwargs: Any) -> str:
+            runner._runs["t_retained"] = TaskRun(
+                spec_path=spec_path, spec_content="# cancel late", task_id="t_retained"
+            )
+            started.set()
+            await release.wait()
+            return "t_retained"
+
+        runner.start_background = _registering_start
+        request_task = asyncio.create_task(
+            api_taskrunner_start(
+                _request(_state(runner), json_body={"spec": "__inline__:# cancel late"})
+            )
+        )
+        await started.wait()
+        request_task.cancel()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        # The registered run still owns its spec file — cleanup must not fire.
+        assert list(runner._work_dir.glob("TASK_*.md")) != []
+
+    @pytest.mark.asyncio
     async def test_cancelled_plan_claim_does_not_orphan_directory(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -1417,3 +1418,160 @@ class TestNonObjectBodiesAcrossConvertedHandlers:
         resp = await handler(req)
         assert resp.status == 400, f"{handler.__name__} on {payload!r}: expected 400"
         assert _body(resp)["code"] == "body_not_object", handler.__name__
+
+
+# ── AUTOSDE no-blocking-call-on-event-loop ──
+
+
+class TestSpecIoRunsOffTheEventLoop:
+    """The handler's potentially blocking filesystem calls run in workers."""
+
+    @staticmethod
+    def _spy(monkeypatch, method: str, match, sink: list[int]):
+        original = getattr(Path, method)
+
+        def _wrapper(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if match(self):
+                sink.append(threading.get_ident())
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, method, _wrapper)
+
+    @pytest.mark.asyncio
+    async def test_inline_spec_write_runs_off_the_event_loop_thread(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        writes: list[int] = []
+        self._spy(monkeypatch, "write_text", lambda p: p.name.startswith("TASK_"), writes)
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_start(
+            _request(_state(runner), json_body={"spec": "__inline__:# hello"})
+        )
+        assert resp.status == 200
+        assert Path(_body(resp)["spec"]).read_text(encoding="utf-8") == "# hello"
+        assert writes and all(thread != loop_thread for thread in writes)
+
+    @pytest.mark.asyncio
+    async def test_spec_path_guard_runs_off_the_event_loop_thread(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("# s", encoding="utf-8")
+        loop_thread = threading.get_ident()
+        stats: list[int] = []
+        self._spy(monkeypatch, "is_file", lambda p: p.name == "spec.md", stats)
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_start(_request(_state(runner), json_body={"spec": str(spec)}))
+        assert resp.status == 200
+        assert stats and all(thread != loop_thread for thread in stats)
+
+    @pytest.mark.asyncio
+    async def test_rejected_start_removes_inline_spec_off_the_loop(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        unlinks: list[int] = []
+        self._spy(monkeypatch, "unlink", lambda p: p.name.startswith("TASK_"), unlinks)
+        runner = _runner(tmp_path)
+        runner.start_background = AsyncMock(side_effect=RuntimeError("cannot start"))
+        resp = await api_taskrunner_start(
+            _request(_state(runner), json_body={"spec": "__inline__:# t"})
+        )
+        assert resp.status == 400
+        assert unlinks and all(thread != loop_thread for thread in unlinks)
+
+    @pytest.mark.asyncio
+    async def test_from_chat_plan_mkdir_runs_off_the_event_loop_thread(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        mkdirs: list[int] = []
+        self._spy(monkeypatch, "mkdir", lambda p: p.name.startswith("plan_"), mkdirs)
+        runner = _runner(tmp_path)
+        runner.update_plan = AsyncMock(return_value=_planned_run("plan_x"))
+        resp = await api_taskrunner_from_chat(
+            _request(_state(runner), json_body={"steps": [{"title": "first"}]})
+        )
+        assert resp.status == 200
+        assert mkdirs and all(thread != loop_thread for thread in mkdirs)
+
+    @pytest.mark.asyncio
+    async def test_from_chat_rollback_rmdir_runs_off_the_event_loop_thread(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        loop_thread = threading.get_ident()
+        rmdirs: list[int] = []
+        self._spy(monkeypatch, "rmdir", lambda p: p.name.startswith("plan_"), rmdirs)
+        runner = _runner(tmp_path)
+        runner.update_plan = AsyncMock(side_effect=ValueError("bad plan"))
+        resp = await api_taskrunner_from_chat(
+            _request(_state(runner), json_body={"steps": [{"title": "first"}]})
+        )
+        assert resp.status == 400
+        assert rmdirs and all(thread != loop_thread for thread in rmdirs)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_inline_write_does_not_orphan_spec(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from kiro_crew.dashboard.handlers import taskrunner as handlers
+
+        started = threading.Event()
+        release = threading.Event()
+        original = handlers._write_inline_spec
+
+        def _blocked_write(work_dir: str | Path, content: str) -> Path:
+            result = original(work_dir, content)
+            started.set()
+            assert release.wait(30)
+            return result
+
+        monkeypatch.setattr(handlers, "_write_inline_spec", _blocked_write)
+        runner = _runner(tmp_path)
+        request_task = asyncio.create_task(
+            api_taskrunner_start(
+                _request(_state(runner), json_body={"spec": "__inline__:# cancel"})
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 30)
+        request_task.cancel()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        assert list(runner._work_dir.glob("TASK_*.md")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_plan_claim_does_not_orphan_directory(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from kiro_crew.dashboard.handlers import taskrunner as handlers
+
+        started = threading.Event()
+        release = threading.Event()
+        original = handlers._make_plan_dir
+
+        def _blocked_claim(work_dir: Path) -> tuple[str, Path]:
+            result = original(work_dir)
+            started.set()
+            assert release.wait(30)
+            return result
+
+        monkeypatch.setattr(handlers, "_make_plan_dir", _blocked_claim)
+        runner = _runner(tmp_path)
+        request_task = asyncio.create_task(
+            api_taskrunner_from_chat(
+                _request(_state(runner), json_body={"steps": [{"title": "first"}]})
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 30)
+        request_task.cancel()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        assert runner._runs == {}
+        assert list(runner._work_dir.glob("plan_*")) == []


### PR DESCRIPTION
## Problem / Motivation

`AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` rule (`blocking: true`,
`file-patterns: src/kiro_crew/**/*.py`) names "large synchronous file IO or
filesystem walks" as calls that must not run on the gateway loop, and closes
with "When in doubt, offload — a leaked worker thread is survivable; a frozen
loop is not." Two task-runner handlers do their filesystem work inline anyway.

`api_taskrunner_start`:

```python
if not spec_path.startswith("__inline__:"):
    resolved = Path(spec_path).resolve()                    # caller-chosen path
    if ".." in Path(spec_path).parts or not resolved.is_file():
        ...
...
fpath.parent.mkdir(parents=True, exist_ok=True)
fpath.write_text(content, encoding="utf-8")                 # caller-supplied body
...
created_spec.unlink(missing_ok=True)                        # rejected-start cleanup
```

`api_taskrunner_from_chat`:

```python
while True:
    task_dir = state.task_runner._work_dir / f"plan_{uuid.uuid4().hex[:8]}"
    try:
        task_dir.mkdir(parents=True, exist_ok=False)
        break
    except FileExistsError:
        continue
...
task_dir.rmdir()                                            # rejected-plan rollback
```

Five blocking syscalls, all on the loop, and the two riskiest take their input
straight from the request body: `write_text` commits an arbitrary,
size-unbounded inline spec, and `resolve()` / `is_file()` run against whatever
path the caller named — a UNC path to a disconnected share resolves at the
mount's timeout, not at RAM speed.

## Why it matters

The rule states the consequence directly: "a single blocking call there freezes
every task — the user's chat turn AND the liveness heartbeat — until the
watchdog kills the process and the supervisor respawns into the same condition
(a crash loop). This has caused multiple production wedges."

Starting a task from a spec is an ordinary dashboard action, so this is not an
exotic path. The inline-spec write scales with a body the caller controls, and
the path guard's cost is set by a filesystem the caller points at. The rollback
`rmdir` and `unlink` are individually small, but they sit on the failure path,
which is exactly where a wedged volume is most likely to be the reason the
operation failed in the first place.

## What changed (motivation → approach → change)

Root cause is simply that the offload was never applied here — the module knows
the rule and cites it by name in `_gate_auto_approve`, which already routes its
synchronous SEL flush through `asyncio.to_thread`. Each site moves to a worker,
grouped so that a sequence costs one hop rather than one hop per call:

- **`_validate_spec_path(raw)`** — the resolve, the `..` check, the `is_file`
  stat and the `is_sensitive_path` denylist move into one function returning
  `(validated_path, failure_code)` — the handler maps the code to its literal
  error response. The validation logic is unchanged; what changes is
  that it runs in a worker and the handler receives *only* a path that passed.
  That is the same property the inline comment asked for ("no gap where
  spec_path could differ from what was checked"), and grouping strengthens it:
  the guard and the value it produces can no longer be separated at all, and no
  `await` lands between them.
- **`_write_inline_spec(work_dir, content)`** — the name mint, the `mkdir` and
  the `write_text` in one hop.
- **`_make_plan_dir(work_dir)`** — the collision-retry loop stays with the
  `mkdir` it retries, so N collisions still cost one hop instead of N.
- The rejected-start `unlink` and the rejected-plan `rmdir` are awaited through
  `asyncio.to_thread`; both keep their existing `except OSError` best-effort
  handling, and the `from_chat` rollback still re-raises the original
  `ValueError` so the handler's 400 is unchanged.

Behaviour deltas (deliberate, driven by CI gates and review):
- The two spec-path error responses now carry machine-readable `code` fields
  (`invalid_spec_path` / `access_denied`), per the error-code contract gate and
  the existing convention (`handlers/prompts.py`); `error-code-baseline.json`
  re-snapshotted for the legitimate drop (taskrunner `missing_code` 43 -> 41).
- A request cancelled mid-flight now removes the spec file / plan directory it
  created (previously orphaned): the `/start` cleanup catches `BaseException`
  (mirroring the `from_chat` rollback), so a cancel during `start_background`
  cleans up the inline spec before the cancellation propagates.
Status codes, response ordering, and best-effort cleanup semantics are
otherwise unchanged.

## Tests

New `TestSpecIoRunsOffTheEventLoop` in
`test/test_handlers_taskrunner_coverage.py`. Each test spies on the real
`pathlib` method (filtered to the file or directory the handler owns, so an
unrelated call cannot decide the result), records `threading.get_ident()`, and
asserts no call landed on the test coroutine's thread — the property holds
however the handler reaches the filesystem, and does not depend on the shape of
the fix:

- `test_inline_spec_write_runs_off_the_event_loop_thread` (`write_text`, also
  asserts the file's contents so an offload that lost the write fails)
- `test_spec_path_guard_runs_off_the_event_loop_thread` (`is_file`, driven with
  a real spec file so the guard passes and the handler returns 200)
- `test_rejected_start_removes_the_inline_spec_off_the_loop` (`unlink`, with
  `start_background` raising)
- `test_from_chat_plan_dir_mkdir_runs_off_the_event_loop_thread` (`mkdir`)
- `test_from_chat_rollback_rmdir_runs_off_the_event_loop_thread` (`rmdir`, with
  `update_plan` raising `ValueError`; still asserts the 400)
- `test_cancelled_inline_write_does_not_orphan_spec` (cancel during the
  shielded write; the drained worker's file is removed, no `TASK_*.md` orphan)
- `test_cancelled_start_backgrounding_does_not_orphan_spec` (cancel after the
  write, during `start_background`; the `BaseException` cleanup removes the
  spec before the cancel propagates)
- `test_cancelled_plan_claim_does_not_orphan_directory` (cancel during the
  plan-directory claim; no `plan_*` orphan, run map left empty)

**Red-before, measured against pristine `origin/main` production code**
(`ad0825392`) with the new tests in place — **5 failed / 100 passed**, every
failure the ident comparison, i.e. the defect itself and not a fixture or
environment artifact:

```
assert ([34652] and False)          # inline spec write_text
assert ([43608] and False)          # spec path is_file
assert ([9724]  and False)          # rejected-start unlink
assert ([31564, 31564] and False)   # plan dir mkdir
assert ([39976] and False)          # rollback rmdir
```

**Green-after:** 105 passed in that module. Blast radius: **451 passed / 1
skipped** across `test_handlers_taskrunner_coverage.py`, `test_taskrunner.py`,
`test_taskrunner_coverage.py`, `test_taskrunner_autoapprove.py`,
`test_taskrunner_atomic_persistence.py` and `test_taskrunner_v2_scenarios.py`.

`flake8`, `isort` and `mypy` are clean on both files. Both are on
`.github/black-baseline.txt` and keep the same pre-existing hunk count before
and after; the added lines are `black`-clean.

## Manual verification

N/A — unit coverage sufficient: the property is which thread a syscall runs on,
observed directly at the `pathlib` call. Reproducing the stall by hand needs a
deliberately wedged volume, which the thread assertion pins without one.

## Related Issues

Self-reported while auditing `AUTOSDE.yaml`'s
`no-blocking-call-on-event-loop` rule against the dashboard handlers. No
separate issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

## Pattern harvest

Rule candidate: an aiohttp handler that creates a filesystem side effect it owns (temp spec file, plan directory) must (1) run the blocking create off the event loop (`asyncio.to_thread`), and (2) treat cancellation as an ownership hazard — shield the worker, drain it to completion on `CancelledError`, then remove the created artifact before re-raising, or a cancelled request orphans the artifact with no owner left holding its path. Grep candidates: `write_text|mkdir|unlink|rmdir` directly inside `async def api_*` handlers.


