### PR TITLE
fix(dashboard): keep document-level keys on the visible file tab

### DIFF
--- a/website/src/components/ArtifactPanel.tsx
+++ b/website/src/components/ArtifactPanel.tsx
@@ -24,6 +24,12 @@ interface Props {
   /** Content captured at open time; the live query overrides it once loaded. */
   content: string
   onClose: () => void
+  /** Is this panel the tab the user can see? A host that keeps background tabs
+   *  mounted and merely hides them — and keeps the whole panel mounted through
+   *  a close — has several live panels at once, each binding document-level
+   *  Escape. Without this, an artifact tab that is off screen closes itself.
+   *  Hosts that mount a single panel can leave this unset. */
+  active?: boolean
   /** Mirror of the local-file submit path: sends a formatted USER message to
    *  the chat session the panel was opened from (panel.slot). When omitted the
    *  submit-to-chat affordance is hidden (read-only embedding). */
@@ -107,7 +113,7 @@ function SubmitBar({ count, submitting, onSubmit, bleed = false }: {
  * `onSubmitComments` (the local-file user-message path) rather than the
  * full-page `iterateWithAgent` navigate — and only for human comments.
  */
-export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSubmitComments, embedded, scrollMemoryKey }: Props) {
+export default memo(function ArtifactPanel({ slug, kind, content, onClose, active: visible = true, onSubmitComments, embedded, scrollMemoryKey }: Props) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
   const navigate = useNavigate()
   const previewRef = useRef<HTMLDivElement>(null)
@@ -196,6 +202,11 @@ export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSub
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
+      // A background tab, or any tab in a closed-but-mounted panel, is still
+      // listening — closing it would dismiss an artifact that is nowhere on
+      // screen. Aliased from the `active` prop: a local `active` in this file
+      // already names the fullscreen icon.
+      if (!visible) return
       // Don't hijack Esc while the user is in an editable field (e.g. the
       // add-instruction textarea) — let the field handle it instead of
       // closing/exiting the panel out from under them.
@@ -205,7 +216,7 @@ export default memo(function ArtifactPanel({ slug, kind, content, onClose, onSub
     }
     document.addEventListener('keydown', h)
     return () => document.removeEventListener('keydown', h)
-  }, [fullscreen, onClose])
+  }, [visible, fullscreen, onClose])
   useEffect(() => {
     if (!fullscreen) return
     document.body.style.overflow = 'hidden'

--- a/website/src/components/MarkdownPanel.tsx
+++ b/website/src/components/MarkdownPanel.tsx
@@ -43,10 +43,10 @@ const cssHighlights: { set(n: string, h: FindHighlight): void; delete(n: string)
     ? (CSS as unknown as { highlights?: { set(n: string, h: FindHighlight): void; delete(n: string): boolean } }).highlights
     : undefined
 const FIND_HL_SUPPORTED = !!FindHighlightCtor && !!cssHighlights
-// Global registry names. Assumes a single active markdown preview at a time
-// (the panel's findActiveRef already encodes that assumption); a second
-// concurrent preview find would share these names — a harmless visual overlap,
-// never a crash.
+// Global registry names, shared by every mounted panel. Only one panel ever has
+// find open, because the `active` gate refuses the chord in every tab but the
+// visible one — so the names cannot be contended. Were two previews ever to
+// search at once they would overlap visually, never crash.
 const FIND_HL_ALL = 'mc-find'
 const FIND_HL_CURRENT = 'mc-find-current'
 
@@ -193,6 +193,12 @@ interface Props {
   onDiffModeChange?: (diffMode: boolean) => void
   /** Render as a SidePanel tab body (fills parent, no resize handle/border). */
   embedded?: boolean
+  /** Is this panel the VISIBLE tab? A host that keeps background tabs mounted
+   *  and merely hides them has several live panels at once, and each installs
+   *  its own document-level key handlers — so without this every hidden tab
+   *  also answers Cmd+F, Escape and Cmd+S. Hosts that mount a single panel can
+   *  leave this unset. */
+  active?: boolean
   /** File-browser rail (grip + tree column) rendered to the RIGHT of the
    *  content, under the shared full-width header — the file-tab body owns the
    *  rail's data and open handling; this panel only places it. */
@@ -831,7 +837,7 @@ export interface MarkdownPanelHandle {
   requestNavigate: (nav: (stillClean: () => boolean) => void) => void
 }
 
-export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPanel({ filePath, content, onContentChange, onDiskContent, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded, savedBaseline, revealLine, onRevealConsumed, browserRail, railOpen, onRailToggle, scrollMemoryKey }: Props, ref) {
+export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPanel({ filePath, content, onContentChange, onDiskContent, onSave, onClose, liveWatch, onSubmitComments, onRefresh, reserveWidth, initialDiffMode, onDiffModeChange, embedded, active = true, savedBaseline, revealLine, onRevealConsumed, browserRail, railOpen, onRailToggle, scrollMemoryKey }: Props, ref) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
   const ime = useImeGuard()
   const qc = useQueryClient()
@@ -1010,8 +1016,14 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
   const findInputRef = useRef<HTMLInputElement>(null)
   const findRangesRef = useRef<Range[]>([])
   // Is this panel the region the cursor is in? Defaults true so Cmd+F right
-  // after opening the doc searches the doc (the reported expectation). Flips
-  // based on where the last pointer-down landed.
+  // after opening the doc searches the doc. Flips based on where the last
+  // pointer-down landed.
+  //
+  // The selector is deliberately unscoped. It answers "did the pointer land in
+  // SOME markdown panel", which every mounted instance answers identically —
+  // and that is sufficient because the `active` gate below already refuses the
+  // chord in every panel but the visible one, and a pointer cannot land inside
+  // a `display:none` sibling.
   const findActiveRef = useRef(true)
 
   useEffect(() => {
@@ -1022,6 +1034,12 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
     document.addEventListener('pointerdown', onPointer, true)
     return () => document.removeEventListener('pointerdown', onPointer, true)
   }, [])
+
+  // Becoming the visible tab is itself the signal that the user is looking at
+  // this document — the same reason the ref defaults to true on mount. Without
+  // this, a click in a sibling tab before the switch would leave the now-visible
+  // panel out of its own find region.
+  useEffect(() => { if (active) findActiveRef.current = true }, [active])
 
   // Highlights are external (CSS.highlights), so clearing never touches the
   // React-owned DOM — no reconciliation hazard.
@@ -1110,12 +1128,17 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
   // the editor's own find takes over cleanly.
   useEffect(() => { if (editing || diffMode) closeFind() }, [editing, diffMode, closeFind])
 
+  // A backgrounded tab must not keep a find bar the user cannot see, nor hold
+  // the module-global highlight names away from the visible panel.
+  useEffect(() => { if (!active) closeFind() }, [active, closeFind])
+
   // Capture-phase Cmd+F: fires before ChatPage's bubble-phase chat-find. We
   // only steal the key in markdown preview when this panel is the active
   // region; otherwise we let it bubble (chat-find) or let the editor handle it.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!hasCommandModifier(e) || e.key.toLowerCase() !== 'f') return
+      if (!active) return                                   // hidden tab: never claim the key
       if (editing || diffMode || !isMarkdown) return       // editor owns it; non-markdown skip
       if (!findActiveRef.current) return                    // cursor is in chat → let chat-find handle
       e.preventDefault()
@@ -1125,7 +1148,7 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
     }
     document.addEventListener('keydown', onKey, true)
     return () => document.removeEventListener('keydown', onKey, true)
-  }, [editing, diffMode, isMarkdown])
+  }, [active, editing, diffMode, isMarkdown])
 
   const findBar = findOpen ? (
     <div data-mc-mdpanel className="absolute top-2 right-3 z-30 flex items-center gap-1.5 bg-bg-elevated border border-border focus-within:border-accent rounded-lg shadow-md px-2.5 py-1.5 text-[13px]">
@@ -1592,6 +1615,11 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
 
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
+      // A background tab is mounted but invisible, so neither key may reach it:
+      // Escape would close — or raise a discard prompt for — a document the user
+      // cannot see, and Cmd+S would let a hidden dirty editor answer a save the
+      // user aimed at the tab in front of them.
+      if (!active) return
       // While the discard-confirm dialog is open, the keyboard belongs to it.
       // Escape dismisses it via the dialog's own handler (re-running the guard
       // here would re-open the dialog the same keystroke just closed), and the
@@ -1603,7 +1631,7 @@ export default memo(forwardRef<MarkdownPanelHandle, Props>(function MarkdownPane
     }
     document.addEventListener('keydown', h)
     return () => document.removeEventListener('keydown', h)
-  }, [guardedClose, editing, dirty, fullscreen, popover, clearHighlightMarks, confirmOpen])
+  }, [active, guardedClose, editing, dirty, fullscreen, popover, clearHighlightMarks, confirmOpen])
 
   const handleChange = useCallback((v: string) => { onContentChange(v); setDirty(true) }, [onContentChange])
   const clearPopover = useCallback(() => { setPopover(null); clearHighlightMarks() }, [clearHighlightMarks])

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -7729,6 +7729,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
             <SidePanel
               tabsCtl={tabsCtl}
               slot={activeSlot || ''}
+              panelHidden={isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen })}
               onFileOpen={handleFileOpen}
               onArtifactOpen={handleArtifactOpen}
               onAddToContext={handleAddToContext}
@@ -7768,6 +7769,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               <SidePanel
                 tabsCtl={tabsCtl}
                 slot={activeSlot || ''}
+                panelHidden={isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen })}
                 onFileOpen={handleFileOpen}
                 onArtifactOpen={handleArtifactOpen}
                 onAddToContext={handleAddToContext}

--- a/website/src/pages/chat/SidePanel.tsx
+++ b/website/src/pages/chat/SidePanel.tsx
@@ -239,6 +239,13 @@ interface SidePanelProps {
   onFileSave: (filePath: string, content: string) => Promise<void>
   /** Close the whole panel (hides the side column). */
   onClose: () => void
+  /** Is the whole panel mounted-but-invisible? A live app or browser tab keeps
+   *  the subtree mounted through a close (its iframe / WebContentsView cannot
+   *  survive a remount), and the find pane hides it while owning the dock — so
+   *  "panel closed" is a visibility state, not an unmount. Tab bodies that bind
+   *  document-level keys need it: the SELECTED tab is still selected while the
+   *  panel is hidden, so tab selection alone does not mean the user can see it. */
+  panelHidden?: boolean
   /** Preview "focus" mode: when true the panel takes its maximum width (chat
    *  shrinks to its minimum), driven by the Web Preview tab's expand toggle. */
   expanded?: boolean
@@ -362,7 +369,7 @@ export default function SidePanel({
   tabsCtl, slot, onFileOpen, onArtifactOpen, onAddToContext,
   projectDir, navLinks, navResolving, sources, selectedSourceUrl, onSelectSource, onReconcileSource,
   issues, selectedIssueUrl, onSelectIssue, onReconcileIssue,
-  onAddSourceToChat, onSubmitComments, onFileSave, onClose,
+  onAddSourceToChat, onSubmitComments, onFileSave, onClose, panelHidden,
   pins, pinsLoading, onJumpToPin, onUnpin,
   slotTitle, chatMode,
   expanded, fillWidth, canDockBottom = true,
@@ -758,7 +765,11 @@ export default function SidePanel({
           return (
             <div key={t.id} className="absolute inset-0" style={{ display: isActive ? 'block' : 'none' }}>
               <TabBody
-                tab={t} active={isActive}
+                // Visible to the user means BOTH: this tab is the selected one
+                // AND the panel itself is on screen. A hidden panel still has a
+                // selected tab, so selection alone would let a closed panel's
+                // editor answer Escape and Cmd+S.
+                tab={t} active={isActive && !panelHidden}
                 slot={slot}
                 onClose={() => handleCloseTab(t.id)}
                 onContentChange={(c) => patchTab(t.id, { content: c })}
@@ -848,8 +859,11 @@ function McpAppTabBody({ tab, slot }: { tab: PanelTab; slot: string }) {
  * Rail visibility is a single app-wide preference; the rail only renders at
  * all when the chat has a project dir whose tree the backend serves.
  */
-function FileTabBody({ tab, projectDir, scrollMemoryKey, onContentChange, onDiskContent, onDiffModeChange, onFileSave, onFileOpen, onAddToContext, onClose, onSubmitComments, onRevealConsumed }: {
+function FileTabBody({ tab, active, projectDir, scrollMemoryKey, onContentChange, onDiskContent, onDiffModeChange, onFileSave, onFileOpen, onAddToContext, onClose, onSubmitComments, onRevealConsumed }: {
   tab: PanelTab
+  /** Is this the visible tab? Background file tabs stay mounted, so the panel
+   *  needs this to keep its Cmd+F handler off a document the user cannot see. */
+  active: boolean
   projectDir?: string
   /** Cross-remount scroll identity (slot + tab id) — see `useScrollMemory`. */
   scrollMemoryKey?: string
@@ -876,6 +890,7 @@ function FileTabBody({ tab, projectDir, scrollMemoryKey, onContentChange, onDisk
     <MarkdownPanel
       ref={panelRef}
       embedded
+      active={active}
       filePath={tab.path || ''}
       content={tab.content || ''}
       scrollMemoryKey={scrollMemoryKey}
@@ -951,6 +966,7 @@ function TabBody({ tab, active, slot, projectDir, onClose, onContentChange, onDi
     return (
       <FileTabBody
         tab={tab}
+        active={active}
         projectDir={projectDir}
         scrollMemoryKey={scrollMemoryKey}
         onContentChange={onContentChange}
@@ -979,6 +995,7 @@ function TabBody({ tab, active, slot, projectDir, onClose, onContentChange, onDi
     return (
       <ArtifactPanel
         embedded
+        active={active}
         slug={tab.artifactSlug || ''}
         kind={tab.artifactKind || 'markdown'}
         content={tab.content || ''}

--- a/website/src/test/MarkdownPanelFindActiveTab.test.tsx
+++ b/website/src/test/MarkdownPanelFindActiveTab.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Who owns a document-level key when several file tabs are mounted at once.
+ *
+ * `SidePanel` keeps every document tab mounted and merely hides the inactive
+ * ones, so N open files means N live `MarkdownPanel` instances, each binding
+ * `document` keydown twice: once capture-phase for the find chord, once for
+ * Escape and Cmd/Ctrl+S. Every one of those bindings must belong to the tab the
+ * user can actually see.
+ *
+ * For the find chord the old failure was silent: whichever panel claimed it
+ * called `stopImmediatePropagation`, so a hidden panel swallowed the key
+ * outright — no find bar anywhere and no chat-find fallback either. For Escape
+ * the failure was worse than silent, since a hidden panel could close a
+ * document that was never on screen.
+ *
+ * `Highlight` / `CSS.highlights` are stubbed BEFORE the dynamic import because
+ * MarkdownPanel captures both into module-level constants at load time. Pierre
+ * is stubbed because markdown preview never mounts it and the real module
+ * pulls in Shiki.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { forwardRef, useImperativeHandle } from 'react'
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PierreEditorHandle } from '../pierre'
+
+const highlightRegistry = new Map<string, Range[]>()
+class StubHighlight {
+  readonly ranges: Range[]
+  constructor(...ranges: Range[]) { this.ranges = ranges }
+}
+vi.stubGlobal('Highlight', StubHighlight)
+vi.stubGlobal('CSS', {
+  highlights: {
+    set: (name: string, hl: StubHighlight) => { highlightRegistry.set(name, hl.ranges) },
+    delete: (name: string) => highlightRegistry.delete(name),
+  },
+  escape: (s: string) => s,
+  supports: () => false,
+})
+
+vi.mock('../pierre', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  PierreEditor: forwardRef<PierreEditorHandle, { file: { contents: string } }>(
+    function PierreEditorStub({ file }, ref) {
+      useImperativeHandle(ref, () => ({ jumpToLine: () => {}, focus: () => {} }), [])
+      return <div data-testid="pierre-editor" data-value={file.contents} />
+    }),
+  PierreCode: ({ file }: { file: { contents: string } }) => (
+    <div data-testid="pierre-code" data-value={file.contents} />
+  ),
+  PierreFilePair: () => <div data-testid="pierre-diff" />,
+}))
+
+vi.mock('../utils/clipboard', () => ({ copyToClipboard: vi.fn(async () => true) }))
+
+vi.mock('../api/client', () => ({
+  api: {
+    artifacts: vi.fn(),
+    artifact: vi.fn(),
+    createArtifact: vi.fn(),
+    updateArtifact: vi.fn(),
+    setArtifactPinned: vi.fn(),
+    revealPath: vi.fn(),
+    fileDiff: vi.fn(),
+  },
+}))
+
+const { api } = await import('../api/client')
+const { default: MarkdownPanel } = await import('../components/MarkdownPanel')
+
+/** The find bar's own input, which is how we tell WHICH panel opened one. */
+const FIND_INPUT = 'Find in document'
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  </MemoryRouter>
+)
+
+/**
+ * Two file tabs, mounted in the order `SidePanel` mounts them and hidden the
+ * way it hides them. Tab A is mounted FIRST, so it registers its document
+ * listener first — which is exactly the panel that used to win the chord
+ * regardless of which tab the user was looking at.
+ */
+function TwoTabs({ activeId, onCloseA, onCloseB }: {
+  activeId: 'a' | 'b'
+  onCloseA?: () => void
+  onCloseB?: () => void
+}) {
+  const common = {
+    embedded: true as const,
+    onContentChange: () => {},
+    onSave: async () => {},
+  }
+  return (
+    <>
+      <div data-testid="tab-a" style={{ display: activeId === 'a' ? 'block' : 'none' }}>
+        <MarkdownPanel
+          {...common}
+          onClose={onCloseA ?? (() => {})}
+          active={activeId === 'a'}
+          filePath="/tmp/a.md"
+          content={'# Alpha\n\nalpha alpha alpha\n'}
+        />
+      </div>
+      <div data-testid="tab-b" style={{ display: activeId === 'b' ? 'block' : 'none' }}>
+        <MarkdownPanel
+          {...common}
+          onClose={onCloseB ?? (() => {})}
+          active={activeId === 'b'}
+          filePath="/tmp/b.md"
+          content={'# Bravo\n\nbravo bravo bravo\n'}
+        />
+      </div>
+    </>
+  )
+}
+
+const tab = (id: 'a' | 'b') => within(screen.getByTestId(`tab-${id}`))
+/** The panel's own root inside a tab. */
+const panelRoot = (id: 'a' | 'b') =>
+  screen.getByTestId(`tab-${id}`).querySelector('[data-mc-mdpanel]') as HTMLElement
+
+const pressFind = () => fireEvent.keyDown(document, { key: 'f', ctrlKey: true })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  qc.clear()
+  highlightRegistry.clear()
+  localStorage.clear()
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true, writable: true, value: vi.fn(),
+  })
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true, status: 200, headers: { get: () => null },
+    json: async () => ({ enabled: false, supported_formats: [] }),
+    text: async () => '',
+  })))
+  vi.mocked(api.artifacts).mockResolvedValue({ artifacts: [] } as never)
+  vi.mocked(api.artifact).mockResolvedValue({ live_dirty: false, pinned: false } as never)
+  vi.mocked(api.fileDiff).mockResolvedValue({ diff: '', original: '', status: 'clean' } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.style.overflow = ''
+})
+
+describe('MarkdownPanel — Cmd+F belongs to the visible file tab', () => {
+  it('opens find in the visible tab, not in the first-mounted hidden one', async () => {
+    render(<TwoTabs activeId="b" />, { wrapper })
+    await waitFor(() => expect(panelRoot('b')).toBeTruthy())
+
+    fireEvent.pointerDown(panelRoot('b'))
+    pressFind()
+
+    expect(tab('b').getByLabelText(FIND_INPUT)).toBeTruthy()
+    expect(tab('a').queryByLabelText(FIND_INPUT)).toBeNull()
+  })
+
+  it('leaves the chord to chat-find when the last pointer-down was outside every panel', async () => {
+    render(<TwoTabs activeId="b" />, { wrapper })
+    await waitFor(() => expect(panelRoot('b')).toBeTruthy())
+
+    // A click in the chat transcript, then the chord: no panel may claim it, and
+    // nothing may stop it — ChatPage listens on the bubble phase.
+    fireEvent.pointerDown(document.body)
+    const chatFind = vi.fn()
+    document.addEventListener('keydown', chatFind)
+    try {
+      pressFind()
+    } finally {
+      document.removeEventListener('keydown', chatFind)
+    }
+
+    expect(tab('a').queryByLabelText(FIND_INPUT)).toBeNull()
+    expect(tab('b').queryByLabelText(FIND_INPUT)).toBeNull()
+    expect(chatFind).toHaveBeenCalledTimes(1)
+  })
+
+  it('hands the find region to the newly visible tab after a switch', async () => {
+    const { rerender } = render(<TwoTabs activeId="a" />, { wrapper })
+    await waitFor(() => expect(panelRoot('a')).toBeTruthy())
+
+    // The user reads tab A, clicks in it, then switches to tab B.
+    fireEvent.pointerDown(panelRoot('a'))
+    rerender(<TwoTabs activeId="b" />)
+    pressFind()
+
+    expect(tab('b').getByLabelText(FIND_INPUT)).toBeTruthy()
+    expect(tab('a').queryByLabelText(FIND_INPUT)).toBeNull()
+  })
+
+  it('closes an open find bar when its tab is backgrounded', async () => {
+    const { rerender } = render(<TwoTabs activeId="a" />, { wrapper })
+    await waitFor(() => expect(panelRoot('a')).toBeTruthy())
+
+    fireEvent.pointerDown(panelRoot('a'))
+    pressFind()
+    expect(tab('a').getByLabelText(FIND_INPUT)).toBeTruthy()
+
+    rerender(<TwoTabs activeId="b" />)
+    expect(tab('a').queryByLabelText(FIND_INPUT)).toBeNull()
+  })
+})
+
+/**
+ * The find chord is not the only document-level key these panels bind. The same
+ * handler that owns Escape also owns Cmd/Ctrl+S, and both ride the one `active`
+ * early-return — so a hidden tab must answer neither.
+ */
+describe('MarkdownPanel — Escape belongs to the visible file tab', () => {
+  it('closes only the visible tab, never a hidden sibling', async () => {
+    const onCloseA = vi.fn()
+    const onCloseB = vi.fn()
+    render(<TwoTabs activeId="b" onCloseA={onCloseA} onCloseB={onCloseB} />, { wrapper })
+    await waitFor(() => expect(panelRoot('b')).toBeTruthy())
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    // Both panels are mounted and both listen on `document`; only the one the
+    // user can see may act. Closing tab A here would discard a document that
+    // was never on screen.
+    expect(onCloseB).toHaveBeenCalledTimes(1)
+    expect(onCloseA).not.toHaveBeenCalled()
+  })
+
+  it('follows the switch, so the newly visible tab is the one Escape closes', async () => {
+    const onCloseA = vi.fn()
+    const onCloseB = vi.fn()
+    const { rerender } = render(
+      <TwoTabs activeId="b" onCloseA={onCloseA} onCloseB={onCloseB} />, { wrapper })
+    await waitFor(() => expect(panelRoot('b')).toBeTruthy())
+
+    rerender(<TwoTabs activeId="a" onCloseA={onCloseA} onCloseB={onCloseB} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCloseA).toHaveBeenCalledTimes(1)
+    expect(onCloseB).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/sidePanelMount.test.ts
+++ b/website/src/test/sidePanelMount.test.ts
@@ -4,6 +4,8 @@
  * null-origin iframe cannot survive a remount, so an unmount loses the drawing.
  */
 import { describe, it, expect } from 'vitest'
+import { join } from 'node:path'
+import { readSource } from './readSource'
 import { shouldMountSidePanel, isSidePanelHidden } from '../pages/chat/sidePanelMount'
 
 const S = (activityOpen: boolean, hasLiveAppTab: boolean, searchOpen = false, hasBrowserTab = false) =>
@@ -28,6 +30,44 @@ describe('side panel mount decision', () => {
   it('is never hidden while the user has the panel open and unobstructed', () => {
     expect(isSidePanelHidden(S(true, true))).toBe(false)
     expect(isSidePanelHidden(S(true, false))).toBe(false)
+  })
+
+  /**
+   * A hidden panel still has a SELECTED tab, so tab selection alone is not
+   * "the user can see this". The tab bodies bind document-level keys (Escape
+   * closes the file, Cmd/Ctrl+S writes it to disk), and a closed panel kept
+   * mounted for a live app/browser tab would otherwise answer both from an
+   * editor that is nowhere on screen.
+   *
+   * A source assertion because the composition is one expression in JSX, and
+   * rendering the whole panel to reach it would test the harness more than the
+   * wiring. What must not regress is that `panelHidden` participates at all.
+   */
+  it('composes tab-body visibility from BOTH tab selection and panel visibility', () => {
+    const src = readSource(join(__dirname, '..', 'pages', 'chat', 'SidePanel.tsx'))
+    expect(src).toContain('active={isActive && !panelHidden}')
+    // ...and the flag has to reach the panel from its host, or the guard above
+    // is dead code that always reads undefined.
+    const host = readSource(join(__dirname, '..', 'pages', 'ChatPage.tsx'))
+    expect(host.match(/panelHidden=\{isSidePanelHidden\(/g) ?? []).toHaveLength(2)
+  })
+
+  /**
+   * Every tab body in the keep-mounted branch that binds a document-level key
+   * needs the same signal, not just the file one. `ArtifactPanel` binds Escape
+   * and would otherwise close an artifact that is off screen. `CliPanel` and
+   * `FolderPanel` scope their handlers to their own elements, so they cannot.
+   */
+  it('passes the same visibility signal to the artifact body', () => {
+    const src = readSource(join(__dirname, '..', 'pages', 'chat', 'SidePanel.tsx'))
+    expect(src).toMatch(/<ArtifactPanel\s+embedded\s+active=\{active\}/)
+    const panel = readSource(join(__dirname, '..', 'components', 'ArtifactPanel.tsx'))
+    // The guard, and the flag in the effect's deps so a switch re-binds it. The
+    // prop is aliased to `visible` there because a local `active` in that file
+    // already names the fullscreen icon.
+    expect(panel).toContain('active: visible = true')
+    expect(panel).toContain('if (!visible) return')
+    expect(panel).toContain('}, [visible, fullscreen, onClose])')
   })
 
   describe('find pane claims the dock', () => {


### PR DESCRIPTION
## Problem / Motivation

The side panel keeps every document tab mounted and merely hides the inactive ones, so N open files means N live `MarkdownPanel` instances — and every one of them answered the document-level keys, visible or not. Three symptoms, one cause:

- **Cmd/Ctrl+F did nothing** once more than one document tab was open. No find bar, and no chat message-search either — the keystroke was swallowed outright.
- **Escape closed a tab the user could not see**, or raised a discard-unsaved-changes prompt for it.
- **Cmd/Ctrl+S was answered by a hidden dirty editor** rather than the tab in front of the user.

With a single tab open all three behave correctly, which is why this read as intermittent rather than broken.

## Why it matters

Two or more open files is the normal working state, so in practice in-file search is simply unavailable — and silently, since the chord produces no feedback at all in either direction.

The Escape and Cmd+S paths are worse than silent. Escape on a background tab runs `guardedClose()`, so a document the user never had on screen is closed or throws up a discard prompt; and a save aimed at the visible tab can be taken by an invisible one, writing a file from an editor nobody is looking at.

## What changed (motivation → approach → change)

**Symptom → root cause.** `MarkdownPanel` binds `document` keydown twice: capture-phase for the find chord, and again for Escape + Cmd/Ctrl+S. Neither binding knew whether its panel was the one the user could see.

For find, whichever instance claimed the chord called `stopImmediatePropagation()`, and nothing distinguished the instances — `findActiveRef` came from a **global** selector:

```js
findActiveRef.current = !!t?.closest?.('[data-mc-mdpanel]')
```

That answers *"did the pointer land in **some** markdown panel"*, which every mounted instance answers identically. Capture listeners fire in registration order, so the winner was the **oldest-mounted** tab. It opened its find bar inside a `display: none` subtree, and its `stopImmediatePropagation()` also suppressed `useMessageSearch`'s chat-find fallback. Hence nothing at all.

The Escape/Cmd+S handler had no visibility check either, so it simply ran in every mounted panel.

**The change** — one gate covers all three keys:

1. **An `active` prop, returning early in both handlers**, threaded `TabBody` → `FileTabBody` → `MarkdownPanel`. It defaults to `true`, so hosts that mount a single panel are unaffected. A backgrounded panel also closes any open find bar, so it cannot hold the module-global `CSS.highlights` names away from the visible panel.
2. **Visible means both axes.** A tab is *selected* within the panel, but the panel itself can also be mounted-and-hidden: `sidePanelMount` keeps the subtree alive through a close whenever a live app or browser tab would lose its iframe or `WebContentsView` on unmount, and the find pane hides it while owning the dock. Selection alone would therefore let a **closed** panel's dirty editor still answer Cmd+S. So `SidePanel` composes `active={isActive && !panelHidden}`, with `panelHidden` supplied by `ChatPage` from the same `isSidePanelHidden(...)` predicate that already sets the subtree's `display: none` — the guard cannot drift from the visibility it tracks.
3. **The find region resets when a panel becomes active.** Without it, a click in a sibling tab before the switch leaves the newly visible tab outside its own find region and the chord falls to chat-find. Becoming visible is the same signal the mount-time `true` default already encodes; a pointer-down in the chat still yields the chord to chat-find, because no active transition occurs.

**What was deliberately left out.** A per-panel `useId` value stamped into `data-mc-mdpanel`, compared via `getAttribute`, so each instance could tell its own subtree from a sibling's. It was implemented, then removed: with the `active` gate in place it cannot answer differently, because a pointer cannot land inside a `display: none` subtree and exactly one panel is ever visible. Removing it left all four find cases passing, so the scoped compare was unfalsifiable — the plain global selector plus the `active` gate is the smaller honest surface.

A DOM-level rendered-ness probe (`offsetParent`, computed style) was also rejected for axis 2: the test environment does no layout, so such a guard is either untestable or silently always-true there, and it would put panel-level knowledge inside a component with no other reason to hold it.

Also deliberately unchanged: the `editing || diffMode || !isMarkdown` gate on find. Extending find to the code, edit and diff surfaces is separate work — those render through Pierre inside a `Virtualizer`, so a DOM `TreeWalker` cannot see off-window matches and needs a different engine.

## Tests

`website/src/test/MarkdownPanelFindActiveTab.test.tsx` — six cases. It mounts two panels in the order `SidePanel` mounts them with the **second** one visible, so the first-registered listener belongs to the hidden panel, which is exactly the instance that used to win.

| Case | What it locks in |
|---|---|
| opens find in the visible tab, not in the first-mounted hidden one | the reported find bug |
| leaves the chord to chat-find when the last pointer-down was outside every panel | the invariant — no panel claims it, nothing calls `stopImmediatePropagation`, so ChatPage's bubble-phase listener still fires |
| hands the find region to the newly visible tab after a switch | no dead chord after a tab switch |
| closes an open find bar when its tab is backgrounded | no stale bar; the global highlight names are released |
| Escape closes only the visible tab, never a hidden sibling | the Escape bug — a hidden panel's `onClose` must not fire |
| Escape follows the switch | the gate tracks visibility rather than mount order |

`website/src/test/sidePanelMount.test.ts` — one case for axis 2: tab-body visibility must be composed from *both* tab selection and panel visibility, and `panelHidden` must actually reach the panel from both hosts. A guard that always reads `undefined` is dead code, and that is the failure mode most likely to creep back in.

**Proven RED → GREEN per gate, independently.** Reverting the find gate fails three of the four find cases, and the failure is the reported symptom — the find input rendering inside the hidden tab. Reverting the Escape gate fails both Escape cases, on a hidden sibling's `onClose` firing once. The chat-find case passes either way and is there as an invariant guard, not as proof.

Cmd/Ctrl+S rides the same early return as Escape, so the Escape cases cover that gate; driving a panel into `editing && dirty` state adds harness complexity without testing a different branch.

## Manual verification

Verified live in a gateway serving this branch's built bundle, with two markdown files open as document tabs: Ctrl+F opens find in the visible tab with no stray bar in the sibling; clicking into tab A then switching to tab B and pressing Ctrl+F opens find in B; opening find and switching away closes it; and clicking in the chat transcript then pressing Ctrl+F still opens the chat message-search pane.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** this change adds no element and restyles none — the find bar is pre-existing and untouched, and no layout, theme, spacing or string changes. What changes is *which mounted panel instance* answers a keyboard chord, so no static view of either surface differs and a still of the find bar would not let a reviewer distinguish the fixed state from the broken one. The behavioural delta is a multi-step interaction (open two tabs, switch, press the chord); the seven cases above are the evidence that discriminates it, proven RED → GREEN per gate.

## Related Issues

Closes #5995

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes; the corrected invariant is recorded in the code comments that previously stated it wrongly
- [x] No secrets, credentials, or internal references in the diff
