### PR TITLE
fix: route personal-shopper embedding calls through the mc-embed bulkhead (#6080)

### DIFF
--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
@@ -38,6 +38,7 @@ from aiohttp import web
 from kiro_crew.apps.builtins.personal_shopper.backend.store import PreferenceStore
 from kiro_crew.apps.manager import app_data_dir, is_app_enabled
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.loop_lock import LoopBoundLock
 
 logger = logging.getLogger(__name__)
@@ -247,7 +248,7 @@ async def _handle_add_preference(request: web.Request) -> web.Response:
         return err
 
     store = await _get_store()
-    entry_id = await asyncio.to_thread(store.add, text, tags=tags or [])
+    entry_id = await run_in_embed_pool(store.add, text, tags=tags or [])
     return web.json_response({"id": entry_id}, status=201)
 
 
@@ -267,7 +268,11 @@ async def _handle_update_preference(request: web.Request) -> web.Response:
         return err
 
     store = await _get_store()
-    await asyncio.to_thread(store.update, entry_id, text=text, tags=tags)
+    # ``store.update`` re-embeds whenever ``text`` is supplied (the store's
+    # UPDATE writes ``_embed(new_text)``), so it belongs on the same bulkhead
+    # as add/search/reembed. A tags-only update does not embed, but routing on
+    # the worst case is what keeps the shared default pool free.
+    await run_in_embed_pool(store.update, entry_id, text=text, tags=tags)
     return web.json_response({"id": entry_id, "updated": True})
 
 
@@ -301,7 +306,7 @@ async def _handle_search_preferences(request: web.Request) -> web.Response:
         return err
 
     store = await _get_store()
-    results = await asyncio.to_thread(
+    results = await run_in_embed_pool(
         store.search, query, top_k=top_k, tag_filter=tag_filter
     )
     return web.json_response(
@@ -334,7 +339,7 @@ async def _handle_reembed_preferences(request: web.Request) -> web.Response:
     everything added in the meantime.
     """
     store = await _get_store()
-    count = await asyncio.to_thread(store.reembed_all)
+    count = await run_in_embed_pool(store.reembed_all)
     return web.json_response({"reembedded": count})
 
 

--- a/src/kiro_crew/gateway_lock.py
+++ b/src/kiro_crew/gateway_lock.py
@@ -104,6 +104,30 @@ class GatewayLock:
         # O_RDWR | O_CREAT without truncation: a failed acquire must leave the
         # incumbent holder's pid intact so we can name it in the error.
         fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+
+        # Windows stale-PID reclaim: on Windows, msvcrt.locking may leave a
+        # lock file that cannot be re-locked after a crash (the OS does not
+        # guarantee release on abnormal termination the way POSIX flock does).
+        # If the recorded PID is confirmed dead, delete the stale file and
+        # re-open a fresh one so try_acquire_lock sees a clean state.
+        if platform_compat.IS_WINDOWS:
+            stale_pid = _read_pid(fd)
+            if (
+                stale_pid is not None
+                and platform_compat.pid_liveness(stale_pid) == platform_compat.PID_DEAD
+            ):
+                logger.info(
+                    "reclaiming stale gateway lock on %s (dead pid %d)",
+                    self._home,
+                    stale_pid,
+                )
+                os.close(fd)
+                try:
+                    os.unlink(self._path)
+                except OSError:
+                    pass
+                fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+
         # platform_compat.try_acquire_lock: fcntl.flock LOCK_EX|LOCK_NB on
         # POSIX; msvcrt.locking LK_NBLCK on Windows. Returns True iff acquired.
         if not platform_compat.try_acquire_lock(fd, exclusive=True):

--- a/test/test_embed_offload_guards.py
+++ b/test/test_embed_offload_guards.py
@@ -1,0 +1,83 @@
+"""Source-assertion tests for embedding offload contracts.
+
+These tests verify that specific call sites route blocking embedding work
+through the ``mc-embed`` bulkhead pool (``run_in_embed_pool``) rather than
+the shared default executor.
+
+The pattern mirrors ``TestWindowsTeardownOffLoop`` in ``test_mcp_discovery.py``:
+assert against the shipped source rather than simulating a platform-specific
+run, because the branches may be unreachable on CI's platform.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+class TestPersonalShopperEmbedOffload:
+    """personal_shopper routes must use run_in_embed_pool for embed-heavy ops.
+
+    ``store.add``, ``store.search``, ``store.update`` and ``store.reembed_all``
+    call the synchronous embedder and block for 60-90s per invocation. These
+    MUST route through ``run_in_embed_pool`` (the bounded mc-embed bulkhead
+    pool) instead of ``asyncio.to_thread`` (the shared default executor) so
+    that embedding work cannot starve fast I/O offloads that share the default
+    pool.
+    """
+
+    def test_store_add_uses_embed_pool(self) -> None:
+        from kiro_crew.apps.builtins.personal_shopper.backend import routes
+
+        src = inspect.getsource(routes._handle_add_preference)
+        assert (
+            "run_in_embed_pool" in src
+        ), "store.add must be offloaded via run_in_embed_pool, not asyncio.to_thread"
+        assert "store.add" in src, "handler must call store.add"
+
+    def test_store_search_uses_embed_pool(self) -> None:
+        from kiro_crew.apps.builtins.personal_shopper.backend import routes
+
+        src = inspect.getsource(routes._handle_search_preferences)
+        assert (
+            "run_in_embed_pool" in src
+        ), "store.search must be offloaded via run_in_embed_pool, not asyncio.to_thread"
+        assert "store.search" in src, "handler must call store.search"
+
+    def test_store_reembed_all_uses_embed_pool(self) -> None:
+        from kiro_crew.apps.builtins.personal_shopper.backend import routes
+
+        src = inspect.getsource(routes._handle_reembed_preferences)
+        assert (
+            "run_in_embed_pool" in src
+        ), "store.reembed_all must be offloaded via run_in_embed_pool, not asyncio.to_thread"
+        assert "store.reembed_all" in src, "handler must call store.reembed_all"
+
+    def test_store_update_uses_embed_pool(self) -> None:
+        """``store.update`` re-embeds on a text change, so it is embed-heavy too.
+
+        ``PreferenceStore.update`` writes ``_embed(new_text)`` whenever ``text``
+        is supplied, which makes it a sibling of add/search/reembed rather than
+        a fast metadata write. Pinning it here stops the offload contract from
+        being a point patch that leaves one embedding path on the shared pool.
+        """
+        from kiro_crew.apps.builtins.personal_shopper.backend import routes, store
+
+        src = inspect.getsource(routes._handle_update_preference)
+        assert (
+            "run_in_embed_pool" in src
+        ), "store.update must be offloaded via run_in_embed_pool, not asyncio.to_thread"
+        assert "store.update" in src, "handler must call store.update"
+        # The premise above must stay true: update embeds on a text change.
+        assert "_embed(new_text)" in inspect.getsource(
+            store.PreferenceStore.update
+        ), "premise broken: store.update no longer embeds, so this pin is stale"
+
+    def test_non_embed_ops_still_use_to_thread(self) -> None:
+        """list_all and delete never embed, so they stay on asyncio.to_thread."""
+        from kiro_crew.apps.builtins.personal_shopper.backend import routes
+
+        list_src = inspect.getsource(routes._handle_list_preferences)
+        assert "asyncio.to_thread" in list_src, "list_all should use asyncio.to_thread"
+
+        delete_src = inspect.getsource(routes._handle_delete_preference)
+        assert "asyncio.to_thread" in delete_src, "delete should use asyncio.to_thread"

--- a/test/test_gateway_lock.py
+++ b/test/test_gateway_lock.py
@@ -105,3 +105,30 @@ def test_read_pid_handles_garbage(tmp_path):
         assert _read_pid(fd) is None
     finally:
         os.close(fd)
+
+
+def test_windows_stale_pid_reclaimed_on_startup(tmp_path, monkeypatch):
+    """On Windows, if the lock file holds a dead PID, the file is deleted and
+    recreated before acquisition so that msvcrt.locking gets a clean file."""
+    from kiro_crew import platform_compat
+
+    # Simulate Windows platform
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    # Make pid_liveness report the stale PID as dead
+    monkeypatch.setattr(platform_compat, "pid_liveness", lambda pid: platform_compat.PID_DEAD)
+
+    # Pre-create a lock file with a fake dead PID
+    lock_file = tmp_path / LOCK_FILENAME
+    lock_file.write_text("999999\n")
+
+    lock = GatewayLock(tmp_path).acquire()
+    try:
+        # The lock should have been acquired successfully over the stale file.
+        assert lock_file.is_file()
+    finally:
+        lock.release()
+
+    # Read the pid stamp only AFTER releasing: on real Windows ``msvcrt.locking``
+    # is a MANDATORY byte-range lock, so a second handle opened while we hold it
+    # fails with ``PermissionError`` rather than returning the contents.
+    assert lock_file.read_text(encoding="utf-8").strip() == str(os.getpid())


### PR DESCRIPTION
## Summary

Fixes #6080 — event loop stall on Windows caused by synchronous embedding inference blocking the asyncio event loop.

Two fixes:

### 1. Route embed-heavy personal_shopper routes through the mc-embed bulkhead
`store.add`, `store.search`, `store.update` and `store.reembed_all` in `personal_shopper/backend/routes.py` used `asyncio.to_thread`, i.e. the shared default executor. With 60-90s embedding inference each, they saturate every worker and starve the fast I/O offloads that share that pool — which is what stalls the gateway's async machinery. All four now use `run_in_embed_pool`, the bounded mc-embed bulkhead that already exists for this class of work.

`store.update` is included because it re-embeds on any text change (its UPDATE writes `_embed(new_text)`). Leaving it behind would make this a point patch with a live sibling on the very path it claims to protect. A tags-only update does not embed, but routing on the worst case is what keeps the default pool free. `list_all` / `delete` / `add_group` never embed and deliberately stay on `asyncio.to_thread`.

### 2. Reclaim a stale gateway.lock on Windows startup
`msvcrt.locking` does not guarantee release on abnormal termination the way POSIX `flock` does, so a crashed gateway can leave a lock file that cannot be re-locked and startup refuses forever. When the recorded PID is confirmed dead via `pid_liveness()`, `gateway_lock.py` now deletes the file and re-opens a fresh one before acquisition. POSIX is untouched: `flock` releases on process death, and the existing dead-owner diagnostics already cover the inherited-descriptor case.

## Scope cut after review

The earlier revision also wrapped both `platform_compat.kill_process_tree` calls in `computer_use/overlay.py` in `asyncio.to_thread`. Both hunks have been **reverted**, along with the `TestOverlayKillProcessTreeOffLoop` tests, because:

- Both sites sit under the module's own comment "This code path cannot run off macOS today", so they cannot reach the blocking Windows `taskkill` branch that motivated the wrap.
- The repo already owns this job as `platform_compat.kill_process_tree_async` (24 call sites), which offloads to `subprocess_executor()`. `asyncio.to_thread` would have put the kill on the *shared default executor* — the pool fix 1 exists to protect.

## Files changed
- `src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py`
- `src/kiro_crew/gateway_lock.py`
- `test/test_embed_offload_guards.py` (new)
- `test/test_gateway_lock.py` (one test added to the existing file)

## Testing
- `test/test_embed_offload_guards.py` + `test/test_gateway_lock.py`: 15 passed locally.
- Every test referencing `personal_shopper` plus `test_executors.py`: 37 passed.
- Gates green locally: `check_black_formatting.py`, `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (no issues in 1182 files).

## Known limitations
- Narrow TOCTOU window in the PID reclaim between the liveness check and the unlink, bounded by the single-writer invariant.
- `PID_UNSIGNALABLE` falls through without reclaiming, which is the correct fail-closed behavior.
