### PR TITLE
ci: locate fork-lane review runs in the override rerun step (#5976)

### DIFF
--- a/.github/workflows/ai-review-human-override.yml
+++ b/.github/workflows/ai-review-human-override.yml
@@ -80,6 +80,16 @@ jobs:
             post_notice "AI-review override not recorded: \`$requested_sha\` is not the current PR head. Re-run the command with \`$head\`."
             exit 1
           fi
+          # Fork PRs are reviewed by the workflow_run-triggered Stage-2 lanes,
+          # which the re-run step must locate differently from the same-repo
+          # pull_request-event lanes. A null head.repo (deleted fork) still
+          # counts as a fork: it cannot be the base repository.
+          head_repo="$(printf '%s' "$pr_json" | jq -r '.head.repo.full_name // ""')"
+          if [ "$head_repo" = "$REPO" ]; then
+            is_fork=false
+          else
+            is_fork=true
+          fi
 
           allowed=false
           permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
@@ -103,6 +113,7 @@ jobs:
             echo "actor=$ACTOR"
             echo "source=$COMMENT_ID"
             echo "reason=$reason"
+            echo "fork=$is_fork"
           } >> "$GITHUB_OUTPUT"
 
       - name: Re-run line reviewers with the human decision
@@ -119,63 +130,146 @@ jobs:
           PR: ${{ github.event.issue.number }}
           HEAD: ${{ steps.context.outputs.head }}
           TARGET: ${{ steps.context.outputs.target }}
+          IS_FORK: ${{ steps.context.outputs.fork }}
         run: |
           set -euo pipefail
 
-          rerun_reviewer() {
-            workflow="$1"
-            label="$2"
-            run_data="$(gh api --method GET \
-              "repos/$REPO/actions/workflows/$workflow/runs" \
-              -f event=pull_request -f head_sha="$HEAD" -f per_page=20)"
-            run_id="$(printf '%s' "$run_data" | jq -r --argjson pr "$PR" --arg head "$HEAD" \
-              '[.workflow_runs[]
-              | select(.head_sha == $head and (.pull_requests | any(.number == $pr)))][0].id // empty')"
-            status="$(printf '%s' "$run_data" | jq -r --argjson pr "$PR" --arg head "$HEAD" \
-              '[.workflow_runs[]
-              | select(.head_sha == $head and (.pull_requests | any(.number == $pr)))][0].status // empty')"
-            if [ -z "$run_id" ]; then
-              echo "::error::No $label workflow run found for PR #$PR at $HEAD"
-              return 1
-            fi
+          post_notice() {
+            jq -n --arg body "$1" '{body: $body}' \
+              | gh api --method POST "repos/$REPO/issues/$PR/comments" \
+                  --input - >/dev/null
+          }
 
+          # The judgment itself recorded in the previous step, so nothing in
+          # this step may fail the run: a red X here is indistinguishable from
+          # a rejected override, and the marker has already been posted. A lane
+          # that cannot be re-run automatically is collected and reported as a
+          # warning plus a PR notice naming what to re-run by hand.
+          failed_lanes=""
+          fail_lane() {
+            echo "::warning::$2"
+            failed_lanes="${failed_lanes:+$failed_lanes, }$1"
+          }
+
+          # Cancel a still-running run first, then re-run it. A pushback
+          # normally arrives after the review comment, while the final gate may
+          # still be running; cancelling keeps a stale verdict from racing the
+          # authoritative human decision.
+          rerun_run() {
+            local run_id="$1"
+            local label="$2"
+            local status="$3"
             if [ "$status" != "completed" ]; then
-              # A pushback normally arrives after the review comment, while the
-              # final gate may still be running. Cancel that run so its stale
-              # verdict cannot race the authoritative human decision.
               gh api --method POST "repos/$REPO/actions/runs/$run_id/cancel" \
                 >/dev/null 2>&1 || true
               for _ in $(seq 1 30); do
-                status="$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.status')"
+                status="$(gh api "repos/$REPO/actions/runs/$run_id" \
+                  --jq '.status' 2>/dev/null || true)"
                 [ "$status" = "completed" ] && break
                 sleep 2
               done
             fi
             if [ "$status" != "completed" ]; then
-              echo "::error::$label workflow run $run_id did not stop in time"
-              return 1
+              fail_lane "$label" "$label workflow run $run_id did not stop in time"
+              return 0
             fi
-
-            gh api --method POST "repos/$REPO/actions/runs/$run_id/rerun" >/dev/null
+            if ! gh api --method POST "repos/$REPO/actions/runs/$run_id/rerun" \
+              >/dev/null; then
+              fail_lane "$label" "could not re-run $label workflow run $run_id"
+              return 0
+            fi
             echo "Re-running $label workflow run $run_id for $HEAD"
           }
 
+          rerun_reviewer() {
+            local workflow="$1"
+            local label="$2"
+            local check_name="$3"
+            local lane="$4"
+            local fork_workflow="$5"
+            local enc details_url run_id run_json run_path status run_data
+
+            if [ "$IS_FORK" = "true" ]; then
+              # A fork PR is reviewed by the workflow_run-triggered Stage-2
+              # lane. Its run objects are keyed to the DEFAULT branch context
+              # (head_branch/head_sha are main's) and their pull_requests
+              # arrays are empty, so no runs query by the PR head can find
+              # them. The lane stamps its own run URL into the details_url of
+              # the check-run it posts on the PR head; read the run id back
+              # from the newest check-run this PR created there.
+              enc="$(jq -rn --arg name "$check_name" '$name | @uri')"
+              details_url="$(gh api --method GET \
+                "repos/$REPO/commits/$HEAD/check-runs?check_name=$enc&per_page=100" \
+                --jq "[.check_runs[] | select(.external_id == \"$lane-pr-$PR\")]
+                      | sort_by(.started_at) | last | .details_url // empty" \
+                2>/dev/null || true)"
+              run_id="$(printf '%s' "$details_url" \
+                | sed -n 's#.*/actions/runs/\([0-9][0-9]*\).*#\1#p')"
+              if [ -z "$run_id" ]; then
+                fail_lane "$label" "no $label fork-lane run recorded for PR #$PR at $HEAD (its check-run carries no run URL); re-run the latest $fork_workflow run manually"
+                return 0
+              fi
+              # The details_url is written by the trusted Stage-2 lane, but a
+              # check-run of this name could in principle be posted by any
+              # workflow with checks:write — verify the resolved run really is
+              # the expected fork lane before re-running anything.
+              run_json="$(gh api "repos/$REPO/actions/runs/$run_id" \
+                2>/dev/null || true)"
+              run_path="$(printf '%s' "$run_json" | jq -r '.path // empty' \
+                2>/dev/null || true)"
+              if [ "$run_path" != ".github/workflows/$fork_workflow" ]; then
+                fail_lane "$label" "check-run for $label points at '$run_path', not $fork_workflow; refusing to re-run it"
+                return 0
+              fi
+              status="$(printf '%s' "$run_json" | jq -r '.status' \
+                2>/dev/null || true)"
+              rerun_run "$run_id" "$label" "$status"
+              return 0
+            fi
+
+            run_data="$(gh api --method GET \
+              "repos/$REPO/actions/workflows/$workflow/runs" \
+              -f event=pull_request -f head_sha="$HEAD" -f per_page=20 \
+              2>/dev/null || true)"
+            run_id="$(printf '%s' "$run_data" | jq -r --argjson pr "$PR" --arg head "$HEAD" \
+              '[.workflow_runs[]
+              | select(.head_sha == $head and (.pull_requests | any(.number == $pr)))][0].id // empty' \
+              2>/dev/null || true)"
+            status="$(printf '%s' "$run_data" | jq -r --argjson pr "$PR" --arg head "$HEAD" \
+              '[.workflow_runs[]
+              | select(.head_sha == $head and (.pull_requests | any(.number == $pr)))][0].status // empty' \
+              2>/dev/null || true)"
+            if [ -z "$run_id" ]; then
+              fail_lane "$label" "no $label workflow run found for PR #$PR at $HEAD"
+              return 0
+            fi
+            rerun_run "$run_id" "$label" "$status"
+          }
+
+          #                workflow             label      fork check-run name / external-id lane / fork workflow
           if [ "$TARGET" = "fable" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "claude-review.yml" "Fable 5"
+            rerun_reviewer "claude-review.yml" "Fable 5" "Opus 4.8 Review" "opus" "fork-opus-review.yml"
           fi
           if [ "$TARGET" = "gpt" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "codex-review.yml" "GPT 5.6"
+            rerun_reviewer "codex-review.yml" "GPT 5.6" "GPT 5.6 Review" "gpt" "fork-gpt-review.yml"
           fi
           # The design-family lanes clear a BLOCK the same way: the re-run's
           # "Resolve human override" step finds this recorded marker, skips the
           # model review, and the gate passes. Re-running is what lets that
           # skip take effect (a deterministic BLOCK would otherwise re-BLOCK).
+          # The FORK design-family lanes consume no override marker, so their
+          # re-run is a fresh review roll rather than a forced pass.
           if [ "$TARGET" = "design" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "design-review.yml" "Design Review"
+            rerun_reviewer "design-review.yml" "Design Review" "Design Review" "design" "fork-design-review.yml"
           fi
           if [ "$TARGET" = "ux" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "ux-review.yml" "UX Review"
+            rerun_reviewer "ux-review.yml" "UX Review" "UX Review" "ux" "fork-ux-review.yml"
           fi
           if [ "$TARGET" = "first-principles" ] || [ "$TARGET" = "all" ]; then
-            rerun_reviewer "first-principles-review.yml" "First Principles Review"
+            rerun_reviewer "first-principles-review.yml" "First Principles Review" "First Principles Review" "first-principles" "fork-first-principles-review.yml"
+          fi
+
+          if [ -n "$failed_lanes" ]; then
+            post_notice "Human judgment recorded, but the following reviewer lane(s) could not be re-run automatically: **$failed_lanes**. Re-run the lane's latest workflow run for \`$HEAD\` manually from the Actions tab." \
+              || echo "::warning::could not post the rerun-failure notice"
           fi

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -159,6 +159,12 @@ jobs:
       # pull request (two PRs may share a commit), and completing that one would
       # publish a verdict computed from a different diff. The sweep matches on
       # this id, so it can only ever finish a run this pull request created.
+      #
+      # `details_url` carries this run's URL: a workflow_run-triggered run is
+      # keyed to the DEFAULT branch context, so this stamp is the only link
+      # from the PR head back to the lane run — the human-override handler
+      # reads it to re-run the lane, and a human clicking the check lands on
+      # the run logs instead of a bare check-run page.
       - name: Open check-run (in progress)
         id: check
         env:
@@ -171,6 +177,7 @@ jobs:
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Design Review" -f head_sha="$HEAD" -f status="in_progress" \
             -f external_id="design-pr-$PR" \
+            -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -615,9 +622,19 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
+            # external_id makes this fallback check-run discoverable by the
+            # override handler's fork rerun lookup, same as the opening POST.
+            # PR can be empty in exactly this branch (HEAD has a workflow_run
+            # fallback, PR does not), and a malformed "design-pr-" id would
+            # match nothing -- stamp it only when the PR is known.
+            ext_args=()
+            if [ -n "${PR:-}" ]; then
+              ext_args=(-f external_id="design-pr-$PR")
+            fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Design Review" -f head_sha="$HEAD" \
-              -f status="completed" -f conclusion="neutral" \
+              -f status="completed" -f conclusion="neutral" "${ext_args[@]}" \
+              -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
               -f "output[title]=Design Review — could not run (advisory)" \
               -f "output[summary]=The fork design review job failed before producing a verdict; re-run it. Advisory — does not block merge." >/dev/null || true
           fi

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -186,6 +186,12 @@ jobs:
       # pull request (two PRs may share a commit), and completing that one would
       # publish a verdict computed from a different diff. The sweep matches on
       # this id, so it can only ever finish a run this pull request created.
+      #
+      # `details_url` carries this run's URL: a workflow_run-triggered run is
+      # keyed to the DEFAULT branch context, so this stamp is the only link
+      # from the PR head back to the lane run — the human-override handler
+      # reads it to re-run the lane, and a human clicking the check lands on
+      # the run logs instead of a bare check-run page.
       - name: Open check-run (in progress)
         id: check
         env:
@@ -198,6 +204,7 @@ jobs:
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="First Principles Review" -f head_sha="$HEAD" -f status="in_progress" \
             -f external_id="first-principles-pr-$PR" \
+            -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -654,9 +661,19 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
+            # external_id makes this fallback check-run discoverable by the
+            # override handler's fork rerun lookup, same as the opening POST.
+            # PR can be empty in exactly this branch (HEAD has a workflow_run
+            # fallback, PR does not), and a malformed "first-principles-pr-" id would
+            # match nothing -- stamp it only when the PR is known.
+            ext_args=()
+            if [ -n "${PR:-}" ]; then
+              ext_args=(-f external_id="first-principles-pr-$PR")
+            fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="First Principles Review" -f head_sha="$HEAD" \
-              -f status="completed" -f conclusion="neutral" \
+              -f status="completed" -f conclusion="neutral" "${ext_args[@]}" \
+              -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
               -f "output[title]=First Principles Review — could not run (advisory)" \
               -f "output[summary]=The fork first-principles review job failed before producing a verdict; re-run it. Advisory — does not block merge." >/dev/null || true
           fi

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -159,6 +159,12 @@ jobs:
       # pull request (two PRs may share a commit), and completing that one would
       # publish a verdict computed from a different diff. The sweep matches on
       # this id, so it can only ever finish a run this pull request created.
+      #
+      # `details_url` carries this run's URL: a workflow_run-triggered run is
+      # keyed to the DEFAULT branch context, so this stamp is the only link
+      # from the PR head back to the lane run — the human-override handler
+      # reads it to re-run the lane, and a human clicking the check lands on
+      # the run logs instead of a bare check-run page.
       - name: Open check-run (in progress)
         id: check
         env:
@@ -171,6 +177,7 @@ jobs:
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="GPT 5.6 Review" -f head_sha="$HEAD" -f status="in_progress" \
             -f external_id="gpt-pr-$PR" \
+            -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -754,9 +761,19 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
+            # external_id makes this fallback check-run discoverable by the
+            # override handler's fork rerun lookup, same as the opening POST.
+            # PR can be empty in exactly this branch (HEAD has a workflow_run
+            # fallback, PR does not), and a malformed "gpt-pr-" id would
+            # match nothing -- stamp it only when the PR is known.
+            ext_args=()
+            if [ -n "${PR:-}" ]; then
+              ext_args=(-f external_id="gpt-pr-$PR")
+            fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="GPT 5.6 Review" -f head_sha="$HEAD" \
-              -f status="completed" -f conclusion="failure" \
+              -f status="completed" -f conclusion="failure" "${ext_args[@]}" \
+              -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
               -f "output[title]=GPT 5.6 Review — could not run" \
               -f "output[summary]=The fork GPT review job failed before producing a verdict; re-run it." >/dev/null || true
           fi

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -163,6 +163,12 @@ jobs:
       # pull request (two PRs may share a commit), and completing that one would
       # publish a verdict computed from a different diff. The sweep matches on
       # this id, so it can only ever finish a run this pull request created.
+      #
+      # `details_url` carries this run's URL: a workflow_run-triggered run is
+      # keyed to the DEFAULT branch context, so this stamp is the only link
+      # from the PR head back to the lane run — the human-override handler
+      # reads it to re-run the lane, and a human clicking the check lands on
+      # the run logs instead of a bare check-run page.
       - name: Open check-run (in progress)
         id: check
         env:
@@ -175,6 +181,7 @@ jobs:
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="Opus 4.8 Review" -f head_sha="$HEAD" -f status="in_progress" \
             -f external_id="opus-pr-$PR" \
+            -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -489,9 +496,19 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
+            # external_id makes this fallback check-run discoverable by the
+            # override handler's fork rerun lookup, same as the opening POST.
+            # PR can be empty in exactly this branch (HEAD has a workflow_run
+            # fallback, PR does not), and a malformed "opus-pr-" id would
+            # match nothing -- stamp it only when the PR is known.
+            ext_args=()
+            if [ -n "${PR:-}" ]; then
+              ext_args=(-f external_id="opus-pr-$PR")
+            fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="Opus 4.8 Review" -f head_sha="$HEAD" \
-              -f status="completed" -f conclusion="failure" \
+              -f status="completed" -f conclusion="failure" "${ext_args[@]}" \
+              -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
               -f "output[title]=Opus 4.8 Review — could not run" \
               -f "output[summary]=The fork Opus review job failed before producing a verdict; re-run it." >/dev/null || true
           fi

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -158,6 +158,12 @@ jobs:
       # pull request (two PRs may share a commit), and completing that one would
       # publish a verdict computed from a different diff. The sweep matches on
       # this id, so it can only ever finish a run this pull request created.
+      #
+      # `details_url` carries this run's URL: a workflow_run-triggered run is
+      # keyed to the DEFAULT branch context, so this stamp is the only link
+      # from the PR head back to the lane run — the human-override handler
+      # reads it to re-run the lane, and a human clicking the check lands on
+      # the run logs instead of a bare check-run page.
       - name: Open check-run (in progress)
         id: check
         env:
@@ -170,6 +176,7 @@ jobs:
           id="$(gh api --method POST "repos/$REPO/check-runs" \
             -f name="UX Review" -f head_sha="$HEAD" -f status="in_progress" \
             -f external_id="ux-pr-$PR" \
+            -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -807,9 +814,19 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             complete "$CHECK_ID" "$conclusion" "$title" || true
           elif [ -n "${HEAD:-}" ]; then
+            # external_id makes this fallback check-run discoverable by the
+            # override handler's fork rerun lookup, same as the opening POST.
+            # PR can be empty in exactly this branch (HEAD has a workflow_run
+            # fallback, PR does not), and a malformed "ux-pr-" id would
+            # match nothing -- stamp it only when the PR is known.
+            ext_args=()
+            if [ -n "${PR:-}" ]; then
+              ext_args=(-f external_id="ux-pr-$PR")
+            fi
             gh api --method POST "repos/$REPO/check-runs" \
               -f name="UX Review" -f head_sha="$HEAD" \
-              -f status="completed" -f conclusion="neutral" \
+              -f status="completed" -f conclusion="neutral" "${ext_args[@]}" \
+              -f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID" \
               -f "output[title]=UX Review — could not run (advisory)" \
               -f "output[summary]=The fork UX review job failed before producing a verdict; advisory, does not block merge." >/dev/null || true
           fi

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -491,12 +491,13 @@ jobs:
                 # -- an errored, throttled or verdict-less run resolves NEUTRAL
                 # and exits 0 -- so `failure` here can only mean a judged-wrong
                 # verdict, never infrastructure noise. NOTE: `/ai-review
-                # override` is a SAME-REPO mechanism (the handler re-runs the
-                # same-repo lanes, whose own runs are what the same-repo reader
-                # below consults; it never touches these Stage-2 fork
-                # check-runs), so a fork false BLOCK is cleared by pushing a new
-                # commit, not by override -- identical to the fork Opus / GPT /
-                # Design lanes, which already block a fork PR the same way.
+                # override` records the judgment and re-runs the Stage-2 fork
+                # lane (located via the run URL its check-run carries), but the
+                # fork lanes consume no override marker, so the re-run is a
+                # fresh review roll -- a fork false BLOCK clears via a clean
+                # re-roll or a new commit, never a forced pass -- identical to
+                # the fork Opus / GPT / Design lanes, which already block a
+                # fork PR the same way.
                 if [ "$fail" -gt 0 ]; then
                   failed+=("$label (BLOCK)")
                 elif [ "$pass" -gt 0 ]; then

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -481,7 +481,15 @@ characters, then posts a **bot-authored** marker comment that the reviewer workf
 trust. Raw PR comments can never turn a gate green directly; only that marker can.
 The scope is **this commit only**, so a new push needs a new judgment. The workflow
 then re-runs the affected reviewer, cancelling an in-flight run first so its stale
-verdict cannot race the human decision.
+verdict cannot race the human decision. On a fork PR the affected reviewer is the
+`workflow_run`-triggered Stage-2 lane, whose run objects are keyed to the default
+branch — the handler locates the lane run through the run URL the lane stamps into
+the `details_url` of the check-run it posts on the PR head, verifies the resolved
+run belongs to the expected fork workflow, and re-runs it. The fork lanes consume
+no override marker, so that re-run is a fresh review roll rather than a forced
+pass. A rerun failure after the judgment has recorded is reported as a warning
+annotation plus a PR notice naming the lane to re-run manually — never as a failed
+run, which would make a recorded judgment look rejected.
 
 ## `pr-readiness.yml`: the aggregator
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -138,6 +138,68 @@ class TestHumanOverrideHandler:
         assert 'rerun_reviewer "ux-review.yml"' in workflow
         assert 'rerun_reviewer "first-principles-review.yml"' in workflow
 
+    def test_rerun_resolves_fork_lane_runs_from_the_stamped_check_run(self) -> None:
+        # A fork PR's reviewers are the workflow_run-triggered Stage-2 lanes.
+        # Their run objects are keyed to the DEFAULT branch context (head_sha
+        # is main's tip, pull_requests is empty), so the same-repo lookup by
+        # PR head can never find them -- the rerun step must branch on the
+        # PR's head repo and read the lane's run id back from the details_url
+        # the lane stamps into its check-run on the PR head.
+        workflow = _workflow("ai-review-human-override.yml")
+        script = _step_script(workflow, "Re-run line reviewers with the human decision")
+
+        assert 'if [ "$IS_FORK" = "true" ]; then' in script
+        assert "check-runs?check_name=$enc" in script
+        assert 'select(.external_id == \\"$lane-pr-$PR\\")' in script
+        assert "sort_by(.started_at) | last" in script
+        # The resolved run must be verified to belong to the expected fork
+        # lane before anything is re-run: any workflow with checks:write
+        # could post a check-run of the same name.
+        assert '[ "$run_path" != ".github/workflows/$fork_workflow" ]' in script
+        for fork_lane in (
+            "fork-opus-review.yml",
+            "fork-gpt-review.yml",
+            "fork-design-review.yml",
+            "fork-ux-review.yml",
+            "fork-first-principles-review.yml",
+        ):
+            assert f'"{fork_lane}"' in script
+
+    def test_rerun_failure_is_a_warning_once_the_judgment_recorded(self) -> None:
+        # The judgment records in the step BEFORE the rerun. A rerun-lookup
+        # failure after that must not red the run -- a red X there is
+        # indistinguishable from a rejected override -- but it must stay
+        # visible: a warning annotation plus a PR notice naming the lanes to
+        # re-run manually.
+        workflow = _workflow("ai-review-human-override.yml")
+        script = _step_script(workflow, "Re-run line reviewers with the human decision")
+
+        assert "::error::" not in script
+        assert "::warning::" in script
+        assert 'if [ -n "$failed_lanes" ]; then' in script
+        assert "post_notice" in script
+        assert "could not be re-run automatically" in script
+
+    def test_fork_lanes_stamp_their_run_url_into_the_check_run(self) -> None:
+        # The only link from a PR head back to the workflow_run-keyed lane run
+        # is the run URL the lane stamps into its check-run's details_url; the
+        # override handler's fork rerun path reads it back. Both the opening
+        # POST and the finalize fallback POST (used when the job dies before
+        # opening one) must carry the stamp -- and the fallback must also
+        # carry the external_id the handler filters on, or the one check-run
+        # holding the run URL is never a lookup candidate.
+        stamp = '-f details_url="$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID"'
+        for name, lane in (
+            ("fork-opus-review.yml", "opus"),
+            ("fork-gpt-review.yml", "gpt"),
+            ("fork-design-review.yml", "design"),
+            ("fork-ux-review.yml", "ux"),
+            ("fork-first-principles-review.yml", "first-principles"),
+        ):
+            workflow = _workflow(name)
+            assert workflow.count(stamp) >= 2, name
+            assert f'ext_args=(-f external_id="{lane}-pr-$PR")' in workflow, name
+
     def test_handler_requires_write_permission_fresh_sha_and_reason(self) -> None:
         workflow = _workflow("ai-review-human-override.yml")
 


### PR DESCRIPTION
## What is the problem?

On a fork PR, `/ai-review override` validates the command and records the human-judgment marker cleanly, then the post-judgment rerun step fails: `##[error]No GPT 5.6 workflow run found for PR #... at <sha>` (observed live on #3514, run 32920636461). Two costs: the operator sees a red X on the override and cannot tell the judgment recorded (it did), and nothing re-runs the fork GPT lane, so the check stays red until someone hunts down the lane run and reruns it by hand.

## Why this issue matters to the user

The override exists so a maintainer's judgment can clear a false AI BLOCK with one comment. On fork PRs -- the main path outside contributions arrive through -- the mechanism half-works: judgment records, but the visible outcome is a failed workflow run, which reads as "override rejected". Maintainers either re-post the override (no-op), or manually rerun a lane run that is deliberately hard to find.

## How our fix solves it

Chain from symptom to root cause: the rerun step looks up reviewer runs via `pull_request`-event runs filtered by PR head SHA and the runs' `pull_requests` array. A fork PR fails both halves. Its reviewers are the `workflow_run`-triggered Stage-2 lanes (`fork-gpt-review.yml` etc.), whose run objects are keyed to the default-branch context -- `head_sha` is main's tip, verified empirically against live runs -- and even the same-repo lanes' (skipped) runs on a fork head carry an empty `pull_requests` array, so the jq filter selects nothing and the job exits 1.

There is no API linkage from a PR head back to a `workflow_run`-keyed lane run, so the fix creates one:

- Each of the five fork lanes stamps its own run URL (`$GITHUB_SERVER_URL/$REPO/actions/runs/$GITHUB_RUN_ID`) into the `details_url` of the check-run it posts on the PR head -- both the opening POST and the finalize fallback POST (the fallback also gains the `external_id`, guarded on PR being known, so it stays a lookup candidate). Side benefit: clicking the check now lands on the run logs instead of a bare check-run page.
- The override rerun step branches on the PR's head repo. Fork PRs resolve the lane's newest check-run by `external_id` (`<lane>-pr-<PR>`), read the run id back from the `details_url` stamp, verify the resolved run's `.path` is the expected fork workflow before touching it, and rerun it. Same-repo PRs keep the existing lookup. All five lanes are covered because `target=all` reruns every lane and would otherwise still red on forks.
- A rerun failure after the judgment has recorded is now a `::warning::` plus a PR notice naming the lane to re-run manually, never a failed run. The notice POST itself is guarded so it cannot re-introduce the red X.

The fork lanes consume no override marker, so the rerun is a fresh review roll rather than a forced pass; the stale `pr-readiness.yml` comment and `docs/ci/ci-and-reviews.md` are updated to state exactly that. Check-runs stamped before this change carry no run URL; the handler degrades to the warning + manual-rerun notice for those, and any new push gets the stamp.

## What tests we did

- Three new workflow-shape tests in `test/test_ai_review_workflows.py`, each mutation-verified red with the workflow changes reverted and green with them: the fork branch + external_id lookup + run-path verification, the no-`::error::`/warning+notice failure contract, and the details_url + external_id stamp in all five fork lanes.
- The lookup jq, URI encoding, sed run-id extraction, and run-path verification were probed against live repository data: a legacy (unstamped) check-run correctly yields no run id (warning path), a stamped URL yields the run id, and the resolved run's path matches `fork-gpt-review.yml`.
- All changed workflows re-parse as YAML and every touched `run:` block passes `bash -n`.
- Full local gates: black/encoding/isort/flake8/docs-lint/brand/harness-parity green; `test/test_ai_review_workflows.py` 171/171; full pytest and mypy failures A/B-proven environment-owned (identical failure sets on the stashed clean tree).

## Any other suggestions on the work

The rerun of a fork lane is a fresh non-deterministic roll. If a forced-pass semantics is ever wanted on fork PRs, the lanes would need their own override-marker resolution step (same-repo lanes have one); that is a deliberate non-goal here and belongs to a separate discussion.

Closes #5976
