### PR TITLE
fix(chat): drop stopped-turn thinking chips once covered (#5815)

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1429,11 +1429,18 @@ type ThinkingAnchor = { tool: string; text?: undefined; ts?: undefined } | { too
  *  it in the old list and re-inserted just before that row again. Returns
  *  `incoming` unchanged (reference-equal) when there is nothing to preserve.
  *
- *  A block with NO recorded anchor (nothing followed it in the old list — the
- *  live turn's in-flight reasoning, or a scan cut short by a turn boundary) is
- *  appended at the tail: the tail IS its position. A block whose anchor MISSES
- *  its lookup is dropped or kept by where the anchor sits relative to the
- *  region the PURE server page (`coverageSource`) actually covers:
+ *  A block with NO recorded anchor because nothing followed it in the old list
+ *  (the live turn's in-flight reasoning) is appended at the tail: the tail IS
+ *  its position. A block whose anchor scan was CUT SHORT by a turn-boundary
+ *  user row (a turn stopped mid-reasoning, or one that emitted no tool call
+ *  and no answer text) is also anchorless, but its turn is OVER — it is kept
+ *  at the tail only while the pure server page does not cover that boundary
+ *  row; once it does, the block is dropped like a covered anchored miss
+ *  (#5815), since keeping it stranded one permanent chip per stopped turn
+ *  below unrelated newer turns, re-appended on every refresh. A block whose
+ *  anchor MISSES its lookup is dropped or kept by where the anchor sits
+ *  relative to the region the PURE server page (`coverageSource`) actually
+ *  covers:
  *
  *  - **Inside the covered region** (at or before the last `existing` row that
  *    `incoming` recognizably contains), with a server-confirmed anchor (a
@@ -1519,13 +1526,14 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
     if (m.content) return [`txt:${m.role}:${m.content.trimEnd()}`]
     return []
   }
-  const preserved: Array<{ msg: M; anchor: ThinkingAnchor | null; anchorIdx: number; confirmed: boolean }> = []
+  const preserved: Array<{ msg: M; anchor: ThinkingAnchor | null; anchorIdx: number; confirmed: boolean; boundaryIdx: number }> = []
   for (let i = 0; i < existing.length; i++) {
     const m = existing[i]
     if (m.role !== 'thinking' || !m.content) continue
     let anchor: ThinkingAnchor | null = null
     let anchorIdx = -1
     let confirmed = false
+    let boundaryIdx = -1
     for (let j = i + 1; j < existing.length; j++) {
       const cand = existing[j]
       const tid = toolAnchorId(cand)
@@ -1541,13 +1549,44 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
         break
       }
       // A confirmed steer does not end this block's turn, so the row after it is
-      // still its anchor. Breaking here instead leaves `anchor` null, and an
-      // unanchored block is appended at the tail — below the answer and its
-      // footer — where the forward scan can never reach an anchorable row again,
-      // so it stays there and is re-appended on every later refresh.
-      if (isTurnBoundaryUser(cand)) break
+      // still its anchor. Breaking here instead would record a turn boundary for
+      // a block whose turn is NOT over — misplacing it at the tail, and (once
+      // the page covers the steer row) dropping reasoning that has a real
+      // anchor further down.
+      //
+      // Record WHICH row ended the scan: an anchorless block with a recorded
+      // boundary belongs to a FINISHED turn (stopped mid-reasoning, or a
+      // reasoning-only turn that emitted no tool call and no text), not to the
+      // live tail, and the tail-keep below uses that to decide whether the
+      // block's turn is inside the covered region and therefore over (#5815).
+      //
+      // An OPTIMISTIC bubble of ANY kind breaks the scan (it may be a new turn,
+      // and reading past it could splice that turn's reasoning onto this block)
+      // but NEVER records a boundary and never authorizes a drop. The predicate
+      // is `optimistic` alone, NOT `steer && optimistic`: a plain send is
+      // stamped optimistic too (keyed on its `sendId`, see `appendMessage`), and
+      // it is just as ambiguous. If the client's idle state was stale the server
+      // takes its QUEUE path — persisting no `user` row for that text at all —
+      // while the turn keeps emitting rows; a refresh covering one of those
+      // later rows would then put this unpersisted bubble INSIDE the covered
+      // region and drop the live turn's reasoning above it. A steer bubble is
+      // ambiguous for its own reason: accepted into the running turn (its
+      // `steer_push` echo pending, real anchor one reconciliation away) or raced
+      // `chat_done` onto the new-turn path. Every attempt to resolve either
+      // ambiguity from text identity proved unsound in review (duplicate-text
+      // turns, missed echoes, pages reaching past the bounded cache window), so
+      // this code declines to guess: only a bubble the server has CONFIRMED
+      // (echo reconciled, the flag deleted) is trustworthy as a boundary. The
+      // cost is a narrow residual — a new-turn-path steer's pre-steer chip can
+      // strand at the tail until reload — tracked as #6075, whose sound fix is a
+      // client-minted id persisted through both backend paths, rather than
+      // resolved with weak evidence here.
+      if (isTurnBoundaryUser(cand)) {
+        if (!cand.meta?.optimistic) boundaryIdx = j
+        break
+      }
     }
-    preserved.push({ msg: m, anchor, anchorIdx, confirmed })
+    preserved.push({ msg: m, anchor, anchorIdx, confirmed, boundaryIdx })
   }
   if (!preserved.length) return incoming
   // Coverage cut: index of the last `existing` row whose identity the PURE
@@ -1606,21 +1645,51 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
     result.push(item)
   }
   for (let p = 0; p < preserved.length; p++) {
-    // The tail keeps: anchorless blocks (nothing followed them — the tail IS
-    // their position), blocks whose anchor row was never server-confirmed (a
-    // racing mid-turn refresh can miss those without the block being stale),
-    // and blocks whose anchor sits PAST the coverage cut (newer than
-    // everything the snapshot contains — the snapshot is old, not the block).
-    // Only a server-confirmed anchor INSIDE the covered region that missed
-    // its lookup has no position in this list (bounded page / rewritten
-    // history) — drop it rather than stranding it at the tail below
-    // unrelated turns (#5798).
+    // The tail keeps: truly anchorless blocks (nothing followed them AT ALL —
+    // the live turn's in-flight reasoning, whose tail IS its position), blocks
+    // whose anchor row was never server-confirmed (a racing mid-turn refresh
+    // can miss those without the block being stale), and blocks whose anchor
+    // sits PAST the coverage cut (newer than everything the snapshot contains
+    // — the snapshot is old, not the block).
+    //
+    // Two shapes are droppable via coverage, both meaning "this block's turn
+    // is over and the snapshot covers it, yet holds no position for the
+    // block":
+    //  - a server-confirmed anchor INSIDE the covered region that missed its
+    //    lookup (bounded page / rewritten history) — dropping it rather than
+    //    stranding it at the tail below unrelated turns is #5798;
+    //  - an anchorless block whose scan was TERMINATED by a turn-boundary
+    //    user row inside the covered region (the turn was stopped
+    //    mid-reasoning, or emitted no tool call and no answer text). The
+    //    boundary row is a persisted user message, so the snapshot covering
+    //    it proves the server's full account of that finished turn — which
+    //    contains no reasoning (reasoning is client-only). Keeping the block
+    //    teleported it to the transcript tail, below unrelated turns, and
+    //    re-appended it there on every later refresh — one permanent stray
+    //    chip per stopped turn (#5815). Dropping matches a page reload.
+    //    A boundary past the cut (or unresolved, coveredIdx < 0 without a
+    //    server-identity eviction proof) keeps the block: the snapshot may
+    //    simply predate it.
     if (used.has(p)) continue
-    const { anchor, anchorIdx, confirmed } = preserved[p]
-    const insideCoverage = anchorIdx >= 0 && anchorIdx <= coveredIdx
-    const anchorMs = anchorIdx >= 0 ? transcriptTsMs(existing[anchorIdx]?.ts) : null
-    const evicted = coveredIdx < 0 && oldestPageMs !== null && anchorMs !== null && anchorMs < oldestPageMs
-    const droppable = anchor !== null && confirmed && (insideCoverage || evicted)
+    const { anchor, anchorIdx, confirmed, boundaryIdx } = preserved[p]
+    const posIdx = anchor !== null ? anchorIdx : boundaryIdx
+    const posRow = posIdx >= 0 ? existing[posIdx] : undefined
+    const insideCoverage = posIdx >= 0 && posIdx <= coveredIdx
+    // The eviction fallback compares the POSITION row's own `ts` against the
+    // page's oldest instant, so it is only sound when that `ts` is
+    // server-minted. An anchor qualifies by `confirmed` (a server tool id, or
+    // an assistant row carrying a server `ts`). A BOUNDARY does not: a plain
+    // turn-boundary `user` row is the composer's optimistic bubble, appended
+    // locally with `new Date().toISOString()` and only a client `sendId` —
+    // the server-minted `mid` arrives with the echo (ChatPage's send path).
+    // A browser clock running behind the server would read that bubble as
+    // older than every page row and evict LIVE reasoning. So a boundary may
+    // use the fallback only once it carries `mid`; without it, `insideCoverage`
+    // is the only route to a drop, which is over-keep — the safe direction.
+    const posTsIsServer = anchor !== null || typeof posRow?.meta?.mid === 'string'
+    const posMs = posRow && posTsIsServer ? transcriptTsMs(posRow.ts) : null
+    const evicted = coveredIdx < 0 && oldestPageMs !== null && posMs !== null && posMs < oldestPageMs
+    const droppable = (anchor !== null ? confirmed : boundaryIdx >= 0) && (insideCoverage || evicted)
     if (!droppable) result.push({ ...preserved[p].msg })
   }
   return result

--- a/website/src/test/ChatSliceCoverageSecondPass.test.tsx
+++ b/website/src/test/ChatSliceCoverageSecondPass.test.tsx
@@ -27,6 +27,7 @@ import { configureStore } from '@reduxjs/toolkit'
 
 import chatReducer, {
   appendSlotMessage,
+  appendQueuedMessage,
   clearFocusToolCallId,
   clearPendingPermissions,
   createSlot,
@@ -267,11 +268,14 @@ describe('chatSlice transcript equality on a repeat slot fetch', () => {
 })
 
 describe('chatSlice slot-detail refresh merges', () => {
-  it('re-inserts a reasoning block above its answer and keeps an unanchored one', () => {
+  it('re-inserts a reasoning block above its answer and drops a stopped-turn orphan once its boundary is covered (#5815)', () => {
     // Reasoning is never persisted server-side, so the refresh fired on
     // chat_done would drop it without this merge. The second block's scan hits
-    // a `user` row before any answer, so it has NO anchor — the tail is its
-    // position and it must still survive rather than being silently dropped.
+    // a `user` row before any answer — its turn is OVER (stopped
+    // mid-reasoning), and the page covers that boundary row, so the server's
+    // full account of the finished turn is known to hold no position for it.
+    // Keeping it teleported the chip to the transcript tail below the newer
+    // turn and re-appended it there on every later refresh.
     let s = chatReducer(initial, setActiveSlot('A'))
     s = chatReducer(s, replaceMessages([
       msg({ role: 'thinking', content: 'because…' }),
@@ -284,9 +288,8 @@ describe('chatSlice slot-detail refresh merges', () => {
       msg({ role: 'user', content: 'next question', ts: '3' }),
     ])))
     const roles = s.messages.map(m => m.role)
-    expect(roles).toEqual(['thinking', 'assistant', 'user', 'thinking'])
+    expect(roles).toEqual(['thinking', 'assistant', 'user'])
     expect(s.messages[0].content).toBe('because…')
-    expect(s.messages[3].content).toBe('orphan reasoning')
   })
 
   it('drops an anchored block whose anchor row is missing from the reloaded page (#5798)', () => {
@@ -335,6 +338,265 @@ describe('chatSlice slot-detail refresh merges', () => {
     s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', page)))
     s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', page)))
     expect(s.messages.map(m => m.content)).toEqual(['in window', 'answer'])
+  })
+
+  it('keeps stopped-turn chips bounded: covered boundaries drop, the live tail survives (#5815)', () => {
+    // Two turns were stopped mid-reasoning (each thinking block's scan hits
+    // the NEXT turn's user row — a finished turn with no tool call and no
+    // answer text), and a third block is the live turn's in-flight reasoning
+    // (nothing follows it at all). The page covers both boundary rows: both
+    // stopped-turn chips are dropped — before #5815 each was teleported to
+    // the tail and stranded there permanently, one chip per stopped turn —
+    // while the truly anchorless live block keeps the tail. A later refresh
+    // over the same window must not resurrect anything.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'first question', ts: '1' }),
+      msg({ role: 'thinking', content: 'stopped reasoning one' }),
+      msg({ role: 'user', content: 'second question', ts: '2' }),
+      msg({ role: 'thinking', content: 'stopped reasoning two' }),
+      msg({ role: 'user', content: 'third question', ts: '3' }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+    ]))
+    const page = [
+      msg({ role: 'user', content: 'first question', ts: '1' }),
+      msg({ role: 'user', content: 'second question', ts: '2' }),
+      msg({ role: 'user', content: 'third question', ts: '3' }),
+    ]
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', page, { running: true })))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', page, { running: true })))
+    const thinking = s.messages.filter(m => m.role === 'thinking').map(m => m.content)
+    expect(thinking).toEqual(['live reasoning'])
+    expect(s.messages[s.messages.length - 1].content).toBe('live reasoning')
+  })
+
+  it('drops a reasoning-only turn once the next turn boundary is covered (#5815)', () => {
+    // A turn can finish emitting ONLY reasoning — no tool call, no answer text
+    // (the backend flushes no assistant row). The block's scan hits the next
+    // user row: turn over, and the page covering that row proves the server's
+    // account of the finished turn holds no position for the block. Same
+    // disposition as a covered anchored miss: drop, matching a page reload.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'thinking', content: 'reasoning with no output' }),
+      msg({ role: 'user', content: 'follow-up', ts: '5' }),
+      msg({ role: 'assistant', content: 'follow-up answer', ts: '6' }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'follow-up', ts: '5' }),
+      msg({ role: 'assistant', content: 'follow-up answer', ts: '6' }),
+    ])))
+    expect(s.messages.filter(m => m.role === 'thinking')).toHaveLength(0)
+  })
+
+  it('keeps a stopped-turn block whose boundary row landed after the refresh snapshot (#5815)', () => {
+    // The boundary-row variant of the mid-turn race: refreshSlot snapshots the
+    // server, THEN the user stops the turn and sends the next message, THEN
+    // the fetch fulfills. The boundary user row sits PAST everything the
+    // snapshot contains — the snapshot is old, not the block. Dropping here
+    // would delete reasoning the user can still be looking at, before any
+    // snapshot has actually covered its turn.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'stopped reasoning' }),
+      msg({ role: 'user', content: 'sent after the snapshot', meta: { clientTs: 'u-2' } }),
+    ]))
+    // Snapshot predates the stop and the next message.
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'stopped reasoning')).toBe(true)
+  })
+
+  it('drops an evicted stopped-turn block when the page shares no identity but is provably newer (#5815)', () => {
+    // The no-overlap fallback, boundary shape: a long-disconnected session
+    // advanced past the bounded page, so the fresh page shares NO row with the
+    // stale cache. The stopped turn's boundary user row carries a server ts
+    // (proven by its server-minted `mid`) older than the page's oldest row —
+    // evicted history — so the block is dropped exactly like an evicted
+    // confirmed anchor; keeping it would strand it permanently below turns
+    // that happened hours later.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'thinking', content: 'ancient stopped reasoning' }),
+      msg({ role: 'user', content: 'ancient next question', ts: '100', meta: { mid: 'm-ancient' } }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'much later question', ts: '5000' }),
+      msg({ role: 'assistant', content: 'much later answer', ts: '5001' }),
+    ], { running: true })))
+    const thinking = s.messages.filter(m => m.role === 'thinking').map(m => m.content)
+    expect(thinking).toEqual(['live reasoning'])
+  })
+
+  it('does not let a PLAIN optimistic send authorize dropping live reasoning (#5815)', () => {
+    // The stale-idle race: the client believed the slot was idle, so the
+    // composer appended its optimistic bubble — a plain `user` row, no
+    // `steer`, stamped `optimistic` from its `sendId`. The server disagreed
+    // and took the QUEUE path, so no `user` row is ever persisted for that
+    // text; meanwhile the turn keeps working and emits a tool frame. A refresh
+    // covering that tool row would put the unpersisted bubble inside the
+    // covered region, and reading it as a finished-turn boundary would drop
+    // the LIVE turn's reasoning above it. Only a server-CONFIRMED bubble (echo
+    // reconciled, flag deleted) may be a boundary.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1', meta: { mid: 'm-q' } }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+      msg({ role: 'user', content: 'and then deploy', ts: '2', meta: { sendId: 's-1', optimistic: true } }),
+      msg({ role: 'tool', content: '🔧 bash', ts: '3', meta: { tool_call_id: 'tc-live' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1', meta: { mid: 'm-q' } }),
+      msg({ role: 'tool', content: '🔧 bash', ts: '3', meta: { tool_call_id: 'tc-live' } }),
+    ], { running: true })))
+    const thinking = s.messages.filter(m => m.role === 'thinking').map(m => m.content)
+    expect(thinking).toEqual(['live reasoning'])
+  })
+
+  it('does not read a mid-turn QUEUED message as a turn boundary (#5815)', () => {
+    // A message sent while the slot is running is NOT persisted as a `user`
+    // row: the backend only enqueues it (queue_append touches the queue alone)
+    // and broadcasts `queue_push`, which this reducer renders as a `queued`
+    // row; the real `user` row appears later, when the drain starts the next
+    // turn. Driven through the actual producer action so the invariant is
+    // pinned at the source. If a queued message ever became a `user` row, the
+    // scan would break there instead of reaching the tool call that really
+    // anchors this block — and because the page covers that later tool row,
+    // the boundary would sit INSIDE the covered region and authorize dropping
+    // the LIVE turn's reasoning.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1', meta: { mid: 'm-q' } }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+    ]))
+    s = chatReducer(s, appendQueuedMessage({ slot: 'A', content: 'and then deploy', ts: '2', queue_id: 'q-1' }))
+    // The turn keeps working after the queued entry lands.
+    s = chatReducer(s, appendSlotMessage({ slot: 'A', message: msg({ role: 'tool', content: '🔧 bash', ts: '3', meta: { tool_call_id: 'tc-live' } }) }))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1', meta: { mid: 'm-q' } }),
+      msg({ role: 'tool', content: '🔧 bash', ts: '3', meta: { tool_call_id: 'tc-live' } }),
+    ], { running: true })))
+    const roles = s.messages.map(m => m.role)
+    expect(roles.filter(r => r === 'thinking')).toHaveLength(1)
+    // Re-anchored above its tool call, not stranded at the tail.
+    expect(roles.indexOf('thinking')).toBeLessThan(roles.indexOf('tool'))
+  })
+
+  it('never evicts on a boundary whose ts is client-minted, however skewed the clock (#5815)', () => {
+    // Same no-overlap shape, but the boundary row is the composer's OPTIMISTIC
+    // bubble: appended locally with `new Date().toISOString()` and only a
+    // client `sendId`, no server-minted `mid`. A browser clock running behind
+    // the server makes that bubble read as older than every page row, which
+    // would evict the block above it — and here that block is LIVE reasoning
+    // of the turn the bubble just started. The eviction fallback must refuse a
+    // client timestamp: keeping is the safe direction.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'thinking', content: 'live reasoning' }),
+      // Skewed client ts: numerically older than the page's oldest row.
+      msg({ role: 'user', content: 'next question', ts: '100', meta: { sendId: 's-local' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'unrelated racing page row', ts: '5000' }),
+      msg({ role: 'assistant', content: 'unrelated answer', ts: '5001' }),
+    ], { running: true })))
+    const thinking = s.messages.filter(m => m.role === 'thinking').map(m => m.content)
+    expect(thinking).toEqual(['live reasoning'])
+  })
+
+  it('does not let an unreconciled optimistic steer authorize dropping pre-steer reasoning (#5815)', () => {
+    // A steer accepted into the RUNNING turn is echoed back as `steer_push`,
+    // which clears the bubble's optimistic flag — but the turn keeps emitting
+    // persisted rows before that echo reconciles. The pre-steer block's scan
+    // breaks at the optimistic bubble (it might be a new turn — reading past
+    // it could splice content), yet the bubble is ambiguous, NOT proof the
+    // turn ended: a refresh covering the tool row that landed after the steer
+    // must not read the bubble as a covered boundary and drop reasoning whose
+    // real anchor is that very tool row, one reconciliation away.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'also check the logs', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true } }),
+      msg({ role: 'tool', content: '🔧 grep logs', ts: '3', meta: { tool_call_id: 'tc-post-steer' } }),
+    ]))
+    // The refresh covers the post-steer tool row; the steer echo has not
+    // reconciled, so the server page has no row for the bubble itself.
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'tool', content: '🔧 grep logs', ts: '3', meta: { tool_call_id: 'tc-post-steer' } }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
+  })
+
+  it('never drops on an optimistic steer bubble, even when the page holds a plain copy of its text (#5815)', () => {
+    // An optimistic steer bubble is ambiguous: an accepted steer whose
+    // steer_push echo has not reconciled, or a message that raced chat_done
+    // onto the new-turn path (persisted as a PLAIN user row, no echo ever).
+    // Resolving that ambiguity from text identity was attempted and retired:
+    // every variant carried a real over-drop hole (duplicate-text turns,
+    // missed echoes, pages reaching past the bounded cache window). The
+    // contract is now: the bubble breaks the scan but NEVER authorizes a
+    // drop — over-keep, not over-drop. The new-turn residual (this chip can
+    // strand until reload) is tracked as issue #6075.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'stopped reasoning' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true } }),
+    ]))
+    // The page holds a persisted plain copy of the bubble's text — under the
+    // retired vouch mechanism this dropped the block; it must be kept.
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '5' }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'stopped reasoning')).toBe(true)
+  })
+
+  it('does not let an older duplicate-text user row vouch for an unresolved steer bubble (#5815)', () => {
+    // The bubble's text can repeat an EARLIER persisted user message ("do it")
+    // that appears in both lists. Under the never-drop contract the bubble is
+    // simply unresolved and the pre-steer block is kept; this pins that a
+    // duplicate-text page row can never be read as evidence against it.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'do it', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'do it', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'do it', ts: '1' }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
+  })
+
+  it('keeps accepted-steer reasoning when a later plain turn reused the steer text (#5815)', () => {
+    // A steer accepted into the running turn whose steer_push echo was MISSED
+    // (WS drop) leaves the bubble optimistic forever on this client. Later
+    // the user sends a plain new-turn message with byte-identical text, so
+    // the page holds BOTH a persisted STEER row and a plain row for that
+    // text. This very refresh replaces the bubble with the persisted steer
+    // row, re-anchoring the block through the confirmed-steer scan path — so
+    // the block must not be deleted one refresh early. This case is why
+    // text-identity resolution of the bubble was retired (see issue #6075):
+    // the plain row belongs to the LATER turn, not to the bubble.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'check the logs', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'check the logs', ts: '3', meta: { steer: true } }),
+      msg({ role: 'assistant', content: 'steered answer', ts: '4' }),
+      msg({ role: 'user', content: 'check the logs', ts: '5' }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
   })
 
   it('keeps a block anchored to unconfirmed text through a racing mid-turn refresh', () => {

--- a/website/src/test/chatSlice.warmSlotCacheBound.test.ts
+++ b/website/src/test/chatSlice.warmSlotCacheBound.test.ts
@@ -883,9 +883,13 @@ describe('switching away from a pane whose own fetch has not landed', () => {
     expect(held.map(m => m.content)).toEqual(['older history', 'first tool', 'answer', 'live reasoning'])
   })
 
-  // Unanchored, so the helper tail-appends it. #4218's re-append loop cannot form:
-  // the upgrade clears the marker, so a later hydrate returns at boundedLen undefined.
-  it('keeps an unanchored block from the replaced region, and cannot re-append it', () => {
+  // The block's scan hit a turn-boundary user row — its turn is over — and the
+  // unbounded upgrade page covers that row, so the server's full account of the
+  // finished turn holds no position for it: dropped (#5815), not tail-appended
+  // where it would strand below newer turns. #4218's re-append loop cannot
+  // form either way: the upgrade clears the marker, so a later hydrate returns
+  // at boundedLen undefined.
+  it('drops a stopped-turn orphan from the replaced region once its boundary is covered (#5815)', () => {
     const thinking = { role: 'thinking', content: 'orphan reasoning', cls: '', ts: '2026-08-13T08:00:00Z' }
     const turn = { role: 'user', content: 'do it', cls: '', ts: '2026-08-13T08:30:00Z', meta: { mid: 'm-u' } }
     const answer = msg('answer', '2026-08-13T09:00:00Z', 'm-2')
@@ -900,8 +904,8 @@ describe('switching away from a pane whose own fetch has not landed', () => {
       slot: 'bg-slot', messages: [older, turn, answer] as never, hasMore: false, bounded: false, total: 3, running: false,
     }))
     const held = store.getState().chat.slotMessages['bg-slot']
-    expect(held.filter(m => m.role === 'thinking')).toHaveLength(1)
-    expect(held[held.length - 1].content).toBe('orphan reasoning')
+    expect(held.filter(m => m.role === 'thinking')).toHaveLength(0)
+    expect(held.map(m => m.content)).toEqual(['older history', 'do it', 'answer'])
     expect(store.getState().chat.slotPaneBounded['bg-slot']).toBeUndefined()
   })
 


### PR DESCRIPTION
# What is the problem?

A preserved client-only `thinking` block whose forward anchor scan is terminated by a turn-boundary `user` row -- a turn stopped mid-reasoning, or a reasoning-only turn that emitted no tool call and no answer text -- ends up anchorless, and `mergePreservedThinking` kept every anchorless block at the transcript tail unconditionally. Each such stopped turn therefore leaves one permanent stray "Thinking" chip teleported below unrelated newer turns, re-added on every later slot-detail refresh until a full page reload. This is the bounded residual left after #5798 / PR #5802 fixed the unbounded mass-wall accumulation.

# Why it matters to the user

In a long-lived tab where turns get stopped (a common babysit/steer workflow), stale reasoning chips pile up at the bottom of the transcript -- one per stopped turn -- below turns they have nothing to do with. They read as duplicated or misplaced output and cannot be dismissed short of reloading the page.

# How the fix solves it

Chain from symptom to root cause: the chip strands because the tail-keep in `mergePreservedThinking` treats every anchorless block as live-tail reasoning. But the scan records WHY a block is anchorless: nothing followed it at all (genuinely live), or the scan was cut short by a turn-boundary user row (turn is over). The fix records that boundary row's index (`boundaryIdx`) and generalizes the #5802 coverage decision to it: when the pure server page covers the persisted boundary row (or proves it evicted via the existing no-overlap ts fallback), the server's full account of that finished turn is known and holds no position for the block -- so it is dropped, exactly like a covered anchored miss, matching what a page reload does.

Kept unchanged, deliberately:
- truly anchorless live-tail blocks (nothing follows them) keep the tail;
- a boundary PAST the coverage cut (mid-turn refresh race: snapshot predates the stop) keeps the block;
- a CONFIRMED steer still never breaks the scan;
- an OPTIMISTIC steer bubble breaks the scan but NEVER records a boundary and never authorizes a drop. The bubble is ambiguous -- an accepted steer whose `steer_push` echo has not reconciled, or a message that raced `chat_done` onto the new-turn path -- and three review rounds showed every attempt to resolve that ambiguity from text identity carries a real over-drop hole (duplicate-text turns, missed echoes, pages reaching past the bounded cache window). The code deliberately declines to guess: over-keep, never over-drop. The narrow over-keep residual (a new-turn-path steer's chip can strand until reload) is tracked as issue #6075, whose sound fix is identity-based (persist a client-minted id through both backend paths), not text-based.
- the #5798/#5802 anchored-coverage handling is untouched.

# What tests we did

- Four drop-direction tests, red on base and green with the fix: covered stopped-turn boundary; multiple stopped turns stay bounded across repeated refreshes while the live tail survives; reasoning-only turn; evicted boundary under the no-overlap fallback.
- Four keep-direction tests pinning the never-drop contract for ambiguous evidence: boundary row landed after the refresh snapshot; unreconciled optimistic steer with post-steer tool row covered; optimistic steer whose text has a plain persisted copy in the page; accepted steer whose text a later plain turn reused.
- Mutation-verified in both directions: reverting the fix reds the drop tests; unbounding `insideCoverage` reds the keep tests.
- Two pre-existing tests that pinned the retired stranded-chip behavior updated to the new contract (refresh path and the warm-cache pane-upgrade path).
- Full local gates: `npx tsc -b` clean, full `npx vitest run` 24305 passed / 0 failed.
- Two model-pinned pre-push reviewers (GPT + Opus) plus three server GPT rounds; every finding was verified against real code. The steer-resolution mechanism those rounds kept finding holes in was removed entirely rather than patched a fourth time.

# Any other suggestions

Issue #6075 tracks the descoped residual with the identity-based fix design. The text-identity-collision limitation of `coverageIds` noted in review is pre-existing, documented in code, and not load-bearing for any drop decision in this PR.

Closes #5815
