### PR TITLE
refactor(dashboard): consolidate three transcript-ts parsers into one

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1216,6 +1216,26 @@ function tsEpoch(ts: string | undefined): number | null {
   return Number.isNaN(ms) ? null : ms
 }
 
+/** THE parser for a transcript `ts` that may be a numeric epoch-SECONDS string
+ *  or an ISO string. Returns epoch MILLISECONDS, or `null` when the value
+ *  cannot be read — the same "decline, not guess" contract `tsEpoch` follows.
+ *
+ *  This is the single spelling of "seconds-or-ISO"; callers that need another
+ *  unit or a non-null sort default convert at the call site rather than
+ *  re-parsing (three hand-rolled copies had already diverged on
+ *  numeric-seconds input — #6004). `tsEpoch` above stays deliberately
+ *  `Date.parse`-only: its prior/warm boundary callers have never accepted a
+ *  numeric-seconds guess, and widening them would change merge behavior.
+ *
+ *  Exported for the unit test that pins this contract. */
+export function transcriptTsMs(ts: string | undefined): number | null {
+  if (!ts) return null
+  const n = Number(ts)
+  if (Number.isFinite(n)) return n * 1000
+  const ms = Date.parse(ts)
+  return Number.isNaN(ms) ? null : ms
+}
+
 /** The ONE writer of a slot's pane transcript and its "has older history" marker.
  *
  *  The two must describe the SAME array. A `true` beside a complete transcript
@@ -1499,15 +1519,6 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
     if (m.content) return [`txt:${m.role}:${m.content.trimEnd()}`]
     return []
   }
-  // Epoch ms for a transcript ts (numeric-seconds or ISO), or null = decline.
-  // Mirrors the refresh reducer's tsNum; used only by the no-overlap fallback.
-  const tsMs = (ts: string | undefined): number | null => {
-    if (!ts) return null
-    const n = Number(ts)
-    if (Number.isFinite(n)) return n * 1000
-    const p = Date.parse(ts)
-    return Number.isNaN(p) ? null : p
-  }
   const preserved: Array<{ msg: M; anchor: ThinkingAnchor | null; anchorIdx: number; confirmed: boolean }> = []
   for (let i = 0; i < existing.length; i++) {
     const m = existing[i]
@@ -1564,7 +1575,7 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
   let oldestPageMs: number | null = null
   if (coveredIdx < 0 && coverageSource.length > 0) {
     for (const m of coverageSource) {
-      const ms = tsMs(m.ts)
+      const ms = transcriptTsMs(m.ts)
       if (ms === null) { oldestPageMs = null; break }
       if (oldestPageMs === null || ms < oldestPageMs) oldestPageMs = ms
     }
@@ -1607,7 +1618,7 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
     if (used.has(p)) continue
     const { anchor, anchorIdx, confirmed } = preserved[p]
     const insideCoverage = anchorIdx >= 0 && anchorIdx <= coveredIdx
-    const anchorMs = anchorIdx >= 0 ? tsMs(existing[anchorIdx]?.ts) : null
+    const anchorMs = anchorIdx >= 0 ? transcriptTsMs(existing[anchorIdx]?.ts) : null
     const evicted = coveredIdx < 0 && oldestPageMs !== null && anchorMs !== null && anchorMs < oldestPageMs
     const droppable = anchor !== null && confirmed && (insideCoverage || evicted)
     if (!droppable) result.push({ ...preserved[p].msg })
@@ -4221,13 +4232,15 @@ const chatSlice = createSlice({
           const aid = m.meta?.approval_id as string | undefined
           if (aid && !statePerms.has(aid)) statePerms.set(aid, m)
         }
+        // Sort key from a transcript ts via the ONE shared parser (#6004).
+        // `?? 0` keeps unreadable/absent ts sorting first, as before. The
+        // comparator only needs a monotonic key, so the parser's native epoch
+        // ms works directly (the old local copy returned epoch seconds —
+        // scaling every readable key by 1000 preserves the order for every
+        // reachable timestamp).
         const tsNum = (v: unknown): number => {
           const s = v == null ? '' : String(v)
-          if (!s) return 0
-          const n = Number(s)
-          if (Number.isFinite(n)) return n  // numeric epoch
-          const p = Date.parse(s)
-          return Number.isFinite(p) ? p / 1000 : 0  // ISO → epoch seconds
+          return transcriptTsMs(s) ?? 0
         }
         const merged = [...messages.filter(m => m.role !== 'permission'), ...statePerms.values()]
         const mergedWithPastes = mergePreservedPastes(state.messages, merged)

--- a/website/src/test/ChatSliceCoverageSecondPass.test.tsx
+++ b/website/src/test/ChatSliceCoverageSecondPass.test.tsx
@@ -59,6 +59,7 @@ import chatReducer, {
   sseToolActivity,
   sseToolResult,
   switchSlot,
+  transcriptTsMs,
   truncateAfterIndex,
 } from '../store/chatSlice'
 import dashboardReducer, { addSlotOptimistic } from '../store/dashboardSlice'
@@ -139,6 +140,32 @@ beforeEach(() => {
   apiMock.setSlotColor.mockResolvedValue({})
   apiMock.chatSlotProject.mockResolvedValue({})
   apiMock.deleteChatSlot.mockResolvedValue({})
+})
+
+describe('transcriptTsMs — the ONE transcript seconds-or-ISO parser (#6004)', () => {
+  // chatSlice used to carry three hand-rolled ts parsers that disagreed on
+  // numeric-seconds input. This pins the single shared contract so a unit
+  // flip, a dropped numeric branch, or a guessed non-null default fails CI.
+  // (It cannot pin the ABSENCE of a future hand-rolled copy — reviewers own
+  // that; route new callers through transcriptTsMs.)
+  it('reads a numeric epoch-seconds string as epoch milliseconds', () => {
+    expect(transcriptTsMs('1724650000')).toBe(1724650000000)
+    expect(transcriptTsMs('1724650000.5')).toBe(1724650000500)
+  })
+
+  it('reads an ISO string as epoch milliseconds', () => {
+    expect(transcriptTsMs('2026-08-26T06:00:00Z')).toBe(Date.parse('2026-08-26T06:00:00Z'))
+    // Offset-aware and Z spellings of the same instant agree — the reason
+    // parse-before-order exists at all (raw strings order by text).
+    expect(transcriptTsMs('2026-08-26T15:00:00+09:00')).toBe(transcriptTsMs('2026-08-26T06:00:00Z'))
+  })
+
+  it('declines (null, never a guessed number) on undefined, empty, and malformed input', () => {
+    expect(transcriptTsMs(undefined)).toBeNull()
+    expect(transcriptTsMs('')).toBeNull()
+    expect(transcriptTsMs('not-a-date')).toBeNull()
+    expect(transcriptTsMs('Infinity')).toBeNull()
+  })
 })
 
 describe('chatSlice transcript equality on a repeat slot fetch', () => {
@@ -519,8 +546,8 @@ describe('chatSlice slot-detail refresh merges', () => {
     expect(perms.find(m => m.meta?.approval_id === 'ap-1')?.meta?.resolved).toBe('approved')
     // The server-only approval is adopted, not dropped.
     expect(perms.find(m => m.meta?.approval_id === 'ap-2')).toBeDefined()
-    // A row with no ts sorts to the front (epoch 0); the ISO row parses to the
-    // same second as ap-1 rather than to a millisecond value.
+    // A row with no ts sorts to the front (key 0); numeric-seconds and ISO
+    // rows both key as epoch ms via the shared transcriptTsMs parser (#6004).
     expect(s.messages[0].content).toBe('no stamp')
     expect(s.messages.map(m => m.content)).toContain('oldest')
   })


### PR DESCRIPTION
# What is the problem?

`website/src/store/chatSlice.ts` carried three hand-rolled transcript-timestamp parsers that disagree on numeric-seconds input:

- `tsEpoch` (module scope, ~1213): `Date.parse` only -- declines a numeric epoch-seconds string.
- `tsMs` (function-local, ~1504, added by #5802): numeric-seconds or ISO, returns epoch **ms**.
- `tsNum` (function-local, ~4224): numeric-seconds or ISO, returns epoch **seconds**, `0` default for sorting.

Each new consumer picked or re-invented a spelling, and the copies had already diverged: the same numeric-seconds `ts` parses to `null`, `n*1000` ms, or `n` seconds depending on which function a caller reaches.

# Why this issue matters to the user

The transcript merge/sort paths these parsers feed decide which chat rows survive a refresh and in what order they render. Three diverging parsers means the next caller silently inherits whichever behavior it happens to sit near, and a future edit to one copy cannot fix the others -- the exact drift class that produced #5798-style transcript bugs. One parser with a pinned contract removes the trap.

# How our fix solves it

Chain from symptom to root cause: the divergence exists because the seconds-or-ISO parse was re-implemented per call site instead of shared. The fix makes the parse exist once:

- **One module-scope parser** `transcriptTsMs(ts)` beside `tsEpoch`: numeric epoch-seconds or ISO string -> epoch **ms**, `null` = decline (the same "decline, not guess" contract `tsEpoch` follows). Its body is token-identical to the old `tsMs`, so the two rewired `tsMs` call sites (no-overlap fallback, anchor eviction) are a pure substitution.
- **`tsNum` becomes a thin sort-key adapter**: `transcriptTsMs(s) ?? 0`. The key's unit flips seconds -> ms, which is order-preserving for a comparator: both branches scale by exactly x1000 (numeric `n` -> `n*1000`, ISO `p/1000` -> `p`), branch classification is character-identical, and `?? 0` reproduces the old `return 0` on the same three decline paths. Verified by an exhaustive pairwise order comparison over 40 edge inputs (empty/whitespace/hex/exponent/negative/`Infinity`/mixed formats): zero reachable divergence.
- **`tsEpoch` is deliberately untouched.** Its only two callers are the prior/warm boundary check in `warmSlotCache.fulfilled`; they have never accepted a numeric-seconds guess, and widening them would change which array survives a warm -- an observable behavior change the issue's pure-refactor constraint forbids. The new parser's doc records this so the asymmetry is a decision, not an accident.

# What tests we did

- New pin suite for `transcriptTsMs` (exported for this test): numeric-seconds string, fractional seconds, ISO with `Z` and offset spellings of the same instant, and decline (`null`, never a guessed number) on `undefined`/empty/malformed/`Infinity`.
- Mutation-verified: flipping the parser's unit fails 2 tests; deleting the numeric branch fails 1 test.
- Pre-existing mixed-format sort test (missing ts + ISO + numeric epochs) passes unchanged -- identical order before/after.
- Full local gates: `npx tsc -b` clean, website vitest suite 24,296 passed / 0 failed (1 expected fail, 3 skipped), targeted suite 78/78, `eslint --max-warnings 0` clean, jscpd 0 clones, scrub-lint clean. The electron node:test lane shows 26 `cancelledByParent` cancellations in `gateway-stop.test.js` in this dev environment on base and branch alike (zero file overlap with this diff).
- Two independent model-pinned pre-push reviews (GPT + Opus lanes): NO BLOCKING FINDINGS; all three advisory comment-accuracy items were folded into this commit.

# Any other suggestions on the work

The pin test cannot assert the ABSENCE of a future fourth hand-rolled copy (a mutation re-introducing a local copy at a call site stays green); the test comment now states that limit explicitly and routes new callers to `transcriptTsMs`. Unifying `tsEpoch`'s callers onto the shared parser would be a deliberate behavior change to the warm-merge staleness check and belongs to its own issue if ever wanted.

Closes #6004
