### PR TITLE
fix(apps): let an app set a cron job timezone and skip_dates at create

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -75,6 +75,13 @@ installed against:
       "cron_expr": "0 9 * * 1-5",
       "message": "Generate daily digest",
       "agent": "digest-agent"
+    },
+    {
+      "name": "market-open",
+      "cron_expr": "30 9 * * 1-5",
+      "message": "Summarise the overnight tape",
+      "timezone": "America/New_York",
+      "skip_dates": ["2026-12-25"]
     }
   ]
 }
@@ -87,6 +94,8 @@ installed against:
 | `cron_expr` | string | Cron expression (mutually exclusive with `every`) |
 | `message` | string | Prompt sent to the agent on each run |
 | `agent` | string | Agent to run (optional, uses default if omitted) |
+| `timezone` | string | IANA zone name the schedule and `skip_dates` are evaluated in, e.g. `America/New_York`. Optional, but an empty value falls back to the gateway config's timezone and then to **UTC** — so `"cron_expr": "0 6 * * *"` without it fires at 06:00 UTC, the wrong calendar day for most users. An unknown zone is rejected at manifest validation. A per-**user** zone is not manifest data: pass `timezone=` to `ctx.cron.add_job` instead |
+| `skip_dates` | string[] | Calendar dates the job must not fire on, evaluated in `timezone`. Must be zero-padded `YYYY-MM-DD` — `2026-1-1` parses but never matches the padded fire-time rendering, so it is rejected at manifest validation rather than silently skipping nothing |
 | `enabled` | boolean | Default `true`. Must be a JSON boolean — any other type is rejected at manifest validation. When `false` the cron is registered **paused** (visible in the Schedule view, resumable) instead of firing on install/enable — for jobs that need user configuration first |
 
 > **Caveat:** disabling an app deletes its registered cron jobs, and re-enabling

--- a/skills/kirocrew-app-dev/SKILL.md
+++ b/skills/kirocrew-app-dev/SKILL.md
@@ -50,6 +50,13 @@ my-app/
       "every": 900,
       "silent": true,
       "persistent_session": false
+    },
+    {
+      "name": "market-open",
+      "message": "Summarise the overnight tape.",
+      "cron_expr": "30 9 * * 1-5",
+      "timezone": "America/New_York",
+      "skip_dates": ["2026-12-25"]
     }
   ],
   "permissions": {
@@ -84,6 +91,8 @@ my-app/
 | `ui.pages[].iconUrl` | Use `icon.svg` file path | String `icon` field only works for builtin apps |
 | `displayName` | Required | Gateway uses it for UI display |
 | `version` | Semver string | Used by update-check crons for comparison |
+| `crons[].timezone` | IANA zone name; omit it only when the hour is zone-agnostic | An empty timezone falls back to the gateway config's zone and then to **UTC**, so `"cron_expr": "0 6 * * *"` without it fires at 06:00 UTC — the wrong calendar day for most users. A per-USER zone is not manifest data: pass `timezone=` to `ctx.cron.add_job` instead |
+| `crons[].skip_dates` | Zero-padded `YYYY-MM-DD`, evaluated in `timezone` | `"2026-1-1"` parses but never matches the padded fire-time rendering, so the skip silently does nothing. Both fields are rejected at manifest validation, not at fire time |
 
 ## Self-Healing Pattern (CRITICAL)
 

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -1337,6 +1337,8 @@ def _cron_defs_from_manifest(
                 "persistent_session": cron.persistent_session,
                 "silent": cron.silent,
                 "enabled": cron.enabled,
+                "timezone": cron.timezone,
+                "skip_dates": cron.skip_dates,
             }
         )
         registered.append(namespaced)
@@ -1537,6 +1539,12 @@ async def register_app_crons_with_service(app_name: str, cron_service: Any) -> l
                 persistent_session=d.get("persistent_session", False),
                 silent=bool(d.get("silent", False)),
                 enabled=bool(d.get("enabled", True)),
+                # An empty timezone resolves to the config zone and then to UTC
+                # at fire time, so a manifest that pins an hour meaningful only
+                # in one zone must have it threaded here, not corrected by a
+                # second write after the job already exists.
+                timezone=d.get("timezone") or "",
+                skip_dates=d.get("skip_dates") or None,
             )
             if job is None:
                 # Lost the race (or already present): another registrar

--- a/src/kiro_crew/apps/cron_sdk.py
+++ b/src/kiro_crew/apps/cron_sdk.py
@@ -203,12 +203,21 @@ class CronSDK:
         persistent_session: bool,
         silent: bool,
         enabled: bool,
+        timezone: str,
+        skip_dates: list[str] | None,
     ) -> dict[str, Any]:
         """Build the kwargs common to the sync/async ``CronService.add_job``.
 
         Threads every field so the job is persisted FULLY-FORMED and owner-tagged
         in ONE locked build+persist (no follow-up unlocked ``_save()`` that could
         race a concurrent create).
+
+        ``timezone``/``skip_dates`` are threaded here rather than left to a
+        follow-up ``update_job``: they are the two calendar-validity-sensitive
+        fields ``CronService.add_job`` owns and validates before its single
+        locked save, so passing them at create keeps the fully-formed-on-first-
+        save invariant instead of persisting a job that resolves to UTC and
+        correcting it in a second write.
         """
         return dict(
             name=name,
@@ -223,6 +232,8 @@ class CronSDK:
             persistent_session=persistent_session,
             silent=silent,
             enabled=enabled,
+            timezone=timezone or "",
+            skip_dates=skip_dates or None,
             created_by=self._owner_prefix,
         )
 
@@ -243,11 +254,22 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
+        skip_dates: list[str] | None = None,
     ) -> Any:
         """Create a cron job owned by this app. **Synchronous** (preserves the
         published SDK contract). See :meth:`add_job_async` for the loop-native
         variant. Raises ``CronSyncOnLoopError`` if called on a running event loop
         (use :meth:`add_job_async` there). Returns the created CronJob object.
+
+        ``timezone`` is an IANA zone name (e.g. ``"America/Los_Angeles"``) that
+        the schedule and any ``skip_dates`` are evaluated in. Leaving it empty
+        falls back to the gateway config's timezone and then to UTC, so an app
+        scheduling against a user's local time should pass it explicitly.
+        ``CronService.add_job`` validates both fields before the single locked
+        save, so an unknown zone or a malformed ``YYYY-MM-DD`` raises
+        ``ValueError`` at create time instead of silently resolving to UTC when
+        the job fires.
         """
         self._vet_command_script(name, command, script)
         job = _run_sync_mutator(
@@ -258,7 +280,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone, skip_dates=skip_dates,
             ),
         )
         self._audit_add(job)
@@ -279,11 +301,17 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
+        skip_dates: list[str] | None = None,
     ) -> Any:
         """Event-loop-native :meth:`add_job`: routes through
         ``CronService.add_job_async`` (bounded store-lock spin offloaded to a
         worker thread), so an on-loop caller awaits without ever parking the
         loop. Returns the created CronJob object.
+
+        ``timezone``/``skip_dates`` behave exactly as in :meth:`add_job` --
+        validated at the persistence owner and folded into the single locked
+        save, so a job never exists with the wrong calendar settings.
         """
         self._vet_command_script(name, command, script)
         job = await self._cron.add_job_async(
@@ -292,7 +320,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone, skip_dates=skip_dates,
             ),
         )
         self._audit_add(job)
@@ -313,6 +341,8 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
+        skip_dates: list[str] | None = None,
     ) -> Any:
         """Atomic add-if-absent by job name; returns None when already present.
 
@@ -321,6 +351,10 @@ class CronSDK:
         so two concurrent registrars (e.g. a CLI enable racing gateway boot)
         cannot both snapshot the name as absent and persist duplicates. The
         bounded lock spin runs in a worker thread, keeping on-loop callers safe.
+
+        ``timezone``/``skip_dates`` are threaded through the same build as
+        :meth:`add_job`, so the winning registrar's job is calendar-correct on
+        its first and only save.
         """
         self._vet_command_script(name, command, script)
         job = await self._cron.add_job_if_absent_async(
@@ -330,7 +364,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone, skip_dates=skip_dates,
             ),
         )
         if job is not None:

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -19,6 +19,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
+from kiro_crew.cron import is_valid_skip_date, is_valid_timezone
 
 # ---------------------------------------------------------------------------
 # Nested manifest types
@@ -154,6 +155,17 @@ def _path_escapes_app_root(rel_path: str, app_root: Path | None) -> bool:
     return False
 
 
+# Expected JSON type per CronEntry field that from_dict type-gates, used to turn
+# a recorded parse-time violation into a message an app author can act on.
+_CRON_FIELD_JSON_TYPES = {
+    "every": "a number of seconds",
+    "agent_sequence": "an array of agent names",
+    "env": "an object of string keys to string values",
+    "timezone": "a string IANA zone name",
+    "skip_dates": "an array of YYYY-MM-DD strings",
+}
+
+
 @dataclass
 class CronEntry:
     """A scheduled agent job declared by an app."""
@@ -170,6 +182,16 @@ class CronEntry:
     env: dict[str, str] = field(default_factory=dict)  # environment variables for the job
     persistent_session: bool = True  # whether to carry context between runs
     silent: bool = False  # suppress dashboard notifications
+    # IANA zone the schedule and skip_dates are evaluated in (e.g.
+    # "America/New_York"). Empty falls back to the gateway config's timezone and
+    # then to UTC, so a job whose hour is only meaningful in one zone -- market
+    # hours, a regional business-day digest -- must name it here. A per-USER zone
+    # is not manifest data: an app that schedules against its user's local time
+    # passes ``timezone`` to ``ctx.cron.add_job`` instead.
+    timezone: str = ""
+    # Calendar dates (YYYY-MM-DD, evaluated in ``timezone``) the job must not
+    # fire on -- e.g. a publisher's own holiday list.
+    skip_dates: list[str] = field(default_factory=list)
     # When False the cron is registered in a paused state (visible in the
     # dashboard Schedule view, resumable) instead of firing on install/enable.
     # Apps that need user configuration before their crons are useful ship
@@ -180,6 +202,14 @@ class CronEntry:
     # silently re-creating the fires-unconfigured bug). Reported as a
     # validation error; never serialized.
     enabled_type_invalid: bool = False
+    # Names of container/numeric fields whose manifest value was PRESENT and
+    # non-null but of the wrong JSON type. Parsing degrades them to the field's
+    # empty value so /api/apps/register cannot 500, and validate() reports each
+    # one -- erasing a wrong-typed value SILENTLY would be its own bug: an
+    # author who wrote "skip_dates": "2026-12-25" (a string, not an array) asked
+    # for a skip, and dropping it without a word lets the job fire on the
+    # excluded date. Same shape as enabled_type_invalid; never serialized.
+    type_invalid_fields: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"name": self.name}
@@ -199,6 +229,10 @@ class CronEntry:
             d["agent_sequence"] = self.agent_sequence
         if self.env:
             d["env"] = self.env
+        if self.timezone:
+            d["timezone"] = self.timezone
+        if self.skip_dates:
+            d["skip_dates"] = self.skip_dates
         if not self.persistent_session:
             d["persistent_session"] = False
         if self.silent:
@@ -212,16 +246,84 @@ class CronEntry:
         def _str_or_empty(v: Any) -> str:
             return v if isinstance(v, str) else ""
 
-        return cls(
+        # app.json is third-party, hand-editable input reached from
+        # /api/apps/register, so a wrong JSON TYPE must not raise:
+        # `data.get(key, [])` defends only the ABSENT key, and an explicit
+        # `"skip_dates": null` (or a scalar, or an object) returns that value,
+        # after which the comprehension raises TypeError / AttributeError out of
+        # from_dict and surfaces as an HTTP 500 rather than a validation error.
+        # Two distinct cases, deliberately treated differently:
+        #   * null == "not set" -> the empty value, no error (mirrors
+        #     _str_or_empty, and JSON null is how generators spell "absent").
+        #   * present, non-null, WRONG type -> the empty value AND a recorded
+        #     violation, because silently erasing it would drop a skip date the
+        #     author asked for and let the job fire on that date.
+        invalid: list[str] = []
+
+        def _list_or_empty(key: str, v: Any) -> list[Any]:
+            if isinstance(v, list):
+                return v
+            if v is not None:
+                invalid.append(key)
+            return []
+
+        def _dict_or_empty(key: str, v: Any) -> dict[Any, Any]:
+            if isinstance(v, dict):
+                return v
+            if v is not None:
+                invalid.append(key)
+            return {}
+
+        def _int_or_zero(key: str, v: Any) -> int:
+            # bool is an int subclass, so `"every": true` would pass isinstance
+            # and coerce to a 1-second interval; it is a type slip, not a
+            # schedule. 0 is already the "not set, use cron_expr" value.
+            if isinstance(v, bool):
+                invalid.append(key)
+                return 0
+            try:
+                return int(v)
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError is the infinity case: json.loads accepts
+                # `"every": 1e1000000` and yields float('inf'), which int()
+                # refuses. NaN lands in ValueError. A merely ENORMOUS finite
+                # value is not caught here and does not need to be -- it is a
+                # valid int, and compute_next_run_ts already absorbs it into
+                # "next run unknown" rather than raising.
+                if v is not None:
+                    invalid.append(key)
+                return 0
+
+        def _str_or_flagged(key: str, v: Any) -> str:
+            # `timezone` gets the recording treatment that plain _str_or_empty
+            # does not, because discarding it silently reproduces the very bug
+            # this field exists to fix: validation would pass, the job would
+            # persist timezone="" and fire in the fallback zone (UTC on a fresh
+            # install), and the author would see a schedule running on the wrong
+            # calendar day with nothing anywhere saying why. A discarded `agent`
+            # or `message` degrades visibly; a discarded zone does not.
+            if isinstance(v, str):
+                return v
+            if v is not None:
+                invalid.append(key)
+            return ""
+
+        entry = cls(
             name=_str_or_empty(data.get("name")),
-            every=int(data.get("every", 0)),
+            every=_int_or_zero("every", data.get("every", 0)),
             cron_expr=_str_or_empty(data.get("cron_expr")),
             agent=_str_or_empty(data.get("agent")),
             message=_str_or_empty(data.get("message")),
             command=_str_or_empty(data.get("command")),
             script=_str_or_empty(data.get("script")),
-            agent_sequence=[str(a) for a in data.get("agent_sequence", [])],
-            env={str(k): str(v) for k, v in data.get("env", {}).items()},
+            agent_sequence=[
+                str(a) for a in _list_or_empty("agent_sequence", data.get("agent_sequence"))
+            ],
+            env={
+                str(k): str(v) for k, v in _dict_or_empty("env", data.get("env")).items()
+            },
+            timezone=_str_or_flagged("timezone", data.get("timezone")),
+            skip_dates=[str(d) for d in _list_or_empty("skip_dates", data.get("skip_dates"))],
             persistent_session=bool(data.get("persistent_session", True)),
             silent=bool(data.get("silent", False)),
             # STRICT boolean: "enabled" gates whether a cron fires at all, so a
@@ -232,6 +334,8 @@ class CronEntry:
             enabled=(data["enabled"] if isinstance(data.get("enabled"), bool) else True),
             enabled_type_invalid=("enabled" in data and not isinstance(data["enabled"], bool)),
         )
+        entry.type_invalid_fields = invalid
+        return entry
 
 
 @dataclass
@@ -1158,6 +1262,30 @@ class AppManifest:
                 errors.append(
                     f"cron entry {cron.name!r}: 'command' and 'script' are mutually exclusive"
                 )
+            # Calendar fields are validated HERE as well as at the persistence
+            # owner. register_app_crons_with_service catches a per-job
+            # ValueError, logs it and moves on, so a bad zone shipped in a
+            # manifest would otherwise register nothing and say so only in the
+            # gateway log -- the app author sees a cron that silently does not
+            # exist. Surfacing it as a manifest validation error reports it at
+            # install/validate time instead.
+            for _bad in cron.type_invalid_fields:
+                errors.append(
+                    f"cron entry {cron.name!r}: {_bad!r} has the wrong JSON type "
+                    f"(expected {_CRON_FIELD_JSON_TYPES.get(_bad, 'a different type')}); "
+                    f"the value was ignored"
+                )
+            if cron.timezone and not is_valid_timezone(cron.timezone):
+                errors.append(
+                    f"cron entry {cron.name!r}: unknown timezone: {cron.timezone!r} "
+                    f"(expected an IANA zone name such as 'America/New_York')"
+                )
+            for _skip in cron.skip_dates:
+                if not is_valid_skip_date(_skip):
+                    errors.append(
+                        f"cron entry {cron.name!r}: invalid skip_date: {_skip!r} "
+                        f"(expected zero-padded YYYY-MM-DD)"
+                    )
             if cron.enabled_type_invalid:
                 errors.append(
                     f"cron entry {cron.name!r}: 'enabled' must be a JSON boolean "

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -2305,6 +2305,8 @@ class TestCronServiceBridge:
                 "env": {"FOO": "bar"},
                 "persistent_session": False,
                 "silent": True,
+                "timezone": "America/New_York",
+                "skip_dates": ["2026-12-25"],
             }
         ]
         self._write_app_crons(tmp_path, "test-app", cron_defs)
@@ -2331,7 +2333,35 @@ class TestCronServiceBridge:
             persistent_session=False,
             silent=True,
             enabled=True,
+            timezone="America/New_York",
+            skip_dates=["2026-12-25"],
         )
+
+    def test_cron_without_timezone_passes_the_empty_sentinel(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        """A def that names no zone keeps today's config-then-UTC fallback."""
+        from unittest.mock import MagicMock, patch
+
+        from kiro_crew.apps.bridges import register_app_crons_with_service
+
+        self._write_app_crons(
+            tmp_path,
+            "test-app",
+            [{"name": "test-app/refresh", "every": 600, "message": "go"}],
+        )
+
+        mock_cron_service = MagicMock()
+        mock_sdk = MagicMock()
+        mock_sdk.list_jobs.return_value = []
+        mock_sdk.add_job_if_absent_async = AsyncMock(return_value=MagicMock(id="abc123"))
+
+        with patch("kiro_crew.apps.bridges.CronSDK", return_value=mock_sdk):
+            _run(register_app_crons_with_service("test-app", mock_cron_service))
+
+        kwargs = mock_sdk.add_job_if_absent_async.call_args.kwargs
+        assert kwargs["timezone"] == ""
+        assert kwargs["skip_dates"] is None
 
     def test_disabled_cron_registers_paused(self, tmp_path, app_env, monkeypatch):
         """A manifest cron with enabled:false is passed through as enabled=False."""
@@ -2478,6 +2508,8 @@ class TestCronServiceBridge:
             persistent_session=False,
             silent=True,
             enabled=True,
+            timezone="",
+            skip_dates=None,
         )
 
     def test_rejects_malicious_command(self, tmp_path, app_env, monkeypatch):
@@ -2609,6 +2641,8 @@ class TestCronServiceBridge:
             env={"K": "V"},
             persistent_session=False,
             silent=True,
+            timezone="America/New_York",
+            skip_dates=["2026-12-25"],
         )
         manifest.crons = [entry]
 
@@ -2621,6 +2655,10 @@ class TestCronServiceBridge:
         assert d["env"] == {"K": "V"}
         assert d["persistent_session"] is False
         assert d["silent"] is True
+        # Without these the declared zone is dropped between the manifest and
+        # the scheduler, and the job fires in UTC.
+        assert d["timezone"] == "America/New_York"
+        assert d["skip_dates"] == ["2026-12-25"]
 
     def test_add_job_exception_logged_and_skipped(self, tmp_path, app_env):
         """Exception from CronSDK.add_job is caught, logged, and execution continues."""

--- a/test/test_cron_sdk.py
+++ b/test/test_cron_sdk.py
@@ -5,7 +5,9 @@ Properties 3, 4, 5, 6: Cron job creation, ownership, filtering, cleanup.
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -13,6 +15,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from kiro_crew.apps.cron_sdk import CronSDK
+from kiro_crew.cron import CronService
 
 
 def _run(value: Any) -> Any:
@@ -51,6 +54,8 @@ class MockCronJob:
     user_paused: bool = False
     every_secs: int | None = None
     cron_expr: str | None = None
+    timezone: str = ""
+    skip_dates: list[str] = field(default_factory=list)
 
 
 class MockCronService:
@@ -64,6 +69,8 @@ class MockCronService:
         # are normalized to concrete empties (never None).
         kwargs["agent_sequence"] = list(kwargs.get("agent_sequence") or [])
         kwargs["env"] = dict(kwargs.get("env") or {})
+        kwargs["skip_dates"] = list(kwargs.get("skip_dates") or [])
+        kwargs["timezone"] = kwargs.get("timezone") or ""
         job = MockCronJob(
             id=f"job-{self._next_id}",
             user_paused=not kwargs.get("enabled", True),
@@ -74,6 +81,13 @@ class MockCronService:
         return job
 
     async def add_job_async(self, **kwargs: Any) -> MockCronJob:
+        return self.add_job(**kwargs)
+
+    async def add_job_if_absent_async(
+        self, predicate: Any, **kwargs: Any
+    ) -> MockCronJob | None:
+        if any(predicate(j) for j in self._jobs):
+            return None
         return self.add_job(**kwargs)
 
     def list_jobs(self, include_disabled: bool = False) -> list[MockCronJob]:
@@ -248,6 +262,152 @@ class TestCronJobCreation:
         assert updated.user_paused is False
         # Resumed job shows up in the active (non-disabled) list again.
         assert job in svc.list_jobs()
+
+
+# ---------------------------------------------------------------------------
+# Calendar fields (timezone / skip_dates) are settable AT CREATE
+# ---------------------------------------------------------------------------
+
+
+class TestCronCalendarFieldsOnCreate:
+    """``timezone``/``skip_dates`` reach ``CronService.add_job`` from the SDK.
+
+    Regression for the gap where ``_add_job_kwargs`` was a closed allowlist that
+    omitted both fields, so an app could only ever create jobs with an empty
+    timezone -- resolving to UTC at fire time -- and had to issue a SECOND
+    ``update_job`` write to correct it. That second write is exactly the
+    half-formed-job window the single locked build+persist exists to remove: a
+    "run at 06:00 local" job briefly exists as 06:00 UTC.
+    """
+
+    def test_add_job_threads_timezone_and_skip_dates(self) -> None:
+        """The sync create path persists both calendar fields on the job."""
+        svc = MockCronService()
+        sdk = CronSDK("digest-app", svc)
+
+        job = _run(sdk.add_job(
+            name="digest-app/daily",
+            message="summarise the last 24 hours",
+            cron_expr="0 6 * * *",
+            timezone="America/Los_Angeles",
+            skip_dates=["2026-12-25"],
+        ))
+
+        assert job.timezone == "America/Los_Angeles"
+        assert job.skip_dates == ["2026-12-25"]
+
+    def test_add_job_defaults_leave_calendar_fields_empty(self) -> None:
+        """Omitting both keeps today's behaviour (config timezone, then UTC)."""
+        svc = MockCronService()
+        sdk = CronSDK("digest-app", svc)
+
+        job = _run(sdk.add_job(
+            name="digest-app/daily", message="go", cron_expr="0 6 * * *",
+        ))
+
+        assert job.timezone == ""
+        assert job.skip_dates == []
+
+    @pytest.mark.asyncio
+    async def test_add_job_async_threads_timezone_and_skip_dates(self) -> None:
+        """The loop-native create path threads both fields too."""
+        svc = MockCronService()
+        sdk = CronSDK("digest-app", svc)
+
+        job = await sdk.add_job_async(
+            name="digest-app/daily",
+            message="go",
+            cron_expr="0 6 * * *",
+            timezone="Australia/Sydney",
+            skip_dates=["2026-01-01", "2026-01-26"],
+        )
+
+        assert job.timezone == "Australia/Sydney"
+        assert job.skip_dates == ["2026-01-01", "2026-01-26"]
+
+    @pytest.mark.asyncio
+    async def test_add_job_if_absent_async_threads_timezone(self) -> None:
+        """The atomic add-if-absent path (app-manifest registration) too."""
+        svc = MockCronService()
+        sdk = CronSDK("digest-app", svc)
+
+        job = await sdk.add_job_if_absent_async(
+            name="digest-app/daily",
+            message="go",
+            cron_expr="0 6 * * *",
+            timezone="Europe/Berlin",
+        )
+
+        assert job is not None
+        assert job.timezone == "Europe/Berlin"
+
+
+class TestCronCalendarFieldsAgainstRealService:
+    """End-to-end against the real ``CronService``: one locked save, validated.
+
+    The mock service above proves the SDK forwards the kwargs; these prove the
+    real persistence owner accepts them at create, writes them in the job's
+    FIRST and only save, and rejects invalid values before anything lands on
+    disk.
+    """
+
+    def _service(self, tmp_path: Path) -> CronService:
+        svc = CronService(base_dir=tmp_path)
+        svc._dir.mkdir(parents=True, exist_ok=True)
+        return svc
+
+    def test_timezone_lands_in_the_first_persisted_write(self, tmp_path: Path) -> None:
+        svc = self._service(tmp_path)
+        sdk = CronSDK("digest-app", svc)
+
+        job = sdk.add_job(
+            name="digest-app/daily",
+            message="summarise the last 24 hours",
+            cron_expr="0 6 * * *",
+            timezone="America/Los_Angeles",
+            skip_dates=["2026-12-25"],
+        )
+
+        assert job.timezone == "America/Los_Angeles"
+        assert job.skip_dates == ["2026-12-25"]
+        # The store on disk carries them, so no follow-up update_job is needed
+        # and the job is never observable with the wrong timezone.
+        on_disk = json.loads(svc._path.read_text())
+        entry = next(j for j in on_disk["jobs"] if j["id"] == job.id)
+        assert entry["timezone"] == "America/Los_Angeles"
+        assert entry["skip_dates"] == ["2026-12-25"]
+        assert entry["created_by"] == "app:digest-app"
+
+    def test_unknown_timezone_raises_and_persists_nothing(self, tmp_path: Path) -> None:
+        """An app author learns at create time, not at fire time."""
+        svc = self._service(tmp_path)
+        sdk = CronSDK("digest-app", svc)
+
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            sdk.add_job(
+                name="digest-app/daily",
+                message="go",
+                cron_expr="0 6 * * *",
+                timezone="Mars/Olympus_Mons",
+            )
+
+        assert svc.list_jobs(include_disabled=True) == []
+
+    def test_malformed_skip_date_raises_and_persists_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        svc = self._service(tmp_path)
+        sdk = CronSDK("digest-app", svc)
+
+        with pytest.raises(ValueError, match="Invalid skip_date"):
+            sdk.add_job(
+                name="digest-app/daily",
+                message="go",
+                cron_expr="0 6 * * *",
+                skip_dates=["25/12/2026"],
+            )
+
+        assert svc.list_jobs(include_disabled=True) == []
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_manifest_hooks.py
+++ b/test/test_manifest_hooks.py
@@ -5,6 +5,9 @@ Properties 12, 13: Hook path validation and manifest round-trip.
 """
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -66,6 +69,10 @@ def _cron_entry() -> st.SearchStrategy[CronEntry]:
         env=_env_dict(),
         persistent_session=st.booleans(),
         silent=st.booleans(),
+        timezone=st.sampled_from(["", "UTC", "America/New_York", "Australia/Sydney"]),
+        skip_dates=st.lists(
+            st.sampled_from(["2026-01-01", "2026-12-25", "2027-07-04"]), max_size=3
+        ),
     )
 
 
@@ -113,6 +120,8 @@ class TestManifestRoundTrip:
             assert rest.env == orig.env
             assert rest.persistent_session == orig.persistent_session
             assert rest.silent == orig.silent
+            assert rest.timezone == orig.timezone
+            assert rest.skip_dates == orig.skip_dates
 
     @settings(max_examples=50)
     @given(hooks=_hooks_config())
@@ -139,6 +148,31 @@ class TestManifestRoundTrip:
         assert restored.env == cron.env
         assert restored.persistent_session == cron.persistent_session
         assert restored.silent == cron.silent
+        assert restored.timezone == cron.timezone
+        assert restored.skip_dates == cron.skip_dates
+
+    def test_to_dict_omits_empty_calendar_fields(self) -> None:
+        """An entry that names no zone or skip dates serializes exactly as before.
+
+        ``AppManifest.signing_payload`` folds each entry's ``to_dict()`` into the
+        signed body, so emitting ``timezone``/``skip_dates`` unconditionally
+        would change the payload of every already-signed manifest and invalidate
+        its signature. Both keys are therefore present only when set.
+        """
+        d = CronEntry(name="refresh", every=600, message="go").to_dict()
+        assert "timezone" not in d
+        assert "skip_dates" not in d
+
+    def test_to_dict_emits_calendar_fields_when_set(self) -> None:
+        """A zone or skip list the publisher declared reaches the signed payload."""
+        d = CronEntry(
+            name="market-open",
+            cron_expr="30 9 * * 1-5",
+            timezone="America/New_York",
+            skip_dates=["2026-12-25"],
+        ).to_dict()
+        assert d["timezone"] == "America/New_York"
+        assert d["skip_dates"] == ["2026-12-25"]
 
     def test_from_dict_coerces_null_string_fields_to_empty(self) -> None:
         """Explicit JSON null on a string field deserializes to "" not "None".
@@ -168,6 +202,164 @@ class TestManifestRoundTrip:
         assert entry.script == ""
         # Non-string fields keep their normal coercion / defaults.
         assert entry.every == 60
+
+    def test_from_dict_coerces_null_container_fields_to_empty(self) -> None:
+        """Explicit JSON null on a list/dict/number field must not raise.
+
+        ``data.get(key, [])`` defends only the ABSENT key. An app.json that
+        writes ``"skip_dates": null`` (hand-edited, or emitted by a generator)
+        returns ``None``, and the comprehension over it raised ``TypeError``
+        straight out of ``from_dict`` -- reached from ``/api/apps/register``,
+        that is an HTTP 500 rather than a validation error. Same for
+        ``"env": null`` (``AttributeError`` on ``.items()``) and
+        ``"every": null`` (``TypeError`` in ``int()``).
+        """
+        entry = CronEntry.from_dict(
+            {
+                "name": "daily",
+                "cron_expr": "0 6 * * *",
+                "every": None,
+                "agent_sequence": None,
+                "env": None,
+                "skip_dates": None,
+            }
+        )
+        assert entry.every == 0
+        assert entry.agent_sequence == []
+        assert entry.env == {}
+        assert entry.skip_dates == []
+
+    @pytest.mark.parametrize("bogus", [5, "0 6 * * *", {"a": 1}, True])
+    def test_from_dict_reports_wrong_typed_containers_instead_of_erasing(
+        self, bogus: Any
+    ) -> None:
+        """A scalar/object where a list belongs degrades to empty AND is REPORTED.
+
+        Degrading is required (the register path must not 500), but degrading
+        SILENTLY is its own bug: an author who wrote
+        ``"skip_dates": "2026-12-25"`` -- a bare string, not an array -- asked
+        for a skip, and dropping it without a word lets the job fire on the
+        excluded date. So the violation is recorded on the entry and surfaces as
+        a validation error, the same shape as ``enabled_type_invalid``. (Before
+        the type gate this string spelled ten one-character skip dates, which
+        validation happened to reject -- loud, but for the wrong reason.)
+        """
+        entry = CronEntry.from_dict(
+            {
+                "name": "daily",
+                "cron_expr": "0 6 * * *",
+                "agent_sequence": bogus,
+                "skip_dates": bogus,
+            }
+        )
+        assert entry.agent_sequence == []
+        assert entry.skip_dates == []
+        assert set(entry.type_invalid_fields) == {"agent_sequence", "skip_dates"}
+
+        errors = AppManifest(
+            name="test-app",
+            version="1.0.0",
+            displayName="Test",
+            description="Test",
+            crons=[entry],
+        ).validate()
+        assert any("skip_dates" in e and "wrong JSON type" in e for e in errors)
+        assert any("agent_sequence" in e and "wrong JSON type" in e for e in errors)
+
+    def test_from_dict_reports_a_wrong_typed_env_and_every(self) -> None:
+        """The dict and numeric readers report their own violations too."""
+        entry = CronEntry.from_dict(
+            {"name": "daily", "cron_expr": "0 6 * * *", "env": ["A=1"], "every": "soon"}
+        )
+        assert entry.env == {}
+        assert entry.every == 0
+        assert set(entry.type_invalid_fields) == {"env", "every"}
+
+    def test_from_dict_flags_a_boolean_every(self) -> None:
+        """``"every": true`` is a type slip, not a 1-second schedule.
+
+        ``bool`` is an ``int`` subclass, so an isinstance check alone would let
+        ``True`` through as ``int(True) == 1`` -- the fastest possible interval,
+        from a manifest that meant nothing of the kind.
+        """
+        entry = CronEntry.from_dict({"name": "daily", "cron_expr": "0 6 * * *", "every": True})
+        assert entry.every == 0
+        assert entry.type_invalid_fields == ["every"]
+
+    def test_from_dict_reports_a_wrong_typed_timezone(self) -> None:
+        """A non-string zone is reported, not quietly dropped to the fallback.
+
+        Discarding it silently reproduces the bug the field exists to fix:
+        validation would pass, the job would persist ``timezone=""`` and fire in
+        the fallback zone (UTC on a fresh install), and nothing would say why the
+        schedule ran on the wrong calendar day. That is why ``timezone`` is
+        recorded while a plain string field like ``agent`` is not -- a dropped
+        agent degrades visibly, a dropped zone does not.
+        """
+        entry = CronEntry.from_dict(
+            {"name": "daily", "cron_expr": "0 6 * * *", "timezone": ["America/New_York"]}
+        )
+        assert entry.timezone == ""
+        assert entry.type_invalid_fields == ["timezone"]
+
+        errors = AppManifest(
+            name="test-app",
+            version="1.0.0",
+            displayName="Test",
+            description="Test",
+            crons=[entry],
+        ).validate()
+        assert any("timezone" in e and "wrong JSON type" in e for e in errors)
+
+    def test_null_timezone_is_not_reported(self) -> None:
+        """Null stays "not set": no error, and the config-then-UTC fallback."""
+        entry = CronEntry.from_dict(
+            {"name": "daily", "cron_expr": "0 6 * * *", "timezone": None}
+        )
+        assert entry.timezone == ""
+        assert entry.type_invalid_fields == []
+
+    def test_from_dict_survives_a_json_infinity_every(self) -> None:
+        """``"every": 1e1000000`` parses to float('inf'), which int() refuses.
+
+        This is reachable from real JSON, not a synthetic value: ``json.loads``
+        accepts an out-of-range float literal and yields ``inf``, so the literal
+        below is what an app.json can legally contain. Unguarded it raised
+        ``OverflowError`` out of ``from_dict`` -- an HTTP 500 on
+        ``/api/apps/register``, the same failure shape as the null case.
+        """
+        data = json.loads('{"name": "daily", "cron_expr": "0 6 * * *", "every": 1e1000000}')
+        assert data["every"] == float("inf")  # the literal really does parse to inf
+
+        entry = CronEntry.from_dict(data)
+        assert entry.every == 0
+        assert entry.type_invalid_fields == ["every"]
+
+    def test_from_dict_survives_negative_infinity_and_nan_every(self) -> None:
+        for value in (float("-inf"), float("nan")):
+            entry = CronEntry.from_dict(
+                {"name": "daily", "cron_expr": "0 6 * * *", "every": value}
+            )
+            assert entry.every == 0
+            assert entry.type_invalid_fields == ["every"]
+
+    def test_null_container_fields_are_not_reported_as_type_violations(self) -> None:
+        """JSON null means "not set", the spelling a generator emits for absent.
+
+        It must not raise (see above) and must not produce a validation error
+        either, mirroring how ``_str_or_empty`` treats a null string field.
+        """
+        entry = CronEntry.from_dict(
+            {
+                "name": "daily",
+                "cron_expr": "0 6 * * *",
+                "every": None,
+                "agent_sequence": None,
+                "env": None,
+                "skip_dates": None,
+            }
+        )
+        assert entry.type_invalid_fields == []
 
 
 # ---------------------------------------------------------------------------
@@ -233,3 +425,57 @@ class TestHookPathValidation:
         )
         errors = manifest.validate()
         assert any("backend.hooks.routes" in e for e in errors)
+
+
+class TestCronCalendarFieldValidation:
+    """``timezone``/``skip_dates`` on a manifest cron are validated at validate().
+
+    ``register_app_crons_with_service`` catches a per-job ``ValueError`` from the
+    persistence owner, logs it and moves on -- so a bad zone shipped in an
+    app.json would otherwise register NOTHING for that cron and say so only in
+    the gateway log, leaving the author with a job that silently does not exist.
+    Reporting it as a manifest validation error surfaces it at install time.
+    """
+
+    def _manifest(self, cron: CronEntry) -> AppManifest:
+        return AppManifest(
+            name="test-app",
+            version="1.0.0",
+            displayName="Test",
+            description="Test",
+            crons=[cron],
+        )
+
+    def test_unknown_timezone_is_a_validation_error(self) -> None:
+        errors = self._manifest(
+            CronEntry(name="daily", cron_expr="0 6 * * *", timezone="Mars/Olympus_Mons")
+        ).validate()
+        assert any("unknown timezone" in e and "daily" in e for e in errors)
+
+    def test_malformed_skip_date_is_a_validation_error(self) -> None:
+        errors = self._manifest(
+            CronEntry(name="daily", cron_expr="0 6 * * *", skip_dates=["25/12/2026"])
+        ).validate()
+        assert any("invalid skip_date" in e and "daily" in e for e in errors)
+
+    def test_non_padded_skip_date_is_rejected(self) -> None:
+        """``2026-1-1`` parses but never matches the zero-padded fire-time form."""
+        errors = self._manifest(
+            CronEntry(name="daily", cron_expr="0 6 * * *", skip_dates=["2026-1-1"])
+        ).validate()
+        assert any("invalid skip_date" in e for e in errors)
+
+    def test_valid_calendar_fields_produce_no_error(self) -> None:
+        errors = self._manifest(
+            CronEntry(
+                name="market-open",
+                cron_expr="30 9 * * 1-5",
+                timezone="America/New_York",
+                skip_dates=["2026-12-25"],
+            )
+        ).validate()
+        assert not [e for e in errors if "timezone" in e or "skip_date" in e]
+
+    def test_absent_calendar_fields_produce_no_error(self) -> None:
+        errors = self._manifest(CronEntry(name="daily", cron_expr="0 6 * * *")).validate()
+        assert not [e for e in errors if "timezone" in e or "skip_date" in e]


### PR DESCRIPTION
## Problem / Motivation

An app cannot say which timezone its cron job runs in at the moment it creates
the job.

`CronSDK.add_job` / `add_job_async` / `add_job_if_absent_async` all route
through `_add_job_kwargs`, a closed allowlist that omitted `timezone` (and
`skip_dates`). `timezone` was not a parameter of the create methods either, so
an app could only ever produce jobs whose timezone is the empty string.
`CronSDK.update_job`, by contrast, is a `**kwargs` passthrough and
`CronService.update_job` documents `timezone` as accepted -- so create silently
dropped a field that update accepted.

The declarative half had the same gap and was worse: `CronEntry` in
`apps/manifest.py` carried no calendar fields at all, so an `app.json` could
not pin an hour that is only meaningful in one zone (market open, a regional
business-day digest) no matter what the SDK accepted.

## Why it matters

Timezone resolution falls all the way back to UTC when the field is empty
(`cron.py`: `tz_name = job.timezone or KiroCrewConfig.load().timezone or "UTC"`),
and a fresh install typically has an empty `config.timezone` too. So an app that
registers "run at 06:00 for this user" from `on_startup` actually registers 06:00
UTC. For a US-Pacific user that fires at 23:00 the previous evening: a daily job
lands on the wrong calendar day, and a job whose payload is "summarise the last
24 hours" silently reports the wrong window.

The app's options today were a second `update_job` write after creation, or
converting the user's local time to a UTC cron expression itself and re-deriving
it twice a year at DST boundaries. The second write is the worse of the two in a
specific way: it reopens exactly the half-formed-job window the single locked
build+persist in `CronService.add_job` exists to close -- the job briefly exists
on disk with the wrong timezone.

## What changed (motivation -> approach -> change)

Symptom: an app-created job fires in UTC. Root cause: the field is dropped at
the app-facing boundary, and every layer BELOW it already handles the field.
`CronJob.timezone` exists, `CronService.add_job` accepts it, `_build_job`
validates it (`is_valid_timezone`) and folds it in before the single `_save()`,
and fire time reads `job.timezone`. The fallback chain to UTC is correct and
intentional; the only defect on this path is that the SDK never let a caller
populate the field. So the fix belongs at that boundary, not in the fallback.
(Two SIBLING create surfaces re-enumerate the same field list and have their own
gaps -- CLI `cron add` and dashboard create; see the deferred-findings comment.
They are separate diffs, not layers below this one.)

- `apps/cron_sdk.py`: `timezone` and `skip_dates` are parameters of all three
  create methods and are threaded through `_add_job_kwargs`. Nothing else moves
  -- `CronService.add_job` already validates them before its single locked save,
  so there is no extra `_save()` and no new race, and an unknown zone or a
  malformed skip date now raises `ValueError` at create instead of degrading to
  UTC when the job fires.
- `apps/manifest.py`: `CronEntry` gains `timezone` / `skip_dates`, round-tripped
  through `from_dict` / `to_dict`. `to_dict` emits each key only when set, so a
  manifest that declares neither produces a byte-identical signing payload and
  an already-signed app keeps its signature valid. The docs
  (`docs/app-kit/manifest-reference.md`) and the app-dev skill gain both fields
  with the UTC trap spelled out.
- `apps/manifest.py` `validate()`: rejects an unknown zone or a non-padded /
  malformed `skip_dates` entry. This is not redundant with the persistence
  owner's validation: `register_app_crons_with_service` catches a per-job
  `ValueError`, logs it and continues, so a bad zone in an `app.json` would
  otherwise register nothing for that cron and report it only in the gateway
  log -- the author sees a cron that silently does not exist. `is_valid_timezone`
  / `is_valid_skip_date` are imported at MODULE scope (`from kiro_crew.cron
  import ...`), not lazily: the repo's `top-level-imports` rule yields only to a
  real cycle or a measured import cost, and neither applies here. No cycle in
  either direction, and `import kiro_crew.apps.manifest` alone already loads 392
  modules while `manifest + cron` also loads 392 -- the manifest's existing
  import closure already contains everything `cron` needs, so a lazy form would
  buy 0 modules and 0.4ms.
- `apps/bridges.py`: `_cron_defs_from_manifest` carries both fields into the
  scheduler definition (and therefore into `app-crons.json`), and
  `register_app_crons_with_service` forwards them to the SDK.
- `apps/manifest.py` `CronEntry.from_dict`: the new `skip_dates` reader needed a
  JSON-type gate, and adding one exposed that the two existing container readers
  needed the same. `data.get(key, [])` defends only the ABSENT key -- an explicit
  `"skip_dates": null` / `"agent_sequence": null` / `"env": null` returns that
  value and the comprehension then raises `TypeError` / `AttributeError` out of
  `from_dict`, which is an HTTP 500 on `/api/apps/register` rather than a
  validation error. Two cases are treated differently on purpose: JSON `null`
  means "not set" and degrades silently (mirroring the pre-existing
  `_str_or_empty`), while a PRESENT wrong-typed value degrades AND is recorded
  in `type_invalid_fields` for `validate()` to report. Erasing it silently
  would be its own bug -- an author who wrote `"skip_dates": "2026-12-25"`
  (a string, not an array) asked for a skip, and dropping it without a word lets
  the job fire on the excluded date. The recording reuses the shape already in
  this dataclass (`enabled_type_invalid`: a parse-time flag `validate()` reports
  and `to_dict` never serializes). `"every": true` is flagged for the same
  reason: `bool` is an `int` subclass, so it would otherwise coerce to a
  1-second interval. `timezone` is gated the same way (`_str_or_flagged`) rather
  than through the plain `_str_or_empty` used by the other string fields,
  because a discarded `agent` or `message` degrades visibly on the first run
  while a discarded zone degrades into a job that runs perfectly at the wrong
  time -- which is the failure this PR exists to close. The numeric conversion
  is total over `null`, a wrong type, `inf`/`-inf` (`json.loads` accepts
  `1e1000000`) and `nan`.

`skip_dates` is included alongside `timezone` rather than left for later because
it is meaningless without one: fire-time skip matching renders the date in the
job's timezone, and both are the same calendar-validity concern that
`_build_job` validates together. Threading only `timezone` would force
`skip_dates` through a follow-up `update_job` -- the half-formed-job window
again, for the field that depends on the one being fixed.

Why an app still passes a per-user zone programmatically: a shipped manifest can
legitimately pin a FIXED zone, but a per-user zone is not manifest data, so
`ctx.cron.add_job(timezone=...)` remains the path for the reporter's use case.
Both surfaces now work.

## Tests

New, each mutation-verified red against this branch's base:

`test/test_cron_sdk.py`
- `add_job`, `add_job_async` and `add_job_if_absent_async` each thread
  `timezone` and `skip_dates` onto the created job (red on base with
  `unexpected keyword argument 'timezone'`).
- Omitting both keeps the empty sentinel, so the existing config-then-UTC
  fallback is unchanged (this one passes on base too -- it is the no-regression
  control).
- Against the REAL `CronService` on a tmp store: the zone and skip list appear
  in the job's first and only persisted write (asserted by reading the store
  JSON), proving no follow-up `update_job` is needed.
- Against the real service: an unknown zone and a malformed skip date each raise
  and leave the store EMPTY, so a rejected value never lands on disk.
- `MockCronService` gained `add_job_if_absent_async` and normalizes the two new
  fields exactly as `_build_job` does, so the mock stays faithful.

`test/test_manifest_hooks.py`
- The `CronEntry` round-trip property covers both new fields.
- `to_dict` OMITS both keys when unset (the signing-payload compatibility
  invariant) and emits them when set.
- `validate()` reports an unknown zone, a malformed `skip_dates` entry, and the
  `2026-1-1` non-padded form that parses but never matches at fire time; valid
  and absent values produce no error.
- `from_dict` survives explicit nulls on `every` / `agent_sequence` / `env` /
  `skip_dates` without raising, and a wrong-typed value (scalar, string, object,
  boolean) is degraded AND reported in `type_invalid_fields`, which `validate()`
  renders as an error. Mutation-verified by removing only the violation
  RECORDING and leaving the degradation in place, so these tests fail on a
  silent erase rather than merely on a crash.

`test/test_app_bridges.py`
- `_register_crons` writes both fields into `app-crons.json`.
- `register_app_crons_with_service` forwards them to the SDK, and forwards the
  `""` / `None` sentinels when the def names neither.

Suite state: 385 passed across the cron/app/manifest test files with
isort / flake8 / mypy clean on all changed source files. A wider
`-k "app or manifest or cron"` sweep is 9479 passed with 30 failures in
`test_file_explorer_app.py`, `test_dev_fleet_app.py`,
`test_host_isolation_floor.py` and `test_xdist_host_budget.py` -- all
environment-owned and A/B proven pre-existing (they fail identically on a
pristine stash of this branch, and the diff touches none of those files).

## Manual verification

N/A -- the real-`CronService` tests exercise the actual persistence path
end-to-end (validation, single locked save, on-disk field names), which is what
manual steps would have checked.

## Related Issues

Fixes #6014
