### PR TITLE
fix: latch plan cancel against the pending-Go race (#6046)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -561,6 +561,12 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         and message.strip().lower().split()[0] in _stop_words
     ):
         tracker.stop()
+        # Same latch as the plan-action Cancel handler (#6046): tracker.stopped
+        # alone does not survive the Slack gateway lazily re-creating a fresh
+        # unstopped tracker on this slot, so without the latch a later Go could
+        # resurrect a plan the user stopped by word. One revocation semantics
+        # across both cancel surfaces (Design review finding).
+        slot._plan_cancelled = True
         slot._auto_run = False
         # Cancel running agents for this slot
         if state.subagents:

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -205,6 +205,83 @@ def _orchestration_stopped(slot: "_ChatSlot", tracker: OrchestrationTracker) -> 
     return bool(slot._stopping) or bool(tracker.stopped)
 
 
+def _is_plan_approval_entry(entry: dict) -> bool:
+    """True when a queued entry is a plan-action Go approval.
+
+    Matches ONLY the structural kind="plan_approval" tag (queue_append's
+    classify-by-metadata contract). Deliberately NOT content: an untagged
+    "go" in the queue is a plain user message (e.g. a linked Slack user's
+    text) and dropping it is data loss (GPT CI finding, round 6). Nor is
+    content matching needed for safety: a drained untagged entry dispatches
+    through _run_chat as an ordinary turn — the queue drain never re-enters
+    api_chat's typed-go branch, and _stage_loop's entry latch blocks any
+    advancement on a cancelled plan regardless.
+    """
+    return entry.get("kind") == "plan_approval"
+
+
+async def _exit_cancelled_plan(state: "DashboardState", slot: "_ChatSlot") -> None:
+    """Terminal teardown for a ``_stage_loop`` entry whose plan is already cancelled.
+
+    Mirrors the loop ``finally``'s exit sequence for the one path that cannot
+    flow through it (the ``finally`` reads ``tracker.current_stage``, unbound
+    when the latch check fires before tracker creation): tell the user WHY
+    nothing ran, flush held notes under the same owner guard, hand off any real
+    message the user queued while the Go was pending, and idle-close only when
+    nothing started. Kept OUTSIDE ``_stage_loop`` so the loop retains exactly
+    one flush seam in its ``finally`` (pinned structurally by
+    test_gateway_appkit_endpoints); the queue-drain seam scan enforces this
+    helper's own flush-above-drain ordering.
+    """
+    stop_msg = "🛑 This plan was already cancelled — ask for a new plan to continue."
+    slot.append("assistant", stop_msg, "msg msg-a")
+    state.broadcast_ws("chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg})
+    # Same owner-guard as the loop finally: flush only when the registered task
+    # is ours / absent / done, so a turn someone else owns keeps its notes.
+    _own_task = slot.task
+    if _own_task is None or _own_task is asyncio.current_task() or _own_task.done():
+        try:
+            slot.flush_deferred_notes()
+        except Exception:
+            logger.warning(
+                "Stage loop: held-note delivery failed at cancelled exit for slot %s",
+                slot.key,
+                exc_info=True,
+            )
+        # Release our own registration so the handoff/idle checks below see the
+        # slot as idle (in the loop finally, _run_chat's teardown has already
+        # done this; no _run_chat ever ran on this path).
+        slot.task = None
+    _next_started = False
+    # A queued plan approval is an approval of the very plan this exit is
+    # refusing — the plan-action handler queues one (kind="plan_approval") when
+    # the slot is busy (a pending loop counts as busy), so two Go clicks racing
+    # a Cancel leave a second approval in the queue. Handing that entry to
+    # _start_next_queued_turn would execute a revoked action through _run_chat
+    # (GPT CI finding). Button approvals are classified by the structural kind
+    # tag per queue_append's contract; a TYPED "go"/"go all" queued through
+    # /api/chat carries no tag by definition, so those fall back to normalized
+    # content (second GPT finding). Filtered here at drain time — not in the
+    # cancel handler — so approvals queued AFTER the cancel but before this
+    # pending loop ran are caught too.
+    if slot._queue:
+        slot._queue[:] = [e for e in slot._queue if not _is_plan_approval_entry(e)]
+    if (
+        not slot.running
+        and not slot._last_turn_auth_required
+        and state._slots.get(slot.key) is slot
+        and slot._queue
+        and not slot._stopping
+    ):
+        state.push_slots_update()
+        _next_started = await _start_next_queued_turn(state, slot)
+    if not _next_started and not slot.running:
+        slot.append("done", "", "done")
+        state.broadcast_ws("chat_done", {"slot": slot.key})
+        slot.task = None
+    state.push_slots_update()
+
+
 async def _stage_loop(
     state: "DashboardState",
     slot: "_ChatSlot",
@@ -215,6 +292,22 @@ async def _stage_loop(
     Iterates through plan stages, calling ``_run_chat`` once per stage.
     Stage boundaries are enforced by Python code, not LLM prompts.
     """
+    # Cancelled-plan latch (#6046): checked BEFORE the lazy tracker creation
+    # below. A Cancel processed after the Go POST was accepted but before this
+    # coroutine ran found no tracker to stop; without this check the loop would
+    # build a fresh (unstopped) tracker and advance stage 1 against a revoked
+    # approval. No await separates this check from the tracker assignment, so a
+    # cancel can only interleave after the tracker exists — where tracker.stop()
+    # and the gates below already observe it. The latch is cleared only when a
+    # new plan is armed, so a later Go cannot resurrect a cancelled plan.
+    if slot._plan_cancelled:
+        logger.info(
+            "Stage loop: plan already cancelled for slot %s; exiting without advancing",
+            slot.key,
+        )
+        await _exit_cancelled_plan(state, slot)
+        return
+
     tracker = slot._orch_tracker
     if tracker is None:
         try:
@@ -756,6 +849,13 @@ async def _stage_loop(
                     slot.key,
                     exc_info=True,
                 )
+        # Same revoked-approval filter as _exit_cancelled_plan, at this drain:
+        # a Go queued WHILE the plan ran, followed by a mid-loop cancel, would
+        # otherwise drain an approval entry into _run_chat here — the
+        # surviving residual both advisory lanes flagged. Only when the
+        # plan is revoked; a paused plan's queued approval is still live.
+        if slot._plan_cancelled and slot._queue:
+            slot._queue[:] = [e for e in slot._queue if not _is_plan_approval_entry(e)]
         if (
             not _cancelled
             and not slot.running
@@ -811,6 +911,23 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
 
     if action == "cancel":
         tracker = slot._orch_tracker
+        # Idempotence read taken BEFORE the latch is set. The latch alone is the
+        # test: it is cleared only when a new plan is armed, so "latch set" means
+        # this plan is already revoked. Deliberately NOT conjoined with tracker
+        # state — the Slack gateway lazily creates a fresh UNSTOPPED tracker on
+        # an orchestrator slot when a subagent result lands, so a result arriving
+        # between two Cancels would make a tracker-based read report the plan as
+        # live again and write a duplicate '🛑 Plan cancelled.' row (Opus review
+        # finding). The unconditional tracker.stop() below still stops such a
+        # gateway-created tracker on every cancel POST.
+        already_cancelled = slot._plan_cancelled
+        # Set unconditionally — NOT only when a tracker exists. The tracker is
+        # created lazily inside _stage_loop, so a Cancel processed in the window
+        # between a Go POST being accepted and its _stage_loop coroutine running
+        # would otherwise no-op entirely and the plan would advance while the
+        # transcript says cancelled (#6046). _stage_loop checks this latch
+        # before creating a tracker.
+        slot._plan_cancelled = True
         if tracker and not tracker.stopped:
             tracker.stop()
         slot._auto_run = False
@@ -820,12 +937,13 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
                 t = state.subagents._tasks.get(a["id"])
                 if t and not t.done():
                     t.cancel()
-        stop_msg = "🛑 Plan cancelled."
-        slot.append("assistant", stop_msg, "msg msg-a")
-        state.broadcast_ws(
-            "chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg}
-        )
-        state.broadcast_ws("chat_done", {"slot": slot.key})
+        if not already_cancelled:
+            stop_msg = "🛑 Plan cancelled."
+            slot.append("assistant", stop_msg, "msg msg-a")
+            state.broadcast_ws(
+                "chat_message", {"slot": slot.key, "role": "assistant", "content": stop_msg}
+            )
+            state.broadcast_ws("chat_done", {"slot": slot.key})
         return web.json_response({"ok": True, "cancelled": True})
 
     # Go or Go All — use Python-controlled stage loop
@@ -838,8 +956,12 @@ async def api_chat_plan_action(request: web.Request) -> web.Response:
         # busy session must not lose the approval if they link the session
         # before the drain; an app relaying a plan action never gains the
         # authenticated-human flag.
+        # kind is a structural origin tag, not bare content: _exit_cancelled_plan
+        # drops revoked approvals by this tag, and queue_append's contract names
+        # metadata (never content equality) as the classification mechanism.
         slot.queue_append(
             "Go",
+            kind="plan_approval",
             meta=containment_meta(state, slot),
             directive_user_origin=not bool(request.get("app", "")),
         )

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -622,6 +622,11 @@ def _reset_auto_run_for_new_plan(slot: "_ChatSlot") -> None:
                 pass
     slot._orch_tracker = None
     slot._auto_run = False
+    # A freshly armed plan starts un-cancelled. This is the ONLY clear site for
+    # the latch — deliberately not Go (api_chat_plan_action): clearing on Go
+    # would let a Go racing a Cancel resurrect the cancelled plan, which is the
+    # same race (#6046) inverted.
+    slot._plan_cancelled = False
 
 
 def _extract_and_redact_plan_metadata(text: str) -> tuple[list[str], str, list[list[str]]]:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2682,6 +2682,7 @@ class _ChatSlot:
         "_dirty_flag",
         "_dirty_gen",
         "_orch_tracker",
+        "_plan_cancelled",
         "_auto_run",
         "_in_stage_execution",
         "_last_turn_auth_required",
@@ -2951,6 +2952,16 @@ class _ChatSlot:
         # "the True I started this save under" from "a NEW True set during it".
         self._dirty_gen: int = 0
         self._orch_tracker: Any = None  # OrchestrationTracker, set by gateway
+        # Plan-cancel latch closing the cancel/Go race (#6046): the Cancel
+        # handler can only stop a tracker that exists, but _stage_loop creates
+        # the tracker lazily, so a cancel processed between a Go POST being
+        # accepted and its _stage_loop coroutine starting would no-op on the
+        # tracker and the plan would advance anyway. The handler sets this flag
+        # unconditionally; _stage_loop checks it before creating a tracker and
+        # exits without advancing. Cleared ONLY when a new plan is armed
+        # (_reset_auto_run_for_new_plan) — never on Go, so a Go on a cancelled
+        # plan cannot resurrect it (that would just invert the race).
+        self._plan_cancelled: bool = False
         self._auto_run: bool = False  # "Go All" — skip stage gates
         # True only while _stage_loop is driving a stage-execution turn. Gates
         # the end-of-turn plan detector so a stage turn whose output happens to

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -6386,6 +6386,16 @@ class GatewayOrchestrator:
                         OrchestrationTracker,
                     )
 
+                    # Deliberately NOT latch-based (slot._plan_cancelled):
+                    # the latch outlives the cancelled plan into the NEXT
+                    # planning turn (it clears only when the new plan is
+                    # armed), so a latch-based drop here would silently
+                    # discard subagent completions belonging to that new
+                    # turn — data loss. tracker.stopped scopes the drop to
+                    # a live-but-stopped orchestration; a stale completion
+                    # landing on a cancelled slot whose tracker is absent
+                    # is bounded accounting noise (the stage loop itself
+                    # stays latched and cannot advance).
                     if not getattr(_slot, "_orch_tracker", None):
                         _slot._orch_tracker = OrchestrationTracker()
                     tracker = _slot._orch_tracker

--- a/test/test_plan_cancel_race.py
+++ b/test/test_plan_cancel_race.py
@@ -1,0 +1,367 @@
+"""A cancel racing the first Go must win, and repeat cancels must be idempotent.
+
+``api_chat_plan_action``'s Cancel branch used to revoke a plan only through the
+tracker (``tracker.stop()`` when ``slot._orch_tracker`` exists). But the tracker
+is created lazily INSIDE ``_stage_loop``, so a Cancel processed in the sub-tick
+window between a Go POST being accepted and its ``_stage_loop`` coroutine
+running found no tracker, no-opped, appended '🛑 Plan cancelled.' — and the Go
+then built a fresh (unstopped) tracker and advanced stage 1. Transcript said
+cancelled; plan proceeded (#6046).
+
+The fix is a slot-level latch, ``slot._plan_cancelled``: set unconditionally by
+the Cancel handler, checked by ``_stage_loop`` before it creates a tracker, and
+cleared only when a NEW plan is armed (``_reset_auto_run_for_new_plan``) — never
+on Go, so a Go cannot resurrect a cancelled plan. The same handler pass also
+made repeat Cancels idempotent in the transcript: the cancelled row is appended
+once, not once per POST.
+
+These tests drive the real HTTP cancel handler against a real ``_stage_loop``,
+mirroring test_orchestrator_cancel_stops_advance.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    """Stage results are captured under ``config_dir()`` -- keep them per-test.
+
+    ``chat_orchestrator`` imports ``config_dir`` into its own namespace, so
+    patching only ``state`` would leave results writing to the live data home.
+    """
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_orchestrator_state(tmp_path, slot_key, titles):
+    """A state whose subagent manager reports nothing pending.
+
+    The loop is fail-closed on the subagent check: a missing manager, or a
+    ``running_agents_for`` returning None, breaks out of the loop on its own, so
+    a test that left either unset would pass without the cancel doing anything.
+    """
+    state = _make_state(tmp_path)
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    state.subagents._tasks = {}
+    slot = state.get_or_create_slot(slot_key, mode="orchestrator")
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    slot._auto_run = True
+    return state, slot
+
+
+async def _cancel(client, slot_key):
+    resp = await client.post(f"/api/chat/slots/{slot_key}/plan-action", json={"action": "cancel"})
+    assert resp.status == 200
+    assert (await resp.json())["cancelled"] is True
+
+
+def _cancelled_rows(slot) -> int:
+    return sum(1 for m in slot.messages if "Plan cancelled" in (m.get("content") or ""))
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_stage_loop_starts_does_not_advance(tmp_path, monkeypatch):
+    """Cancel processed before the stage loop creates a tracker: NO stage runs.
+
+    This is the #6046 window itself: the Go's ``_stage_loop`` task is created
+    but has not executed its first line, so ``slot._orch_tracker`` is still
+    None when the Cancel lands. The tracker guard alone no-ops here; only the
+    latch can stop the pending loop.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-pre-loop", ["First", "Second"])
+
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        # The #6046 interleaving is "Cancel fully processed before _stage_loop's
+        # first line runs". Awaiting the HTTP round-trip yields to the event
+        # loop, which would start an already-created loop task and make the
+        # ordering a coin flip — so process the cancel first, then schedule the
+        # loop exactly as the Go handler does. What the loop observes is
+        # identical: latch set, no tracker.
+        assert slot._orch_tracker is None, "setup: the race window requires no tracker yet"
+        await _cancel(client, "cancel-pre-loop")
+        assert slot._plan_cancelled is True
+        assert slot._orch_tracker is None, "cancel must not have created a tracker"
+
+        loop_task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+        slot.task = loop_task
+        await asyncio.wait_for(loop_task, timeout=5)
+
+    assert stages_run == [], f"cancelled-before-start plan still advanced: ran {stages_run}"
+    assert slot._orch_tracker is None, "the pending loop must not build a tracker after cancel"
+    assert slot.task is None, "early exit must release the slot for later messages"
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_appends_exactly_one_cancelled_row(tmp_path):
+    """Repeat Cancel POSTs keep returning ok:true but write ONE transcript row."""
+    state, slot = _make_orchestrator_state(tmp_path, "double-cancel", ["First"])
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        await _cancel(client, "double-cancel")
+        await _cancel(client, "double-cancel")
+        await _cancel(client, "double-cancel")
+
+    assert slot._plan_cancelled is True
+    assert (
+        _cancelled_rows(slot) == 1
+    ), f"expected exactly one cancelled row, transcript has {_cancelled_rows(slot)}"
+
+
+@pytest.mark.asyncio
+async def test_new_plan_clears_cancel_latch_and_runs(tmp_path, monkeypatch):
+    """Arming a NEW plan clears the latch; the fresh plan runs normally."""
+    from kiro_crew.dashboard.chat import _stage_loop
+    from kiro_crew.dashboard.chat_title import _reset_auto_run_for_new_plan
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-then-replan", ["First"])
+
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        await _cancel(client, "cancel-then-replan")
+        assert slot._plan_cancelled is True
+
+        # The plan detector arms a new plan through this reset — the ONLY site
+        # that clears the latch (a bare Go must not).
+        _reset_auto_run_for_new_plan(slot)
+        slot._stage_titles = ["Fresh stage"]
+        slot._auto_run = True
+        assert slot._plan_cancelled is False
+
+        await asyncio.wait_for(_stage_loop(state, slot, auto_run=True), timeout=5)
+
+    assert stages_run == [1], f"freshly armed plan should run its stage, ran {stages_run}"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_early_exit_hands_off_queued_message(tmp_path, monkeypatch):
+    """A message queued during the race window is dispatched, not stranded.
+
+    Go creates the pending loop and sets ``slot.task`` (so ``api_chat`` queues
+    incoming messages), the user types one, then Cancel wins the race. The
+    early exit must mirror the loop ``finally``'s queued-work handoff — both
+    review lanes flagged the original early return for stranding that message
+    until the user's next turn.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-queued", ["First", "Second"])
+
+    handed_off: list[object] = []
+
+    async def _mock_start_next_queued_turn(_state, _slot):
+        handed_off.append(_slot._queue.pop(0) if _slot._queue else None)
+        return True
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn",
+        _mock_start_next_queued_turn,
+    )
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        raise AssertionError("cancelled plan must not run a stage")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        await _cancel(client, "cancel-queued")
+        # A second Go click racing the Cancel: the plan-action handler queues a
+        # kind="plan_approval" entry when the slot is busy. It approves the
+        # revoked plan and must be dropped, not dispatched (GPT CI finding).
+        # Enqueued through the REAL handler so this test also pins that the
+        # handler tags approvals structurally rather than as bare content
+        # (Design review finding).
+        slot.task = asyncio.get_running_loop().create_future()  # busy → handler queues
+        resp = await client.post("/api/chat/slots/cancel-queued/plan-action", json={"action": "go"})
+        assert resp.status == 200 and (await resp.json()).get("queued") is True
+        assert (
+            slot._queue and slot._queue[0].get("kind") == "plan_approval"
+        ), "handler must tag queued approvals structurally, not as bare content"
+        slot.task = None
+        # An untagged typed "go" is a PLAIN user message at drain time — it
+        # must be preserved and handed off, not deleted (GPT round-6 finding:
+        # content matching deletes linked Slack users' real messages).
+        slot.queue_append("go")
+        # The message the user typed while the Go POST was in flight.
+        slot.queue_append("follow-up while plan pending")
+
+        loop_task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+        slot.task = loop_task
+        await asyncio.wait_for(loop_task, timeout=5)
+
+    assert len(handed_off) == 1, "queued message was stranded by the cancelled early exit"
+    assert handed_off[0] is not None and handed_off[0]["content"] == "go", (
+        "the tagged approval must be dropped; the untagged typed 'go' is a plain "
+        f"user message and hands off first: {handed_off}"
+    )
+    assert [e["content"] for e in slot._queue] == ["follow-up while plan pending"]
+    assert slot._orch_tracker is None
+
+
+@pytest.mark.asyncio
+async def test_mid_loop_cancel_drops_queued_approval_at_finally_drain(tmp_path, monkeypatch):
+    """A Go queued while the plan ran must not drain after a mid-loop cancel.
+
+    The loop ``finally`` hands off queued work; without filtering, a
+    kind="plan_approval" entry queued mid-plan would dispatch through
+    ``_run_chat`` after the cancel — the residual both advisory lanes flagged.
+    A real user message queued alongside must still be handed off.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-finally-drain", ["First", "Second"])
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    stages_run: list[int] = []
+    handed_off: list[object] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+        if len(stages_run) == 1:
+            entered.set()
+            await release.wait()
+
+    async def _mock_start_next_queued_turn(_state, _slot):
+        handed_off.append(_slot._queue.pop(0) if _slot._queue else None)
+        return True
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator._start_next_queued_turn",
+        _mock_start_next_queued_turn,
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        loop_task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            # Queued while the plan runs: a tagged button approval (dropped)
+            # and an untagged typed "go all" — a PLAIN user message at drain
+            # time, preserved (GPT round-6: content matching is data loss).
+            slot.queue_append("Go", kind="plan_approval")
+            slot.queue_append("go all")
+            slot.queue_append("real message during plan")
+            await _cancel(client, "cancel-finally-drain")
+        finally:
+            release.set()
+        await asyncio.wait_for(loop_task, timeout=5)
+
+    assert stages_run == [1]
+    assert len(handed_off) == 1 and handed_off[0]["content"] == "go all", (
+        "finally drain must drop only the tagged approval; the untagged 'go all' "
+        f"is a plain message and hands off first: {handed_off}"
+    )
+    assert [e["content"] for e in slot._queue] == ["real message during plan"]
+
+
+def test_is_plan_approval_entry_matches_tag_only():
+    """Only the structural tag matches; untagged content is NEVER dropped.
+
+    An untagged "go" in the queue is a plain user message (e.g. a linked
+    Slack user's text) — deleting it is data loss. It is also harmless to
+    keep: a drained entry dispatches through _run_chat as an ordinary turn,
+    never re-entering api_chat's typed-go branch, and the stage-loop latch
+    blocks advancement on a cancelled plan regardless.
+    """
+    from kiro_crew.dashboard.chat_orchestrator import _is_plan_approval_entry
+
+    assert _is_plan_approval_entry({"content": "Go", "kind": "plan_approval"})
+    assert not _is_plan_approval_entry({"content": "go", "kind": ""})
+    assert not _is_plan_approval_entry({"content": "Go All", "kind": ""})
+    assert not _is_plan_approval_entry({"content": "real message", "kind": ""})
+    assert not _is_plan_approval_entry({"content": "go", "kind": "synthetic_recovery"})
+
+
+@pytest.mark.asyncio
+async def test_stop_word_cancel_also_sets_latch(tmp_path):
+    """The typed stop-word surface revokes with the same finality as Cancel.
+
+    ``api_chat``'s stop-word branch used to call only ``tracker.stop()`` — the
+    Slack gateway can lazily re-create a fresh unstopped tracker on the slot,
+    after which a later Go would pass a tracker-only check and resurrect the
+    stopped plan. Both cancel surfaces must set the latch (Design review
+    finding).
+    """
+    from kiro_crew.context_management import MAX_STAGE_ROUNDS, OrchestrationTracker
+
+    state, slot = _make_orchestrator_state(tmp_path, "stop-word", ["First", "Second"])
+    tracker = OrchestrationTracker(stage_timeout_seconds=60)
+    # has_escalated is derived: a stage at its round limit is the escalated state
+    # in which the stop-word branch is reachable.
+    tracker._stage_rounds[1] = MAX_STAGE_ROUNDS
+    slot._orch_tracker = tracker
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat", json={"slot": "stop-word", "message": "stop"})
+        assert resp.status == 200
+        assert (await resp.json()).get("stopped") is True
+
+    assert tracker.stopped is True
+    assert slot._plan_cancelled is True, "stop-word cancel must set the same latch as Cancel"
+
+
+@pytest.mark.asyncio
+async def test_normal_cancel_of_running_plan_still_stops_it(tmp_path, monkeypatch):
+    """The pre-existing path: cancel mid-``_run_chat`` still stops the plan."""
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    state, slot = _make_orchestrator_state(tmp_path, "cancel-running", ["First", "Second"])
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    stages_run: list[int] = []
+
+    async def _mock_run_chat(_state, _slot, _message, **_kwargs):
+        stages_run.append(len(stages_run) + 1)
+        _slot.append("assistant", f"stage {len(stages_run)} body", "msg msg-a")
+        if len(stages_run) == 1:
+            entered.set()
+            await release.wait()
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        loop_task = asyncio.create_task(_stage_loop(state, slot, auto_run=True))
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            await _cancel(client, "cancel-running")
+
+            tracker = slot._orch_tracker
+            assert tracker is not None and tracker.stopped is True
+            assert slot._plan_cancelled is True
+            assert slot._auto_run is False
+        finally:
+            # An assertion failure above must not leave the mocked _run_chat
+            # parked in release.wait() ("Task was destroyed but it is pending").
+            release.set()
+        await asyncio.wait_for(loop_task, timeout=5)
+
+    assert stages_run == [1], f"cancel of a running plan still advanced: ran {stages_run}"
+    assert _cancelled_rows(slot) == 1


### PR DESCRIPTION
## Summary

Closes #6046.

`POST /api/chat/slots/{slot}/plan-action` with `action=cancel` revoked a plan only through the tracker (`tracker.stop()` when `slot._orch_tracker` exists). But the tracker is created lazily inside `_stage_loop`, so a Cancel processed in the sub-tick window between a Go POST being accepted and its `_stage_loop` coroutine running its first lines no-opped on the tracker, appended `🛑 Plan cancelled.` — and the Go then built a fresh (unstopped) tracker and advanced stage 1. The transcript said cancelled while the plan proceeded. Pre-existing, made reachable from more UI surfaces by #6040.

## Fix

- **Slot-level latch** `slot._plan_cancelled` (declared in `_ChatSlot.__slots__`/init): the cancel handler sets it unconditionally — not only when a tracker exists.
- **`_stage_loop` checks the latch before creating a tracker** and exits without advancing any stage. No `await` separates the check from the tracker assignment, so a cancel can only interleave after the tracker exists, where `tracker.stop()` and the existing gates already observe it.
- **Cleared only when a NEW plan is armed** (`_reset_auto_run_for_new_plan`, the single choke point both plan-arm sites call) — deliberately never on Go, so a Go on a cancelled plan cannot resurrect it (that would just invert the race).
- **The typed stop-word cancel (`/api/chat`, `chat_handlers.py`) sets the same latch.** It is the second plan-revoking `tracker.stop()` caller (2 of 2 sites grepped); without the latch, the Slack gateway lazily re-creating a fresh unstopped tracker would let a later Go resurrect a plan the user stopped by word. Both cancel surfaces now revoke with the same finality.
- **Queued button approvals are dropped at BOTH queue drains once the plan is revoked** — the cancelled early exit AND the loop `finally`'s handoff (a Go queued mid-plan followed by a mid-loop cancel would otherwise dispatch a revoked approval through `_run_chat`). `_is_plan_approval_entry()` matches ONLY the structural `kind="plan_approval"` tag (per `queue_append`'s classify-by-metadata contract) — deliberately not content: an untagged "go" in the queue is a plain user message (e.g. a linked Slack user's text) and deleting it would be data loss; it is also harmless to keep, since a drained entry dispatches through `_run_chat` as an ordinary turn (the queue drain never re-enters `api_chat`'s typed-go branch, verified at `chat_runner.py` `_start_next_queued_turn` → `_run_chat`), and the stage-loop latch blocks advancement on a cancelled plan regardless. Real user messages still hand off.
- **Declared trade-off — the Slack gateway's subagent-result guard keeps its original `tracker.stopped` read.** A latch-based drop there was tried and reverted: the latch outlives the cancelled plan into the NEXT planning turn (it clears only when the new plan arms), so it would silently discard subagent completions belonging to that new turn — data loss. `tracker.stopped` scopes the drop to a live-but-stopped orchestration; the residual (a stale completion landing on a cancelled slot whose tracker is absent records bounded accounting noise) is accepted and documented in a code comment — the stage loop itself stays latched and cannot advance.
- **Repeat cancels are idempotent in the transcript**: the `🛑 Plan cancelled.` row is appended once per cancelled plan, not once per POST. Declared rider: pre-existing cosmetic harm (duplicate rows), fixed in the same handler pass because #6040 made Cancel reachable from more surfaces. The idempotence reads the latch alone — not tracker state, which can be lazily re-created unstopped between two Cancels. `ok:true` is still returned on every cancel POST (client contract unchanged).
- **The early exit mirrors the loop `finally`'s teardown** via a dedicated helper `_exit_cancelled_plan` (both pre-push review lanes flagged the initial bare return): it posts a visible refusal row, flushes held notes under the same owner guard, hands off queued real messages, and idle-closes only when nothing started. It cannot flow through the `finally` itself, which reads `tracker.current_stage` (unbound on this path); the loop keeps exactly one flush seam in its `finally` (pinned structurally by test_gateway_appkit_endpoints), and the repo's queue-drain seam scan enforces the helper's own flush-above-drain ordering.

Server half only — no client-side changes to the #6040 behaviour, no tracker-lifecycle redesign.

## Tests (`test/test_plan_cancel_race.py`)

- cancel processed before the stage loop runs → no stage advances, no tracker created, slot released
- double/triple cancel → exactly one cancelled transcript row
- cancel then newly-armed plan → latch cleared, fresh plan runs normally
- cancel of a running plan (pre-existing path) → still stops it
- message queued during the race window → handed off by the cancelled early exit; the tagged `plan_approval` entry is dropped while an untagged typed "go" is preserved as a plain message (enqueued through the real handler, pinning the structural tag)
- Go queued mid-plan + mid-loop cancel → the loop `finally`'s drain drops only the tagged approval, hands off untagged entries and real messages
- typed stop-word cancel → sets the same latch as Cancel
- `_is_plan_approval_entry` → tag-only; untagged content and differently-tagged automation never match

## Verification

- `isort` / `flake8` / `mypy` / diff-scoped black gate: clean
- Targeted suites green: `test_plan_cancel_race.py`, `test_orchestrator_cancel_stops_advance.py`, `test_plan_mode.py`, `test_chat_title.py`, `test_ws_and_plan_memory_fixes.py`, `test_dashboard_chat.py` (816 tests)
- Pre-push reviews: GPT lane (gpt-5.6-sol) 1 High — queued-turn handoff bypass — fixed with a pinning test; Opus lane (claude-opus-5) PASS with 1 Medium + 4 Low — handoff fixed, idempotence read simplified per its finding, refusal-visibility row added, test-hygiene `try/finally` added; SEL-parity advisory declined (pre-existing parity: the `_orchestration_stopped` break emits no event either, and the cancel POST is already SEL-audited at the API layer)

No UI changes; backend only.
