### PR TITLE
fix(desktop): don't nag a downgrade when running ahead of the channel feed

### DIFF
--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -345,6 +345,97 @@ function resolveChannel(stamped, preference) {
 }
 
 /**
+ * Is `candidate` a STRICTLY NEWER version than `current`? Returns null when the
+ * comparison cannot be made (either string unparseable, or semver unavailable).
+ *
+ * Uses electron-updater's own bundled `semver` so the ordering matches the
+ * library's, and understands the prerelease stamps this app ships
+ * (`0.3.0-insider.13`, `0.1.2-nightly.<ts>`). `require`d inline — like the
+ * `fs`/`child_process` requires elsewhere in this module — so the pure helper
+ * stays loadable outside an Electron runtime; a stubbed/absent semver yields
+ * null (fail-open) rather than throwing.
+ *
+ * @param {string} candidate
+ * @param {string} current
+ * @returns {boolean|null}
+ */
+function isNewerVersion(candidate, current) {
+  if (!candidate || !current) return null;
+  let semver;
+  try {
+    semver = require("semver");
+  } catch {
+    return null;
+  }
+  const a = semver.valid(candidate) || semver.valid(semver.coerce(candidate));
+  const b = semver.valid(current) || semver.valid(semver.coerce(current));
+  if (!a || !b) return null;
+  try {
+    return semver.gt(a, b);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Should a discovered version drive the AUTOMATIC update path — the background
+ * download and the "update found" nudge?
+ *
+ * - YES for a genuine upgrade (candidate strictly newer than the running build).
+ * - YES for ANY version when the FOLLOWED channel differs from the build's own
+ *   DEFAULT (no-preference) channel: that is a deliberate channel switch — the
+ *   user's stored preference has actively moved this install off the lane it
+ *   would otherwise follow — where landing on an older build of the chosen
+ *   channel is the intended, user-initiated outcome `allowDowngrade=true` exists
+ *   for.
+ * - NO for a same-channel version that is NOT newer than the running build.
+ *   That is a build running AHEAD of what its own channel has published
+ *   (locally-built or prerelease bytes ahead of the feed): from that channel's
+ *   point of view there is nothing to install, so electron-updater's
+ *   difference-based `update-available` (which fires for any version ≠ running,
+ *   because allowDowngrade=true) would otherwise nag a DOWNGRADE. This is the
+ *   bug this guard closes.
+ *
+ * **Why the switch signal is the DEFAULT lane, not the byte stamp.** A promoted
+ * stable release ships the soaked insider candidate's exact bytes, so its
+ * version keeps the insider stamp (`0.3.0-insider.13`) and `channelForVersion`
+ * reports `insider` for a build that is, in fact, a stable install following the
+ * stable feed with no deliberate switch. Keying the exemption on that raw stamp
+ * (`followed=stable !== stamped=insider`) therefore fired for the ENTIRE
+ * promoted-stable population — and for any prerelease-stamped build running ahead
+ * of stable (`0.5.0-insider.20`) — re-opening the exact downgrade nag this guard
+ * removes. So the comparison uses `defaultChannel = resolveChannel(stamped, "")`
+ * (the lane with no preference, which folds promoted-insider bytes to stable),
+ * and the exemption fires only when the FOLLOWED channel differs from THAT — i.e.
+ * an explicit preference actually moved the install to a non-default lane.
+ *
+ * `allowDowngrade` stays true, so a real channel switch and any EXPLICIT user
+ * download still roll the version; only the unsolicited auto-path is suppressed.
+ *
+ * Fail-open: an unrankable comparison (isNewerVersion → null) is treated as
+ * offerable, so a version we cannot compare is never silently hidden.
+ *
+ * TRADE-OFF (deliberate, not accidental): a same-channel version RETRACTION —
+ * the feed intentionally repointed to an older build — also reads as "not
+ * newer, same channel" and is therefore no longer auto-applied. The client
+ * cannot tell a retraction from an ahead-of-feed dev build by version alone, and
+ * silently DOWNGRADING a user on the next restart is the more dangerous default,
+ * so the safe direction is to not auto-act. A deliberate `retracted` feed flag
+ * could re-enable that path explicitly in future.
+ *
+ * @param {{candidate:string, current:string, followedChannel:string, defaultChannel:(string|null)}} o
+ * @returns {boolean}
+ */
+function shouldAutoOffer({ candidate, current, followedChannel, defaultChannel }) {
+  if (followedChannel && defaultChannel && followedChannel !== defaultChannel) {
+    return true;
+  }
+  const newer = isNewerVersion(candidate, current);
+  if (newer === null) return true;
+  return newer;
+}
+
+/**
  * Build the per-channel feed DIRECTORY url for the generic provider. Pure +
  * testable.
  *
@@ -1142,6 +1233,14 @@ function initAutoUpdate(deps) {
   let installing = false;
   let quitHandled = false;
   let checking = false;
+  // The channel the LAST configureFeed() pointed the updater at. Captured at
+  // check time because the update-available handler's direction gate must
+  // compare the candidate against the channel its FEED was configured for, not
+  // against a live currentChannel() read: the preference can flip mid-flight
+  // (an in-flight stable check, then the user picks insider), and re-reading it
+  // in the handler would treat a stable-feed downgrade as a deliberate insider
+  // switch and stage it. Null until the first configureFeed().
+  let feedChannel = null;
 
   /**
    * Version of the update currently being fetched/held -- NOT the running
@@ -1183,6 +1282,10 @@ function initAutoUpdate(deps) {
 
   function configureFeed() {
     const channel = currentChannel();
+    // Record the channel this check's feed is configured for, so the
+    // update-available handler compares the candidate against THIS lane rather
+    // than a currentChannel() that may have changed since (see feedChannel).
+    feedChannel = channel;
     // A package install reads its channel file from a per-format subdirectory,
     // so the two Linux formats never overwrite each other's metadata.
     const url = buildFeedBase({ base: feedBase, channel, variant: linux.format });
@@ -1590,6 +1693,50 @@ function initAutoUpdate(deps) {
   // and the consent paths share one guarded entry point (startDownload).
   autoUpdater.on("update-available", (info) => {
     foundVersion = (info && info.version) || null;
+    // Direction gate — the fix for the "update to an OLDER version" nag.
+    // electron-updater fires this for ANY feed version that DIFFERS from the
+    // running one, because allowDowngrade=true — so on a build running ahead of
+    // its channel's published latest it reports a DOWNGRADE as available. When
+    // this is a same-channel version that is not newer, suppress the automatic
+    // path entirely: discard any stage armed for it, report up to date, and do
+    // NOT download or nag. A deliberate channel switch (followed !== default
+    // lane) is exempt, and explicit user downloads are unaffected.
+    if (
+      foundVersion &&
+      !shouldAutoOffer({
+        candidate: foundVersion,
+        current: app.getVersion(),
+        // The channel THIS candidate's feed was configured for, captured at
+        // check time (feedChannel), NOT a live currentChannel() read. If the
+        // preference flipped while this check was in flight, a live read would
+        // pair the new channel with the OLD feed's candidate and wrongly treat
+        // a stale-feed downgrade as a deliberate switch. Falls back to a live
+        // read only before the first configureFeed() has run.
+        followedChannel: feedChannel || currentChannel(),
+        // The lane this build follows with NO preference. Folds a promoted
+        // stable build's insider-stamped bytes back to stable, so only an
+        // explicit preference that MOVES the install off its default lane reads
+        // as a deliberate channel switch (see shouldAutoOffer).
+        defaultChannel: resolveChannel(channelForVersion(app.getVersion()), ""),
+      })
+    ) {
+      log.info(
+        `[update] feed offers ${foundVersion} but running ${app.getVersion()} is not older `
+          + "on the same channel — treating as up to date (suppressing downgrade nag)",
+      );
+      if (updateReady || stagedVersion) {
+        // A downgrade staged before this guard existed (or by a race) must not
+        // survive to install on the next quit.
+        updateReady = false;
+        stagedVersion = null;
+        stagedNotes = "";
+        quitHandled = false;
+        app.removeListener("before-quit", deferredInstallOnQuit);
+      }
+      foundVersion = null;
+      emit("not-available");
+      return;
+    }
     // A stage is only useful if it is still the latest thing on the feed.
     // Because the RUNNING version never changes mid-session, the updater
     // reports "available" for the staged version too — so the comparison
@@ -1704,6 +1851,8 @@ module.exports = {
   channelForFlavor,
   channelForVersion,
   resolveChannel,
+  isNewerVersion,
+  shouldAutoOffer,
   buildFeedBase,
   configureUpdater,
   classifyError,

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -5,6 +5,8 @@ const {
   channelForFlavor,
   channelForVersion,
   resolveChannel,
+  isNewerVersion,
+  shouldAutoOffer,
   buildFeedBase,
   configureUpdater,
   readExternallyManaged,
@@ -194,6 +196,206 @@ test("configureUpdater: allowDowngrade=true (difference-based gate: retraction +
   // based: a feed repointed to an older version (retraction) or a stable
   // preference on an insider build (switch-back downgrade) must be offered.
   assert.strictEqual(updater.allowDowngrade, true);
+});
+
+// ---------------------------------------------------------------------------
+// Downgrade-nag guard: allowDowngrade=true means the library reports
+// "available" for ANY feed version that differs from the running one, so a
+// build running AHEAD of its channel's published latest gets nagged to install
+// an OLDER build. isNewerVersion + shouldAutoOffer are the direction gate that
+// suppresses that automatic path while leaving deliberate channel switches and
+// explicit downloads alone.
+// ---------------------------------------------------------------------------
+
+test("isNewerVersion: strictly-greater release core is newer, older/equal is not", () => {
+  assert.strictEqual(isNewerVersion("0.5.0", "0.3.0"), true);
+  assert.strictEqual(isNewerVersion("0.3.0", "0.5.0"), false); // the reported bug
+  assert.strictEqual(isNewerVersion("1.0.0", "1.0.0"), false);
+});
+
+test("isNewerVersion understands the prerelease stamps this app ships", () => {
+  // A prerelease sorts BELOW its release core; a higher core wins regardless.
+  assert.strictEqual(isNewerVersion("0.3.0-insider.13", "0.3.0"), false);
+  assert.strictEqual(isNewerVersion("0.3.0", "0.3.0-insider.13"), true);
+  assert.strictEqual(isNewerVersion("0.5.0-nightly.20260801t000000", "0.3.0"), true);
+});
+
+test("isNewerVersion: unrankable input is null (fail-open, never a false 'not newer')", () => {
+  assert.strictEqual(isNewerVersion("", "1.0.0"), null);
+  assert.strictEqual(isNewerVersion("1.0.0", undefined), null);
+});
+
+test("shouldAutoOffer: same-channel downgrade is NOT offered (the fix)", () => {
+  // Exactly the reported case: a stable-stamped 0.5.0 following the stable feed
+  // whose latest published build is 0.3.0.
+  assert.strictEqual(
+    shouldAutoOffer({
+      candidate: "0.3.0",
+      current: "0.5.0",
+      followedChannel: "stable",
+      defaultChannel: "stable",
+    }),
+    false,
+  );
+});
+
+test("shouldAutoOffer: same-channel upgrade IS offered", () => {
+  assert.strictEqual(
+    shouldAutoOffer({
+      candidate: "0.6.0",
+      current: "0.5.0",
+      followedChannel: "stable",
+      defaultChannel: "stable",
+    }),
+    true,
+  );
+});
+
+test("shouldAutoOffer: a deliberate channel switch is exempt (followed != default lane)", () => {
+  // The user's explicit preference moved this install OFF its default lane
+  // (stable -> insider): landing on an older build of the chosen channel is the
+  // intended, user-initiated outcome allowDowngrade exists for.
+  assert.strictEqual(
+    shouldAutoOffer({
+      candidate: "0.3.0-insider.4",
+      current: "0.5.0",
+      followedChannel: "insider",
+      defaultChannel: "stable",
+    }),
+    true,
+  );
+});
+
+test("shouldAutoOffer: promoted-stable bytes are NOT read as a switch (byte-stamp trap)", () => {
+  // A promoted stable build carries the insider stamp, but with no preference it
+  // follows stable and its DEFAULT lane is also stable, so followed == default:
+  // it is a same-channel install and a lower feed version must NOT be offered.
+  // (Keying on the raw stamp — insider — would wrongly exempt it.)
+  assert.strictEqual(
+    shouldAutoOffer({
+      candidate: "0.3.0",
+      current: "0.5.0-insider.20",
+      followedChannel: "stable",
+      defaultChannel: "stable",
+    }),
+    false,
+  );
+});
+
+test("shouldAutoOffer: an unrankable version is offered (fail-open, no silent hide)", () => {
+  assert.strictEqual(
+    shouldAutoOffer({
+      candidate: "garbage",
+      current: "0.5.0",
+      followedChannel: "stable",
+      defaultChannel: "stable",
+    }),
+    true,
+  );
+});
+
+test("guard: a same-channel downgrade neither nags nor auto-downloads", async () => {
+  // Reproduces the screenshots: stable-stamped 0.5.0 on the stable feed, feed
+  // latest is 0.3.0, auto-download ON. The pre-fix behavior downloaded 0.3.0
+  // and popped "Update ready"; the guard must report up to date instead.
+  const seen = [];
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "0.5.0" });
+  deps.getAutoDownloadPreference = () => true;
+  deps.notifyUpdateFound = (v, o) => seen.push([v, o]);
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "0.3.0", releaseNotes: "older" });
+  assert.strictEqual(calls.downloadUpdate, 0, "a same-channel downgrade must never auto-download");
+  assert.deepStrictEqual(seen, [], "a same-channel downgrade must never fire the OS nudge");
+  assert.ok(!states.some((s) => s.state === "found"), "must not surface a 'found' downgrade");
+  assert.strictEqual(states.at(-1).state, "not-available", "reports up to date instead");
+});
+
+test("guard: a same-channel UPGRADE still auto-downloads (no regression)", async () => {
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "0.5.0" });
+  deps.getAutoDownloadPreference = () => true;
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "0.6.0", releaseNotes: "newer" });
+  assert.strictEqual(calls.downloadUpdate, 1, "a real upgrade must still download");
+  assert.ok(states.some((s) => s.state === "found"), "a real upgrade must still surface 'found'");
+});
+
+test("guard: a prerelease-stamped build ahead of stable is NOT nagged (byte-stamp trap)", async () => {
+  // The regression both local reviewers caught: an insider-STAMPED build
+  // (0.5.0-insider.20) with no channel preference follows the STABLE feed by
+  // default. channelForVersion() reports 'insider' for the bytes, but the
+  // install is a plain stable follower running ahead of the stable feed's 0.3.0.
+  // Keying the switch exemption on the raw stamp would treat followed=stable !=
+  // stamped=insider as a deliberate switch and re-open the downgrade nag; keying
+  // it on the DEFAULT lane (also stable) correctly reads it as same-channel.
+  const seen = [];
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "0.5.0-insider.20" });
+  deps.getAutoDownloadPreference = () => true;
+  deps.notifyUpdateFound = (v, o) => seen.push([v, o]);
+  // No getChannelPreference override -> defaults to "" -> follows stable.
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "0.3.0", releaseNotes: "older stable" });
+  assert.strictEqual(calls.downloadUpdate, 0, "a promoted/ahead build must not auto-download a downgrade");
+  assert.deepStrictEqual(seen, [], "no OS nudge for a byte-stamp-only channel mismatch");
+  assert.ok(!states.some((s) => s.state === "found"), "must not surface a 'found' downgrade");
+  assert.strictEqual(states.at(-1).state, "not-available");
+});
+
+test("guard: an EXPLICIT channel switch off the default lane is still offered", async () => {
+  // Stable-stamped build whose user explicitly picked insider: the preference
+  // moves it off its default (stable) lane, so a lower insider build is a
+  // deliberate switch and must still be offered.
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "0.5.0" });
+  deps.getAutoDownloadPreference = () => true;
+  deps.getChannelPreference = () => "insider";
+  const u = initAutoUpdate(deps);
+  await u.check();
+  emit("update-available", { version: "0.4.0-insider.1", releaseNotes: "insider lane" });
+  assert.strictEqual(calls.downloadUpdate, 1, "a deliberate channel switch must still download");
+  assert.ok(states.some((s) => s.state === "found"), "a deliberate switch must surface 'found'");
+});
+
+test("guard: a channel flip mid-check does not authorize a stale-feed downgrade (TOCTOU)", async () => {
+  // The GPT [BLOCK-MERGE] on #6011: an in-flight STABLE check, then the user
+  // picks insider before the response lands. The candidate (0.3.0) came from
+  // the stable feed the check configured; the guard must compare against THAT
+  // captured lane (feedChannel), not the now-insider live preference. A live
+  // read would make followedChannel=insider != default=stable, wrongly treat
+  // the stable downgrade as a deliberate insider switch, and stage it.
+  let pref = "";
+  const { deps, calls, emit, states } = makeDeps({ appVersion: "0.5.0" });
+  deps.getAutoDownloadPreference = () => true;
+  deps.getChannelPreference = () => pref;
+  const u = initAutoUpdate(deps);
+  await u.check(); // configureFeed() captures feedChannel = "stable"
+  pref = "insider"; // user flips the switcher while the check is in flight
+  emit("update-available", { version: "0.3.0", releaseNotes: "stale stable feed" });
+  assert.strictEqual(calls.downloadUpdate, 0, "a stale-feed downgrade must not download after a mid-check channel flip");
+  assert.ok(!states.some((s) => s.state === "found"), "must not surface a 'found' downgrade");
+  assert.strictEqual(states.at(-1).state, "not-available");
+});
+
+test("guard: a stage armed for a downgrade is discarded and disarmed", async () => {
+  // A 0.3.0 stage carried over (from before the fix, or a race): a later check
+  // that re-reports 0.3.0 on the same channel must drop it so it cannot install
+  // on the next quit.
+  const { deps, emit, states, appRemoved } = makeDeps({ appVersion: "0.5.0" });
+  deps.getAutoDownloadPreference = () => true;
+  const u = initAutoUpdate(deps);
+  await u.check();
+  // Force a staged state by driving the downloaded event directly.
+  emit("update-downloaded", { version: "0.3.0" });
+  assert.strictEqual(u.isReady(), true, "precondition: a stage exists");
+  states.length = 0;
+  emit("update-available", { version: "0.3.0" });
+  assert.strictEqual(u.isReady(), false, "the downgrade stage must be discarded");
+  assert.ok(
+    appRemoved.some((r) => r.ev === "before-quit"),
+    "the deferred-install-on-quit hook must be removed",
+  );
+  assert.strictEqual(states.at(-1).state, "not-available");
 });
 
 test("configureUpdater: allowPrerelease=true (nightly/insider stamps are semver prereleases)", () => {


### PR DESCRIPTION
## Problem / Motivation

On the desktop app, a build running **ahead** of its channel's published latest is prompted to "update" to an **older** version. Reported case: running **v0.5.0** on the **Stable** channel, the About panel and the "Update ready" modal offer *Kiro Crew 0.3.0*, and with **Auto-update on restart** on it auto-downloads the 0.3.0 downgrade and stages it for the next restart.

## Why it matters

Any user whose installed build is newer than the channel's latest published release — a locally-built / prerelease build, or simply someone ahead of the current stable line — is nagged to downgrade, and with auto-download on is silently rolled back to an older version on their next restart. That erodes trust in the updater and can revert a user off a newer build without consent.

## What changed (motivation → approach → change)

- **Symptom:** on 0.5.0, offered 0.3.0.
- **Root cause:** `configureUpdater` sets `autoUpdater.allowDowngrade = true` (deliberate — it supports channel switch-back and version retraction), so electron-updater's `update-available` fires for **any** feed version that *differs* from the running one, including an older one. The `update-available` handler took `info.version` and drove the found/download path with no direction check.
- **Change** (`website/electron/auto-update.js`):
  - Add `isNewerVersion(candidate, current)` — a semver comparison via electron-updater's bundled `semver`, understanding the `-insider.N` / `-nightly.<ts>` stamps this app ships; returns `null` (fail-open) on unrankable input.
  - Add `shouldAutoOffer({candidate, current, followedChannel, defaultChannel})` — the direction gate. It offers a genuine upgrade, and any version when the **followed** channel differs from the build's **default (no-preference)** lane (a deliberate channel switch), but **not** a same-channel version that is not newer.
  - The switch signal is derived from the **default lane**, not the raw byte stamp. A *promoted* stable build carries an insider stamp (`0.3.0-insider.13`) yet follows stable, so keying on `channelForVersion` would wrongly treat that whole population (and any prerelease-stamped build ahead of stable, e.g. `0.5.0-insider.20`) as "switched" and re-open the nag. `defaultChannel = resolveChannel(channelForVersion(version), "")` folds promoted-insider bytes back to stable.
  - New guard at the top of the `update-available` handler: a same-channel non-newer version now reports `not-available` and neither downloads nor nudges, and **discards any downgrade stage** armed for it (so a stage from before this fix cannot install on the next quit).
- `allowDowngrade` stays `true`: deliberate channel switches and explicit user downloads still roll the version.
- **Trade-off (documented):** a same-channel *retraction* is no longer auto-applied — it is indistinguishable from an ahead-of-feed build by version alone, and silently downgrading a user on restart is the riskier default. A future explicit `retracted` feed flag could re-enable that path deliberately.

## Tests

`website/electron/test/auto-update.test.js` (new cases):
- `isNewerVersion`: release-core ordering, prerelease-stamp ordering (`-insider.N` / `-nightly`), `null` on unrankable input.
- `shouldAutoOffer`: same-channel downgrade suppressed; same-channel upgrade offered; deliberate switch (followed ≠ default lane) offered; **promoted-stable byte-stamp trap** not read as a switch; unrankable fails open.
- Handler integration: a same-channel downgrade neither nags nor auto-downloads (reproduces the report); a same-channel **upgrade** still auto-downloads (no regression); a **prerelease-stamped build ahead of stable** is not nagged (byte-stamp trap); an **explicit channel switch** off the default lane is still offered; a stage armed for a downgrade is discarded and the `before-quit` hook removed.

Full electron suite: **1344 pass, 0 fail**. ESLint clean on the changed files.

## Manual verification

N/A — unit coverage sufficient. The updater module is written test-first with every Electron surface injected, so the found/download/stage lifecycle is exercised directly by the unit + integration tests above. No renderer/UI change.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** main-process updater logic only (`website/electron/auto-update.js`); no renderer output or UI pixels change.

## Related Issues

no linked issue: found during in-session diagnosis of the 0.5.0 → 0.3.0 downgrade nag; not separately tracked.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
