### PR TITLE
fix(auto-research): move the campaign filesystem work off the gateway loop

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -600,6 +600,80 @@ def _campaign_dir(campaign_id: str) -> Path:
     return d
 
 
+def _read_text_or_missing(path: Path) -> str | None:
+    """Read *path*, or return ``None`` when it does not exist.
+
+    Blocking; call through ``asyncio.to_thread``. The existence check rides
+    with the read so the pair costs one worker hop and a file removed between
+    them reads as missing rather than raising. Any OTHER ``OSError`` still
+    propagates, so an unreadable file keeps its 500 rather than being
+    downgraded to "no findings yet".
+    """
+    try:
+        return path.read_text()
+    except FileNotFoundError:
+        return None
+
+
+def _read_json_or_missing(path: Path) -> Any:
+    """Parse a JSON file, or return ``None`` when it is missing or unusable.
+
+    Blocking; call through ``asyncio.to_thread``. Both callers already treated
+    a corrupt file as "no data", so the parse error is folded in here.
+    """
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _write_text(path: Path, text: str) -> None:
+    """Write *text* to *path*. Blocking; call off-loop.
+
+    Deliberately does NOT create missing parents: both callers wrote into an
+    existing campaign directory before the off-loop move, so a concurrent
+    campaign deletion must keep winning (recreating the directory here would
+    resurrect a deleted campaign's data).
+    """
+    path.write_text(text)
+
+
+def _write_new_cycle_files(pending: list[tuple[Path, str]]) -> bool:
+    """Write each cycle file that does not exist yet. Blocking; call off-loop.
+
+    The "already written by an earlier poll" check stays with the write it
+    guards, so idempotence costs no per-cycle stat on the event loop. Returns
+    whether anything was written.
+    """
+    wrote = False
+    for fpath, text in pending:
+        if fpath.exists():
+            continue
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_text(text)
+        wrote = True
+    return wrote
+
+
+def _copy_parent_findings(src: Path, dst: Path) -> None:
+    """Seed a forked campaign with its parent's findings. Blocking; call off-loop."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        content = src.read_text()
+    except FileNotFoundError:
+        return
+    dst.write_text(content)
+
+
+def _unlink_if_present(path: Path) -> bool:
+    """Remove *path*, reporting whether it was there. Blocking; call off-loop."""
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+
+
 def _questions_path(campaign_id: str) -> Path | None:
     """Path to the agent's pending clarification question (if any)."""
     d = _safe_campaign_dir(campaign_id)
@@ -878,6 +952,33 @@ def _campaign_transition_lock(campaign_id: str) -> asyncio.Lock:
         lock = asyncio.Lock()
         locks[campaign_id] = lock
     return lock
+
+
+async def _settle_before_cancellation(task: "asyncio.Task[Any]") -> Any:
+    """Await *task* and guarantee it SETTLES before cancellation propagates
+    out of this coroutine.
+
+    ``asyncio.to_thread`` keeps running after its awaiting task is cancelled,
+    so a caller holding the campaign transition lock would release it while
+    the filesystem mutation is still in flight — letting a lock-serialized
+    DELETE interleave and have its directory resurrected by the worker's
+    ``mkdir``. Mirrors the shield-and-settle discipline of the terminal
+    settlement in the watchdog path.
+    """
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError as cancelled:
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                # Repeated shutdown cancellation must not cancel the worker
+                # wait; the thread finishes regardless, so keep settling.
+                continue
+            except Exception:
+                # The worker failed; the cancellation below still wins.
+                break
+        raise cancelled
 
 
 def _guarded_txn(
@@ -2305,9 +2406,11 @@ async def _poll_workflow_campaign(
             # progress, mark it FAILED rather than let it sit zombie forever.
             d = _safe_campaign_dir(campaign_id)
             run_file = (d / _WORKFLOW_RUN_FILE) if d else None
-            if run_file and run_file.exists():
+            run_meta = (
+                await asyncio.to_thread(_read_json_or_missing, run_file) if run_file else None
+            )
+            if isinstance(run_meta, dict):
                 try:
-                    run_meta = json.loads(run_file.read_text())
                     started_ts = float(run_meta.get("ts", 0))
                     if started_ts and (time.time() - started_ts) > 3600:
                         await _guarded_transition(
@@ -2358,11 +2461,10 @@ async def _poll_workflow_campaign(
             # per-investigation progress, and total_cycles is a UI counter, not the
             # DW round count. The DW script's max_rounds caps exploration rounds;
             # per_round is already bounded by parallel_workers to limit fan-out).
+            pending: list[tuple[Path, str]] = []
             for i in range(len(investigate)):
                 cycle_no = cycle_offset + i + 1
                 fpath = d.joinpath("findings", "cycle_%03d.json" % cycle_no)
-                if fpath.exists():
-                    continue  # already written by an earlier poll (idempotent)
                 meta, fin = investigate[i]
                 label = str(meta.get("label", ""))
                 insight = label[len("investigate: ") :] if label.startswith("investigate: ") else label
@@ -2375,13 +2477,21 @@ async def _poll_workflow_campaign(
                     "new_findings_count": 1,
                     "evidence_strength": "moderate",
                 }
-                fpath.parent.mkdir(parents=True, exist_ok=True)
-                fpath.write_text(json.dumps(finding, indent=2))
-                wrote = True
-            if wrote:
-                count = len(_list_cycle_files(campaign_id))
+                pending.append((fpath, json.dumps(finding, indent=2)))
+            if pending:
 
-                def _persist_cycle_count() -> None:
+                def _write_and_persist_cycles() -> bool:
+                    """Write new cycle files AND persist the count in ONE worker.
+
+                    The bookkeeping rides in the same worker as the mutation so a
+                    task cancellation delivered at an await cannot land between
+                    them — the thread finishes both or neither, mirroring
+                    ``_txn_and_notify``'s commit-then-notify discipline. Blocking;
+                    call off-loop.
+                    """
+                    if not _write_new_cycle_files(pending):
+                        return False
+                    count = len(_list_cycle_files(campaign_id))
                     db = _get_db()
                     try:
                         db.execute("BEGIN")
@@ -2396,8 +2506,17 @@ async def _poll_workflow_campaign(
                         db.commit()
                     finally:
                         db.close()
+                    return True
 
-                await asyncio.to_thread(_persist_cycle_count)
+                # One worker hop for the whole batch, bookkeeping included.
+                # Settled before cancellation can release the transition lock
+                # (see _settle_before_cancellation).
+                wrote = bool(
+                    await _settle_before_cancellation(
+                        asyncio.create_task(asyncio.to_thread(_write_and_persist_cycles))
+                    )
+                )
+            if wrote:
                 _emit_sse(
                     {
                         "type": "new_finding",
@@ -2412,7 +2531,11 @@ async def _poll_workflow_campaign(
                 if not report:
                     fs = (result or {}).get("findings") or []
                     report = "\n\n".join(str(x) for x in fs) if isinstance(fs, list) else ""
-                d.joinpath("FINDINGS.md").write_text(_redact_llm(report) or "(no findings gathered)")
+                await asyncio.to_thread(
+                    _write_text,
+                    d.joinpath("FINDINGS.md"),
+                    _redact_llm(report) or "(no findings gathered)",
+                )
 
                 def _complete_and_notify() -> dict | None:
                     r = _guarded_txn(
@@ -2797,10 +2920,11 @@ async def _handle_action(request: web.Request) -> web.Response:
         fork_dir = _safe_campaign_dir(result["id"])
         if parent_dir is None or fork_dir is None:
             return web.json_response({"error": "Invalid campaign ID"}, status=400)
-        fork_dir.mkdir(parents=True, exist_ok=True)
-        parent_findings = parent_dir / "FINDINGS.md"
-        if parent_findings.exists():
-            (fork_dir / "parent_findings.md").write_text(parent_findings.read_text())
+        # One hop: the copy reads the parent's findings (unbounded LLM output)
+        # and writes them into the fork, neither of which belongs on the loop.
+        await asyncio.to_thread(
+            _copy_parent_findings, parent_dir / "FINDINGS.md", fork_dir / "parent_findings.md"
+        )
         _audit("campaign_forked", result["id"], parent=cid)
         return web.json_response(result, status=201)
 
@@ -2915,8 +3039,8 @@ async def _handle_nudge(request: web.Request) -> web.Response:
     # Guarded: a Stop/Pause that committed while this handler ran must win —
     # restoring RUNNING over it would resurrect a campaign with no worker.
     qp = _questions_path(cid)
-    if qp and qp.exists():
-        qp.unlink()
+    cleared = await asyncio.to_thread(_unlink_if_present, qp) if qp is not None else False
+    if cleared:
         await _guarded_transition(
             cid, CampaignStatus.RUNNING, allowed_current=(CampaignStatus.NEEDS_INPUT,)
         )
@@ -3020,7 +3144,7 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     if d is None:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     findings_path = d / "FINDINGS.md"
-    if not findings_path.exists():
+    if not await asyncio.to_thread(findings_path.exists):
         return web.json_response({"error": "No findings yet"}, status=404)
 
     def _read_export_row() -> sqlite3.Row | None:
@@ -3038,7 +3162,9 @@ async def _handle_to_artifact(request: web.Request) -> web.Response:
     if row is None:
         return web.json_response({"error": "Not found"}, status=404)
     question = row["question"]
-    findings_md = findings_path.read_text()
+    findings_md = await asyncio.to_thread(_read_text_or_missing, findings_path)
+    if findings_md is None:
+        return web.json_response({"error": "No findings yet", "code": "findings_missing"}, status=404)
     subs = json.loads(row["sub_questions"] or "[]")
 
     # Prefer an LLM-authored report (synthesized + nicely formatted). Cap the
@@ -3203,7 +3329,7 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
     if d is None:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     findings_path = d / "FINDINGS.md"
-    if not findings_path.exists():
+    if not await asyncio.to_thread(findings_path.exists):
         return web.json_response({"error": "No findings yet"}, status=404)
     # Access knowledge store and pipeline from app state
     state = request.app.get("state")
@@ -3213,13 +3339,16 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
     pipeline = request.app.get("knowledge_pipeline")
     if pipeline is None:
         return web.json_response({"error": "Knowledge pipeline unavailable"}, status=503)
+    raw_findings = await asyncio.to_thread(_read_text_or_missing, findings_path)
+    if raw_findings is None:
+        return web.json_response({"error": "No findings yet", "code": "findings_missing"}, status=404)
     # The Knowledge Library is an external surface (content surfaces to users and
     # agents via RAG/search), so redact credentials + exfil URLs before ingestion.
     # The agent may have encountered secrets mid-research; ingesting raw would
     # leak them. Write a sanitized copy and ingest THAT, never the raw file.
-    redacted = _redact_finding({"v": findings_path.read_text()})["v"]
+    redacted = _redact_finding({"v": raw_findings})["v"]
     sanitized_path = d / "findings_for_knowledge.md"
-    sanitized_path.write_text(redacted)
+    await asyncio.to_thread(_write_text, sanitized_path, redacted)
     uri = str(sanitized_path.resolve())
     # Dedup check
     existing = await asyncio.to_thread(store.get_source_by_uri, uri)
@@ -3408,12 +3537,9 @@ async def _handle_grill_tree(request: web.Request) -> web.Response:
     if d is None:
         return web.json_response({"error": "Invalid campaign ID"}, status=400)
     tree_path = d / "grill_tree.json"
-    if not tree_path.exists():
+    tree = await asyncio.to_thread(_read_json_or_missing, tree_path)
+    if tree is None:
         return web.json_response({"tree": []})
-    try:
-        tree = json.loads(tree_path.read_text())
-    except (json.JSONDecodeError, OSError):
-        tree = []
     # Never trust LLM output: node text/recommended fields are model-generated,
     # so redact credentials + exfiltration URLs before serving to the dashboard
     # (same treatment as cycle findings via _redact_finding).

--- a/test/test_auto_research_onloop_fs.py
+++ b/test/test_auto_research_onloop_fs.py
@@ -1,0 +1,357 @@
+"""Off-loop filesystem discipline for the auto_research backend.
+
+``test_auto_research_onloop_db.py`` pins this module's *database* discipline
+with a static ratchet: no ``async def`` in ``handlers.py`` may reach
+``_get_db`` on the event loop. This module is the same guard for its
+filesystem calls.
+
+The blocking condition is not hypothetical. ``FINDINGS.md`` is the campaign
+report an LLM research loop produces, so its size is bounded by the model's
+output rather than by anything this code controls, and ``_handle_action``'s
+fork path reads one and writes it straight back out.
+``RESEARCH_DIR`` lives under the Kiro Crew home, which is
+operator-configurable and may be a synced or network volume.
+``_poll_workflow_campaign`` is a polling adapter, so its reads and writes recur
+for the life of a campaign. AUTOSDE ``no-blocking-call-on-event-loop`` — which
+this module already cites by name — lists "large synchronous file IO" among the
+calls that must not run on the gateway loop.
+
+Two guards, mirroring the DB module:
+
+1. a static AST ratchet, so a new inline ``read_text`` / ``write_text`` /
+   ``mkdir`` / ``unlink`` in an ``async def`` fails here rather than in
+   production;
+2. behavioural proof on the thread the IO ACTUALLY ran on, for the read path a
+   user hits most (the grill tree) and for the write path that leaves a file
+   behind (the knowledge-library export).
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import json
+import threading
+from pathlib import Path
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.apps.builtins.auto_research import handlers as h
+
+BASE = "/api/apps/auto-research"
+
+#: ``pathlib.Path`` methods that hit the filesystem. Deliberately a name-based
+#: set, like ``_DB_TOUCHING_FNS`` next door: it over-matches a same-named method
+#: on some other object, which fails safe (a spurious offload), and it is the
+#: only shape a static check can see without type inference.
+_FS_METHODS = frozenset(
+    {
+        "exists",
+        "is_file",
+        "is_dir",
+        "is_symlink",
+        "stat",
+        "lstat",
+        "samefile",
+        "read_text",
+        "read_bytes",
+        "write_text",
+        "write_bytes",
+        "mkdir",
+        "rmdir",
+        "unlink",
+        "touch",
+        "chmod",
+        "iterdir",
+        "glob",
+        "rglob",
+    }
+)
+
+#: Module-level functions in ``os``/``shutil`` that do the same.
+_FS_FUNCS = frozenset(
+    {"listdir", "scandir", "walk", "makedirs", "copyfile", "copytree", "rmtree", "which"}
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path):
+    with (
+        mock.patch.object(h, "DB_PATH", tmp_path / "t.db"),
+        mock.patch.object(h, "RESEARCH_DIR", tmp_path / "r"),
+    ):
+        yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _no_autonudge(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(h, "_autonudge_instance", lambda: None)
+
+
+def _app(**keys: Any) -> web.Application:
+    app = web.Application()
+    for k, v in keys.items():
+        app[k] = v
+    return app
+
+
+def _mk(path: str, *, app: web.Application, match: dict) -> web.Request:
+    req = make_mocked_request("GET", f"{BASE}/{path}", app=app, match_info=match)
+    req["user"] = "test-user"
+    return req
+
+
+def _body(resp: web.Response) -> Any:
+    return json.loads(resp.text or "")
+
+
+def _spy(monkeypatch: pytest.MonkeyPatch, method: str, target: Path, sink: list[str]) -> None:
+    """Record the thread name of a real ``Path`` call against *target*."""
+    original = getattr(Path, method)
+
+    def _wrapper(self: Path, *args: object, **kwargs: object) -> object:
+        if self == target:
+            sink.append(threading.current_thread().name)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, _wrapper)
+
+
+# --- 1. static ratchet -------------------------------------------------------
+
+
+def _module_tree() -> ast.Module:
+    src = Path(inspect.getsourcefile(h)).read_text(encoding="utf-8")
+    return ast.parse(src)
+
+
+class TestStaticRatchet:
+    def test_no_async_def_touches_the_filesystem_directly(self):
+        """A nested sync helper is fine — it runs in the worker it is handed to.
+        What is flagged is a filesystem call in the ``async def``'s OWN body,
+        which is the shape that runs on the gateway loop.
+        """
+        violations: list[str] = []
+
+        def scan(node: ast.AsyncFunctionDef) -> None:
+            stack = list(ast.iter_child_nodes(node))
+            while stack:
+                n = stack.pop()
+                if isinstance(n, (ast.FunctionDef, ast.Lambda, ast.AsyncFunctionDef)):
+                    continue  # body runs off-loop when offloaded
+                if isinstance(n, ast.Call):
+                    fn = n.func
+                    if isinstance(fn, ast.Attribute) and fn.attr in _FS_METHODS:
+                        violations.append(f"{node.name}:{n.lineno} calls .{fn.attr}()")
+                    elif isinstance(fn, ast.Attribute) and fn.attr in _FS_FUNCS:
+                        violations.append(f"{node.name}:{n.lineno} calls {fn.attr}()")
+                stack.extend(ast.iter_child_nodes(n))
+
+        for node in ast.walk(_module_tree()):
+            if isinstance(node, ast.AsyncFunctionDef):
+                scan(node)
+
+        assert not violations, (
+            "filesystem call(s) on the event loop (offload via asyncio.to_thread "
+            "/ run_in_executor, or move them into a sync helper you hand to "
+            "one):\n" + "\n".join(violations)
+        )
+
+    def test_the_ratchet_can_actually_fail(self):
+        """Guard against a scan that passes because it sees nothing: the same
+        walk must flag a known-bad snippet."""
+        bad = ast.parse(
+            "async def h(p):\n"
+            "    if p.exists():\n"
+            "        return p.read_text()\n"
+            "    return None\n"
+        )
+        found = [
+            n.func.attr
+            for node in ast.walk(bad)
+            for n in ast.walk(node)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr in _FS_METHODS
+        ]
+        assert set(found) == {"exists", "read_text"}
+
+
+# --- 2. behavioural proof ----------------------------------------------------
+
+
+class TestGrillTreeReadsOffLoop:
+    @pytest.mark.asyncio
+    async def test_tree_read_runs_off_the_event_loop(
+        self, _isolate: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        cid = "aaaa0001"
+        d = h.RESEARCH_DIR / cid
+        d.mkdir(parents=True)
+        tree_path = d / "grill_tree.json"
+        tree_path.write_text(json.dumps([{"text": "why?"}]))
+        reads: list[str] = []
+        _spy(monkeypatch, "read_text", tree_path, reads)
+
+        resp = await h._handle_grill_tree(_mk("x/grill-tree", app=_app(), match={"id": cid}))
+
+        assert resp.status == 200
+        assert _body(resp)["tree"], "the tree must still be served, not just offloaded"
+        assert reads and all(t != "MainThread" for t in reads)
+
+    @pytest.mark.asyncio
+    async def test_absent_tree_is_still_an_empty_list(self, _isolate: Path):
+        """Control: folding the exists() check into the worker read must not
+        change what a campaign with no tree returns."""
+        cid = "aaaa0002"
+        (h.RESEARCH_DIR / cid).mkdir(parents=True)
+
+        resp = await h._handle_grill_tree(_mk("x/grill-tree", app=_app(), match={"id": cid}))
+
+        assert _body(resp) == {"tree": []}
+
+    @pytest.mark.asyncio
+    async def test_malformed_tree_is_still_an_empty_list(self, _isolate: Path):
+        """Control: a corrupt file was already treated as no data."""
+        cid = "aaaa0003"
+        d = h.RESEARCH_DIR / cid
+        d.mkdir(parents=True)
+        (d / "grill_tree.json").write_text("{not json")
+
+        resp = await h._handle_grill_tree(_mk("x/grill-tree", app=_app(), match={"id": cid}))
+
+        assert _body(resp) == {"tree": []}
+
+
+class TestKnowledgeExportIoOffLoop:
+    def _state(self, existing: dict | None = None) -> MagicMock:
+        store = MagicMock()
+        store.get_source_by_uri.return_value = existing
+        store.add_source.return_value = {"id": 1}
+        return MagicMock(knowledge_store=store)
+
+    @pytest.mark.asyncio
+    async def test_findings_read_and_sanitized_write_run_off_the_event_loop(
+        self, _isolate: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        cid = "aaaa0004"
+        d = h.RESEARCH_DIR / cid
+        d.mkdir(parents=True)
+        findings = d / "FINDINGS.md"
+        findings.write_text("# findings\n")
+        sanitized = d / "findings_for_knowledge.md"
+        reads: list[str] = []
+        writes: list[str] = []
+        _spy(monkeypatch, "read_text", findings, reads)
+        _spy(monkeypatch, "write_text", sanitized, writes)
+        app = _app(state=self._state(), knowledge_pipeline=MagicMock(ingest=AsyncMock()))
+
+        await h._handle_to_knowledge(_mk("x/to-knowledge", app=app, match={"id": cid}))
+
+        assert sanitized.exists(), "the sanitized copy must still be written"
+        assert reads and all(t != "MainThread" for t in reads)
+        assert writes and all(t != "MainThread" for t in writes)
+
+    @pytest.mark.asyncio
+    async def test_absent_findings_is_still_a_404(self, _isolate: Path):
+        """Control: the existence probe runs off-loop ahead of the guards, so a
+        campaign with no findings must still 404 rather than raising."""
+        cid = "aaaa0005"
+        (h.RESEARCH_DIR / cid).mkdir(parents=True)
+
+        resp = await h._handle_to_knowledge(_mk("x/to-knowledge", app=_app(), match={"id": cid}))
+
+        assert resp.status == 404
+
+
+class TestWriteHelperDeletionRace:
+    def test_write_text_does_not_resurrect_a_deleted_campaign_dir(self, tmp_path: Path):
+        """A concurrent campaign deletion must keep winning.
+
+        ``_handle_to_knowledge`` and ``_poll_workflow_campaign`` both write into
+        an existing campaign directory. If the off-loop write helper created
+        missing parents, a DELETE racing the write would have its directory
+        silently recreated and the deleted campaign's data resurrected (and
+        possibly ingested). The helper must surface the missing directory
+        instead, exactly as the pre-offload inline ``write_text`` did.
+        """
+        gone = tmp_path / "deleted-campaign" / "findings_for_knowledge.md"
+
+        with pytest.raises(FileNotFoundError):
+            h._write_text(gone, "stale findings")
+
+        assert not gone.parent.exists(), "the write must not recreate the deleted directory"
+
+
+class TestGuardOrderBeforeRead:
+    """The full findings read must come AFTER the prerequisite guards.
+
+    An eager read would let an unreadable findings file (here: a directory
+    squatting on the FINDINGS.md path, so ``read_text`` raises
+    ``IsADirectoryError`` while ``exists()`` is still true) surface as a 500
+    where the guards' 404/503 must win — the pre-offload order on main.
+    """
+
+    @pytest.mark.asyncio
+    async def test_to_knowledge_unavailable_service_still_503s_with_unreadable_findings(
+        self, _isolate: Path
+    ):
+        cid = "aaaa0006"
+        d = h.RESEARCH_DIR / cid
+        (d / "FINDINGS.md").mkdir(parents=True)  # exists, but unreadable as a file
+
+        resp = await h._handle_to_knowledge(_mk("x/to-knowledge", app=_app(), match={"id": cid}))
+
+        assert resp.status == 503, "the service guard must answer before the full read"
+
+    @pytest.mark.asyncio
+    async def test_to_artifact_orphaned_row_still_404s_with_unreadable_findings(
+        self, _isolate: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(h, "_HAS_ARTIFACTS", True)
+        cid = "aaaa0007"
+        d = h.RESEARCH_DIR / cid
+        (d / "FINDINGS.md").mkdir(parents=True)  # exists, but unreadable as a file
+        # No campaigns row for cid: the DB guard must answer 404 before the read.
+
+        resp = await h._handle_to_artifact(_mk("x/to-artifact", app=_app(), match={"id": cid}))
+
+        assert resp.status == 404, "the orphaned-row guard must answer before the full read"
+
+
+class TestCancellationSettlesWorker:
+    @pytest.mark.asyncio
+    async def test_cancellation_waits_for_the_worker_to_settle(self):
+        """A cancellation delivered while the off-loop write worker runs must
+        not propagate (releasing the campaign transition lock) until the
+        worker thread has finished — otherwise a lock-serialized DELETE can
+        interleave with the still-running writes and have its directory
+        resurrected by the worker's ``mkdir``.
+        """
+        release = threading.Event()
+        finished: list[bool] = []
+
+        def worker() -> bool:
+            release.wait(timeout=10)
+            finished.append(True)
+            return True
+
+        task = asyncio.create_task(
+            h._settle_before_cancellation(asyncio.create_task(asyncio.to_thread(worker)))
+        )
+        await asyncio.sleep(0.05)  # let the worker thread start
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done(), "cancellation must not settle before the worker finishes"
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert finished, "the worker ran to completion before cancellation propagated"


### PR DESCRIPTION
## Problem / Motivation

`test_auto_research_onloop_db.py` pins this module's *database* discipline with
a static ratchet — no `async def` in `handlers.py` may reach `_get_db` on the
event loop — and its docstring explains why: a single blocking call there "can
freeze the whole gateway past the loop-stall watchdog budget (25s) and hard-exit
the process".

Its **filesystem** calls have no equivalent guard, and nineteen of them run
inline across seven async handlers:

| handler | calls |
| --- | --- |
| `_poll_workflow_campaign` | `exists`, `read_text` (run metadata), `exists` + `mkdir` + `write_text` per cycle file, `write_text` (`FINDINGS.md`) |
| `_handle_action` | `mkdir`, `exists`, `write_text(read_text())` (fork seed) |
| `_handle_nudge` | `exists`, `unlink` |
| `_handle_to_artifact` | `exists`, `read_text` |
| `_handle_to_knowledge` | `exists`, `read_text`, `write_text` |
| `_handle_grill_tree` | `exists`, `read_text` |

The module is not unaware of the rule — it offloads 45 other calls and cites
`no-blocking-call-on-event-loop` by name in a comment. `_handle_to_artifact` is
the clearest illustration: it awaits `asyncio.to_thread(_read_export_row)` for a
small indexed SELECT, then reads the campaign's whole findings file on the loop
a few lines later.

## Why it matters

The sizes here are not this code's to bound. `FINDINGS.md` is the report an LLM
research loop wrote — its length is set by the model, and `_handle_action`'s
fork path reads one and writes it straight back out in a single expression, so a
large campaign is paid twice. `RESEARCH_DIR` sits under the KiroCrew home, which
is operator-configurable and may be a synced or network volume. And
`_poll_workflow_campaign` is a polling adapter: its reads and writes recur for
the life of every running campaign, so this is not a once-per-request cost.

`AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` (`blocking: true`,
`file-patterns: src/kiro_crew/**/*.py`) lists "large synchronous file IO or
filesystem walks" among the calls that must not run on the loop, and states the
consequence: every task on the gateway loop — the user's chat turn and the
liveness heartbeat — freezes until the watchdog kills the process and the
supervisor respawns into the same condition.

## What changed (motivation → approach → change)

Root cause is the absence of a guard rather than any single wrong decision: the
DB discipline was ratcheted and the filesystem discipline was left to
case-by-case judgement, so it drifted. The fix restores the same standard and
then pins it.

Each site moves to `asyncio.to_thread`, grouped so a *sequence* costs one worker
hop rather than one per call, via six helpers placed beside the
module's existing path helpers — five blocking IO helpers plus one async
cancellation guard:

- `_read_text_or_missing(path)` / `_read_json_or_missing(path)` — fold the
  existence check into the read. A file removed between the two now reads as
  missing instead of raising, which narrows an existing race rather than widening
  one. `_read_text_or_missing` catches **only** `FileNotFoundError`, so an
  unreadable file still propagates its `OSError` and keeps its 500 rather than
  being downgraded to "No findings yet". `_read_json_or_missing` also folds in
  the parse error, because both of its callers already treated a corrupt file as
  no data. In the two export handlers (`_handle_to_artifact`,
  `_handle_to_knowledge`) the existence probe stays a separate off-loop call at
  its original guard position and the full read runs **after** the DB-row /
  knowledge-service guards — an earlier revision's eager read let an unreadable
  findings file 500 where `main` answered 404/503 (caught in review, locked by
  `TestGuardOrderBeforeRead`).
- `_write_text(path, text)` — plain write. Deliberately does **not** create
  missing parents: both callers write into an existing campaign directory, so a
  concurrent campaign deletion keeps winning (an earlier revision's
  `mkdir(parents=True)` would have resurrected a deleted campaign's directory;
  caught in review and locked by `TestWriteHelperDeletionRace`).
- `_write_new_cycle_files(pending)` — keeps the "already written by an earlier
  poll" idempotence check with the write it guards, so N cycle files cost one hop
  and no per-cycle `stat` on the loop.
- `_copy_parent_findings(src, dst)` — the fork seed's read and write in one hop.
- `_unlink_if_present(path)` — `unlink`, reporting whether it was there, so
  `_handle_nudge` no longer stats and then deletes.
- `_settle_before_cancellation(task)` — async cancellation guard for the one
  offloaded write that runs under `_campaign_transition_lock`
  (`_poll_workflow_campaign`'s cycle-write worker). **This changes cancellation
  semantics, not just IO placement**: `asyncio.to_thread` keeps running after
  its awaiting task is cancelled, so an unshielded cancel would release the
  transition lock while the worker thread is mid-write, letting a
  lock-serialized DELETE interleave and have its directory resurrected by the
  worker's `mkdir`. The helper re-shields until the worker settles, then
  re-raises the original cancellation — so a shutdown cancellation now waits
  for the in-flight cycle write (bounded by that single batch write; the same
  trade the module's watchdog terminal-settlement path already makes, whose
  shield-and-settle discipline this mirrors). Locked by
  `TestCancellationSettlesWorker` with red-before proof against the unshielded
  variant.

Behaviour is unchanged at every endpoint: same status codes, same bodies, same
"absent file" and "corrupt file" outcomes. The tests below assert those
explicitly rather than leaving them implied.

## Tests

New `test/test_auto_research_onloop_fs.py`, deliberately shaped like its DB
sibling: a static ratchet plus behavioural proof.

**1. The ratchet.** An AST walk over `handlers.py` asserting no `async def`
performs a `pathlib`/`os`/`shutil` filesystem call in its **own** body. A nested
sync helper is skipped, since that body runs in the worker it is handed to — the
same allowance `_DB_TOUCHING_FNS` makes next door. This is the part that keeps
the fix from decaying: the twentieth inline `read_text` fails here rather than in
production.

`test_the_ratchet_can_actually_fail` guards the guard — the same walk must flag
a known-bad snippet, so a scan that silently matches nothing cannot pass as a
green ratchet.

**2. Behavioural proof**, on the thread the IO actually ran on (`MainThread`
fails), with the spy filtered to the exact path the handler owns:

- `test_tree_read_runs_off_the_event_loop` — the grill-tree read, and the tree is
  still served, so an offload that lost the value fails too.
- `test_findings_read_and_sanitized_write_run_off_the_event_loop` — the
  knowledge-library export's read *and* its sanitized write, with the written
  file asserted present.

**3. Controls**, which pass before and after, covering the ways this refactor
could go wrong:

- `test_absent_tree_is_still_an_empty_list` and
  `test_malformed_tree_is_still_an_empty_list` — folding `exists()` and the JSON
  parse into one worker call must not change either empty outcome.
- `test_absent_findings_is_still_a_404` — the missing-file 404 must survive the
  existence probe moving off-loop.
- `TestGuardOrderBeforeRead` (2 tests, added during drive-to-green) — the full
  findings read must come after the prerequisite guards: a directory squatting
  on the FINDINGS.md path (`exists()` true, read raises `IsADirectoryError`)
  must still get the orphaned-row 404 (`to-artifact`) and the
  service-unavailable 503 (`to-knowledge`), never a 500. Red-before against the
  eager-read revision, green-after.
- `test_write_text_does_not_resurrect_a_deleted_campaign_dir` (added during
  drive-to-green) — the off-loop write helper must **not** create missing
  parents: a `DELETE` racing the knowledge export or the poll's `FINDINGS.md`
  write must keep winning, so the helper raises `FileNotFoundError` and the
  deleted directory stays gone. Red-before against the parent-creating helper
  revision (`DID NOT RAISE FileNotFoundError`), green-after.

**Red-before, measured against pristine `origin/main` production code**
(`c7f5ba788`) with the new file in place — **3 failed / 4 passed**. The ratchet
names all nineteen sites, and the two thread assertions fail on `MainThread`;
the four controls and the ratchet self-check pass, as they should:

```
_poll_workflow_campaign:2308 calls .exists()      _handle_action:2800 calls .mkdir()
_poll_workflow_campaign:2310 calls .read_text()   _handle_action:2802 calls .exists()
_poll_workflow_campaign:2364 calls .exists()      _handle_action:2803 calls .read_text()
_poll_workflow_campaign:2378 calls .mkdir()       _handle_action:2803 calls .write_text()
_poll_workflow_campaign:2379 calls .write_text()  _handle_nudge:2918 calls .exists()
_poll_workflow_campaign:2415 calls .write_text()  _handle_nudge:2919 calls .unlink()
_handle_to_artifact:3023 calls .exists()          _handle_to_knowledge:3206 calls .exists()
_handle_to_artifact:3041 calls .read_text()       _handle_to_knowledge:3220 calls .read_text()
_handle_grill_tree:3395 calls .exists()           _handle_to_knowledge:3222 calls .write_text()
_handle_grill_tree:3398 calls .read_text()
```

plus `assert (['MainThread'] and False)` for the grill-tree read and the
knowledge-export write.

**Green-after:** 10 passed (including the three drive-added regression
tests). Blast radius on the current head: **451 passed** across the
new file, `test_auto_research.py`, `test_auto_research_handlers_coverage.py`,
`test_auto_research_onloop_db.py` and
`test_auto_research_workflow_template_cov80.py`.

Repo gates run as `AGENTS.md` specifies them:
`scripts/check_black_formatting.py` and `scripts/check_subprocess_encoding.py`
both pass on the real `origin/main...HEAD` scope, and `flake8`, `isort` and
`mypy` are clean on both files.

## Manual verification

N/A — unit coverage sufficient: the property is which thread a syscall runs on,
observed directly at the `pathlib` call, plus a static ratchet over the module.
Reproducing the stall by hand would need a deliberately wedged volume, which
neither guard requires.

## Related Issues

Self-reported while auditing `AUTOSDE.yaml`'s `no-blocking-call-on-event-loop`
rule against the app backends; the DB half of this discipline was already
ratcheted in `test_auto_research_onloop_db.py`. No separate issue was filed.

## Pattern harvest

Rule candidate: lint
Pattern: inline pathlib/os/shutil filesystem call in an `async def` handler body (blocks the gateway event loop)

This PR ships the generalization itself: the static AST ratchet in
`test/test_auto_research_onloop_fs.py` fails on any future inline filesystem
call in this module's async handlers, mirroring the DB ratchet next door.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

no linked issue: this fix was found by direct profiling of the gateway event loop, not from a tracked issue.
