### PR TITLE
fix(heartbeat): read HEARTBEAT.md off the gateway event loop

### DIFF
--- a/src/kiro_crew/heartbeat.py
+++ b/src/kiro_crew/heartbeat.py
@@ -112,6 +112,26 @@ def _rewrite_heartbeat_locked(
             return len(appended)
 
 
+def _ensure_heartbeat_file(path: Path) -> None:
+    """Create the workspace dir and seed HEARTBEAT.md. Blocking; call off-loop."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(_HEADER, encoding="utf-8")
+
+
+def _read_heartbeat_file(path: Path) -> str | None:
+    """Return HEARTBEAT.md's stripped content, or ``None`` if it is absent.
+
+    Blocking; call off-loop. The existence check rides with the read so a file
+    removed between them cannot turn a missing file into a raised
+    ``FileNotFoundError``, and so the pair costs one worker hop rather than two.
+    """
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
 class HeartbeatService:
     """Periodic wake-up that runs background maintenance tasks."""
 
@@ -141,10 +161,11 @@ class HeartbeatService:
         self._file_lock = asyncio.Lock()
 
     async def start(self) -> None:
-        path = heartbeat_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        if not path.exists():
-            path.write_text(_HEADER, encoding="utf-8")
+        # Off the loop: start() is awaited on the gateway boot path, before
+        # KIROCREW_READY, and workspace_dir() may sit on a network or synced
+        # volume where mkdir + write_text block (AUTOSDE
+        # no-blocking-call-on-event-loop, no-new-work-on-gateway-boot-path).
+        await asyncio.to_thread(_ensure_heartbeat_file, heartbeat_path())
         self._task = asyncio.create_task(self._loop())
         logger.info("Heartbeat started (interval=%ds)", self._interval)
 
@@ -226,9 +247,12 @@ class HeartbeatService:
         # Hold the file lock across the whole read→process→rewrite window so a
         # concurrent cycle can't rewrite the file from a stale snapshot.
         async with self._file_lock:
-            if not path.exists():
+            # Off the loop, like the rewrite that closes this same lock window
+            # below: this runs every tick for the life of the process, and the
+            # file lives under workspace_dir().
+            content = await asyncio.to_thread(_read_heartbeat_file, path)
+            if content is None:
                 return
-            content = path.read_text(encoding="utf-8").strip()
             tasks = _extract_tasks(content)
             if not tasks or not self._on_task:
                 return

--- a/test/test_heartbeat_file_io_offload.py
+++ b/test/test_heartbeat_file_io_offload.py
@@ -1,0 +1,165 @@
+"""HEARTBEAT.md's reads belong off the event loop, like its writes already are.
+
+Two sites are pinned.
+
+1. ``_process_heartbeat_file`` opens its lock window with an ``exists()`` +
+   ``read_text()`` and closes it with ``asyncio.to_thread(_rewrite_heartbeat_locked,
+   ...)``, whose comment already says "the entire durable transaction runs off
+   the gateway event-loop thread". Same file, same critical section, opposite
+   treatment — and unlike the rewrite, the read runs on EVERY tick for the life
+   of the process.
+2. ``start()`` seeds the file on the gateway boot path, before KIROCREW_READY.
+
+``workspace_dir()`` is operator-configurable and routinely sits on a synced or
+network volume, so neither call is guaranteed to be a RAM-speed syscall. A stall
+here freezes the loop the liveness heartbeat is supposed to prove alive — the
+self-inflicted version of the watchdog hard-exit in issue #2960.
+
+Asserted on the thread the IO ACTUALLY ran on, matching
+``test_heartbeat_sel_prune_offload.py``: an inline call reports ``MainThread``
+and fails.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.heartbeat as hb_mod
+from kiro_crew.heartbeat import _HEADER, HeartbeatService
+
+
+def _spy(monkeypatch: pytest.MonkeyPatch, method: str, target: Path, sink: list[str]) -> None:
+    """Record the thread name of a real ``Path`` call against *target*."""
+    original = getattr(Path, method)
+
+    def _wrapper(self: Path, *args: object, **kwargs: object) -> object:
+        if self == target:
+            sink.append(threading.current_thread().name)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, _wrapper)
+
+
+def _service() -> HeartbeatService:
+    memory = MagicMock()
+    memory.rebuild_index.return_value = 0
+    return HeartbeatService(memory=memory, on_task=None)
+
+
+class TestStartSeedsTheFileOffLoop:
+    @pytest.mark.asyncio
+    async def test_seed_write_runs_off_the_event_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "ws" / "HEARTBEAT.md"
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        writes: list[str] = []
+        _spy(monkeypatch, "write_text", target, writes)
+        svc = _service()
+
+        await svc.start()
+        svc.stop()
+
+        assert target.read_text(encoding="utf-8") == _HEADER
+        assert writes and all(t != "MainThread" for t in writes)
+
+    @pytest.mark.asyncio
+    async def test_parent_mkdir_runs_off_the_event_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "ws" / "HEARTBEAT.md"
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        mkdirs: list[str] = []
+        _spy(monkeypatch, "mkdir", target.parent, mkdirs)
+        svc = _service()
+
+        await svc.start()
+        svc.stop()
+
+        assert mkdirs and all(t != "MainThread" for t in mkdirs)
+
+    @pytest.mark.asyncio
+    async def test_an_existing_file_is_not_overwritten(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The seed stays conditional — moving it to a worker must not turn
+        start() into a truncation of the operator's task list."""
+        target = tmp_path / "ws" / "HEARTBEAT.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# Heartbeat Tasks\n\n- keep me\n", encoding="utf-8")
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        svc = _service()
+
+        await svc.start()
+        svc.stop()
+
+        assert "- keep me" in target.read_text(encoding="utf-8")
+
+
+class TestTickReadsTheFileOffLoop:
+    @pytest.mark.asyncio
+    async def test_read_runs_off_the_event_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "HEARTBEAT.md"
+        target.write_text(f"{_HEADER}- do a thing\n", encoding="utf-8")
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        reads: list[str] = []
+        _spy(monkeypatch, "read_text", target, reads)
+        seen: list[str] = []
+
+        async def _on_task(text: str, _deliver: str) -> str:
+            seen.append(text)
+            return "done"
+
+        svc = HeartbeatService(memory=MagicMock(), on_task=_on_task)
+
+        await svc._process_heartbeat_file()
+
+        assert seen == ["do a thing"]
+        assert reads and all(t != "MainThread" for t in reads)
+
+    @pytest.mark.asyncio
+    async def test_missing_file_is_a_no_op_and_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The existence check moved INTO the worker, so a file that never
+        existed — or that vanished between the check and the read — must still
+        return quietly rather than surfacing FileNotFoundError."""
+        target = tmp_path / "gone" / "HEARTBEAT.md"
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        on_task = MagicMock()
+        svc = HeartbeatService(memory=MagicMock(), on_task=on_task)
+
+        await svc._process_heartbeat_file()
+
+        on_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_read_happens_inside_the_file_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Offloading must not move the read outside the lock the rewrite
+        relies on — otherwise two cycles could rewrite from stale snapshots."""
+        target = tmp_path / "HEARTBEAT.md"
+        target.write_text(_HEADER, encoding="utf-8")
+        monkeypatch.setattr(hb_mod, "heartbeat_path", lambda: target)
+        held: list[bool] = []
+        _spy(monkeypatch, "read_text", target, [])
+        original = Path.read_text
+        svc = HeartbeatService(memory=MagicMock(), on_task=None)
+
+        def _wrapper(self: Path, *args: object, **kwargs: object) -> object:
+            if self == target:
+                held.append(svc._file_lock.locked())
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _wrapper)
+
+        await svc._process_heartbeat_file()
+
+        assert held == [True]


### PR DESCRIPTION
## Problem / Motivation

`HeartbeatService._process_heartbeat_file` holds `_file_lock` across a
read → process → rewrite window. The rewrite half is already offloaded, and its
comment states the intent:

```python
# ... The entire durable transaction runs off the gateway event-loop thread.
appended_count = await asyncio.to_thread(_rewrite_heartbeat_locked, path, tasks, keep)
```

The read half of that same window is not:

```python
async with self._file_lock:
    if not path.exists():          # on the loop
        return
    content = path.read_text(encoding="utf-8").strip()   # on the loop
```

Same file, same critical section, opposite treatment — and the asymmetry runs
the wrong way round. The rewrite happens only on a tick that actually found
tasks; the **read happens on every tick, at `_DEFAULT_INTERVAL` = 60s, for the
life of the process**.

`start()` has the same gap, on the boot path:

```python
async def start(self) -> None:
    path = heartbeat_path()
    path.parent.mkdir(parents=True, exist_ok=True)     # on the loop
    if not path.exists():
        path.write_text(_HEADER, encoding="utf-8")     # on the loop
```

`await self.heartbeat_svc.start()` runs at `slack/gateway.py:5236`, roughly
5000 lines before the `KIROCREW_READY` print — squarely inside the window
`AUTOSDE.yaml`'s second blocking rule, `no-new-work-on-gateway-boot-path`,
defines.

## Why it matters

`heartbeat_path()` is `workspace_dir() / "HEARTBEAT.md"`. The workspace is
operator-configurable and routinely lives somewhere that is not a local SSD — a
OneDrive/Drive-synced folder, an SMB share, an external volume. None of these
guarantee a RAM-speed `read_text`.

`AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` (`blocking: true`,
`file-patterns: src/kiro_crew/**/*.py`) lists "large synchronous file IO or
filesystem walks" among the calls that must not run on the loop, and states the
consequence: "a single blocking call there freezes every task — the user's chat
turn AND the liveness heartbeat — until the watchdog kills the process and the
supervisor respawns into the same condition (a crash loop). This has caused
multiple production wedges." Issue #2960 is the same failure arriving from a
different direction ("starving the loop until the watchdog hard-exits the
gateway").

Here the rule bites with an extra turn of the screw: the blocking call belongs
to the **heartbeat itself**. A stalled read freezes the loop whose liveness the
heartbeat exists to demonstrate, so the watchdog's kill-and-respawn lands the
process straight back on the same volume, on the same read, every 60 seconds.

## What changed (motivation → approach → change)

Root cause is a per-call rather than per-operation offload decision: the write
was recognised as blocking IO and the read beside it was not, though both touch
the same file on the same volume.

- **`_read_heartbeat_file(path) -> str | None`** — a module-level blocking
  helper that returns the stripped content, or `None` when the file is absent.
  The existence check moves *into* it rather than staying on the loop as a
  separate `exists()`: the pair then costs one worker hop instead of two, and a
  file deleted between the two calls returns `None` instead of raising
  `FileNotFoundError` — a narrowing of the existing race, not a widening.
  `_process_heartbeat_file` awaits it through `asyncio.to_thread` **inside**
  `_file_lock`, so the read → process → rewrite serialization the rewrite
  depends on is untouched.
- **`_ensure_heartbeat_file(path)`** — the `mkdir` and the conditional seed
  write in one blocking helper, awaited from `start()` through
  `asyncio.to_thread`. The seed stays conditional; an existing file is never
  rewritten.

No behaviour change: same lock scope, same tick semantics, same seed contents,
same no-op on a missing file. The module's existing offload convention
(`run_in_executor(maintenance_executor(), ...)` for the FTS rebuild, history
prune and SEL prune; `asyncio.to_thread` for the rewrite) is what this follows.

## Tests

New `test/test_heartbeat_file_io_offload.py`, asserting on the thread the IO
**actually ran on** — the same technique as the neighbouring
`test_heartbeat_sel_prune_offload.py`, which pins the SEL prune's pool by
thread name. A spy wraps the real `pathlib` method, filtered to the exact target
path so an unrelated call cannot decide the result; an inline call reports
`MainThread` and fails.

Three offload assertions:

- `test_seed_write_runs_off_the_event_loop` (`write_text`, also asserts the
  seeded contents)
- `test_parent_mkdir_runs_off_the_event_loop` (`mkdir`)
- `test_read_runs_off_the_event_loop` (`read_text`, driven end to end — the task
  line is parsed and dispatched to `on_task`)

Three negative controls, which pass **both** before and after and exist to catch
the ways this refactor could go wrong rather than to prove the defect:

- `test_an_existing_file_is_not_overwritten` — moving the seed to a worker must
  not turn `start()` into a truncation of the operator's task list
- `test_missing_file_is_a_no_op_and_does_not_raise` — the existence check moved
  inside the worker, so an absent file must still return quietly
- `test_the_read_happens_inside_the_file_lock` — asserts `_file_lock.locked()`
  at the moment of the read, so the offload cannot silently move it out of the
  window the rewrite relies on

**Red-before, measured against pristine `origin/main` production code**
(`c7f5ba788`) with the new file in place — **3 failed / 3 passed**, the three
offload assertions failing on the thread name and the three controls passing, as
they should:

```
AssertionError: assert (['MainThread'] and False)                 # seed write_text
AssertionError: assert (['MainThread'] and False)                 # parent mkdir
AssertionError: assert (['MainThread', 'asyncio_0'] and False)    # tick read_text
```

(The third records two entries because the offloaded rewrite re-reads the file
on `asyncio_0`; the `MainThread` entry is the inline read this PR removes.)

**Green-after:** 6 passed. Blast radius: **200 passed / 3 skipped** across the
whole `-k heartbeat` selection. That run also reports 32 collection errors in
`test_bench_download_fd.py` and `test_discord_doctor.py` (`KeyError: 'file'`);
they are pre-existing on this machine and unrelated — verified earlier today by
stashing a change and re-running those two files on pristine main for the same
result.

`flake8`, `isort` and `mypy` are clean on both files; the new test file is
`black`-clean. `heartbeat.py` is on `.github/black-baseline.txt` and keeps the
same three pre-existing hunks before and after, none in the changed lines.

## Manual verification

N/A — unit coverage sufficient: the property is which thread a syscall runs on,
observed directly at the `pathlib` call. Demonstrating the stall by hand needs a
deliberately wedged volume, which the thread assertions pin without one.

## Related Issues

Related to #2960 (loop starvation escalating to a watchdog hard-exit) as another
instance of the same class, but independent of it — no fix here depends on that
issue. Self-reported while auditing `AUTOSDE.yaml`'s
`no-blocking-call-on-event-loop` rule; no separate issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
