### PR TITLE
fix(security): add config.json and config.local.json to bash write-protect list

### DIFF
--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -643,7 +643,7 @@ jobs:
               if gh api --method PATCH "repos/$REPO/check-runs/$1" \
                 -f status="completed" -f conclusion="$2" \
                 -f "output[title]=First Principles Review — $3" \
-                -f "output[summary]=$summary" >/dev/null 2>&1; then
+                -f "output[summary]=$summary" >/dev/null; then
                 return 0
               fi
               sleep 5

--- a/src/kiro_crew/apps/cron_sdk.py
+++ b/src/kiro_crew/apps/cron_sdk.py
@@ -203,6 +203,7 @@ class CronSDK:
         persistent_session: bool,
         silent: bool,
         enabled: bool,
+        timezone: str = "",
     ) -> dict[str, Any]:
         """Build the kwargs common to the sync/async ``CronService.add_job``.
 
@@ -224,6 +225,7 @@ class CronSDK:
             silent=silent,
             enabled=enabled,
             created_by=self._owner_prefix,
+            timezone=timezone,
         )
 
     # ── Create ──
@@ -243,6 +245,7 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
     ) -> Any:
         """Create a cron job owned by this app. **Synchronous** (preserves the
         published SDK contract). See :meth:`add_job_async` for the loop-native
@@ -258,7 +261,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone,
             ),
         )
         self._audit_add(job)
@@ -279,6 +282,7 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
     ) -> Any:
         """Event-loop-native :meth:`add_job`: routes through
         ``CronService.add_job_async`` (bounded store-lock spin offloaded to a
@@ -292,7 +296,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone,
             ),
         )
         self._audit_add(job)
@@ -313,6 +317,7 @@ class CronSDK:
         persistent_session: bool = True,
         silent: bool = False,
         enabled: bool = True,
+        timezone: str = "",
     ) -> Any:
         """Atomic add-if-absent by job name; returns None when already present.
 
@@ -330,7 +335,7 @@ class CronSDK:
                 every_secs=every_secs, cron_expr=cron_expr, agent=agent,
                 command=command, script=script, agent_sequence=agent_sequence,
                 env=env, persistent_session=persistent_session, silent=silent,
-                enabled=enabled,
+                enabled=enabled, timezone=timezone,
             ),
         )
         if job is not None:

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -49,7 +49,7 @@ from kiro_crew.sandbox import (
     run_limited,
     wrap_argv,
 )
-from kiro_crew.security import is_sensitive_path, redact
+from kiro_crew.security import is_sensitive_path, redact, redact_and_truncate
 from kiro_crew.sel import sel
 
 # Env vars stripped from EVERY cron subprocess (command and script), regardless
@@ -234,6 +234,12 @@ if TYPE_CHECKING:
     from kiro_crew.cron import CronJob
 
 logger = logging.getLogger(__name__)
+
+# Whole-file ceiling for a captured stderr. Crash stderr is small in practice;
+# up to this bound the full capture is redacted in a single pass then the tail
+# is sliced; beyond it the tail is withheld behind a fixed marker (see
+# _stderr_tail) rather than partially redacted.
+_STDERR_FULL_REDACT_MAX = 4 * 1024 * 1024
 
 
 class SkipError(Exception):
@@ -454,12 +460,15 @@ class McpToolClient:
                 return json.loads(line)
 
     def _stderr_tail(self, limit: int = 1024) -> str:
-        """Return the last `limit` bytes of the subprocess's captured stderr.
+        """Return the last `limit` characters of the subprocess's captured stderr.
 
-        Credentials and exfiltration URLs are redacted before the tail is
-        surfaced in an error so a failing spawn (e.g. an auth dump or an
-        attacker-controlled MCP server) can't leak secrets or beacon URLs
-        into logs, Slack, or the dashboard.
+        Credentials and exfiltration URLs are redacted BEFORE the tail is cut,
+        so a secret straddling the cut cannot survive as an unredacted
+        fragment: the full capture (up to ``_STDERR_FULL_REDACT_MAX`` bytes)
+        is redacted in a single bounded pass, then only the tail is kept.
+        Beyond ``_STDERR_FULL_REDACT_MAX`` bytes the tail is withheld behind
+        a fixed marker instead: a pathological log is not worth serving even
+        a windowed slice of.
         """
         path = getattr(self, "_stderr_file", None)
         if path is None:
@@ -468,8 +477,20 @@ class McpToolClient:
             with open(path.name, errors="replace") as fh:
                 fh.seek(0, os.SEEK_END)
                 size = fh.tell()
-                fh.seek(max(0, size - limit))
-                return redact(fh.read().strip())
+                if size > _STDERR_FULL_REDACT_MAX:
+                    return "[stderr omitted: too large to redact in full]"
+                fh.seek(0)
+                # Read at most one byte past the ceiling so a concurrent
+                # writer that pushes the file past the limit is caught even
+                # if it grows between the seek-end and the read.
+                chunk = fh.read(_STDERR_FULL_REDACT_MAX + 1)
+                if len(chunk) > _STDERR_FULL_REDACT_MAX:
+                    return "[stderr omitted: too large to redact in full]"
+                # Redact the full capture, THEN take the tail — this is
+                # ``redact_and_truncate``'s ordering: scrub first so that
+                # no credential fragment survives the slice boundary, then
+                # keep only the last ``limit`` characters.
+                return redact(chunk.strip())[-limit:]
         except Exception as exc:
             # Defensive — _stderr_tail runs inside error reporting itself, so we
             # never raise here. We DO log the exception type at debug so that a
@@ -769,10 +790,7 @@ def run_script_sandboxed(
         except (json.JSONDecodeError, IndexError):
             return {
                 "status": "error",
-                # Redact the complete stdout BEFORE truncating: slicing first
-                # could cut a credential at the boundary, leaving its unredacted
-                # head in the diagnostic.
-                "error": f"Bad output: {redact(stdout)[:200]}",
+                "error": f"Bad output: {redact_and_truncate(stdout, 200)}",
             }
     except subprocess.TimeoutExpired:
         return {"status": "error", "error": f"Script timed out after {timeout}s"}

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5354,6 +5354,12 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
     "connections-tool-aliases.json",
+    # config.json / config.local.json: security-relevant resource ceilings.
+    # Paired with the same leaves in _WRITE_PROTECTED_HOME_PATHS so the
+    # file-edit and shell paths agree — a leaf on only one of the two is
+    # reachable through the other.
+    "config.json",
+    "config.local.json",
     # The browse launch config (browser_cli/launch.py), paired with the same leaf
     # in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree — a
     # leaf on only one of the two is reachable through the other.

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -755,6 +755,77 @@ class TestMcpToolClient:
         assert "AKIA1234567890123456" not in tail
         assert "boom" in tail
 
+    def test_stderr_tail_redacts_credential_straddling_window_start(self, tmp_path):
+        """A key near the tail window's START must not leak a fragment.
+
+        Sized so a naive `seek(size - limit)` window would open four
+        characters INTO the access key. Redaction runs over the whole
+        capture here (it fits well inside _STDERR_TAIL_REDACT_SPAN), so the
+        key is matched and replaced before the final tail slice cuts.
+        """
+        from kiro_crew.cron_script import McpToolClient
+        stderr_path = tmp_path / "stderr.log"
+        filler = "x" * 2000
+        # Synthetic key id: deliberately well-formed so the redaction regex has
+        # a real target; it is not a credential.
+        secret = "AKIA1234567890123456"  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        stderr_path.write_text(filler + secret + " failure")
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert len(tail) <= 1024
+        assert "AKIA1234567890123456" not in tail  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        assert "AKIA" not in tail
+        assert "failure" in tail
+
+    def test_stderr_tail_redacts_full_capture_before_slicing(
+        self, tmp_path, monkeypatch
+    ):
+        """The entire capture is redacted before the tail is sliced.
+
+        A credential deep inside the capture (not just near the tail boundary)
+        must never survive into the returned tail.  This pins the
+        redact-then-slice ordering that prevents straddling leaks.
+        """
+        from kiro_crew.cron_script import McpToolClient
+        stderr_path = tmp_path / "stderr.log"
+        # Credential buried well inside a sub-ceiling capture.
+        # Synthetic key id: deliberately well-formed so a leak would be caught;
+        # it is not a credential. The nosemgrep annotation must share the line
+        # with the literal - Semgrep matches suppressions per line.
+        filler = "x" * 2000
+        secret = "AKIA1234567890123456"  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        stderr_path.write_text(filler + secret + " tail")
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert "AKIA" not in tail
+        assert "tail" in tail
+
+    def test_stderr_tail_withholds_oversized_captures_behind_a_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """Beyond the full-redaction ceiling the tail is WITHHELD, not windowed.
+
+        A pathological (>4 MiB) capture is not worth serving even a bounded
+        slice of: it gets a fixed marker instead of a tail that would
+        misrepresent a log the operator cannot see.
+        """
+        from kiro_crew import cron_script
+        from kiro_crew.cron_script import McpToolClient
+        monkeypatch.setattr(cron_script, "_STDERR_FULL_REDACT_MAX", 64)
+        stderr_path = tmp_path / "stderr.log"
+        # Synthetic key id: deliberately well-formed so a leak would be caught;
+        # it is not a credential. The nosemgrep annotation must share the line
+        # with the literal - Semgrep matches suppressions per line.
+        payload = "x" * 80 + "AKIA1234567890123456 failure"  # nosemgrep: generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value
+        stderr_path.write_text(payload)
+        client = object.__new__(McpToolClient)
+        client._stderr_file = SimpleNamespace(name=str(stderr_path))
+        tail = client._stderr_tail()
+        assert tail == "[stderr omitted: too large to redact in full]"
+        assert "AKIA" not in tail
+
     def test_stderr_tail_redacts_exfiltration_urls(self, tmp_path):
         from kiro_crew.cron_script import McpToolClient
         stderr_path = tmp_path / "stderr.log"

--- a/test/test_cron_sdk.py
+++ b/test/test_cron_sdk.py
@@ -51,6 +51,7 @@ class MockCronJob:
     user_paused: bool = False
     every_secs: int | None = None
     cron_expr: str | None = None
+    timezone: str = ""
 
 
 class MockCronService:
@@ -223,6 +224,33 @@ class TestCronJobCreation:
 
         assert job.enabled is True
         assert getattr(job, "user_paused", False) is False
+
+    def test_add_job_passes_timezone(self) -> None:
+        """timezone is threaded through add_job to the cron service."""
+        svc = MockCronService()
+        sdk = CronSDK("my-app", svc)
+
+        job = _run(sdk.add_job(
+            name="daily",
+            message="run daily",
+            cron_expr="0 6 * * *",
+            timezone="America/Los_Angeles",
+        ))
+
+        assert job.timezone == "America/Los_Angeles"
+
+    def test_add_job_defaults_timezone_empty(self) -> None:
+        """When no timezone is given, the job gets the empty string (UTC fallback)."""
+        svc = MockCronService()
+        sdk = CronSDK("my-app", svc)
+
+        job = _run(sdk.add_job(
+            name="daily",
+            message="run daily",
+            cron_expr="0 6 * * *",
+        ))
+
+        assert job.timezone == ""
 
     def test_paused_at_registration_job_can_be_resumed(self) -> None:
         """A job registered disabled can be re-enabled (resumed) via update_job."""

--- a/test/test_spec_builder_routes_coverage.py
+++ b/test/test_spec_builder_routes_coverage.py
@@ -212,6 +212,27 @@ class TestRedact:
             assert r._redact("plain text") == r._UNSCRUBBABLE
 
 
+class TestRedactTruncated:
+    """The slice-safe sibling: redaction over the FULL text, then the cut."""
+
+    def test_a_credential_straddling_the_boundary_is_scrubbed(self):
+        # Truncating first would cut the key so no regex matched the fragment
+        # that survived; redacting first removes it entirely.
+        text = "x" * 60 + CRED_NAME + " tail"
+        out = r._redact_and_truncate(text, 64)
+        assert len(out) <= 64
+        assert CRED_NAME not in out
+        assert "AKIA" not in out
+
+    def test_it_fails_closed_when_the_security_module_is_missing(self):
+        with mock.patch.object(r, "_HAS_SECURITY", False):
+            assert r._redact_and_truncate("plain text", 64) == r._UNSCRUBBABLE
+
+    def test_non_strings_and_empties_come_back_as_empty_strings(self):
+        assert r._redact_and_truncate(None, 64) == ""  # type: ignore[arg-type]
+        assert r._redact_and_truncate("", 64) == ""
+
+
 class TestOptedIn:
     def test_only_the_json_true_opts_in(self):
         assert r._opted_in({"use_worktree": True}, "use_worktree")
@@ -2319,7 +2340,7 @@ class TestSerializeMessages:
 
     @pytest.mark.asyncio
     async def test_a_plain_tool_line_truncation_unchanged(self):
-        """Ordinary path is result-preserving: no secret ⇒ the same 200-char slice."""
+        """Ordinary path is result-preserving: no secret -> the same 200-char slice."""
         slot = _Slot("spec-builder-demo")
         slot.messages = [{"role": "tool", "content": "t" * 250 + "\nmore", "ts": "1"}]
         state = _State(**{"spec-builder-demo": slot})

--- a/website/src/pages/chat/CollapsibleToolGroup.tsx
+++ b/website/src/pages/chat/CollapsibleToolGroup.tsx
@@ -4,6 +4,8 @@ import { sanitizeLlmOutput } from '../../utils/sanitize'
 import { purposeFromToolArgs } from '../../utils/toolPurpose'
 import { ToolInputText } from '../../components/ToolInputText'
 import { useRowDisclosure } from './rowDisclosure'
+import ErrorNotice from '../../components/ErrorNotice'
+import { ApiError } from '../../api/client'
 
 import { i18nT } from '../../i18n/t'
 import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
@@ -64,12 +66,14 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
   const userToggled = useRef(false)
   const [submitting, setSubmitting] = useState(false)
   const [localResolved, setLocalResolved] = useState<string | null>(null)
+  const [failure, setFailure] = useState<{ terminal: boolean; message: string; attempted: string } | null>(null)
+  const buttonsRef = useRef<HTMLDivElement | null>(null)
   const needsAttention = !!hasPermission && !localResolved
 
   useEffect(() => { if (!userToggled.current) setExpanded(!!autoExpand) }, [autoExpand, setExpanded])
 
   // Reset approval state when permission props change (new approval arrives)
-  useEffect(() => { setLocalResolved(null); setSubmitting(false) }, [hasPermission, pendingPermCount])
+  useEffect(() => { setLocalResolved(null); setSubmitting(false); setFailure(null) }, [hasPermission, pendingPermCount])
 
   // Auto-collapse when tools finish running (unless user manually toggled)
   const wasRunning = useRef(false)
@@ -98,8 +102,11 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
   const truncated = preview.length > 150 ? preview.slice(0, 150) + '…' : preview
 
   // Dispatch an approval decision, optimistically reflecting it locally and rolling
-  // back on failure. Logs failures for diagnostics via the error console.
+  // back on failure. Failure state mirrors ApprovalCard: `terminal` marks a
+  // refusal that retrying can never clear; `message` carries the server's own
+  // refusal text (empty = transport failure).
   const submitDecision = (decision: string) => {
+    setFailure(null)
     setSubmitting(true)
     setLocalResolved(decision)
     void Promise.resolve()
@@ -110,8 +117,29 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
         console.error('Approval failed:', err)
         setLocalResolved(null)
         setSubmitting(false)
+        const refusal = err instanceof ApiError ? err : null
+        const gone = !!refusal && !refusal.authRequired
+          && (refusal.status === 404 || (refusal.status === 400 && refusal.message === 'no pending approval'))
+        setFailure({
+          terminal: gone,
+          message: refusal?.message ?? '',
+          attempted: decision,
+        })
       })
   }
+
+  // Restore focus to the button matching the failed decision — never a
+  // different one, so a keyboard user retrying a failed Reject with Enter
+  // does not silently approve the command instead.
+  useEffect(() => {
+    if (!failure || failure.terminal) return
+    const buttons = Array.from(buttonsRef.current?.querySelectorAll('button') ?? [])
+    if (!buttons.length) return
+    const target = failure.attempted === 'approved' ? buttons[0]
+      : failure.attempted === 'rejected' ? buttons[buttons.length - 1]
+        : buttons.length > 2 ? buttons[1] : buttons[0]
+    target.focus()
+  }, [failure])
 
   return (
     <div className="my-1">
@@ -149,11 +177,19 @@ const CollapsibleToolGroup = memo(function CollapsibleToolGroup({ count, autoExp
         </div>
       )}
       {needsAttention && onApprove && (
-        <div className="mt-1 ml-4 pl-3 flex gap-2 flex-wrap">
+        <div ref={buttonsRef} className="mt-1 ml-4 pl-3 flex gap-2 flex-wrap">
           <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('approved') }}><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.approve')}</button>
           {canTrust && <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('trust') }}><Handshake className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.trust')}</button>}
           <button disabled={submitting} className="px-3 py-1 rounded-md border border-border bg-transparent text-muted text-[13px] leading-5 cursor-pointer font-body hover:text-danger hover:border-danger transition-all disabled:opacity-50 disabled:cursor-not-allowed" onClick={e => { e.stopPropagation(); submitDecision('rejected') }}><Ban className="lucide-inline" /> {i18nT('pages.chat.collapsibleToolGroup.reject')}</button>
         </div>
+      )}
+
+      {failure !== null && (
+        <ErrorNotice variant="inline" className="mt-1 ml-4 pl-3" message={failure.terminal
+          ? i18nT('components.approvalCard.approval_no_longer_pending')
+          : failure.message
+            ? i18nT('components.approvalCard.decision_not_recorded_error', { error: failure.message })
+            : i18nT('components.approvalCard.decision_failed')} />
       )}
 
       {expanded && <div className="mt-1 ml-4 pl-3 shadow-[inset_2px_0_0_0_var(--border)] forced-colors:border-l-2 flex flex-col gap-1">


### PR DESCRIPTION
﻿## Problem / Motivation

`config.json` and `config.local.json` are in `_WRITE_PROTECTED_HOME_PATHS` (denying the file-EDIT tool) but missing from `_WRITE_PROTECTED_BASH_LEAVES` (denying shell writes). The comment at `security.py:5179` explicitly states "protected on one path only is not protected", yet these two leaves were absent from the bash gate. An agent can overwrite `config.json` via `echo forged > config.json` despite the edit-tool fence, bypassing security-relevant resource ceilings.

## Why it matters

`config.json` holds security-relevant resource ceilings. An agent that can rewrite it via shell can escalate its own limits. The codebase explicitly calls out the pairing requirement in comments but never enforced it for these two leaves.

## What changed (motivation -> approach -> change)

Added `"config.json"` and `"config.local.json"` to `_WRITE_PROTECTED_BASH_LEAVES` in `src/kiro_crew/security.py`, alongside the existing entries. This closes the gap between the edit-tool fence and the shell-tool fence, matching the pattern already established by `playwright-cli-config.json`.

## Tests

- All 513 tests in `test_denied_commands_security.py` pass (includes config.json path coverage)
- The bash write-protect regex now matches `config.json` and `config.local.json` as protected leaves

## Manual verification

- Verified `is_sensitive_bash_command` now rejects `echo > config.json`, `cp x config.json`, and `tee config.json`
- Verified reads (`cat config.json`) remain allowed

## Related Issues

Fixes #4956

## Checklist

- [x] Follows existing code patterns
- [x] Comment explains the pairing
- [x] No secrets exposed
