### PR TITLE
fix: allow '+' in AWS profile names for SSM remote crews (#6042)

### DIFF
--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import _DEFAULT_PORT, config_dir
 from kiro_crew.instances.constants import TTL_PATTERN
+from kiro_crew.instances.validation import _AWS_PROFILE_RE as _validation_aws_profile_re
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +66,11 @@ _REMOTE_BIN_RE = re.compile(r"^[A-Za-z0-9._/~\- ]{0,512}\Z")
 # authoritative validation lives with the tunnel manager (validation.py).
 _SSM_TARGET_RE = re.compile(r"^(i|mi)-[a-f0-9]{8,17}\Z")
 # aws_profile: named profile in ~/.aws/config; conservative charset, no shell
-# metacharacters. Empty string means "default credential chain".
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.\-]{0,128}\Z")
+# metacharacters ('+' is legal: IAM entity names permit it, and SSO-derived
+# profiles use "<account>+<permission-set>"). Single source of truth lives in
+# validation.py; the empty "default credential chain" value is handled by the
+# `if self.aws_profile` guard at the check site rather than by the pattern.
+_AWS_PROFILE_RE = _validation_aws_profile_re
 # aws_region: standard AWS region shape (e.g. us-east-1, eu-west-2). Empty
 # string means "use the profile's/environment's default region".
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z|^\Z")
@@ -237,7 +241,10 @@ class Instance:
                     f"hex digits"
                 )
             if self.aws_profile and not _AWS_PROFILE_RE.match(self.aws_profile):
-                raise InvalidInstanceError(f"invalid aws_profile {self.aws_profile!r}")
+                raise InvalidInstanceError(
+                    f"invalid aws_profile {self.aws_profile!r} "
+                    f"(allowed: letters, digits, '.', '_', '+', '-')"
+                )
             if self.aws_region and not _AWS_REGION_RE.match(self.aws_region):
                 raise InvalidInstanceError(f"invalid aws_region {self.aws_region!r}")
             if not _SSM_RUN_AS_RE.match(self.ssm_run_as):

--- a/src/kiro_crew/instances/validation.py
+++ b/src/kiro_crew/instances/validation.py
@@ -50,7 +50,13 @@ _DEFAULT_SSM_RUN_AS = "ec2-user"
 
 # aws_profile: a named profile from ~/.aws/config. Conservative charset (no
 # shell metacharacters, no leading '-' to avoid being parsed as an option).
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}\Z")
+# '+' is included because IAM entity names permit it and it flows into
+# generated profile names (e.g. SSO-derived "<account>+<permission-set>");
+# it is not a shell metacharacter and the value is only ever passed as a
+# discrete ``--profile <value>`` argv element. This is the single source of
+# truth for the charset: registry.py aliases this compiled pattern for its
+# early record check.
+_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+-]{1,128}\Z")
 
 # aws_region: standard AWS region shape (e.g. us-east-1, us-gov-west-1).
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z")
@@ -184,7 +190,7 @@ def validate_aws_profile(aws_profile: str) -> str:
     if not _AWS_PROFILE_RE.match(profile):
         raise SsmValidationError(
             f"aws_profile {profile!r} contains invalid characters "
-            f"(allowed: letters, digits, '.', '_', '-')"
+            f"(allowed: letters, digits, '.', '_', '+', '-')"
         )
     return profile
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -4102,10 +4102,13 @@ class TestSsmValidation:
         assert validate_aws_profile("") == ""
         assert validate_aws_region("") == ""
         assert validate_aws_profile("my-profile_1.x") == "my-profile_1.x"
+        # '+' is legal in profile names: IAM entity names permit it, and SSO
+        # tooling derives "<account>+<permission-set>" shaped profiles.
+        assert validate_aws_profile("AdminAccess+dev") == "AdminAccess+dev"
         assert validate_aws_region("us-east-1") == "us-east-1"
         assert validate_aws_region("us-gov-west-1") == "us-gov-west-1"
         # Option injection + metacharacters + bogus region shapes are refused.
-        for bad in ("-oProxyCommand=x", "a b", "a;b", "a$(b)"):
+        for bad in ("-oProxyCommand=x", "-dev", "a b", "a;b", "a$(b)", "a$b"):
             with pytest.raises(SsmValidationError):
                 validate_aws_profile(bad)
         for bad in ("useast1", "US-EAST-1", "us-east-1; rm -rf /", "-us-east-1"):
@@ -4227,6 +4230,48 @@ class TestSsmRegistry:
         raw = (tmp_path / "instances.json").read_text(encoding="utf-8")
         for marker in ("AKIA", "ASIA", "aws_secret_access_key", "aws_session_token"):
             assert marker not in raw
+
+    def test_aws_profile_allows_plus_and_rejects_metacharacters(self, tmp_path):
+        """The record check accepts '+' (SSO-derived profile names) but still
+        refuses whitespace and shell metacharacters, mirroring validation.py."""
+        from kiro_crew.instances.registry import InvalidInstanceError
+
+        reg = self._reg(tmp_path)
+        inst = reg.add(
+            name="SSO box",
+            connection_method="ssm",
+            ssm_target="i-0123456789abcdef0",
+            aws_profile="AdminAccess+dev",
+            instance_id="sso",
+        )
+        assert inst.aws_profile == "AdminAccess+dev"
+        assert reg.list()[0].aws_profile == "AdminAccess+dev"
+        for i, bad in enumerate(("a b", "a;b", "a$(b)", "a$b")):
+            with pytest.raises(InvalidInstanceError):
+                reg.add(
+                    name="bad profile",
+                    connection_method="ssm",
+                    ssm_target="i-0123456789abcdef0",
+                    aws_profile=bad,
+                    instance_id=f"bad-{i}",
+                )
+
+    def test_aws_profile_regex_is_single_sourced(self):
+        """The registry's early record check aliases validation.py's pattern.
+
+        There is exactly one AWS-profile charset: registry._AWS_PROFILE_RE is
+        the SAME compiled object as validation._AWS_PROFILE_RE, so the two
+        check sites cannot drift. If someone re-introduces a second copy this
+        identity check fails even when the copies happen to be textually
+        equal. Note the pattern accepts a leading '-' by design: option
+        injection is blocked by the separate startswith('-') guard in
+        validation.validate_aws_profile, not by the character class, and the
+        empty "default chain" value is handled by the `if self.aws_profile`
+        guard at the registry check site.
+        """
+        from kiro_crew.instances import registry, validation
+
+        assert registry._AWS_PROFILE_RE is validation._AWS_PROFILE_RE
 
     def test_ssm_run_as_defaults_and_round_trips(self, tmp_path):
         """A record written before ssm_run_as existed must load as the default.


### PR DESCRIPTION
## Summary

Adding a remote crew over the SSM start-session route rejected AWS profile names containing `+` with "aws_profile '...' contains invalid characters". `+` is legal in AWS named profiles: the shared config/credentials files are INI files whose section names allow it, and IAM entity names explicitly permit `+`, which flows into generated profile names — especially IAM Identity Center (SSO) derived profiles shaped like `<account>+<permission-set>` (e.g. `AdminAccess+dev`).

Closes #6042

## Changes

- `src/kiro_crew/instances/validation.py` — widen `_AWS_PROFILE_RE` to `^[A-Za-z0-9_.+-]{1,128}\Z` (the authoritative check in `validate_aws_profile()`), and add `'+'` to the allowed-list in the error message. This is now the single source of truth for the charset.
- `src/kiro_crew/instances/registry.py` — the early record check no longer owns a duplicate copy of the pattern: it aliases `validation._AWS_PROFILE_RE` (no import cycle — `instances/validation.py` imports only `re`; the empty "default credential chain" value the old `{0,128}` bound admitted is handled by the existing `if self.aws_profile` guard at the check site). Its error message now names the allowed characters in plain English (previously it named none — the confusion that produced this issue).
- `test/test_instances.py` — accepts `AdminAccess+dev` through both the validator and the registry record check; still rejects a leading `-`, whitespace, and shell metacharacters (`;`, `$`, `$( )`); an identity test pins that the two check sites share one compiled pattern, so a re-introduced duplicate fails even if textually equal.

## Safety argument

The profile value is passed only as a discrete `--profile <value>` argv element (`cloud/ssm.py` `build_port_forward_argv`/`build_interactive_session_argv`, `cloud/aws.py` `_build_argv`, plus `ssm_token_mint.py`, `diagnostics.py`, and `ssh_tunnel_manager.py`, which all route through `validate_aws_profile` first). It is never interpolated into a shell string, never exported as an env var, and `+` is not a shell metacharacter and not special in an INI section name. The existing `startswith('-')` guard still blocks option injection. The widening is minimal and evidence-backed: no whitespace and no shell metacharacters were admitted.

The website frontend has no third copy of the charset (the Settings form passes the value through and surfaces the server error), so no frontend change is needed.

## Review

Two pre-push model-pinned review lanes: GPT (gpt-5.6-sol) PASS with zero findings; Opus (claude-opus-5) PASS with zero blocking findings and three advisories — A1/A2 adopted (leading-`-` rationale documented in the identity test; registry error message names the allowed characters), A3 (validation strips whitespace before matching while the registry matches raw — a pre-existing divergence that fails closed, the stricter check running first) noted here and left unchanged as out of scope. The First Principles lane's Subtraction (delete the duplicate registry charset and alias validation's compiled pattern) is adopted in this revision; its Watch item (four sibling profile regexes elsewhere still reject `+`: `cloud/ec2.py:78`, `deploy/profiles.py:81`, `deploy/handlers.py:228`, `validation.py` `_WM_PROFILE_RE`) is tracked as a follow-up issue rather than widened here, keeping this PR scoped to the reported SSM add path.

## Testing

- `python -m pytest test/test_instances.py` — 233 passed
- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` — clean
- `check_black_formatting.py`, `check_subprocess_encoding.py`, brand-name and harness-parity gates (diff-scoped against main) — pass

no linked issue: n/a — Closes #6042 above.
