### PR TITLE
fix(subagent): stop the injection notice contradicting its own reason

### DIFF
--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -140,7 +140,10 @@ completion — this path fires for every terminal state, including runs that
 never executed (the never-ran reading comes from the record's execution marker,
 never from its error wording):
 
-- completed: `The agent finished but result delivery timed out.`
+- completed: `The agent finished, but its result could not be delivered.`
+  The line names no mechanism: `<reason>` above it already carries one, and
+  most call sites pass something other than a timeout (a dead provider, a
+  died ACP process, a raw exception string).
 - failed after execution began: `The agent failed before a result could be delivered.`
 - failed before execution (approval or queued rejection, no output exists):
   `The run failed before it started, so there is no result to deliver.`

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1470,7 +1470,17 @@ def _injection_notice_outcome(info: "SubagentInfo") -> str:
     their record without it) with no wording contract between ``error``
     strings and this notice. The "no result to deliver" phrasings are guarded
     on the absence of any output so they can never contradict the result-path
-    recovery hint. Pure function of the record, unit-tested per branch.
+    recovery hint.
+
+    The completed branch names no delivery MECHANISM. Only two of the six
+    ``notify_injection_failed`` call sites pass a timeout; the rest pass
+    "provider dead after prompt-busy retries", "ACP process died", a raw
+    ``str(exception)`` and the last injection-failure reason. Since the notice
+    prints ``reason`` on the line directly above this one, asserting a timeout
+    here would contradict it — and the reader is an LLM deciding whether to
+    retry. The cause belongs to ``reason``; this line states only the outcome.
+
+    Pure function of the record, unit-tested per branch.
     """
     never_ran = info._exec_started is None and not info.result and not info.result_path
     outcome = info.outcome
@@ -1482,7 +1492,7 @@ def _injection_notice_outcome(info: "SubagentInfo") -> str:
         if never_ran:
             return "The run failed before it started, so there is no result to deliver."
         return "The agent failed before a result could be delivered."
-    return "The agent finished but result delivery timed out."
+    return "The agent finished, but its result could not be delivered."
 
 
 # Event callback: (event_type, info, extra_data) -> None

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -1265,11 +1265,12 @@ class TestNotifyInjectionFailed:
 class TestInjectionNoticeOutcome:
     """The pure helper maps a terminal record to a truthful outcome line."""
 
-    def test_completed_keeps_the_finished_copy(self) -> None:
+    def test_completed_states_the_outcome_without_a_mechanism(self) -> None:
         info = _info(done=True, result="ok")
-        assert sa._injection_notice_outcome(info) == (
-            "The agent finished but result delivery timed out."
-        )
+        line = sa._injection_notice_outcome(info)
+        assert line == "The agent finished, but its result could not be delivered."
+        # The cause belongs to ``reason``, printed on the line above this one.
+        assert "timed out" not in line
 
     def test_failed_run_does_not_claim_finished(self) -> None:
         info = _info(done=True, error="Timed out after 30 minutes", _exec_started=123.0)
@@ -1318,6 +1319,79 @@ class TestInjectionNoticeOutcome:
         assert sa._injection_notice_outcome(info) == (
             "The agent failed before a result could be delivered."
         )
+
+
+class TestInjectionNoticeDoesNotContradictItsReason:
+    """A completed run's outcome line must not name a mechanism.
+
+    ``notify_injection_failed`` prints ``reason`` one line above the outcome
+    line, and most of its callers pass something that is not a timeout:
+    ``slack/gateway.py`` sends "provider dead after prompt-busy retries",
+    "ACP process died", a raw ``str(exception)`` from a failed injection turn,
+    and the last injection-failure reason after the attempt cap. A completed
+    branch that asserts "delivery timed out" contradicts every one of them, in
+    a message whose reader is the LLM deciding what to do next.
+    """
+
+    #: The reasons the four non-timeout call sites actually pass, verbatim.
+    NON_TIMEOUT_REASONS = [
+        "provider dead after prompt-busy retries",
+        "ACP process died",
+        "AcpError: stream closed while waiting for result",
+        "no active session for parent",
+    ]
+
+    async def _notice_for(self, info: SubagentInfo, reason: str) -> str:
+        seen: list[dict] = []
+
+        async def _on_event(_etype: str, _info: SubagentInfo, extra: dict) -> None:
+            seen.append(extra)
+
+        mgr = _manager(on_event=_on_event)
+        with patch("kiro_crew.dashboard.chat_utils.dashboard_slot_key", return_value="slot-1"):
+            mgr.notify_injection_failed(info, reason=reason)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert seen, "expected a subagent_injection_failed event"
+        return str(seen[0]["failure_msg"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reason", NON_TIMEOUT_REASONS)
+    async def test_a_non_timeout_reason_is_not_overridden_by_the_outcome_line(
+        self, reason: str
+    ) -> None:
+        info = _info(parent_session_key="dash:1", done=True, result="ok", _exec_started=123.0)
+        msg = await self._notice_for(info, reason)
+        assert reason in msg, "the caller's reason must still be shown"
+        assert (
+            "timed out" not in msg
+        ), f"the notice says the delivery timed out while its own reason says {reason!r}"
+        assert "The agent finished, but its result could not be delivered." in msg
+
+    @pytest.mark.asyncio
+    async def test_a_real_timeout_still_reads_as_one(self) -> None:
+        """Neutral copy loses nothing: the timeout callers say so in ``reason``."""
+        info = _info(parent_session_key="dash:1", done=True, result="ok", _exec_started=123.0)
+        msg = await self._notice_for(info, "injection timed out after 300s")
+        assert "injection timed out after 300s" in msg
+        assert "The agent finished, but its result could not be delivered." in msg
+
+    @pytest.mark.asyncio
+    async def test_the_result_recovery_hint_still_agrees_with_the_line(self) -> None:
+        """ "could not be delivered" must not read as "there is nothing to read":
+        when a result file exists the notice still points at it."""
+        info = _info(
+            parent_session_key="dash:1",
+            done=True,
+            result="ok",
+            result_path="/tmp/subagent-result.txt",
+            _exec_started=123.0,
+        )
+        with patch("os.path.getsize", return_value=42):
+            msg = await self._notice_for(info, "ACP process died")
+        assert "The agent finished, but its result could not be delivered." in msg
+        assert "/tmp/subagent-result.txt" in msg
+        assert "Use the read tool" in msg
 
 
 class TestNotifyInjectionFailedOutcomeCopy:
@@ -1374,7 +1448,7 @@ class TestNotifyInjectionFailedOutcomeCopy:
         assert "finished" not in msg
 
     @pytest.mark.asyncio
-    async def test_post_run_delivery_timeout_keeps_existing_copy_and_hint(
+    async def test_post_run_delivery_failure_keeps_the_completed_copy_and_hint(
         self, tmp_path: Path
     ) -> None:
         result = tmp_path / "result.txt"
@@ -1383,7 +1457,7 @@ class TestNotifyInjectionFailedOutcomeCopy:
             parent_session_key="dash:1", done=True, result="hello", result_path=str(result)
         )
         msg = await self._notice_for(info)
-        assert "The agent finished but result delivery timed out." in msg
+        assert "The agent finished, but its result could not be delivered." in msg
         assert "Result saved at" in msg
 
 


### PR DESCRIPTION
## Problem / Motivation

When a sub-agent reaches a terminal state but its report cannot be injected into
the parent session, `notify_injection_failed` builds a notice whose second line
is the caller's `reason` and whose fourth is `_injection_notice_outcome(info)`.
For a run that actually completed, that outcome line is:

```python
return "The agent finished but result delivery timed out."
```

Only **two** of the six call sites pass a timeout. The other four pass something
else entirely — `slack/gateway.py`:

| line | `reason` |
| --- | --- |
| 6305 | `"provider dead after prompt-busy retries"` |
| 6326 | `"ACP process died"` |
| 7066 | `str(t.exception())` from the failed injection turn |
| 7338 | `_last_failure_reason` after the attempt cap |

So the message contradicts itself:

```
[Subagent completion event]
Agent `a1` ❌ ACP process died
Task: …
The agent finished but result delivery timed out.
```

This is the residual the reviewer named on merged #5900, which introduced the
outcome-aware line:

> One residual worth noting: three of the gateway's `notify_injection_failed`
> call sites pass non-timeout reasons ("provider dead", "ACP process died", last
> failure reason), and the completed branch still asserts "timed out".

(There are four, counting `str(exception)` at 7066.)

## Why it matters

`failure_msg` is not only rendered in the dashboard slot — it is queued into
`slot._pending_subagent_failures` and drained into the **LLM's context** on the
next `_run_chat` turn. So the reader deciding what to do next is a model, and
the two mechanisms call for different responses: a delivery timeout invites a
retry of the injection, while "the ACP process died" or "provider dead after
prompt-busy retries" means the transport is gone and the sensible move is to
read the result off disk. Handing the model a confident, specific, wrong
mechanism is worse than handing it none.

`docs/system-specs/common/injected-messages.md` documents the string, so the
wrong copy is also the specified copy.

## What changed (motivation → approach → change)

Root cause is that one branch of the helper describes the *mechanism* of the
delivery failure while the notice already prints that mechanism, from a value
the helper cannot see. The two can only agree by accident.

The completed branch now states the outcome and nothing else:

```python
return "The agent finished, but its result could not be delivered."
```

- **A real timeout loses nothing.** Its callers already say so in `reason`
  (`"injection timed out after 300s"`, `"delivery timed out"`), so the specific
  cause still reaches the reader — and the old copy said "timed out" twice.
- **The `stopped` and `failed` branches are untouched.** They describe the run's
  own terminal state, which the record does know, and they are not in tension
  with `reason`.
- **The docstring records the constraint** so the next edit does not put a
  mechanism back: the cause belongs to `reason`, this line states the outcome.
- **`docs/system-specs/common/injected-messages.md` is updated in the same
  commit**, per `AGENTS.md`, including a note on why the line names no
  mechanism.

## Tests

New `TestInjectionNoticeDoesNotContradictItsReason` in
`test/test_subagent_coverage.py`, driving the real
`notify_injection_failed` and reading the queued `failure_msg` — the same
end-to-end shape the neighbouring `TestNotifyInjectionFailedOutcomeCopy` uses:

- `test_a_non_timeout_reason_is_not_overridden_by_the_outcome_line`, parametrized
  over the four reasons the non-timeout call sites actually pass. Asserts the
  caller's reason is still shown, that `"timed out"` does not appear anywhere in
  the notice, and that the new line is present.
- `test_a_real_timeout_still_reads_as_one` — a **control**: with
  `reason="injection timed out after 300s"` the reader still learns it was a
  timeout, so the neutral copy costs nothing.
- `test_the_result_recovery_hint_still_agrees_with_the_line` — a **control**
  against the obvious way this could go wrong: "could not be delivered" must not
  read as "there is nothing to read", so with a `result_path` present the notice
  still points at the file and still says `Use the read tool`.

Two existing tests asserted the old wording and are updated, not deleted:
`test_completed_keeps_the_finished_copy` becomes
`test_completed_states_the_outcome_without_a_mechanism` (and now also asserts
`"timed out" not in line`), and
`test_post_run_delivery_timeout_keeps_existing_copy_and_hint` becomes
`test_post_run_delivery_failure_keeps_the_completed_copy_and_hint`.

**Red-before, measured against pristine `origin/main` production code**
(`10c422628`) with the new tests in place — **8 failed / 262 passed**. The four
parametrized failures state the defect in one line each:

```
AssertionError: the notice says the delivery timed out while its own
                reason says 'ACP process died'
AssertionError: the notice says the delivery timed out while its own
                reason says 'provider dead after prompt-busy retries'
AssertionError: the notice says the delivery timed out while its own
                reason says 'AcpError: stream closed while waiting for result'
AssertionError: the notice says the delivery timed out while its own
                reason says 'no active session for parent'
```

**Green-after:** 270 passed in that module. Blast radius: **1303 passed / 26
skipped** across the whole `-k "subagent or injected"` selection. That run also
reports 32 collection errors in `test_bench_download_fd.py` and
`test_discord_doctor.py` (`KeyError: 'file'`), pre-existing on this machine and
unrelated — verified earlier today by stashing a change and re-running those two
files on pristine main for the same result.

`flake8`, `isort` and `mypy` are clean.

On `scripts/docs-lint.sh`: I do not have a pass to report from this host. Its
wrapper execs `python3`, which here resolves to the Windows Store shim (exit 49
before the lint runs), and the real 3.10 install ships `python.exe` with no
`python3.exe`, so putting it first on `PATH` does not shadow the shim. What the
lint enforces is that every doc is indexed and every link resolves; this change
edits one line of prose inside an existing section of an existing doc and
creates, moves, renames and deletes nothing, so it cannot affect either
property. CI runs the real gate.

## Manual verification

N/A — unit coverage sufficient: the defect is the text of a generated message,
and the tests read that message end to end out of the queued event rather than
asserting on the helper alone.

## Related Issues

Residual named by the reviewer on merged #5900 (`fix: derive injection-timeout
notice copy from the run's outcome (#5882)`). Independent of the open
run-coordinator stack — #5281 adds `notify_injection_failed` call sites but
touches neither `_injection_notice_outcome` nor this wording, so there is no
overlapping hunk. No separate issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
