### PR TITLE
fix: allow '+' in AWS profile names on deploy/EC2/WM paths (#6055)

### DIFF
--- a/src/kiro_crew/cloud/ec2.py
+++ b/src/kiro_crew/cloud/ec2.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from kiro_crew.cloud import aws, sizes
+from kiro_crew.deploy import profiles as profiles_mod
 from kiro_crew.validation import FieldSpec, ValidationError, validate_field
 
 logger = logging.getLogger(__name__)
@@ -75,8 +76,12 @@ _TAG_RE = re.compile(r"^[a-zA-Z0-9-]{1,51}$")
 _TAG_SPEC = FieldSpec(name="tag", type=str, max_len=51, pattern=_TAG_RE)
 _REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
 _REGION_SPEC = FieldSpec(name="region", type=str, max_len=32, pattern=_REGION_RE)
-_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-_PROFILE_SPEC = FieldSpec(name="profile", type=str, max_len=128, pattern=_PROFILE_RE)
+# The profile charset ('+' admitted for IAM Identity Center derived names,
+# leading '-' excluded so a value is never option-shaped, \Z anchor — #6055)
+# is deploy/profiles.py's PROFILE_SPEC, aliased rather than re-spelled here
+# (same idiom as deploy/handlers.py; cloud/ already depends on deploy via the
+# shared aws-bin resolver in cloud/aws.py).
+_PROFILE_SPEC = profiles_mod.PROFILE_SPEC
 _CIDR_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}/\d{1,2}$")
 _CIDR_SPEC = FieldSpec(name="allow_ssh_cidr", type=str, max_len=18, pattern=_CIDR_RE)
 # repo/ref reach a `git clone --branch '<ref>' '<repo>'` in the instance

--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -224,9 +224,11 @@ _LOCAL_DIR_SPEC = FieldSpec(name="local_dir", type=str, max_len=4096, pattern=_L
 # profile/region are LLM-influenceable (chat-native skill) and flow into subprocess
 # argv (--profile/--region) on every aws call, so they get schema validation too.
 # Both allow empty (clears profile / falls back to default region); the pattern is
-# only enforced on non-empty values by validate_field.
-_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-_PROFILE_SPEC = FieldSpec(name="profile", type=str, max_len=128, pattern=_PROFILE_RE)
+# only enforced on non-empty values by validate_field. The profile charset
+# ('+' admitted for IAM Identity Center derived names, leading '-' excluded,
+# \Z anchor — #6055) is profiles.py's PROFILE_SPEC, aliased like REGION_SPEC
+# below rather than re-spelled here.
+_PROFILE_SPEC = profiles_mod.PROFILE_SPEC
 _REGION_SPEC = profiles_mod.REGION_SPEC
 
 # artifact_slug is LLM-influenceable (chat-native skill) and is used in a store

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -78,7 +78,12 @@ _NOTE_MAX = 256
 
 # Same shapes handlers.py enforces for the legacy single-profile config — these
 # values flow into subprocess argv (--profile/--region) on every aws call.
-_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+# '+' admitted for IAM Identity Center derived profiles
+# ("<account>+<permission-set>", #6051); first char excludes '-' so a name is
+# never option-shaped, and \Z rejects trailing newlines. Also used by
+# discover_aws_profiles() to filter `aws configure list-profiles` lines
+# (stripped before matching, so the anchor change is behavior-neutral there).
+_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
 PROFILE_SPEC = FieldSpec(name="profile", type=str, max_len=128, pattern=_PROFILE_RE)
 # Multi-segment to admit GovCloud (us-gov-west-1) alongside standard regions;
 # max_len=32 keeps the backtracking surface negligible.

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
@@ -107,7 +107,7 @@ def ensure_lambda_oac(profile, region):
 
 def _validate_args(profile: str, region: str, dist_id: str, slug: str) -> None:
     """Validate all argv before any aws call. Exit 2 on mismatch."""
-    _PROFILE_RE = re.compile(r"^[a-zA-Z0-9._:/-]+$")
+    _PROFILE_RE = re.compile(r"^[a-zA-Z0-9._:/+-]+$")
     _REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
     _DIST_ID_RE = re.compile(r"^[A-Z0-9]{13,14}$")
     _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
@@ -66,7 +66,7 @@ def aws(profile, region, *args):
 def _validate_args(profile: str, region: str, dist_id: str, slug: str) -> None:
     """Validate all argv before any aws call. Exit 2 on mismatch."""
     import re as _re
-    _PROFILE_RE = _re.compile(r"^[a-zA-Z0-9._:/-]+$")
+    _PROFILE_RE = _re.compile(r"^[a-zA-Z0-9._:/+-]+$")
     _REGION_RE = _re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
     _DIST_ID_RE = _re.compile(r"^[A-Z0-9]{13,14}$")
     _SLUG_RE = _re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1454,7 +1454,12 @@ def _validate_artifact_save(cleaned: dict) -> None:
 
 # Shared slug pattern (matches _ARTIFACT_SLUG_RE + deploy slug validation).
 _WM_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
-_WM_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+# '+' admitted for IAM Identity Center derived profiles
+# ("<account>+<permission-set>", #6051); first char excludes '-' so a stored
+# profile is never option-shaped when it later reaches `--profile <value>`
+# argv. \Z is load-bearing here: this path matches the raw value WITHOUT a
+# strip, so the old $ anchor let a trailing-newline value through.
+_WM_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
 _WM_URL_RE = re.compile(r"^https?://.{1,2048}$")
 _WM_LIFECYCLE_STATUSES = {"draft", "deploying", "live", "error", "expired"}
 _WM_LIST_CAP = 50

--- a/test/test_aws_profile_charset.py
+++ b/test/test_aws_profile_charset.py
@@ -1,0 +1,198 @@
+"""Regression tests for the four sibling AWS-profile character classes (#6055).
+
+IAM Identity Center derives profile names shaped ``<account>+<permission-set>``
+(e.g. ``AdminAccess+dev``), so ``+`` must be accepted. The SSM/instances pair
+was fixed by #6051; these tests pin the four remaining hand-copied patterns:
+
+* ``kiro_crew.cloud.ec2._PROFILE_SPEC`` (EC2 wizard — aliases
+  ``profiles.PROFILE_SPEC``)
+* ``kiro_crew.deploy.profiles._PROFILE_RE`` (deploy profile registry + the
+  ``aws configure list-profiles`` discovery filter)
+* ``kiro_crew.deploy.handlers._PROFILE_SPEC`` (deploy-web HTTP boundary —
+  aliases ``profiles.PROFILE_SPEC``)
+* ``kiro_crew.validation._WM_PROFILE_RE`` (workspace-manager webapp_metadata)
+
+All four values only ever reach a subprocess as a discrete ``--profile <value>``
+argv element (never a shell string), so the widened class must still exclude
+whitespace and shell metacharacters, must reject option-shaped (leading ``-``)
+values, and must anchor with ``\\Z`` so a trailing newline cannot slip past
+``$``'s end-of-line leniency.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kiro_crew import validation as validation_mod
+from kiro_crew.cloud import aws as cloud_aws
+from kiro_crew.cloud import ec2
+from kiro_crew.deploy import engine as engine_mod
+from kiro_crew.deploy import handlers
+from kiro_crew.deploy import profiles as profiles_mod
+from kiro_crew.validation import (
+    ARTIFACT_SAVE_SCHEMA,
+    ValidationError,
+    validate_field,
+    validate_tool_args,
+)
+
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt", reason="deploy profile discovery is POSIX-only by design"
+)
+
+_PATTERNS = {
+    # ec2 and handlers alias profiles.PROFILE_SPEC (same idiom as handlers'
+    # _REGION_SPEC); pin each boundary's ACTUAL pattern so a future divergent
+    # local copy is still caught here.
+    "cloud.ec2": ec2._PROFILE_SPEC.pattern,
+    "deploy.profiles": profiles_mod._PROFILE_RE,
+    "deploy.handlers": handlers._PROFILE_SPEC.pattern,
+    "workspace-manager": validation_mod._WM_PROFILE_RE,
+}
+
+_ACCEPTED = [
+    "AdminAccess+dev",  # the IAM Identity Center shape from the report
+    "123456789012+PowerUserAccess",
+    "p",  # single char (quantifier still means >= 1)
+    "a.b_c-d",  # the full legacy charset keeps working
+    "dev+test.2-x_9",
+]
+
+_REJECTED = [
+    "-leading-dash",  # option-shaped: must never reach --profile argv
+    "--profile",
+    "+extra trailing junk",  # whitespace stays excluded even around '+'
+    "has space",
+    "semi;colon",
+    "pipe|pipe",
+    "dollar$(x)",
+    "back`tick",
+    "newline\ninside",
+    "trailing\n",  # \Z regression: $ matched just before a trailing newline
+    "tab\t",
+    "",
+]
+
+
+class TestProfilePatternCharset:
+    """The compiled patterns themselves, exercised via .match like production."""
+
+    @pytest.mark.parametrize("site", sorted(_PATTERNS))
+    @pytest.mark.parametrize("value", _ACCEPTED)
+    def test_accepts_legal_profiles(self, site: str, value: str) -> None:
+        assert _PATTERNS[site].match(value), f"{site} rejected legal profile {value!r}"
+
+    @pytest.mark.parametrize("site", sorted(_PATTERNS))
+    @pytest.mark.parametrize("value", _REJECTED)
+    def test_rejects_unsafe_values(self, site: str, value: str) -> None:
+        assert not _PATTERNS[site].match(value), f"{site} accepted unsafe value {value!r}"
+
+
+class TestEc2ValidateProfile:
+    def test_plus_profile_accepted(self) -> None:
+        assert ec2.validate_profile("AdminAccess+dev") == "AdminAccess+dev"
+
+    @pytest.mark.parametrize("bad", ["-foo", "evil;rm -rf", "a b"])
+    def test_unsafe_profiles_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            ec2.validate_profile(bad)
+
+    def test_empty_profile_still_allowed(self) -> None:
+        # Empty means "no --profile" downstream; the pattern is only enforced
+        # on non-empty values (pre-existing semantics, must not change).
+        assert ec2.validate_profile("") == ""
+
+    def test_trailing_newline_normalized_by_sanitizer(self) -> None:
+        # validate_field strips via sanitize_string BEFORE the pattern check,
+        # so a trailing newline is normalized away rather than rejected here;
+        # the \Z anchor is the defense for the raw-match call sites.
+        assert ec2.validate_profile("AdminAccess+dev\n") == "AdminAccess+dev"
+
+
+class TestDeployProfilesSpec:
+    def test_plus_profile_accepted(self) -> None:
+        assert validate_field("AdminAccess+dev", profiles_mod.PROFILE_SPEC) == "AdminAccess+dev"
+
+    @pytest.mark.parametrize("bad", ["-foo", "evil;rm -rf"])
+    def test_unsafe_profiles_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            validate_field(bad, profiles_mod.PROFILE_SPEC)
+
+    @_POSIX_ONLY
+    def test_discovery_keeps_plus_profiles_and_drops_option_shaped(self, monkeypatch) -> None:
+        # `aws configure list-profiles` output lines are stripped before the
+        # filter, so the \Z anchor is behavior-neutral here; the widened class
+        # is what lets SSO-derived names show up in discovery at all.
+        out = "default\nAdminAccess+dev\n-cursed\nbad name!\nok.two\n"
+        monkeypatch.setattr(profiles_mod.engine, "run_aws", lambda *a, **k: (0, out, ""))
+        assert profiles_mod.discover_aws_profiles() == ["default", "AdminAccess+dev", "ok.two"]
+
+
+class TestDeployHandlersSpec:
+    def test_plus_profile_accepted(self) -> None:
+        assert validate_field("AdminAccess+dev", handlers._PROFILE_SPEC) == "AdminAccess+dev"
+
+    @pytest.mark.parametrize("bad", ["-foo", "evil;rm -rf"])
+    def test_unsafe_profiles_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            validate_field(bad, handlers._PROFILE_SPEC)
+
+    def test_empty_profile_still_allowed(self) -> None:
+        # "" clears the profile (falls back to default) — pre-existing
+        # empty-value semantics that the charset change must not disturb.
+        assert validate_field("", handlers._PROFILE_SPEC) == ""
+
+
+class TestWorkspaceManagerProfile:
+    @staticmethod
+    def _args(profile: str) -> dict:
+        return {
+            "name": "t",
+            "content": "x",
+            "kind": "webapp",
+            "webapp_metadata": {"deploy_target": {"profile": profile}},
+        }
+
+    def test_plus_profile_accepted(self) -> None:
+        result = validate_tool_args(self._args("AdminAccess+dev"), ARTIFACT_SAVE_SCHEMA)
+        assert result["webapp_metadata"]["deploy_target"]["profile"] == "AdminAccess+dev"
+
+    @pytest.mark.parametrize("bad", ["-foo", "evil;rm -rf"])
+    def test_unsafe_profiles_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError, match="invalid profile"):
+            validate_tool_args(self._args(bad), ARTIFACT_SAVE_SCHEMA)
+
+    def test_trailing_newline_rejected_raw(self) -> None:
+        # This call site matches the raw stored value (no strip), so the old $
+        # anchor let "p\n" through — \Z is a real tightening here.
+        assert not validation_mod._WM_PROFILE_RE.match("AdminAccess+dev\n")
+
+    def test_empty_profile_still_allowed(self) -> None:
+        result = validate_tool_args(self._args(""), ARTIFACT_SAVE_SCHEMA)
+        assert result["webapp_metadata"]["deploy_target"]["profile"] == ""
+
+
+class TestPatternLengthBound:
+    """The quantifier bounds length to 128 inside the pattern itself, matching
+    the max_len=128 caps the FieldSpec sites enforce (and #6051's sibling)."""
+
+    @pytest.mark.parametrize("site", sorted(_PATTERNS))
+    def test_128_chars_accepted_129_rejected(self, site: str) -> None:
+        assert _PATTERNS[site].match("a" * 128)
+        assert not _PATTERNS[site].match("a" * 129)
+
+
+class TestDiscreteArgvIntegration:
+    """The safety argument for the widened charset rests on the profile only
+    ever reaching the aws CLI as a discrete ``--profile <value>`` argv pair —
+    pin that end-to-end for both subprocess chokepoints."""
+
+    def test_cloud_build_argv_keeps_plus_profile_discrete(self) -> None:
+        argv = cloud_aws._build_argv(["sts", "get-caller-identity"], "AdminAccess+dev", "")
+        assert argv[-2:] == ["--profile", "AdminAccess+dev"]
+
+    def test_deploy_engine_aws_keeps_plus_profile_discrete(self) -> None:
+        argv = engine_mod._aws(["s3", "ls"], "AdminAccess+dev")
+        assert argv[-2:] == ["--profile", "AdminAccess+dev"]

--- a/test/test_deploy_script_validation.py
+++ b/test/test_deploy_script_validation.py
@@ -39,6 +39,10 @@ class TestAttachBackendValidation:
         """Known-good inputs should not raise."""
         self.mod._validate_args("my-profile", "us-west-2", "E1A2B3C4D5E6F7", "my-app")
 
+    def test_sso_plus_profile_passes(self):
+        """IAM Identity Center derived names contain '+' (#6055)."""
+        self.mod._validate_args("AdminAccess+dev", "us-west-2", "E1A2B3C4D5E6F7", "my-app")
+
     def test_empty_profile_allowed(self):
         """Empty profile (default) should pass."""
         self.mod._validate_args("", "us-east-1", "ABCDEFGHIJKLM", "demo-app")
@@ -81,6 +85,10 @@ class TestDetachBackendValidation:
 
     def test_valid_args_pass(self):
         self.mod._validate_args("my-profile", "us-west-2", "E1A2B3C4D5E6F7", "my-app")
+
+    def test_sso_plus_profile_passes(self):
+        """IAM Identity Center derived names contain '+' (#6055)."""
+        self.mod._validate_args("AdminAccess+dev", "us-west-2", "E1A2B3C4D5E6F7", "my-app")
 
     def test_empty_profile_allowed(self):
         self.mod._validate_args("", "ap-southeast-2", "ABCDEFGHIJKLM", "demo")


### PR DESCRIPTION
## Problem / Motivation

IAM Identity Center derives AWS named profiles shaped `<account>+<permission-set>` (e.g. `AdminAccess+dev`), and `+` is legal in AWS profile names. PR #6051 fixed the SSM/instances validator pair, but the same SSO user still hits an "invalid characters" rejection on the EC2 wizard, deploy-profiles, deploy-handlers and workspace-manager paths — four hand-copied `re.compile(r"^[A-Za-z0-9_.-]+$")` literals, each missing the same character.

## Why it matters

Any IAM Identity Center user with a derived profile is locked out of the EC2 remote-crew wizard, deploy-web profile registration/discovery, and webapp deploy-target metadata — the exact flows #6051 unblocked one step earlier. The defect is a duplicated one-character omission, so it keeps resurfacing site by site (this is its second round after #6042).

## What changed (motivation → approach → change)

Observed symptom → each site's charset rejects `+` → widen the class at each site, mirroring what #6051 did for the instances pair, while auditing (not normalising) each site's own semantics.

The four enumerated sites become `^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z`:

- `+` **admitted** (the fix).
- **First char excludes `-`** so a profile can never be option-shaped. The merged #6051 site blocks this with an explicit `startswith('-')` guard; these sites are `FieldSpec`-pattern driven with no imperative hook, so the guard is encoded in the regex. (The old class accepted a leading `-`; per the review checklist below this weakness is fixed in the same commit rather than widened past.)
- **`\Z` replaces `$`**, closing `$`'s match-before-trailing-newline leniency.
- **`{0,127}` quantifier** makes the existing 128-char cap local to the pattern (all four sites already cap at 128 via `max_len=128` / an explicit length check), matching the #6051 sibling's bounded form.
- Caller-side quantifier/empty-value semantics unchanged at all four sites (empty still means "no --profile" where it did before).

Pre-push review found the same missing `+` at two more sites the issue did not enumerate, **newly reachable** once the registry admits `+` names: the artifact-deploy skill scripts' `_validate_args` profile classes. Widened with `+` only (`^[a-zA-Z0-9._:/+-]+$`) — their own charset family, anchors and guards are deliberately kept (they take `--profile` from operator CLI argv, a different trust boundary; residual anchor work is tracked in #6063).

### Per-site safety audit (why widening is safe)

| Site | Reaches subprocess as | Option injection | Whitespace/shell metachars | Anchor |
|---|---|---|---|---|
| `cloud/ec2.py` `_PROFILE_SPEC` | `cloud/aws.py:_build_argv` → discrete `["--profile", v]`, `popen_limited`, no shell, sandbox-wrapped | first-char class rejects `-` | none admitted | `\Z`; now **aliases `profiles.PROFILE_SPEC`** (cloud/ already depends on deploy via the shared aws-bin resolver) — adopted from First Principles round 2 |
| `deploy/profiles.py` `_PROFILE_RE` | `deploy/engine.py:_aws` → discrete `["--profile", v]`, `run_limited`, no shell, sandbox-wrapped | first-char class rejects `-` | none admitted | `\Z` (the `discover_aws_profiles` scan strips each `list-profiles` line before matching, so the anchor change is behavior-neutral there) |
| `deploy/handlers.py` `_PROFILE_SPEC` | same `engine.run_aws` chokepoint | first-char class rejects `-` | none admitted | `\Z`; empty-allowed semantics preserved; now **aliases `profiles.PROFILE_SPEC`** (same idiom as its `_REGION_SPEC` one line below) instead of carrying a byte-identical copy — adopted from First Principles round 1 |
| `validation.py` `_WM_PROFILE_RE` | stored metadata later fed to `engine.run_aws` | first-char class rejects `-` | none admitted | `\Z` is load-bearing: this path matches the raw value without a strip, so the old `$` accepted a trailing-newline value — now rejected |
| `attach_backend.py` / `detach_backend.py` scripts | discrete `(["--profile", v] if v else [])` | argparse boundary (operator CLI); unchanged | none admitted (class never had whitespace/metachars) | unchanged (`$`), tracked in #6063 |

The profile value is never interpolated into a shell string anywhere on these paths (`grep shell=True src/kiro_crew/{cloud,deploy}` is clean), and notably never into the `credential_process` line (that embeds only `account`/`role`, whose charsets are unchanged).

### Server review rounds 1–2 disposition

Round 2 — First Principles (CONCERNS, advisory): after round 1's handlers de-dup, `ec2._PROFILE_SPEC` was the next byte-identical spelling of `profiles.PROFILE_SPEC`, with the cloud→deploy import edge already present (`cloud/aws.py` imports the shared aws-bin resolver from `deploy/engine`) — **adopted**: ec2 now aliases `profiles.PROFILE_SPEC` too. `deploy/profiles.py` is now the single spelling of this charset on these paths; the remaining compiles are `validation.py`'s `_WM_PROFILE_RE` (genuinely stuck: `deploy/profiles.py` imports `kiro_crew.validation`, so an alias would be circular — per FP round 2's own analysis) and the standalone skill scripts (no package import context by design). The charset-contract test pins each boundary's actual pattern, containing any future divergence. GPT 5.6 / Opus 4.8 / Design: no blocking findings on round 2.

### Server review round 1 disposition

First Principles (CONCERNS, advisory): `handlers._PROFILE_SPEC` had become a byte-identical second spelling of `profiles.PROFILE_SPEC` with the aliasing idiom one line below — **adopted**: deleted the local `_PROFILE_RE`/`_PROFILE_SPEC` and aliased `profiles_mod.PROFILE_SPEC`, exactly as `_REGION_SPEC` does; the charset-contract test now pins `handlers._PROFILE_SPEC.pattern` so a future divergent local copy is still caught. GPT 5.6 / Opus 4.8 / Design: no blocking findings on round 1.

### Pre-push review disposition (dual model)

- GPT 5.6 Sol: PASS, zero findings (caller compat, `\Z` behavior, backtracking surface, cross-platform tests, scope all verified clean).
- Opus 5: PASS + 2 CONCERNS, 3 INFO. Adopted: the two script siblings (above), the `{0,127}` bounded quantifier, and end-to-end discrete-argv assertions. Deferred to #6063 with reasoning: `aws_consent.py:97`'s `$` anchor (already admits `+`, already requires leading alphanumeric; consequence bounded to a CLI resolve failure; keeping the consent module out of this review surface). Noted: a registry entry stored under the old class (e.g. leading `-`) still loads and lists — it is only rejected on re-register, so there is no upgrade-path data loss; such a name was already unusable as `--profile -foo`.

### Out of scope, deliberately

- Consolidating the remaining sibling patterns into one shared constant — the remaining sites genuinely differ in empty-value/anchor semantics or trust boundary; tracked as #6063. (The one pair for which that rationale did NOT hold — handlers/profiles, byte-identical spec with the aliasing idiom already adjacent — was de-duplicated in this PR per First Principles round 1.)
- The SSM/instances path — already fixed by #6051 (no file overlap; this PR was verified against main after #6051 merged).

## Tests

`test/test_aws_profile_charset.py` (new, 119 cases):
- All four compiled patterns accept `AdminAccess+dev` and the legacy charset; reject option-shaped (`-leading-dash`, `--profile`), whitespace, shell metacharacters, trailing-newline, and empty values.
- The 128-char bound is enforced inside the pattern (`128` accepted, `129` rejected) at all four sites.
- `ec2.validate_profile`: `+` accepted; empty still allowed; trailing newline normalized by `sanitize_string` before the pattern (documents the layered behavior at FieldSpec sites).
- `deploy/profiles`: `PROFILE_SPEC` accepts `+`; `discover_aws_profiles` keeps `+` names and drops option-shaped/garbage lines (POSIX-only, mirroring production's `os.name == "nt"` early return).
- `deploy/handlers`: `+` accepted; empty-allowed semantics pinned.
- Workspace-manager: `+` accepted through `validate_tool_args`; raw trailing-newline now rejected; empty still allowed.
- End-to-end: `cloud/aws._build_argv` and `deploy/engine._aws` keep a `+` profile as a discrete `["--profile", "AdminAccess+dev"]` pair — pins the property the whole safety argument rests on.

`test/test_deploy_script_validation.py`: `AdminAccess+dev` accepted by both scripts' `_validate_args`.

Local gates: isort / flake8 / mypy / black ratchet / subprocess-encoding ratchet all green; full `python -m pytest` run twice (with the change and on clean main): 69250 passed, and the failing set (82, host-environment classes) is byte-identical between the two runs — zero regressions from this change.

## Manual verification

N/A — unit coverage sufficient: the change is four compiled regex literals plus two script charsets, and every acceptance/rejection boundary plus the argv chokepoints are pinned by the new tests.

## Related Issues

Closes #6055
Follow-up: #6063 (charset consolidation + residual `$` anchor sites)

## Checklist

- [x] At most two commits (one), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior contract changes
- [x] No secrets, credentials, or internal references in the diff


