### PR TITLE
fix(acp): a failed PID-file append must not leak an untracked runtime

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2850,61 +2850,99 @@ class AcpClient:
         _spawn_label = (
             "claude-agent-acp" if self._is_claude else f"{KIRO_CLI_BIN} {KIRO_CLI_SUBCMD}"
         )
-        # Windows resource ceiling, applied while the child is still SUSPENDED,
-        # then resumed. No-op on POSIX (CREATE_SUSPENDED is 0 there). OFFLOADED
-        # because the Windows path reads the config file and walks the process
-        # and thread tables (see the note on finish_suspended_spawn); the child
-        # is frozen until it returns, so this is the one await the spawn cannot
-        # skip.
-        await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(),
-            functools.partial(finish_suspended_spawn, self._process, self._pid, label=_spawn_label),
-        )
-        self._start_time = await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), _get_start_time, self._pid
-        )
-        if self._scratch_dir is not None:
-            # Liveness anchor for the scratch sweeps -- see acp/runtime.py's
-            # twin block. Off-loop, fail-open.
+        # Everything from here to the end of _spawn runs with a LIVE subprocess
+        # that nothing has recorded yet, so every step must be guarded. Without
+        # this, any exception in the window — finish_suspended_spawn, the
+        # start-time read, the two PID-file appends, the descendant scan — unwinds
+        # out of _spawn leaving that process running and absent from both PID
+        # files. It is then unreachable by every agent-runtime reaper (they all
+        # read those files, and the /proc orphan scan declines managed agent
+        # runtimes on purpose), so it leaks until the host reboots.
+        #
+        # ensure_ready()'s retry loop cannot substitute for this: it only catches
+        # AcpTimeoutError / AcpError, and nothing raised in this window is either
+        # of those — an OSError from the executor or a wedged file lock sails
+        # straight past it and its `finally` records metrics only.
+        #
+        # BaseException so a CancelledError mid-window cleans up too. Mirrors the
+        # twin guard in acp/runtime.py around reader startup + handshake.
+        try:
+            # Windows resource ceiling, applied while the child is still SUSPENDED,
+            # then resumed. No-op on POSIX (CREATE_SUSPENDED is 0 there). OFFLOADED
+            # because the Windows path reads the config file and walks the process
+            # and thread tables (see the note on finish_suspended_spawn); the child
+            # is frozen until it returns, so this is the one await the spawn cannot
+            # skip.
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(),
-                functools.partial(agent_scratch.record_owner, self._scratch_dir, self._pid),
+                functools.partial(
+                    finish_suspended_spawn, self._process, self._pid, label=_spawn_label
+                ),
             )
-        logger.info("Spawned %s (PID %d)", _spawn_label, self._pid)
-        # Track root PID and do an early descendant scan.  kiro-cli forks
-        # child processes quickly after launch.  Recording them here means
-        # _kill_process() can clean up even if _initialize_session() fails.
-        from kiro_crew.session import (  # circular: session -> config.loader -> providers.acp -> acp.client
-            _track_child_pids,
-            _track_pid,
-            _track_session_pid,
-        )
+            self._start_time = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), _get_start_time, self._pid
+            )
+            if self._scratch_dir is not None:
+                # Liveness anchor for the scratch sweeps -- see acp/runtime.py's
+                # twin block. Off-loop, fail-open.
+                await asyncio.get_running_loop().run_in_executor(
+                    subprocess_executor(),
+                    functools.partial(agent_scratch.record_owner, self._scratch_dir, self._pid),
+                )
+            logger.info("Spawned %s (PID %d)", _spawn_label, self._pid)
+            # Track root PID and do an early descendant scan.  kiro-cli forks
+            # child processes quickly after launch.  Recording them here means
+            # _kill_process() can clean up even if _initialize_session() fails.
+            from kiro_crew.session import (  # circular: session -> config.loader -> providers.acp -> acp.client
+                _track_child_pids,
+                _track_pid,
+                _track_session_pid,
+            )
 
-        # The PID-file trackers each take an exclusive file lock and do a
-        # read-modify-append under it — blocking syscalls that must not run
-        # on the event loop: ensure_ready() awaits _spawn() from the loop on
-        # every cold start, so a contended or wedged lock holder here would
-        # stall every task including the liveness heartbeat. Ride the same
-        # executor as the descendant scans below.
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(subprocess_executor(), _track_pid, self._pid)
-        # Separate file for startup cleanup.
-        await _loop.run_in_executor(subprocess_executor(), _track_session_pid, self._pid)
-        await asyncio.sleep(0.3)
-        early_descendants = await _loop.run_in_executor(
-            subprocess_executor(), _get_child_pids, self._pid
-        )
-        if early_descendants:
-            self._child_pids = await _loop.run_in_executor(
-                subprocess_executor(), _capture_child_records, early_descendants
+            # The PID-file trackers each take an exclusive file lock and do a
+            # read-modify-append under it — blocking syscalls that must not run
+            # on the event loop: ensure_ready() awaits _spawn() from the loop on
+            # every cold start, so a contended or wedged lock holder here would
+            # stall every task including the liveness heartbeat. Ride the same
+            # executor as the descendant scans below.
+            _loop = asyncio.get_running_loop()
+            await _loop.run_in_executor(subprocess_executor(), _track_pid, self._pid)
+            # Separate file for startup cleanup.
+            await _loop.run_in_executor(subprocess_executor(), _track_session_pid, self._pid)
+            await asyncio.sleep(0.3)
+            early_descendants = await _loop.run_in_executor(
+                subprocess_executor(), _get_child_pids, self._pid
             )
-            await _loop.run_in_executor(
-                subprocess_executor(), _track_child_pids, self._child_pids, self._pid or 0
-            )
-            logger.info("Early tracking %d descendants of PID %d", len(self._child_pids), self._pid)
+            if early_descendants:
+                self._child_pids = await _loop.run_in_executor(
+                    subprocess_executor(), _capture_child_records, early_descendants
+                )
+                await _loop.run_in_executor(
+                    subprocess_executor(), _track_child_pids, self._child_pids, self._pid or 0
+                )
+                logger.info(
+                    "Early tracking %d descendants of PID %d", len(self._child_pids), self._pid
+                )
 
-        if self._process.stderr:
-            self._stderr_task = asyncio.ensure_future(self._drain_stderr(self._process.stderr))
+            if self._process.stderr:
+                self._stderr_task = asyncio.ensure_future(self._drain_stderr(self._process.stderr))
+        except BaseException:
+            logger.error(
+                "Spawn of %s (PID %s) failed after the process was live; killing it so it "
+                "cannot leak untracked",
+                _spawn_label,
+                self._pid,
+                exc_info=True,
+            )
+            try:
+                await self._kill_process(force=True)
+            except Exception:
+                logger.warning(
+                    "Cleanup kill after a failed spawn did not complete for PID %s",
+                    self._pid,
+                    exc_info=True,
+                )
+            raise
 
     async def _drain_stderr(self, stderr: asyncio.StreamReader) -> None:
         # Count of suppressed high-frequency marker lines (see

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1096,30 +1096,59 @@ class AcpRuntime:
             profile=RLIMIT_PROFILE_SESSION_HOST,
         )
         self._pid = self._process.pid
-        # Windows resource ceiling, applied while the child is still SUSPENDED,
-        # then resumed. No-op on POSIX (CREATE_SUSPENDED is 0 there). This shared
-        # runtime multiplexes many session handles, so an unbounded fork/memory
-        # blowup here takes down every session on it, not just one. Offloaded for
-        # the same reason as in `AcpClient._spawn`: the Windows path reads config
-        # and walks the process and thread tables, and this runtime's event loop
-        # is serving every other session while it spawns.
-        await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(),
-            functools.partial(
-                finish_suspended_spawn, self._process, self._pid, label=f"{KIRO_CLI_BIN} acp"
-            ),
-        )
-        self._start_time = _get_start_time(self._pid)
-        self._spawn_monotonic = time.monotonic()
-        self._last_activity = time.monotonic()
-        if self._scratch_dir is not None:
-            # Liveness anchor for the scratch sweeps: a dir whose recorded
-            # owner is dead is reclaimable. Off-loop (file write), fail-open
-            # (an unowned dir falls under the grace-window rule instead).
+        # The subprocess is LIVE from here on but nothing has recorded it yet, so
+        # this window needs the same guard AcpClient._spawn has. finish_suspended_spawn
+        # documents its own resume failure as FATAL, and _get_start_time can raise;
+        # all four runtime.spawn() callers (providers/acp.py:726, :825 catch
+        # AcpRuntimeError; session.py:1416, :1490 catch AcpRuntimeDead) let anything
+        # else through, so a raise here left a live process absent from both PID
+        # files -- unreachable by every agent-runtime reaper and leaking until the
+        # host reboots. kill() reaps it before we re-raise.
+        #
+        # BaseException so a cancellation mid-window cleans up too. This is the same
+        # guard as the reader/handshake one below; they stay separate blocks because
+        # only the later one has reader/stderr tasks to tear down.
+        try:
+            # Windows resource ceiling, applied while the child is still SUSPENDED,
+            # then resumed. No-op on POSIX (CREATE_SUSPENDED is 0 there). This shared
+            # runtime multiplexes many session handles, so an unbounded fork/memory
+            # blowup here takes down every session on it, not just one. Offloaded for
+            # the same reason as in `AcpClient._spawn`: the Windows path reads config
+            # and walks the process and thread tables, and this runtime's event loop
+            # is serving every other session while it spawns.
             await asyncio.get_running_loop().run_in_executor(
                 subprocess_executor(),
-                functools.partial(agent_scratch.record_owner, self._scratch_dir, self._pid),
+                functools.partial(
+                    finish_suspended_spawn, self._process, self._pid, label=f"{KIRO_CLI_BIN} acp"
+                ),
             )
+            self._start_time = _get_start_time(self._pid)
+            self._spawn_monotonic = time.monotonic()
+            self._last_activity = time.monotonic()
+            if self._scratch_dir is not None:
+                # Liveness anchor for the scratch sweeps: a dir whose recorded
+                # owner is dead is reclaimable. Off-loop (file write), fail-open
+                # (an unowned dir falls under the grace-window rule instead).
+                await asyncio.get_running_loop().run_in_executor(
+                    subprocess_executor(),
+                    functools.partial(agent_scratch.record_owner, self._scratch_dir, self._pid),
+                )
+        except BaseException:
+            logger.error(
+                "AcpRuntime: spawn failed after the process was live (PID %s); reaping it "
+                "so it cannot leak untracked",
+                self._pid,
+                exc_info=True,
+            )
+            try:
+                await self.kill()
+            except Exception:
+                logger.warning(
+                    "AcpRuntime: cleanup reap after a failed spawn did not complete for PID %s",
+                    self._pid,
+                    exc_info=True,
+                )
+            raise
         logger.info(
             "AcpRuntime spawned backend=%s agent=%s (PID %d)",
             self._acp_backend,
@@ -1133,17 +1162,42 @@ class AcpRuntime:
         # A LIVE runtime is already protected during the periodic sweep because
         # AcpSessionProvider._pid feeds _collect_active_pids — this only closes
         # the cross-restart leak.
+        # Shield this shared runtime's PID from the periodic orphan sweep.
+        # _bg_runtime and companion subagent runtimes are held only in
+        # SessionManager instance attributes (not registered sessions /
+        # warm-pool providers), so _collect_active_pids would otherwise
+        # classify them as orphans and SIGKILL them mid-use.
+        #
+        # Ordered BEFORE the two file appends, which is the only ordering that
+        # is safe: register_protected_pid is an in-memory set insert under a
+        # threading lock with no IO, so it cannot fail for the reasons an append
+        # can (ENOSPC, a wedged file lock). Behind the appends it was reachable
+        # only if they both succeeded, so one failed append escalated into a
+        # LIVE runtime losing its shield and being SIGKILLed mid-use by the very
+        # sweep this call exists to hide it from.
+        register_protected_pid(self._pid)
         try:
             _track_pid(self._pid)
             _track_session_pid(self._pid)
-            # Shield this shared runtime's PID from the periodic orphan sweep.
-            # _bg_runtime and companion subagent runtimes are held only in
-            # SessionManager instance attributes (not registered sessions /
-            # warm-pool providers), so _collect_active_pids would otherwise
-            # classify them as orphans and SIGKILL them mid-use.
-            register_protected_pid(self._pid)
         except Exception:
-            logger.debug("AcpRuntime: PID tracking failed for %s", self._pid, exc_info=True)
+            # A runtime that is not in the PID files is unreachable by every
+            # agent-runtime reaper: cleanup_orphaned_sessions,
+            # _periodic_pid_sweep and cleanup_orphaned_session_roots all read
+            # those files, and the /proc orphan scan declines managed agent
+            # runtimes on purpose (session_pid._MANAGED_AGENT_MARKERS is a
+            # negative gate) precisely because this lifecycle is meant to own
+            # them. So the process keeps working, holds hundreds of MB, and
+            # leaks for the rest of the host's uptime.
+            #
+            # ERROR, not debug: this log line is the only signal that will ever
+            # be emitted for that leak. #2985 made a failed PID-file REWRITE
+            # loud for the same reason; this is the append half.
+            logger.error(
+                "AcpRuntime: PID tracking failed for %s — this runtime is now "
+                "invisible to every reaper and will leak until the host reboots",
+                self._pid,
+                exc_info=True,
+            )
 
         # Everything after the subprocess exists must be guarded: if reader
         # startup or the initialize handshake fails (kiro-cli hang / auth stall),

--- a/test/test_acp_spawn_offload.py
+++ b/test/test_acp_spawn_offload.py
@@ -388,3 +388,248 @@ class TestSpawnCancellationSandboxCleanup:
 
         assert not Path(sandbox_file).exists(), "cancelled spawn orphaned the sandbox file"
         assert runtime._sandbox_cleanup is None
+
+
+class TestSpawnFailureCannotLeaveAnUntrackedProcess:
+    """A LIVE subprocess that is absent from both PID files is unreachable by
+    every agent-runtime reaper — ``cleanup_orphaned_sessions``,
+    ``_periodic_pid_sweep`` and ``cleanup_orphaned_session_roots`` all read
+    those files, and the ``/proc`` orphan scan declines managed agent runtimes
+    on purpose (``_MANAGED_AGENT_MARKERS`` is a negative gate). So it holds its
+    hundreds of MB until the host reboots.
+
+    ``AcpClient._spawn`` reaches that state whenever anything in the window
+    between the subprocess existing and the tracking appends completing raises:
+    the exception unwinds out of ``_spawn`` with the process still running.
+    ``ensure_ready``'s retry loop does not save it — that only catches
+    ``AcpTimeoutError`` / ``AcpError``, and an ``OSError`` from one of these
+    executor hops is neither.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raise_in",
+        ["finish_suspended_spawn", "track_pid", "track_session_pid", "child_scan"],
+    )
+    async def test_client_spawn_kills_the_process_when_the_window_raises(
+        self, tmp_path, raise_in
+    ) -> None:
+        client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 4242
+        mock_proc.returncode = None
+        mock_proc.stderr = None
+
+        boom = OSError("no space left on device")
+
+        def _raise_if(name):
+            def _inner(*_a, **_kw):
+                if raise_in == name:
+                    raise boom
+
+            return _inner
+
+        killed = AsyncMock()
+
+        with (
+            patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+            patch.object(client_mod, "ensure_agent_materialized"),
+            patch(
+                "kiro_crew.acp.client.wrap_argv",
+                return_value=(["/usr/bin/kiro-cli", "acp"], None),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=mock_proc,
+            ),
+            patch.object(
+                client_mod,
+                "finish_suspended_spawn",
+                side_effect=_raise_if("finish_suspended_spawn"),
+            ),
+            patch.object(client_mod, "_get_start_time", return_value=1.0),
+            patch("kiro_crew.session._track_pid", side_effect=_raise_if("track_pid")),
+            patch(
+                "kiro_crew.session._track_session_pid",
+                side_effect=_raise_if("track_session_pid"),
+            ),
+            patch.object(client_mod, "_get_child_pids", side_effect=_raise_if("child_scan")),
+            patch.object(client, "_kill_process", killed),
+            pytest.raises(OSError),
+        ):
+            await client._spawn()
+
+        await _stop_stderr_drain(client)
+
+        # The process was live when the failure landed, so the ONLY correct
+        # outcome is that _spawn reaps it before re-raising. Anything else is a
+        # permanent leak with no log line and no reaper that can reach it.
+        killed.assert_awaited_once_with(force=True)
+
+    @pytest.mark.asyncio
+    async def test_client_spawn_reports_the_failure_at_error(self, tmp_path, caplog) -> None:
+        """The kill is silent to the user otherwise: nothing downstream sees a
+        spawn that died after the process existed."""
+        client = AcpClient(work_dir=tmp_path / "workspace", session_key="k")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 4243
+        mock_proc.returncode = None
+        mock_proc.stderr = None
+
+        with (
+            caplog.at_level("ERROR"),
+            patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+            patch.object(client_mod, "ensure_agent_materialized"),
+            patch(
+                "kiro_crew.acp.client.wrap_argv",
+                return_value=(["/usr/bin/kiro-cli", "acp"], None),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=mock_proc,
+            ),
+            patch.object(client_mod, "finish_suspended_spawn"),
+            patch.object(client_mod, "_get_start_time", return_value=1.0),
+            patch("kiro_crew.session._track_pid"),
+            patch(
+                "kiro_crew.session._track_session_pid",
+                side_effect=OSError("no space left on device"),
+            ),
+            patch.object(client_mod, "_get_child_pids", return_value=[]),
+            patch.object(client, "_kill_process", AsyncMock()),
+            pytest.raises(OSError),
+        ):
+            await client._spawn()
+
+        await _stop_stderr_drain(client)
+        assert any(
+            r.levelname == "ERROR" and "4243" in r.getMessage() for r in caplog.records
+        ), "a spawn that failed with a live process must say so at ERROR"
+
+
+class TestRuntimeShieldSurvivesAFailedAppend:
+    """``AcpRuntime.spawn`` shields its PID from the periodic orphan sweep with
+    ``register_protected_pid`` — an in-memory set insert with no IO. Behind the
+    two PID-file appends it was reachable only when BOTH succeeded, so a single
+    failed append (ENOSPC, a wedged file lock) escalated into a LIVE runtime
+    losing its shield and being SIGKILLed mid-use by the sweep the call exists
+    to hide it from.
+
+    The shield must therefore be registered BEFORE the appends, and a failed
+    append must be reported at ERROR rather than swallowed at debug — that log
+    line is the only signal the resulting leak will ever produce.
+    """
+
+    @staticmethod
+    def _patch_prelude(monkeypatch, tmp_path, mock_proc):
+        async def resolve_bin() -> str:
+            return "/usr/bin/kiro-cli"
+
+        monkeypatch.setattr(runtime_mod, "_resolve_kiro_bin_for_spawn", resolve_bin)
+        monkeypatch.setattr(runtime_mod, "ensure_agent_materialized", lambda agent: None)
+        monkeypatch.setattr(runtime_mod, "wrap_argv", lambda argv, mode, **kw: (list(argv), None))
+        monkeypatch.setattr(runtime_mod, "cgroup_scope_argv", lambda argv: list(argv))
+        monkeypatch.setattr(runtime_mod, "resolve_krb5_ccname", lambda env: None)
+        monkeypatch.setattr(runtime_mod, "inject_xdist_auto_cap", lambda env: None)
+        monkeypatch.setattr(runtime_mod, "_get_start_time", lambda pid: 1.0)
+
+        async def fake_spawn(*_a, **_kw):
+            return mock_proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raise_in", ["finish_suspended_spawn", "get_start_time"])
+    async def test_runtime_spawn_reaps_the_process_when_the_window_raises(
+        self, tmp_path, monkeypatch, raise_in
+    ) -> None:
+        """The sibling of the client-side window. ``finish_suspended_spawn``
+        documents its own resume failure as FATAL and ``_get_start_time`` can
+        raise, and every ``runtime.spawn()`` caller catches only
+        ``AcpRuntimeError`` / ``AcpRuntimeDead`` -- so an ``OSError`` here used to
+        propagate with a live, unrecorded process behind it."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 5151
+        mock_proc.returncode = None
+        mock_proc.stderr = None
+        mock_proc.stdout = None
+        self._patch_prelude(monkeypatch, tmp_path, mock_proc)
+
+        boom = OSError("resume failed")
+
+        if raise_in == "finish_suspended_spawn":
+            monkeypatch.setattr(
+                runtime_mod,
+                "finish_suspended_spawn",
+                lambda *a, **kw: (_ for _ in ()).throw(boom),
+            )
+        else:
+            monkeypatch.setattr(
+                runtime_mod, "_get_start_time", lambda pid: (_ for _ in ()).throw(boom)
+            )
+
+        monkeypatch.setattr(runtime_mod, "register_protected_pid", lambda pid: None)
+        monkeypatch.setattr(runtime_mod, "_track_pid", lambda pid: None)
+        monkeypatch.setattr(runtime_mod, "_track_session_pid", lambda pid: None)
+
+        reaped = AsyncMock()
+        monkeypatch.setattr(AcpRuntime, "kill", reaped, raising=True)
+
+        runtime = AcpRuntime(work_dir=tmp_path / "workspace")
+        with pytest.raises(OSError):
+            await runtime.spawn()
+
+        reaped.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shield_is_registered_even_when_the_append_fails(
+        self, tmp_path, monkeypatch, caplog
+    ) -> None:
+        class _StopSpawn(Exception):
+            pass
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 5150
+        mock_proc.returncode = None
+        mock_proc.stderr = None
+        mock_proc.stdout = None
+        self._patch_prelude(monkeypatch, tmp_path, mock_proc)
+
+        protected: list[int] = []
+        monkeypatch.setattr(runtime_mod, "register_protected_pid", protected.append)
+        monkeypatch.setattr(
+            runtime_mod,
+            "_track_pid",
+            lambda pid: (_ for _ in ()).throw(OSError("no space left on device")),
+        )
+        monkeypatch.setattr(runtime_mod, "_track_session_pid", lambda pid: None)
+
+        runtime = AcpRuntime(work_dir=tmp_path / "workspace")
+
+        # The reader loop asserts on a real stdout; this test is not about it,
+        # and an unretrieved task exception would surface against an unrelated
+        # test at collection.
+        async def _no_reader(_self) -> None:
+            return None
+
+        monkeypatch.setattr(AcpRuntime, "_reader_loop", _no_reader, raising=True)
+        # Stop at the handshake: everything under test has already run by then.
+        monkeypatch.setattr(
+            AcpRuntime, "_send_and_await", AsyncMock(side_effect=_StopSpawn()), raising=True
+        )
+        monkeypatch.setattr(AcpRuntime, "kill", AsyncMock(), raising=True)
+
+        with caplog.at_level("ERROR"), pytest.raises(_StopSpawn):
+            await runtime.spawn()
+
+        assert protected == [5150], (
+            "a failed PID-file append must not cost the live runtime its "
+            "sweep shield — register_protected_pid has to run first"
+        )
+        assert any(
+            r.levelname == "ERROR" and "5150" in r.getMessage() for r in caplog.records
+        ), "a runtime that could not be recorded leaks silently unless this is an ERROR"


### PR DESCRIPTION
## What is the problem?

An agent runtime that is absent from `kiro_pids.txt` / `kiro_session_pids.txt` is
unreachable by every reaper we have. `cleanup_orphaned_sessions`,
`_periodic_pid_sweep` and `cleanup_orphaned_session_roots` all read those files,
and the `/proc` orphan scan declines managed agent runtimes on purpose
(`_MANAGED_AGENT_MARKERS` is a negative gate) because this lifecycle is meant to
own them. The process keeps working, holds hundreds of MB, and leaks until the
host reboots.

There are two ways an entry goes missing. #2985 closed the first: the file being
*rewritten* and silently losing lines, now atomic and reported at ERROR. This PR
closes the second, the entry never being written at all, which has three distinct
causes on the spawn side.

**1. The failure had no signal.** `acp/runtime.py` wrapped both appends in a `try`
whose handler logged at **debug**, so the resulting permanent leak produced one
debug line and nothing else.

**2. A failed append could terminate a healthy runtime.**
`register_protected_pid` sat in that same `try`, **behind** the two file writes, so
it was reachable only when both succeeded. One failed append therefore cost a LIVE
runtime its sweep shield and let `_periodic_pid_sweep` terminate it mid-use -- the
exact outcome that call exists to prevent. This one fails in the opposite
direction from a leak and nobody had noted it.

**3. Both spawn paths had an unguarded live-process window.** Between the
subprocess existing and the tracking appends completing, anything that raises
unwinds with a live, unrecorded process.

- `acp/client.py`: `ensure_ready`'s retry loop does not cover it -- it catches
  `AcpTimeoutError` / `AcpError` only, and an `OSError` out of one of those
  executor hops is neither, so it sails past and the `finally` records metrics.
- `acp/runtime.py`: the window holds `finish_suspended_spawn` (whose own docstring
  calls a resume failure FATAL) and `_get_start_time`, while every caller catches
  something narrower -- `AcpRuntimeError` at `providers/acp.py:726` and `:825`,
  `AcpRuntimeDead` at `session.py:1416` and `:1490`.

The runtime half of item 3 was found by First Principles Review on the first
revision, which correctly pointed out that closing only the client window made it
a point patch. Both are closed now.

## Why this issue matters to the user

The failure mode is the worst kind: no error, no log line, no degraded behaviour
at the time. A runtime holds hundreds of MB; a handful nobody reaps is measured in
gigabytes the user cannot get back without noticing the processes and reaping them
by hand. Memory is simply lower than yesterday, and stays lower until reboot.

Item 2 is worse than a leak because it fails the other way: a transient append
failure could take out a runtime the user was actively talking to.

The trigger needs no crash. A data home on a filesystem that hits `ENOSPC`, or a
contended file lock, turns a spawn into a permanent leak.

## How our fix solves it

Symptom to root cause:

1. Memory disappears with no error and no leaked-process report.
2. The runtimes holding it are alive but absent from the PID files.
3. Every agent-runtime reaper consults only those files, and the `/proc` scan
   deliberately declines agent runtimes, so an absent entry is unreachable.
4. Entries go absent because the append raised, and the raise was either swallowed
   at debug or escaped an unguarded window.
5. Root cause: a failed append is neither reported nor fail-closed.

Four changes, no new mechanism, no new config key, flag, or exported symbol:

- **`acp/runtime.py`** -- `register_protected_pid` moves ahead of the two appends.
  It is a set insert under a threading lock with no IO, so it cannot fail for the
  reasons an append can.
- **`acp/runtime.py`** -- the swallowed handler goes from `logger.debug` to
  `logger.error`, naming the consequence. That line is the only signal the leak
  will ever produce, which is the same reason #2985 made a failed rewrite loud.
- **`acp/client.py`** and **`acp/runtime.py`** -- both post-spawn windows are
  guarded on `BaseException` (cancellation included) and reap the process before
  re-raising, matching the guard already present in `acp/runtime.py` around reader
  startup and the handshake. In runtime.py the new guard stays a separate block
  from that one because only the later one has reader/stderr tasks to tear down.

Deliberately out of scope, and left to the maintainers:

- Giving the `/proc` scan a **report-only agent-runtime arm**, so a sweep that
  sees an our-uid, init-parented, `_is_managed_agent_process`-positive PID in no
  active set and in no PID file says so instead of passing in silence. Needs no
  authority to terminate anything, so it has no blast radius -- but it is cleanly
  separable and belongs in its own PR.
- The **fail-closed versus availability** question: whether a runtime that cannot
  be tracked should be terminated outright rather than logged and left running.
  That is a policy call, not a defect.

This PR only makes the existing behaviour honest and stops both windows leaking.

## What tests we did

Eight tests in `test/test_acp_spawn_offload.py`, beside that file's existing
spawn-window contracts. All eight are **mutation-verified** -- with the source
reverted and the tests kept they fail, and the runtime-window pair reports
"Awaited 0 times" specifically.

- Four parametrized over the raise sites in the client window
  (`finish_suspended_spawn`, `_track_pid`, `_track_session_pid`, the descendant
  scan), asserting the live process is reaped before the exception propagates.
- Two parametrized over the runtime window (`finish_suspended_spawn`,
  `_get_start_time`), asserting the same.
- One asserting the client-side failure is reported at ERROR with the PID.
- One asserting the runtime keeps its sweep shield when an append fails, and logs
  at ERROR -- a behavioural assertion on `register_protected_pid` calls, not a
  source-order check.

Also green locally: `isort`, `flake8`, `mypy` on both touched files, and the
neighbouring suites in one run -- `test_acp_client.py`, `test_acp_runtime.py`,
`test_acp_client_more_coverage.py`, `test_pid_lifecycle.py`,
`test_pid_sweep_helpers.py`, `test_acp_spawn_offload.py` = 1058 passed.

A full local `pytest test/` run shows 84 pre-existing failures, none in
`acp` / `pid` / `spawn` / `track`; the same 84 reproduce on clean `main` with an
identical harness, so they are host-owned and unrelated.

## Any other suggestions on the work

The remaining gap on #2930 is that the reaper still has **no signal** for this
class: an iteration that sees a managed agent runtime nobody owns is a defect
firing, and today it passes in silence. That is the report-only arm above.

Separately, the environment stamp the issue asks for already exists and works
(`KIROCREW_SPAWNED`). What is missing is the **owning data home**, which is what
would let a scan tell our runtimes from another gateway's without consulting the
PID file at all.

Refs #2930
