### PR TITLE
fix(chat): honor a Stop pressed while the turn is still being prepared

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5790,6 +5790,24 @@ async def _run_chat(
         except SessionClosingError:
             logger.info("Aborting dispatch for %s — gateway is shutting down", session_key)
             return
+        # Stop-before-dispatch gate: a Stop pressed during the async prep above
+        # (session cold start, context build) finds no session to cancel —
+        # SessionManager.stop_turn answers "idle" and the stop card resolves —
+        # so nothing downstream would ever honor it and the turn would open and
+        # stream to completion behind a card that says stopped (#5464). The
+        # point-in-time _stop_state is useless here (the idle resolution has
+        # already snapped it back), so compare _stop_generation, which counts
+        # stop INITIATIONS and never rewinds, against the turn-entry snapshot —
+        # the same durable signal the stop-hook suppression uses. Synchronous,
+        # beside the begin_turn gate, so no await separates the read from the
+        # stream's turn registration.
+        if getattr(slot, "_stop_generation", 0) != _stop_gen_turn_start:
+            logger.info(
+                "Aborting dispatch for %s — Stop was pressed while the turn "
+                "was still being prepared (no session existed to cancel yet)",
+                session_key,
+            )
+            return
         async for event in event_stream:
             # Heartbeat every 5s during long operations
             if time.time() - last_heartbeat > 5:

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -13407,6 +13407,115 @@ class TestStopHistoryBanner:
 # ── Tests: AcpProcessDied handler in _run_chat ──
 
 
+class TestStopDuringSessionPrep:
+    """A Stop pressed while the turn is still being prepared must not open it.
+
+    During ``get_or_create``'s cold start the session is not registered yet,
+    so ``SessionManager.stop_turn`` answers ``"idle"`` and the stop resolves
+    without cancelling anything. The dispatch gate in ``_run_chat`` is what
+    honors that stop: it compares ``slot._stop_generation`` against the
+    turn-entry snapshot and refuses to open the turn (#5464 — [Stopped] card
+    shown while the response streams to completion).
+    """
+
+    def _make_state_and_slot(self, tmp_path):
+        from kiro_crew.dashboard.chat_runner import _run_chat
+
+        state = _make_state(tmp_path)
+        state.sessions.release = MagicMock()
+        state.sessions.reset = AsyncMock()
+        state.sessions.set_approval_policy = MagicMock()
+        state.sessions.check_context_usage = MagicMock()
+        state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.is_yolo_active = MagicMock(return_value=False)
+        state._background_tasks = set()
+
+        slot = state.get_or_create_slot("stop-prep-slot")
+        slot.append("user", "hello", "msg msg-u")
+        return state, slot, _run_chat
+
+    def _make_client(self, stream_calls):
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        client = MagicMock()
+        client.shutdown = AsyncMock()
+
+        async def _stream(msg):
+            stream_calls.append(msg)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="full response")
+            yield LLMEvent(kind=EVENT_COMPLETE, stop_reason="end_turn")
+
+        client.stream = _stream
+        client.stream_command = _stream
+        return client
+
+    @pytest.mark.asyncio
+    async def test_stop_during_get_or_create_aborts_dispatch(self, tmp_path: Path) -> None:
+        """Stop lands mid-cold-start → the turn never opens, nothing streams.
+
+        The stop is simulated exactly as the /stop handler leaves it for this
+        race: ``_stop_state`` flips idle → soft_pending (bumping
+        ``_stop_generation``) and, because ``stop_turn`` found no session and
+        answered "idle", snaps straight back to idle. A point-in-time state
+        check at dispatch sees nothing — only the generation delta survives.
+        """
+        state, slot, _run_chat = self._make_state_and_slot(tmp_path)
+        stream_calls: list[str] = []
+        client = self._make_client(stream_calls)
+
+        async def _slow_create(*args, **kwargs):
+            # Stop pressed while the session is still being created.
+            slot._stop_state = "soft_pending"
+            slot._stop_state = "idle"
+            return client, True, False
+
+        state.sessions.get_or_create = AsyncMock(side_effect=_slow_create)
+
+        await _run_chat(state, slot, "hello")
+
+        assert stream_calls == [], (
+            "the turn was dispatched despite a Stop during session prep — "
+            "the full response would stream behind a [Stopped] card (#5464)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_stop_dispatches_normally(self, tmp_path: Path) -> None:
+        """Control: without a Stop, the same setup opens the turn exactly once."""
+        state, slot, _run_chat = self._make_state_and_slot(tmp_path)
+        stream_calls: list[str] = []
+        client = self._make_client(stream_calls)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        await _run_chat(state, slot, "hello")
+
+        assert len(stream_calls) == 1, "the dispatch gate must not fire without a Stop"
+
+    @pytest.mark.asyncio
+    async def test_stop_of_a_previous_turn_does_not_abort_the_next(self, tmp_path: Path) -> None:
+        """A stop generation inherited from an EARLIER turn must not trip the gate.
+
+        The gate compares against the snapshot taken at THIS turn's entry, so a
+        slot whose previous turn was stopped (generation already > 0) still
+        dispatches its next turn normally.
+        """
+        state, slot, _run_chat = self._make_state_and_slot(tmp_path)
+        # A previous turn was stopped and resolved before this turn began.
+        slot._stop_state = "soft_pending"
+        slot._stop_state = "idle"
+
+        stream_calls: list[str] = []
+        client = self._make_client(stream_calls)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        await _run_chat(state, slot, "hello")
+
+        assert (
+            len(stream_calls) == 1
+        ), "a stale stop generation from a previous turn aborted a fresh turn"
+
+
 class TestAcpProcessDiedRecovery:
     """Verify _run_chat handles AcpProcessDied with retry logic, redaction, and session reset."""
 


### PR DESCRIPTION
## Problem / Motivation

Pressing Stop while the agent is preparing a turn (the window between the user message and the provider dispatch: session cold start, context build) does nothing. The `[Stopped]` card renders, but the response still opens and streams to completion behind it.

Reproduced live on an isolated pod at main `33f2589` (macOS, model `auto`): Stop pressed ~7s after sending a long prompt, SEL recorded `dashboard_stop outcome=idle` for the running slot, the `[Stopped]` card rendered — and the full 2000-line response still streamed into the transcript.

## Why it matters

This is the dominant reproducible path behind #5464 ("Stop button does nothing, the agent outputs its full response"). It hits exactly the users most likely to press Stop — those who just sent a message they regret — because the first turn of a fresh session spends seconds in cold start, and a Stop in that window is silently discarded while the UI claims success. The wasted turn also bills real credits.

## What changed (motivation → approach → change)

- **Symptom**: Stop during turn prep is a no-op; the turn still opens and streams to completion behind a resolved `[Stopped]` card.
- **Root cause**: `_run_chat`'s async prep runs before `SessionManager` has a session registered under the turn's key. A Stop in that window reaches `SessionManager.stop_turn`, which finds no session and answers `"idle"`; the handler resolves the stop card and snaps `_stop_state` back to `"idle"`. Nothing downstream remembers the request, so the dispatch that follows opens the turn normally.
- **Change**: add a synchronous stop-before-dispatch gate in `_run_chat`, beside the existing `begin_turn` lease-dispatch race gate. It compares `slot._stop_generation` — the monotonic count of stop initiations that turn teardown never rewinds, already used by the stop-hook suppression for exactly this "stop resolved before we could look" problem — against the turn-entry snapshot, and refuses to open the turn when a Stop landed during prep. A point-in-time `_stop_state` check cannot work here because the idle resolution has already reset it. The gate sits in the same no-await span as `begin_turn`, so no stop can slip between the check and the stream's turn registration.

## Tests

`test/test_dashboard_chat.py::TestStopDuringSessionPrep` (3 tests):

- `test_stop_during_get_or_create_aborts_dispatch` — simulates the exact race (stop initiated and idle-resolved inside `get_or_create`) and asserts the provider stream is never opened. Fails on main without the gate.
- `test_no_stop_dispatches_normally` — control: the same setup without a Stop dispatches exactly once (no false positives).
- `test_stop_of_a_previous_turn_does_not_abort_the_next` — a stop generation inherited from an earlier turn must not trip the gate; only a delta against this turn's entry snapshot counts.

Local gates: full backend pytest (68 961 passed; 14 failures also fail on clean main `33f2589` on this host — environment-dependent, list below; 2 more are xdist-parallel flakes that pass in isolation), isort, flake8, mypy, `tsc -b`, vitest (24 250 passed).

<details>
<summary>Pre-existing failures (identical on clean main, this host)</summary>

- `test/test_xdist_host_budget.py` (6) and `test/test_host_isolation_floor.py` (1) — free-memory-dependent worker-budget assertions
- `test/test_cloud_aws.py` (4) — host AWS CLI interaction
- `test/test_terminal_handler.py` `@pty_integration` (2) — pty integration on this host
- `src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py` (1)

</details>

## Manual verification

Reproduced the bug on an isolated pod (`kirocrew pod up`) at main `33f2589` before the fix: Stop during cold start → SEL `dashboard_stop outcome=idle` → `[Stopped]` card → full response streamed anyway. The same sequence with this change dispatch-gates the turn (unit test drives the identical state transitions; the gate logs `Aborting dispatch … Stop was pressed while the turn was still being prepared`).

## Related Issues

Refs #5464

The other half of that report (Steer showing "Steered into the running turn" while the backend never echoes `steering_consumed`, so the text is requeued and answered as a separate turn — reproduced on both `gpt-5.6-sol` and `claude-haiku-4.5`) is a distinct seam and is not addressed here; details in the issue thread.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
