### PR TITLE
fix: allow '+' in AWS profile names for SSM remote crews

### DIFF
--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -65,8 +65,9 @@ _REMOTE_BIN_RE = re.compile(r"^[A-Za-z0-9._/~\- ]{0,512}\Z")
 # authoritative validation lives with the tunnel manager (validation.py).
 _SSM_TARGET_RE = re.compile(r"^(i|mi)-[a-f0-9]{8,17}\Z")
 # aws_profile: named profile in ~/.aws/config; conservative charset, no shell
-# metacharacters. Empty string means "default credential chain".
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.\-]{0,128}\Z")
+# metacharacters. '+' is allowed (AWS permits it, and SSO profile names often
+# carry it). Empty string means "default credential chain".
+_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+\-]{0,128}\Z")
 # aws_region: standard AWS region shape (e.g. us-east-1, eu-west-2). Empty
 # string means "use the profile's/environment's default region".
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z|^\Z")

--- a/src/kiro_crew/instances/validation.py
+++ b/src/kiro_crew/instances/validation.py
@@ -50,7 +50,10 @@ _DEFAULT_SSM_RUN_AS = "ec2-user"
 
 # aws_profile: a named profile from ~/.aws/config. Conservative charset (no
 # shell metacharacters, no leading '-' to avoid being parsed as an option).
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}\Z")
+# '+' is included because AWS allows it in profile names and IAM Identity Center
+# (SSO) commonly derives them as ``<account>+<permission-set>``; it is neither a
+# shell metacharacter nor an option prefix, so admitting it is injection-safe.
+_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+-]{1,128}\Z")
 
 # aws_region: standard AWS region shape (e.g. us-east-1, us-gov-west-1).
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z")
@@ -184,7 +187,7 @@ def validate_aws_profile(aws_profile: str) -> str:
     if not _AWS_PROFILE_RE.match(profile):
         raise SsmValidationError(
             f"aws_profile {profile!r} contains invalid characters "
-            f"(allowed: letters, digits, '.', '_', '-')"
+            f"(allowed: letters, digits, '.', '_', '+', '-')"
         )
     return profile
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -4102,10 +4102,15 @@ class TestSsmValidation:
         assert validate_aws_profile("") == ""
         assert validate_aws_region("") == ""
         assert validate_aws_profile("my-profile_1.x") == "my-profile_1.x"
+        # '+' is valid in AWS profile names (SSO derives them as
+        # ``<account>+<permission-set>``), so it must be accepted.
+        assert validate_aws_profile("AdminAccess+dev") == "AdminAccess+dev"
+        assert validate_aws_profile("123456789012+PowerUser") == "123456789012+PowerUser"
         assert validate_aws_region("us-east-1") == "us-east-1"
         assert validate_aws_region("us-gov-west-1") == "us-gov-west-1"
         # Option injection + metacharacters + bogus region shapes are refused.
-        for bad in ("-oProxyCommand=x", "a b", "a;b", "a$(b)"):
+        # A leading '+' is fine, but a leading '-' is still option injection.
+        for bad in ("-oProxyCommand=x", "a b", "a;b", "a$(b)", "-dev"):
             with pytest.raises(SsmValidationError):
                 validate_aws_profile(bad)
         for bad in ("useast1", "US-EAST-1", "us-east-1; rm -rf /", "-us-east-1"):
@@ -4193,6 +4198,27 @@ class TestSsmRegistry:
         reloaded = self._reg(tmp_path).get(inst.id)
         assert reloaded.connection_method == "ssm"
         assert reloaded.ssm_target == "i-0123456789abcdef0"
+
+    def test_add_ssm_instance_accepts_profile_with_plus(self, tmp_path):
+        """AWS profile names may contain '+' (common for SSO-derived names).
+
+        A '+' and interior '-' are both legal; only a *leading* '-' is refused
+        (option injection), so an SSO name like ``user+demo-space-Admin`` must
+        round-trip unchanged.
+        """
+        reg = self._reg(tmp_path)
+        inst = reg.add(
+            name="SSO Box",
+            connection_method="ssm",
+            ssm_target="i-0123456789abcdef0",
+            aws_profile="user+demo-space-Admin",
+            aws_region="eu-west-2",
+            remote_port=7777,
+        )
+        assert inst.aws_profile == "user+demo-space-Admin"
+        # Round-trips through disk unchanged.
+        reloaded = self._reg(tmp_path).get(inst.id)
+        assert reloaded.aws_profile == "user+demo-space-Admin"
 
     def test_ssm_requires_target_and_ssh_requires_host(self, tmp_path):
         from kiro_crew.instances.registry import InvalidInstanceError


### PR DESCRIPTION
## Problem / Motivation

See #6042 — adding a remote crew over the SSM `start-session` route rejects AWS
profile names containing `+` (valid in AWS, and common for SSO-derived names).

## Why it matters

`+` profile names are the norm on AWS IAM Identity Center (SSO), where profiles
are derived as `<account>+<permission-set>` (e.g. `AdminAccess+dev`). On that
very common setup a user cannot add an SSM-connected remote crew with their real
profile name, and there is no in-app workaround short of maintaining a duplicate,
renamed profile.

## What changed (motivation → approach → change)

Add `+` to the profile-name charset in both the authoritative guard
(`instances/validation.py`) and the registry early-reject
(`instances/registry.py`), and update the validator's error message. `+` is
neither a shell metacharacter nor an option prefix, so this stays injection-safe:
the separate leading-`-` guard still rejects option injection and the value is
passed as an argv element (no shell). Interior `-` was already allowed; only a
leading `-` remains rejected.

## Tests

- `TestSsmValidation::test_profile_and_region` — extended to assert
  `validate_aws_profile` accepts `AdminAccess+dev` / `123456789012+PowerUser` and
  still rejects a leading `-`.
- `TestSsmRegistry::test_add_ssm_instance_accepts_profile_with_plus` — new: a
  `+`/interior-`-` profile round-trips through `registry.add` and disk unchanged.

## Manual verification

`python -m pytest test/test_instances.py` → 230 passed, 2 skipped. black
(baselined gate), `isort`, `flake8`, and `mypy` pass for the changed files.

## Screenshots / video

N/A — backend validation charset fix, no UI change.

## Related Issues

Fixes #6042

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the instances doc describes this as a "charset check" without enumerating allowed characters, so no documented behavior changes.
- [x] No secrets, credentials, or internal references in the diff
