### PR TITLE
fix: bound PIPE-stdio child reaps via shared kill_and_reap (#5989)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1158,25 +1158,17 @@ async def _run_cmd(
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             await _kill_tree(proc.pid)
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            await proc.wait()
+            await platform_compat.kill_and_reap(proc)
             return -1, "", f"timeout ({timeout}s)"
         except asyncio.CancelledError:
             # Backend shutdown/restart cancels in-flight handlers: the child
             # runs in its own process group and would outlive us (a canceled
             # rebase never reaches its --abort path, wedging the worktree).
+            # kill_and_reap is best-effort throughout, so an already-reaped
+            # child cannot REPLACE the in-flight CancelledError with
+            # ProcessLookupError and swallow the cancellation.
             await _kill_tree(proc.pid)
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                # Already reaped: an unguarded kill here would REPLACE the
-                # in-flight CancelledError with ProcessLookupError, swallowing
-                # the cancellation (#2096).
-                pass
-            await proc.wait()
+            await platform_compat.kill_and_reap(proc)
             raise
         return proc.returncode or 0, (stdout or b"").decode(errors="replace"), (stderr or b"").decode(errors="replace")
     finally:
@@ -1371,11 +1363,7 @@ async def _start_run(
             # so a worktree-controlled build can't outlive its run record.
             if proc is not None and proc.returncode is None:
                 await _kill_tree(proc.pid)
-                try:
-                    proc.kill()
-                except ProcessLookupError:
-                    pass
-                await proc.wait()
+                await platform_compat.kill_and_reap(proc)
             async with _RUNS_LOCK:
                 _RUNS[rid]["status"] = "done"
                 _RUNS[rid]["exit_code"] = -1

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/github_issues.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/providers/github_issues.py
@@ -38,6 +38,7 @@ from kiro_crew.apps.builtins.ops_mission_control.backend.providers.base import (
     ActionResult,
     TruncatedSignals,
 )
+from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 
 logger = logging.getLogger(__name__)
@@ -90,8 +91,7 @@ async def _run_gh(args: list[str]) -> tuple[int, str, str]:
         try:
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT_SECS)
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
+            await kill_and_reap(proc)
             return 1, "", f"gh timed out after {_GH_TIMEOUT_SECS:.0f}s"
         return (
             proc.returncode or 0,

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py
@@ -1921,3 +1921,67 @@ class TestPollersMarkTruncationSoAbsenceIsNotRecovery(unittest.IsolatedAsyncioTe
         with mock.patch.object(github_issues, "_run_gh", side_effect=_fake_under):
             result = await github_issues.GitHubIssuesAdapter().poll()
         self.assertNotIsInstance(result, TruncatedSignals)
+
+
+class TestRunGhTimeoutReapsChild(unittest.IsolatedAsyncioTestCase):
+    """A timed-out ``gh`` must be tree-killed and reaped by draining pipes.
+
+    After ``wait_for`` cancels ``communicate()``, a killed child blocked
+    writing into a full stderr pipe makes a bare ``wait()`` hang the polling
+    task forever (#5989) — the reap must be a SECOND ``communicate()``.
+    """
+
+    async def test_timeout_reaps_child_via_communicate_not_wait(self):
+        from kiro_crew import platform_compat
+        from kiro_crew.apps.builtins.ops_mission_control.backend.providers import (
+            github_issues,
+        )
+
+        class HangProc:
+            pid = 4242
+            returncode: int | None = None
+            kill_calls = 0
+            wait_calls = 0
+            communicate_calls = 0
+
+            async def communicate(self):
+                HangProc.communicate_calls += 1
+                if HangProc.communicate_calls == 1:
+                    raise asyncio.TimeoutError
+                HangProc.returncode = -9
+                return b"", b""
+
+            def kill(self):
+                HangProc.kill_calls += 1
+
+            async def wait(self):
+                HangProc.wait_calls += 1
+                return -9
+
+        async def fake_spawn(*argv, **kwargs):
+            return HangProc()
+
+        killed: list[tuple[int, int]] = []
+
+        async def fake_tree_kill(pid, sig):
+            killed.append((pid, sig))
+            return True
+
+        with (
+            mock.patch.object(
+                github_issues,
+                "sandboxed_spawn_argv",
+                lambda argv, **kw: (argv, {}, None),
+            ),
+            mock.patch.object(github_issues, "create_subprocess_limited", fake_spawn),
+            mock.patch.object(platform_compat, "kill_process_tree_async", fake_tree_kill),
+        ):
+            rc, out, err = await github_issues._run_gh(["issue", "list"])
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, "")
+        self.assertIn("timed out", err)
+        self.assertEqual(killed, [(HangProc.pid, platform_compat.SIGKILL)])
+        self.assertEqual(HangProc.kill_calls, 1)
+        self.assertEqual(HangProc.communicate_calls, 2)
+        self.assertEqual(HangProc.wait_calls, 0)

--- a/src/kiro_crew/apps/lifecycle_scripts.py
+++ b/src/kiro_crew/apps/lifecycle_scripts.py
@@ -18,6 +18,7 @@ prevent.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 from typing import Any
@@ -29,6 +30,12 @@ from kiro_crew.apps.registry import minimal_env
 from kiro_crew.sandbox import cgroup_scope_argv, create_subprocess_limited, wrap_argv
 
 logger = logging.getLogger(__name__)
+
+#: Seconds a timed-out lifecycle script gets between the graceful SIGTERM and
+#: the SIGKILL escalation, so an install/uninstall hook's cleanup trap can run
+#: without the timeout path being able to hang on a trap that never exits.
+#: Mirrors the app-build grace in ``registry._KILL_GRACE_PERIOD``.
+_TERM_GRACE_SECS = 5
 
 
 async def run_lifecycle_script(
@@ -89,14 +96,19 @@ async def run_lifecycle_script(
                 # killpg on POSIX, taskkill /T on Windows — via platform_compat.
                 # Async variant offloads the Windows taskkill spawn to
                 # subprocess_executor so this lifecycle-script timeout path
-                # never blocks the event loop on taskkill.exe.
+                # never blocks the event loop on taskkill.exe. SIGTERM first so
+                # a script's cleanup trap can run.
                 await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGTERM)
             except OSError:
-                proc.kill()
-            try:
-                await proc.wait()
-            except Exception:
                 pass
+            # Bounded grace: drain pipes while the trap runs. communicate()
+            # returns once the child exits; a script that ignores the TERM
+            # outlives the grace and is escalated to a SIGKILL tree kill with
+            # a bounded, pipe-draining reap.
+            with contextlib.suppress(Exception, asyncio.TimeoutError):
+                await asyncio.wait_for(proc.communicate(), timeout=_TERM_GRACE_SECS)
+            if proc.returncode is None:
+                await platform_compat.kill_and_reap(proc)
             return {"output": f"script timed out after {timeout}s", "failed": True}
     finally:
         if cleanup:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -2210,16 +2210,15 @@ async def _communicate_with_timeout(
     gateway's — every caller in this module does. If the group kill fails
     (e.g. the child already exited, or it was never made a group leader) we
     fall back to a pid-scoped ``proc.kill()`` so the child is never left
-    un-reaped.
+    un-reaped. The reap itself goes through the shared
+    ``platform_compat.kill_and_reap``, which drains the pipes via
+    ``communicate()`` under a bound so a killed child blocked writing into a
+    full pipe cannot hang the caller.
     """
     try:
         return await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        try:
-            await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
-        except OSError:
-            proc.kill()
-        await proc.wait()
+        await platform_compat.kill_and_reap(proc)
         raise
 
 
@@ -3729,11 +3728,7 @@ async def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
     try:
         await asyncio.wait_for(proc.wait(), timeout=_KILL_GRACE_PERIOD)
     except asyncio.TimeoutError:
-        try:
-            await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
-        except OSError:
-            proc.kill()
-        await proc.wait()
+        await platform_compat.kill_and_reap(proc)
 
 
 async def _git_fetch_commit(

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -41,6 +41,7 @@ from kiro_crew.embeddings import (
 from kiro_crew.executors import embed_executor, run_in_embed_pool
 from kiro_crew.history import is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     cgroup_scope_argv,
@@ -896,8 +897,7 @@ async def _ensure_pip_available() -> tuple[bool, str]:
         try:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
+            await kill_and_reap(proc)
             logger.warning("ensurepip bootstrap timed out")
             return False, "pip bootstrap (ensurepip) timed out"
         if proc.returncode != 0:
@@ -1041,8 +1041,7 @@ async def api_memory_enable_embeddings(request: web.Request) -> web.Response:
                     try:
                         _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
                     except asyncio.TimeoutError:
-                        proc.kill()
-                        await proc.wait()
+                        await kill_and_reap(proc)
                         logger.warning("faiss-cpu install timed out")
                         _embedding_setup_status = {
                             "step": "idle",

--- a/src/kiro_crew/instances/token_mint.py
+++ b/src/kiro_crew/instances/token_mint.py
@@ -20,12 +20,12 @@ Security (standard practices):
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import re
 
 from kiro_crew.config.paths import CONFIG_DIR_NAME, LEGACY_CONFIG_DIR_NAME
 from kiro_crew.instances.constants import DEFAULT_MINT_TIMEOUT_SECS, TTL_PATTERN
+from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -438,11 +438,7 @@ async def mint_remote_token(
     try:
         stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
     except asyncio.TimeoutError as e:
-        proc.kill()
-        try:
-            await proc.wait()
-        except ProcessLookupError:
-            pass
+        await kill_and_reap(proc)
         raise TokenMintError(f"timed out minting token on {ssh_host} after {timeout_secs}s") from e
 
     stdout = stdout_b.decode("utf-8", "replace")
@@ -523,9 +519,7 @@ async def run_remote_kirocrew(
     try:
         _out, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
     except asyncio.TimeoutError:
-        proc.kill()
-        with contextlib.suppress(ProcessLookupError):
-            await proc.wait()
+        await kill_and_reap(proc)
         return -1, f"timed out after {timeout_secs}s"
     err = err_b.decode("utf-8", "replace").strip()
     # Proxy-controlled stderr (e.g. a WSSH banner) can carry credential-looking

--- a/src/kiro_crew/platform/update_provider.py
+++ b/src/kiro_crew/platform/update_provider.py
@@ -20,7 +20,6 @@ ungoverned default, where the gateway keeps its built-in update behaviour).
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import os
 import platform
@@ -29,6 +28,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Protocol, runtime_checkable
 
+from kiro_crew import platform_compat
 from kiro_crew.platform_compat import (
     IS_POSIX,
     trusted_system_bin,
@@ -77,41 +77,23 @@ async def _read_bounded_output(
 
 
 async def _kill_and_reap(proc: asyncio.subprocess.Process) -> None:
-    """Kill *proc* AND its descendants, then wait for it under a bound.
+    """Delegate to :func:`kiro_crew.platform_compat.kill_and_reap`.
 
-    Used on BOTH the timeout and the cancellation path. Cancellation matters as
-    much as timeout: a gateway shutdown (SIGTERM) cancels the update task, and
-    without this the updater keeps replacing files after the process that
-    started it is gone, leaving a half-updated installation nobody supervises.
-
-    The whole TREE is signalled, not just the direct child. An update command is
-    a shell line (``curl … | sh``, ``pkg update | tee log``), so killing only
-    the shell leaves the pipeline members running and can leave ``communicate()``
-    waiting on pipes those survivors still hold. Every spawn that reaches here
-    is started with ``start_new_session`` on POSIX so the tree is its own process
-    group and cannot reach back into the gateway's.
-
-    The reap is bounded: a descendant that ignores the signal must not turn
-    cleanup into a hang on the shutdown path. Both the kill and the reap are
-    best-effort, since the caller is already handling a timeout or a
-    cancellation and must not have it masked by a cleanup error.
+    Kept as a module-level seam rather than a bare re-export so the
+    module-local ceiling below keeps bounding the reap: existing callers
+    (including function-local imports elsewhere) and tests resolve both
+    names on THIS module.
     """
-    # Function-local deliberately: the tests patch
-    # ``kiro_crew.platform_compat.kill_process_tree_async`` on the SOURCE module,
-    # and a module-scope ``from`` import would freeze the reference so the patch
-    # could not reach it.
-    from kiro_crew import platform_compat
-
-    with contextlib.suppress(Exception):
-        await platform_compat.kill_process_tree_async(proc.pid, platform_compat.SIGKILL)
-    with contextlib.suppress(Exception):
-        proc.kill()
-    with contextlib.suppress(Exception, asyncio.TimeoutError):
-        await asyncio.wait_for(proc.communicate(), timeout=_REAP_TIMEOUT_SECS)
+    # Module-object attribute lookup happens at call time, so tests patching
+    # ``kiro_crew.platform_compat.kill_process_tree_async`` (inside the shared
+    # helper) still intercept the tree kill.
+    await platform_compat.kill_and_reap(proc, timeout=_REAP_TIMEOUT_SECS)
 
 
 #: Ceiling on waiting for a killed updater tree. A descendant that ignores the
 #: signal must not turn cleanup into a hang while the gateway is shutting down.
+#: Mirrors the shared default so the updater's bound stays independently
+#: patchable without touching every other reap site.
 _REAP_TIMEOUT_SECS = 10
 
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3095,6 +3095,82 @@ async def kill_process_tree_async(pid: int, sig: int = SIGTERM) -> bool:
     return await loop.run_in_executor(subprocess_executor(), kill_process_tree, pid, sig)
 
 
+#: Ceiling on waiting for a killed process tree. A descendant that ignores the
+#: signal must not turn cleanup into a hang while the caller is already
+#: handling a timeout or a cancellation — often on the shutdown path, where an
+#: unbounded reap would wedge the whole teardown.
+REAP_TIMEOUT_SECS: float = 10
+
+
+async def kill_and_reap(proc: asyncio.subprocess.Process, *, timeout: float | None = None) -> None:
+    """Kill *proc* AND its descendants, then wait for it under a bound.
+
+    The shared cleanup for a PIPE-stdio child whose ``communicate()`` was
+    abandoned by ``asyncio.wait_for`` — used on BOTH the timeout and the
+    cancellation path. Cancellation matters as much as timeout: a gateway
+    shutdown cancels the owning task, and without this the child keeps
+    running after the process that started it is gone.
+
+    The whole TREE is signalled, not just the direct child. A spawned command
+    is often a shell line (``curl … | sh``, ``pip … | tee log``), so killing
+    only the shell leaves the pipeline members running and can leave
+    ``communicate()`` waiting on pipes those survivors still hold. A child
+    sharing the caller's own process group (spawned without
+    ``start_new_session``) has no tree of its own to signal — the group kill
+    is skipped for it and the pid-scoped ``kill()`` below covers it, instead
+    of tripping :func:`kill_process_tree`'s broadcast guard on every routine
+    timeout.
+
+    The reap goes through ``communicate()`` rather than ``wait()`` so the
+    pipes are drained: ``wait_for`` already cancelled the original
+    ``communicate()``, and a killed child blocked writing into a full pipe
+    would make a bare ``wait()`` hang the calling task forever. The reap is
+    bounded by *timeout* (default :data:`REAP_TIMEOUT_SECS`). Both the kill
+    and the reap are best-effort, since the caller is already handling a
+    timeout or a cancellation and must not have it masked by a cleanup error.
+
+    The whole sequence runs in a shielded inner task: a (repeat) cancellation
+    of the caller landing mid-cleanup must not abandon the kill or leave the
+    child un-reaped — the cancellation is absorbed until cleanup finishes and
+    then re-delivered once.
+    """
+
+    async def _cleanup() -> None:
+        same_group = False
+        if IS_POSIX:
+            with contextlib.suppress(Exception):
+                same_group = os.getpgid(proc.pid) == _OWN_PGID
+        if not same_group:
+            # Bare-name lookup resolves through this module's namespace at
+            # call time, so tests patching ``kiro_crew.platform_compat.
+            # kill_process_tree_async`` still intercept the tree kill.
+            with contextlib.suppress(Exception):
+                await kill_process_tree_async(proc.pid, SIGKILL)
+        with contextlib.suppress(Exception):
+            proc.kill()
+        with contextlib.suppress(Exception, asyncio.TimeoutError):
+            await asyncio.wait_for(
+                proc.communicate(),
+                timeout=REAP_TIMEOUT_SECS if timeout is None else timeout,
+            )
+
+    cleanup = asyncio.ensure_future(_cleanup())
+    cancelled = False
+    while True:
+        try:
+            await asyncio.shield(cleanup)
+            break
+        except asyncio.CancelledError:
+            # Either the CALLER was (re-)cancelled while the shield kept the
+            # cleanup running, or the cleanup itself ended cancelled. Absorb
+            # until the cleanup has genuinely finished, then re-deliver.
+            cancelled = True
+            if cleanup.done():
+                break
+    if cancelled:
+        raise asyncio.CancelledError
+
+
 async def descendant_termination_handles_async(
     pid: int,
     retained_handles: Mapping[int, int] | None = None,

--- a/test/test_apps_registry.py
+++ b/test/test_apps_registry.py
@@ -67,9 +67,16 @@ class _TimeoutProc:
         self.returncode: int | None = None
         self.kill_calls = 0
         self.wait_calls = 0
+        self.communicate_calls = 0
 
     async def communicate(self) -> tuple[bytes, bytes]:
-        raise asyncio.TimeoutError
+        self.communicate_calls += 1
+        if self.communicate_calls == 1:
+            raise asyncio.TimeoutError
+        # The reap: pipes drained, exit status collected.
+        if self.returncode is None:
+            self.returncode = -9
+        return b"", b""
 
     def kill(self) -> None:
         self.kill_calls += 1
@@ -141,10 +148,12 @@ async def test_communicate_with_timeout_kills_whole_process_tree(monkeypatch):
 
     # Whole-tree kill was invoked with the child's pid + SIGKILL ...
     assert killed == [(proc.pid, registry.platform_compat.SIGKILL)]
-    # ... the child was reaped ...
-    assert proc.wait_calls == 1
-    # ... and the single-process fallback was NOT needed.
-    assert proc.kill_calls == 0
+    # ... the child was reaped by draining pipes via a SECOND communicate(),
+    # never a bare wait() that a full pipe could hang (#5989) ...
+    assert proc.communicate_calls == 2
+    assert proc.wait_calls == 0
+    # ... and the helper's pid-scoped kill backs up the group signal.
+    assert proc.kill_calls == 1
 
 
 @pytest.mark.asyncio
@@ -160,7 +169,8 @@ async def test_communicate_with_timeout_falls_back_when_group_kill_fails(monkeyp
         await registry._communicate_with_timeout(proc, timeout=0.01)
 
     assert proc.kill_calls == 1
-    assert proc.wait_calls == 1
+    assert proc.communicate_calls == 2
+    assert proc.wait_calls == 0
 
 
 @pytest.fixture(autouse=True)
@@ -208,7 +218,8 @@ async def test_fetch_app_manifest_reaps_clone_tree_on_timeout(monkeypatch):
     assert result is None
     # ... but the clone's whole process group was killed and the child reaped.
     assert killed == [proc.pid]
-    assert proc.wait_calls == 1
+    assert proc.communicate_calls == 2
+    assert proc.wait_calls == 0
 
 
 # --------------------------------------------------------------------------
@@ -246,7 +257,8 @@ async def test_list_registry_reaps_detect_probe_tree_on_timeout(monkeypatch):
     await registry.list_registry()
 
     assert killed == [proc.pid]
-    assert proc.wait_calls == 1
+    assert proc.communicate_calls == 2
+    assert proc.wait_calls == 0
 
 
 # --------------------------------------------------------------------------
@@ -286,7 +298,8 @@ async def test_install_from_registry_reaps_detect_probe_tree_on_timeout(monkeypa
     await registry.install_from_registry("demoapp")
 
     assert killed == [proc.pid]
-    assert proc.wait_calls == 1
+    assert proc.communicate_calls == 2
+    assert proc.wait_calls == 0
 
 
 # --------------------------------------------------------------------------
@@ -319,6 +332,54 @@ async def test_kill_process_group_reaps_and_escalates_to_sigkill(monkeypatch):
     assert proc.returncode is not None
     # Portable liveness check — never the prohibited raw ``os.kill(pid, 0)``.
     assert not platform_compat.pid_exists(pid)
+
+
+@pytest.mark.asyncio
+async def test_kill_process_group_escalation_reaps_via_communicate_not_wait(monkeypatch):
+    """The SIGKILL escalation reaps by draining pipes via communicate(); a
+    bare wait() on a killed child blocked writing into a full pipe would
+    hang the app-build timeout path forever (#5989)."""
+    monkeypatch.setattr(registry, "_KILL_GRACE_PERIOD", 0.01)
+    killed: list[tuple[int, int]] = []
+
+    async def _tree(pid, sig):
+        killed.append((pid, sig))
+        return True
+
+    monkeypatch.setattr(registry.platform_compat, "kill_process_tree_async", _tree)
+
+    class _StubbornProc:
+        pid = 987654
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.kill_calls = 0
+            self.wait_calls = 0
+            self.communicate_calls = 0
+
+        async def wait(self) -> int:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                # The site's own grace wait: SIGTERM is ignored, so this
+                # outlives _KILL_GRACE_PERIOD and the escalation fires.
+                await asyncio.sleep(3600)
+            raise AssertionError("bare wait() used as the post-SIGKILL reap (#5989)")
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            self.communicate_calls += 1
+            self.returncode = -9
+            return b"", b""
+
+        def kill(self) -> None:
+            self.kill_calls += 1
+
+    proc = _StubbornProc()
+    await registry._kill_process_group(proc)
+
+    pc = registry.platform_compat
+    assert killed == [(proc.pid, pc.SIGTERM), (proc.pid, pc.SIGKILL)]
+    assert proc.wait_calls == 1  # the grace wait only — never the reap
+    assert proc.communicate_calls == 1
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -2139,6 +2139,11 @@ async def test_run_cmd_cancel_with_reaped_child_propagates_cancellation(monkeypa
     )
     monkeypatch.setattr(mod, "create_subprocess_limited", fake_spawn)
     monkeypatch.setattr(mod, "_kill_tree", AsyncMock())
+    # The shared reap helper also signals the tree; intercept it so the fake
+    # pid never reaches a real killpg, and shrink its bound so the reap of a
+    # still-blocking communicate() cannot stall this test.
+    monkeypatch.setattr(mod.platform_compat, "kill_process_tree_async", AsyncMock())
+    monkeypatch.setattr(mod.platform_compat, "REAP_TIMEOUT_SECS", 0.01)
 
     task = asyncio.ensure_future(mod._run_cmd(["/bin/true"]))
     # Bounded so a future early-return in _run_cmd fails fast, not a hang.
@@ -2166,11 +2171,19 @@ async def test_start_run_readline_overrun_kills_process_tree(monkeypatch):
         pid = 424242
         returncode: int | None = None
         stdout = FakeStdout()
+        wait_calls = 0
+        communicate_calls = 0
 
         def kill(self):
             FakeProc.returncode = -9
 
+        async def communicate(self):
+            FakeProc.communicate_calls += 1
+            FakeProc.returncode = FakeProc.returncode or -9
+            return b"", b""
+
         async def wait(self):
+            FakeProc.wait_calls += 1
             FakeProc.returncode = FakeProc.returncode or -9
             return FakeProc.returncode
 
@@ -2182,6 +2195,9 @@ async def test_start_run_readline_overrun_kills_process_tree(monkeypatch):
 
     monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(mod, "_kill_tree", fake_kill_tree)
+    # The shared reap helper also signals the tree; intercept it so the fake
+    # pid never reaches a real killpg on the host.
+    monkeypatch.setattr(mod.platform_compat, "kill_process_tree_async", AsyncMock())
     FakeProc.returncode = None
 
     # Absolute: the spawn shim execs without a PATH search, so only a bare name
@@ -2198,7 +2214,11 @@ async def test_start_run_readline_overrun_kills_process_tree(monkeypatch):
     assert rec["status"] == "done" and rec["exit_code"] == -1
     assert any("chunk is longer than limit" in line for line in rec["output"])
     assert killed == [424242]  # tree reaped exactly once
-    assert FakeProc.returncode is not None  # proc.kill()/wait() completed
+    assert FakeProc.returncode is not None  # proc.kill() ran
+    # The reap drains pipes via communicate(), never a bare wait() that a
+    # full pipe could hang (#5989).
+    assert FakeProc.communicate_calls == 1
+    assert FakeProc.wait_calls == 0
 
 
 # --- Codex R35 regressions ---

--- a/test/test_dev_fleet_server_more_coverage.py
+++ b/test/test_dev_fleet_server_more_coverage.py
@@ -49,6 +49,7 @@ class _FakeProc:
         self.stdout = self
         self.kills = 0
         self.waits = 0
+        self.communicates = 0
         self._lines = list(lines or [])
         self._rc = rc
         self._readline_error = readline_error
@@ -63,7 +64,10 @@ class _FakeProc:
 
     # -- communicate side (used by _run_cmd) --
     async def communicate(self) -> tuple[bytes, bytes]:
-        if self._communicate_delay is not None:
+        self.communicates += 1
+        # A killed child's pipes close: the post-kill reap returns promptly
+        # rather than re-serving the hang that triggered the timeout.
+        if self._communicate_delay is not None and self.kills == 0:
             await asyncio.sleep(self._communicate_delay)
         self.returncode = self._rc
         return b"out", b"err"
@@ -189,13 +193,20 @@ async def test_run_cmd_timeout_kills_tree_and_reports(monkeypatch, tmp_path):
     _spawn_returns(monkeypatch, proc)
     killed: list[int] = []
     monkeypatch.setattr(mod, "_kill_tree", AsyncMock(side_effect=killed.append))
+    # The shared reap helper also signals the tree; intercept it so a fake pid
+    # never reaches a real killpg on the host.
+    monkeypatch.setattr(mod.platform_compat, "kill_process_tree_async", AsyncMock())
 
     rc, out, err = await mod._run_cmd(["git", "status"], timeout=0)
 
     assert (rc, out, err) == (-1, "", "timeout (0s)")
     assert killed == [proc.pid]
-    # kill() + wait() both ran, and the missing cleanup file was tolerated.
-    assert (proc.kills, proc.waits) == (1, 1)
+    # The reap drains pipes via communicate() after kill(); a bare wait() on
+    # a killed child blocked writing into a full pipe would hang the caller
+    # forever (#5989). With timeout=0 the site's own communicate() is
+    # cancelled before it ever runs, so the single recorded call IS the reap.
+    # The missing cleanup file was tolerated.
+    assert (proc.kills, proc.communicates, proc.waits) == (1, 1, 0)
 
 
 @pytest.mark.asyncio
@@ -287,6 +298,9 @@ async def test_start_run_stream_error_reaps_live_child(monkeypatch):
     _spawn_returns(monkeypatch, proc)
     killed: list[int] = []
     monkeypatch.setattr(mod, "_kill_tree", AsyncMock(side_effect=killed.append))
+    # The shared reap helper also signals the tree; intercept it so the fake
+    # pid never reaches a real killpg on the host.
+    monkeypatch.setattr(mod.platform_compat, "kill_process_tree_async", AsyncMock())
 
     rid = await mod._start_run("sync", ["kirocrew", "sync"])
     rec = await _drain_run(rid)
@@ -306,6 +320,9 @@ async def test_start_run_stream_error_tolerates_already_reaped_child(monkeypatch
     )
     _spawn_returns(monkeypatch, proc)
     monkeypatch.setattr(mod, "_kill_tree", AsyncMock())
+    # The shared reap helper also signals the tree; intercept it so the fake
+    # pid never reaches a real killpg on the host.
+    monkeypatch.setattr(mod.platform_compat, "kill_process_tree_async", AsyncMock())
 
     rid = await mod._start_run("sync", ["kirocrew", "sync"])
     rec = await _drain_run(rid)

--- a/test/test_enable_embeddings_faiss.py
+++ b/test/test_enable_embeddings_faiss.py
@@ -331,6 +331,11 @@ class TestFaissInstallTimeout:
                 assert "timed out" in body["error"]
 
         proc.kill.assert_called_once()
+        # The critical pin: the reap drains pipes via a SECOND communicate();
+        # a bare wait() on a killed pip blocked writing into a full stderr
+        # pipe would hang the handler forever (#5989).
+        assert proc.communicate.call_count == 2
+        proc.wait.assert_not_awaited()
         assert mem_mod._embedding_setup_status["step"] == "idle"
         assert "timed out" in str(mem_mod._embedding_setup_status["error"])
 

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -1483,7 +1483,11 @@ class TestEnsurePipEdgeCases:
         assert ok is False
         assert "timed out" in err
         proc.kill.assert_called_once()
-        proc.wait.assert_awaited_once()
+        # The critical pin: the reap drains pipes via a SECOND communicate();
+        # a bare wait() on a killed child blocked writing into a full stderr
+        # pipe would hang the handler forever (#5989).
+        assert proc.communicate.call_count == 2
+        proc.wait.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_temp_wrapper_is_unlinked_even_when_already_gone(self, tmp_path: Path) -> None:

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -26,6 +26,8 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew import platform_compat
+
 # ── config flag + constants ────────────────────────────────────────────────
 
 
@@ -2894,6 +2896,82 @@ class TestTokenMintGeneric:
         assert rc == 255
         assert "AKIAIOSFODNN7EXAMPLE" not in err
         assert "[REDACTED: credential]" in err
+
+    class _HangProc:
+        """First ``communicate`` times out; the reap (a SECOND communicate)
+        records itself and returns. ``wait`` must never be touched: on a
+        killed child blocked writing into a full stderr pipe it hangs the
+        caller forever (#5989)."""
+
+        def __init__(self) -> None:
+            self.pid = 4242
+            self.returncode: int | None = None
+            self.kill_calls = 0
+            self.wait_calls = 0
+            self.communicate_calls = 0
+
+        async def communicate(self):
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise asyncio.TimeoutError
+            self.returncode = -9
+            return b"", b""
+
+        def kill(self) -> None:
+            self.kill_calls += 1
+
+        async def wait(self) -> int:
+            self.wait_calls += 1
+            return -9
+
+    def test_mint_timeout_reaps_child_via_communicate_not_wait(self, monkeypatch):
+        from kiro_crew.instances import token_mint as tm
+
+        proc = self._HangProc()
+
+        async def fake_exec(*a, **k):
+            return proc
+
+        killed: list[tuple[int, int]] = []
+
+        async def _tree(pid, sig):
+            killed.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", _tree)
+        with pytest.raises(tm.TokenMintError, match="timed out minting"):
+            asyncio.run(tm.mint_remote_token("cd-1", ttl="20h"))
+        assert killed == [(proc.pid, platform_compat.SIGKILL)]
+        assert proc.kill_calls == 1
+        assert proc.communicate_calls == 2
+        assert proc.wait_calls == 0
+
+    def test_run_remote_kirocrew_timeout_reaps_child_via_communicate_not_wait(
+        self, monkeypatch
+    ):
+        from kiro_crew.instances import token_mint as tm
+
+        proc = self._HangProc()
+
+        async def fake_exec(*a, **k):
+            return proc
+
+        killed: list[tuple[int, int]] = []
+
+        async def _tree(pid, sig):
+            killed.append((pid, sig))
+            return True
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", _tree)
+        rc, err = asyncio.run(tm.run_remote_kirocrew("cd-1", "restart"))
+        assert rc == -1
+        assert "timed out after" in err
+        assert killed == [(proc.pid, platform_compat.SIGKILL)]
+        assert proc.kill_calls == 1
+        assert proc.communicate_calls == 2
+        assert proc.wait_calls == 0
 
 
 class TestDiagnostics:

--- a/test/test_lifecycle_scripts_cov80.py
+++ b/test/test_lifecycle_scripts_cov80.py
@@ -23,19 +23,25 @@ class _Process:
 
     def __init__(self, *, output: bytes = b"", returncode: int = 0, hang: bool = False) -> None:
         self.pid = 4242
-        self.returncode = returncode
+        # A hung child has no exit status until something kills it.
+        self.returncode: int | None = None if hang else returncode
         self._output = output
         self._hang = hang
         self.killed = False
         self.waited = False
+        self.communicate_calls = 0
 
     async def communicate(self):
-        if self._hang:
+        self.communicate_calls += 1
+        if self._hang and not self.killed:
+            # Still hanging: both the site's own wait and the TERM grace
+            # window time out until the SIGKILL escalation lands.
             raise asyncio.TimeoutError
         return self._output, None
 
     def kill(self) -> None:
         self.killed = True
+        self.returncode = -9
 
     async def wait(self) -> int:
         self.waited = True
@@ -138,11 +144,47 @@ async def test_timeout_kills_the_process_tree(admit, monkeypatch, tmp_path) -> N
         killed.append((pid, sig))
 
     monkeypatch.setattr(platform_compat, "kill_process_tree_async", _kill_tree)
+    monkeypatch.setattr(lifecycle_scripts, "_TERM_GRACE_SECS", 0.01)
     result = await lifecycle_scripts.run_lifecycle_script("demo-app", "sleep 99", timeout=7)
     assert result == {"output": "script timed out after 7s", "failed": True}
-    assert killed == [(proc.pid, platform_compat.SIGTERM)]
-    assert proc.waited is True
+    # Graceful SIGTERM first with a bounded grace window (a script's cleanup
+    # trap can run), then the shared helper escalates the whole tree to
+    # SIGKILL when the child ignored the TERM.
+    assert killed == [(proc.pid, platform_compat.SIGTERM), (proc.pid, platform_compat.SIGKILL)]
+    # The pid-scoped kill is the helper's second barrel after the tree signal.
+    assert proc.killed is True
+    # The critical pin: every post-kill wait drains pipes via communicate();
+    # a bare wait() on a killed child blocked writing into a full pipe would
+    # hang the caller forever (#5989). Calls: the site's own wait, the TERM
+    # grace, and the escalation reap.
+    assert proc.communicate_calls == 3
+    assert proc.waited is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_grace_lets_a_term_trap_finish_without_sigkill(
+    admit, monkeypatch, tmp_path
+) -> None:
+    """A script whose TERM trap exits within the grace window is never
+    SIGKILLed — the graceful path stays graceful."""
+    (tmp_path / "demo-app").mkdir()
+    proc = _Process(hang=True)
+    admit(proc)
+    killed: list[tuple[int, Any]] = []
+
+    async def _kill_tree(pid, sig):
+        killed.append((pid, sig))
+        # The script's TERM trap runs and the child exits inside the grace
+        # window: the next communicate() returns instead of hanging.
+        proc._hang = False
+        proc.returncode = 0
+
+    monkeypatch.setattr(platform_compat, "kill_process_tree_async", _kill_tree)
+    result = await lifecycle_scripts.run_lifecycle_script("demo-app", "sleep 99", timeout=7)
+    assert result == {"output": "script timed out after 7s", "failed": True}
+    assert killed == [(proc.pid, platform_compat.SIGTERM)]  # no SIGKILL escalation
     assert proc.killed is False
+    assert proc.waited is False
 
 
 @pytest.mark.asyncio

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -4084,3 +4084,116 @@ class TestTrustedGitBin:
             property(lambda _s: (_ for _ in ()).throw(AssertionError("probed on POSIX"))),
         )
         assert pc.trusted_git_bin() is None
+
+
+class TestKillAndReap:
+    """The shared kill-the-tree + bounded-pipe-draining-reap helper (#5989)."""
+
+    @staticmethod
+    def _proc(pid: int = 4242):
+        from unittest import mock
+
+        proc = mock.MagicMock()
+        proc.pid = pid
+        proc.kill = mock.MagicMock()
+        proc.communicate = mock.AsyncMock(return_value=(b"", b""))
+        proc.wait = mock.AsyncMock()
+        return proc
+
+    @pytest.mark.asyncio
+    async def test_kills_the_whole_tree_then_the_pid(self) -> None:
+        """A spawned command is often a shell line, so the whole group must be
+        signalled; the pid-scoped kill backs up a group signal that missed."""
+        from unittest import mock
+
+        proc = self._proc(pid=4242)
+        with mock.patch.object(pc, "kill_process_tree_async", mock.AsyncMock()) as tree:
+            await pc.kill_and_reap(proc)
+        tree.assert_awaited_once()
+        assert tree.await_args.args == (4242, pc.SIGKILL)
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reaps_via_communicate_never_wait(self) -> None:
+        """The reap must drain the pipes: a killed child blocked writing into
+        a full pipe makes a bare ``wait()`` hang the calling task forever."""
+        from unittest import mock
+
+        proc = self._proc()
+        with mock.patch.object(pc, "kill_process_tree_async", mock.AsyncMock()):
+            await pc.kill_and_reap(proc)
+        proc.communicate.assert_awaited_once()
+        proc.wait.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bounds_the_reap(self) -> None:
+        """A descendant that ignores SIGKILL's effects on the pipe (e.g. an
+        inherited fd held open) must not turn cleanup into a hang."""
+        import asyncio
+        from unittest import mock
+
+        assert 0 < pc.REAP_TIMEOUT_SECS <= 30
+        proc = self._proc(pid=1)
+
+        async def _never_returns():
+            await asyncio.sleep(3600)
+
+        proc.communicate = _never_returns
+        with mock.patch.object(pc, "kill_process_tree_async", mock.AsyncMock()):
+            # Outer bound is a hang detector only; the helper's own bound
+            # (passed explicitly) is what must return first.
+            await asyncio.wait_for(pc.kill_and_reap(proc, timeout=0.01), timeout=30)
+
+    @pytest.mark.asyncio
+    async def test_tolerates_dead_child_and_mock_pids(self) -> None:
+        """Best-effort throughout: an already-exited child (or a non-int test
+        pid refused by the broadcast guard) must not mask the caller's own
+        timeout or cancellation handling."""
+        from unittest import mock
+
+        proc = mock.MagicMock()  # pid is a MagicMock -> tree kill refuses it
+        proc.kill = mock.MagicMock(side_effect=ProcessLookupError())
+        proc.communicate = mock.AsyncMock(side_effect=RuntimeError("already reaped"))
+        await pc.kill_and_reap(proc)
+
+    @pytest.mark.asyncio
+    async def test_repeat_cancellation_does_not_abandon_cleanup(self) -> None:
+        """A second Task.cancel() landing mid-cleanup is a BaseException that
+        escapes ``suppress(Exception)``: without the shield it aborts the
+        cleanup before the reap, leaving the killed child un-drained. The
+        helper must finish the kill + reap, then re-deliver the cancellation
+        exactly once."""
+        import asyncio
+        from unittest import mock
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        events: list[str] = []
+
+        class Proc:
+            pid = 4242
+
+            def kill(self):
+                events.append("killed")
+
+            async def communicate(self):
+                events.append("reap-started")
+                started.set()
+                await release.wait()
+                events.append("reaped")
+                return b"", b""
+
+        async def _caller():
+            with mock.patch.object(pc, "kill_process_tree_async", mock.AsyncMock()):
+                await pc.kill_and_reap(Proc())
+
+        task = asyncio.ensure_future(_caller())
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()  # the repeat cancellation that used to abort the reap
+        await asyncio.sleep(0)
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert events == ["killed", "reap-started", "reaped"]

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1568,10 +1568,11 @@ def test_bundled_skill_assets_are_not_imported():
 
 _GATEWAY_REL = "slack/gateway.py"
 
-#: Functions that own the kill-the-tree + bounded-reap contract. The module
-#: helper lives in `platform/update_provider.py`; the two `_startup_child`
-#: methods are the boot-path equivalent (kill and reap split in two).
-_TREE_KILL_FUNCS = frozenset({"_kill_and_reap", "_kill_startup_child"})
+#: Functions that own the kill-the-tree + bounded-reap contract. The shared
+#: helper is `platform_compat.kill_and_reap` (`_kill_and_reap` is its delegate
+#: in `platform/update_provider.py`); the two `_startup_child` methods are the
+#: boot-path equivalent (kill and reap split in two).
+_TREE_KILL_FUNCS = frozenset({"kill_and_reap", "_kill_and_reap", "_kill_startup_child"})
 
 
 @functools.cache


### PR DESCRIPTION
## Problem

Ten call sites across six modules shared one defect shape: a child process spawned with PIPE stdio is awaited via `asyncio.wait_for(proc.communicate(), timeout=...)`, and on timeout is killed with `proc.kill()` and then reaped with a bare `await proc.wait()`. Because `wait_for` has already cancelled the pipe readers, a killed child blocked writing into a full stderr pipe is never drained, so `wait()` can hang the calling task indefinitely. `proc.kill()` also signals only the direct child, so a shell-spawned pipeline leaves members alive holding the pipes open.

Sites: `dashboard/handlers/memory.py` (ensurepip + faiss install), `instances/token_mint.py` (mint + remote exec), `apps/lifecycle_scripts.py`, `apps/registry.py` (`_communicate_with_timeout` + `_kill_process_group` escalation tail), `apps/builtins/dev_fleet/server.py` (`_run_cmd` timeout/cancel arms + `_start_run` stream-error reap), `apps/builtins/ops_mission_control/backend/providers/github_issues.py` (`_run_gh`).

The same defect was fixed point-wise in #5834, #5821/#5833, and #5975; this is the cause-level follow-up (#5989) asking for a shared helper instead of more point patches.

## Why it matters

Each of these paths runs on the gateway's single event loop. A hang here wedges the owning task forever: a timed-out `gh` poll wedges Ops Mission Control's polling, a timed-out pip install wedges the embeddings-enable handler, a timed-out lifecycle script wedges app install/uninstall, and a timed-out SSH mint wedges instance token flow. Killed-but-unreaped pipeline descendants also leak and keep pipes open until gateway restart.

## Fix

Symptoms → root cause → change:

- **Root cause**: post-kill reaping via `wait()` on undrained pipes, and pid-scoped kills on tree-spawning commands, duplicated at every site.
- **Change**: promote `update_provider._kill_and_reap` — the already-correct private implementation — to a public `platform_compat.kill_and_reap` (+ `REAP_TIMEOUT_SECS`), and route all ten sites through it. `platform_compat` already owns `kill_process_tree_async` and `SIGKILL`, so the move removes the helper's function-local import rather than adding one.
- The helper tree-kills via `kill_process_tree_async`, backs up with a pid-scoped `proc.kill()`, and reaps through a **bounded `communicate()`** that drains the pipes. Hardened during review: the whole cleanup runs in a **shielded inner task**, so a (repeat) cancellation landing mid-cleanup cannot abandon the kill or leave the child un-reaped — it is absorbed until cleanup finishes, then re-delivered once. A child sharing the gateway's own process group (spawned without `start_new_session`) skips the group signal quietly instead of tripping `kill_process_tree`'s broadcast guard's ERROR log on every routine timeout.
- `update_provider` keeps `_kill_and_reap` as a thin delegate (with its module-local `_REAP_TIMEOUT_SECS` still bounding the reap and still patchable), so its tests and `slack/gateway.py`'s ~17 function-local-import call sites keep working unchanged. `slack/gateway.py` itself is untouched.
- `lifecycle_scripts.py` keeps its graceful SIGTERM and gains a **bounded grace window** (`_TERM_GRACE_SECS = 5`, mirroring `registry._KILL_GRACE_PERIOD`): a script's TERM trap can run to exit, and only a child that ignores the TERM is escalated to the SIGKILL helper. Previously the grace was unbounded (the hang being fixed).
- `apps/registry.py:_communicate_with_timeout` keeps its tree-kill-first behavior; only the unbounded reap changed. Its previous `except OSError` fallback let a non-OSError kill failure (e.g. the non-int-pid `ValueError` guard) escape and crash the caller; the helper's best-effort contract removes that latent bug.
- `dev_fleet` keeps its deliberately stronger `_kill_tree` (escaped-group sweep) and uses the helper only for the kill + reap tail.

**Excluded** (`await proc.wait()` occurrences that do NOT match the defect shape — plain exit-status waits on a drained/healthy child): `registry.py` `_drain()` post-EOF wait in the build runner, `dev_fleet/server.py` `rc = await proc.wait()` after the readline loop hits EOF, and `update_provider._read_bounded_output`'s wait after both pipes are drained to EOF.

## Tests

Every converted site is pinned by a regression test proven non-vacuous: with the source fix stashed and the tests kept, **19 pins go red on unmodified code** (16 in the first round, plus the repeat-cancellation pin, the grace-window pin, and the `_kill_process_group` escalation pin), and all are green with the fix.

- New `TestKillAndReap` in `test/test_platform_compat.py`: tree-then-pid kill order, reap via `communicate()` never `wait()`, bounded reap, dead-child/mock-pid tolerance, and repeat-cancellation shielding.
- Per-site pins in `test_handlers_memory_coverage.py`, `test_enable_embeddings_faiss.py`, `test_instances.py`, `test_lifecycle_scripts_cov80.py`, `test_apps_registry.py`, `test_dev_fleet_app.py`, `test_dev_fleet_server_more_coverage.py`, and `ops_mission_control/tests/test_providers.py`, following the pattern from #5838/#5985 (`wait()` never awaited; reap is a second `communicate()`).
- Test doubles extended for interface parity (`communicate` counters); every test reaching the helper's tree kill with a fake int pid patches `kill_process_tree_async` so no test can reach a real `killpg` on the host.
- `test_spawn_audit.py`'s `_TREE_KILL_FUNCS` ratchet now also recognizes the public `kill_and_reap` name.

Local gates: isort, flake8, mypy (1105 files), black/subprocess-encoding/brand/harness-parity diff gates, and 2103 targeted tests across 15 files — all green.

## Manual verification

Two model-pinned pre-push reviews ran against this branch (GPT 5.6 Sol and Opus 5, read-only, mirroring the repo's reviewer charters). All five findings were fixed in this revision: repeat-cancellation cleanup abandonment (High), two tests reaching a real `killpg` with a fake pid (BLOCKING), zero TERM grace in lifecycle scripts (Medium), ERROR-log noise at non-session-leader sites (Medium-low), and the spawn-audit ratchet gap (Low).

## Screenshots

N/A — backend-only change, no user-visible dashboard or app state.

Closes #5989
