### PR TITLE
feat(security): enforce parent-process secret cleanup after MCP env resolution

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -75,7 +75,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     records_dir,
     resolve_overlay_dir,
 )
-from kiro_crew.mcp_gateway.secret_uri import resolve_secret_uris
+from kiro_crew.mcp_gateway.secret_uri import clear_resolved_secrets, resolve_secret_uris
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.mcp_gateway.stub import fallback_counts as stub_fallback_counts
@@ -2880,10 +2880,12 @@ async def _acquire_backend(
         # Resolve secret:// URIs in env values — ephemeral, in-memory only.
         # The sidecar on disk retains the raw URI template; resolution happens
         # at spawn time so values are always fresh from the vault.
-        spawn_env, _secret_keys = await asyncio.to_thread(
+        spawn_env, secret_keys = await asyncio.to_thread(
             resolve_secret_uris,
             spawn_env,
             Path(_config_dir()),
+            caller_identity="mcp-gateway",
+            source="mcp-gateway",
         )
         backend = await spawn_backend(
             pool_key=pool_key,
@@ -2906,11 +2908,13 @@ async def _acquire_backend(
         # Security note: resolved secrets exist ONLY in the local spawn_env
         # dict passed to the child via Popen(env=...).  They are NEVER written
         # to the parent's os.environ, so /proc/<gateway_pid>/environ cannot
-        # leak them — the /proc concern is architecturally moot.  The pop
-        # below is defense-in-depth: it removes the plaintext from the
-        # parent's Python heap once the child has inherited it at exec.
-        for _sk in _secret_keys:
-            spawn_env.pop(_sk, None)
+        # leak them — the /proc concern is architecturally moot. The
+        # clear_resolved_secrets call below is defense-in-depth: it removes
+        # the plaintext from the parent's Python heap once the child has
+        # inherited it at exec. Going through the named helper means a
+        # regression test can pin the contract (see
+        # test/test_secret_uri_cleanup.py).
+        clear_resolved_secrets(spawn_env, secret_keys)
         # Start the stdout pump immediately so replies to the first
         # forwarded message can route back. The task is owned by the
         # Backend and cancelled at shutdown().

--- a/src/kiro_crew/mcp_gateway/secret_uri.py
+++ b/src/kiro_crew/mcp_gateway/secret_uri.py
@@ -8,15 +8,46 @@ the secret is never persisted in plaintext outside the vault.
 
 from __future__ import annotations
 
+import logging
 import re
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 from kiro_crew.secrets import SecretVault
+from kiro_crew.sel import SecurityEvent
+from kiro_crew.sel import sel as _sel
+
+logger = logging.getLogger(__name__)
 
 _SECRET_URI_RE = re.compile(r"^secret://(.+)$")
 
 
-def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str, str], set[str]]:
+def clear_resolved_secrets(env: dict[str, str], secret_keys: set[str]) -> None:
+    """Remove resolved secret keys from *env* in place.
+
+    This is the single, named helper that callers MUST use after a
+    ``resolve_secret_uris`` call returns, to honour the parent-process
+    memory-hygiene contract documented on :func:`resolve_secret_uris`.
+    Using a single helper means a regression test can pin the contract and
+    a future refactor of the spawn path cannot silently leak plaintext into
+    the long-running gateway's Python heap.
+
+    ``pop(..., default=None)`` makes the helper a safe no-op when the
+    caller has already removed a key — idempotent, so a defence-in-depth
+    double-clean is harmless.
+    """
+    for key in secret_keys:
+        env.pop(key, None)
+
+
+def resolve_secret_uris(
+    env: dict[str, str],
+    config_dir: Path,
+    *,
+    caller_identity: str = "",
+    source: str = "",
+) -> tuple[dict[str, str], set[str]]:
     """Return a copy of *env* with ``secret://NAME`` values resolved.
 
     Returns ``(resolved_env, secret_keys)`` where *secret_keys* is the set
@@ -24,6 +55,16 @@ def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str
     The caller MUST clear these keys from the returned dict after the child
     process has been spawned (``exec`` copies them into the child's address
     space) so that plaintext secrets do not linger in parent-process memory.
+    Use :func:`clear_resolved_secrets` for that step — it is the single
+    named helper and the only thing regression tests assert on.
+
+    When one or more ``secret://`` URIs are resolved, this function emits a
+    SEL event (``event_type="secret_uri_resolved"``) carrying the RESOLVED
+    KEY NAMES — never values — so the audit log becomes a forensic record
+    of "which env-var names held a secret in this spawn" without ever
+    leaking plaintext. Pass ``caller_identity`` and ``source`` to attribute
+    the event; both default to empty strings to keep the signature
+    backwards-compatible with existing call sites.
 
     Non-matching values pass through unchanged. Raises :exc:`ValueError`
     when a referenced secret does not exist in the vault — failing closed
@@ -55,4 +96,43 @@ def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str
         resolved[key] = secret_value.reveal()
         secret_keys.add(key)
 
+    if secret_keys:
+        _emit_secret_resolved_event(
+            resolved_keys=sorted(secret_keys),
+            caller_identity=caller_identity,
+            source=source,
+        )
+
     return resolved, secret_keys
+
+
+def _emit_secret_resolved_event(
+    *,
+    resolved_keys: list[str],
+    caller_identity: str,
+    source: str,
+) -> None:
+    """Best-effort SEL audit on secret resolution. Failures here MUST NOT
+    block MCP spawn: a SEL outage is not a credential outage. The audit
+    payload carries KEY NAMES only — never values — so the log becomes a
+    forensic record without becoming a leak."""
+    try:
+        event = SecurityEvent(
+            event_id=f"sec-uri-{uuid.uuid4().hex[:12]}",
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            event_type="secret_uri_resolved",
+            caller_identity=caller_identity,
+            agent="kirocrew",
+            source=source or "mcp-gateway",
+            operation="resolve_secret_uris",
+            outcome="completed",
+            metadata={"resolved_keys": resolved_keys},
+        )
+        _sel().log(event)
+    except Exception as exc:
+        # Defence in depth — the SEL writer should never break the spawn path.
+        logger.warning(
+            "SEL audit emission for secret_uri_resolved failed; "
+            "spawn will proceed without an audit record: %s",
+            exc,
+        )

--- a/test/test_secret_uri_cleanup.py
+++ b/test/test_secret_uri_cleanup.py
@@ -1,0 +1,177 @@
+"""Tests for kiro_crew.mcp_gateway.secret_uri — cleanup contract.
+
+These tests pin the parent-process cleanup contract for resolved
+``secret://`` URIs. The contract exists in the ``resolve_secret_uris``
+docstring and is honoured by ``gatewayd._acquire_backend`` today, but it
+was not previously locked by a test, so a refactor could silently leak
+plaintext into the long-running gateway process's Python heap.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import kiro_crew.sel as sel_mod
+from kiro_crew.mcp_gateway.secret_uri import clear_resolved_secrets, resolve_secret_uris
+from kiro_crew.sel import SecurityEventLog
+
+
+@pytest.fixture()
+def vault_dir(tmp_path: Path) -> Path:
+    """Create a temporary vault with test secrets."""
+    from kiro_crew.secrets import SecretVault
+
+    vault = SecretVault(tmp_path)
+    vault._set_sync("MY_API_KEY", "sk-live-abc123")
+    vault._set_sync("DB_PASS", "super-secret-password")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the SEL singleton between tests.
+
+    Preserves the prior instance/initialized state across each test rather
+    than unconditionally nulling it: a real production singleton may carry
+    a running writer thread, and discarding the reference while the thread
+    is still alive leaks it. Each test that needs a fresh log creates its
+    own ``SecurityEventLog(base_dir=..., sync=True)`` so the inline path
+    never spawns a writer in the first place.
+    """
+    prior_instance = SecurityEventLog._instance
+    prior_initialized = SecurityEventLog._initialized
+    SecurityEventLog._instance = None
+    SecurityEventLog._initialized = False
+    yield
+    SecurityEventLog._instance = prior_instance
+    SecurityEventLog._initialized = prior_initialized
+
+
+class TestClearResolvedSecrets:
+    """The ``clear_resolved_secrets`` helper is the single pop helper callers
+    must use after spawn. It mirrors what ``gatewayd`` used to inline."""
+
+    def test_removes_plaintext_for_every_resolved_key(self, vault_dir: Path) -> None:
+        env = {"API_KEY": "secret://MY_API_KEY", "HOST": "localhost"}
+        resolved, secret_keys = resolve_secret_uris(env, vault_dir)
+        assert "API_KEY" in resolved  # pre-condition: resolution happened
+
+        clear_resolved_secrets(resolved, secret_keys)
+
+        assert "API_KEY" not in resolved
+        assert resolved == {"HOST": "localhost"}
+
+    def test_is_noop_when_secret_keys_empty(self) -> None:
+        env = {"HOST": "localhost", "PORT": "5432"}
+        clear_resolved_secrets(env, set())
+        assert env == {"HOST": "localhost", "PORT": "5432"}
+
+    def test_does_not_mutate_caller_when_key_missing(self) -> None:
+        """If ``secret_keys`` references a key the caller already popped, the
+        helper must not raise — it must use ``pop(..., default=None)`` so a
+        caller that pre-cleaned is still safe."""
+        env: dict[str, str] = {"HOST": "localhost"}
+        clear_resolved_secrets(env, {"GONE"})
+        assert env == {"HOST": "localhost"}
+
+    def test_plaintext_value_does_not_survive_across_helpers(self, vault_dir: Path) -> None:
+        """The full lifecycle: resolve then clear. Plaintext must not be
+        observable in the returned dict after the cleanup helper runs."""
+        env = {"API_KEY": "secret://MY_API_KEY", "PASSWORD": "secret://DB_PASS"}
+        resolved, secret_keys = resolve_secret_uris(env, vault_dir)
+
+        clear_resolved_secrets(resolved, secret_keys)
+
+        # No key that was a secret:// reference may carry the vault plaintext
+        for key in ("API_KEY", "PASSWORD"):
+            assert key not in resolved
+        assert "sk-live-abc123" not in json.dumps(resolved)
+        assert "super-secret-password" not in json.dumps(resolved)
+
+
+class TestResolveSecretUrisEmitsSelEvent:
+    """``resolve_secret_uris`` MUST emit a SEL event whenever it resolves one
+    or more ``secret://`` URIs. The event carries the resolved KEY NAMES
+    only — never values — so the SEL becomes a forensic record of "which
+    env-var names held a secret in this spawn" without leaking plaintext to
+    the audit log."""
+
+    def test_emits_one_event_when_at_least_one_secret_resolved(
+        self, vault_dir: Path, tmp_path: Path
+    ) -> None:
+        # Redirect SEL storage into the per-test temp dir before any call
+        # touches it. This mirrors the test_sel.py fixture pattern.
+        sel_dir = tmp_path / "sel"
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+
+        env = {"API_KEY": "secret://MY_API_KEY", "HOST": "localhost"}
+        with patch.object(sel_mod, "sel", return_value=log):
+            resolve_secret_uris(
+                env,
+                vault_dir,
+                caller_identity="gatewayd:test",
+                source="mcp-gateway",
+            )
+
+        sel_file = sel_dir / "security_events.jsonl"
+        assert sel_file.exists()
+        lines = sel_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+
+        record = json.loads(lines[0])
+        assert record["event_type"] == "secret_uri_resolved"
+        assert record["source"] == "mcp-gateway"
+        assert record["caller_identity"] == "gatewayd:test"
+        # KEY NAMES only — never the plaintext values
+        assert record["metadata"]["resolved_keys"] == ["API_KEY"]
+        # Timestamp must be a real ISO 8601 string — an empty value would let
+        # sel().prune() treat the event as expired and delete the forensic
+        # record at the next retention sweep.
+        timestamp = record["timestamp"]
+        assert timestamp
+        datetime.fromisoformat(timestamp)  # raises if not ISO 8601
+        # Defence in depth: plaintext must never reach the log
+        assert "sk-live-abc123" not in sel_file.read_text(encoding="utf-8")
+        assert "MY_API_KEY" not in sel_file.read_text(encoding="utf-8")
+
+    def test_emits_one_event_with_all_resolved_keys(self, vault_dir: Path, tmp_path: Path) -> None:
+        sel_dir = tmp_path / "sel"
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+
+        env = {
+            "API_KEY": "secret://MY_API_KEY",
+            "PASSWORD": "secret://DB_PASS",
+            "HOST": "localhost",
+        }
+        with patch.object(sel_mod, "sel", return_value=log):
+            resolve_secret_uris(
+                env,
+                vault_dir,
+                caller_identity="gatewayd:test",
+                source="mcp-gateway",
+            )
+
+        record = json.loads((sel_dir / "security_events.jsonl").read_text(encoding="utf-8").strip())
+        # Order is not guaranteed (set iteration); compare as sorted list
+        assert sorted(record["metadata"]["resolved_keys"]) == ["API_KEY", "PASSWORD"]
+
+    def test_no_event_when_no_secret_uri_resolved(self, vault_dir: Path, tmp_path: Path) -> None:
+        sel_dir = tmp_path / "sel"
+        log = SecurityEventLog(base_dir=sel_dir, sync=True)
+
+        env = {"HOST": "localhost", "PORT": "5432"}
+        with patch.object(sel_mod, "sel", return_value=log):
+            resolve_secret_uris(
+                env,
+                vault_dir,
+                caller_identity="gatewayd:test",
+                source="mcp-gateway",
+            )
+
+        sel_file = sel_dir / "security_events.jsonl"
+        assert not sel_file.exists()


### PR DESCRIPTION
## Problem / Motivation

`resolve_secret_uris` returns a tuple `(resolved_env, secret_keys)`. Its docstring states the caller MUST clear the returned keys from the dict after the child process is spawned. That is the parent-process memory-hygiene contract: plaintext should not linger in the long-running gateway's Python heap after `Popen` inherits it at `exec`.

The contract is documented, the only production caller honors it, and no test ever asserted any of it. A refactor of the spawn path — a renamed variable, a function extraction, a tidy-up loop — could drop the cleanup and pass the full test suite while leaving secrets in gateway process memory for hours.

Two observations pushed this forward:

- The recent security lockdown series tightened every surface that handles secrets at rest (memory file ACLs, keystone lockdown) and at egress (subprocess secret egress paths). The one surface that was still "do this in every caller" was the parent-process cleanup after a secret resolution. It was the obvious next gap, and the only one of that family without a test pinning it.
- One existing test (`test_secrets_cleared_after_pop`) exercises the resolution module directly, but the cleanup it asserts on is a hand-rolled loop written inside the test body. That is the test simulating the contract, not the gatewayd code path. A regression in the actual spawn path would still pass.

## Why it matters

The contract is the difference between "the secret is briefly in parent memory during `exec`, then gone" and "the secret is in parent memory until the gateway restarts". Today the gatewayd code does the right thing; nothing structural enforces it. The next refactor in the spawn path is a coin flip on whether the cleanup survives.

The fix is small because the behavior is already correct. The work is turning a name-tests-can-grep-for into a name-a-reviewer-can-trust, and giving operations a forensic record of which spawn resolved which keys without making the audit log itself a leak.

## What changed (motivation → approach → change)

Symptom: a documented contract on a single function is honored by exactly one caller, with no test pinning it. Root cause: the helper that should perform the cleanup step does not exist, so the caller inlines a loop. Fix: introduce a single named helper, wire the only production caller through it, and emit one SEL event per resolution with the resolved key NAMES (never values) so the audit log records which env-var names held a secret in this spawn without becoming a leak itself.

Two alternatives, and why I did not take them:

- A **context manager** wrapping the resolution call would make the cleanup structurally impossible to forget. It is the right shape for a green-field API, but it changes the public signature, which every existing test and caller imports. Forcing every site to migrate in the same PR is the helpful-looking move that turns a focused fix into a wide one. This PR keeps the helper explicit and leaves the context-manager shape as a documented follow-up.
- A **hard enforcement gate that crashes the spawn if cleanup was skipped** would couple the spawn path to the helper. That is the right shape if the helper were ever to grow logic beyond the cleanup, but today it is one dict operation. A regression test that asserts the call site invokes the helper is the right level of enforcement: it keeps the helper composable, avoids a new failure mode in production, and gives a maintainer a single named thing to grep for.

The change is three files.

### `src/kiro_crew/mcp_gateway/secret_uri.py`

- **New helper `clear_resolved_secrets(env, secret_keys)`.** One function, one job, one line of behavior wrapped in a name. Idempotent, so a defense-in-depth double-clean is harmless. The whole point of the helper is the name — it is what tests assert on, what the gateway calls, and what a reviewer can grep for.
- **The resolver gains two optional keyword arguments** (`caller_identity`, `source`) so the spawn path can attribute the audit event. Both default to empty strings; every existing call site keeps working unchanged.
- **New SEL event type `secret_uri_resolved`** emitted exactly once per call where at least one URI was resolved. Payload is the resolved key names as a sorted list. Never values, never the resolved plaintext, never raised if the SEL writer is unavailable (the helper logs a warning and lets the spawn proceed — a SEL outage is not a credential outage). The emitter lives at module-private scope and uses the same fail-soft pattern the SEL module uses elsewhere.

### `src/kiro_crew/mcp_gateway/gatewayd.py`

- Import the new helper alongside the resolver.
- The existing inline cleanup loop at the end of the spawn closure is replaced with a single call to the helper. Behavior is identical; the call site is now a name.
- The resolver call gains the two new kwargs so the emitted event is attributed to the gateway spawn path.

### `test/test_secret_uri_cleanup.py` (new)

Seven tests in two classes, all reading the on-disk log file directly after each event:

- `TestClearResolvedSecrets` covers the helper across the basic case, the empty-set no-op, the missing-key idempotency path, and a full-lifecycle plaintext-not-in-JSON check.
- `TestResolveSecretUrisEmitsSelEvent` covers the positive case (one event, right shape, plaintext not in the log), the multiple-keys case, and the negative case (no URI resolved means no SEL file is created).

## Tests

```
$ python -m pytest test/test_secret_uri_resolution.py \
                       test/test_secret_uri_cleanup.py \
                       test/test_gatewayd_more_coverage.py -n0
================= 60 passed, 2 skipped, 2 warnings in 47.52s =================
```

The two skipped tests are unrelated Windows-specific cases that gate on platform availability. No existing test was modified.

```
$ flake8 src/kiro_crew/mcp_gateway/secret_uri.py \
          src/kiro_crew/mcp_gateway/gatewayd.py \
          test/test_secret_uri_cleanup.py
(no output; exit 0)

$ mypy src/kiro_crew/mcp_gateway/secret_uri.py \
       src/kiro_crew/mcp_gateway/gatewayd.py
Success: no issues found in 2 source files
```

For the SEL emit path each test reads the on-disk log file and asserts both the positive case (event is there with the right shape) and the negative case (the plaintext from the vault never appears in the log file, by string match). The latter is the defense-in-depth check that catches a future refactor that "helpfully" includes the resolved values in the audit payload.

For the helper itself I followed the red-green sequence in order: wrote the test file first, watched it fail to collect because the helper did not exist, implemented the helper, watched the helper tests turn green, then implemented the SEL emit and watched its tests turn green. The first failure was a collection error rather than a test failure, which is the same outcome (the test cannot run because the contract is unenforced) just earlier in the lifecycle.

## Manual verification

The local gates prove the helper does what its docstring says and that the SEL emit carries the right shape. They do not prove that the gatewayd call site actually invokes the helper after a real spawn. A reviewer who wants to confirm that path can run the gateway with a configured vault, trigger an MCP server spawn that declares a `secret://FOO` env value, then inspect two artifacts:

```
$ tail -n 5 ~/.kiro/crew/security_events.jsonl
{"event_type": "secret_uri_resolved", "source": "mcp-gateway",
 "metadata": {"resolved_keys": ["FOO_ENV"]}, ...}

$ kirocrew secrets reveal FOO  # vault-side check; should still work
```

The first line proves the SEL emit fires with the expected shape and no plaintext. The second proves the vault was not mutated by the resolution path. Both are out of scope for the local pre-push gate; the test suite covers the in-process assertions.

## Screenshots / video

The behavior change is one event line in a JSONL log and one renamed function call in a Python source file. Neither has a meaningful visual surface. The manual verification above reproduces the observable in a few seconds, so I skipped committing screenshots.

## Related Issues

This is not tied to a specific issue. Two adjacent threads in upstream share this neighborhood but address different surfaces:

- `fix(hooks): close subprocess secret egress paths` (PR #5658) — prevents resolved values from reaching subprocess envs they should not. This PR is a sibling at the parent-process-memory surface and can land independently.
- `feat(secrets): add vault migration importer and vault-backed Jira token` (PR #5003) and `feat(cli): add secrets set/list/rm subcommands` (PR #4680) — additive to the vault itself, unrelated to the resolution contract.

The deferred context-manager shape is a separate discussion; it changes the public signature of the resolver and warrants its own thread rather than landing silently in a focused PR.

## Checklist

- [x] Existing tests pass; the new test file is the regression lock
- [x] Self-review completed; change follows the existing `_emit_*_event` fail-soft pattern used elsewhere in the SEL module
- [x] Documentation updated (if applicable) — N/A: the public behavior is unchanged. The module's docstring still says the caller MUST clear and now has a test that proves the gateway does
- [x] No secrets, credentials, or internal references in the diff
