### PR TITLE
fix(instances): allow '+' in AWS profile names (#6042)

### DIFF
--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -65,8 +65,9 @@ _REMOTE_BIN_RE = re.compile(r"^[A-Za-z0-9._/~\- ]{0,512}\Z")
 # authoritative validation lives with the tunnel manager (validation.py).
 _SSM_TARGET_RE = re.compile(r"^(i|mi)-[a-f0-9]{8,17}\Z")
 # aws_profile: named profile in ~/.aws/config; conservative charset, no shell
-# metacharacters. Empty string means "default credential chain".
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.\-]{0,128}\Z")
+# metacharacters. '+' is allowed for AWS SSO/Identity Center derived names.
+# Empty string means "default credential chain".
+_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+\-]{0,128}\Z")
 # aws_region: standard AWS region shape (e.g. us-east-1, eu-west-2). Empty
 # string means "use the profile's/environment's default region".
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z|^\Z")

--- a/src/kiro_crew/instances/validation.py
+++ b/src/kiro_crew/instances/validation.py
@@ -50,7 +50,9 @@ _DEFAULT_SSM_RUN_AS = "ec2-user"
 
 # aws_profile: a named profile from ~/.aws/config. Conservative charset (no
 # shell metacharacters, no leading '-' to avoid being parsed as an option).
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}\Z")
+# '+' is allowed because AWS SSO/Identity Center profile names commonly use it
+# (e.g. "AdminAccess+dev").
+_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+\-]{1,128}\Z")
 
 # aws_region: standard AWS region shape (e.g. us-east-1, us-gov-west-1).
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z")
@@ -184,7 +186,7 @@ def validate_aws_profile(aws_profile: str) -> str:
     if not _AWS_PROFILE_RE.match(profile):
         raise SsmValidationError(
             f"aws_profile {profile!r} contains invalid characters "
-            f"(allowed: letters, digits, '.', '_', '-')"
+            f"(allowed: letters, digits, '.', '_', '+', '-')"
         )
     return profile
 

--- a/test/test_aws_profile_plus_char.py
+++ b/test/test_aws_profile_plus_char.py
@@ -1,0 +1,56 @@
+"""Regression test for issue #6042: AWS profile names containing '+'.
+
+AWS IAM Identity Center (SSO) commonly generates profile names that encode
+``<permission-set>+<account-alias>`` (e.g. ``AdminAccess+dev``). The ``+``
+character is safe: profiles are passed only as ``aws`` CLI argv elements and
+``+`` is neither a shell metacharacter nor able to start an option flag.
+
+Both the authoritative validation (``instances/validation.py``) and the early-
+reject guard (``instances/registry.py``) must accept ``+`` in profile names.
+"""
+import re
+
+import pytest
+
+from kiro_crew.instances.validation import (
+    SsmValidationError,
+    validate_aws_profile,
+)
+
+
+class TestAwsProfilePlusChar:
+    """Ensure '+' is accepted in AWS profile names (issue #6042)."""
+
+    def test_sso_derived_profile_accepted(self):
+        """AdminAccess+dev is a real-world SSO profile name."""
+        assert validate_aws_profile("AdminAccess+dev") == "AdminAccess+dev"
+
+    def test_plus_in_various_positions(self):
+        """'+' anywhere in the name (not leading '-') is valid."""
+        assert validate_aws_profile("a+b") == "a+b"
+        assert validate_aws_profile("prod+admin") == "prod+admin"
+        assert validate_aws_profile("my.org+role_name") == "my.org+role_name"
+
+    def test_leading_dash_still_rejected(self):
+        """Option-injection guard must still block leading '-'."""
+        with pytest.raises(SsmValidationError):
+            validate_aws_profile("-badprofile")
+        with pytest.raises(SsmValidationError):
+            validate_aws_profile("-oProxyCommand=x")
+
+    def test_shell_metacharacters_still_rejected(self):
+        """Shell-unsafe characters must remain blocked."""
+        for bad in ("profile;rm", "a|b", "a&b", "$(cmd)", "a`cmd`b"):
+            with pytest.raises(SsmValidationError):
+                validate_aws_profile(bad)
+
+    def test_registry_regex_accepts_plus(self):
+        """The early-reject regex in registry.py must also allow '+'."""
+        from kiro_crew.instances.registry import _AWS_PROFILE_RE
+
+        assert _AWS_PROFILE_RE.match("AdminAccess+dev")
+        assert _AWS_PROFILE_RE.match("a+b+c")
+        # Still rejects metacharacters
+        assert not _AWS_PROFILE_RE.match("a;b")
+        assert not _AWS_PROFILE_RE.match("a|b")
+        assert not _AWS_PROFILE_RE.match("a&b")


### PR DESCRIPTION
## Summary

Fixes #6042 — AWS profile names containing `+` are now accepted in the SSM start-session connection route.

## Problem

AWS IAM Identity Center (SSO) commonly generates profile names that encode `<permission-set>+<account-alias>` (e.g. `AdminAccess+dev`). The `+` character is valid in AWS named profiles (INI section names), but our validation regex rejected it.

## Changes

- **`src/kiro_crew/instances/validation.py`** — Added `+` to `_AWS_PROFILE_RE` character class, updated error message and comment.
- **`src/kiro_crew/instances/registry.py`** — Added `+` to the early-reject twin regex and updated comment.
- **`test/test_aws_profile_plus_char.py`** — New regression test file with 5 tests:
  - Accepts `AdminAccess+dev` (real-world SSO profile)
  - Accepts `+` in various positions
  - Still rejects leading `-` (option-injection guard)
  - Still rejects shell metacharacters (`;`, `|`, `&`, `$()`, backticks)
  - Registry regex also accepts `+`

## Safety

`+` is safe in this context: `aws_profile` is passed only as an `aws` CLI argv element (never embedded in a shell string). `+` is neither a shell metacharacter nor able to start an option flag, so the existing leading-`-` and metachar defenses remain intact.

## Testing

All new and existing tests pass.