### PR TITLE
fix(tips): give every /api/tips/feedback refusal a machine-readable code

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1301,
+    "missing_code": 1297,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1327,
+  "_compliant": 1333,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -193,9 +193,6 @@
       "dynamic_status": 5,
       "missing_code": 39,
       "opaque_body": 2
-    },
-    "tips.py": {
-      "missing_code": 4
     }
   }
 }

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -1024,6 +1024,12 @@ async def api_tips_status(request: web.Request) -> web.Response:
     )
 
 
+# Cap on the `id` a feedback call may name. Tip ids are catalog- or
+# curated-authored slugs; the bound exists so an unbounded client string is
+# never carried into the persisted dismissal state.
+_TIP_ID_MAX_CHARS = 100
+
+
 async def api_tips_feedback(request: web.Request) -> web.Response:
     """POST /api/tips/feedback — record user feedback on a tip.
 
@@ -1047,19 +1053,41 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except ValueError:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response(
+            {"error": "invalid JSON", "code": "invalid_json"}, status=400
+        )
 
     if not isinstance(body, dict):
-        return web.json_response({"error": "body must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "body must be a JSON object", "code": "body_not_object"},
+            status=400,
+        )
 
     tip_id = body.get("id", "")
     action = body.get("action", "")
-    if not isinstance(tip_id, str) or not isinstance(action, str) or len(tip_id) > 100:
-        return web.json_response({"error": "invalid fields"}, status=400)
+    if not isinstance(tip_id, str) or not isinstance(action, str):
+        return web.json_response(
+            {"error": "id and action must be strings", "code": "invalid_field_type"},
+            status=400,
+        )
+    # Split from the isinstance check above: a client fixes an oversized id by
+    # sending a shorter one, and a wrong type by sending a different type. A
+    # `code` is API surface that cannot be narrowed later, so the two refusals
+    # must not share one.
+    if len(tip_id) > _TIP_ID_MAX_CHARS:
+        return web.json_response(
+            {
+                "error": f"id exceeds {_TIP_ID_MAX_CHARS} characters",
+                "code": "tip_id_too_long",
+            },
+            status=400,
+        )
 
     valid_actions = ("shown", "ack", "dismiss", "snooze", "helpful", "optout", "optin")
     if action not in valid_actions:
-        return web.json_response({"error": "invalid action"}, status=400)
+        return web.json_response(
+            {"error": "invalid action", "code": "invalid_action"}, status=400
+        )
 
     now = time.time()
 

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -2083,3 +2083,118 @@ class TestRelinkedStateMigration:
         st = self._load(tmp_path, {"tips": [bad]})
         assert st.tips[0]["doc"] == ""
         assert st.tips[0]["doc_link"] == ""
+
+
+class TestFeedbackErrorCodes:
+    """Every refusal from ``POST /api/tips/feedback`` carries a machine-readable
+    ``code``, per the contract gate in ``test/test_error_code_contract.py``.
+
+    The prose stays where it is and keeps its meaning — it is demoted to
+    advisory, not removed — so an existing client that only reads ``error`` is
+    unaffected. What changes is that a client no longer has to match English to
+    tell "the body was not JSON" from "that action does not exist".
+    """
+
+    @staticmethod
+    async def _refuse(tmp_path: Path, raw: bytes) -> tuple[int, dict]:
+        """Drive the REAL handler with *raw* as the request body."""
+        import types
+        from unittest.mock import Mock
+
+        from aiohttp import streams
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.tips import TipsCache, api_tips_feedback
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = TipsCache()
+            cache.state = TipsState()
+            state = types.SimpleNamespace(_tips_cache=cache)
+
+            payload = streams.StreamReader(Mock(_reading_paused=False), 2 ** 16,
+                                           loop=asyncio.get_event_loop())
+            payload.feed_data(raw)
+            payload.feed_eof()
+            req = make_mocked_request("POST", "/api/tips/feedback", payload=payload)
+            req.app["state"] = state
+            resp = await api_tips_feedback(req)
+            return resp.status, json.loads(resp.body)
+
+    @pytest.mark.asyncio
+    async def test_body_is_not_json(self, tmp_path: Path) -> None:
+        status, body = await self._refuse(tmp_path, b"not json at all")
+        assert status == 400
+        assert body["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_body_is_json_but_not_an_object(self, tmp_path: Path) -> None:
+        status, body = await self._refuse(tmp_path, b'["id", "action"]')
+        assert status == 400
+        assert body["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_non_string_id_is_a_type_refusal(self, tmp_path: Path) -> None:
+        status, body = await self._refuse(
+            tmp_path, json.dumps({"id": 7, "action": "ack"}).encode()
+        )
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    @pytest.mark.asyncio
+    async def test_non_string_action_is_a_type_refusal(self, tmp_path: Path) -> None:
+        status, body = await self._refuse(
+            tmp_path, json.dumps({"id": "t", "action": ["ack"]}).encode()
+        )
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    @pytest.mark.asyncio
+    async def test_oversized_id_is_a_length_refusal_not_a_type_refusal(
+        self, tmp_path: Path
+    ) -> None:
+        """The 100-char cap and the isinstance checks share one prose string on
+        main. They are different failures — the client fixes them differently —
+        so they must not share one code: a code is API surface that cannot be
+        narrowed later.
+        """
+        status, body = await self._refuse(
+            tmp_path, json.dumps({"id": "x" * 101, "action": "ack"}).encode()
+        )
+        assert status == 400
+        assert body["code"] == "tip_id_too_long"
+
+    @pytest.mark.asyncio
+    async def test_id_at_the_cap_is_accepted(self, tmp_path: Path) -> None:
+        """Boundary: 100 characters is still valid — the split must not move it."""
+        status, _ = await self._refuse(
+            tmp_path, json.dumps({"id": "x" * 100, "action": "helpful"}).encode()
+        )
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tmp_path: Path) -> None:
+        status, body = await self._refuse(
+            tmp_path, json.dumps({"id": "t", "action": "explode"}).encode()
+        )
+        assert status == 400
+        assert body["code"] == "invalid_action"
+
+    @pytest.mark.asyncio
+    async def test_every_refusal_carries_both_a_code_and_its_prose(
+        self, tmp_path: Path
+    ) -> None:
+        """The ratchet for this file: no refusal path may regress to prose-only,
+        and none may drop the advisory text an existing client still reads.
+        """
+        for raw in (
+            b"not json at all",
+            b'["id", "action"]',
+            json.dumps({"id": 7, "action": "ack"}).encode(),
+            json.dumps({"id": "t", "action": ["ack"]}).encode(),
+            json.dumps({"id": "x" * 101, "action": "ack"}).encode(),
+            json.dumps({"id": "t", "action": "explode"}).encode(),
+        ):
+            status, body = await self._refuse(tmp_path, raw)
+            assert status == 400, raw
+            assert isinstance(body.get("code"), str) and body["code"], raw
+            assert isinstance(body.get("error"), str) and body["error"], raw


### PR DESCRIPTION
## Problem / Motivation

`error-code-baseline.json` — the repo's own Track B worklist — lists
`tips.py` with `missing_code: 4`. All four are in `api_tips_feedback`
(`POST /api/tips/feedback`), and on `main` each one is identified only by an
English sentence:

```python
return web.json_response({"error": "invalid JSON"}, status=400)
return web.json_response({"error": "body must be a JSON object"}, status=400)
return web.json_response({"error": "invalid fields"}, status=400)
return web.json_response({"error": "invalid action"}, status=400)
```

A client that needs to tell these apart has to match on the prose.

## Why it matters

The reasoning is `test/test_error_code_contract.py`'s own, applied to this
file: the dashboard is localized, the sentence is produced in Python, and it
never passes through a catalog — so it lands untranslated in a translated
page. And per AIP-193 / Azure, prose shipped without an identifier *becomes*
the contract: reword it later and you break whoever matched on it.

This file is a good place to pay that down because the **consumer side already
exists**. `apiFailure` in `website/src/api/client.ts` calls
`parseErrorCode(errText)` and journals the backend `code` into every error
report. The frontend is already reading a field the backend was not sending.

## What changed (motivation → approach → change)

Every response keeps its status, and every one gains the code the rest of the
tree already uses: `invalid_json` (66 existing uses), `body_not_object` (15),
`invalid_action` (4). The prose is demoted to advisory throughout.

Two of the three surviving strings are byte-identical to `main`
(`invalid JSON`, `body must be a JSON object`, `invalid action`). The
`invalid fields` string is the exception: because that branch is split (below),
its one message becomes two — `id and action must be strings` and
`id exceeds 100 characters`. A client matching on the old sentence would stop
matching, which is exactly the fragility the `code` exists to remove; nothing
in the repo or in `website/src` matched it.

The `invalid fields` branch is **split in two**. On `main` a single 400 covers
both a type failure (`id`/`action` not a string) and the 100-character `id`
cap. Those are different failures — a client fixes one by sending a different
type and the other by sending a shorter string — and a `code` is API surface
that cannot be narrowed later, so they must not share one identity. They
become `invalid_field_type` and `tip_id_too_long`, matching the existing
`<field>_too_long` convention (`key_too_long`, `name_too_long`,
`value_too_long`). The cap moves into `_TIP_ID_MAX_CHARS` so the bound and the
message it reports cannot drift apart. The boundary itself does not move — 100
characters is still accepted, and there is a test pinning that.

**Deliberately not done:** `handlers/_shared.py::read_bounded_json` already
returns `invalid_json` / `body_not_object` and would have replaced the first
two branches. Swapping it in also adds a 64 KB cap with a new `413` refusal and
changes the 400 prose — a behavior change outside this contract. Left for
whoever wants to argue that change on its own merits.

**No frontend change is required, and that was verified rather than assumed.**
`tipsFeedback` (`client.ts:3236`) is the only wrapper for this route, and both
of its consumers were read:

- `components/TipCard.tsx` — the dismiss and opt-out mutations declare no
  `onError` at all, and the two engagement calls are fire-and-forget
  (`.catch(() => {})`). No refusal reaches the UI.
- `pages/settings/ChatPanel.tsx` — `onError` ignores the error object and
  renders `i18nT('pages.settings.chatPanel.failed_to_save_tips_preference')`,
  a catalog string. Already contract-correct.

So there is no `res.error` render to move for this route, and no consumer edit
that would be honest to include.

### Baseline

`missing_code` 1334 -> 1330, and the `tips.py` entry is gone. `_compliant` moves 1223 -> 1228.

The +5 against -4 is deliberate, not drift: this PR splits the single `invalid fields` refusal into `invalid_field_type` and `tip_id_too_long`, so four uncoded sites become five coded ones.

Both numbers are stated against a regenerated control at `main` `609c2e101`, which for this base agrees exactly with the committed baseline (1334 / 1223) — an earlier revision of this description had to discount an 11-point `_compliant` under-count on `main`, and that is now gone.

The +5 against -4 is deliberate, not drift: this PR splits the single `invalid fields` refusal into `invalid_field_type` and `tip_id_too_long`, so four uncoded sites become five coded ones.

Rebased onto current `main` `609c2e101` (`missing_code: 1334`). The
baseline was **regenerated** from the live tree with the repo's own
`python test/test_error_code_contract.py --update`, never hand-merged: the
totals in this file are relative to this PR's base, so adding or reconciling
numbers across branches would be meaningless. Diffing the regenerated file
against `main`'s shows exactly one changed entry -- `tips.py`, removed -- and
no other file added, removed, or changed. `missing_code`, the number the gate
actually enforces, moves by exactly the four this PR converts.

## Tests

`test/test_tips.py::TestFeedbackErrorCodes`, driving the real handler through
`make_mocked_request` rather than asserting on the source:

| Test | Locks in |
|---|---|
| `test_body_is_not_json` | `invalid_json` |
| `test_body_is_json_but_not_an_object` | `body_not_object` |
| `test_non_string_id_is_a_type_refusal` | `invalid_field_type` |
| `test_non_string_action_is_a_type_refusal` | `invalid_field_type` |
| `test_oversized_id_is_a_length_refusal_not_a_type_refusal` | `tip_id_too_long` — the split |
| `test_id_at_the_cap_is_accepted` | 100 chars still returns 200 — the boundary does not move |
| `test_unknown_action` | `invalid_action` |
| `test_every_refusal_carries_both_a_code_and_its_prose` | per-file ratchet: no path may regress to prose-only, and none may drop the advisory text |

**Red before:** on the parent commit, 7 of the 8 fail with `KeyError: 'code'`.
The 8th — `test_id_at_the_cap_is_accepted` — passes before and after by design;
it is the control that proves the split did not move the boundary.

**Green after:** `test_tips.py` 149 passed / 2 skipped / 0 failed.
`test_error_code_contract.py` (the ratchet) 6 passed. `flake8`, `isort` and
`mypy` clean on both files; `scripts/check_black_formatting.py` passes on the
3 changed files.

## Manual verification

N/A — unit coverage sufficient: the tests drive the real `api_tips_feedback`
through an actual aiohttp request rather than a stub, and no rendered surface
changes (both consumers were audited above and neither displays a refusal from
this route).

## Related Issues

No issue — this is the `tips.py` line item from `error-code-baseline.json`'s
own worklist ("drive `missing_code` to zero, one PR per file or per
directory").

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->





