### PR TITLE
feat(messaging): deliver file_send natively on Telegram

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1363,
+    "missing_code": 1359,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1154,
+  "_compliant": 1167,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -97,7 +97,7 @@
       "missing_code": 15
     },
     "dashboard/handlers/files.py": {
-      "missing_code": 108
+      "missing_code": 104
     },
     "dashboard/handlers/kiro_prerequisite.py": {
       "missing_code": 1

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -131,6 +131,7 @@ from kiro_crew.dashboard.handlers.files import (  # noqa: E402, F401
     _write_file_restricted,
     api_browse_dirs,
     api_browse_files,
+    api_channel_upload_file,
     api_dashboard_config,
     api_file_diff,
     api_file_download,

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -29,13 +29,18 @@ from aiohttp.client_exceptions import ClientConnectionResetError
 from aiohttp.multipart import BodyPartReader
 
 from kiro_crew import platform_compat
+from kiro_crew.config import loader as config_loader
 from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
 from kiro_crew.dashboard import part_stream
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
+from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
 from kiro_crew.dashboard.state import DashboardState
-from kiro_crew.hooks import safe_read_prefix
+from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes, safe_read_prefix
+from kiro_crew.messaging import upload_gate
+from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.link import is_channel_session_key
+from kiro_crew.messaging.outbound_files import OutboundFile
 from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.sandbox import popen_limited, sandboxed_spawn_argv
@@ -415,10 +420,168 @@ async def api_outbox_list(request: web.Request) -> web.Response:
     return web.json_response({"files": entries[:50]})
 
 
+def _gate_upload_file(
+    file_path: str, filename: str, *, tool_kind: str
+) -> tuple[web.Response | None, Path | None, bytes | None]:
+    """The shared admission gate for shipping a local file to a channel.
+
+    One site computes the judgment for every channel-upload endpoint —
+    containment (outbox or workspace root), the descriptor-safe read, the
+    binary MIME allowlist, and the content credential scans — so the Slack
+    and channel legs cannot drift apart gate by gate. Returns
+    ``(error_response, None, None)`` on refusal, ``(None, resolved, bytes)``
+    when the file may ship. *tool_kind* keys the SEL records so each caller
+    keeps its own audit lane.
+
+    Blocking by design (a full read of up to ``MAX_FILE_BYTES`` plus content
+    regex scans): async handlers MUST run it off the event loop via
+    ``asyncio.to_thread`` — SEL appends are internally locked, so the audit
+    calls are thread-safe. The loader is called through its module so tests
+    (and config reloads) resolve at call time, not import time.
+    """
+
+    def _audit_denial(error: str, *, outcome: str = "denied") -> None:
+        _sel().log_tool_invocation(
+            session_key="api",
+            source="api",
+            tool_name="file_send",
+            tool_kind=tool_kind,
+            outcome=outcome,
+            downstream_service=tool_kind,
+            error=error,
+        )
+
+    if not file_path or not filename:
+        _audit_denial("missing_required_fields")
+        return (
+            web.json_response(
+                {"error": "file_path, filename required", "code": "missing_required_fields"},
+                status=400,
+            ),
+            None,
+            None,
+        )
+    # The name is DELIVERED (Slack upload title, Telegram document name,
+    # Discord message text fallback), so a credential embedded in it leaves
+    # with the file. Checked in the shared gate so no leg can drift from the
+    # others, and before path resolution so a sensitive name never even
+    # selects a file. Mirrors the MCP-side file_send refusal.
+    if redact(filename) != filename:
+        _audit_denial("sensitive_filename_rejected")
+        return (
+            web.json_response(
+                {
+                    "error": "filename contains sensitive content",
+                    "code": "sensitive_filename",
+                },
+                status=400,
+            ),
+            None,
+            None,
+        )
+    resolved = Path(file_path).resolve()
+    allowed_outbox = config_loader.outbox_dir().resolve()
+    allowed_workspace = config_loader.workspace_root().resolve()
+    if not (resolved.is_relative_to(allowed_outbox) or resolved.is_relative_to(allowed_workspace)):
+        _audit_denial(f"path_not_allowed: {file_path}")
+        return (
+            web.json_response(
+                {
+                    "error": "file_path must be under the outbox directory or the workspace root",
+                    "code": "path_not_allowed",
+                },
+                status=403,
+            ),
+            None,
+            None,
+        )
+    try:
+        raw = safe_read_file_bytes(str(resolved))
+    except FileTooLargeError as e:
+        _audit_denial(f"file_too_large: {e}")
+        return (
+            web.json_response({"error": str(e), "code": "file_too_large"}, status=413),
+            None,
+            None,
+        )
+    if raw is None:
+        _audit_denial(f"safe_read_file_bytes rejected: {file_path}")
+        return (
+            web.json_response(
+                {
+                    "error": f"File not found or access denied: {file_path}",
+                    "code": "file_not_found",
+                },
+                status=404,
+            ),
+            None,
+            None,
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        # Binary file — only allow known-safe media types
+        guessed_type = mimetypes.guess_type(filename)[0] or ""
+        if guessed_type not in BINARY_MIME_ALLOWLIST:
+            _audit_denial(f"binary_mime_not_allowed: {guessed_type}")
+            return (
+                web.json_response(
+                    {
+                        "error": f"Binary file type not allowed: {guessed_type or 'unknown'}",
+                        "code": "binary_mime_not_allowed",
+                    },
+                    status=400,
+                ),
+                None,
+                None,
+            )
+        text = None  # signal: skip text redaction path
+        # Scan binary content for embedded credentials (e.g. base64-encoded keys in PDFs)
+        binary_text = raw.decode("latin-1")
+        if redact(binary_text) != binary_text:
+            _audit_denial("binary_credential_detected")
+            return (
+                web.json_response(
+                    {
+                        "error": "binary file contains embedded credentials",
+                        "code": "binary_credential_detected",
+                    },
+                    status=400,
+                ),
+                None,
+                None,
+            )
+    if text is not None:
+        try:
+            redacted = redact(text)
+            if redacted != text:
+                _audit_denial("content_redacted")
+                return (
+                    web.json_response(
+                        {
+                            "error": "file content was redacted; upload aborted",
+                            "code": "content_redacted",
+                        },
+                        status=400,
+                    ),
+                    None,
+                    None,
+                )
+        except Exception as redact_err:
+            _audit_denial(f"redaction_failed: {redact_err}", outcome="error")
+            return (
+                web.json_response(
+                    {"error": f"Redaction failed: {redact_err}", "code": "redaction_failed"},
+                    status=500,
+                ),
+                None,
+                None,
+            )
+    return None, resolved, raw
+
+
 async def api_slack_upload_file(request: web.Request) -> web.Response:
     """POST /api/slack/upload-file — upload a file to Slack (internal, called by file_send)."""
-    from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes  # noqa: F811
-
     state: DashboardState = request.app["state"]
     slack = state.slack_client
     if not slack:
@@ -446,126 +609,15 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
     file_path_raw = body.get("file_path", "")
     filename = body.get("filename", "")
     thread_ts = body.get("thread_ts")
-    if not file_path_raw or not filename:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="denied",
-            error="missing_required_fields",
-        )
-        return web.json_response({"error": "file_path, filename required"}, status=400)
+    # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content
+    # (no-blocking-call-on-event-loop).
+    error_resp, resolved, raw = await asyncio.to_thread(
+        _gate_upload_file, file_path_raw, filename, tool_kind="slack"
+    )
+    if error_resp is not None:
+        return error_resp
+    assert resolved is not None and raw is not None  # narrowed by the gate
     file_path = file_path_raw
-    resolved = Path(file_path).resolve()
-    from kiro_crew.config.loader import outbox_dir, workspace_root  # noqa: F811
-
-    allowed_outbox = outbox_dir().resolve()
-    allowed_workspace = workspace_root().resolve()
-    if not (resolved.is_relative_to(allowed_outbox) or resolved.is_relative_to(allowed_workspace)):
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="denied",
-            downstream_service="slack",
-            error=f"path_not_allowed: {file_path}",
-        )
-        return web.json_response(
-            {
-                "error": "file_path must be under the outbox directory or the workspace root",
-                "code": "path_not_allowed",
-            },
-            status=403,
-        )
-    try:
-        raw = safe_read_file_bytes(str(resolved))
-    except FileTooLargeError as e:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="denied",
-            downstream_service="slack",
-            error=f"file_too_large: {e}",
-        )
-        return web.json_response({"error": str(e)}, status=413)
-    if raw is None:
-        _sel().log_tool_invocation(
-            session_key="api",
-            source="api",
-            tool_name="file_send",
-            tool_kind="slack",
-            outcome="denied",
-            downstream_service="slack",
-            error=f"safe_read_file_bytes rejected: {file_path}",
-        )
-        return web.json_response(
-            {"error": f"File not found or access denied: {file_path}"}, status=404
-        )
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError:
-        # Binary file — only allow known-safe media types
-        guessed_type = mimetypes.guess_type(filename)[0] or ""
-        if guessed_type not in BINARY_MIME_ALLOWLIST:
-            _sel().log_tool_invocation(
-                session_key="api",
-                source="api",
-                tool_name="file_send",
-                tool_kind="slack",
-                outcome="denied",
-                downstream_service="slack",
-                error=f"binary_mime_not_allowed: {guessed_type}",
-            )
-            return web.json_response(
-                {"error": f"Binary file type not allowed: {guessed_type or 'unknown'}"}, status=400
-            )
-        text = None  # signal: skip text redaction path
-        # Scan binary content for embedded credentials (e.g. base64-encoded keys in PDFs)
-        binary_text = raw.decode("latin-1")
-        if redact(binary_text) != binary_text:
-            _sel().log_tool_invocation(
-                session_key="api",
-                source="api",
-                tool_name="file_send",
-                tool_kind="slack",
-                outcome="denied",
-                downstream_service="slack",
-                error="binary_credential_detected",
-            )
-            return web.json_response(
-                {"error": "binary file contains embedded credentials"}, status=400
-            )
-    if text is not None:
-        try:
-            redacted = redact(text)
-            if redacted != text:
-                _sel().log_tool_invocation(
-                    session_key="api",
-                    source="api",
-                    tool_name="file_send",
-                    tool_kind="slack",
-                    outcome="denied",
-                    downstream_service="slack",
-                    error="content_redacted",
-                )
-                return web.json_response(
-                    {"error": "file content was redacted; upload aborted"}, status=400
-                )
-        except Exception as redact_err:
-            _sel().log_tool_invocation(
-                session_key="api",
-                source="api",
-                tool_name="file_send",
-                tool_kind="slack",
-                outcome="error",
-                downstream_service="slack",
-                error=f"redaction_failed: {redact_err}",
-            )
-            return web.json_response({"error": f"Redaction failed: {redact_err}"}, status=500)
     # Resolve thread_ts and channel from linked slot when not explicitly provided
     target_channel = body.get("channel", "")
     channel_from_session_map = False
@@ -707,6 +759,169 @@ async def api_slack_upload_file(request: web.Request) -> web.Response:
             error=safe_error,
         )
         return web.json_response({"error": safe_error}, status=500)
+
+
+async def api_channel_upload_file(request: web.Request) -> web.Response:
+    """POST /api/channel/upload-file — deliver a file to the caller's own
+    conversation on a non-Slack channel (internal, called by file_send).
+
+    The Slack counterpart above has its own identity ladder; this one serves
+    every transport-registry channel through the SAME send ladder the
+    cross-surface reply mirror uses (``_resolve_mirror_target``): channel-scope
+    governance, transport registration, proactive-send capability, and
+    ``may_send_to`` recipient re-authorization, all fail-closed and
+    SEL-audited in one place — plus the restricted-session ceiling the
+    renderers' extraction path enforces, on the same shared predicate. The
+    destination comes exclusively from the caller's session map entry — a
+    request cannot name an arbitrary conversation, which is what keeps this
+    endpoint from being a broadcast primitive. Delivery today: Telegram via
+    the purpose-built ``send_document`` (name-preserving); Discord is an
+    explicit skip until its transport grows a document verb that preserves an
+    admitted filename (see the delivery-branch comment below).
+
+    "Cannot deliver here" is a SKIP (``delivered: false``), not an error: most
+    sessions mirror nowhere, and the caller falls back to the dashboard card
+    and the Slack leg exactly as before this endpoint existed.
+    """
+    state: DashboardState = request.app["state"]
+    try:
+        body = await request.json()
+    except ValueError:
+        _sel().log_tool_invocation(
+            session_key="api",
+            source="api",
+            tool_name="file_send",
+            tool_kind="channel",
+            outcome="denied",
+            error="invalid_json_body",
+        )
+        return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+    def _skip(reason: str) -> web.Response:
+        _sel().log_tool_invocation(
+            session_key="api",
+            source="api",
+            tool_name="file_send",
+            tool_kind="channel",
+            outcome="skipped",
+            error=reason,
+        )
+        return web.json_response({"ok": True, "delivered": False, "skipped": reason})
+
+    session_key = request.headers.get("X-Session-Key", "").strip()
+    if not session_key or not getattr(state, "sessions", None):
+        return _skip("no_session")
+    from kiro_crew.dashboard.chat_runner import _resolve_mirror_target
+
+    # Off-loop like the admission gate below: the ladder reloads governance
+    # profiles and reads the persisted session map — synchronous filesystem
+    # work (no-blocking-call-on-event-loop). The session map's reads are
+    # lock-guarded, so the call is thread-safe.
+    target = await asyncio.to_thread(_resolve_mirror_target, state, session_key)
+    if target is None:
+        # No mirror link, a Slack link (the Slack leg owns those), a missing or
+        # capability-less transport, a governance denial, or a may_send_to
+        # refusal — the ladder audited the ones that matter; all mean the same
+        # thing here: this caller has no non-Slack conversation to deliver to.
+        return _skip("no_channel_destination")
+    link, transport = target
+    # The restricted ceiling the renderers' extraction path already enforces:
+    # an incognito/temporary session ships no local file bytes to a channel,
+    # and an explicit file_send must not be the bypass. Same shared predicate
+    # (which SEL-audits the denial), same skip shape as every other "cannot
+    # deliver here" answer. Checked before capability probing: a restricted
+    # caller learns nothing about which channels could upload.
+    if await upload_gate.uploads_restricted(
+        state,
+        session_key,
+        channel_type=link.channel_type,
+        persisted_probe=_probe_persisted_session,
+    ):
+        return _skip("restricted_session")
+    deliver = None
+    if link.channel_type == "telegram":
+        deliver = getattr(transport, "send_document", None)
+    # Discord is deliberately NOT wired: its transport upload verb serves the
+    # image-extraction pipeline, whose filename sanitizer maps any non-raster
+    # mime to `.bin` (`upload_filename`) — correct for LLM-authored reference
+    # paths, but it would deliver `report.pdf` as `report.bin` here. Until the
+    # transport grows a document verb that preserves an ADMITTED name (the
+    # gate already scanned it), Discord callers keep the dashboard-link
+    # fallback rather than a corrupted attachment.
+    if deliver is None:
+        return _skip(f"channel_upload_unsupported:{link.channel_type}")
+    # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content
+    # (no-blocking-call-on-event-loop).
+    error_resp, resolved, raw = await asyncio.to_thread(
+        _gate_upload_file,
+        body.get("file_path", ""),
+        body.get("filename", ""),
+        tool_kind="channel",
+    )
+    if error_resp is not None:
+        return error_resp
+    assert resolved is not None and raw is not None  # narrowed by the gate
+    filename = body.get("filename", "")
+    # Display-form redaction, not just literal: redact() scans bytes, and the
+    # channel's renderer strips markup at display time — ``AKIA**…**`` passes
+    # a literal scan and displays as an intact key. Same boundary rule every
+    # renderer sink applies (``redact_for_display``) before text reaches a
+    # transport.
+    description, _ = redact_for_display(body.get("description", "") or "", redact)
+    outbound = OutboundFile(
+        path=str(resolved),
+        data=raw,
+        alt=description,
+        mime=mimetypes.guess_type(filename)[0] or "application/octet-stream",
+    )
+    try:
+        mid = await deliver(
+            link.channel_id,
+            outbound,
+            caption=description,
+            thread_id=link.thread_id,
+        )
+    except Exception as e:
+        # A transport / network exception can carry file paths, host and URL
+        # fragments, or credentials embedded in a URL. Sanitize before it
+        # reaches the client or the audit record (see api_slack_upload_file).
+        safe_error, _ = redact_credentials(str(e))
+        safe_error, _ = redact_exfiltration_urls(safe_error)
+        _sel().log_tool_invocation(
+            session_key="api",
+            source="api",
+            tool_name="file_send",
+            tool_kind="channel",
+            outcome="error",
+            downstream_service=link.channel_type,
+            error=safe_error,
+        )
+        return web.json_response({"error": safe_error}, status=502)
+    if not mid:
+        # The transport reported failure without raising (the clients return
+        # an empty id on an API-level refusal).
+        _sel().log_tool_invocation(
+            session_key="api",
+            source="api",
+            tool_name="file_send",
+            tool_kind="channel",
+            outcome="error",
+            downstream_service=link.channel_type,
+            error="delivery_reported_no_message_id",
+        )
+        return web.json_response({"error": "channel delivery failed"}, status=502)
+    _sel().log_tool_invocation(
+        session_key="api",
+        source="api",
+        tool_name="file_send",
+        tool_kind="channel",
+        outcome="completed",
+        downstream_service=link.channel_type,
+        resources=f"channel_type={link.channel_type} file={body.get('file_path', '')}",
+    )
+    return web.json_response(
+        {"ok": True, "delivered": True, "channel_type": link.channel_type}
+    )
 
 
 async def api_upload(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/routes/taskrunner.py
+++ b/src/kiro_crew/dashboard/routes/taskrunner.py
@@ -53,6 +53,7 @@ def register(app: web.Application) -> None:
     app.router.add_post("/api/upload", handlers.api_upload)
     app.router.add_post("/api/upload/file", handlers.api_upload_file)
     app.router.add_post("/api/slack/upload-file", handlers.api_slack_upload_file)
+    app.router.add_post("/api/channel/upload-file", handlers.api_channel_upload_file)
     app.router.add_post("/api/slack/pins", handlers.api_slack_pins)
     app.router.add_post("/api/slack/reactions", handlers.api_slack_reactions)
     app.router.add_post("/api/chat/slots/{name}/slack-link", chat.api_chat_slot_slack_link)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -372,6 +372,7 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         "/api/outbox/notify",
         "/api/notifications/agent",  # MCP-only (send_notification tool); no browser caller
         "/api/slack/upload-file",
+        "/api/channel/upload-file",
         "/api/slack/pins",
         "/api/slack/reactions",
         "/api/slack-profile",  # MCP-only (slack_profile tool); no browser caller

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -305,9 +305,12 @@ def schemas() -> list[dict[str, Any]]:
             "name": "file_send",
             "description": (
                 "Send a file to the user. Copies the file to the outbox and "
-                "notifies the dashboard/Slack with a download link. Use when "
-                "you've generated a report, export, artifact, or any file the "
-                "user should receive."
+                "notifies the dashboard with a download link. When this "
+                "session is linked to a Telegram conversation the file is "
+                "also delivered there natively; otherwise it uploads to "
+                "Slack when the caller's Slack identity permits it. Use "
+                "when you've generated a report, export, artifact, or any "
+                "file the user should receive."
             ),
             "inputSchema": {
                 "type": "object",
@@ -737,6 +740,39 @@ def file_send(name: str, args: dict[str, Any]) -> str:
     )
     if d.get("error"):
         return f"Error: {d['error']}"
+    # Native channel delivery first: when the caller's session is linked to a
+    # non-Slack conversation with a document-capable transport (a Telegram
+    # chat today), the file belongs THERE — the user who asked for it is
+    # reading that surface, and the dashboard card is the fallback, not the
+    # delivery. The endpoint resolves the destination exclusively from the
+    # caller's session map entry (this tool cannot name a conversation) and
+    # answers ``delivered: false`` for every "no destination here" case — in
+    # which case the Slack leg below runs exactly as it always has.
+    #
+    # The caller is resolved STRICTLY and pinned on the wire. The default
+    # lenient resolution includes a /proc ancestor walk, under which an
+    # unidentified subagent resolves to its PARENT slot — and the file would
+    # deliver into the parent's linked conversation. No verified identity, no
+    # native delivery; the Slack leg keeps its own three-state classifier.
+    #
+    # An EXPLICIT ``channel`` argument names a destination the caller chose,
+    # so the session-link inference must stand down entirely: running the
+    # native leg first would reroute the file to the linked chat instead of
+    # the named Slack channel.
+    channel_warning = ""
+    strict_key = mcp_core._resolve_session_key_strict()
+    if strict_key and not args.get("channel"):
+        channel_resp = mcp_core._post(
+            "/api/channel/upload-file",
+            {"file_path": str(dest), "filename": dest.name, "description": desc},
+            session_key=strict_key,
+        )
+        if channel_resp.get("delivered"):
+            via = channel_resp.get("channel_type") or "channel"
+            msg = f"File sent: {dest.name} ({desc})" if desc else f"File sent: {dest.name}"
+            return f"{msg} (delivered to {via})"
+        if channel_resp.get("error"):
+            channel_warning = f" (channel upload failed: {channel_resp['error']})"
     # Also upload to Slack when the caller's Slack identity permits it.
     #
     # Resolve identity as a THREE-state result (see
@@ -781,7 +817,7 @@ def file_send(name: str, args: dict[str, Any]) -> str:
         if slack_resp.get("error"):
             slack_warning = f" (Slack upload failed: {slack_resp['error']})"
     msg = f"File sent: {dest.name} ({desc})" if desc else f"File sent: {dest.name}"
-    return msg + slack_warning
+    return msg + channel_warning + slack_warning
 
 
 HANDLERS: dict[str, Callable[[str, dict[str, Any]], str]] = {

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -1031,6 +1031,44 @@ class TelegramClient:
         result = await self._api_multipart("sendPhoto", params, [photo], field_names=["photo"])
         return result.get("message_id") if isinstance(result, dict) else None
 
+    async def send_document(
+        self,
+        chat_id: int,
+        document: "OutboundFile",
+        *,
+        caption: str | None = None,
+        message_thread_id: int | None = None,
+        disable_notification: bool = True,
+    ) -> int | None:
+        """Upload ONE file via ``sendDocument``. Returns the message_id or None.
+
+        The generic-file counterpart of :meth:`send_photo`, for attachments that
+        are not raster images (PDF, CSV, archives — whatever the caller's own
+        gates admitted). Sent silently by default: every current caller has
+        already landed a text bubble for the same turn, and a second ping for
+        the same action is the pattern the other media sends avoid.
+
+        ``filenames`` pins the document's real name: the multipart sanitizer is
+        aimed at LLM-authored reference paths, and this caller's name has
+        already passed the file_send gates — letting the sanitizer rewrite the
+        extension would break the receiver's file-type association.
+        """
+        params: dict[str, Any] = {"chat_id": chat_id}
+        if message_thread_id is not None:
+            params["message_thread_id"] = message_thread_id
+        if caption:
+            params["caption"] = caption[:TELEGRAM_MAX_CAPTION]
+        if disable_notification:
+            params["disable_notification"] = True
+        result = await self._api_multipart(
+            "sendDocument",
+            params,
+            [document],
+            field_names=["document"],
+            filenames=[Path(document.path).name],
+        )
+        return result.get("message_id") if isinstance(result, dict) else None
+
     async def send_voice(
         self,
         chat_id: int,

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -19,6 +19,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
+from kiro_crew.messaging.outbound_files import OutboundFile
 from kiro_crew.messaging.tables import TABLE_POLICY_NATIVE
 from kiro_crew.messaging.transport import (
     ConfiguredChannelTarget,
@@ -233,6 +234,29 @@ class TelegramTransport(MessagingTransport):
         mid = await self._client.send_message(
             int(conversation_id),
             content,
+            message_thread_id=int(thread_id) if thread_id else None,
+        )
+        return str(mid or "")
+
+    async def send_document(
+        self,
+        conversation_id: str,
+        file: "OutboundFile",
+        *,
+        caption: str = "",
+        thread_id: str | None = None,
+    ) -> str:
+        """Send one validated file into this conversation. Returns the message id.
+
+        The transport-level upload verb, Discord's ``send_message_with_files``
+        counterpart: a caller holding a transport does not reach past it into
+        the client. ``file`` carries validated bytes (the ``OutboundFile``
+        contract — the path is provenance, never re-opened).
+        """
+        mid = await self._client.send_document(
+            int(conversation_id),
+            file,
+            caption=caption or None,
             message_thread_id=int(thread_id) if thread_id else None,
         )
         return str(mid or "")

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -8,13 +8,15 @@ Tests the api_slack_upload_file handler's channel routing:
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from kiro_crew.dashboard.handlers.files import api_slack_upload_file
+from kiro_crew.dashboard.handlers.files import api_channel_upload_file, api_slack_upload_file
 from kiro_crew.dashboard.state import DashboardState
 
 
@@ -551,3 +553,355 @@ class TestFileUploadSlotThreading:
                 body = await resp.json()
                 assert "not authorized" in body.get("error", "")
                 slack.upload_file.assert_not_called()
+
+
+class TestChannelUploadEndpoint:
+    """POST /api/channel/upload-file — the non-Slack parity leg of file_send.
+
+    Destination comes exclusively from the caller's session map entry via the
+    shared send ladder; these tests fake the ladder's answer and verify the
+    handler's own obligations: skip-vs-error semantics, the shared admission
+    gate, and the per-channel delivery calls.
+    """
+
+    def _app(self, state=None):
+        if state is None:
+            state = MagicMock(spec=DashboardState)
+            state.sessions = MagicMock()
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/channel/upload-file", api_channel_upload_file)
+        return app
+
+    @staticmethod
+    def _link(channel_type, channel_id="42", thread_id=None):
+        from kiro_crew.messaging.link import ChannelLink
+
+        return ChannelLink(channel_type=channel_type, channel_id=channel_id, thread_id=thread_id)
+
+    @pytest.mark.asyncio
+    async def test_a_restricted_session_gets_no_native_delivery(self, tmp_path, outbox_file):
+        # The renderers' extraction path enforces the restricted ceiling
+        # (incognito/temporary sessions ship no local file bytes); an explicit
+        # file_send must not be the bypass. Same shared predicate, same skip
+        # shape as every other "cannot deliver here" answer.
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="123")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram", "42"), transport),
+        ), patch(
+            "kiro_crew.messaging.upload_gate.uploads_restricted",
+            new=AsyncMock(return_value=True),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body["delivered"] is False
+        assert body["skipped"] == "restricted_session"
+        transport.send_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_credential_bearing_filename_is_rejected_for_both_legs(self, tmp_path):
+        # The Slack leg rejects a sensitive filename at its send site; the
+        # channel leg must not be the bypass. Enforced in the SHARED gate so
+        # neither leg can drift: checked before path resolution, so the name
+        # never even selects a file.
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="123")
+        app = self._app()
+        leaky_name = "AKIA" + "IOSFODNN7EXAMPLE" + ".txt"
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram", "42"), transport),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(tmp_path / leaky_name), "filename": leaky_name},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 400
+        assert "filename contains sensitive content" in body.get("error", "")
+        transport.send_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_outbound_text_is_redacted_in_display_form(self, tmp_path, outbox_file):
+        # redact() scans literal bytes; a channel renderer strips markdown
+        # delimiters at display, so AKIA**…** passes a literal scan and
+        # displays as an intact key. The caption must go through
+        # redact_for_display before delivery — same boundary rule as every
+        # renderer sink.
+        from unittest.mock import AsyncMock
+
+        key = "AKIA" + "IOSFODNN7EXAMPLE"
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="900")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram", "42"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={
+                        "file_path": str(outbox_file),
+                        "filename": "report.txt",
+                        "description": f"{key[:4]}**{key[4:]}**",
+                    },
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200 and body["delivered"] is True
+        _, kwargs = transport.send_document.call_args
+        caption = kwargs["caption"]
+        # What the channel DISPLAYS (delimiters stripped) must not reassemble
+        # the key.
+        assert key not in caption.replace("*", "").replace("`", "").replace("_", "")
+
+    @pytest.mark.asyncio
+    async def test_destination_resolution_runs_off_the_event_loop(self, tmp_path, outbox_file):
+        # The ladder reloads governance profiles and reads the persisted
+        # session map — synchronous filesystem work. Like the admission gate,
+        # it must not run inline in the async handler
+        # (no-blocking-call-on-event-loop).
+        from unittest.mock import AsyncMock
+
+        loop_thread = threading.get_ident()
+        seen: dict = {}
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="123")
+
+        def _fake_resolver(state, session_key):
+            seen["thread"] = threading.get_ident()
+            return None  # skip path; the thread identity is the assertion
+
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            side_effect=_fake_resolver,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                assert (await resp.json())["skipped"] == "no_channel_destination"
+        assert seen.get("thread") is not None, "resolver must have run"
+        assert seen["thread"] != loop_thread, "resolver ran ON the event loop thread"
+        assert asyncio.get_event_loop() is not None  # loop alive throughout
+
+    @pytest.mark.asyncio
+    async def test_no_session_key_is_a_skip_not_an_error(self, tmp_path):
+        """Destination is resolved before the file is even read."""
+        app = self._app()
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/channel/upload-file",
+                json={"file_path": str(tmp_path / "missing.txt"), "filename": "missing.txt"},
+            )
+            body = await resp.json()
+        assert resp.status == 200
+        assert body == {"ok": True, "delivered": False, "skipped": "no_session"}
+
+    @pytest.mark.asyncio
+    async def test_no_destination_is_a_skip(self, tmp_path, outbox_file):
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=None,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "dashboard:chat-1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body["delivered"] is False
+        assert body["skipped"] == "no_channel_destination"
+
+    @pytest.mark.asyncio
+    async def test_telegram_destination_gets_send_document(self, tmp_path, outbox_file):
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="123")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram", "42", thread_id="7"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={
+                        "file_path": str(outbox_file),
+                        "filename": "report.txt",
+                        "description": "weekly numbers",
+                    },
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body == {"ok": True, "delivered": True, "channel_type": "telegram"}
+        transport.send_document.assert_awaited_once()
+        args, kwargs = transport.send_document.call_args
+        assert args[0] == "42"
+        outbound = args[1]
+        # The OutboundFile contract: the gated bytes ARE the payload.
+        assert outbound.data == b"hello world"
+        assert outbound.path == str(outbox_file)
+        assert kwargs["caption"] == "weekly numbers"
+        assert kwargs["thread_id"] == "7"
+
+    @pytest.mark.asyncio
+    async def test_discord_destination_is_an_explicit_skip(self, tmp_path, outbox_file):
+        # Deliberate: Discord's transport upload verb serves the image
+        # extraction pipeline, whose sanitizer maps any non-raster mime to
+        # `.bin` — report.pdf would arrive as report.bin. Until a
+        # name-preserving document verb exists, Discord callers keep the
+        # dashboard-link fallback rather than a corrupted attachment.
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_message_with_files"])
+        transport.send_message_with_files = AsyncMock(return_value="900")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("discord", "555"), transport),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "discord:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body["delivered"] is False
+        assert body["skipped"] == "channel_upload_unsupported:discord"
+        transport.send_message_with_files.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_channel_without_an_upload_verb_is_a_skip(self, tmp_path, outbox_file):
+        transport = MagicMock(spec_set=["send_message"])  # no upload verb
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("teams", "t1"), transport),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "teams:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body["delivered"] is False
+        assert body["skipped"] == "channel_upload_unsupported:teams"
+
+    @pytest.mark.asyncio
+    async def test_path_outside_allowed_roots_is_denied(self, tmp_path):
+        from unittest.mock import AsyncMock
+
+        stray = tmp_path / "stray.txt"
+        stray.write_text("x", encoding="utf-8")
+        outbox = tmp_path / "outbox"
+        outbox.mkdir()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock()
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=workspace
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(stray), "filename": "stray.txt"},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 403
+        assert body.get("code") == "path_not_allowed"
+        transport.send_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_is_a_502_with_a_sanitized_error(self, tmp_path, outbox_file):
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(side_effect=RuntimeError("boom"))
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 502
+        assert "boom" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_message_id_is_a_502(self, tmp_path, outbox_file):
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("telegram"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={"file_path": str(outbox_file), "filename": "report.txt"},
+                    headers={"X-Session-Key": "telegram:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 502
+        assert body["error"] == "channel delivery failed"

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -1118,6 +1118,106 @@ class TestFileSend:
             out = _call_tool("file_send", {"path": str(src)})
         assert out == "File sent: report.txt (Slack upload failed: not in channel)"
 
+    def test_channel_delivery_takes_precedence_over_slack(self, tmp_path, monkeypatch):
+        # A caller linked to a Telegram chat or Discord DM gets the file THERE;
+        # the Slack owner-DM leg is the fallback, not a second copy.
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:chat-1")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+
+        def _post(path: str, body: dict | None = None, **_kw: object) -> dict:
+            if path == "/api/channel/upload-file":
+                return {"ok": True, "delivered": True, "channel_type": "telegram"}
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_post) as m:
+            out = _call_tool("file_send", {"path": str(src)})
+        assert out == "File sent: report.txt (delivered to telegram)"
+        assert all(c[0][0] != "/api/slack/upload-file" for c in m.call_args_list)
+
+    def test_channel_skip_leaves_the_slack_leg_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:chat-1")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+
+        def _post(path: str, body: dict | None = None, **_kw: object) -> dict:
+            if path == "/api/channel/upload-file":
+                return {"ok": True, "delivered": False, "skipped": "no_channel_destination"}
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_post) as m:
+            out = _call_tool("file_send", {"path": str(src)})
+        assert out == "File sent: report.txt"
+        assert any(c[0][0] == "/api/slack/upload-file" for c in m.call_args_list)
+
+    def test_channel_failure_warns_and_falls_back_to_slack(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:chat-1")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+
+        def _post(path: str, body: dict | None = None, **_kw: object) -> dict:
+            if path == "/api/channel/upload-file":
+                return {"error": "telegram api 400"}
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_post) as m:
+            out = _call_tool("file_send", {"path": str(src)})
+        assert out == "File sent: report.txt (channel upload failed: telegram api 400)"
+        assert any(c[0][0] == "/api/slack/upload-file" for c in m.call_args_list)
+
+    def test_an_explicit_slack_channel_beats_native_delivery(self, tmp_path, monkeypatch):
+        # channel="C…" names a DESTINATION the caller chose; the native leg's
+        # session-link inference must not silently reroute the file to the
+        # linked Telegram chat instead of the named Slack channel.
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:chat-1")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+
+        def _post(path: str, body: dict | None = None, **_kw: object) -> dict:
+            if path == "/api/channel/upload-file":
+                return {"ok": True, "delivered": True, "channel_type": "telegram"}
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_post) as m:
+            out = _call_tool("file_send", {"path": str(src), "channel": "C0TRACKED123"})
+        assert all(c[0][0] != "/api/channel/upload-file" for c in m.call_args_list), (
+            "native delivery must not run for an explicitly named channel"
+        )
+        assert any(c[0][0] == "/api/slack/upload-file" for c in m.call_args_list)
+        assert out == "File sent: report.txt"
+
+    def test_an_unidentified_caller_gets_no_native_delivery(self, tmp_path, monkeypatch):
+        # The lenient session resolver includes a /proc ancestor walk, under
+        # which an unidentified subagent resolves to its PARENT slot — and the
+        # file would deliver into the parent's conversation. No strict
+        # identity, no native delivery; the Slack leg keeps its own classifier.
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+        with patch.object(mcp_core, "_post", return_value={"ok": True}) as m:
+            out = _call_tool("file_send", {"path": str(src)})
+        assert out == "File sent: report.txt"
+        assert all(c[0][0] != "/api/channel/upload-file" for c in m.call_args_list)
+
+    def test_native_delivery_pins_the_strict_identity_on_the_wire(self, tmp_path, monkeypatch):
+        # The endpoint resolves the destination from the caller's session map
+        # entry, so the request must carry the VERIFIED key — not whatever the
+        # default resolution would re-derive server-side.
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:chat-9")
+        src = tmp_path / "report.txt"
+        src.write_text("ok")
+
+        def _post(path: str, body: dict | None = None, **kw: object) -> dict:
+            if path == "/api/channel/upload-file":
+                assert kw.get("session_key") == "dashboard:chat-9"
+                return {"ok": True, "delivered": True, "channel_type": "discord"}
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_post) as m:
+            out = _call_tool("file_send", {"path": str(src)})
+        assert out == "File sent: report.txt (delivered to discord)"
+        assert any(c[0][0] == "/api/channel/upload-file" for c in m.call_args_list)
+
 
 # ── argument validation seam ──────────────────────────────────────────────
 

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -922,6 +922,57 @@ class TestMultipartShape:
         client._api_multipart.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_a_document_takes_sendDocument_with_its_real_name(self) -> None:
+        client = TelegramClient(token="t:1")
+        seen: list[Any] = []
+
+        async def _mp(method: str, params: dict, files: Any, **kw: Any) -> Any:
+            seen.append((method, params, list(files), kw["field_names"], kw.get("filenames")))
+            return {"message_id": 9}
+
+        client._api_multipart = _mp  # type: ignore[method-assign]
+        doc = OutboundFile(
+            path="/tmp/box/report.pdf", data=b"%PDF-1.4", alt="", mime="application/pdf"
+        )
+        mid = await client.send_document(7, doc, caption="x" * 2000, message_thread_id=3)
+        assert mid == 9
+        method, params, files, names, filenames = seen[0]
+        assert method == "sendDocument" and names == ["document"]
+        # The real filename is pinned: the multipart sanitizer is aimed at
+        # LLM-authored reference paths, and rewriting this already-gated name's
+        # extension would break the receiver's file-type association.
+        assert filenames == ["report.pdf"]
+        assert params["chat_id"] == 7 and params["message_thread_id"] == 3
+        # Caption capped at Telegram's 1024; the send stays silent (the text
+        # bubble for the same turn already pinged).
+        assert len(params["caption"]) == 1024
+        assert params["disable_notification"] is True
+        assert files == [doc]
+
+    @pytest.mark.asyncio
+    async def test_the_transport_document_verb_converts_ids_and_returns_str(self) -> None:
+        # The endpoint hands the transport a str conversation id off a
+        # ChannelLink; the Bot API wants ints. The verb owns that conversion,
+        # like send_message beside it.
+        from kiro_crew.telegram.transport import TelegramTransport
+
+        client = TelegramClient(token="t:1")
+        seen: list[Any] = []
+
+        async def _send_document(chat_id: int, document: Any, **kw: Any) -> int:
+            seen.append((chat_id, document, kw))
+            return 44
+
+        client.send_document = _send_document  # type: ignore[method-assign]
+        transport = TelegramTransport(client)
+        doc = _png("report.png")
+        mid = await transport.send_document("42", doc, caption="here", thread_id="7")
+        assert mid == "44"
+        chat_id, document, kw = seen[0]
+        assert chat_id == 42 and document is doc
+        assert kw["caption"] == "here" and kw["message_thread_id"] == 7
+
+    @pytest.mark.asyncio
     async def test_the_album_cap_bounds_one_call(self) -> None:
         client = TelegramClient(token="t:1")
         seen: list[int] = []


### PR DESCRIPTION
## Problem / Motivation

`file_send` (`mcp_tools/messaging.py`) copies the file to the outbox, notifies the dashboard, and uploads natively to **Slack only**. A session linked to a Telegram chat gets a dashboard download link — while an inline `![...](path)` image reference in a reply on that same channel uploads natively (#5131). Two paths, two behaviours, same file. Telegram also had no `sendDocument` at all, leaving #823 half-done (photos shipped in #5131).

## Why it matters

A user who asks for a file in Telegram should receive it there, like they already receive images referenced in replies.

## What changed (motivation → approach → change)

- **Telegram `sendDocument`** (client + transport verb), mirroring `send_photo`/`send_message` beside them: caption capped at 1024, silent by default, the real filename pinned on the multipart part (the untrusted-name sanitizer targets LLM-authored paths; rewriting an already-gated name's extension would break the receiver's file-type association). Closes the document half of #823.
- **`POST /api/channel/upload-file`** (strict-internal, like the Slack leg): resolves the destination **exclusively from the caller's session map entry** through `_resolve_mirror_target` — the same fail-closed, SEL-audited send ladder the cross-surface reply mirror uses (channel governance, transport registration, proactive-send capability, `may_send_to` recipient re-authorization) — and enforces the **restricted-session ceiling** (`upload_gate.uploads_restricted`, the same shared predicate the renderers' extraction path uses) before probing capability, so an incognito/temporary session cannot use `file_send` as the bypass. A request cannot name an arbitrary conversation, which is what keeps this endpoint from being a broadcast primitive. Delivery: Telegram via the new `send_document`; every other answer — including Discord, see below — is an explicit skip (`delivered: false`), not an error.
- **Shared admission gate, off the event loop.** The Slack handler's validation block (path containment under outbox/workspace, descriptor-safe read, binary MIME allowlist, text + latin-1 content credential scans) is factored into `_gate_upload_file`, used by both legs so the two gates cannot drift — and both handlers run it via `asyncio.to_thread` (`no-blocking-call-on-event-loop`: the gate reads up to `MAX_FILE_BYTES` and regex-scans the content; SEL appends are internally locked, so the audit calls are thread-safe off-loop). The gate is the Slack leg's original checks PLUS one addition: a filename credential scan (`redact(filename)`), added when review found the channel leg would otherwise deliver a credential-bearing name — so `/api/slack/upload-file` gains one new 400 refusal (`sensitive_filename`) it did not previously have at the gate (its own late send-site check remains). Everything else is unchanged and the existing Slack-leg suites pin it.
- **Error-code contract on the shared gate.** Factoring the gate initially made every refusal a `status=<variable>` response, which the error-code ratchet correctly rejected; the gate now answers every refusal with a literal status AND a machine-readable `code` (`sensitive_filename`, `path_not_allowed`, `file_too_large`, `file_not_found`, `binary_mime_not_allowed`, `binary_credential_detected`, `content_redacted`, `redaction_failed`, `missing_required_fields`). Because the gate is shared, the Slack leg's refusals gain these `code` fields too, and `error-code-baseline.json` is re-snapshotted for the improvement (`missing_code` 108→105 for `handlers/files.py`) — a ratchet tightening, per the contract test's own `--update`.
- **`file_send` ordering and identity.** The caller is resolved **strictly** (`_resolve_session_key_strict` — the lenient default includes a `/proc` ancestor walk, under which an unidentified subagent resolves to its parent slot and would deliver the file into the parent's conversation) and the verified key is pinned on the wire; no strict identity, no native delivery. The caller's own non-Slack conversation is tried first; on any "no destination here" answer the Slack leg runs exactly as before. Behaviour changes only for telegram-linked callers — where today's owner-Slack-DM fallback is the bug this fixes.
- **Discord is deliberately NOT wired.** Its transport upload verb serves the image-extraction pipeline, whose filename sanitizer maps any non-raster mime to `.bin` (`upload_filename`) — correct for LLM-authored reference paths, but `report.pdf` would arrive as `report.bin` here (GPT round-4 finding, verified). Discord callers keep the dashboard-link fallback until the transport grows a document verb that preserves an admitted filename; that follow-up is tracked in the review thread.

Outbox retention was in this PR's first push and is **withdrawn**: the opportunistic prune raced concurrent same-name sends (unlink after a stale stat can delete a just-written replacement), and both Design Review and First Principles flagged the deletion policy (retroactive, no knob, one of three identical unbounded buffers) as needing a real design. Follow-up filed; see the disposition comments.

## Tests

- Endpoint (`test_file_send_channel.py`): telegram delivery (bytes-are-the-payload contract, caption, thread id), the deliberate Discord skip, display-form caption redaction, credential-bearing filename refusal, destination-before-read ordering (no session key → skip, not 404), no-destination skip, **restricted-session skip (transport never called)**, unsupported-channel skip, path-containment denial, transport failure → 502 with sanitized error, empty message id → 502.
- MCP side (`test_mcp_core_coverage.py`): channel delivery suppresses the Slack leg; skip leaves the Slack leg byte-identical; channel failure warns and falls back; **an unidentified caller (no strict identity) gets no native delivery**; **the verified key is pinned on the wire**.
- Telegram (`test_telegram_parity.py`): `sendDocument` multipart shape (field name, pinned filename, caption cap, silence), transport verb id conversion.
- The three security-blocker tests were run red-first against the pre-fix head (restricted bypass, ancestor-walk delivery, missing wire pin) and green after.
- Suites: 273 passed across the affected files; `test_security_posture.py` + `test_spawn_audit.py` green (new endpoint registered strict-internal); flake8 / isort / mypy / black ratchet clean.

## Manual verification

N/A — delivery is pinned at the transport-verb seam with the same fake-transport contract the reply mirror tests use; no live bot credentials in CI.

Fixes #823

<!-- no-visual-delta -->
**Why no screenshot:** Backend-only change (MCP tool leg, gateway endpoint, Telegram client verb); no rendered UI surface is touched.
