### PR TITLE
refactor(subagent): read the cost sweep's subtree once, not three times

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -630,13 +630,10 @@ def check_memory_available(min_gb: float = 4.0, path: str = "/proc/meminfo") -> 
 # Process-subtree readers (relocated from the upstream mcp_gateway pool,
 # which is absent in this fork). Pure-stdlib /proc walkers: on non-Linux hosts
 # every /proc access raises OSError and these degrade to -1 / [] gracefully.
-#
-# ONE ceiling for every reader. RSS, CPU and the two counts used to carry their
-# own copy of the same 256, which is how they could have drifted apart; they now
-# read one constant, and the aliases below exist only so external references
-# keep resolving.
+# ONE ceiling for every reading. RSS, CPU and the two counts used to be three
+# walks carrying two copies of the same 256, which is how they could have
+# drifted apart.
 _SUBTREE_MAX_PROCS = 256
-_RSS_SUBTREE_MAX_PROCS = _SUBTREE_MAX_PROCS
 
 
 def _single_proc_rss_kb(pid: int) -> int:
@@ -707,9 +704,11 @@ class _SubtreeSample(NamedTuple):
       unreadable (it is gone, or the host has no ``/proc``).
     * ``jiffies`` — summed utime+stime clock ticks; an unreadable pid
       contributes 0, since a *delta* of jiffies is what the caller consumes.
-    * ``procs`` / ``stubs`` — ``None`` means UNMEASURABLE, never zero. Rendering
-      "0 processes" for a live runtime would be a lie; the surface renders
-      ``None`` as an em dash instead.
+    * ``procs`` / ``stubs`` — how many processes a runtime carries, and how many
+      of them are MCP stubs, matched on ``STUB_MODULE``, the module path the
+      rewriter itself puts on the stub launch line. ``None`` means UNMEASURABLE,
+      never zero. Rendering "0 processes" for a live runtime would be a lie; the
+      surface renders ``None`` as an em dash instead.
     """
 
     rss_kb: int
@@ -722,7 +721,6 @@ def _proc_subtree_sample(
     pid: Optional[int],
     *,
     rss: bool = True,
-    cpu: bool = True,
     counts: bool = True,
 ) -> _SubtreeSample:
     """Walk ``pid``'s process subtree ONCE and return every reading from it.
@@ -731,19 +729,19 @@ def _proc_subtree_sample(
     memory lives in a child process, so all four readings describe the whole
     subtree rather than the root pid alone.
 
-    The point of one pass is not only the ~3x fewer ``/proc`` reads: three
-    separate walks ran at three different instants, so a process that exited
-    between them was counted by one reader and missed by another. Reading every
+    The point of one pass is not only the ~3x fewer ``/proc`` reads: the three
+    readers this replaced ran at three different instants, so a process that
+    exited between them was counted by one and missed by another. Reading every
     metric off a single frontier is what makes "the same set of processes" true
     of the *result* and not merely of the walk rules.
 
-    The keyword flags let a single-metric caller skip the per-process reads it
-    does not need, so a wrapper costs exactly what it cost before this walk was
-    shared. Skipped metrics come back as their own unmeasurable sentinel.
+    ``rss`` / ``counts`` let a caller that only needs the CPU total skip those
+    per-process reads, so it costs what it cost before this walk was shared.
+    Skipped metrics come back as their own unmeasurable sentinel.
 
     Blocking: reads a handful of ``/proc`` entries per process in the subtree,
     so it belongs on an executor thread, never on the event loop (see
-    ``_reaper_loop`` → ``_sample_live_costs``).
+    ``_reaper_loop`` -> ``_sample_live_costs``).
     """
     if not pid:
         return _SubtreeSample(-1, 0, None, None)
@@ -753,7 +751,7 @@ def _proc_subtree_sample(
     countable = counts and platform_compat.IS_LINUX and own_rss >= 0
     rss_total = own_rss if (rss and own_rss >= 0) else -1
     needles = (STUB_MODULE,)
-    jiffies = _proc_cpu_jiffies(pid) if cpu else 0
+    jiffies = _proc_cpu_jiffies(pid)
     procs = 1
     stubs = 1 if countable and platform_compat.process_matches(pid, needles) else 0
     seen = {pid}
@@ -769,8 +767,7 @@ def _proc_subtree_sample(
                     kb = _single_proc_rss_kb(child)
                     if kb > 0:
                         rss_total += kb
-                if cpu:
-                    jiffies += _proc_cpu_jiffies(child)
+                jiffies += _proc_cpu_jiffies(child)
                 if countable:
                     procs += 1
                     if platform_compat.process_matches(child, needles):
@@ -782,35 +779,11 @@ def _proc_subtree_sample(
     return _SubtreeSample(rss_total, jiffies, procs, stubs)
 
 
-def _proc_rss_kb(pid: Optional[int]) -> int:
-    """Resident set size (KiB) for ``pid`` **and all its descendants**, or -1.
-
-    Thin wrapper over :func:`_proc_subtree_sample`. Callers that need more than
-    one reading should take the sample directly rather than call two wrappers,
-    which would walk the subtree twice.
-    """
-    return _proc_subtree_sample(pid, cpu=False, counts=False).rss_kb
-
-
-def _proc_subtree_counts(pid: Optional[int]) -> tuple[Optional[int], Optional[int]]:
-    """``(processes, mcp_stubs)`` in ``pid``'s subtree, or ``(None, None)``.
-
-    The two count columns of the Sessions surface: how many processes a runtime
-    carries, and how many of them are MCP stubs — matched on ``STUB_MODULE``,
-    the module path the rewriter itself puts on the stub launch line.
-
-    Thin wrapper over :func:`_proc_subtree_sample`; see there for the
-    unmeasurable-vs-zero contract.
-    """
-    sample = _proc_subtree_sample(pid, cpu=False)
-    return (sample.procs, sample.stubs)
-
-
 def _subtree_cpu_jiffies(pid: int) -> int:
     """Sum utime+stime across ``pid`` and its descendants (clock ticks).
 
-    Thin wrapper over :func:`_proc_subtree_sample`, so the CPU subtree is the
-    same subtree the RSS and count readings describe.
+    Thin wrapper over :func:`_proc_subtree_sample`, so the CPU subtree the
+    Sessions session rows read is the same subtree the task rows describe.
     """
     return _proc_subtree_sample(pid, rss=False, counts=False).jiffies
 
@@ -1071,8 +1044,6 @@ def resolve_max_subagents(cfg: KiroCrewConfig) -> int:
 
 
 _CLK_TCK = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
-# Alias kept for external references; the CPU walk shares the one ceiling now.
-_CPU_SUBTREE_MAX_PROCS = _SUBTREE_MAX_PROCS
 
 
 def validate_cwd(cwd: str, allowed_roots: list[str]) -> tuple[str, str]:

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -18,7 +18,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Protocol
 
 from kiro_crew.acp.liveness import (
     VERDICT_DEAD,
@@ -627,10 +627,16 @@ def check_memory_available(min_gb: float = 4.0, path: str = "/proc/meminfo") -> 
     return (True, -1.0)
 
 
-# Process-subtree RSS readers (relocated from the upstream mcp_gateway pool,
+# Process-subtree readers (relocated from the upstream mcp_gateway pool,
 # which is absent in this fork). Pure-stdlib /proc walkers: on non-Linux hosts
 # every /proc access raises OSError and these degrade to -1 / [] gracefully.
-_RSS_SUBTREE_MAX_PROCS = 256
+#
+# ONE ceiling for every reader. RSS, CPU and the two counts used to carry their
+# own copy of the same 256, which is how they could have drifted apart; they now
+# read one constant, and the aliases below exist only so external references
+# keep resolving.
+_SUBTREE_MAX_PROCS = 256
+_RSS_SUBTREE_MAX_PROCS = _SUBTREE_MAX_PROCS
 
 
 def _single_proc_rss_kb(pid: int) -> int:
@@ -666,80 +672,147 @@ def _proc_children(pid: int) -> list[int]:
     return kids
 
 
-def _proc_rss_kb(pid: Optional[int]) -> int:
-    """Resident set size (KiB) for ``pid`` **and all its descendants**.
+def _parse_cpu_jiffies(stat: bytes) -> int:
+    """Sum utime+stime (clock ticks) from raw ``/proc/<pid>/stat`` bytes.
+
+    Splits after the final ``)`` so a ``comm`` containing spaces/parens is
+    handled. utime/stime are fields 14/15 (1-indexed) → indices 11/12 of the
+    post-comm tokens. Returns 0 on any parse error.
+    """
+    try:
+        rparen = stat.rindex(b")")
+        fields = stat[rparen + 2 :].split()
+        return int(fields[11]) + int(fields[12])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _proc_cpu_jiffies(pid: int) -> int:
+    """utime+stime (clock ticks) for a single pid, 0 on error."""
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            return _parse_cpu_jiffies(fh.read())
+    except OSError:
+        return 0
+
+
+class _SubtreeSample(NamedTuple):
+    """Every subtree reading the cost sweep needs, from ONE walk.
+
+    Each field keeps the sentinel its own reader had, because the four readings
+    are unmeasurable in different ways and collapsing any of them into zero is
+    the bug class the count columns were added to fix:
+
+    * ``rss_kb`` — summed KiB, or ``-1`` when the root pid's own status is
+      unreadable (it is gone, or the host has no ``/proc``).
+    * ``jiffies`` — summed utime+stime clock ticks; an unreadable pid
+      contributes 0, since a *delta* of jiffies is what the caller consumes.
+    * ``procs`` / ``stubs`` — ``None`` means UNMEASURABLE, never zero. Rendering
+      "0 processes" for a live runtime would be a lie; the surface renders
+      ``None`` as an em dash instead.
+    """
+
+    rss_kb: int
+    jiffies: int
+    procs: Optional[int]
+    stubs: Optional[int]
+
+
+def _proc_subtree_sample(
+    pid: Optional[int],
+    *,
+    rss: bool = True,
+    cpu: bool = True,
+    counts: bool = True,
+) -> _SubtreeSample:
+    """Walk ``pid``'s process subtree ONCE and return every reading from it.
 
     A subagent's kiro-cli process is frequently a thin launcher whose real
-    memory lives in a child process. Counting only ``pid``'s own ``VmRSS``
-    under-reports the true footprint, so we sum the whole subtree.
+    memory lives in a child process, so all four readings describe the whole
+    subtree rather than the root pid alone.
 
-    Returns -1 if ``pid`` is falsy or its own status cannot be read; otherwise
-    the summed KiB (descendants that vanish mid-walk are simply skipped, so the
-    result degrades gracefully to parent-only when ``children`` is unreadable).
+    The point of one pass is not only the ~3x fewer ``/proc`` reads: three
+    separate walks ran at three different instants, so a process that exited
+    between them was counted by one reader and missed by another. Reading every
+    metric off a single frontier is what makes "the same set of processes" true
+    of the *result* and not merely of the walk rules.
+
+    The keyword flags let a single-metric caller skip the per-process reads it
+    does not need, so a wrapper costs exactly what it cost before this walk was
+    shared. Skipped metrics come back as their own unmeasurable sentinel.
+
+    Blocking: reads a handful of ``/proc`` entries per process in the subtree,
+    so it belongs on an executor thread, never on the event loop (see
+    ``_reaper_loop`` → ``_sample_live_costs``).
     """
     if not pid:
-        return -1
-    own = _single_proc_rss_kb(pid)
-    if own < 0:
-        return -1
-    total = own
+        return _SubtreeSample(-1, 0, None, None)
+    # The counts share RSS's liveness probe: a root pid whose own status cannot
+    # be read has nothing to attribute, so there is nothing to count either.
+    own_rss = _single_proc_rss_kb(pid) if (rss or counts) else -1
+    countable = counts and platform_compat.IS_LINUX and own_rss >= 0
+    rss_total = own_rss if (rss and own_rss >= 0) else -1
+    needles = (STUB_MODULE,)
+    jiffies = _proc_cpu_jiffies(pid) if cpu else 0
+    procs = 1
+    stubs = 1 if countable and platform_compat.process_matches(pid, needles) else 0
     seen = {pid}
     frontier = [pid]
-    while frontier and len(seen) < _RSS_SUBTREE_MAX_PROCS:
+    while frontier and len(seen) < _SUBTREE_MAX_PROCS:
         nxt: list[int] = []
         for parent in frontier:
             for child in _proc_children(parent):
                 if child in seen:
                     continue
                 seen.add(child)
-                kb = _single_proc_rss_kb(child)
-                if kb > 0:
-                    total += kb
+                if rss_total >= 0:
+                    kb = _single_proc_rss_kb(child)
+                    if kb > 0:
+                        rss_total += kb
+                if cpu:
+                    jiffies += _proc_cpu_jiffies(child)
+                if countable:
+                    procs += 1
+                    if platform_compat.process_matches(child, needles):
+                        stubs += 1
                 nxt.append(child)
         frontier = nxt
-    return total
+    if not countable:
+        return _SubtreeSample(rss_total, jiffies, None, None)
+    return _SubtreeSample(rss_total, jiffies, procs, stubs)
+
+
+def _proc_rss_kb(pid: Optional[int]) -> int:
+    """Resident set size (KiB) for ``pid`` **and all its descendants**, or -1.
+
+    Thin wrapper over :func:`_proc_subtree_sample`. Callers that need more than
+    one reading should take the sample directly rather than call two wrappers,
+    which would walk the subtree twice.
+    """
+    return _proc_subtree_sample(pid, cpu=False, counts=False).rss_kb
 
 
 def _proc_subtree_counts(pid: Optional[int]) -> tuple[Optional[int], Optional[int]]:
     """``(processes, mcp_stubs)`` in ``pid``'s subtree, or ``(None, None)``.
 
-    The companion to :func:`_proc_rss_kb` for the two count columns of the
-    Sessions surface: how many processes a runtime carries, and how many of them
-    are MCP stubs — matched on ``STUB_MODULE``, the module path the rewriter
-    itself puts on the stub launch line.
+    The two count columns of the Sessions surface: how many processes a runtime
+    carries, and how many of them are MCP stubs — matched on ``STUB_MODULE``,
+    the module path the rewriter itself puts on the stub launch line.
 
-    ``None`` means UNMEASURABLE, never zero. A host without ``/proc`` cannot walk
-    a subtree at all, and rendering that as "0 processes" for a live runtime
-    would be a lie — the surface renders ``None`` as an em dash instead.
-
-    Walk order, depth and the ``_RSS_SUBTREE_MAX_PROCS`` ceiling mirror
-    ``_proc_rss_kb`` so both readings describe the same set of processes.
-
-    Blocking: reads one ``/proc`` entry per process in the subtree, so it belongs
-    on an executor thread, never on the event loop (see ``_reaper_loop``).
+    Thin wrapper over :func:`_proc_subtree_sample`; see there for the
+    unmeasurable-vs-zero contract.
     """
-    if not pid or not platform_compat.IS_LINUX:
-        return (None, None)
-    if _single_proc_rss_kb(pid) < 0:
-        return (None, None)  # pid gone or /proc unreadable: nothing to attribute
-    needles = (STUB_MODULE,)
-    procs = 1
-    stubs = 1 if platform_compat.process_matches(pid, needles) else 0
-    seen = {pid}
-    frontier = [pid]
-    while frontier and len(seen) < _RSS_SUBTREE_MAX_PROCS:
-        nxt: list[int] = []
-        for parent in frontier:
-            for child in _proc_children(parent):
-                if child in seen:
-                    continue
-                seen.add(child)
-                procs += 1
-                if platform_compat.process_matches(child, needles):
-                    stubs += 1
-                nxt.append(child)
-        frontier = nxt
-    return (procs, stubs)
+    sample = _proc_subtree_sample(pid, cpu=False)
+    return (sample.procs, sample.stubs)
+
+
+def _subtree_cpu_jiffies(pid: int) -> int:
+    """Sum utime+stime across ``pid`` and its descendants (clock ticks).
+
+    Thin wrapper over :func:`_proc_subtree_sample`, so the CPU subtree is the
+    same subtree the RSS and count readings describe.
+    """
+    return _proc_subtree_sample(pid, rss=False, counts=False).jiffies
 
 
 def _attributed_count(total: Optional[int], sharers: int, previous: Optional[int]) -> Optional[int]:
@@ -998,53 +1071,8 @@ def resolve_max_subagents(cfg: KiroCrewConfig) -> int:
 
 
 _CLK_TCK = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
-_CPU_SUBTREE_MAX_PROCS = 256
-
-
-def _parse_cpu_jiffies(stat: bytes) -> int:
-    """Sum utime+stime (clock ticks) from raw ``/proc/<pid>/stat`` bytes.
-
-    Splits after the final ``)`` so a ``comm`` containing spaces/parens is
-    handled. utime/stime are fields 14/15 (1-indexed) → indices 11/12 of the
-    post-comm tokens. Returns 0 on any parse error.
-    """
-    try:
-        rparen = stat.rindex(b")")
-        fields = stat[rparen + 2 :].split()
-        return int(fields[11]) + int(fields[12])
-    except (ValueError, IndexError):
-        return 0
-
-
-def _proc_cpu_jiffies(pid: int) -> int:
-    """utime+stime (clock ticks) for a single pid, 0 on error."""
-    try:
-        with open(f"/proc/{pid}/stat", "rb") as fh:
-            return _parse_cpu_jiffies(fh.read())
-    except OSError:
-        return 0
-
-
-def _subtree_cpu_jiffies(pid: int) -> int:
-    """Sum utime+stime across ``pid`` and its descendants (clock ticks).
-
-    Walks the same kernel children list as ``pool._proc_rss_kb`` so the CPU
-    subtree matches the RSS subtree.
-    """
-    total = _proc_cpu_jiffies(pid)
-    seen = {pid}
-    frontier = [pid]
-    while frontier and len(seen) < _CPU_SUBTREE_MAX_PROCS:
-        nxt: list[int] = []
-        for parent in frontier:
-            for child in _proc_children(parent):
-                if child in seen:
-                    continue
-                seen.add(child)
-                total += _proc_cpu_jiffies(child)
-                nxt.append(child)
-        frontier = nxt
-    return total
+# Alias kept for external references; the CPU walk shares the one ceiling now.
+_CPU_SUBTREE_MAX_PROCS = _SUBTREE_MAX_PROCS
 
 
 def validate_cwd(cwd: str, allowed_roots: list[str]) -> tuple[str, str]:
@@ -1938,24 +1966,22 @@ class SubagentManager:
                 logger.debug("on_orphan_dm raised", exc_info=True)
         logger.warning("Orphan notification (no delivery channel wired): %s", msg[:200])
 
-    def _live_shared_count(
-        self, pid: int | None, agents: "list[SubagentInfo] | None" = None
-    ) -> int:
+    def _live_shared_count(self, pid: int | None, agents: "list[SubagentInfo]") -> int:
         """Count live session-shared subagents sharing runtime *pid* (>= 1).
 
         Used to average the shared AcpRuntime's measured RSS/CPU across the
         sessions currently running inside it, so each shared subagent is charged
         an empirical per-session share rather than the whole process.
 
-        *agents* lets an off-loop caller pass the snapshot it already took, so the
-        count never iterates the live registry from a worker thread (see
-        ``_sample_live_costs``). Omitted, it reads the registry directly, which is
-        correct on the event loop.
+        *agents* is the registry snapshot the caller already took, and is
+        required: the sole caller runs on a worker thread (see
+        ``_sample_live_costs``), where iterating the live registry would raise
+        ``RuntimeError`` the moment the event loop registered or evicted an
+        agent. An on-loop caller passes ``list(self._agents.values())``.
         """
         if not pid:
             return 1
-        pool = agents if agents is not None else list(self._agents.values())
-        n = sum(1 for a in pool if not a.done and a._session_sharing and a._pid == pid)
+        n = sum(1 for a in agents if not a.done and a._session_sharing and a._pid == pid)
         return n if n > 0 else 1
 
     def _sample_live_costs(self) -> None:
@@ -1967,9 +1993,10 @@ class SubagentManager:
         seeds the CPU baseline (no delta yet). Best-effort: a dead/unreadable
         pid is simply skipped.
 
-        BLOCKING, and therefore off-loop: every live agent costs several ``/proc``
-        walks (RSS subtree, CPU jiffies, process+stub counts), so the caller
-        hands this to :func:`maintenance_executor` and the body must stay
+        BLOCKING, and therefore off-loop: every live agent costs ONE ``/proc``
+        subtree walk (:func:`_proc_subtree_sample`, which returns RSS, CPU
+        jiffies and the process/stub counts from a single frontier), so the
+        caller hands this to :func:`maintenance_executor` and the body must stay
         thread-safe. Concretely that means it takes ONE snapshot of the agent
         registry up front and derives everything, sharer counts included, from
         that list: iterating the live dict from a worker thread would raise
@@ -1989,44 +2016,23 @@ class SubagentManager:
             # by the number of concurrently-live shared sessions on that PID — an
             # empirical per-session average, not a guessed constant
             # (dynamic-subagent-sizing.md §session-sharing cost model).
-            if info._session_sharing:
-                shared_n = self._live_shared_count(pid_owner := info._pid, agents=agents)
-                rss_kb = _proc_rss_kb(pid_owner)
-                if rss_kb > 0 and shared_n > 0:
-                    gb = (rss_kb / (1024 * 1024)) / shared_n
-                    info.last_rss_gb = gb
-                    if gb > info.peak_rss_gb:
-                        info.peak_rss_gb = gb
-                procs, stubs = _proc_subtree_counts(pid_owner)
-                info.last_procs = _attributed_count(procs, shared_n, info.last_procs)
-                info.last_stubs = _attributed_count(stubs, shared_n, info.last_stubs)
-                jiffies = _subtree_cpu_jiffies(pid_owner)
-                if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev and shared_n > 0:
-                    dt = now - info._cpu_sample_ts
-                    if dt > 0:
-                        cores = ((jiffies - info._cpu_jiffies_prev) / (_CLK_TCK * dt)) / shared_n
-                        info.last_cpu_cores = cores
-                        if cores > info.peak_cpu_cores:
-                            info.peak_cpu_cores = cores
-                info._cpu_jiffies_prev = jiffies
-                info._cpu_sample_ts = now
-                continue
-            pid = info._pid
-            rss_kb = _proc_rss_kb(pid)
-            if rss_kb > 0:
-                gb = rss_kb / (1024 * 1024)
+            #
+            # Sole tenant of its own process: the subtree reading IS this run's,
+            # which is a share of one.
+            shared_n = self._live_shared_count(info._pid, agents) if info._session_sharing else 1
+            sample = _proc_subtree_sample(info._pid)
+            if sample.rss_kb > 0 and shared_n > 0:
+                gb = (sample.rss_kb / (1024 * 1024)) / shared_n
                 info.last_rss_gb = gb
                 if gb > info.peak_rss_gb:
                     info.peak_rss_gb = gb
-            procs, stubs = _proc_subtree_counts(pid)
-            # Sole tenant of its own process: the subtree reading IS this run's.
-            info.last_procs = _attributed_count(procs, 1, info.last_procs)
-            info.last_stubs = _attributed_count(stubs, 1, info.last_stubs)
-            jiffies = _subtree_cpu_jiffies(pid)
-            if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev:
+            info.last_procs = _attributed_count(sample.procs, shared_n, info.last_procs)
+            info.last_stubs = _attributed_count(sample.stubs, shared_n, info.last_stubs)
+            jiffies = sample.jiffies
+            if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev and shared_n > 0:
                 dt = now - info._cpu_sample_ts
                 if dt > 0:
-                    cores = (jiffies - info._cpu_jiffies_prev) / (_CLK_TCK * dt)
+                    cores = ((jiffies - info._cpu_jiffies_prev) / (_CLK_TCK * dt)) / shared_n
                     info.last_cpu_cores = cores
                     if cores > info.peak_cpu_cores:
                         info.peak_cpu_cores = cores

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -753,7 +753,7 @@ class TestPidHelpers:
 
 class TestLiveSharedCount:
     def test_no_pid_counts_as_one(self) -> None:
-        assert _manager()._live_shared_count(None) == 1
+        assert _manager()._live_shared_count(None, []) == 1
 
     def test_counts_live_sharers_on_the_same_pid(self) -> None:
         mgr = _manager()
@@ -766,10 +766,23 @@ class TestLiveSharedCount:
         dead._session_sharing = True
         dead._pid = 777
         mgr._agents["dead"] = dead
-        assert mgr._live_shared_count(777) == 3
+        assert mgr._live_shared_count(777, list(mgr._agents.values())) == 3
 
     def test_unknown_pid_floors_at_one(self) -> None:
-        assert _manager()._live_shared_count(31337) == 1
+        mgr = _manager()
+        assert mgr._live_shared_count(31337, list(mgr._agents.values())) == 1
+
+    def test_snapshot_is_required_not_read_from_the_live_registry(self) -> None:
+        """The sole caller runs off-loop, so the count must never touch
+        ``self._agents``: it can only see what the caller snapshotted."""
+        mgr = _manager()
+        info = _info("s0")
+        info._session_sharing = True
+        info._pid = 777
+        mgr._agents[info.id] = info
+        assert mgr._live_shared_count(777, []) == 1, "an empty snapshot means no sharers seen"
+        with pytest.raises(TypeError):
+            mgr._live_shared_count(777)  # type: ignore[call-arg]
 
 
 class TestProcSubtreeCounts:
@@ -818,6 +831,112 @@ class TestProcSubtreeCounts:
         assert procs is not None and procs < sa._RSS_SUBTREE_MAX_PROCS * 3
 
 
+class TestProcSubtreeSample:
+    """``_proc_subtree_sample`` — the ONE walk every reading now comes off.
+
+    The three readers it replaced ran three independent walks at three different
+    instants, so a process that exited between them was counted by one and
+    missed by another. These pin both halves of the claim: the readings are the
+    same values the separate readers produced, and they cost one walk.
+    """
+
+    #: 1 runtime + 3 children; two of the children are MCP stubs.
+    TREE = {10: [11, 12, 13], 11: [], 12: [], 13: []}
+    RSS = {10: 1000, 11: 200, 12: 30, 13: 4}
+    JIFFIES = {10: 100, 11: 50, 12: 25, 13: 10}
+    STUBS = {11, 12}
+
+    @contextlib.contextmanager
+    def _fake_tree(self):
+        with (
+            patch.object(sa.platform_compat, "IS_LINUX", True),
+            patch.object(sa, "_single_proc_rss_kb", side_effect=lambda p: self.RSS.get(p, -1)),
+            patch.object(sa, "_proc_cpu_jiffies", side_effect=lambda p: self.JIFFIES.get(p, 0)),
+            patch.object(sa, "_proc_children", side_effect=lambda p: self.TREE.get(p, [])),
+            patch.object(
+                sa.platform_compat,
+                "process_matches",
+                side_effect=lambda p, needles: p in self.STUBS and needles == (sa.STUB_MODULE,),
+            ),
+        ):
+            yield
+
+    def test_one_sample_carries_all_four_readings(self) -> None:
+        with self._fake_tree():
+            sample = sa._proc_subtree_sample(10)
+        assert sample.rss_kb == sum(self.RSS.values())
+        assert sample.jiffies == sum(self.JIFFIES.values())
+        assert (sample.procs, sample.stubs) == (4, 2)
+
+    def test_the_wrappers_still_report_what_they_always_did(self) -> None:
+        """Value preservation: consolidating must not move a single number, or
+        the learned-cost store and ``compute_max_subagents`` would see a step."""
+        with self._fake_tree():
+            assert sa._proc_rss_kb(10) == sum(self.RSS.values())
+            assert sa._subtree_cpu_jiffies(10) == sum(self.JIFFIES.values())
+            assert sa._proc_subtree_counts(10) == (4, 2)
+
+    def test_the_subtree_is_walked_once_not_once_per_metric(self) -> None:
+        seen: list[int] = []
+        with (
+            self._fake_tree(),
+            patch.object(
+                sa,
+                "_proc_children",
+                side_effect=lambda p: (seen.append(p), self.TREE.get(p, []))[1],
+            ),
+        ):
+            sa._proc_subtree_sample(10)
+        assert sorted(seen) == [10, 11, 12, 13], "each process's children read exactly once"
+
+    def test_no_pid_is_unmeasurable_in_every_column(self) -> None:
+        assert sa._proc_subtree_sample(None) == sa._SubtreeSample(-1, 0, None, None)
+
+    def test_non_linux_loses_only_the_counts(self) -> None:
+        """Counts are ``None`` off Linux, but RSS and CPU keep their own
+        sentinels — the columns are unmeasurable in different ways."""
+        with self._fake_tree(), patch.object(sa.platform_compat, "IS_LINUX", False):
+            sample = sa._proc_subtree_sample(10)
+        assert (sample.procs, sample.stubs) == (None, None)
+        assert sample.rss_kb == sum(self.RSS.values())
+        assert sample.jiffies == sum(self.JIFFIES.values())
+
+    def test_dead_root_keeps_the_cpu_walk(self) -> None:
+        """An unreadable root status means RSS and the counts have nothing to
+        attribute, but jiffies is consumed as a *delta*, so its walk stands."""
+        with self._fake_tree(), patch.object(sa, "_single_proc_rss_kb", return_value=-1):
+            sample = sa._proc_subtree_sample(10)
+        assert sample.rss_kb == -1
+        assert (sample.procs, sample.stubs) == (None, None)
+        assert sample.jiffies == sum(self.JIFFIES.values())
+
+    def test_a_skipped_metric_costs_no_reads(self) -> None:
+        """A single-metric wrapper must not pay for the other two, or sharing the
+        walk would have made every caller slower."""
+        with (
+            self._fake_tree(),
+            patch.object(
+                sa,
+                "_proc_cpu_jiffies",
+                side_effect=AssertionError("CPU read on an RSS-only sample"),
+            ),
+        ):
+            assert sa._proc_rss_kb(10) == sum(self.RSS.values())
+
+    def test_the_walk_is_bounded_by_the_one_shared_ceiling(self) -> None:
+        assert sa._RSS_SUBTREE_MAX_PROCS == sa._SUBTREE_MAX_PROCS
+        assert sa._CPU_SUBTREE_MAX_PROCS == sa._SUBTREE_MAX_PROCS
+        with (
+            patch.object(sa.platform_compat, "IS_LINUX", True),
+            patch.object(sa, "_single_proc_rss_kb", return_value=1024),
+            patch.object(sa, "_proc_cpu_jiffies", return_value=1),
+            patch.object(sa, "_proc_children", side_effect=lambda p: [p * 10, p * 10 + 1]),
+            patch.object(sa.platform_compat, "process_matches", return_value=False),
+        ):
+            sample = sa._proc_subtree_sample(2)
+        assert sample.procs is not None and sample.procs < sa._SUBTREE_MAX_PROCS * 3
+
+
 class TestAttributedCount:
     def test_unmeasured_keeps_the_last_good_reading(self) -> None:
         assert sa._attributed_count(None, 1, 7) == 7
@@ -843,11 +962,8 @@ class TestSampleLiveCounts:
     """The sweep must write procs/mcp on both the shared and exclusive paths."""
 
     def _patched(self, counts: tuple[int, int]):
-        return (
-            patch.object(sa, "_proc_rss_kb", return_value=1024 * 1024),
-            patch.object(sa, "_subtree_cpu_jiffies", return_value=0),
-            patch.object(sa, "_proc_subtree_counts", return_value=counts),
-        )
+        sample = sa._SubtreeSample(1024 * 1024, 0, counts[0], counts[1])
+        return (patch.object(sa, "_proc_subtree_sample", return_value=sample),)
 
     def test_shared_runtime_counts_are_split_per_sharer(self) -> None:
         mgr = _manager()
@@ -856,8 +972,8 @@ class TestSampleLiveCounts:
             info._session_sharing = True
             info._pid = 777
             mgr._agents[info.id] = info
-        rss, cpu, counts = self._patched((21, 18))
-        with rss, cpu, counts:
+        (sample,) = self._patched((21, 18))
+        with sample:
             mgr._sample_live_costs()
         for info in mgr._agents.values():
             assert info.last_procs == 7
@@ -868,8 +984,8 @@ class TestSampleLiveCounts:
         info = _info("solo")
         info._pid = 999
         mgr._agents["solo"] = info
-        rss, cpu, counts = self._patched((7, 6))
-        with rss, cpu, counts:
+        (sample,) = self._patched((7, 6))
+        with sample:
             mgr._sample_live_costs()
         assert info.last_procs == 7
         assert info.last_stubs == 6
@@ -880,13 +996,33 @@ class TestSampleLiveCounts:
         info._pid = 999
         info.last_procs, info.last_stubs = 7, 6
         mgr._agents["solo"] = info
-        with (
-            patch.object(sa, "_proc_rss_kb", return_value=-1),
-            patch.object(sa, "_subtree_cpu_jiffies", return_value=0),
-            patch.object(sa, "_proc_subtree_counts", return_value=(None, None)),
+        with patch.object(
+            sa, "_proc_subtree_sample", return_value=sa._SubtreeSample(-1, 0, None, None)
         ):
             mgr._sample_live_costs()
         assert (info.last_procs, info.last_stubs) == (7, 6)
+
+    def test_one_walk_per_agent_not_one_per_metric(self) -> None:
+        """The whole point of #3970: RSS, CPU and both counts come off ONE walk.
+
+        Patching the shared sample is not enough to prove that — a sweep that
+        still called three readers would also pass the assertions above. Count
+        the walks instead.
+        """
+        mgr = _manager()
+        for idx in range(2):
+            info = _info(f"s{idx}")
+            info._pid = 900 + idx
+            mgr._agents[info.id] = info
+        walks: list[object] = []
+
+        def _sample(pid, **kwargs):  # noqa: ANN001, ANN003 — test double
+            walks.append(pid)
+            return sa._SubtreeSample(1024, 0, 4, 2)
+
+        with patch.object(sa, "_proc_subtree_sample", side_effect=_sample):
+            mgr._sample_live_costs()
+        assert walks == [900, 901], "exactly one subtree walk per live agent"
 
     def test_sweep_reads_the_registry_once_so_it_is_thread_safe(self) -> None:
         """The sweep runs on an executor thread, so it must not iterate the live
@@ -908,8 +1044,8 @@ class TestSampleLiveCounts:
                 return super().values()
 
         mgr._agents = _CountingRegistry(real)  # type: ignore[assignment]
-        rss, cpu, counts = self._patched((4, 2))
-        with rss, cpu, counts:
+        (sample,) = self._patched((4, 2))
+        with sample:
             mgr._sample_live_costs()
         assert reads["n"] == 1, "the registry must be snapshotted exactly once"
 

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -378,25 +378,25 @@ class TestProcRssReaders:
             assert sa._proc_children(1234) == []
 
     def test_subtree_rss_falsy_pid(self) -> None:
-        assert sa._proc_rss_kb(None) == -1
-        assert sa._proc_rss_kb(0) == -1
+        assert sa._proc_subtree_sample(None, counts=False).rss_kb == -1
+        assert sa._proc_subtree_sample(0, counts=False).rss_kb == -1
 
     def test_subtree_rss_unreadable_parent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda _pid: -1)
-        assert sa._proc_rss_kb(99) == -1
+        assert sa._proc_subtree_sample(99, counts=False).rss_kb == -1
 
     def test_subtree_rss_sums_descendants(self, monkeypatch: pytest.MonkeyPatch) -> None:
         tree = {1: [2, 3], 2: [4], 3: [], 4: []}
         monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 * pid)
         monkeypatch.setattr(sa, "_proc_children", lambda pid: tree.get(pid, []))
-        assert sa._proc_rss_kb(1) == 100 + 200 + 300 + 400
+        assert sa._proc_subtree_sample(1, counts=False).rss_kb == 100 + 200 + 300 + 400
 
     def test_subtree_rss_ignores_cycles_and_dead_children(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 if pid == 1 else -1)
         monkeypatch.setattr(sa, "_proc_children", lambda pid: [1, 2] if pid == 1 else [])
-        assert sa._proc_rss_kb(1) == 100
+        assert sa._proc_subtree_sample(1, counts=False).rss_kb == 100
 
 
 class TestReadIntFile:
@@ -785,52 +785,6 @@ class TestLiveSharedCount:
             mgr._live_shared_count(777)  # type: ignore[call-arg]
 
 
-class TestProcSubtreeCounts:
-    """``_proc_subtree_counts`` — the reading task rows were missing entirely."""
-
-    def test_no_pid_is_unmeasurable(self) -> None:
-        assert sa._proc_subtree_counts(None) == (None, None)
-
-    def test_non_linux_is_unmeasurable_not_zero(self) -> None:
-        with patch.object(sa.platform_compat, "IS_LINUX", False):
-            assert sa._proc_subtree_counts(4242) == (None, None)
-
-    def test_dead_pid_is_unmeasurable(self) -> None:
-        with (
-            patch.object(sa.platform_compat, "IS_LINUX", True),
-            patch.object(sa, "_single_proc_rss_kb", return_value=-1),
-        ):
-            assert sa._proc_subtree_counts(4242) == (None, None)
-
-    def test_counts_the_subtree_and_its_stubs(self) -> None:
-        # 1 runtime + 3 children, two of which are stubs.
-        children = {10: [11, 12, 13], 11: [], 12: [], 13: []}
-        stub_pids = {11, 12}
-        with (
-            patch.object(sa.platform_compat, "IS_LINUX", True),
-            patch.object(sa, "_single_proc_rss_kb", return_value=1024),
-            patch.object(sa, "_proc_children", side_effect=lambda p: children.get(p, [])),
-            patch.object(
-                sa.platform_compat,
-                "process_matches",
-                side_effect=lambda p, needles: p in stub_pids and needles == (sa.STUB_MODULE,),
-            ),
-        ):
-            assert sa._proc_subtree_counts(10) == (4, 2)
-
-    def test_walk_is_bounded(self) -> None:
-        """A pathological tree cannot walk past the shared subtree ceiling."""
-        with (
-            patch.object(sa.platform_compat, "IS_LINUX", True),
-            patch.object(sa, "_single_proc_rss_kb", return_value=1024),
-            patch.object(sa, "_proc_children", side_effect=lambda p: [p * 10, p * 10 + 1]),
-            patch.object(sa.platform_compat, "process_matches", return_value=False),
-        ):
-            procs, stubs = sa._proc_subtree_counts(2)
-        assert stubs == 0
-        assert procs is not None and procs < sa._RSS_SUBTREE_MAX_PROCS * 3
-
-
 class TestProcSubtreeSample:
     """``_proc_subtree_sample`` — the ONE walk every reading now comes off.
 
@@ -838,6 +792,11 @@ class TestProcSubtreeSample:
     instants, so a process that exited between them was counted by one and
     missed by another. These pin both halves of the claim: the readings are the
     same values the separate readers produced, and they cost one walk.
+
+    This class also absorbs what ``TestProcSubtreeCounts`` used to assert for the
+    #3953 count contract, and strengthens it: no-pid, non-Linux and dead-root are
+    now checked across all four columns at once rather than the two count columns
+    alone.
     """
 
     #: 1 runtime + 3 children; two of the children are MCP stubs.
@@ -868,13 +827,18 @@ class TestProcSubtreeSample:
         assert sample.jiffies == sum(self.JIFFIES.values())
         assert (sample.procs, sample.stubs) == (4, 2)
 
-    def test_the_wrappers_still_report_what_they_always_did(self) -> None:
+    def test_the_readings_still_report_what_they_always_did(self) -> None:
         """Value preservation: consolidating must not move a single number, or
-        the learned-cost store and ``compute_max_subagents`` would see a step."""
+        the learned-cost store and ``compute_max_subagents`` would see a step.
+
+        The expected values are what the three separate readers produced for this
+        tree: summed RSS, summed jiffies, and the count pair from #3954.
+        """
         with self._fake_tree():
-            assert sa._proc_rss_kb(10) == sum(self.RSS.values())
+            sample = sa._proc_subtree_sample(10)
+            assert sample.rss_kb == sum(self.RSS.values())
+            assert (sample.procs, sample.stubs) == (4, 2)
             assert sa._subtree_cpu_jiffies(10) == sum(self.JIFFIES.values())
-            assert sa._proc_subtree_counts(10) == (4, 2)
 
     def test_the_subtree_is_walked_once_not_once_per_metric(self) -> None:
         seen: list[int] = []
@@ -911,21 +875,24 @@ class TestProcSubtreeSample:
         assert sample.jiffies == sum(self.JIFFIES.values())
 
     def test_a_skipped_metric_costs_no_reads(self) -> None:
-        """A single-metric wrapper must not pay for the other two, or sharing the
-        walk would have made every caller slower."""
+        """The one CPU-only caller must not pay for RSS and the counts, or
+        sharing the walk would have made the session rows slower."""
         with (
             self._fake_tree(),
             patch.object(
                 sa,
-                "_proc_cpu_jiffies",
-                side_effect=AssertionError("CPU read on an RSS-only sample"),
+                "_single_proc_rss_kb",
+                side_effect=AssertionError("RSS read on a CPU-only sample"),
+            ),
+            patch.object(
+                sa.platform_compat,
+                "process_matches",
+                side_effect=AssertionError("stub match on a CPU-only sample"),
             ),
         ):
-            assert sa._proc_rss_kb(10) == sum(self.RSS.values())
+            assert sa._subtree_cpu_jiffies(10) == sum(self.JIFFIES.values())
 
-    def test_the_walk_is_bounded_by_the_one_shared_ceiling(self) -> None:
-        assert sa._RSS_SUBTREE_MAX_PROCS == sa._SUBTREE_MAX_PROCS
-        assert sa._CPU_SUBTREE_MAX_PROCS == sa._SUBTREE_MAX_PROCS
+    def test_the_walk_is_bounded_by_one_ceiling(self) -> None:
         with (
             patch.object(sa.platform_compat, "IS_LINUX", True),
             patch.object(sa, "_single_proc_rss_kb", return_value=1024),
@@ -934,6 +901,7 @@ class TestProcSubtreeSample:
             patch.object(sa.platform_compat, "process_matches", return_value=False),
         ):
             sample = sa._proc_subtree_sample(2)
+        assert sample.stubs == 0
         assert sample.procs is not None and sample.procs < sa._SUBTREE_MAX_PROCS * 3
 
 
@@ -2319,5 +2287,4 @@ class TestPlatformConstants:
         assert sa._CLK_TCK > 0
 
     def test_subtree_walk_caps_are_bounded(self) -> None:
-        assert sa._RSS_SUBTREE_MAX_PROCS > 0
-        assert sa._CPU_SUBTREE_MAX_PROCS > 0
+        assert sa._SUBTREE_MAX_PROCS > 0

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -578,16 +578,24 @@ class TestSampleLiveCosts:
         info._pid = 4242
         return info
 
+    @staticmethod
+    def _sample(rss_kb: int = -1, jiffies: int = 0):
+        """The one subtree reading the sweep takes per agent."""
+        from kiro_crew.subagent import _SubtreeSample
+
+        return _SubtreeSample(rss_kb, jiffies, None, None)
+
     def test_rss_high_water(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
 
         m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
         info = self._agent()
         m._agents = {"a1": info}
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
         # Two polls: 2 GB then 1 GB — peak must stick at 2.
         rss_seq = iter([2 * 1024 * 1024, 1 * 1024 * 1024])
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: next(rss_seq))
+        monkeypatch.setattr(
+            sub, "_proc_subtree_sample", lambda pid, **kw: self._sample(rss_kb=next(rss_seq))
+        )
         m._sample_live_costs()
         m._sample_live_costs()
         assert info.peak_rss_gb == pytest.approx(2.0, abs=0.01)
@@ -598,7 +606,6 @@ class TestSampleLiveCosts:
         m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
         info = self._agent()
         m._agents = {"a1": info}
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: -1)  # ignore RSS
         monkeypatch.setattr(sub, "_CLK_TCK", 100)
 
         # Control wall-clock: poll1 t=10, poll2 t=11 (dt=1s).
@@ -609,8 +616,11 @@ class TestSampleLiveCosts:
         # StopIteration into unrelated event-loop cleanup.
         monkeypatch.setattr(sub.time, "monotonic", lambda: next(times, 11.0))
         # jiffies: 1000 then 1100 → 100 jiffies / (100 tck * 1s) = 1.0 core.
+        # RSS stays -1 so only the CPU half of the sample is under test.
         jiff = iter([1000, 1100])
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: next(jiff))
+        monkeypatch.setattr(
+            sub, "_proc_subtree_sample", lambda pid, **kw: self._sample(jiffies=next(jiff))
+        )
 
         m._sample_live_costs()  # seeds baseline, no delta
         assert info.peak_cpu_cores == 0.0
@@ -626,12 +636,11 @@ class TestSampleLiveCosts:
         m._agents = {"d": done}
         called = {"n": 0}
 
-        def _rss(pid):
+        def _walk(pid, **kw):
             called["n"] += 1
-            return 1024 * 1024
+            return self._sample(rss_kb=1024 * 1024)
 
-        monkeypatch.setattr(sub, "_proc_rss_kb", _rss)
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        monkeypatch.setattr(sub, "_proc_subtree_sample", _walk)
         m._sample_live_costs()
         assert called["n"] == 0  # done agent not sampled
         assert done.peak_rss_gb == 0.0
@@ -655,15 +664,18 @@ class TestSampleLiveCosts:
 
         # Shared runtime measures 4 GB RSS; with 2 live shared sessions each
         # agent is charged 2 GB, never the full 4 GB.
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 4 * 1024 * 1024)
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
+        monkeypatch.setattr(
+            sub, "_proc_subtree_sample", lambda pid, **kw: self._sample(rss_kb=4 * 1024 * 1024)
+        )
         m._sample_live_costs()
 
         assert a.peak_rss_gb == pytest.approx(2.0, abs=0.01)
         assert b.peak_rss_gb == pytest.approx(2.0, abs=0.01)
         # Single shared session → full measured RSS (divisor 1).
         b.done = True
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 3 * 1024 * 1024)
+        monkeypatch.setattr(
+            sub, "_proc_subtree_sample", lambda pid, **kw: self._sample(rss_kb=3 * 1024 * 1024)
+        )
         m._sample_live_costs()
         assert a.peak_rss_gb == pytest.approx(3.0, abs=0.01)
 
@@ -946,9 +958,12 @@ class TestLastSampleAndMemoryRows:
         m = _mgr(running=1, max_concurrent=16, last_ts=0.0)
         info = self._agent()
         m._agents = {"a1": info}
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
         rss_seq = iter([2 * 1024 * 1024, 1 * 1024 * 1024])
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: next(rss_seq))
+        monkeypatch.setattr(
+            sub,
+            "_proc_subtree_sample",
+            lambda pid, **kw: sub._SubtreeSample(next(rss_seq), 0, None, None),
+        )
         m._sample_live_costs()
         m._sample_live_costs()
 
@@ -964,8 +979,11 @@ class TestLastSampleAndMemoryRows:
         a = self._agent(id="a1", _session_sharing=True)
         b = self._agent(id="a2", _session_sharing=True)
         m._agents = {"a1": a, "a2": b}
-        monkeypatch.setattr(sub, "_subtree_cpu_jiffies", lambda pid: 0)
-        monkeypatch.setattr(sub, "_proc_rss_kb", lambda pid: 2 * 1024 * 1024)
+        monkeypatch.setattr(
+            sub,
+            "_proc_subtree_sample",
+            lambda pid, **kw: sub._SubtreeSample(2 * 1024 * 1024, 0, None, None),
+        )
         m._sample_live_costs()
 
         assert a.last_rss_gb == pytest.approx(1.0, abs=0.01)

--- a/test/test_subagent_stall_attribution.py
+++ b/test/test_subagent_stall_attribution.py
@@ -467,7 +467,9 @@ async def test_dead_does_not_skip_two_sweep_when_a_sibling_shares_the_runtime():
     sibling = _info(turns=1, _pid=4242, _session_sharing=True)
     sibling.id = "sibling00"
     _register(mgr, victim, sibling)
-    assert mgr._live_shared_count(4242) == 2, "test setup: siblings must share the pid"
+    assert (
+        mgr._live_shared_count(4242, list(mgr._agents.values())) == 2
+    ), "test setup: siblings must share the pid"
 
     # Sweep 1: no immediate flag — it only becomes a suspect.
     assert await _flag_with_dead(mgr, victim, now) is False, "DEAD skipped dampening"
@@ -495,7 +497,9 @@ async def test_dead_does_not_skip_two_sweep_for_a_lone_agent_in_a_shared_runtime
     now = 1_000.0
     info = _info(turns=1, _pid=4242, last_activity=now - 25, _session_sharing=True)
     _register(mgr, info)
-    assert mgr._live_shared_count(4242) == 1, "test setup: no live sibling, parent unseen"
+    assert (
+        mgr._live_shared_count(4242, list(mgr._agents.values())) == 1
+    ), "test setup: no live sibling, parent unseen"
 
     # Sweep 1: the sibling count says "alone", but the parent shares the pid.
     assert await _flag_with_dead(mgr, info, now) is False, "lone shared agent kept fast path"
@@ -529,5 +533,7 @@ async def test_a_done_sibling_does_not_restore_the_fast_path():
     finished = _info(turns=1, _pid=4242, _session_sharing=True, done=True)
     finished.id = "finished0"
     _register(mgr, info, finished)
-    assert mgr._live_shared_count(4242) == 1, "a done sibling must not count as live"
+    assert (
+        mgr._live_shared_count(4242, list(mgr._agents.values())) == 1
+    ), "a done sibling must not count as live"
     assert await _flag_with_dead(mgr, info, now) is False, "shared agent kept fast path"


### PR DESCRIPTION
## What is the problem?

Every 60 seconds the reaper sweep measures each live subagent, and it walked the same process subtree three separate times to do it: once for RSS, once for CPU jiffies, once for the process and MCP-stub counts. Three walks off the same `/proc` children frontier, with the same 256-process ceiling, in the same sweep.

Two costs follow. A runtime carrying N processes paid about 3N `children` reads per sweep instead of N. And because the three walks ran at three different instants, a process that exited between them was counted by one reader and missed by another, so `_proc_subtree_counts`'s docstring claim that its walk "describe[s] the same set of processes" as `_proc_rss_kb` was true of the walk rules and false of the result.

This is the debt #3954 knowingly took on when it added the third walk to fix #3953, deferred there by First Principles Review.

## Why this issue matters to the user

The numbers on the Sessions surface come off these walks, and so do the learned-cost store and `compute_max_subagents`. Nothing here is user-visible as an error, but a row whose RSS, CPU and process count describe three slightly different moments is a row you cannot reason about, and the redundant reads scale with how many subagents someone actually runs.

## How our fix solves it

One walk, one frontier, four readings.

- **`_proc_subtree_sample(pid)`** does a single BFS and returns a `_SubtreeSample(rss_kb, jiffies, procs, stubs)`. `_sample_live_costs` calls it once per live agent, so the whole sweep is one walk per agent, and every column on a row now genuinely describes the same set of processes.
- **The three readers are gone, not wrapped.** `_proc_rss_kb` and `_proc_subtree_counts` had zero consumers anywhere in `src/` once the sweep stopped calling them, so keeping them as wrappers would have shipped two functions for nobody. Only `_subtree_cpu_jiffies` survives, because it has one real consumer: `dashboard/session_memory.py:180`. It reads the sample with `rss=False, counts=False`, so the session rows pay exactly what they paid before the walk was shared.
- **One ceiling, one constant.** `_RSS_SUBTREE_MAX_PROCS` and `_CPU_SUBTREE_MAX_PROCS` were two copies of the same 256, which is how they could have drifted apart. They are now a single `_SUBTREE_MAX_PROCS` and the aliases are deleted, not kept: nothing in `src/` referenced them. Because the two ceilings were already equal, collapsing the walks is value-preserving by construction - the learned-cost store and `compute_max_subagents` see the same numbers as before.
- **Each unmeasurable sentinel is preserved separately**, because the columns are unmeasurable in different ways: `-1` for RSS, `0` for jiffies (the caller consumes a delta, so an unreadable pid contributing 0 is correct), and `None` for the counts, which must never become zero. "0 processes" for a live runtime is the exact bug class #3953 / #3954 fixed once already.
- **`_live_shared_count`'s `agents` snapshot is now required** and the live-registry fallback is gone (step 2 of the issue). The sole caller runs on a worker thread, where iterating `self._agents` would raise `RuntimeError` the moment the event loop registered or evicted an agent mid-sweep; the fallback was a footgun with no production user.
- **The overclaiming docstring is corrected** rather than deleted: the "same set of processes" property is what the single pass actually delivers, so it is now stated as a consequence of the shared walk.

The sweep also loses its duplicated shared-vs-exclusive branches. A sole tenant is a share of one, so both paths are now the same code with `shared_n = 1`.

### Scope deliberately left out, both filed

- **The session-row counter (the issue's step 3), #6086.** It cannot join this pass mechanically, and the reason is worth recording: that counter walks `_iter_descendant_pids` (`acp/runtime.py:392`), which has **no ceiling at all**, not a different one as the issue and the first rounds of its discussion both state. Unifying it therefore means deciding whether the session row starts truncating at 256 where today it never truncates - an observable behaviour change on a surface this PR is not about. #6086 carries that decision plus the coupled item (routing both counters through `platform_compat.process_matches`, deleting the then-single-consumer `_read_cmdline`).
- **`mcp_gateway/pool.py`'s own copy of the RSS walker, #6096.** `pool.py:181` is a line-for-line sibling of the walk this PR just collapsed, with its own `_RSS_SUBTREE_MAX_PROCS`. It is the last unfixed instance of the same cause. Untouched here because sharing it raises a dependency-direction question (should a gateway pool import from `subagent`, or should both import a third module), and filed so the deferral is not silent.

The piecemeal-vs-combined fork was the open call `crew: needs human` was applied for. A maintainer took the narrow-first branch.

## What tests we did

New tests in `test/test_subagent_coverage.py` (`TestProcSubtreeSample`), plus one in `TestSampleLiveCounts`:

- the single sample carries all four readings off one walk;
- **value preservation** - the sample reports exactly what the three separate readers produced for a synthetic tree;
- **walk-once**, asserted two ways: each process's children are read exactly once per sample, and the sweep takes exactly one walk per live agent;
- every sentinel: no pid, non-Linux (counts `None` but RSS and CPU keep their own sentinels), and a dead root pid (RSS `-1` and counts `None`, but the CPU walk still stands, because a jiffies delta needs it);
- the CPU-only caller pays for no RSS read and no stub match;
- a pathological tree still terminates under the one ceiling.

`TestProcSubtreeCounts` folded into `TestProcSubtreeSample` rather than being kept alongside it. Its five cases are each subsumed and strengthened: no-pid, non-Linux and dead-root are now asserted across all four columns instead of the two count columns alone, and the subtree/stub count and the ceiling bound are asserted on the new class's tree. The four `_proc_rss_kb` behaviour tests were retargeted at the sample and keep their unique case (a `children` list that names its own parent).

Mutation-verified, four ways - each mutation applied to the fix and confirmed red:

| Mutation | Test that caught it |
|---|---|
| sweep calls three separate readers again | `test_one_walk_per_agent_not_one_per_metric` |
| unmeasurable counts collapse to numbers | 4 sentinel tests |
| the walk ignores its `cpu` opt-out (pre-subtraction shape) | `test_a_skipped_metric_costs_no_reads` |
| `_subtree_cpu_jiffies` drops `rss=False, counts=False` | `test_a_skipped_metric_costs_no_reads` |

Gates: `flake8`, `isort` and `black` clean on both changed source files. `mypy` reports the same 2 pre-existing errors in `transcribe.py` on this branch and on base, A/B verified. 393 passed across the five directly affected test modules; 2325 passed / 5 skipped across every test matching subagent, session_memory, spawn, reaper or sizing; the full local suite's 116 failures are in unrelated modules and A/B-identical on base.

## Any other suggestions on the work

If #3920 (attribute stall-detection evidence to the subagent's own child process) lands after this, plumb the child-level evidence through `_proc_subtree_sample` rather than adding a fourth walk - the frontier is already there, and a per-child reading is a field on the sample, not another pass.

Closes #3970
