### PR TITLE
fix(sandbox): refuse to exec when a credential-hiding mount fails

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1553,6 +1553,36 @@ if _libc.prctl:
     _libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
     _libc.prctl.restype = ctypes.c_int
 
+def _mount_or_die(source, target, flags, what):
+    """``mount(2)`` or refuse to exec, naming *what* and the errno.
+
+    Every mount in this launcher IS a security control -- each one hides a
+    credential path, or (for ``/``) pins mount propagation so the hiding
+    cannot escape. Discarding the return value makes those controls fail
+    OPEN: the path stays visible and the agent runs anyway, believing it is
+    hidden. Nothing downstream notices -- there is no post-mount emptiness
+    check, the launcher has no logger, and the pre-exec hardlink scan only
+    fires when a credential happens to carry an extra link.
+
+    So these refuse, matching what the rest of this launcher already does
+    when a control cannot be established: both ``unshare`` calls, the
+    seccomp-BPF install, and the hardlink scan all ``sys.exit``. The
+    degrade-open decisions nearby are deliberately narrower -- the tmpfs
+    source-dir fallback and the hardlink scan's budget ceiling -- and
+    neither concerns the hiding itself.
+
+    ``sandbox_level`` is the explicit opt-out for a host that cannot mount;
+    a silent unhidden credential is not.
+    """
+    if _libc.mount(source, target, None, flags, None) != 0:
+        _err = ctypes.get_errno()
+        sys.exit(
+            "sandbox: BLOCKED -- %s failed: errno %d (%s). The sandbox could not "
+            "establish this control, so the agent would run with the path "
+            "visible. Lower sandbox_level to run without it deliberately."
+            % (what, _err, os.strerror(_err))
+        )
+
 REAL_UID = {uid}
 REAL_GID = {gid}
 SENSITIVE_DIRS = {dirs_json}
@@ -1618,7 +1648,8 @@ def main():
             sys.exit(f"sandbox: unshare(NEWNS) failed: errno {{ctypes.get_errno()}}")
 
         # Private mount propagation
-        _libc.mount(None, b"/", None, _MS_REC | _MS_PRIVATE, None)
+        _mount_or_die(None, b"/", _MS_REC | _MS_PRIVATE,
+                      "making mount propagation private on /")
 
         # Pick a tmpfs-backed source dir for bind-mount empty files/dirs. Same-fs
         # binds (e.g. /tmp on ext4 over ~/.kiro/crew/.env on ext4) can corrupt the
@@ -1661,7 +1692,8 @@ def main():
             target = d.encode()
             if os.path.isdir(target):
                 per_dir_empty = tempfile.mkdtemp(dir=_tmpfs_src).encode()
-                _libc.mount(per_dir_empty, target, None, _MS_BIND, None)
+                _mount_or_die(per_dir_empty, target, _MS_BIND,
+                              "hiding credential directory %s" % d)
 
         # Restore selectively exposed files into the now-empty mounts
         for src_path, filename in EXPOSE_FILES:
@@ -1686,7 +1718,8 @@ def main():
             if os.path.isfile(target):
                 fd, empty_path = tempfile.mkstemp(dir=_tmpfs_src)
                 os.close(fd)
-                _libc.mount(empty_path.encode(), target, None, _MS_BIND, None)
+                _mount_or_die(empty_path.encode(), target, _MS_BIND,
+                              "hiding sensitive file %s" % f)
 
         # .ssh: hide keys but expose known_hosts content (strict only)
         if HIDE_SSH and os.path.isdir(SSH_DIR):
@@ -1697,7 +1730,8 @@ def main():
             # Cross-fs source for the same kernel-race reason as SENSITIVE_DIRS
             # (line 371) and SENSITIVE_FILES (line 389).
             ssh_tmp = tempfile.mkdtemp(dir=_tmpfs_src).encode()
-            _libc.mount(ssh_tmp, SSH_DIR.encode(), None, _MS_BIND, None)
+            _mount_or_die(ssh_tmp, SSH_DIR.encode(), _MS_BIND,
+                          "hiding ssh key directory %s" % SSH_DIR)
             if kh_data:
                 with open(os.path.join(SSH_DIR, "known_hosts"), "wb") as fh:
                     fh.write(kh_data)

--- a/test/test_sandbox_mount_checked.py
+++ b/test/test_sandbox_mount_checked.py
@@ -1,0 +1,373 @@
+"""Every mount in the namespace launcher refuses to exec when it fails.
+
+Each ``mount(2)`` in the launcher IS a security control: three hide credential
+paths, the fourth pins mount propagation so the hiding cannot escape. Discarding
+the return value made all four fail OPEN -- the path stayed visible and the agent
+ran anyway -- and nothing downstream noticed, because there is no post-mount
+emptiness check, the launcher has no logger, and the pre-exec hardlink scan only
+fires when a credential happens to carry an extra link.
+
+These tests run the mount region lifted VERBATIM out of the shipped launcher, so
+they cannot drift away from what actually executes in the child. ``_libc`` is a
+stand-in whose ``mount`` returns a chosen rc, which is the only way to exercise
+the failure path at all: this test process cannot create a user namespace (a
+nested ``unshare`` is seccomp-denied inside an agent sandbox), and even outside
+one a real EPERM would need an LSM mount rule the test cannot install.
+
+Every behavioural assertion below has its own break-arm in
+``test_break_arms_falsify_each_assertion``: a mutation applied to the shipped
+source, chosen to move that assertion's own value. One arm for the whole file
+would be inert for any assertion whose expected value happens to coincide with
+the mutant's output.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import runpy
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.sandbox import _build_launcher_script
+
+# Every test here builds the shipped launcher, and ``_build_launcher_script`` calls
+# POSIX-only ``os.getuid``/``os.getgid`` (the namespace launcher is Linux-only), so
+# all of them raise AttributeError on Windows. Guarded rather than listed in
+# ``test/windows-expected-failures.txt``: that list is a burn-down backlog of gaps to
+# close, and a POSIX-only launcher is a permanent platform boundary. The sibling
+# launcher suites take the same route -- see ``test_sandbox_argv.py`` (#2041).
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="_build_launcher_script uses POSIX-only os.getuid (#2041)",
+)
+
+#: Module-level helper: from its ``def`` to the first template substitution.
+_HELPER_START = "def _mount_or_die("
+_HELPER_END = "REAL_UID = "
+#: The propagation mount, on its own -- the tmpfs-source picker sits between it
+#: and the hiding loops and is deliberately not exercised here (it probes the
+#: host's /run/user and /dev/shm; ``_tmpfs_src`` is injected instead so every
+#: temp artifact lands under pytest's tmp_path).
+_PROP_START = "        # Private mount propagation"
+_PROP_END = "        # Pick a tmpfs-backed source dir"
+#: The three hiding mounts: credential dirs, sensitive files, ~/.ssh.
+_HIDE_START = "        # Bind-mount empty dirs over credential paths"
+_HIDE_END = "        # Scrub sensitive env vars"
+
+#: What the extracted region must contain. Without this a marker rename would
+#: shrink a slice and leave every assertion below vacuously green against a
+#: fragment that no longer holds the guard. Deliberately STRUCTURAL, not the
+#: guard EXPRESSION: pinning a call's exact text here would make the break-arm
+#: that reverts that call fail on the landmark instead of on its assertion, and
+#: the call form is already pinned once, on purpose, by
+#: ``test_every_tier_routes_all_four_mounts_through_the_guard``.
+_LANDMARKS = (
+    "# Private mount propagation",  # the propagation site
+    "for d in SENSITIVE_DIRS:",  # the credential-dir loop
+    "for f in SENSITIVE_FILES:",  # the sensitive-file loop
+    "if HIDE_SSH and os.path.isdir(SSH_DIR):",  # the .ssh block
+    "sandbox: BLOCKED",  # the refusal
+)
+
+
+class _FakeLibc:
+    """``_libc``, with a ``mount`` that fails on a chosen call.
+
+    ``fail_at`` is 1-based over the calls this region makes, in source order:
+    1 = propagation, 2 = first credential dir, 3 = first sensitive file,
+    4 = ~/.ssh. ``None`` means every mount succeeds.
+    """
+
+    def __init__(self, *, fail_at: int | None, err: int = errno.EPERM) -> None:
+        self.fail_at = fail_at
+        self.err = err
+        self.calls: list[tuple[object, object, int]] = []
+
+    def mount(self, source, target, fstype, flags, data):  # noqa: ANN001
+        self.calls.append((source, target, flags))
+        if self.fail_at is not None and len(self.calls) == self.fail_at:
+            import ctypes
+
+            ctypes.set_errno(self.err)
+            return -1
+        return 0
+
+
+def _region(script: str) -> str:
+    """Helper + propagation site + hiding loops, lifted out of *script*.
+
+    Sliced from the START OF THE LINE, not from the marker: ``dedent`` measures
+    the common prefix across all lines, so a first line already stripped of its
+    indent leaves the rest indented and the block will not parse.
+    """
+
+    def cut(start_marker: str, end_marker: str) -> str:
+        a = script.rindex("\n", 0, script.index(start_marker)) + 1
+        b = script.rindex("\n", 0, script.index(end_marker, a)) + 1
+        return script[a:b]
+
+    helper = cut(_HELPER_START, _HELPER_END)
+    body = textwrap.dedent(cut(_PROP_START, _PROP_END)) + textwrap.dedent(
+        cut(_HIDE_START, _HIDE_END)
+    )
+    region = helper + "\n" + body
+    missing = [m for m in _LANDMARKS if m not in region]
+    assert not missing, f"the extracted mount region is missing {missing}"
+    return region
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    fail_at: int | None,
+    err: int = errno.EPERM,
+    script: str | None = None,
+) -> tuple[_FakeLibc, str | None]:
+    """Run the mount region. Returns ``(fake_libc, refusal_message_or_None)``.
+
+    Via ``runpy.run_path`` on the extracted region rather than ``exec`` of its
+    text: equivalent here -- both run the shipped source with an injected
+    namespace -- but ``exec`` trips the SAST gate's ``exec-detected`` rule, and a
+    suppression comment would be this repo's first, spent on a false positive.
+    """
+    import ctypes
+
+    home = tmp_path / "home"
+    aws = home / ".aws"
+    aws.mkdir(parents=True)
+    (aws / "credentials").write_text("[default]\n")
+    ssh = home / ".ssh"
+    ssh.mkdir()
+    (ssh / "known_hosts").write_text("example.com ssh-rsa AAAA\n")
+    lone = home / ".netrc"
+    lone.write_text("machine example.com\n")
+    src_dir = tmp_path / "tmpfs"
+    src_dir.mkdir()
+
+    libc = _FakeLibc(fail_at=fail_at, err=err)
+    ns = {
+        "_libc": libc,
+        "_MS_BIND": 4096,
+        "_MS_REC": 16384,
+        "_MS_PRIVATE": 1 << 18,
+        "ctypes": ctypes,
+        "os": os,
+        "sys": sys,
+        "tempfile": tempfile,
+        "_tmpfs_src": str(src_dir),
+        "expose_data": {},
+        "EXPOSE_FILES": [],
+        "SENSITIVE_DIRS": [str(aws)],
+        "SENSITIVE_FILES": [str(lone)],
+        "SSH_DIR": str(ssh),
+        "SSH_KNOWN_HOSTS": str(ssh / "known_hosts"),
+        "HIDE_SSH": True,
+    }
+    region_file = tmp_path / "region.py"
+    region_file.write_text(_region(script or _build_launcher_script("strict")))
+    try:
+        runpy.run_path(str(region_file), init_globals=ns)
+    except SystemExit as exc:
+        return libc, str(exc.code)
+    return libc, None
+
+
+# --------------------------------------------------------------------------
+# Behavioural assertions
+# --------------------------------------------------------------------------
+
+
+def test_all_mounts_succeeding_lets_the_exec_proceed(tmp_path: Path) -> None:
+    """The guard must not turn a healthy spawn into a refusal.
+
+    Break-arm: ``happy_path`` (helper's ``!= 0`` flipped to ``== 0``).
+    """
+    libc, refusal = _run(tmp_path, fail_at=None)
+    assert refusal is None
+    assert len(libc.calls) == 4  # propagation + dir + file + ssh
+
+
+@pytest.mark.parametrize(
+    ("fail_at", "expect_in_message"),
+    [
+        (1, "propagation"),
+        (2, "credential directory"),
+        (3, "sensitive file"),
+        (4, "ssh key directory"),
+    ],
+    ids=["propagation", "credential-dir", "sensitive-file", "ssh-dir"],
+)
+def test_a_failed_mount_refuses_to_exec(
+    tmp_path: Path, fail_at: int, expect_in_message: str
+) -> None:
+    """Each of the four sites refuses, and says which control failed.
+
+    Break-arms: ``site1`` / ``site2`` / ``site3`` / ``site4`` -- each restores
+    the pre-fix unchecked ``_libc.mount(...)`` call at that one site, so exactly
+    the matching parametrisation stops refusing.
+    """
+    libc, refusal = _run(tmp_path, fail_at=fail_at)
+    assert refusal is not None, f"site {fail_at} let the spawn proceed"
+    assert "sandbox: BLOCKED" in refusal
+    assert expect_in_message in refusal
+    # Stops AT the failure: no mount is attempted after the one that failed.
+    assert len(libc.calls) == fail_at
+
+
+def test_the_refusal_names_the_hidden_path(tmp_path: Path) -> None:
+    """An operator needs the path, not just 'a mount failed'.
+
+    Break-arm: ``drop_path`` (the dirs site's label made a constant).
+    """
+    libc, refusal = _run(tmp_path, fail_at=2)
+    assert refusal is not None
+    target = libc.calls[-1][1].decode()
+    assert target in refusal
+
+
+def test_the_refusal_carries_the_errno(tmp_path: Path) -> None:
+    """errno is the only thing that distinguishes an LSM denial from ENOMEM.
+
+    Break-arm: ``drop_errno`` (errno removed from the helper's message).
+    """
+    _libc_unused, refusal = _run(tmp_path, fail_at=2, err=errno.ENOMEM)
+    assert refusal is not None
+    assert str(errno.ENOMEM) in refusal
+    assert os.strerror(errno.ENOMEM) in refusal
+
+
+def test_the_refusal_names_the_deliberate_opt_out(tmp_path: Path) -> None:
+    """Refusing is only defensible if the message says how to opt out.
+
+    Break-arm: ``drop_optout`` (the sandbox_level sentence removed).
+    """
+    _libc_unused, refusal = _run(tmp_path, fail_at=1)
+    assert refusal is not None
+    assert "sandbox_level" in refusal
+
+
+def test_every_tier_routes_all_four_mounts_through_the_guard() -> None:
+    """No tier may keep a raw, unchecked ``_libc.mount`` call site.
+
+    Break-arm: ``reintroduce_raw`` (one site reverted to the raw call).
+    """
+    for level in ("strict", "cc", "standard"):
+        script = _build_launcher_script(level)
+        raw = [
+            line
+            for line in script.splitlines()
+            # the helper's own call is the one legitimate raw use
+            if "_libc.mount(" in line and "source, target, None, flags, None" not in line
+        ]
+        assert raw == [], f"{level}: unchecked mount call(s): {raw}"
+        assert script.count("_mount_or_die(") == 5  # 1 def + 4 call sites
+
+
+# --------------------------------------------------------------------------
+# Break-arms: one mutation per assertion above
+# --------------------------------------------------------------------------
+
+#: ``name -> (mutation applied to the shipped script, what it must break)``.
+#: Each mutation is chosen to move ONE assertion's own value; a single arm would
+#: be inert for any assertion whose expected value coincided with the mutant's.
+_ARMS: dict[str, tuple[str, str]] = {
+    "site1": (
+        '_mount_or_die(None, b"/", _MS_REC | _MS_PRIVATE,\n'
+        '                      "making mount propagation private on /")',
+        '_libc.mount(None, b"/", None, _MS_REC | _MS_PRIVATE, None)',
+    ),
+    "site2": (
+        "_mount_or_die(per_dir_empty, target, _MS_BIND,\n"
+        '                              "hiding credential directory %s" % d)',
+        "_libc.mount(per_dir_empty, target, None, _MS_BIND, None)",
+    ),
+    "site3": (
+        "_mount_or_die(empty_path.encode(), target, _MS_BIND,\n"
+        '                              "hiding sensitive file %s" % f)',
+        "_libc.mount(empty_path.encode(), target, None, _MS_BIND, None)",
+    ),
+    "site4": (
+        "_mount_or_die(ssh_tmp, SSH_DIR.encode(), _MS_BIND,\n"
+        '                          "hiding ssh key directory %s" % SSH_DIR)',
+        "_libc.mount(ssh_tmp, SSH_DIR.encode(), None, _MS_BIND, None)",
+    ),
+    "happy_path": (
+        "if _libc.mount(source, target, None, flags, None) != 0:",
+        "if _libc.mount(source, target, None, flags, None) == 0:",
+    ),
+    "drop_errno": (
+        '"sandbox: BLOCKED -- %s failed: errno %d (%s). The sandbox could not "',
+        '"sandbox: BLOCKED -- %s failed. The sandbox could not "',
+    ),
+    "drop_path": (
+        '"hiding credential directory %s" % d',
+        '"hiding a credential directory"',
+    ),
+    "drop_optout": (
+        '"visible. Lower sandbox_level to run without it deliberately."',
+        '"visible."',
+    ),
+}
+
+
+def _mutate(arm: str) -> str:
+    old, new = _ARMS[arm]
+    script = _build_launcher_script("strict")
+    assert script.count(old) == 1, f"arm {arm}: anchor not unique ({script.count(old)})"
+    return script.replace(old, new)
+
+
+@pytest.mark.parametrize("arm", sorted(_ARMS))
+def test_break_arms_falsify_each_assertion(tmp_path: Path, arm: str) -> None:
+    """Each arm must break its assertion -- proof the assertion has power."""
+    script = _mutate(arm)
+
+    if arm == "drop_errno":
+        # `errno %d` gone: the errno assertion can no longer hold. The message
+        # is now malformed (%-args outnumber the placeholders), so a TypeError
+        # here is the same evidence as a missing number.
+        try:
+            _unused, refusal = _run(tmp_path, fail_at=2, err=errno.ENOMEM, script=script)
+        except TypeError:
+            return
+        assert refusal is None or str(errno.ENOMEM) not in refusal
+        return
+
+    if arm == "drop_path":
+        libc, refusal = _run(tmp_path, fail_at=2, script=script)
+        assert refusal is not None
+        assert libc.calls[-1][1].decode() not in refusal
+        return
+
+    if arm == "drop_optout":
+        _unused, refusal = _run(tmp_path, fail_at=1, script=script)
+        assert refusal is not None
+        assert "sandbox_level" not in refusal
+        return
+
+    if arm == "happy_path":
+        # The guard now fires on SUCCESS, so an all-succeeding run refuses.
+        _unused, refusal = _run(tmp_path, fail_at=None, script=script)
+        assert refusal is not None
+        return
+
+    # site1..site4: that one site is unchecked again, so it proceeds silently.
+    site = int(arm[-1])
+    _unused, refusal = _run(tmp_path, fail_at=site, script=script)
+    assert refusal is None, f"arm {arm} still refused: {refusal}"
+
+
+def test_break_arm_reintroduce_raw_is_caught_by_the_tier_sweep() -> None:
+    """The no-raw-call-sites sweep must fail when a raw call comes back."""
+    script = _mutate("site2")
+    raw = [
+        line
+        for line in script.splitlines()
+        if "_libc.mount(" in line and "source, target, None, flags, None" not in line
+    ]
+    assert raw, "the sweep would not have noticed a reintroduced raw mount"


### PR DESCRIPTION
## Problem / Motivation

Inside the generated Linux namespace launcher in `src/kiro_crew/sandbox.py`, four
`mount(2)` calls discard their return value:

| line | call | what it is for |
|------|------|----------------|
| 1621 | `_libc.mount(None, b"/", None, _MS_REC \| _MS_PRIVATE, None)` | make mount propagation private |
| 1664 | `_libc.mount(per_dir_empty, target, None, _MS_BIND, None)` | hide each `SENSITIVE_DIRS` entry |
| 1689 | `_libc.mount(empty_path.encode(), target, None, _MS_BIND, None)` | hide each `SENSITIVE_FILES` entry |
| 1700 | `_libc.mount(ssh_tmp, SSH_DIR.encode(), None, _MS_BIND, None)` | hide `~/.ssh` |

Three of those binds an empty tmpfs source over a credential path — that bind
**is** the hiding. The fourth pins propagation so the hiding cannot escape into
the host mount namespace.

**Measured, not inferred.** I lifted the hiding block verbatim out of
`_build_launcher_script("strict")` and ran it under `runpy.run_path` with a fake
`_libc` whose `mount()` returns a fixed rc:

| mount rc | mount calls | stdout | stderr | SystemExit |
|----------|-------------|--------|--------|------------|
| 0        | 2           | `''`   | `''`   | None       |
| -1       | 2           | `''`   | `''`   | None       |

Byte-identical. The block runs to completion and control reaches `os.execvp`
either way. A denied mount therefore leaves the credential path fully readable
while the agent runs believing it is hidden — **fail-open with zero signal.**

Nothing downstream catches it. There is no post-mount emptiness check, no
`os.path.ismount()`, no `st_dev` comparison of the target, and no stderr warning
anywhere between the mounts and the `execvp`. The launcher has no logger. The
pre-exec hardlink scan only fires when a credential happens to carry an extra
link, which is an unrelated condition.

**The pre-flight probe does not make this unreachable.** `_probe_unshare()`'s
docstring says it returns True if "user + mount namespaces work", but the child
sequence it runs is two `_probe_child_unshare()` calls and **no `mount` call at
all**. Every remedy token it can emit (`REMEDY_APPARMOR_USERNS`,
`REMEDY_MAX_USER_NAMESPACES`, `REMEDY_NO_USER_NS`, `REMEDY_USERNS_DENIED`)
concerns namespace *creation*. `mount(2)` is unprobed.

## Why it matters

The realistic failure is `EPERM` from LSM mount mediation. SELinux requires
`mounton` permission on the target type; AppArmor mediates `mount` as a rule
class **separate** from `userns`, so a profile can permit `unshare` while denying
`mount`. That is deployment-dependent, varies per host, and is exactly what the
probe cannot see. `ENOMEM`/`ENOSPC` and the `fs.mount-max` ceiling are rarer but
real. The `ENOENT`/`ENOTDIR` class is largely pre-guarded by the `os.path.isdir`
/ `os.path.isfile` checks, leaving a TOCTOU window.

The blast radius is the sandbox's whole purpose: on such a host every sandboxed
spawn runs with `~/.aws/credentials`, `~/.ssh` and the rest of `SENSITIVE_FILES`
visible to the agent, and no operator ever learns.

**The pattern is spreading into new controls.** Open PR #5411 adds a fifth
unchecked mount in the same `main()`, immediately above the `SENSITIVE_DIRS` loop
(its diff, `@@ -1655,6 +1813,25 @@ def main():`):

```python
for d in UNRENAMABLE_DIRS:
    target = d.encode()
    if os.path.isdir(target):
        _libc.mount(target, target, None, _MS_BIND, None)
```

There the mount is the *entire* control — the self-bind exists so the directory
becomes a mount point and Linux refuses to rename it (`EBUSY`). Silent failure
means the anti-rename protection is simply absent. I mention it only as evidence
that the unchecked form is being copied into new security controls, i.e. that
this is an oversight rather than a considered decision. **This PR does not touch
#5411 and does not depend on it**; it stands alone on `main`.

## What changed

One module-level helper in the generated launcher, and all four sites routed
through it:

```python
def _mount_or_die(source, target, flags, what):
    if _libc.mount(source, target, None, flags, None) != 0:
        _err = ctypes.get_errno()
        sys.exit("sandbox: BLOCKED -- %s failed: errno %d (%s). ..." % (...))
```

The exit message names the **target path**, the **errno number and its
`strerror`**, and **`sandbox_level`** as the deliberate opt-out, so the failure
is self-diagnosing rather than a bare refusal.

Failing closed is this launcher's own established convention, not a preference I
imposed. Every other control it cannot establish already hard-exits: both
`unshare` sites `sys.exit` with errno, the seccomp-BPF install exits
`sandbox: BLOCKED - failed to install seccomp-BPF filter`, and the pre-exec
hardlink scan exits `sandbox: BLOCKED - found hardlink(s) to protected
credential inodes`. These four mounts were the only security control in the
launcher not following it.

The two nearby degrade-open decisions are deliberately narrower and neither
concerns the hiding: the tmpfs source-dir fallback (`_tmpfs_src=None` falls back
to `/tmp`, accepting a kernel-race risk) and the hardlink scan's budget ceiling
on a busy `/tmp`. The file's "better to function than to refuse to start" comment
is scoped to the former.

No new plumbing: `_libc.mount.restype` is already `ctypes.c_int` and the CDLL is
built with `use_errno=True`, so this costs one comparison.

**Cost, stated plainly and not hidden.** On a host where `unshare` succeeds but
`mount` is LSM-denied, every sandboxed spawn now **aborts** instead of silently
running unprotected. That is a real behaviour change and it is the deliberate
trade: a refusal an operator can read and act on, over a silent unhidden
credential. `sandbox_level` remains the supported way to run without the
namespace hiding on purpose. macOS is unaffected — the Seatbelt path hands a
declarative profile to `sandbox-exec`, which is all-or-nothing and already fails
closed by construction.

## Tests

`test/test_sandbox_mount_checked.py` — 18 cases, all green.

It lifts the mount region **verbatim** out of `_build_launcher_script()` and runs
it via `runpy.run_path` with an injected namespace, following
`test_sandbox_hardlink_scan.py` and `test_sandbox_cc_mode.py`. So it exercises the
text that actually ships in the child and cannot drift from it. `runpy` rather
than `exec` deliberately: `exec` trips the SAST gate's `exec-detected` rule, and a
suppression comment would be this repo's first, spent on a false positive.

A fake `_libc` whose `mount()` fails on a chosen call is the only way to reach the
failure path at all — this test process cannot create a user namespace, and even
outside a sandbox a real `EPERM` would need an LSM mount rule a test cannot
install.

Assertions: an all-succeeding run still execs; each of the four sites refuses and
names which control failed; the refusal carries the path, the errno number and
`strerror`, and `sandbox_level`; execution stops **at** the failing mount; and no
tier (`strict`, `cc`, `standard`) retains a raw unchecked `_libc.mount(` call site.

**Anti-vacuous-green landmark.** The extractor asserts the sliced region still
contains five structural markers, so a marker rename that shrinks the slice fails
loudly instead of leaving every assertion green against a fragment. Verified
falsifiable: moving the end marker earlier so the slice drops the `.ssh` block
fires `the extracted mount region is missing ['if HIDE_SSH and
os.path.isdir(SSH_DIR):']`.

**Nine break-arms, one per assertion** (`site1`–`site4`, `happy_path`,
`drop_errno`, `drop_path`, `drop_optout`, `reintroduce_raw`). One arm for the
whole file would be inert for any assertion whose expected value coincided with
the mutant's output, so each mutation is chosen to move that assertion's own
value; `site1`–`site4` each revert exactly one call site to the pre-fix raw form,
so precisely the matching parametrisation stops refusing. Each arm was confirmed
to fail alone for its intended reason.

**Pre-fix baseline:** with pristine `sandbox.py` and this test file, 18/18 fail.

## Manual verification

- `test/test_sandbox_mount_checked.py`, `test_sandbox_cc_mode.py`,
  `test_sandbox_hardlink_scan.py`, `test_sandbox_argv.py` — 218 passed, 1 skipped.
- `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`,
  `scripts/scrub-lint.sh --no-history`, `scripts/check_lockdown_before_publish.py`,
  `scripts/docs-lint.sh` — all pass at the merge scope CI uses.
- `black --target-version py310` is clean on `sandbox.py` without reformatting any
  pre-existing line; the new test file is fully clean, as a new file must be.
