### PR TITLE
feat(connections): warm-mint table + dead-mint expiry sweep

### DIFF
--- a/docs/architecture/design-notes/README.md
+++ b/docs/architecture/design-notes/README.md
@@ -12,6 +12,7 @@ grows into a subsystem should become a spec under
 | [mcp-oauth-ownership.md](mcp-oauth-ownership.md) | Who owns an MCP server's OAuth tokens, and why that ownership is contested. |
 | [connections-status-tiers.md](connections-status-tiers.md) | The authorization axis behind a Connections card: grant-presence status, source-backed connected-since, what Cancel releases, and which mint tiers exist. |
 | [connections-l1-smoke.md](connections-l1-smoke.md) | The Connections launch-gate ladder, and what an automated smoke run over a real stored grant can and cannot prove. |
+| [connections-warm-table.md](connections-warm-table.md) | Serving every card's approval URL from one shared kiro-cli process: why the session is held, why the spec set is grant-blind, and what a respawn costs. |
 | [mcp-entry-provenance.md](mcp-entry-provenance.md) | Which entries in a shared MCP config file a sync may rewrite: the write-authorship marker and its four outcomes. |
 | [mcp-gateway-claim-push.md](mcp-gateway-claim-push.md) | Event-driven caller identity for pooled MCP stubs. |
 | [mcp-gateway-oversize-response.md](mcp-gateway-oversize-response.md) | Handling an MCP tool response that exceeds the gateway read buffer. |

--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -1,0 +1,102 @@
+# Connections warm-mint table
+
+Cold mint (`kiro_crew.connections.mint`) spawns one kiro-cli process per provider for one
+approval URL: ~7.5s per card. `kiro_crew.connections.warm` serves the whole gallery from one
+process, and every rule below answers an observed failure.
+
+**Placement.** All warm code is in `src/kiro_crew/connections/warm.py`; the dashboard handler
+adds only endpoint wiring and a function-local `expire_dead_mints` import on the status path,
+keeping the mint engine off the gateway's boot path.
+
+**Scope boundary: slice N2a ships the TABLE half; the LIFECYCLE is DEFERRED to slice N2b.**
+Shipped now: the shared row shape (`shared`/`generation`/`activation`), the liveness registry
+those stamps are read against, and `expire_dead_mints()` on the status path. Deferred to N2b:
+everything that spawns, activates, parks or kills a process -- spec planning, the spawn/respawn
+rules, tool-alias key shape, the reaper, `warm_mint_all`, and the filesystem-drift guard that
+covers their synchronous helpers. Every section below except *Measured facts* therefore
+describes N2b's half, and N2b lands those tests together with the code. With no activation
+live no row is ever `shared`, so the shipped `expire_dead_mints()` call is a no-op scan whose
+predicate is nonetheless complete for the parked case, because a reader blind to a parked
+process withdraws a URL that process can still redeem.
+
+## Measured facts
+
+- Activation costs a fixed ~5.18s whether the spec carries one remote server or six, and an
+  initialized process mints in ~5.4s. ACP `initialize`, the expensive half, is paid once at
+  spawn, so one activation warms every card.
+- **A challenge is half per-process and half per-session.** The PKCE verifier is a value in
+  process memory and coexists with its peers (six proven live); the loopback callback *server*
+  is one of the session's MCP children, so `session/terminate` reaps it -- popping the URL and
+  destroying the handle left a `redirect_uri` whose port accepted a bare connect, then reset
+  every real exchange with zero bytes. So the session is *held*, and redeemability takes two
+  questions: `generation_is_live` (the process holds the verifier) **and** `activation_is_live`
+  (the session still answers the redirect). Process liveness alone passed the
+  terminated-session case.
+
+## Specs are read once at spawn
+
+A spec written after spawn is invisible (`set_mode` answers "Mode not found") and a rewrite is
+not honoured, so the whole set is written before spawn and any change needs a *new process*,
+tracked by `_WarmSpecPlan.digest`. A respawn destroys every peer's in-flight consent listener,
+so respawn frequency is the dominant design pressure:
+
+- **The spec universe is registry-derived and blind to grant and cancel state.** Connect writes
+  an MCP entry for the provider being connected, so a config-derived plan changed on every
+  click, and a plan tracking "who needs a URL now" changed on every completed consent and every
+  Cancel -- either retired a process holding other cards' listeners.
+- **Digest equality is not the respawn test** -- it reads a set that *shrank* as one that
+  changed. `_plan_is_servable` asks whether every entry the new plan needs is already resident
+  with an identical authorization ask, re-activating on the same process when it is: a Connect
+  costing 0.13s instead of 7.5s. An unservable change **parks** rather than kills, so the
+  outgoing generation keeps serving the consents it holds until the reaper collects it, once
+  its rows are gone or expired.
+
+## Cut against the shipped engine
+
+`mint.py` (PR #3154) is the reviewed engine and owns the row table, the row identity token,
+grant detection, spec emission and the manifest sweep; warm imports all of it and adds only
+what is genuinely per-process. Two adaptations:
+
+- `_mint_holder_alive` is deliberately **not** reused -- it reads the row's own `client`, which
+  a shared row does not own, so it answers False for every warm row. `_warm_row_alive` asks the
+  generation/activation pair instead.
+- Warm spec names are fixed (`kirocrew-mint-warm-*`), with no `-<pid>-<8hex>` suffix, keeping
+  them out of the cold engine's manifest sweep. That shared prefix is a hazard in reverse -- a
+  *cold* spec for a server named `warm-*` matches the warm glob -- so `_is_stale_warm_spec`
+  refuses anything matching the cold name shape, and both patterns must share one **character
+  class**: while warm accepted `[A-Za-z]` and cold only `[a-z]`, a mixed-case alias produced a
+  live cold spec the warm sweep read as its own and unlinked.
+
+## Tool-alias key shape
+
+`resolve_tool_aliases` de-collides by registry **slug**, keying `@slug/tool`, while a warm spec
+mounts under `mcp_server_alias(slug)`. Where the two differ a slug-keyed entry names a server
+the spec never mounted, kiro-cli applies no rename, and the collision returns silently, so
+`connections_tool_aliases` re-points keys at the mounted alias and leaves the resolver
+authoritative over which tools collide. Every registry slug is slash-free today, so this is an
+identity map holding the shape contract of the spec we write, not a live defect. Semantics are
+#3260's -- **every** claimant is renamed, none keeps the bare name; an earlier draft asserted
+the pre-#3260 rule and those assertions were not carried forward.
+
+## Filesystem work never runs on the loop
+
+Every flow reads the user's config, the shared agents directory, or kiro-cli's OAuth cache, any
+of which can sit on a network mount where a stat is unbounded, so the synchronous helpers are
+reached through `asyncio.to_thread` -- enforced by a fixed-point drift guard in
+`test/test_connections_warm.py` that reuses the mint engine's own primitive sets so the two
+cannot drift apart.
+
+## Seams and residuals
+
+**Revocation** is PR #5899's, through `_expire_shared_mints`; **proactive refresh** attaches in
+`_warm_mint_reaper`; **a supervisor/watchdog** is absent, as are the accessors it would need.
+Two residuals:
+
+- **A cancel between the claim and the activation leaks the claim.** `warm_mint_all` takes its
+  claim outside any `try`/`finally` and `_warm_activate` catches `Exception`, not
+  `BaseException`, so a `CancelledError` in that window leaves rows `minting` with no watcher:
+  nothing expires them, `_shared_mints_pending` stays true, and the process is never retired.
+  Unreachable while `warm_mint_all` has no caller, and **must be closed before N2b wires it up.**
+- **A hard gateway kill strands warm spec files.** They carry no manifest row, so the cold
+  engine's aged-row sweep cannot see them. The next spawn's write-time sweep removes them, so
+  the exposure is bounded, but it is not a clean teardown.

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -104,6 +104,14 @@ class MintState(TypedDict, total=False):
     agent: str  # ephemeral spec name
     spec_path: str  # the exact file this flow wrote, and the only one it deletes
     pid: int  # sweep-protected for as long as the process is held
+    # Set only by the warm table (:mod:`kiro_crew.connections.warm`). A shared row
+    # owns no ``client``: its URL was minted on a process it shares with every
+    # other card, so redeemability is judged by generation AND activation liveness
+    # instead. Declared here because the table itself is shared, and a row type
+    # that cannot describe half its rows pushes every read through a cast.
+    shared: bool
+    generation: int  # the shared process that holds this row's PKCE verifier
+    activation: int  # the session that owns this row's loopback listener
 
 
 _mints: dict[str, MintState] = {}

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -1,0 +1,121 @@
+"""The shared warm-mint TABLE: which shared rows still hold a redeemable URL.
+
+The cold path (:mod:`kiro_crew.connections.mint`) pays a full kiro-cli spawn PER provider
+for one approval URL. The warm design serves every card's URL from ONE process instead, and
+splits in two: the TABLE (this module) and the LIFECYCLE that fills it.
+
+This slice ships the TABLE half only -- the row shape a shared mint uses (``shared`` /
+``generation`` / ``activation`` on :class:`~kiro_crew.connections.mint.MintState`), the
+liveness registry those stamps are read against (:class:`_WarmMintRuntime`), and the
+withdrawal chokepoint the dashboard's status path calls (:func:`expire_dead_mints`).
+Nothing here spawns, activates, parks or kills a process.
+
+Redeemability takes TWO questions and they die independently: the PKCE verifier lives in
+the PROCESS (``generation_is_live``) while the loopback listener answering the redirect
+belongs to the SESSION (``activation_is_live``). Process liveness alone passed a
+terminated-session row, which is how a card kept serving an unredeemable URL. Both
+failures are recorded in ``docs/architecture/design-notes/connections-warm-table.md``.
+
+DEFERRED to slice N2b: the entire lifecycle -- spec planning, spawn, activation, parking,
+the reaper, and ``warm_mint_all``. Until it lands nothing sets ``shared`` on a row, so
+:func:`expire_dead_mints` is a no-op scan and the registry below stays empty. Both are
+written to answer correctly the moment N2b starts filling them, parked generations
+included: a reader blind to a parked process withdraws a code that process can still
+redeem, so completing the predicate later would mean revisiting this decision under a
+live bug.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kiro_crew.connections.mint import MintState, _dispose_mint, _mints, _mints_lock
+
+logger = logging.getLogger(__name__)
+
+
+def _runtime_alive(runtime: Any) -> bool:
+    """Liveness of one warm process. Never raises into a mint."""
+    if runtime is None:
+        return False
+    try:
+        return bool(runtime.is_alive())
+    except Exception:  # noqa: BLE001 — liveness must never raise into a mint
+        logger.debug("warm mint liveness check failed", exc_info=True)
+        return False
+
+
+class _WarmMintRuntime:
+    """The liveness registry a shared row's ``generation``/``activation`` are read against.
+
+    Both containers are filled by the deferred lifecycle (slice N2b) and are empty until it
+    lands. They are READ here rather than in N2b because the reader is what decides whether
+    a card's URL is withdrawn, and the parked case is exactly the one where a wrong answer
+    destroys a code the user could still redeem.
+    """
+
+    def __init__(self) -> None:
+        self._runtime: Any = None
+        #: Bumped on every spawn. Rows record the generation that minted them, letting a
+        #: stand-down tell "nothing needs this" from "killing it strands a user mid-consent".
+        self._generation = 0
+        #: Generations kept alive ONLY because a card still holds one of their URLs.
+        self._retiring: list[tuple[int, Any]] = []
+        #: Live sessions by activation id -- each owns the loopback servers for its
+        #: challenges, so one is held while a card points at one of its URLs.
+        self._sessions: dict[int, Any] = {}
+
+    def is_alive(self) -> bool:
+        return _runtime_alive(self._runtime)
+
+    def generation_is_live(self, generation: int) -> bool:
+        """True while the process that minted ``generation`` can still redeem."""
+        if generation <= 0:
+            return False
+        if generation == self._generation:
+            return self.is_alive()
+        return any(
+            parked == generation and _runtime_alive(runtime) for parked, runtime in self._retiring
+        )
+
+    def activation_is_live(self, activation: int) -> bool:
+        """True while the SESSION that minted ``activation`` still listens."""
+        if activation <= 0:
+            return False
+        return activation in self._sessions
+
+
+_warm_mint = _WarmMintRuntime()
+
+
+def _warm_row_alive(entry: MintState) -> bool:
+    """Whether a SHARED row's URL can still actually be redeemed.
+
+    Two things must be alive and they die independently: the PKCE verifier in the PROCESS,
+    and the loopback listener in the SESSION. Process liveness alone passed a
+    terminated-session row, which is how a card kept serving an unredeemable URL -- which
+    is also why the cold engine's ``_mint_holder_alive`` is deliberately NOT reused: it
+    reads the row's own ``client``, which a shared row does not own.
+    """
+    if not _warm_mint.generation_is_live(int(entry.get("generation") or 0)):
+        return False
+    return _warm_mint.activation_is_live(int(entry.get("activation") or 0))
+
+
+async def expire_dead_mints() -> list[str]:
+    """Withdraw every shared row whose holding process is gone. THE chokepoint."""
+    doomed: list[str] = []
+    async with _mints_lock:
+        for slug, entry in _mints.items():
+            if not entry.get("shared") or entry.get("state") != "waiting":
+                continue
+            if _warm_row_alive(entry):
+                continue
+            entry["state"] = "expired"
+            entry["reason"] = "mint_process_gone"
+            await _dispose_mint(entry)
+            doomed.append(slug)
+    if doomed:
+        logger.info("Withdrew %d approval URL(s) whose minting process is gone", len(doomed))
+    return doomed

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -385,7 +385,14 @@ async def api_connections_status(request: web.Request) -> web.Response:
     # for grant presence -- test_the_handlers_package_does_not_import_the_mint_engine
     # keeps that engine off the boot path.
     from kiro_crew.connections.status import _STATUS_SCHEMA_VERSION, collect_connection_statuses
+    from kiro_crew.connections.warm import expire_dead_mints
 
+    # Withdraw shared rows whose minting process is gone BEFORE the statuses are
+    # read, so a card cannot be served an approval URL nothing can redeem. Keyed on
+    # the fact rather than a cause, which is what covers a process that went away by
+    # a route no expiry path anticipated; cheap enough to run per request because
+    # liveness is a returncode read, not I/O.
+    await expire_dead_mints()
     statuses = await collect_connection_statuses()
     return web.json_response({"schema_version": _STATUS_SCHEMA_VERSION, "connections": statuses})
 

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -1,0 +1,130 @@
+"""Warm-table tests: the row-liveness registry and the withdrawal chokepoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.connections import warm
+from kiro_crew.connections.mint import _mints
+
+
+@pytest.fixture(autouse=True)
+def _clean_mint_table():
+    _mints.clear()
+    yield
+    _mints.clear()
+
+
+class _Runtime:
+    """A stand-in for one kiro-cli process, with the liveness answer we choose."""
+
+    def __init__(self, alive: bool | BaseException) -> None:
+        self._alive = alive
+
+    def is_alive(self) -> bool:
+        if isinstance(self._alive, BaseException):
+            raise self._alive
+        return self._alive
+
+
+# ── redeemability takes TWO questions, and they die independently ──
+
+
+def test_a_row_stamped_with_no_holder_at_all_is_never_alive():
+    assert warm._warm_mint.generation_is_live(0) is False
+    assert warm._warm_mint.activation_is_live(0) is False
+
+
+def test_the_current_generation_is_live_exactly_while_its_process_is(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(True))
+    assert warm._warm_mint.generation_is_live(4) is True
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    assert warm._warm_mint.generation_is_live(4) is False
+
+
+def test_a_parked_generation_stays_live_while_its_own_process_can_still_redeem(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A parked process still holds its peers' verifiers, so answering False for it would
+    withdraw a URL the user can still redeem."""
+    monkeypatch.setattr(warm._warm_mint, "_generation", 9)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(3, _Runtime(True)), (4, _Runtime(False))])
+    assert warm._warm_mint.generation_is_live(3) is True
+    assert warm._warm_mint.generation_is_live(4) is False
+    assert warm._warm_mint.generation_is_live(5) is False
+
+
+def test_a_liveness_probe_that_raises_reads_as_dead_rather_than_failing_the_scan():
+    """``expire_dead_mints`` runs on every status request, so a raising probe must not
+    take the request down with it."""
+    assert warm._runtime_alive(_Runtime(OSError("no such process"))) is False
+    assert warm._runtime_alive(None) is False
+
+
+def test_a_live_process_with_a_dead_session_does_not_keep_a_row_alive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Process liveness alone passed a terminated-session row -- the observed failure that
+    put the session question into the predicate at all."""
+    monkeypatch.setattr(warm._warm_mint, "_generation", 2)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(True))
+    row = {"state": "waiting", "shared": True, "generation": 2, "activation": 6}
+    assert warm._warm_row_alive(row) is False  # type: ignore[arg-type]
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {6: object()})
+    assert warm._warm_row_alive(row) is True  # type: ignore[arg-type]
+
+
+# ── withdrawal is keyed on the FACT that the holder is gone ──
+
+
+@pytest.mark.asyncio
+async def test_a_row_whose_generation_is_gone_is_withdrawn():
+    _mints["linear"] = {
+        "state": "waiting",
+        "oauth_url": "https://l/consent",
+        "shared": True,
+        "generation": 99,
+        "activation": 1,
+    }
+    assert await warm.expire_dead_mints() == ["linear"]
+    assert _mints["linear"]["state"] == "expired"
+    assert _mints["linear"]["reason"] == "mint_process_gone"
+
+
+@pytest.mark.asyncio
+async def test_a_cold_row_is_left_to_the_cold_engine():
+    """``_mint_holder_alive`` answers False for a shared row, so the warm chokepoint
+    must judge only shared rows -- and leave a cold row's own verdict alone."""
+    _mints["linear"] = {"state": "waiting", "oauth_url": "https://cold", "client": object()}
+    assert await warm.expire_dead_mints() == []
+    assert _mints["linear"]["state"] == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_a_shared_row_not_yet_serving_a_url_is_left_alone():
+    """Only a row actually SERVING a URL can be serving a dead one; a claim still minting
+    is the activation's to fill or release."""
+    _mints["linear"] = {"state": "minting", "shared": True, "generation": 99}
+    assert await warm.expire_dead_mints() == []
+    assert _mints["linear"]["state"] == "minting"
+
+
+@pytest.mark.asyncio
+async def test_a_row_whose_process_and_session_both_live_keeps_its_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(True))
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {2: object()})
+    _mints["linear"] = {
+        "state": "waiting",
+        "oauth_url": "https://l/consent",
+        "shared": True,
+        "generation": 5,
+        "activation": 2,
+    }
+    assert await warm.expire_dead_mints() == []
+    assert _mints["linear"]["state"] == "waiting"


### PR DESCRIPTION
## Problem / Motivation

The Connections plan (slice N2; the disconnect slice is #5899) serves every card's OAuth approval URL from one warm process. Before that process can land, two things must exist: mint-state rows that say which process/generation/activation owns them, and a sweep on the status path that withdraws a shared row whose backing process or session has died — otherwise the dashboard can hand the user an approval URL that can no longer be redeemed.

This PR is the table and the sweep. **Re-slice provenance:** the warm lifecycle (`warm_mint_all`, spec planning, park-vs-kill, the reaper) was originally in this PR as latent code; the Coverage Gate correctly refused ~600 sub-80%-covered lines and its message forbids baselining, so per maintainer decision the lifecycle was carved out (preserved verbatim; the pre-trim head `342e3c421` remains on this PR's history). It returns as slice N2b together with its caller and lifecycle tests; issue #6110's three advisories all live in that removed code and now gate N2b, not this PR.

## Why it matters

A dead approval URL dead-ends an OAuth connect with no error the user can act on. Landing the table + sweep first gives N2b's warm process a reviewed, fully covered safety net to write into — and keeps each PR reviewable (this diff is 371 add+del; combined, the slice cleared neither the size convention nor the Coverage Gate).

## What changed (motivation → approach → change)

Goal: a status path that never serves an unredeemable warm URL. Approach: liveness is decided per row against the runtime that stamped it, not globally. `src/kiro_crew/connections/warm.py` (new, 121 lines) carries `_WarmMintRuntime`'s liveness predicates (`is_alive`, `generation_is_live`, `activation_is_live` — redeemability is two questions: process alive AND session held, see `_warm_row_alive`) and `expire_dead_mints()`, which withdraws a shared row whose generation/activation is no longer live and leaves cold rows to the cold engine. `src/kiro_crew/connections/mint.py` gains the optional warm-ownership row fields. `src/kiro_crew/dashboard/handlers/connections.py` (+8/−1) runs the sweep immediately before the existing status collector.

**Scope boundary, stated up front:** nothing in this slice sets `shared` on a row, so in production the sweep scans and withdraws nothing until N2b lands the warm process. The kept code is genuinely reachable (it runs on every Connections status request) and is at 100% statement+branch coverage; the design note and commit message state the same boundary. The `generation_is_live` parked-generation branch is deliberately kept complete even though nothing parks a generation yet — narrowing it would be exactly wrong the moment N2b parks a process still holding a redeemable consent.

## Tests

9 tests in `test/test_connections_warm.py`, locking: a row whose generation is gone is withdrawn; a cold row is left to the cold engine; a no-holder row is never alive; the current generation is live exactly while its process is; a parked generation stays live while its own process can still redeem; a liveness probe that raises reads as dead rather than failing the scan; a live process with a dead session does not keep a row alive; a shared row not yet serving a URL is left alone; a row whose process and session both live keeps its URL. `src/kiro_crew/connections/warm.py`: 51 stmts, 18 branches, 0 missed — 100%. Targeted set (warm + status + mint suites): 145 passed.

## Manual verification

N/A — unit coverage sufficient: the slice's only reachable behavior is the sweep on the status path, fully exercised in tests; no user-facing flow changes until N2b.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only Python module, tests, and design note; no watched frontend paths in the diff.

## Related Issues

no linked issue: this PR closes nothing; #6110 tracks the three advisories in the deferred lifecycle half and gates the N2b successor slice (#5899 is the sibling disconnect slice).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
