### PR TITLE
fix(terminal): code every JSON refusal with the reason its audit already records

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1357,
+    "missing_code": 1350,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1189,
+  "_compliant": 1196,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -160,9 +160,6 @@
     },
     "dashboard/handlers/taskrunner.py": {
       "missing_code": 54
-    },
-    "dashboard/handlers/terminal.py": {
-      "missing_code": 7
     },
     "dashboard/handlers/themes.py": {
       "dynamic_status": 4,

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -1001,7 +1001,7 @@ async def api_terminal_create(request: web.Request) -> web.Response:
             resources=f"max_sessions={max_sessions}",
         )
         return web.json_response(
-            {"error": f"Max {max_sessions} sessions"},
+            {"error": f"Max {max_sessions} sessions", "code": "terminal_max_sessions"},
             status=429,
         )
 
@@ -1072,9 +1072,15 @@ async def api_terminal_redact(request: web.Request) -> web.Response:
         if not isinstance(text, str):
             raise TypeError
     except Exception:
-        return web.json_response({"error": "expected JSON body {text: string}"}, status=400)
+        return web.json_response(
+            {"error": "expected JSON body {text: string}", "code": "terminal_invalid_body"},
+            status=400,
+        )
     if len(text.encode("utf-8", errors="replace")) > _REDACT_MAX_BYTES:
-        return web.json_response({"error": "selection too large"}, status=413)
+        return web.json_response(
+            {"error": "selection too large", "code": "terminal_selection_too_large"},
+            status=413,
+        )
     # This is the ONLY credential scan on the path from PTY output to a model,
     # so it runs unconditionally and there is no configuration that skips it.
     # A contiguous selection is also the only input the redactors can be
@@ -1093,7 +1099,10 @@ async def api_terminal_redact(request: web.Request) -> web.Response:
     except Exception:
         # Fail closed: the caller gets no text to insert.
         logger.exception("terminal: selection redaction failed")
-        return web.json_response({"error": "redaction failed"}, status=500)
+        return web.json_response(
+            {"error": "redaction failed", "code": "terminal_redaction_failed"},
+            status=500,
+        )
     return web.json_response({"text": redacted})
 
 
@@ -1446,19 +1455,27 @@ async def api_terminal_complete(request: web.Request) -> web.Response:
     except Exception:
         _log_complete(caller, "denied", "invalid_body")
         return web.json_response(
-            {"error": "expected JSON body "
-                      "{session_id: string, token?: string, folders_only?: boolean, "
-                      "argv?: string[]}"},
+            {
+                "error": "expected JSON body "
+                         "{session_id: string, token?: string, folders_only?: boolean, "
+                         "argv?: string[]}",
+                "code": "terminal_invalid_body",
+            },
             status=400,
         )
     if len(token) > _COMPLETE_TOKEN_MAX:
         _log_complete(caller, "denied", "token_too_long")
-        return web.json_response({"error": "token too long"}, status=413)
+        return web.json_response(
+            {"error": "token too long", "code": "terminal_token_too_long"}, status=413
+        )
 
     sess = _get_registry(request).get(session_id)
     if sess is None:
         _log_complete(caller, "denied", "unknown_session")
-        return web.json_response({"error": "Unknown terminal session"}, status=404)
+        return web.json_response(
+            {"error": "Unknown terminal session", "code": "terminal_unknown_session"},
+            status=404,
+        )
 
     cwd = await _session_cwd_cached(sess)
     dir_part, prefix = _split_path_token(token)

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -3280,3 +3280,110 @@ class TestPollTerminalTitles:
              patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
             await terminal.poll_terminal_titles(self._app(sess))  # must not raise
         ws.send_str.assert_not_awaited()
+
+
+class TestTerminalRefusalCodes:
+    """Every JSON refusal from the terminal routes carries a machine-readable
+    ``code`` (contract gate: ``test/test_error_code_contract.py``).
+
+    Only the JSON routes are in scope. ``api_terminal_ws``, create's auth/enable
+    guards, and delete answer ``web.Response(text=...)`` — a plain-text contract
+    that carries no envelope to put a code in, and giving them one would change
+    their content type rather than complete this one.
+    """
+
+    @staticmethod
+    def _body(resp):
+        return json.loads(resp.body)
+
+    @pytest.mark.asyncio
+    async def test_create_refuses_over_the_session_cap_with_a_code(self):
+        registry = {"s1": _make_session(), "s2": _make_session()}
+        req = _make_request(registry=registry)
+        with patch.object(
+            terminal, "_get_config", return_value={"enabled": True, "max_sessions": 2}
+        ), patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            resp = await terminal.api_terminal_create(req)
+        assert resp.status == 429
+        assert self._body(resp)["code"] == "terminal_max_sessions"
+
+    @pytest.mark.asyncio
+    async def test_redact_refusals_are_coded(self):
+        cases = [
+            ({"text": 42}, 400, "terminal_invalid_body"),
+            ({"text": "x" * (terminal._REDACT_MAX_BYTES + 1)}, 413,
+             "terminal_selection_too_large"),
+        ]
+        for body, status, code in cases:
+            req = _make_request()
+            req.json = AsyncMock(return_value=body)
+            with patch.object(terminal, "_is_enabled", return_value=True):
+                resp = await terminal.api_terminal_redact(req)
+            assert resp.status == status, body
+            assert self._body(resp)["code"] == code, body
+
+    @pytest.mark.asyncio
+    async def test_a_failed_redaction_is_coded_and_still_fails_closed(self):
+        """The 500 must name the operation without carrying the selection: this
+        route exists to keep a credential out of the model's input, so its own
+        failure must not put the text back in the response."""
+        secret = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        req = _make_request()
+        req.json = AsyncMock(return_value={"text": secret})
+        with patch.object(terminal, "_is_enabled", return_value=True), \
+             patch.object(terminal, "redact_exfiltration_urls", side_effect=RuntimeError):
+            resp = await terminal.api_terminal_redact(req)
+        assert resp.status == 500
+        assert self._body(resp)["code"] == "terminal_redaction_failed"
+        assert "wJalrXUtnFEMI" not in resp.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("body", "status", "reason"),
+        [
+            ({"session_id": 42}, 400, "invalid_body"),
+            ({"session_id": "s1", "token": "x" * (4096 + 1)}, 413, "token_too_long"),
+            ({"session_id": "missing"}, 404, "unknown_session"),
+        ],
+    )
+    async def test_complete_refusal_code_is_the_audited_reason(
+        self, body: dict, status: int, reason: str
+    ) -> None:
+        """`_log_complete` already records a fixed reason word for every refusal
+        and the response then dropped it. The code is that word, so the audit
+        trail and the API cannot drift apart."""
+        req = _make_request(registry={})
+        req.json = AsyncMock(return_value=body)
+        with patch.object(terminal, "_is_enabled", return_value=True), \
+             patch.object(terminal, "_sel") as mock_sel:
+            log = MagicMock()
+            mock_sel.return_value.log_api_access = log
+            resp = await terminal.api_terminal_complete(req)
+
+        assert resp.status == status
+        assert self._body(resp)["code"] == f"terminal_{reason}"
+        assert log.call_args.kwargs["resources"] == reason
+
+    @pytest.mark.asyncio
+    async def test_every_json_refusal_carries_a_code_and_its_prose(self):
+        """Per-file ratchet: no JSON refusal may regress to prose-only."""
+        collected = []
+
+        req = _make_request()
+        req.json = AsyncMock(return_value={"text": 42})
+        with patch.object(terminal, "_is_enabled", return_value=True):
+            collected.append(await terminal.api_terminal_redact(req))
+
+        req = _make_request(registry={})
+        req.json = AsyncMock(return_value={"session_id": "missing"})
+        with patch.object(terminal, "_is_enabled", return_value=True), \
+             patch.object(terminal, "_sel") as mock_sel:
+            mock_sel.return_value.log_api_access = MagicMock()
+            collected.append(await terminal.api_terminal_complete(req))
+
+        for resp in collected:
+            body = self._body(resp)
+            assert resp.status >= 400, body
+            assert isinstance(body.get("code"), str) and body["code"], body
+            assert isinstance(body.get("error"), str) and body["error"], body


### PR DESCRIPTION
## Problem / Motivation

`AGENTS.md`: *"Backend-owned strings have no catalog path yet, so a new non-2xx
JSON body MUST carry a machine-readable `code` field."*
`error-code-baseline.json` — the worklist that ratchets the existing debt down —
listed `dashboard/handlers/terminal.py` with `missing_code: 7`.

The completion route already computes the identity those responses were
missing. Every refusal on it audits first:

```python
_log_complete(caller, "denied", "token_too_long")
return web.json_response({"error": "token too long"}, status=413)
```

`invalid_body`, `token_too_long`, `unknown_session`, `invalid_argv` — a fixed
reason word, written to the audit log, then dropped on the way to the client.

## Why it matters

A client cannot distinguish these refusals without matching English. That
matters most on `/api/terminal/complete`, which fires per keystroke and whose
404 (`Unknown terminal session`) means "reconnect", while its 413 means "stop
sending". And `/api/terminal/redact` is the credential scan between PTY output
and the model: a caller that cannot tell "your selection is too big" from "the
scan itself failed" cannot tell a retryable refusal from a fail-closed one.

## What changed (motivation → approach → change)

Each response carries the reason its own audit already records, prefixed
`terminal_` to match the single code the file already had
(`terminal_invalid_argv`) — so the vocabulary is the file's own, not invented:

| Route | Refusal | Code | Audit reason |
|---|---|---|---|
| `complete` | malformed body | `terminal_invalid_body` | `invalid_body` |
| `complete` | 413 token cap | `terminal_token_too_long` | `token_too_long` |
| `complete` | 404 no session | `terminal_unknown_session` | `unknown_session` |
| `redact` | malformed body | `terminal_invalid_body` | — |
| `redact` | 413 selection cap | `terminal_selection_too_large` | — |
| `redact` | 500 scan failed | `terminal_redaction_failed` | — |
| `create` | 429 session cap | `terminal_max_sessions` | — |

The redact route has no audit reason on its three JSON refusals, so those are
named for what they are. Every prose string is unchanged.

**Only the JSON routes are in scope, and that is a deliberate boundary.** The
WebSocket upgrade, create's auth and enable guards, and delete all answer
`web.Response(status=..., text="Unauthorized")` — a plain-text contract with no
envelope to put a code in. Giving them one means changing their content type,
which is a different change from this one and not what the baseline counts. The
file therefore reaches `missing_code: 0` with 16 plain-text refusals still
plain text, on purpose.

**No frontend change is required, and that was verified rather than assumed.**
Both consumers discard the response body on failure:

- `CliPanel.tsx` (redact): `if (!res.ok) throw new Error(\`redact ${res.status}\`)`,
  caught into a local `'failed'` state. The body is never read.
- `TerminalCompletion.tsx` (complete):
  `if (!r.ok) throw new Error(\`terminal completion failed: ${r.status}\`)` —
  status only, with `retry: false`.

`/api/terminal/sessions` is not POSTed from the dashboard at all. So there is no
`res.error` render to move for these routes, and no consumer edit that would be
honest to include.

### Baseline

`missing_code` 1357 -> 1350 -- exactly the seven -- and the
`dashboard/handlers/terminal.py` entry is gone. `_compliant` moves
1189 -> 1196.

Rebased onto current `main` (which had moved to `missing_code: 1357`). The
baseline was **regenerated** from the live tree with the repo's own
`python test/test_error_code_contract.py --update`, never hand-merged: the
totals in this file are relative to this PR's base, so adding or reconciling
numbers across branches would be meaningless. Diffing the regenerated file
against `main`'s shows exactly one changed entry --
`dashboard/handlers/terminal.py`, removed -- and no other file added, removed,
or changed. `missing_code`, the number the gate enforces, moves by exactly
seven.

## Tests

`TestTerminalRefusalCodes` in `test/test_terminal_handler.py` — the existing
classes for these routes assert `resp.status` only, so none of them covered a
body:

| Test | Locks in |
|---|---|
| `test_create_refuses_over_the_session_cap_with_a_code` | `terminal_max_sessions` |
| `test_redact_refusals_are_coded` | `terminal_invalid_body`, `terminal_selection_too_large` |
| `test_a_failed_redaction_is_coded_and_still_fails_closed` | `terminal_redaction_failed` **and** that the selection does not come back in the 500 — this route exists to keep a credential out of the model's input, so its own failure must not put the text back |
| `test_complete_refusal_code_is_the_audited_reason` | for all three: `code == "terminal_" + the word the audit recorded`, asserted against the captured SEL call |
| `test_every_json_refusal_carries_a_code_and_its_prose` | per-file ratchet: no JSON path may regress to prose-only |

**Red before / green after:** on this branch the two terminal suites report
**56 failed / 297 passed**; with the handler change stashed, **56 failed / 290
passed** — the same 56, none of them touched by this diff. They are
pre-existing Windows failures in `TestResolveShell` and the PTY paths (no
`/bin/sh`, no `pty` module), unrelated to this contract; the delta is exactly
the 7 new passes. `test_error_code_contract.py` (the ratchet) passes.

`flake8` and `isort` clean; `scripts/check_black_formatting.py` passes on the 3
changed files. `terminal.py` is in `.github/black-baseline.txt`, so per
`AGENTS.md` it was deliberately **not** run through `black` — doing so rewrites
86 lines of untouched code and buries a 26-line change.

## Manual verification

N/A — unit coverage sufficient: the tests drive the real handlers, and no
rendered surface changes (both consumers were audited above and neither reads a
refusal body from these routes).

## Related Issues

No issue — this is the `dashboard/handlers/terminal.py` line item from
`error-code-baseline.json`'s own worklist ("drive `missing_code` to zero, one PR
per file or per directory, moving each frontend consumer in the same PR").

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


