### PR TITLE
fix(telegram): make failed-upload recovery lossless and budget it in UTF-16 units

### DIFF
--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -186,6 +186,63 @@ def _display_safe(text: str) -> str:
     return safe
 
 
+def _utf16_len(text: str) -> int:
+    """Length of *text* in UTF-16 code units — the unit of Telegram's caps.
+
+    Python counts code points; the Bot API counts UTF-16 units, so every
+    astral character (emoji, most notably) costs 2 against Telegram's 4096
+    while costing 1 against ``len``. The entity machinery in
+    ``telegram/client.py`` already measures in these units; message budgets
+    here historically did not.
+    """
+    return len(text) + sum(1 for ch in text if ord(ch) > 0xFFFF)
+
+
+def _utf16_cut(text: str, limit: int) -> int:
+    """Largest CODE-POINT index whose prefix fits ``limit`` UTF-16 units.
+
+    Returning a code-point index means ``str`` slicing can never bisect a
+    surrogate pair: an astral character either fits whole or is excluded
+    whole. The floor of 2 is load-bearing — at ``limit=1`` a leading astral
+    character (2 units) would cut at index 0, and a caller consuming the
+    text chunk by chunk would stop making progress.
+    """
+    budget = max(2, limit)
+    units = 0
+    for index, ch in enumerate(text):
+        units += 2 if ord(ch) > 0xFFFF else 1
+        if units > budget:
+            return index
+    return len(text)
+
+
+def _utf16_chunks(text: str, limit: int) -> list[str]:
+    """Split ``text`` into pieces of at most ``limit`` UTF-16 units each.
+
+    Prefers newline boundaries so a line (one restored image reference, in
+    the recovery caller) stays whole within one message; a single line
+    larger than the whole budget is hard-cut at a code-point boundary
+    rather than dropped. Boundary newlines are consumed by the split.
+    """
+    chunks: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        candidate = f"{current}\n{line}" if current else line
+        if _utf16_len(candidate) <= max(2, limit):
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+        while _utf16_len(line) > max(2, limit):
+            cut = _utf16_cut(line, limit)
+            chunks.append(line[:cut])
+            line = line[cut:]
+        current = line
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 def md_to_telegram_html_safe(text: str) -> str:
     """Redact against the rendered form, THEN translate markdown to HTML.
 
@@ -1458,12 +1515,22 @@ class TelegramRenderer(Renderer):
         restored = _display_safe(
             "\n".join(f"![{item.alt or 'image'}]({item.path})" for item in files)
         )
-        await self._client.send_message(
-            self._chat_id,
-            f"⚠️ Couldn't upload:\n{restored}"[: self._limit()],
-            message_thread_id=self._thread_id,
-            disable_notification=True,
-        )
+        # One truncated bubble used to keep only what fit under the cap — with
+        # several failed images the LATER references vanished silently. And the
+        # cap itself was measured in code points while Telegram counts UTF-16
+        # units, so emoji-dense alt text passed the slice and bounced at the
+        # API. Chunk the redacted whole by UTF-16 budget instead (redaction
+        # first, so the scanner saw the contiguous text; a chunk is a pure
+        # substring of it). Header rides the first bubble only.
+        header = "⚠️ Couldn't upload:\n"
+        budget = self._limit() - _utf16_len(header)
+        for index, chunk in enumerate(_utf16_chunks(restored, budget)):
+            await self._client.send_message(
+                self._chat_id,
+                f"{header}{chunk}" if index == 0 else chunk,
+                message_thread_id=self._thread_id,
+                disable_notification=True,
+            )
 
     async def _seal_current(
         self,

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -34,6 +34,9 @@ from kiro_crew.telegram.renderer import (
     TelegramApprovalDecider,
     TelegramRenderer,
     _display_safe,
+    _utf16_chunks,
+    _utf16_cut,
+    _utf16_len,
 )
 from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES, TelegramInboundMessage
 
@@ -294,6 +297,70 @@ class TestOutboundImages:
         renderer._buf = ["Here it is."]
         await renderer.on_done()
         assert _AWS_KEY not in "".join(text for text, _ in client.sent)
+
+    @pytest.mark.asyncio
+    async def test_recovery_of_many_failed_uploads_drops_no_reference(self) -> None:
+        # One truncated bubble used to keep only what fit under the cap: with
+        # enough failed images, every reference past it vanished silently.
+        renderer, client = _renderer()
+        renderer.authorize_upload_root("/tmp")
+        client.media_fails = True
+        files = [_png(f"chart-{i:03d}.png") for i in range(200)]
+        renderer._extract_uploads = AsyncMock(  # type: ignore[method-assign]
+            return_value=("Here they are.", files)
+        )
+        renderer._buf = ["Here they are."]
+        await renderer.on_done()
+        landed = "\n".join(text for text, _ in client.sent)
+        for item in files:
+            assert item.path in landed, f"recovery dropped {item.path}"
+        # Every recovery bubble stays within the channel budget, measured in
+        # Telegram's unit.
+        for text, _ in client.sent:
+            assert _utf16_len(text) <= renderer._limit()
+
+    @pytest.mark.asyncio
+    async def test_recovery_respects_telegram_utf16_budget(self) -> None:
+        # Telegram's cap counts UTF-16 code units; the old slice counted code
+        # points. An astral char costs 2 units, so emoji-dense alt text passed
+        # the slice while overflowing the real limit, and the send bounced.
+        renderer, client = _renderer()
+        renderer.authorize_upload_root("/tmp")
+        client.media_fails = True
+        dense = OutboundFile(
+            path="/tmp/chart.png",
+            data=b"\x89PNG\r\n\x1a\n",
+            alt="🚀" * 3000,
+            mime="image/png",
+        )
+        renderer._extract_uploads = AsyncMock(  # type: ignore[method-assign]
+            return_value=("Here.", [dense])
+        )
+        renderer._buf = ["Here."]
+        await renderer.on_done()
+        assert client.sent, "recovery bubbles must land"
+        for text, _ in client.sent:
+            assert _utf16_len(text) <= renderer._limit(), "bubble exceeds the API cap"
+        # Chunked, not truncated: no part of the alt text was dropped.
+        assert sum(text.count("🚀") for text, _ in client.sent) == 3000
+
+    def test_utf16_cut_floor_prevents_zero_progress(self) -> None:
+        # limit=1 with a leading astral char would otherwise cut at index 0
+        # forever; the floor of 2 guarantees any single char makes progress.
+        assert _utf16_cut("🚀abc", 1) >= 1
+        chunks = _utf16_chunks("🚀" * 5, 1)
+        assert "".join(chunks) == "🚀" * 5
+        assert all(_utf16_len(chunk) <= 2 for chunk in chunks)
+
+    def test_utf16_chunks_pack_lines_and_lose_nothing(self) -> None:
+        text = "\n".join(f"![a](/tmp/{i}.png)" for i in range(40))
+        chunks = _utf16_chunks(text, 100)
+        assert len(chunks) > 1, "must actually split for this to test packing"
+        assert all(_utf16_len(chunk) <= 100 for chunk in chunks)
+        # Newline-boundary packing: reassembled lines are exactly the input
+        # lines — nothing dropped, no line bisected.
+        lines = [line for chunk in chunks for line in chunk.split("\n")]
+        assert lines == text.split("\n")
 
     @pytest.mark.asyncio
     async def test_a_length_rotation_holds_a_STRADDLING_reference(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

When Telegram fails to upload extracted images, `_send_uploads` restores the image references into a recovery bubble. That bubble has two defects:

1. **Truncating recovery.** The combined restored markup is sliced to one message (`[: self._limit()]`). When several images fail together, every reference past the cap is silently dropped — the user is told "Couldn't upload" but never learns which of the later files were lost.
2. **Wrong length unit.** The slice counts Python code points, but Telegram's 4096 cap counts **UTF-16 code units** (an astral character — most emoji — costs 2). Emoji-dense alt text passes the slice and the send bounces at the API, so the recovery bubble itself fails to land.

## Why it matters

The recovery path exists precisely because uploads fail; a recovery that loses data (defect 1) or fails to send (defect 2) defeats its purpose. Consequence is bounded — reference lines, not the answer, since Telegram restores references only — but it is real data loss on the exact path meant to prevent it.

## What changed (motivation → approach → change)

The entity machinery in `telegram/client.py` already measures in UTF-16 units for offsets; message budgets did not. This change scopes the correct unit to the recovery path (the channel-wide code-point/UTF-16 budget mismatch elsewhere is pre-existing display truncation, not data loss, and is deliberately out of scope):

- `_utf16_len` — length in UTF-16 code units.
- `_utf16_cut` — largest **code-point** index whose prefix fits a UTF-16 budget, so `str` slicing can never bisect a surrogate pair. The `max(2, …)` floor is load-bearing: at `limit=1` a leading astral char would cut at index 0 and a chunking consumer would stop making progress.
- `_utf16_chunks` — newline-boundary packing so each restored reference stays whole within one bubble; a single line over the whole budget is hard-cut at a code-point boundary rather than dropped.
- `_send_uploads` recovery now redacts the restored whole first (so the display scanner sees the contiguous text and every chunk is a pure substring of what it scanned), then sends it in UTF-16-budgeted chunks — header on the first bubble only.

## Tests

Red-first — both behavior tests fail against the old code with the exact defect modes (`recovery dropped /tmp/chart-128.png`; `bubble exceeds the API cap`):

- `test_recovery_of_many_failed_uploads_drops_no_reference` — 200 failed images; every reference must appear across the recovery bubbles, and every bubble stays within the budget measured in Telegram's unit.
- `test_recovery_respects_telegram_utf16_budget` — 3000-emoji alt text (fits in code points, overflows UTF-16); every bubble within the cap, nothing truncated.
- `test_utf16_cut_floor_prevents_zero_progress` — the `limit=1` + astral-char pathological case makes progress and loses nothing.
- `test_utf16_chunks_pack_lines_and_lose_nothing` — line-aware packing round-trips exactly.

Full `test_telegram_parity.py` + `test_telegram.py`: 649 passed. flake8 / isort / mypy / black ratchet clean.

## Manual verification

N/A — the failure path needs a Telegram API upload failure; behavior is pinned by the unit tests above against the same FakeClient contract the existing recovery tests use.
