### PR TITLE
fix(browser): keep generated sessions reachable after scratch cleanup

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -149,6 +149,46 @@ system prompt states only the loop and the ref rule. The verbs:
 
 Sessions are selected with `-s=<name>` on any command.
 
+### Generated session reachability
+
+Each agent process receives a generated `PLAYWRIGHT_CLI_SESSION`
+(`kc-<random>`). For generated sessions only, `PWTEST_SOCKETS_DIR` and
+`PWTEST_DAEMON_SESSION_DIR` point at separate short namespaces under
+`<data-home>/pw/<8hex>/s` and `/d`. A `playwright-cli list` in one agent
+therefore cannot enumerate peer chat families. Operator-configured PWTEST roots
+are treated as base directories and receive the same generated-session
+namespace. Relative configured roots are rejected because the gateway and agent
+working directories can differ. Operator-provided non-`kc-` session names
+preserve their complete existing Playwright environment and are not redirected.
+
+Keeping both locations outside scratch means a daemon remains reachable after
+its agent process or scratch directory is gone. Operator cleanup supplies the
+generated session's `/s` and `/d` paths with the corresponding PWTEST variables
+and then uses the ordinary `playwright-cli -s=<name> close` protocol. Kiro Crew
+does not execute the CLI, connect to the socket, or
+signal a process automatically: proving cross-process ownership and complete
+agent-tree quiescence is not possible from agent-writable filesystem state on
+all supported platforms. Crash orphan reclamation therefore remains open under
+#5986; this change removes the permanent-unreachability root cause and enables
+operator-controlled cleanup without adding unattended close authority.
+
+The generated socket root is rejected when its worst-case AF_UNIX path exceeds
+the upstream 103-byte budget. Before either variable is injected, the installed
+`@playwright/cli` package resolved from the active launcher is checked through
+the same package anchor as browser revision detection (a stale standalone
+fallback is never accepted), and its serving `playwright-core` sources must
+contain both hooks on their execution paths (`process.env.PWTEST_SOCKETS_DIR ||`
+and `process.env.PWTEST_DAEMON_SESSION_DIR`). A future upstream
+rename/removal therefore logs a warning and fails back instead of silently
+returning sockets to scratch. The source verdict is cached by path, mtime, and
+size so an upgrade invalidates it.
+
+Kiro-Crew-owned lifecycle directories are created
+owner-only and then restricted with the fail-loud platform helper before their
+environment variables are exported. A crash can leave a small per-session
+registry/socket namespace behind; safe connect-test-then-prune remains part of
+#5986 rather than adding unattended deletion authority in this partial fix.
+
 ### Auth
 
 Two paths, chosen by whose browser holds the session.

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -109,7 +109,7 @@ from kiro_crew.acp.types import (
     TurnUsage,
 )
 from kiro_crew.agent import ensure_agent_materialized
-from kiro_crew.browser_cli.launch import browser_session_env
+from kiro_crew.browser_cli.launch import browser_session_env, browser_socket_env
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import (
     COMPACT_WAIT_TIMEOUT_SECS,
@@ -2798,7 +2798,11 @@ class AcpClient:
         # Own browser session per agent process: the CLI resolves a nameless
         # command to one shared ``default`` browser, so without this two agents
         # navigate and close each other's pages (see browser_session_env).
-        env.update(browser_session_env(env))
+        browser_env = browser_session_env(env)
+        env.update(browser_env)
+        if browser_env:
+            lifecycle_env = {**os.environ, **browser_env}
+            env.update(await self._to_thread_guarding_sandbox(browser_socket_env, lifecycle_env))
         # Per-process scratch containment (#5063) -- see acp/runtime.py's
         # twin block. Allocated off-loop, fail-open; owner recorded after
         # spawn; reclamation is liveness-keyed, never age-keyed.

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -92,7 +92,7 @@ from kiro_crew.acp.types import (
     JsonRpcRequest,
 )
 from kiro_crew.agent import ensure_agent_materialized
-from kiro_crew.browser_cli.launch import browser_session_env
+from kiro_crew.browser_cli.launch import browser_session_env, browser_socket_env
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
@@ -1054,7 +1054,15 @@ class AcpRuntime:
         # one run-scoped process. What this buys is isolation BETWEEN families,
         # which is where the reported corruption came from. The docs tell an
         # agent sharing a process with a concurrent browser user to pass -s=.
-        env.update(browser_session_env(env))
+        browser_env = browser_session_env(env)
+        env.update(browser_env)
+        if browser_env:
+            lifecycle_env = {**os.environ, **browser_env}
+            env.update(
+                await self._to_thread_guarding_sandbox(
+                    browser_socket_env, lifecycle_env
+                )
+            )
         # Per-process scratch containment (#5063): the agent's temp AND its
         # prompt-guided work products land in an owned directory instead of
         # the shared system temp dir. Allocated off-loop (mkdir + config read)

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -27,6 +27,7 @@ import os
 import re
 import subprocess
 from collections.abc import Callable
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -298,6 +299,62 @@ def _cli_package_dirs() -> list[Path]:
         if package.is_dir():
             dirs.append(package)
     return dirs
+
+
+_LIFECYCLE_SOURCE_MAX_BYTES = 32 * 1024 * 1024
+
+
+@lru_cache(maxsize=8)
+def _source_contains(path_text: str, mtime_ns: int, size: int, needle: bytes) -> bool:
+    """Whether one version-pinned installed source file contains *needle*."""
+    del mtime_ns  # cache-key only: invalidates the answer after an upgrade
+    if size <= 0 or size > _LIFECYCLE_SOURCE_MAX_BYTES:
+        return False
+    try:
+        return needle in Path(path_text).read_bytes()
+    except OSError:
+        return False
+
+
+def cli_lifecycle_env_supported() -> bool:
+    """Whether the installed CLI honors both stable lifecycle env variables.
+
+    The variable names are upstream test-prefixed seams rather than a declared
+    compatibility API. Checking the package that will actually launch the
+    daemon turns a future rename/removal into a loud fail-back instead of
+    silently putting sockets under scratch again. Answers false when the CLI is
+    absent or its serving playwright-core tree cannot be attributed.
+    """
+    packages = _cli_package_dirs()
+    if not packages:
+        return False
+    # _cli_package_dirs is most-specific-first: once an active launcher was
+    # attributed, never let a stale standalone fallback satisfy its contract.
+    package = packages[0]
+    manifest = _manifest_for_cli_package(package)
+    if manifest is None:
+        return False
+    core_root = manifest.parent
+    registry = core_root / "lib" / "tools" / "cli-client" / "registry.js"
+    bundle = core_root / "lib" / "coreBundle.js"
+    try:
+        registry_stat = registry.stat()
+        bundle_stat = bundle.stat()
+    except OSError:
+        return False
+    registry_ok = _source_contains(
+        str(registry),
+        registry_stat.st_mtime_ns,
+        registry_stat.st_size,
+        b"process.env.PWTEST_DAEMON_SESSION_DIR",
+    )
+    sockets_ok = _source_contains(
+        str(bundle),
+        bundle_stat.st_mtime_ns,
+        bundle_stat.st_size,
+        b"process.env.PWTEST_SOCKETS_DIR ||",
+    )
+    return registry_ok and sockets_ok
 
 
 def _manifest_for_cli_package(package: Path) -> Path | None:

--- a/src/kiro_crew/browser_cli/launch.py
+++ b/src/kiro_crew/browser_cli/launch.py
@@ -54,7 +54,9 @@ import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
+from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.browser_cli.install import cli_lifecycle_env_supported
 from kiro_crew.config.paths import config_dir
 
 logger = logging.getLogger(__name__)
@@ -71,11 +73,120 @@ LAUNCH_ENGINE = "chromium"
 #: addresses. Its name is fixed by the CLI, not by us.
 SESSION_ENV = "PLAYWRIGHT_CLI_SESSION"
 
+#: The variable playwright-core reads before ``os.tmpdir()`` when choosing the
+#: daemon control-socket root. Its name is upstream's test-prefixed public seam,
+#: but it is the only supported way to keep the socket reachable after an
+#: agent's per-process scratch directory is reclaimed.
+SOCKETS_ENV = "PWTEST_SOCKETS_DIR"
+
+#: The registry root holding ``<workspace-hash>/<session>.session`` metadata.
+#: Fixed beside the socket root so controlled teardown can locate the socket
+#: without executing the user-writable playwright-cli wrapper.
+DAEMON_DIR_ENV = "PWTEST_DAEMON_SESSION_DIR"
+
+#: Short common root; each generated session gets its own `/<8hex>/s` and
+#: `/<8hex>/d` subtree so `playwright-cli list` cannot enumerate peer chats.
+_LIFECYCLE_DIR = "pw"
+_UNIX_SOCKET_PATH_MAX_BYTES = 103
+
 #: Marks a generated name as Kiro Crew's in ``playwright-cli list``, so an
 #: operator can tell an agent's browser from one they opened themselves.
 _SESSION_PREFIX = "kc-"
 
 _CONFIG_FILE = "playwright-cli-config.json"
+
+
+def _session_leaf(session_name: str) -> str:
+    """Filesystem leaf for one generated ``kc-<8hex>`` session."""
+    if not session_name.startswith(_SESSION_PREFIX):
+        return ""
+    leaf = session_name.removeprefix(_SESSION_PREFIX)
+    return leaf if len(leaf) == 8 and all(c in "0123456789abcdef" for c in leaf) else ""
+
+
+def socket_dir(session_name: str, base: Path | None = None) -> Path:
+    """Stable, per-session daemon-socket root outside agent scratch."""
+    root = base if base is not None else config_dir() / _LIFECYCLE_DIR
+    return root / _session_leaf(session_name) / "s"
+
+
+def daemon_dir(session_name: str, base: Path | None = None) -> Path:
+    """Stable, per-session Playwright registry root outside agent scratch."""
+    root = base if base is not None else config_dir() / _LIFECYCLE_DIR
+    return root / _session_leaf(session_name) / "d"
+
+
+def browser_socket_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Environment additions keeping daemon sockets reachable and discoverable.
+
+    ``playwright-cli`` launches its daemon after Kiro Crew has pointed
+    ``TMPDIR`` at a per-process scratch directory. Without ``SOCKETS_ENV`` the
+    socket disappears when that scratch is reclaimed. ``DAEMON_DIR_ENV`` fixes
+    the corresponding session registry location, letting Kiro Crew find and
+    validate the exact generated session file at controlled teardown without
+    executing the user-writable CLI wrapper.
+
+    This helper is called only when Kiro Crew generated ``SESSION_ENV``.
+    Existing location variables are treated as operator-selected BASE roots,
+    then namespaced by the generated session; non-generated operator sessions
+    never call this helper. Both final directories are owner-restricted. If
+    validation or preparation fails, no partial additions are returned and the
+    current TMPDIR/default-registry behavior remains. This helper performs
+    filesystem I/O and event-loop callers MUST offload it.
+    """
+    session_name = env.get(SESSION_ENV, "").strip()
+    if not _session_leaf(session_name):
+        return {}
+    if not cli_lifecycle_env_supported():
+        logger.warning(
+            "installed playwright-cli does not expose the stable daemon "
+            "socket/session hooks; leaving its lifecycle environment unchanged"
+        )
+        return {}
+    configured_sockets = env.get(SOCKETS_ENV, "").strip()
+    configured_daemons = env.get(DAEMON_DIR_ENV, "").strip()
+    if (
+        configured_sockets
+        and not Path(configured_sockets).is_absolute()
+        or configured_daemons
+        and not Path(configured_daemons).is_absolute()
+    ):
+        logger.warning("Playwright lifecycle root overrides must be absolute paths")
+        return {}
+    sockets_path = socket_dir(
+        session_name, Path(configured_sockets) if configured_sockets else None
+    )
+    daemons_path = daemon_dir(
+        session_name, Path(configured_daemons) if configured_daemons else None
+    )
+    additions: dict[str, str] = {}
+    # Upstream builds `<root>/cli/<16-char-workspace>-<11-char-session>.sock`.
+    # Check the complete shortest non-trimmed form; if even that cannot fit,
+    # makeSocketPath raises and browsing fails before cleanup can help.
+    worst_case = sockets_path / "cli" / "0000000000000000-kc-00000000.sock"
+    if (
+        not platform_compat.IS_WINDOWS
+        and len(os.fsencode(str(worst_case))) > _UNIX_SOCKET_PATH_MAX_BYTES
+    ):
+        logger.warning(
+            "Playwright socket directory is too long for AF_UNIX (%d bytes): %s",
+            len(os.fsencode(str(worst_case))),
+            sockets_path,
+        )
+        return {}
+    for key, path in ((SOCKETS_ENV, sockets_path), (DAEMON_DIR_ENV, daemons_path)):
+        try:
+            platform_compat.make_owner_only_dir(path)
+            platform_compat.restrict_dir_to_owner(path)
+        except OSError:
+            logger.warning(
+                "could not prepare Playwright lifecycle directory at %s; "
+                "browser daemon cleanup may be unavailable",
+                path,
+            )
+            return {}
+        additions[key] = str(path)
+    return additions
 
 
 def launch_config_path() -> Path:

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -670,8 +670,24 @@ class TestAcpClientSessionKey:
         the same session key (a pooled process is spawned before it is claimed).
         """
         names = []
+        caller_sockets = str(tmp_path / "caller-controlled-sockets")
+        caller_daemons = str(tmp_path / "caller-controlled-daemons")
+
+        def _lifecycle_env(resolved_env):
+            assert resolved_env.get("PWTEST_SOCKETS_DIR") != caller_sockets
+            assert resolved_env.get("PWTEST_DAEMON_SESSION_DIR") != caller_daemons
+            assert resolved_env["PLAYWRIGHT_CLI_SESSION"].startswith("kc-")
+            return {}
+
         for _ in range(2):
-            client = AcpClient(work_dir=tmp_path, session_key="same-key")
+            client = AcpClient(
+                work_dir=tmp_path,
+                session_key="same-key",
+                extra_env={
+                    "PWTEST_SOCKETS_DIR": caller_sockets,
+                    "PWTEST_DAEMON_SESSION_DIR": caller_daemons,
+                },
+            )
             with (
                 patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
                 patch(
@@ -679,6 +695,7 @@ class TestAcpClientSessionKey:
                     return_value=(["/usr/bin/kiro-cli", "acp"], None),
                 ),
                 patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+                patch("kiro_crew.acp.client.browser_socket_env", side_effect=_lifecycle_env),
                 patch("kiro_crew.session._track_pid"),
                 patch("kiro_crew.session._track_session_pid"),
             ):
@@ -703,6 +720,8 @@ class TestAcpClientSessionKey:
     async def test_spawn_keeps_an_operator_set_browser_session(self, tmp_path, monkeypatch):
         """An operator who named a session means that one browser."""
         monkeypatch.setenv("PLAYWRIGHT_CLI_SESSION", "chrome")
+        monkeypatch.delenv("PWTEST_SOCKETS_DIR", raising=False)
+        monkeypatch.delenv("PWTEST_DAEMON_SESSION_DIR", raising=False)
         client = AcpClient(work_dir=tmp_path, session_key="k")
         with (
             patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
@@ -724,6 +743,8 @@ class TestAcpClientSessionKey:
             env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
             assert env is not None
             assert env["PLAYWRIGHT_CLI_SESSION"] == "chrome"
+            assert "PWTEST_SOCKETS_DIR" not in env
+            assert "PWTEST_DAEMON_SESSION_DIR" not in env
 
         await _stop_stderr_drain(client)
 

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -1365,3 +1365,52 @@ class TestManifestResolution:
         monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", "/nonexistent-prefix")
         assert mod._browsers_manifest_path() is None
         assert _REAL_REQUIRED_REVISIONS() is None
+
+
+def _lifecycle_contract_tree(tmp_path: Path) -> tuple[Path, Path]:
+    package = tmp_path / "node_modules" / "@playwright" / "cli"
+    core = package / "node_modules" / "playwright-core"
+    (core / "lib" / "tools" / "cli-client").mkdir(parents=True)
+    (core / "browsers.json").write_text('{"browsers": []}', encoding="utf-8")
+    registry = core / "lib" / "tools" / "cli-client" / "registry.js"
+    bundle = core / "lib" / "coreBundle.js"
+    return package, registry, bundle
+
+
+def test_lifecycle_env_contract_is_confirmed_from_serving_cli_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package, registry, bundle = _lifecycle_contract_tree(tmp_path)
+    registry.write_text("process.env.PWTEST_DAEMON_SESSION_DIR", encoding="utf-8")
+    bundle.write_text("process.env.PWTEST_SOCKETS_DIR || os.tmpdir()", encoding="utf-8")
+    monkeypatch.setattr(mod, "_cli_package_dirs", lambda: [package])
+    mod._source_contains.cache_clear()
+
+    assert mod.cli_lifecycle_env_supported() is True
+
+
+def test_lifecycle_env_contract_fails_when_upstream_hook_disappears(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package, registry, bundle = _lifecycle_contract_tree(tmp_path)
+    registry.write_text("process.env.PWTEST_DAEMON_SESSION_DIR", encoding="utf-8")
+    bundle.write_text("// lifecycle socket override removed upstream", encoding="utf-8")
+    monkeypatch.setattr(mod, "_cli_package_dirs", lambda: [package])
+    mod._source_contains.cache_clear()
+
+    assert mod.cli_lifecycle_env_supported() is False
+
+
+def test_lifecycle_contract_never_falls_through_to_stale_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    active, active_registry, active_bundle = _lifecycle_contract_tree(tmp_path / "active")
+    stale, stale_registry, stale_bundle = _lifecycle_contract_tree(tmp_path / "stale")
+    active_registry.write_text("// hook removed", encoding="utf-8")
+    active_bundle.write_text("// hook removed", encoding="utf-8")
+    stale_registry.write_text("process.env.PWTEST_DAEMON_SESSION_DIR", encoding="utf-8")
+    stale_bundle.write_text("process.env.PWTEST_SOCKETS_DIR || os.tmpdir()", encoding="utf-8")
+    monkeypatch.setattr(mod, "_cli_package_dirs", lambda: [active, stale])
+    mod._source_contains.cache_clear()
+
+    assert mod.cli_lifecycle_env_supported() is False

--- a/test/test_browser_cli_launch.py
+++ b/test/test_browser_cli_launch.py
@@ -352,7 +352,12 @@ def test_both_agent_spawn_paths_name_their_browser_session() -> None:
     from kiro_crew.acp import client, runtime
 
     for module in (client, runtime):
-        assert "env.update(browser_session_env(env))" in inspect.getsource(module)
+        source = inspect.getsource(module)
+        assert "browser_env = browser_session_env(env)" in source
+        assert "env.update(browser_env)" in source
+        assert "if browser_env:" in source
+        assert "lifecycle_env = {**os.environ, **browser_env}" in source
+        assert "browser_socket_env" in source
 
 
 def test_the_session_name_does_not_travel_as_extra_env() -> None:
@@ -374,3 +379,110 @@ def test_the_session_name_does_not_travel_as_extra_env() -> None:
         source = inspect.getsource(module)
         assert "extra_env.update(browser_session_env" not in source
         assert "browser_session_env" in source
+
+
+def test_browser_socket_env_prepares_stable_owner_only_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sockets = tmp_path / "sockets"
+    daemons = tmp_path / "daemons"
+    prepared: list[Path] = []
+    monkeypatch.setattr(mod, "socket_dir", lambda _session, _base=None: sockets)
+    monkeypatch.setattr(mod, "daemon_dir", lambda _session, _base=None: daemons)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    monkeypatch.setattr(
+        mod.platform_compat, "make_owner_only_dir", lambda path: prepared.append(Path(path))
+    )
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+
+    assert mod.browser_socket_env({mod.SESSION_ENV: "kc-a1b2c3d4"}) == {
+        mod.SOCKETS_ENV: str(sockets),
+        mod.DAEMON_DIR_ENV: str(daemons),
+    }
+    assert prepared == [sockets, daemons]
+
+
+def test_browser_socket_env_namespaces_configured_bases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    own_socket_base = tmp_path / "operator-sockets"
+    own_daemon_base = tmp_path / "daemons"
+    prepared: list[Path] = []
+    monkeypatch.setattr(
+        mod.platform_compat, "make_owner_only_dir", lambda path: prepared.append(Path(path))
+    )
+    monkeypatch.setattr(mod.platform_compat, "restrict_dir_to_owner", lambda _path: None)
+    monkeypatch.setattr(mod, "_UNIX_SOCKET_PATH_MAX_BYTES", 10_000)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: str(own_socket_base),
+        mod.DAEMON_DIR_ENV: str(own_daemon_base),
+    }
+    assert mod.browser_socket_env(env) == {
+        mod.SOCKETS_ENV: str(own_socket_base / "a1b2c3d4" / "s"),
+        mod.DAEMON_DIR_ENV: str(own_daemon_base / "a1b2c3d4" / "d"),
+    }
+    assert prepared == [
+        own_socket_base / "a1b2c3d4" / "s",
+        own_daemon_base / "a1b2c3d4" / "d",
+    ]
+
+
+def test_browser_socket_env_fails_without_partial_additions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail(_path: Path) -> None:
+        raise OSError("no space")
+
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    monkeypatch.setattr(mod.platform_compat, "make_owner_only_dir", _fail)
+
+    assert mod.browser_socket_env({mod.SESSION_ENV: "kc-a1b2c3d4"}) == {}
+
+
+def test_browser_socket_env_refuses_an_overlong_unix_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    long_root = tmp_path / ("x" * 100)
+    monkeypatch.setattr(mod, "socket_dir", lambda _session, _base=None: long_root)
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    monkeypatch.setattr(mod.platform_compat, "IS_WINDOWS", False)
+
+    assert mod.browser_socket_env({mod.SESSION_ENV: "kc-a1b2c3d4"}) == {}
+
+
+def test_browser_socket_env_refuses_non_generated_session() -> None:
+    assert mod.browser_socket_env({mod.SESSION_ENV: "chrome"}) == {}
+
+
+def test_browser_socket_env_fails_back_when_upstream_contract_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: False)
+    # No lifecycle directory may be created when the installed CLI does not
+    # prove it honors both environment variables.
+    called: list[Path] = []
+    monkeypatch.setattr(
+        mod.platform_compat,
+        "make_owner_only_dir",
+        lambda path: called.append(Path(path)),
+    )
+
+    assert mod.browser_socket_env({mod.SESSION_ENV: "kc-a1b2c3d4"}) == {}
+    assert called == []
+
+
+def test_browser_socket_env_refuses_relative_configured_roots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mod, "cli_lifecycle_env_supported", lambda: True)
+    env = {
+        mod.SESSION_ENV: "kc-a1b2c3d4",
+        mod.SOCKETS_ENV: "relative/sockets",
+        mod.DAEMON_DIR_ENV: "relative/daemons",
+    }
+
+    assert mod.browser_socket_env(env) == {}


### PR DESCRIPTION
## Problem / Motivation

A `playwright-cli` daemon deliberately outlives the individual command that opened it. Kiro Crew points each agent process's `TMPDIR` at a per-process scratch directory, and Playwright derives its Unix control socket from that temporary root. When scratch is reclaimed, the socket disappears while the daemon and Chromium tree remain alive. The CLI then answers "browser is not open" and the surviving daemon is no longer reachable through ordinary lifecycle commands.

## Why it matters

On one long-running host this produced 19 detached `cliDaemon` processes, with roughly 10.7 GB belonging to daemons no live session claimed. Preserving the control socket does not automatically kill crash orphans, but it removes the permanent-unreachability root cause: generated sessions remain visible to `playwright-cli list` and can be closed through the CLI's own protocol after their originating scratch directory is gone.

## What changed (motivation → approach → change)

The earlier revisions of this PR attempted automatic process-table reaping. Review correctly established that unattended SIGKILL could not prove cross-process ownership safely on every supported platform: scratch metadata is agent-writable, PID/group identities can be reused, and macOS has no pidfd equivalent. That design is fully removed.

This revision implements the smaller safe direction from #5986: keep generated browser sessions reachable, without adding automatic close authority.

1. PR #5960 already gives each agent process a generated `PLAYWRIGHT_CLI_SESSION` (`kc-<8hex>`). For a newly generated name only, both ACP spawn paths now inject short, per-session lifecycle roots:
   - `PWTEST_SOCKETS_DIR=<base>/<8hex>/s`
   - `PWTEST_DAEMON_SESSION_DIR=<base>/<8hex>/d`
   The default base is `<data-home>/pw`; absolute operator-configured roots are treated as bases and namespaced identically. A session's ordinary `playwright-cli list` therefore does not enumerate peer chat families.
2. These roots sit outside per-process scratch, so both the daemon socket and `<workspace-hash>/<session>.session` metadata survive scratch reclamation. This does not create a new same-UID security boundary: latest `main` already documents that Playwright's user-global default registry lets `list` show every browser on the machine. The diff reduces ambient visibility and adds no close/read/signal authority.
3. Operator-provided non-`kc-` session names preserve their complete existing Playwright location environment. They are never redirected. For generated sessions, lifecycle bases are selected only from the trusted gateway `os.environ` plus the generated session name; caller/app/cron `extra_env` is excluded, and returned trusted paths override caller PWTEST values in the final child env. Relative configured lifecycle roots are rejected because gateway and agent working directories can differ.
4. Before injecting either test-prefixed upstream hook, Kiro Crew resolves the active `@playwright/cli` package through the existing package anchor and verifies exact `playwright-core` execution snippets for both variables. Missing/renamed hooks fail back with a warning; a stale standalone package can never satisfy a different active installation. The source verdict is bounded and cached by path/mtime/size.
5. Kiro-Crew-owned lifecycle directories are created owner-only and then checked through the fail-loud platform restriction helper before their env vars are exported. The final namespaced AF_UNIX path is checked against Playwright's 103-byte budget; overlong roots fail back to existing behavior.
6. Filesystem preparation runs through each spawn path's cancellation-safe sandbox guard. No new event-loop blocking window is introduced.

This PR deliberately performs no registry read, socket connection, external CLI execution, automatic close, or numeric PID/process-group signal. Crash-orphan reclamation remains an open design problem under #5986; this change enables operator-controlled cleanup and future graceful lifecycle work without creating cross-session kill authority.

## Tests

- `test_browser_cli_launch.py`
  - generated session names are unique and regenerate inherited `kc-` values;
  - both ACP spawn paths inject the generated session and stable lifecycle env;
  - operator session overrides receive no `PWTEST_*` location variables;
  - socket/registry bases are namespaced per generated session, relative roots are refused, owner restrictions are applied, preparation is all-or-nothing, and overlong AF_UNIX roots fail closed.
- `test_browser_cli_install.py`
  - the active serving Playwright package is accepted only when both lifecycle hooks are present on their execution paths;
  - a missing hook fails closed and a stale fallback package cannot satisfy the active installation.
- `test_acp_client.py`
  - an operator `PLAYWRIGHT_CLI_SESSION=chrome` remains unchanged and does not enter Kiro Crew lifecycle locations.
- Local validation after the final rebase: 882 ACP/browser tests passed; black gate, isort, flake8, mypy (`--platform linux`), docs-lint, subprocess-encoding gate, spawn audit, and portability regex all passed. One unrelated liveness timing test failed only in a parallel aggregate run and passed standalone on both this branch and clean latest `main`.
- Independent GPT review found one cancellation-guard issue; it was fixed by routing `browser_socket_env` through `AcpClient._to_thread_guarding_sandbox`. Later focused review confirmed the same-UID peer-control concern is pre-existing on `main`, while the diff reduces default visibility; the real relative-root and stale-package probe issues were fixed. No new blocker remained.

## Manual verification

N/A — this revision changes only inherited environment placement. Unit tests pin the exact env passed by both spawn paths, and the upstream Playwright source contract for `PWTEST_SOCKETS_DIR` / `PWTEST_DAEMON_SESSION_DIR` is exercised through those paths. No user-visible UI changes.

## Related Issues

Related: #5986 — partial fix only; this PR intentionally does not close the crash-orphan issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only environment and lifecycle-path change; no rendered surface is touched.

