### PR TITLE
fix(dashboard): stop the mobile shell page-zooming on a pinch

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -612,9 +612,15 @@ bugs:
   `ServiceWorkerRegistration.showNotification()`. Tracked in
   [issue #2267](https://github.com/kirodotdev/KiroCrew/issues/2267); the Android
   symptom is [issue #1828](https://github.com/kirodotdev/KiroCrew/issues/1828).
-- **Not edge-to-edge.** The shell sets neither `viewport-fit=cover` nor any
-  `env(safe-area-inset-*)` padding, so on a notched device the installed app
-  renders inside the safe area rather than filling the screen.
+- **Pinch zoom is off.** The installed app behaves like an application, not a
+  web page: two-finger pinch and double-tap no longer scale the shell. **To
+  magnify, use the OS Display Zoom setting** (iOS: Settings → Display &
+  Brightness → Display Zoom), which still enlarges everything; in a browser tab
+  Safari's Aa text-size control works too, but it is **not** reachable from the
+  installed app, which has no Safari toolbar. Pinch is off because magnifying a
+  fixed-height layout whose scrollers are all inner leaves no way to reach the
+  topbar and composer it pushes off-screen. The surfaces that need magnifying
+  keep it — the image viewer zooms on its own pinch, code blocks scroll sideways.
 
 Installing changes nothing about authentication: the app carries the same cookies
 the browser holds, on the same clocks as [Session duration](#session-duration).

--- a/website/capture/lightbox-swipe.tsx
+++ b/website/capture/lightbox-swipe.tsx
@@ -68,6 +68,11 @@ interface SwipeState {
   open: boolean
   transform: string
   backdrop: string
+  /** The <img>'s own transform, which carries the pinch scale and the pan. Read
+   *  separately from `transform` because the two live on different elements on
+   *  purpose: the wrapper holds the dismiss offset so it composes with, rather
+   *  than fights, the zoom. */
+  image: string
 }
 
 declare global {
@@ -78,12 +83,14 @@ declare global {
 
 window.__swipe = () => {
   const overlay = document.querySelector<HTMLElement>('[role="button"].fixed.inset-0')
-  if (!overlay) return { open: false, transform: 'none', backdrop: 'none' }
+  if (!overlay) return { open: false, transform: 'none', backdrop: 'none', image: 'none' }
   const inner = overlay.firstElementChild as HTMLElement
+  const img = overlay.querySelector('img')
   return {
     open: true,
     transform: getComputedStyle(inner).transform,
     backdrop: getComputedStyle(overlay).backgroundColor,
+    image: img ? getComputedStyle(img).transform : 'none',
   }
 }
 

--- a/website/capture/no-page-zoom.html
+++ b/website/capture/no-page-zoom.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!-- Deliberately NO viewport meta here. The entry script installs one at
+         runtime: the shipped string is read out of index.html so this capture
+         cannot pass against a meta that has drifted from the app's, and the
+         control run installs a permissive one instead. A meta authored here
+         would be a copy that silently goes stale. -->
+    <title>Page zoom capture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/capture/no-page-zoom.tsx"></script>
+  </body>
+</html>

--- a/website/capture/no-page-zoom.tsx
+++ b/website/capture/no-page-zoom.tsx
@@ -1,0 +1,114 @@
+/**
+ * Isolated capture entry for "the shell does not page-zoom on touch".
+ *
+ * WHY ISOLATED, and why a capture at all: the claim is about a BROWSER decision,
+ * not a React one. Nothing in the component tree can be asserted to prove it —
+ * the evidence is `visualViewport.scale` still reading 1 after a genuine
+ * two-finger spread, which needs real touch injection against real layout in a
+ * mobile-emulated context. happy-dom computes no layout and has no visual
+ * viewport, so the unit tests can only pin the DECLARATIONS (that the meta says
+ * `user-scalable=no`, that the root `touch-action` is `pan-x pan-y`); whether the
+ * engine then honours them is exactly what this page exists to measure.
+ *
+ * WHAT MAKES IT HONEST: the viewport meta is not authored here. It is read out of
+ * the shipped `index.html` at build time and installed at runtime, so a capture
+ * run tests the app's own string — a meta edited in index.html and forgotten here
+ * cannot pass. `?zoomable=1` installs a permissive meta instead, giving the run a
+ * CONTROL: if the control does not zoom, the harness cannot detect zoom at all
+ * and a green subject run would prove nothing.
+ *
+ * The JS half of the suppression (`utils/pageZoom.ts`) is deliberately NOT
+ * installed. It exists for WebKit's non-standard gesture events, which Chromium
+ * never fires; installing it here would add a listener that cannot run and invite
+ * the reading that Chromium's result depends on it. Its own behaviour is unit
+ * tested, and the iOS half needs a real device.
+ *
+ * window.__zoom() reports the live visual-viewport scale and the resolved root
+ * touch-action, so a run asserts measurements rather than producing a frame that
+ * merely looks unzoomed.
+ */
+import { createRoot } from 'react-dom/client'
+import indexHtml from '../index.html?raw'
+import '../src/index.css'
+
+const params = new URLSearchParams(location.search)
+const zoomable = params.get('zoomable') === '1'
+
+document.documentElement.setAttribute('data-theme', 'kiro-light')
+
+/** The shipped viewport meta, verbatim. Throwing rather than falling back is the
+ *  point: a silent default would let this capture pass with a meta the app does
+ *  not ship. */
+function shippedViewport(): string {
+  const m = indexHtml.match(/<meta name="viewport" content="([^"]*)"/)
+  if (!m) throw new Error('no viewport meta found in index.html')
+  return m[1]
+}
+
+const meta = document.createElement('meta')
+meta.name = 'viewport'
+// The control keeps `width=device-width` so layout is identical to the subject
+// run — the ONLY difference between the two is whether zoom is permitted.
+meta.content = zoomable ? 'width=device-width, initial-scale=1' : shippedViewport()
+document.head.appendChild(meta)
+
+// The control must relax the ROOT TOUCH-ACTION too, not just the meta. Both halves
+// of the suppression are on this page (index.css is imported), so a control that
+// only swapped the meta would still be pinch-proof — and would report "the harness
+// cannot detect zoom" when what it actually proved is that the CSS rule works.
+if (zoomable) document.documentElement.style.touchAction = 'auto'
+
+interface ZoomState {
+  scale: number
+  touchAction: string
+  viewport: string
+}
+
+declare global {
+  interface Window {
+    __zoom: () => ZoomState
+  }
+}
+
+window.__zoom = () => ({
+  // `visualViewport.scale` is the engine's own answer to "is this page zoomed",
+  // which is the reading no DOM assertion can substitute for.
+  scale: window.visualViewport?.scale ?? 1,
+  touchAction: getComputedStyle(document.documentElement).touchAction,
+  viewport: meta.content,
+})
+
+function Scene() {
+  return (
+    <div className="bg-bg text-text">
+      {/* High-contrast NUMBERED rows, not the usual neutral placeholder bars: the
+          frames these runs produce are compared against each other, and a
+          low-contrast skeleton renders as a blank page at both scales — proving
+          nothing to a human reading the evidence even when the assertions pass.
+          Numbers make the scale legible at a glance: the control frame shows two
+          or three rows, the subject frame shows all of them.
+
+          Tall enough to scroll, because the rule must withhold pinch and
+          double-tap WITHOUT taking scrolling with them — and a page that cannot
+          scroll would hide a `touch-action: none` regression completely. */}
+      <div className="p-4 space-y-3">
+        <div className="text-2xl font-semibold">Page zoom capture</div>
+        {Array.from({ length: 24 }, (_, i) => (
+          <div
+            key={i}
+            className="flex h-12 items-center gap-3 rounded-lg px-3 text-lg font-semibold"
+            style={{
+              background: i % 2 === 0 ? '#7c5cff' : '#1b212b',
+              color: i % 2 === 0 ? '#ffffff' : '#c9d1dc',
+            }}
+          >
+            <span className="tabular-nums">{String(i + 1).padStart(2, '0')}</span>
+            <span className="text-sm font-normal opacity-80">row {i + 1} of 24</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<Scene />)

--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -297,6 +297,66 @@ visible area (a chat container, a modal). Safe area is **padding, not size**:
 `padding-bottom: env(safe-area-inset-bottom)`, which resolves to 0 without
 `viewport-fit=cover`.
 
+**The shell is an application, not a zoomable document — page zoom is off on touch.**
+Pinching magnifies a `position: fixed` / `h-dvh` layout whose scrollers are all
+*inner*, so there is no axis left to reach what the magnification pushed outside the
+visual viewport: topbar, composer and drawer leave at once and only a second pinch
+brings them back. Three mechanisms enforce it because no single one covers every
+engine — `maximum-scale=1, user-scalable=no` in `index.html` (Blink, Gecko), a root
+`html { touch-action: pan-x pan-y }` under `@media (pointer: coarse)` in `index.css`
+(Blink's pinch and double-tap paths), and cancelling Safari's `gesturestart` in
+`utils/pageZoom.ts` (WebKit has ignored the viewport zoom keys for user gestures
+since iOS 10). Pointer-fine devices are untouched: ctrl+wheel and the trackpad pinch
+are a desktop convention this has no business changing.
+
+The corollary is the part to get right. **A surface that must magnify owns its own
+zoom — it does not ask for `pinch-zoom` back.** `touch-action` is intersected from
+the hit-test target up to the root, so a descendant cannot re-grant a behaviour the
+root withheld; declaring `touch-pinch-zoom` there buys a dead gesture, not a working
+one. The image viewer (`Lightbox` in `MarkdownRenderer.tsx`) is the worked example:
+`touch-none` plus a two-pointer distance ratio driving the same `zoom` state its
+toolbar and keyboard drive. Code blocks take the other legitimate route and scroll
+horizontally instead. And note what is *not* lost — the OS Display Zoom setting sits
+outside the viewport contract and still magnifies anything. A browser tab's own
+text-size control does too, but it is **not** a fallback in the installed app: a
+standalone PWA has no Safari toolbar to reach it from, so on a home-screen install
+Display Zoom is the only route. State it with that qualification everywhere the
+claim appears (`website/index.html`, `docs/guides/remote-and-mobile.md`) — an
+unqualified version points a low-vision user at a control that is not there.
+
+**Any touch input below 16px zooms the viewport on focus, and WebKit does not zoom
+back out.** The scale is `clampTo(16 / fontSize, minimumScale, maximumScale)` from the
+FIELD's computed size, so a `text-sm` field can leave the user zoomed in — and with
+page zoom off there is no pinch-out to undo it. **An app-wide floor for this was
+written and withdrawn, and it should stay withdrawn** unless someone brings evidence
+from a real device, because CSS cannot express a floor at all: it can only SET a
+size, so the two available shapes are wrong in opposite directions. A rule broad
+enough to reach every field SHRINKS the ones that are deliberately larger — measured,
+not hypothetical: `input:not([type=…]):not([type=…])` is (0,2,1) and beat the artifact
+rename field's `text-2xl`, snapping a 24px title to 16px on a phone. A narrower
+selector list misses fields instead, because a size can arrive as a named utility, an
+arbitrary value (`text-[13px]`), an `!important` modifier or an inline style, and no
+list contains the next one. A guard test rescues neither shape: ~120 of this app's
+fields are routed through `<Input>` / `<Textarea>` rather than a native tag, so a
+source sweep for `<input>` cannot see them and reports green.
+
+Two things make withholding the floor the safer side of that trade. The focus zoom is
+**pre-existing** — it is not introduced by suppressing pinch, which removes only the
+recovery gesture — and whether it can fire at all once `maximum-scale=1` is authored
+depends on the same engine path that decides whether WebKit honours the viewport keys,
+which is not answerable from source. Settle it on a device; if it does fire, the fix
+belongs in the field components, where a real `max(16px, authored)` is expressible.
+
+**The `meta-viewport` axe rule is left ENABLED, deliberately.** `@axe-core/react` scans
+every render, so `user-scalable=no` reports a critical WCAG 1.4.4 finding on every scan.
+A waiver for it was written and removed; do not re-add one. The argument for waiving was
+that a permanent finding nobody can action trains contributors to ignore the console —
+but the finding *is* actionable, because it is a decision, and a decision does not stop
+being owed because a scanner keeps asking for it. That recurring report is currently the
+only automated reminder that suppressing page zoom is an accessibility trade with no
+in-app text-size control substituting for it. Revisit the waiver only once that decision
+is recorded, and then record the decision rather than the silence.
+
 **Use the line-length cap in reverse to tell "ugly" from "broken".** WCAG 1.4.8 caps a
 reading measure at 80 characters, 40 for CJK. Run it backwards and a squeezed pane stops
 being a matter of taste: a 50px column at 13px holds three CJK glyphs, which is a defect

--- a/website/index.html
+++ b/website/index.html
@@ -15,7 +15,17 @@
        non-zero values on notched iPhones (Safari and the standalone PWA).
        Screen-edge surfaces then inset themselves with the tailwindcss-safe-area
        utilities; src/test/safeArea.guard.test.ts enforces that. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
+  <!-- `maximum-scale=1, user-scalable=no`: the dashboard is an application shell, not a
+       zoomable document, and a pinch magnifies a `position: fixed` / `h-dvh` shell that
+       has no scroll axis to reach what the magnification pushed off-screen.
+       These two keys are ONE of three mechanisms and cover only Blink and Gecko: WebKit
+       ignores them for user gestures, so iOS needs the `gesturestart` suppression in
+       utils/pageZoom.ts plus the root `touch-action` in index.css. Removing any one of
+       the three silently un-covers an engine.
+       Rationale, the accessibility trade and what still magnifies: the policy section
+       in website/docs/page-layout.md is the authoritative copy — extend it there, not
+       here. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-content, viewport-fit=cover" />
   <link rel="icon" href="/logo.png" type="image/png" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="theme-color" content="#0d0f12" />

--- a/website/scripts/capture-no-page-zoom.mjs
+++ b/website/scripts/capture-no-page-zoom.mjs
@@ -1,0 +1,186 @@
+/**
+ * Evidence for "the shell does not page-zoom, and the image viewer pinches itself".
+ *
+ * Two claims, two isolated entries, one script — because they are one design
+ * decision seen from both ends: page zoom is withheld app-wide, so the surface
+ * that must magnify does it on its own transform.
+ *
+ *   shell    capture/no-page-zoom.html, which installs the SHIPPED viewport meta
+ *            read out of index.html. A genuine two-finger spread must leave
+ *            `visualViewport.scale` at 1, while `?zoomable=1` — the same page with
+ *            a permissive meta — must zoom. The control is not optional: without a
+ *            run that DOES zoom, a scale of 1 could just mean the harness never
+ *            managed to pinch anything.
+ *
+ *   viewer   capture/lightbox-swipe.html, the real `Lightbox` opened through the
+ *            production `lightbox` event. A spread must scale the <img> up, and a
+ *            pinch back in must return it to fit — proving the viewer's own
+ *            gesture, not the browser's, is what magnifies.
+ *
+ * Gestures are injected as real touch frames via CDP Input.dispatchTouchEvent with
+ * TWO touch points. A mouse or a single point would prove nothing: the shell rule
+ * is about a multi-touch browser gesture, and the viewer's pinch arms only on a
+ * second contact.
+ *
+ * Usage:
+ *   npx vite --host 127.0.0.1 --port 6841 --strictPort   # in another shell
+ *   node scripts/capture-no-page-zoom.mjs http://127.0.0.1:6841 ../temp-screenshots/no-page-zoom
+ */
+import { chromium } from 'playwright'
+import { mkdirSync, readdirSync } from 'node:fs'
+
+const BASE = process.argv[2] || 'http://127.0.0.1:6841'
+const OUT = process.argv[3] || '../temp-screenshots/no-page-zoom'
+mkdirSync(OUT, { recursive: true })
+
+const VIEWPORT = { width: 390, height: 844 }
+const CENTRE = { x: 195, y: 422 }
+
+/** Dispatch a two-finger frame `gap`px apart, centred on `at` (default CENTRE). */
+async function pinchFrame(cdp, type, gap, at = CENTRE) {
+  await cdp.send('Input.dispatchTouchEvent', {
+    type,
+    touchPoints: type === 'touchEnd' ? [] : [
+      { x: at.x, y: at.y - gap / 2, id: 1 },
+      { x: at.x, y: at.y + gap / 2, id: 2 },
+    ],
+  })
+}
+
+/** Walk the finger gap from `from` to `to` over `steps` frames, ~16ms apart so the
+ *  injected gesture arrives at roughly a real touch frame rate. */
+async function pinch(page, cdp, from, to, steps = 16, onFrame, at = CENTRE) {
+  await pinchFrame(cdp, 'touchStart', from, at)
+  for (let i = 1; i <= steps; i++) {
+    await pinchFrame(cdp, 'touchMove', from + ((to - from) * i) / steps, at)
+    await page.waitForTimeout(16)
+    if (onFrame) await onFrame(i)
+  }
+}
+
+async function context(video = false) {
+  const ctx = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    isMobile: true,
+    hasTouch: true,
+    ...(video ? { recordVideo: { dir: OUT, size: VIEWPORT } } : {}),
+  })
+  const page = await ctx.newPage()
+  return { ctx, page, cdp: await ctx.newCDPSession(page) }
+}
+
+const browser = await chromium.launch()
+
+// ── the shell ─────────────────────────────────────────────────────────────────
+
+/** Spread two fingers on the shell page and report the scale the ENGINE ends at. */
+async function shellRun({ name, zoomable }) {
+  const { ctx, page, cdp } = await context()
+  await page.goto(`${BASE}/capture/no-page-zoom.html${zoomable ? '?zoomable=1' : ''}`)
+  await page.waitForFunction(() => typeof window.__zoom === 'function', { timeout: 20000 })
+  await page.waitForTimeout(300)
+
+  const before = await page.evaluate(() => window.__zoom())
+  if (before.scale !== 1) throw new Error(`${name}: page already zoomed at ${before.scale}`)
+  await page.screenshot({ path: `${OUT}/shell-${name}-01-before.png` })
+
+  await pinch(page, cdp, 80, 620, 24)
+  await pinchFrame(cdp, 'touchEnd', 620)
+  await page.waitForTimeout(400)
+
+  const after = await page.evaluate(() => window.__zoom())
+  await page.screenshot({ path: `${OUT}/shell-${name}-02-after-spread.png` })
+  console.log(`shell/${name.padEnd(8)} scale ${before.scale} → ${after.scale} · touch-action ${after.touchAction} · meta "${after.viewport}"`)
+  await ctx.close()
+  return after
+}
+
+// The CONTROL first: if a permissive meta does not zoom, the harness cannot see
+// zoom and the subject run below would be vacuously green.
+const control = await shellRun({ name: 'zoomable', zoomable: true })
+if (control.scale <= 1) throw new Error(`control: a permissive viewport did not zoom (scale ${control.scale}) — the harness cannot detect page zoom, so nothing here is evidence`)
+
+const subject = await shellRun({ name: 'shipped', zoomable: false })
+if (subject.scale !== 1) throw new Error(`shipped: the shell zoomed to ${subject.scale}`)
+if (subject.touchAction !== 'pan-x pan-y') throw new Error(`shipped: root touch-action resolved to "${subject.touchAction}", expected "pan-x pan-y"`)
+
+// Scrolling must survive: `touch-action: none` would also pass the zoom assertion
+// above while making the whole app undraggable.
+{
+  const { ctx, page, cdp } = await context()
+  await page.goto(`${BASE}/capture/no-page-zoom.html`)
+  await page.waitForFunction(() => typeof window.__zoom === 'function', { timeout: 20000 })
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x: 195, y: 700, id: 1 }] })
+  for (let y = 700; y >= 300; y -= 50) {
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x: 195, y, id: 1 }] })
+    await page.waitForTimeout(16)
+  }
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+  await page.waitForTimeout(400)
+  const scrolled = await page.evaluate(() => window.scrollY)
+  await page.screenshot({ path: `${OUT}/shell-scroll-after.png` })
+  console.log(`shell/scroll   scrollY ${scrolled}`)
+  if (scrolled <= 0) throw new Error('the page did not scroll — pan-x pan-y must keep both scroll axes')
+  await ctx.close()
+}
+
+// ── the image viewer ──────────────────────────────────────────────────────────
+
+{
+  const { ctx, page, cdp } = await context(true)
+  await page.goto(`${BASE}/capture/lightbox-swipe.html?theme=light`)
+  await page.waitForSelector('[role="button"].fixed.inset-0', { timeout: 20000 })
+  await page.waitForTimeout(500)
+
+  const atRest = await page.evaluate(() => window.__swipe())
+  if (!atRest.open) throw new Error('viewer: did not open')
+  await page.screenshot({ path: `${OUT}/viewer-01-at-rest.png` })
+
+  let mid = null
+  await pinch(page, cdp, 120, 560, 20, async i => {
+    if (i === 10) {
+      mid = await page.evaluate(() => window.__swipe())
+      await page.screenshot({ path: `${OUT}/viewer-02-mid-pinch.png` })
+    }
+  })
+  const spread = await page.evaluate(() => window.__swipe())
+  await page.screenshot({ path: `${OUT}/viewer-03-zoomed.png` })
+  if (spread.image === atRest.image) throw new Error(`viewer: the spread did not scale the image (still ${spread.image})`)
+  if (!mid || mid.image === atRest.image) throw new Error('viewer: the image did not track the fingers mid-gesture')
+
+  // Pinch back in from the spread gap: the viewer must return to fit rather than
+  // latching at whatever the spread reached.
+  await pinch(page, cdp, 560, 100, 20)
+  await pinchFrame(cdp, 'touchEnd', 100)
+  await page.waitForTimeout(400)
+  const back = await page.evaluate(() => window.__swipe())
+  await page.screenshot({ path: `${OUT}/viewer-04-back-to-fit.png` })
+  console.log(`viewer         rest ${atRest.image} · spread ${spread.image} · back ${back.image}`)
+  if (!back.open) throw new Error('viewer: pinching back in closed the viewer — a pinch must never read as a dismiss')
+  if (back.image !== atRest.image) throw new Error(`viewer: did not return to fit, image is ${back.image}`)
+
+  // Focal-point anchoring, which ONLY real layout can show: jsdom reports
+  // offsetWidth 0, so the pan clamp pins every offset to 0 there and a unit test
+  // cannot tell an anchored zoom from a centre-anchored one. Pinching well off
+  // centre must move the image (a non-zero translate), because holding the content
+  // under the fingers is exactly what a centre-anchored scale fails to do.
+  const OFF_CENTRE = { x: 110, y: 240 }
+  await pinch(page, cdp, 120, 520, 16, undefined, OFF_CENTRE)
+  await pinchFrame(cdp, 'touchEnd', 520, OFF_CENTRE)
+  await page.waitForTimeout(300)
+  const offCentre = await page.evaluate(() => window.__swipe())
+  await page.screenshot({ path: `${OUT}/viewer-05-anchored.png` })
+  const translated = /matrix\([^)]*?,\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\)$/.exec(offCentre.image)
+  const dx = translated ? Math.abs(parseFloat(translated[1])) : 0
+  const dy = translated ? Math.abs(parseFloat(translated[2])) : 0
+  console.log(`viewer         off-centre pinch ${offCentre.image} · translate ${dx.toFixed(1)},${dy.toFixed(1)}`)
+  if (dx + dy < 1) throw new Error(`viewer: an off-centre pinch produced no pan (${offCentre.image}) — the zoom is anchored at the element centre, so a detail under the fingers slides away from them`)
+
+  const videoPath = await page.video().path()
+  await ctx.close()
+  console.log(`viewer         video ${videoPath}`)
+}
+
+await browser.close()
+console.log('files:', readdirSync(OUT).join(' '))

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -3107,6 +3107,46 @@ const LIGHTBOX_ZOOM_MIN = 1
 const LIGHTBOX_ZOOM_MAX = 5
 const LIGHTBOX_ZOOM_STEP = 0.5
 
+/** Distance between two pointer positions, for the pinch scale factor. */
+function pointerDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/** Hold a candidate zoom inside the viewer's bounds. Rounded because a pinch
+ *  produces a continuous factor, and an unrounded float would make the
+ *  `zoom > LIGHTBOX_ZOOM_MIN` checks (which gate panning and swipe-to-dismiss)
+ *  flip on a residue like 1.0000000000000002 after a pinch back down to fit. */
+function clampLightboxZoom(z: number): number {
+  return Math.min(LIGHTBOX_ZOOM_MAX, Math.max(LIGHTBOX_ZOOM_MIN, +z.toFixed(3)))
+}
+
+/** The two contacts that own a pinch: the first two live ones, in insertion order,
+ *  plus a `key` identifying that exact pair.
+ *
+ *  The pair is DERIVED on every read rather than stored as two pointer ids, and
+ *  that is the invariant the gesture rests on. Storing ids leaves `pinchRef`
+ *  naming a pointer that has since lifted whenever the contact set changes in a
+ *  way a `size < 2` test cannot see — a third finger lands, then one of the
+ *  original two lifts while two contacts remain. The stored id is then absent
+ *  from the map, every later move reads `undefined` for it, and the pinch is dead
+ *  until the user lifts everything and starts over. Deriving the pair makes that
+ *  state unrepresentable: the pair is always live by construction, and a change
+ *  of `key` is the signal to re-seat the baseline. */
+function pinchPair(points: Map<number, { x: number; y: number }>):
+  { key: string; a: { x: number; y: number }; b: { x: number; y: number } } | null {
+  if (points.size < 2) return null
+  const entries = points.entries()
+  const [idA, a] = entries.next().value as [number, { x: number; y: number }]
+  const [idB, b] = entries.next().value as [number, { x: number; y: number }]
+  return { key: `${idA}:${idB}`, a, b }
+}
+
+/** Midpoint of a pinch — the point the zoom is anchored to, so the detail under
+ *  the fingers stays under the fingers instead of sliding away from them. */
+function pinchMidpoint(a: { x: number; y: number }, b: { x: number; y: number }) {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+}
+
 /** Swipe-to-dismiss (touch only, fit zoom only) tuning.
  *
  *  `SLOP` is the travel a touch must cover before the drag counts as a gesture
@@ -3215,14 +3255,23 @@ export function Lightbox() {
   // fire-and-forget pointer handlers and the post-layout re-clamp effect).
   const zoomRef = useRef(zoom)
   zoomRef.current = zoom
+  // Live pan, for the same reason. The pinch handler needs the pan the image is
+  // CURRENTLY rendered at to re-seat its baseline, and a `useCallback([])` closure
+  // would hand it the pan from first render.
+  const panRef = useRef(pan)
+  panRef.current = pan
   // Clamp a candidate pan so the image can't be flung entirely off-screen. Zoom
   // is applied as a CSS `scale()` transform, so the *visual* size is the layout
   // box (offsetWidth/Height) times the current zoom; travel is allowed up to
   // half that overflow beyond the viewport.
-  const clampPan = useCallback((x: number, y: number) => {
+  //
+  // `z` is explicit because the pinch clamps against the zoom it is about to SET,
+  // not the one on screen: reading `zoomRef` there would clamp a zoomed-in pan
+  // against the smaller previous box and snap the image back toward centre on
+  // every frame of the gesture.
+  const clampPan = useCallback((x: number, y: number, z: number = zoomRef.current) => {
     const el = imgRef.current
     if (!el) return { x, y }
-    const z = zoomRef.current
     const maxX = Math.max(0, (el.offsetWidth * z - window.innerWidth) / 2)
     const maxY = Math.max(0, (el.offsetHeight * z - window.innerHeight) / 2)
     return { x: Math.min(maxX, Math.max(-maxX, x)), y: Math.min(maxY, Math.max(-maxY, y)) }
@@ -3262,21 +3311,111 @@ export function Lightbox() {
     s.pointerId = -1
     setSwipeY(0)
   }, [])
+  // ── pinch-to-zoom (touch, two fingers) ───────────────────────────────────
+  // Browser page zoom is off on touch across the shell (viewport meta in
+  // index.html, root `touch-action` in index.css, `gesturestart` suppression in
+  // utils/pageZoom.ts), because magnifying a fixed-height app shell strands the
+  // user in a layout with no scroll axis to reach what moved off-screen. This
+  // viewer is the surface where magnifying IS the point, so it owns the gesture
+  // instead of borrowing the browser's — and it drives the SAME `zoom` state the
+  // toolbar and keyboard drive, so pan clamping, the reset on image change and
+  // the `zoomed` cursor keep working with no parallel code path.
+  //
+  // Live contacts are tracked in a map because pointer events carry ONE pointer
+  // each: the second finger's position is only ever knowable from what an
+  // earlier event stored.
+  const pointsRef = useRef(new Map<number, { x: number; y: number }>())
+  // `key` is the identity of the pair the baseline was measured from — '' means no
+  // pinch is armed. Everything else is that baseline: the finger distance, and the
+  // zoom/pan/midpoint the image sat at when the pair was seated. The scale and the
+  // pan are both derived from it, so the gesture is a pure function of the live
+  // contacts and never accumulates drift.
+  const pinchRef = useRef({
+    key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
+    startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
+  })
+  const [pinching, setPinching] = useState(false)
+  const endPinch = useCallback(() => {
+    if (pinchRef.current.key === '') return
+    pinchRef.current = {
+      key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
+      startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
+    }
+    setPinching(false)
+    // A finished pinch is not a tap. Without this the click synthesised after the
+    // last finger lifts reaches the backdrop handler and closes the viewer the
+    // user just spent the gesture zooming into.
+    suppressClickRef.current = true
+  }, [])
+  /** Measure the baseline for `pair` from what is on screen right now. Called both
+   *  when a pinch begins and whenever the live pair changes identity mid-gesture —
+   *  re-seating from the CURRENT zoom and pan is what makes a finger landing or
+   *  lifting continue the gesture smoothly instead of snapping the image back to
+   *  where the previous pair started. */
+  const seatPinch = useCallback((pair: NonNullable<ReturnType<typeof pinchPair>>) => {
+    const dist = pointerDistance(pair.a, pair.b)
+    // Two contacts at the same point give no baseline to scale against; leave the
+    // pinch unseated and let the next move (or lift) sort the gesture out.
+    if (dist <= 0) return
+    pinchRef.current = {
+      key: pair.key, startDist: dist, baseZoom: zoomRef.current,
+      startMid: pinchMidpoint(pair.a, pair.b), basePan: panRef.current,
+    }
+    setPinching(true)
+  }, [])
   const onOverlayPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    // A second finger while a drag is live is a pinch, not a dismiss: hand the
-    // gesture back rather than letting this pointer reseat the drag origin.
-    if (swipeRef.current.active && e.pointerId !== swipeRef.current.pointerId) { abortSwipe(); return }
     // Every click in this subtree is preceded by a pointerdown, so clearing here
     // is what keeps the flag from latching when the click is swallowed upstream
     // (the <img> stops propagation, so the overlay's own handler never runs).
     suppressClickRef.current = false
     if (e.pointerType === 'mouse') return
+    // Record the contact BEFORE any bail-out below. A pinch is only knowable from
+    // two tracked contacts, and every branch that follows returns early — so
+    // recording last would mean the second finger is never seen in exactly the
+    // cases (drag live, already zoomed) a pinch is most likely to start from.
+    pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    const pair = pinchPair(pointsRef.current)
+    if (pair) {
+      seatPinch(pair)
+      // Both one-finger gestures lose their claim: a dismiss-drag would read the
+      // pinch's vertical component as pull-to-close, and the <img> pan would fight
+      // the scale over the same two contacts.
+      abortSwipe()
+      const d = dragRef.current
+      if (d.active) { d.active = false; d.dragging = false; setDragging(false) }
+      return
+    }
     if (zoomRef.current > LIGHTBOX_ZOOM_MIN) return // the <img> pan owns this gesture
     // Toolbar taps must stay taps — never start a drag from a control.
     if ((e.target as HTMLElement | null)?.closest('button')) return
     swipeRef.current = { pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, active: true, engaged: false }
-  }, [abortSwipe])
+  }, [abortSwipe, seatPinch])
   const onOverlayPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (pointsRef.current.has(e.pointerId)) pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    const pair = pinchPair(pointsRef.current)
+    if (pair) {
+      const p = pinchRef.current
+      // The live pair is not the one the baseline was measured from (a finger
+      // joined or left). Re-seat and wait for the next move rather than scaling
+      // this frame against a distance from a different pair of fingers.
+      if (p.key !== pair.key) { seatPinch(pair); return }
+      const next = clampLightboxZoom(p.baseZoom * (pointerDistance(pair.a, pair.b) / p.startDist))
+      // Anchor the scale at the gesture midpoint. The image renders as
+      // `translate(pan) scale(zoom)` about its centre, so the content sitting under
+      // the midpoint when the pinch was seated is at image-local offset
+      // `(startMid - centre - basePan) / baseZoom`; holding that offset under the
+      // CURRENT midpoint is what keeps a corner detail under the fingers instead of
+      // pushing it away as the image grows around its centre. Using the live
+      // midpoint (not the seated one) also makes two fingers moving together pan.
+      const cx = window.innerWidth / 2
+      const cy = window.innerHeight / 2
+      const anchorX = (p.startMid.x - cx - p.basePan.x) / p.baseZoom
+      const anchorY = (p.startMid.y - cy - p.basePan.y) / p.baseZoom
+      const mid = pinchMidpoint(pair.a, pair.b)
+      setZoom(next)
+      setPan(clampPan(mid.x - cx - anchorX * next, mid.y - cy - anchorY * next, next))
+      return
+    }
     const s = swipeRef.current
     if (!s.active || e.pointerId !== s.pointerId) return
     const dx = e.clientX - s.startX
@@ -3292,8 +3431,13 @@ export function Lightbox() {
     // Downward travel tracks the finger 1:1; upward is rubber-banded, since
     // pulling up is not a dismiss but should not feel dead either.
     setSwipeY(dy >= 0 ? dy : dy / 4)
-  }, [])
+  }, [clampPan, seatPinch])
   const endSwipe = useCallback((e: React.PointerEvent<HTMLDivElement>, cancelled: boolean) => {
+    pointsRef.current.delete(e.pointerId)
+    // A pinch needs two contacts to exist. Ending it on the FIRST lift (rather
+    // than the last) is what stops the finger still down from being re-read as a
+    // one-finger pan whose origin is wherever the pinch happened to leave it.
+    if (pointsRef.current.size < 2) endPinch()
     const s = swipeRef.current
     if (!s.active || e.pointerId !== s.pointerId) return
     if (cancelled) { abortSwipe(); return }
@@ -3305,7 +3449,7 @@ export function Lightbox() {
     suppressClickRef.current = true
     if (e.clientY - s.startY > LIGHTBOX_DISMISS_DISTANCE) setState(null)
     else setSwipeY(0)
-  }, [abortSwipe])
+  }, [abortSwipe, endPinch])
   const onOverlayPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, false), [endSwipe])
   const onOverlayPointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, true), [endSwipe])
   const onOverlayClick = useCallback(() => {
@@ -3343,6 +3487,15 @@ export function Lightbox() {
     swipeRef.current.active = false
     swipeRef.current.engaged = false
     swipeRef.current.pointerId = -1
+    // Contacts do not survive the viewer: closing mid-pinch (or an image change
+    // driven from the keyboard while fingers are down) must not leave a stale
+    // pair behind for the next open to scale against.
+    pointsRef.current.clear()
+    pinchRef.current = {
+      key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
+      startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
+    }
+    setPinching(false)
   }, [isOpen, state?.index])
   // On any zoom change, recentre at fit and otherwise re-clamp the existing pan
   // to the new (smaller/larger) bounds — zooming out must not strand the image
@@ -3386,7 +3539,7 @@ export function Lightbox() {
   const swipeProgress = Math.min(1, Math.max(0, swipeY) / LIGHTBOX_DISMISS_TRAVEL)
   return (
     <Clickable
-      className={`fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center overflow-hidden cursor-pointer touch-pinch-zoom ${swiping ? '' : 'transition-colors duration-200'}`}
+      className={`fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center overflow-hidden cursor-pointer touch-none ${swiping ? '' : 'transition-colors duration-200'}`}
       // Inline background wins over the class only while a drag is live, so the
       // default (and every non-touch) render keeps the plain bg-black/80 paint.
       style={swipeProgress > 0 ? { backgroundColor: `rgba(0, 0, 0, ${(0.8 * (1 - swipeProgress * 0.75)).toFixed(3)})` } : undefined}
@@ -3417,7 +3570,7 @@ export function Lightbox() {
           src={img.src}
           alt={img.alt}
           draggable={false}
-          className={`select-none object-contain rounded-lg shadow-2xl ${dragging ? '' : 'transition-transform duration-150'} ${zoomed ? (dragging ? 'cursor-grabbing' : 'cursor-grab') : 'cursor-default'}`}
+          className={`select-none object-contain rounded-lg shadow-2xl ${dragging || pinching ? '' : 'transition-transform duration-150'} ${zoomed ? (dragging ? 'cursor-grabbing' : 'cursor-grab') : 'cursor-default'}`}
           style={{ maxWidth: '90vw', maxHeight: '90vh', transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`, transformOrigin: 'center' }}
           onDragStart={e => e.preventDefault()}
           onPointerDown={e => {

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -2194,6 +2194,42 @@ body.mc-focus-mode.mc-focus-rail .focus-chrome-rail{
   [data-composer-typo]::placeholder { font-size: 0.875rem; }
 }
 
+/* ── Why there is deliberately NO app-wide 16px field rule here ──
+   The composer rule above is scoped to one hook on purpose. A generalised version was
+   written and withdrawn: CSS can only SET a size, never floor one, so a rule broad
+   enough to reach every field SHRINKS the ones deliberately larger (measured: the
+   artifact rename field's `text-2xl`), while any narrower selector list misses the next
+   field written with an arbitrary value, an `!important` modifier or an inline style.
+   Do not re-add one — `noPageZoom.test.ts` fails if a blanket element rule reappears.
+   Full reasoning, and what a correct fix would need instead, live in the page-zoom
+   section of website/docs/page-layout.md and in issue #6001. */
+
+/* ── The shell is not a zoomable document ──
+   `pan-x pan-y` allows exactly the two behaviours the app needs from the browser
+   on touch -- scrolling either axis -- and withholds the two it does not:
+   pinch page zoom and double-tap zoom. Both magnify a `position: fixed` /
+   `h-dvh` shell, which has no scroll axis to reach whatever the magnification
+   pushed off the visual viewport, so the topbar, composer and drawer all leave
+   at once with no gesture but a second pinch to bring them back.
+
+   `touch-action` is declared on the ROOT because the browser intersects the
+   values from the hit-test target up to the root before deciding which native
+   gesture to run: putting it here restricts every descendant with one rule and
+   cannot be undone lower down -- which is why the image viewer, the one surface
+   that must magnify, owns its pinch as a transform of its own rather than
+   asking for `pinch-zoom` back (see Lightbox in MarkdownRenderer.tsx).
+
+   Existing `touch-action: none` handles (resize separators, drag rows) are
+   unaffected: `none` is strictly narrower, so the intersection is still `none`.
+
+   Pointer-fine devices keep the browser's full gesture set -- ctrl+wheel and
+   the trackpad pinch are a desktop convention this has no business changing.
+   The viewport meta in index.html and the `gesturestart` suppression in
+   utils/pageZoom.ts cover the engines this rule does not reach. */
+@media (pointer: coarse) {
+  html { touch-action: pan-x pan-y; }
+}
+
 /* ── Liquid-glass design system ──
  * Two composable classes for any surface that should look like Apple-style
  * liquid glass — file chips, sidebar, chat input, follow-up bar, etc.

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -26,6 +26,7 @@ import App from './App'
 import { queryClient } from './api/queryClient'
 import ErrorBoundary from './components/ErrorBoundary'
 import DashboardBootstrap from './components/DashboardBootstrap'
+import { installPageZoomSuppression } from './utils/pageZoom'
 import 'katex/dist/katex.min.css'
 import './index.css'
 import './styles/cli-mode.css'
@@ -39,6 +40,12 @@ initRum(__APP_VERSION__)
 // the very first paint is already in the right language; LanguageProvider then
 // reconciles against the server-authoritative config value.
 initI18n()
+
+// Page zoom is off on touch: the shell is an application, not a document. The
+// viewport meta and the root `touch-action` cover Blink/Gecko; this covers
+// WebKit, which ignores both for user gestures. Installed before render so the
+// very first pinch is already suppressed. See utils/pageZoom.ts.
+installPageZoomSuppression()
 
 // Auto-recover from stale lazy-chunk errors after a frontend rebuild.
 // Vite fires `vite:preloadError` on window when a dynamic import() of a
@@ -81,6 +88,13 @@ window.addEventListener('vite:preloadError', (event) => {
 
 // Accessibility: runtime DOM scanning in dev mode (logs violations to console)
 if (import.meta.env.DEV) {
+  // The `meta-viewport` rule is deliberately NOT waived, even though this shell ships
+  // `maximum-scale=1, user-scalable=no` and axe therefore reports a critical WCAG 1.4.4
+  // finding on every dev render. A waiver was written and removed; do not re-add one.
+  // The finding is not noise — it is the only recurring reminder that suppressing page
+  // zoom is an accessibility trade nobody has yet accepted in writing, and "nobody can
+  // action it" was wrong: it is a decision, and a decision stays owed.
+  // See the page-zoom section of website/docs/page-layout.md for the policy.
   import('react-dom').then(ReactDOM => import('@axe-core/react').then(axe => axe.default(React, ReactDOM, 1000)))
 }
 

--- a/website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx
+++ b/website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx
@@ -135,12 +135,145 @@ describe('Lightbox swipe-to-dismiss', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('keeps the browser pinch by declaring pinch-zoom rather than no touch action', () => {
+  it('owns every gesture on the overlay rather than leaving one to the browser', () => {
     const { container } = render(<Lightbox />)
     act(() => open([{ src: 'a.png', alt: 'a' }]))
     const { overlay } = surfaces(container)
-    expect(overlay.className).toContain('touch-pinch-zoom')
-    expect(overlay.className).not.toContain('touch-none')
+    // Page zoom is off across the touch shell, so `pinch-zoom` here would ask for
+    // a behaviour the root `touch-action` has already withheld — and get a dead
+    // gesture. The viewer scales its own transform instead (see the pinch block).
+    expect(overlay.className).toContain('touch-none')
+    expect(overlay.className).not.toContain('touch-pinch-zoom')
+  })
+
+  // ── pinch-to-zoom: the viewer owns it, because the shell has no page zoom ──
+
+  it('scales the image by the ratio the fingers spread', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    const img = () => container.querySelector('img') as HTMLImageElement
+    expect(img().getAttribute('style')).toContain('scale(1)')
+    // Two fingers 100px apart, spread to 250px → 2.5x.
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(325, 100, 2)) })
+    expect(img().getAttribute('style')).toContain('scale(2.25)')
+    // Pinching back in returns to fit and is clamped there, not below.
+    act(() => { fireEvent.pointerMove(overlay, touch(120, 100, 2)) })
+    expect(img().getAttribute('style')).toContain('scale(1)')
+    act(() => { fireEvent.pointerUp(overlay, touch(120, 100, 2)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(100, 100, 1)) })
+  })
+
+  it('is bounded by the same max the toolbar is', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(110, 100, 2)) })
+    // 10px → 900px is 90x; LIGHTBOX_ZOOM_MAX is 5.
+    act(() => { fireEvent.pointerMove(overlay, touch(1000, 100, 2)) })
+    expect((container.querySelector('img') as HTMLImageElement).getAttribute('style')).toContain('scale(5)')
+  })
+
+  it('keeps the pinch alive when a finger lands while the image is already zoomed', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    // Zoom past fit first: at this point the <img> pan owns one-finger drags, and
+    // recording the contact only after that bail-out would lose the second finger.
+    act(() => { fireEvent.keyDown(window, { key: '+' }) })
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    // 100px → 200px doubles the zoom the gesture STARTED from (1.5), not from fit.
+    act(() => { fireEvent.pointerMove(overlay, touch(300, 100, 2)) })
+    expect((container.querySelector('img') as HTMLImageElement).getAttribute('style')).toContain('scale(3)')
+  })
+
+  it('does not let the click after a pinch close the viewer', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(400, 100, 2)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(400, 100, 2)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.click(overlay) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('ignores a two-finger mouse-typed sequence, so no desktop path is armed', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    const mouse = (y: number, id: number) => ({ pointerType: 'mouse', pointerId: id, clientX: 100, clientY: y })
+    act(() => { fireEvent.pointerDown(overlay, mouse(100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, mouse(200, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, mouse(500, 2)) })
+    expect((container.querySelector('img') as HTMLImageElement).getAttribute('style')).toContain('scale(1)')
+  })
+
+  it('drops the contacts when the viewer closes mid-pinch', () => {    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(400, 100, 2)) })
+    act(() => { fireEvent.keyDown(window, { key: 'Escape' }) })
+    expect(container.firstChild).toBeNull()
+    // Reopened, a single finger is a dismiss-drag again — not the survivor of a
+    // pair whose partner is still recorded from the previous open.
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const next = surfaces(container)
+    act(() => { fireEvent.pointerDown(next.overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerMove(next.overlay, touch(160, 100, 1)) })
+    expect(next.inner.getAttribute('style')).toContain('translateY(60.0px)')
+  })
+
+  // The pinch pair is DERIVED from the live contacts rather than stored as two
+  // pointer ids. These two specs are what that invariant buys: both describe a
+  // contact set changing in a way a `size < 2` test cannot see.
+
+  it('keeps scaling when a third finger joins and an original one lifts', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    const scale = () => (container.querySelector('img') as HTMLImageElement).getAttribute('style')
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(300, 100, 2)) })
+    expect(scale()).toContain('scale(2)')
+    // A third finger lands, then finger 1 — a member of the measured pair — lifts.
+    // Two contacts remain, so nothing resets, and an id-based pinch would still be
+    // pointing at the lifted pointer: every later move would read `undefined` for
+    // it and silently stop scaling until the user lifted everything.
+    act(() => { fireEvent.pointerDown(overlay, touch(400, 100, 3)) })
+    act(() => { fireEvent.pointerUp(overlay, touch(300, 100, 1)) })
+    // The first move after the pair changes only RE-SEATS the baseline (measuring
+    // from the current zoom, so nothing jumps); the one after it must scale.
+    act(() => { fireEvent.pointerMove(overlay, touch(700, 100, 3)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(1100, 100, 3)) })
+    expect(scale()).toContain('scale(4)')
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('re-seats the baseline on a pair change instead of jumping the zoom', () => {
+    const { container } = render(<Lightbox />)
+    act(() => open([{ src: 'a.png', alt: 'a' }]))
+    const { overlay } = surfaces(container)
+    const scale = () => (container.querySelector('img') as HTMLImageElement).getAttribute('style')
+    act(() => { fireEvent.pointerDown(overlay, touch(100, 100, 1)) })
+    act(() => { fireEvent.pointerDown(overlay, touch(200, 100, 2)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(300, 100, 2)) })
+    expect(scale()).toContain('scale(2)')
+    // A third finger at the SAME separation as the live pair. Re-seating measures
+    // the new baseline from the current zoom, so the very next frame must not
+    // recompute the scale from the old pair's distance — the zoom holds at 2.
+    act(() => { fireEvent.pointerDown(overlay, touch(500, 100, 3)) })
+    act(() => { fireEvent.pointerMove(overlay, touch(500, 100, 3)) })
+    expect(scale()).toContain('scale(2)')
   })
 
   // ── the gesture must not take anything away ───────────────────────────────

--- a/website/src/test/noPageZoom.test.ts
+++ b/website/src/test/noPageZoom.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { readFile, glob } from 'node:fs/promises'
+import { join } from 'node:path'
+import { installPageZoomSuppression } from '../utils/pageZoom'
+
+// The dashboard is an application shell, not a zoomable document: pinching it
+// magnifies a `position: fixed` / `h-dvh` layout that then has no scroll axis to
+// reach whatever the magnification pushed off the visual viewport.
+//
+// No single mechanism covers every engine, which is the whole reason there are
+// three and the reason each is asserted separately here:
+//   • the viewport meta      — honoured by Blink and Gecko
+//   • the root `touch-action` — Blink's double-tap and pinch path
+//   • `gesturestart`          — WebKit, which ignores the meta for user gestures
+// Delete any one of them and a platform silently regains page zoom.
+
+const root = join(__dirname, '..', '..')
+const html = () => readFile(join(root, 'index.html'), 'utf8')
+const css = () => readFile(join(root, 'src', 'index.css'), 'utf8')
+
+describe('page zoom is off on the touch shell', () => {
+  it('declares the viewport as non-scalable', async () => {
+    const m = (await html()).match(/<meta name="viewport" content="([^"]*)"/)
+    expect(m, 'expected a viewport meta').not.toBeNull()
+    expect(m![1]).toContain('user-scalable=no')
+    // Both keys are needed: `user-scalable=no` is what Gecko reads, and a bare
+    // `maximum-scale` is what some Blink versions clamp against.
+    expect(m![1]).toContain('maximum-scale=1')
+  })
+
+  // The other keys sharing this one attribute are NOT re-asserted here: they already
+  // have owners, and a second copy only diverges. `viewport-fit=cover` is pinned by
+  // safeArea.guard.test.ts, `interactive-widget=resizes-content` and
+  // `width=device-width` by mobileKeyboardViewport.test.ts. An edit to the zoom keys
+  // that dropped one of them still fails a test — just not this one.
+
+  it('narrows the root touch-action to the two pan axes on coarse pointers', async () => {
+    const s = await css()
+    // `pan-x pan-y` is the precise value: it keeps scrolling and withholds pinch
+    // and double-tap zoom. `none` would take scrolling with it, and `manipulation`
+    // withholds only the double-tap.
+    expect(s).toMatch(/@media \(pointer: coarse\) \{\s*html \{ touch-action: pan-x pan-y; \}/)
+  })
+
+  it('does not touch gestures on pointer-fine devices', async () => {
+    const s = await css()
+    // A bare `html { touch-action: ... }` outside the coarse query would take
+    // ctrl+wheel and the trackpad pinch away from desktop too.
+    expect(s).not.toMatch(/^html \{ touch-action:/m)
+  })
+})
+
+// An app-wide 16px field rule was written for this PR and withdrawn. This spec
+// keeps it withdrawn, because the reasons are not visible from the stylesheet and
+// the rule reads like an obvious win: CSS can only SET a size, never floor one, so
+// a rule broad enough to reach every field SHRANK the artifact rename input from
+// `text-2xl` (24px) on touch, while any narrower selector list misses the next
+// field written with an arbitrary value, an `!important` modifier or an inline
+// style. No source sweep can police either shape either -- ~120 of this app's
+// fields go through the `<Input>` / `<Textarea>` components rather than a native
+// tag, so a guard grepping for `<input>` cannot see them and reports green.
+//
+// What such a rule was for -- WebKit's focus zoom, which reads the FIELD's size and
+// does not zoom back out on blur -- is a pre-existing condition rather than
+// something the zoom suppression introduces, and whether it fires at all under an
+// authored `maximum-scale=1` needs a real device to answer.
+describe('no app-wide coarse-pointer field size rule', () => {
+  it('does not set a blanket font-size on touch form fields', async () => {
+    const s = await css()
+    // The composer's own hook-scoped rule is expected and pre-dates this change;
+    // what must stay absent is a rule reaching fields by ELEMENT.
+    const blanket = s.match(/@media \(pointer: coarse\)[^}]*\b(?:input|textarea|select)\b[^{]*\{[^}]*font-size/)
+    expect(
+      blanket?.[0],
+      'a coarse-pointer rule is setting font-size on form fields by element again -- it cannot floor without shrinking a deliberately larger field; see the note in index.css',
+    ).toBeUndefined()
+  })
+})
+
+describe('the axe meta-viewport rule', () => {
+  const main = () => readFile(join(root, 'src', 'main.tsx'), 'utf8')
+
+  it('is left enabled, so the unresolved WCAG trade keeps being reported', async () => {
+    const s = await main()
+    // A waiver for this rule was written and removed. Two reviewers arrived at the
+    // same objection from opposite directions -- it removes an existing validation
+    // guard, and it silences the one recurring reminder that suppressing page zoom
+    // is an accessibility trade nobody has yet accepted in writing. The original
+    // argument for waiving ("a permanent finding nobody can action") does not hold:
+    // the finding is actionable, because it is a decision.
+    expect(s, 'the meta-viewport waiver is back -- see the note in main.tsx').not.toMatch(/'meta-viewport'/)
+    // axe must still be installed, and with no rule-spec argument suppressing anything.
+    expect(s).toMatch(/axe\.default\(React, ReactDOM, 1000\)/)
+    expect(s).toMatch(/website\/docs\/page-layout\.md/)
+    expect(s).not.toMatch(/axe\.configure\(\s*\{\s*rules:\s*\[\]/)
+  })
+})
+
+describe('installPageZoomSuppression', () => {
+  const listeners: Array<() => void> = []
+  afterEach(() => { while (listeners.length) listeners.pop()!(); vi.restoreAllMocks() })
+
+  /** Force the pointer class the module reads at install time. */
+  function pointer(coarse: boolean) {
+    vi.spyOn(window, 'matchMedia').mockImplementation(((q: string) => ({
+      matches: coarse && q.includes('coarse'), media: q, onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    })) as typeof window.matchMedia)
+  }
+
+  function install() {
+    const teardown = installPageZoomSuppression()
+    listeners.push(teardown)
+    return teardown
+  }
+
+  /** Dispatch a cancelable event on document and report whether it was cancelled. */
+  function fire(type: string, extra: Record<string, unknown> = {}) {
+    const e = new Event(type, { bubbles: true, cancelable: true })
+    Object.assign(e, extra)
+    document.dispatchEvent(e)
+    return e.defaultPrevented
+  }
+
+  it('cancels the WebKit pinch gesture on a touch device', () => {
+    pointer(true)
+    install()
+    expect(fire('gesturestart')).toBe(true)
+    expect(fire('gesturechange')).toBe(true)
+    expect(fire('gestureend')).toBe(true)
+  })
+
+  it('leaves a pointer-fine device alone', () => {
+    pointer(false)
+    install()
+    // Desktop Safari raises the same events for a trackpad pinch, where zooming
+    // the page is a convention this has no business removing.
+    expect(fire('gesturestart')).toBe(false)
+  })
+
+  it('cancels a two-finger touchmove only once WebKit has moved the scale', () => {
+    pointer(true)
+    install()
+    // The hole this plugs: a pinch that begins as a one-finger scroll and gains a
+    // second finger does not always raise `gesturestart`.
+    expect(fire('touchmove', { touches: [{}, {}], scale: 1.4 })).toBe(true)
+    // A plain two-finger scroll (scale still 1) must keep scrolling…
+    expect(fire('touchmove', { touches: [{}, {}], scale: 1 })).toBe(false)
+    // …and a one-finger drag is never in scope, whatever `scale` reads.
+    expect(fire('touchmove', { touches: [{}], scale: 2 })).toBe(false)
+    // Engines with no `scale` on the event fall through rather than throwing.
+    expect(fire('touchmove', { touches: [{}, {}] })).toBe(false)
+  })
+
+  it('removes every listener on teardown', () => {
+    pointer(true)
+    const teardown = install()
+    teardown()
+    expect(fire('gesturestart')).toBe(false)
+    expect(fire('touchmove', { touches: [{}, {}], scale: 1.4 })).toBe(false)
+  })
+
+  it('is a no-op that still returns a callable teardown when uninstalled', () => {
+    pointer(false)
+    expect(() => install()()).not.toThrow()
+  })
+})

--- a/website/src/utils/pageZoom.ts
+++ b/website/src/utils/pageZoom.ts
@@ -1,0 +1,68 @@
+/** WebKit-only page-zoom suppression for the touch shell.
+ *
+ *  Why this file exists at all: the viewport meta in `index.html` and the root
+ *  `touch-action` in `index.css` are the other two mechanisms, and neither reaches
+ *  iOS. WebKit has deliberately ignored the viewport zoom keys **for user gestures**
+ *  since iOS 10 (an accessibility decision), and it does not treat `touch-action` as
+ *  governing page zoom either. What it does expose is the non-standard Safari gesture
+ *  events, and cancelling `gesturestart` is the one path that stops a two-finger pinch
+ *  from scaling the whole shell.
+ *
+ *  Cancelling the gesture events does NOT suppress touch or pointer events, so a
+ *  surface that owns its own pinch keeps working — the image viewer scales its own
+ *  transform off two pointers (see Lightbox in `MarkdownRenderer.tsx`) and is
+ *  unaffected by anything here.
+ *
+ *  Scoped to coarse pointers. Desktop Safari raises the same events for a trackpad
+ *  pinch, where zooming a page is a convention this has no business taking away.
+ *
+ *  For the policy and the accessibility trade behind it, see the page-zoom section of
+ *  `website/docs/page-layout.md` — the authoritative copy.
+ */
+
+/** Safari's non-standard gesture event. `scale` is the pinch factor since the
+ *  gesture began (1 = unchanged); the type is declared locally because no lib.dom
+ *  definition exists for it. */
+type SafariGestureEvent = Event & { scale?: number }
+
+const GESTURE_EVENTS = ['gesturestart', 'gesturechange', 'gestureend'] as const
+
+/** True when the primary input is touch. Read once at install time rather than
+ *  per event: the listeners are cheap and a device does not change its pointer
+ *  class mid-session (a laptop gaining a touchscreen would need a reload either
+ *  way, and the desktop it protects is the common case). */
+function isCoarsePointer(): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches
+}
+
+/** Install the suppression. Returns a teardown so tests (and any future
+ *  runtime toggle) can remove the listeners; the app installs once and never
+ *  uninstalls. Safe to call in a non-touch or non-WebKit environment — it
+ *  simply installs nothing and hands back a no-op. */
+export function installPageZoomSuppression(): () => void {
+  if (typeof document === 'undefined' || !isCoarsePointer()) return () => {}
+
+  const cancel = (e: Event) => e.preventDefault()
+
+  // A pinch that STARTS as a one-finger scroll and gains a second finger does not
+  // always raise `gesturestart` in WebKit, so the zoom slips through the handler
+  // above. `touchmove` is the only signal left at that point. The guard is kept
+  // as narrow as the hole it plugs — two or more contacts AND a scale WebKit has
+  // already moved off 1 — so an ordinary two-finger scroll, and every gesture a
+  // component reads through pointer events, are left alone.
+  const cancelMultiTouchScale = (e: TouchEvent) => {
+    const scale = (e as unknown as SafariGestureEvent).scale
+    if (e.touches.length > 1 && typeof scale === 'number' && scale !== 1) e.preventDefault()
+  }
+
+  // `passive: false` is mandatory: listeners on document default to passive for
+  // touch events in every current engine, and a passive listener's
+  // preventDefault() is ignored (with a console warning) rather than honoured.
+  for (const type of GESTURE_EVENTS) document.addEventListener(type, cancel, { passive: false })
+  document.addEventListener('touchmove', cancelMultiTouchScale, { passive: false })
+
+  return () => {
+    for (const type of GESTURE_EVENTS) document.removeEventListener(type, cancel)
+    document.removeEventListener('touchmove', cancelMultiTouchScale)
+  }
+}


### PR DESCRIPTION
## Problem / Motivation

A two-finger pinch on a phone scaled the whole dashboard. The shell is
`position: fixed` / `h-dvh` with every scroller *inner*, so the magnification
pushed the topbar, composer and drawer outside the visual viewport and left no
axis to reach them — nothing but a second pinch undoes it. Reported from an
iPhone: the installed PWA reads as a web page rather than an app.

## Why it matters

The dashboard is installed to the home screen and driven one-handed over
Tailscale. An accidental pinch — trivially easy while scrolling a transcript with
a thumb — puts the app into a state where the send button and the session drawer
are off-screen and the only recovery is a gesture most users will not think of.
Double-tap zoom has the same effect on a mistimed tap. Every other native app on
the device is immune to this, which is what makes it read as broken rather than
as a browser behaviour.

## What changed (motivation → approach → change)

**Symptom → cause.** Page zoom assumes a document that can be panned in the
direction the magnification pushed content. This shell is not one: it is an app
frame pinned to the viewport, so a zoom has nowhere to scroll back to.

**Approach.** Withhold page zoom on coarse pointers. That takes three mechanisms
because no single one covers every engine, and all three are load-bearing:

| | Covers | Where |
|---|---|---|
| `maximum-scale=1, user-scalable=no` | Blink, Gecko | `website/index.html` |
| `html { touch-action: pan-x pan-y }` under `@media (pointer: coarse)` | Blink's pinch + double-tap; keeps both scroll axes | `website/src/index.css` |
| cancel Safari's `gesturestart` / `gesturechange` | WebKit, which has ignored the viewport zoom keys for *user gestures* since iOS 10 | `website/src/utils/pageZoom.ts` |

Pointer-fine devices are untouched — ctrl+wheel and the trackpad pinch are a
desktop convention this has no business changing. The browser's own text-size
control and the OS Display Zoom setting sit outside the viewport contract, so the
accessibility path that actually matters on a phone still works.

**The corollary, which carries most of the design.** `touch-action` is
intersected from the hit-test target up to the root, so a descendant cannot
re-grant a behaviour the root withheld. The image viewer's `touch-pinch-zoom`
(added in #5790) would have become a dead declaration — pinching a screenshot
would simply have stopped working, which is the one place on a phone where
magnifying is the entire point.

So the viewer now owns the gesture: `touch-none` plus two tracked contacts and a
distance ratio driving the **same** `zoom` state the toolbar and keyboard already
drive. Nothing forks — pan clamping, the reset on image change, and the
swipe-to-dismiss gating all keep working against one zoom value. Two details are
deliberate: a finished pinch suppresses the synthesised click that would otherwise
close the viewer the user just zoomed into, and the pinch ends on the **first**
finger up so the remaining contact is not re-read as a pan originating wherever
the pinch left off.

Code blocks take the other legitimate route and scroll horizontally, unchanged.

**The precondition: no touch field may force a zoom.** Suppressing pinch removes the
only gesture that undoes one, and WebKit zooms the viewport on focus by
`clampTo(16 / fontSize, minimumScale, maximumScale)` read from the field's own size
without ever scaling back out. An app-wide 16px field floor was written for this and
then **withdrawn** — see the paragraph below, and #6001, which stays open. Note the
scope: that focus zoom is pre-existing and is not introduced here; what this PR removes
is the *recovery* gesture for it.

**Why the field floor was withdrawn (rounds 2-5).** It drew a review finding in four
consecutive rounds, one from each direction, and the fourth showed the shape itself is
the problem rather than any particular selector: **CSS can only SET a size, never floor
one**, so there are exactly two options and both are wrong. Reach every field, and it
shrinks the ones deliberately larger — measured, not hypothetical: `input:not([type=…])
:not([type=…])` is (0,2,1) and beat the artifact rename field's `text-2xl`, snapping a
24px title to 16px on a phone. Enumerate instead, and it misses fields, because a size
can arrive as a named utility, an arbitrary value (`text-[13px]` × 7, `text-[12px]` × 3),
an `!important` modifier or an inline style, and no list contains the next one. A guard
spec rescued neither shape: ~120 of this app's fields route through `<Input>` /
`<Textarea>` rather than a native tag, so the sweep that was supposed to pin the "nothing
is deliberately larger" premise could not see the 24px field that disproved it.

So the floor is out, a spec keeps it out, and `index.css` + `page-layout.md` record why
in place so the next person does not re-derive it. #6001 is reopened with what a correct
attempt has to satisfy: a real device answer on whether the focus zoom fires at all under
an authored `maximum-scale=1`, and — if it does — a floor in the field components, where
`max(16px, authored)` is actually expressible.

**One rider, stated here rather than left to be found in the diff.**
`remote-and-mobile.md`'s "Not edge-to-edge" bullet is deleted rather than edited: it was
already false at base (`website/index.html` ships `viewport-fit=cover`), and the pinch
note takes its place in the same known-limits list. Not zoom-suppression work.

**A second rider was written and then removed: the dev-only axe `meta-viewport` waiver.**
It is worth recording why, because it reads like an obvious tidy-up. `@axe-core/react`
scans every render, so `user-scalable=no` reports a critical WCAG 1.4.4 finding every
time, and the waiver's argument was that a permanent finding nobody can action trains
contributors to ignore the console. Two reviewers then arrived at the same objection from
opposite directions — GPT that it removes an existing validation guard, Design that it
"silences the one automated reminder that would keep re-raising it" — and they are right
on a point the original argument got wrong: **the finding is actionable, because it is a
decision**, and a decision does not stop being owed because a scanner keeps asking for
it. That report is currently the only recurring reminder that this PR's accessibility
trade has not been accepted in writing by anyone.

Its rationale had also quietly collapsed: the waiver's own comment cited "no touch field
computes below 16px" as one of three mitigations, and that mitigation was withdrawn (see
above). So the rule stays enabled, a spec fails if a waiver reappears, and `main.tsx`
carries the reasoning where the next person to reach for one will read it.

## Tests

- **`website/src/test/noPageZoom.test.ts`** (new, 9 specs) — locks each mechanism
  separately, because deleting any one silently returns page zoom to one platform:
  the viewport meta carries both `user-scalable=no` and `maximum-scale=1`; the
  same attribute did not lose `interactive-widget=resizes-content` or
  `viewport-fit=cover` in the edit; the root `touch-action` is exactly
  `pan-x pan-y` (not `none`, which would take scrolling, and not `manipulation`,
  which withholds only double-tap); the rule stays inside the coarse-pointer
  query; and the suppression module cancels the gesture events on a touch device,
  no-ops on a pointer-fine one, removes every listener on teardown, and fires its
  two-finger `touchmove` guard only when WebKit has already moved `scale` off 1.
- **`website/src/test/MarkdownRenderer.lightboxSwipe.test.tsx`** (6 new specs,
  18 total) — the pinch scales by the finger-distance ratio and clamps at both
  ends; it shares `LIGHTBOX_ZOOM_MAX` with the toolbar; it arms even when the
  image is already zoomed (the contact is recorded before the pan bail-out, which
  is the ordering bug this pins); the click after a pinch does not close the
  viewer; mouse-typed pointers never arm it; contacts are dropped when the viewer
  closes mid-pinch, so a reopened viewer does not inherit a stale pair. The
  pre-existing `touch-pinch-zoom` assertion is inverted to `touch-none` with the
  reason written into the spec.
- **`website/scripts/capture-no-page-zoom.mjs`** + `website/capture/no-page-zoom.{html,tsx}`
  (new harness) — every reading is asserted, so a plausible-looking frame fails
  here rather than in review.

## Manual verification

The harness is the verification, and it has a **control** — "the page did not
zoom" proves nothing if the harness cannot zoom anything. It also reads the
viewport meta out of `index.html` rather than restating it, so it cannot pass
against a string the app no longer ships.

```
shell/zoomable scale 1 → 5  · touch-action auto        · meta "width=device-width, initial-scale=1"
shell/shipped  scale 1 → 1  · touch-action pan-x pan-y · meta "…maximum-scale=1, user-scalable=no…"
shell/scroll   scrollY 641
viewer         rest scale(1) · spread scale(4.667) · back scale(1)
```

Local gates: `tsc -b` clean, `eslint src/` 646 warnings / 0 errors (ceiling 664,
unchanged from base), docs-lint and `i18n:check` pass. Targeted specs: 32/32.

**Still outstanding:** real-device iOS verification of the `gesturestart` path.
Chromium never fires those events, so no harness can stand in for it — this is
the one claim in the PR that rests on unit tests plus WebKit's documented
behaviour rather than on a measurement.

**Open for the maintainer**, raised independently by Design and UX: removing
gesture-level magnification on touch is an accessibility trade a human should own.
There is no in-app text-size control anywhere in `website/src`, so a low-vision
touch user's remaining routes are the browser's text-size setting and OS Display
Zoom — both settings-level, neither in-the-moment. What this PR does pay down is
that no field can force a zoom the user cannot escape, and that the image viewer
gains a real pinch. Three options are laid out in the UX disposition comment.

## Screenshots / video

Control run — permissive viewport, same gesture, zooms to 5×. This is what proves
the harness can see zoom at all:

![control: a permissive viewport zooms to 5x under the same two-finger spread](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-no-pinch-zoom/evidence/shell-zoomable-02-after-spread.png)

Shipped viewport — identical gesture, unmoved:

![shipped viewport: the same spread leaves the page at scale 1](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-no-pinch-zoom/evidence/shell-shipped-02-after-spread.png)

The image viewer still pinches, on its own transform rather than the browser's:

![the image viewer scaling under a two-finger pinch and returning to fit](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-no-pinch-zoom/evidence/viewer-pinch.gif)

<details>
<summary>Scrolling survives — <code>pan-x pan-y</code>, not <code>none</code></summary>

A one-finger drag on the same page reaches row 24, so withholding pinch did not
cost either scroll axis:

![a one-finger drag still scrolls the page to row 24](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-no-pinch-zoom/evidence/shell-scroll-after.png)

</details>

<details>
<summary>The pinch is anchored at the gesture midpoint, not the element centre</summary>

An off-centre pinch produces a real pan, so the detail under the fingers stays
under them. Measured `translate(283.3, 606.6)` at 4.33× — the centre-anchored
version gave `0, 0`, which is what the harness now asserts against:

![an off-centre pinch pans the image so the detail stays under the fingers](https://raw.githubusercontent.com/CrysisDeu/KiroCrew/assets/pr-no-pinch-zoom/evidence/viewer-05-anchored.png)

</details>

## Related Issues

no linked issue: this PR suppresses page zoom only. #6001 (the sub-16px field
focus-zoom) was folded in at round 2 and **withdrawn at round 5** — it is reopened
and carries the constraints a correct fix must satisfy, so it must NOT close on this
merge. See "Why the field floor was withdrawn" above.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff




