### PR TITLE
fix: exit the gateway stub with os._exit to stop shutdown SIGABRT

### DIFF
--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -31,7 +31,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.executors import configure_default_executor, subprocess_executor
@@ -2043,13 +2043,46 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
     return 0
 
 
+def _hard_exit(code: int) -> NoReturn:
+    """Terminate without interpreter finalization.
+
+    ``sys.exit()`` cannot be used here. The ``stub-stdin`` daemon thread parks
+    in ``sys.stdin.buffer.readline()`` for the life of the process, holding that
+    stream's lock, and interpreter finalization tries to flush and close the
+    same ``BufferedReader``. CPython cannot acquire the lock and aborts the
+    process with ``Fatal Python error: _enter_buffered_busy`` (SIGABRT, exit
+    134, core dumped) instead of returning ``code``.
+
+    Finalization is skipped, so do its two jobs that matter here explicitly:
+    ``logging.shutdown()`` drains handler buffers (the only handler is a
+    ``StreamHandler`` on stderr, configured in :func:`_amain`), then stderr is
+    flushed. stdout is deliberately NOT flushed here: every stdout frame is
+    written and flushed by the dedicated ``stub-stdout`` daemon writer thread,
+    which holds the buffer's lock while blocked on a stalled downstream pipe —
+    flushing from this thread would deadlock on that lock and the process
+    would never reach ``os._exit``. Nothing else is owed — the
+    atexit-registered thread-pool joins in ``kiro_crew.executors`` hold no
+    unflushed state, only threads the OS reclaims, and skipping them also
+    drops a teardown hang risk on a wedged filesystem read.
+    """
+    try:
+        logging.shutdown()
+    except Exception:  # pragma: no cover — never block exit on log teardown
+        pass
+    try:
+        sys.stderr.flush()
+    except (OSError, ValueError):
+        pass
+    os._exit(code)
+
+
 def main() -> None:
     """Sync entry point for ``python -m kiro_crew.mcp_gateway.stub``."""
     try:
         rc = asyncio.run(_amain())
     except KeyboardInterrupt:
         rc = 0
-    sys.exit(rc)
+    _hard_exit(rc)
 
 
 if __name__ == "__main__":

--- a/test/test_mcp_gateway_stub_shutdown.py
+++ b/test/test_mcp_gateway_stub_shutdown.py
@@ -1,0 +1,131 @@
+"""The stub must not exit through interpreter finalization.
+
+``stub-stdin`` is a daemon thread that parks in ``sys.stdin.buffer.readline()``
+for the life of the process, holding that ``BufferedReader``'s lock. Finalization
+flushes and closes the same stream, cannot take the lock, and aborts the process
+with ``Fatal Python error: _enter_buffered_busy`` (SIGABRT) instead of returning
+the exit code. :func:`_hard_exit` bypasses finalization after doing its two
+relevant jobs by hand.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from kiro_crew.mcp_gateway import stub
+
+
+class TestHardExit:
+    def test_drains_logging_then_flushes_stderr_then_exits(self, monkeypatch) -> None:
+        calls: list[str] = []
+
+        class _Stream:
+            def __init__(self, name: str) -> None:
+                self._name = name
+
+            def flush(self) -> None:
+                calls.append(f"flush:{self._name}")
+
+        monkeypatch.setattr(stub.logging, "shutdown", lambda: calls.append("logging"))
+        monkeypatch.setattr(stub.sys, "stdout", _Stream("out"))
+        monkeypatch.setattr(stub.sys, "stderr", _Stream("err"))
+        monkeypatch.setattr(stub.os, "_exit", lambda code: calls.append(f"exit:{code}"))
+
+        stub._hard_exit(3)
+
+        # logging.shutdown() drains handler buffers into stderr, so it has to run
+        # before stderr is flushed or those records are lost. stdout is owned by
+        # the stub-stdout writer thread (which flushes per frame and may hold the
+        # buffer lock while blocked on a stalled pipe), so _hard_exit must NOT
+        # touch it -- flushing it here could deadlock before os._exit.
+        assert calls == ["logging", "flush:err", "exit:3"]
+
+    def test_exit_still_fires_when_teardown_raises(self, monkeypatch) -> None:
+        codes: list[int] = []
+
+        class _BrokenStream:
+            def flush(self) -> None:
+                raise ValueError("I/O operation on closed file")
+
+        def _boom() -> None:
+            raise RuntimeError("handler already closed")
+
+        monkeypatch.setattr(stub.logging, "shutdown", _boom)
+        monkeypatch.setattr(stub.sys, "stdout", _BrokenStream())
+        monkeypatch.setattr(stub.sys, "stderr", _BrokenStream())
+        monkeypatch.setattr(stub.os, "_exit", lambda code: codes.append(code))
+
+        stub._hard_exit(0)
+
+        assert codes == [0]
+
+    def test_main_does_not_exit_through_finalization(self) -> None:
+        # Regression guard: sys.exit() on this path is what caused the abort.
+        src = inspect.getsource(stub.main)
+        assert "_hard_exit(rc)" in src
+        assert "sys.exit(rc)" not in src
+
+
+class TestHardExitEndToEnd:
+    """End-to-end proof, in a real subprocess, that the pattern the stub uses
+    exits cleanly under ``_hard_exit`` with the requested code intact.
+
+    Deliberately NOT exercised here: the ``sys.exit`` failure mode this PR
+    fixes. Reproducing it means aborting a child with SIGABRT, and every
+    platform's crash tooling persists an artifact somewhere no tmp dir can
+    contain (the kernel core pattern or a piped collector such as
+    systemd-coredump on Linux, ReportCrash on macOS, WER on Windows). The
+    regression is instead locked in by
+    ``TestHardExit.test_main_does_not_exit_through_finalization`` (main() must
+    call ``_hard_exit``, never ``sys.exit``) plus the ``_hard_exit`` unit
+    tests above -- together they fail if the fix is reverted, without ever
+    crashing a process.
+    """
+
+    _PROGRAM = textwrap.dedent("""
+        import os, sys, threading, time
+
+        def _reader():
+            sys.stdin.buffer.readline()   # parks holding the BufferedReader lock
+
+        threading.Thread(target=_reader, name="stub-stdin", daemon=True).start()
+        time.sleep(0.4)                   # let the thread reach the read
+        try:
+            sys.stderr.flush()
+        except (OSError, ValueError):
+            pass
+        os._exit(7)
+        """)
+
+    def _run(self, cwd: Path) -> tuple[int, str]:
+        # stdin must stay OPEN and silent: subprocess.run(stdin=PIPE) closes it
+        # immediately, readline() returns b"" at EOF, the thread exits, and the
+        # scenario no longer models the real stub. Holding the write end here
+        # is what parks the reader in the same state the real stub sits in.
+        proc = subprocess.Popen(
+            [sys.executable, "-c", self._PROGRAM],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+        )
+        try:
+            rc = proc.wait(timeout=60)
+            assert proc.stderr is not None
+            return rc, proc.stderr.read().decode("utf-8", "replace")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+            for handle in (proc.stdin, proc.stderr):
+                if handle is not None:
+                    handle.close()
+
+    def test_hard_exit_preserves_code(self, tmp_path: Path) -> None:
+        rc, err = self._run(cwd=tmp_path)
+        assert rc == 7, err
+        assert "_enter_buffered_busy" not in err


### PR DESCRIPTION
## Problem / Motivation

`python -m kiro_crew.mcp_gateway.stub` aborts on every shutdown instead of exiting with its return code.

`_blocking_reader` runs as the `stub-stdin` daemon thread and parks in `sys.stdin.buffer.readline()` for the life of the process, holding that `BufferedReader`'s lock. `main()` ended with `sys.exit(rc)`, whose interpreter finalization flushes and closes that same stream. CPython cannot acquire the lock, so it aborts rather than deadlock:

```
Fatal Python error: _enter_buffered_busy: could not acquire lock for
<_io.BufferedReader name='<stdin>'> at interpreter shutdown, possibly due to daemon threads
Python runtime state: finalizing
```

The process exits 134 (SIGABRT) and writes a core dump.

## Why it matters

The intended `rc` never reaches the caller, so a clean stub exit is indistinguishable from a crash — `_amain()` deliberately returns `1` on `bridge_liveness_dead` and `0` otherwise, and both currently surface as 134.

Every stub shutdown also emits a `Fatal Python error` block on stderr and drops a core file. That is noise in logs and crash reporters for a path that is not actually a crash, and it trains readers to ignore a message that elsewhere means something real.

## What changed (motivation → approach → change)

**Symptom** — exit 134 + `_enter_buffered_busy` on a normal shutdown.

**Root cause** — a daemon thread blocked in `sys.stdin.buffer.readline()` holds the `BufferedReader` lock that interpreter finalization needs in order to flush and close the same stream. This is inherent to the reader's design (it must stay parked to notice EOF), so the exit path is what has to change, not the thread.

**Approach considered and rejected** — closing or detaching stdin before `sys.exit()` still contends the same lock, and joining the reader is not possible because it is blocked on a read that only EOF ends.

**The change** — a `_hard_exit(code)` helper that does finalization's two relevant jobs by hand and then skips the rest:

1. `logging.shutdown()` drains handler buffers. `_amain()` configures `logging.basicConfig(stream=sys.stderr)` and the liveness-failure path logs immediately before returning, so omitting this would silently drop those records.
2. `sys.stderr` is flushed. `sys.stdout` is deliberately not touched: every stdout frame is written and flushed by the dedicated `stub-stdout` daemon writer thread, which can hold the buffer's lock while blocked on a stalled downstream pipe — flushing it from the exiting thread would deadlock before `os._exit`.
3. `os._exit(code)`.

Nothing else is owed at this point. The atexit-registered thread-pool joins in `kiro_crew.executors` hold no unflushed state — only threads the OS reclaims — and skipping them also removes a teardown hang risk on a wedged filesystem read, which is the same concern the surrounding code already offloads work to avoid. `crash_guard` is installed in `cli.py` and `slack/gateway.py`, not in the stub process, so no breadcrumb handler is bypassed.

Scope is one new function plus its single call site. Paths that run *before* the reader thread spawns are untouched and still use `sys.exit()`, where finalization is safe and preferable.

## Tests

`test/test_mcp_gateway_stub_shutdown.py`

| Test | Behavior locked in |
|---|---|
| `test_drains_logging_then_flushes_stderr_then_exits` | Exact ordering: `logging.shutdown()` runs **before** stderr is flushed (reversed, records buffered in the handler are lost), stdout is never flushed (its lock may be held by the blocked `stub-stdout` writer thread), and the code is passed through to `os._exit`. |
| `test_exit_still_fires_when_teardown_raises` | A raising `logging.shutdown()` and closed streams must not prevent the exit — teardown is best-effort, never a new failure mode. |
| `test_main_does_not_exit_through_finalization` | Source guard: `main()` contains `_hard_exit(rc)` and no longer contains `sys.exit(rc)`. |
| `test_hard_exit_preserves_code` (`TestHardExitEndToEnd`) | End-to-end in a real subprocess: with a `stub-stdin` daemon thread parked in `readline`, the flush-then-`os._exit` sequence returns the requested exit code cleanly. The originally-included aborting (`sys.exit`) counterpart was removed in review: an intentional SIGABRT leaves a crash artifact outside any temp dir on every platform (core pattern / systemd-coredump / ReportCrash / WER). The regression stays locked in by `test_main_does_not_exit_through_finalization` plus the `_hard_exit` units — reverting the fix fails 3 tests. |
| `test_hard_exit_preserves_code` | Same subprocess harness under `_hard_exit` returns 7 cleanly with no abort text. |

One harness detail worth flagging for reviewers: the parked-reader state only holds while stdin stays **open and silent**. `subprocess.run(stdin=PIPE)` closes it immediately, `readline()` hits EOF, the thread exits and the scenario stops modeling the real stub — so the test holds the write end open with `Popen`. A future refactor to `subprocess.run` would make the end-to-end test silently stop testing anything.

## Manual verification

Before automating it, the failure and the fix were confirmed by hand with a standalone script matching the stub's structure, run as `sleep 30 | python3 repro.py` on CPython 3.12.13: exit 134 with `_enter_buffered_busy` under `sys.exit`, exit 7 clean under the flush-then-`os._exit` sequence. The clean-exit half is now automated as `TestHardExitEndToEnd`; the aborting half remains manual-only evidence (recorded here), since automating it would persist crash artifacts outside the test's temp dir.

Gates run locally:

- 4/4 new tests pass
- 74 existing `mcp_gateway_stub` / `gatewayd_self_exit` / `gateway_pipe_death` tests pass, 2 skipped, no regressions
- `mypy src/kiro_crew/mcp_gateway/stub.py` — no issues
- `flake8` and `isort` — clean on both files
- `scripts/check_black_formatting.py` — passes. `stub.py` is listed in `.github/black-baseline.txt` (line 351), so it is deliberately left unformatted rather than carrying unrelated churn; the new test file is formatted with the pinned `black==26.3.1`
- `./scripts/docs-lint.sh` — 235 files scanned, all checks pass

Not done: exercising a live stub end-to-end under a real `kiro-cli` gateway. The change is on the process's final statement and is covered by the subprocess test, but a maintainer with a running gateway can confirm the observable difference is a clean exit code in place of 134.

## Pattern harvest

Rule candidate: grep/semgrep
Pattern: `sys.exit()` (or falling off `main`) in a long-lived process that starts a daemon thread parked in `sys.stdin.buffer.readline()` — interpreter finalization deadlocks on the `BufferedReader` lock and aborts with `_enter_buffered_busy` (SIGABRT), losing the exit code. Exit such processes via a flush-then-`os._exit` helper instead.

## Related Issues

None found — searched open PRs and issues for `_enter_buffered_busy`, `SIGABRT`, `hard_exit` and `stub shutdown` with no matches.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes; `docs-lint.sh` passes
- [x] No secrets, credentials, or internal references in the diff



