### PR TITLE
docs(acp): correct watchdog comments that misstate WORKING bounding and the stderr clock

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -3394,7 +3394,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Tool stall suspect (s)",
-      "help": "Idle seconds before an UNKNOWN-verdict in-flight tool is cancelled and the turn routed to tool-stall recovery (continue-nudge, no re-run of the original message). WORKING tools (e.g. a matched live build child) are never cancelled regardless of duration. Default 1h: generous enough for long builds and MCP tools on macOS, where the liveness oracle degrades (no /proc) and cannot distinguish a live build from a stall, while still landing inside the turn's own ceiling (agent.chat_turn_timeout_secs) so recovery is reachable. A window at or past that ceiling is clamped at load with a warning.",
+      "help": "Idle seconds before an UNKNOWN-verdict in-flight tool is cancelled and the turn routed to tool-stall recovery (continue-nudge, no re-run of the original message). WORKING tools (e.g. a matched live build child) are never cancelled regardless of duration. Default 1h: generous enough for long builds and MCP tools on macOS, where the liveness oracle degrades (no /proc) and cannot distinguish a live build from a stall, while still landing inside the turn's own ceiling (agent.chat_turn_timeout_secs) so recovery is reachable. Enforcement is at handle construction, not config load: a window past the headroom fraction of the transport's per-prompt timeout is clamped with a warning, while one that merely exceeds agent.chat_turn_timeout_secs is warned about but left as set, because the same handle also serves callers that pass a larger prompt timeout (review and cron turns).",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 3600.0
@@ -3408,7 +3408,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Hard cap (s)",
-      "help": "Absolute ceiling for UNKNOWN-verdict forbearance (e.g. the extended probably-thinking window). Applies ONLY to UNKNOWN verdicts — never to a WORKING session. Default 1h, bounded by the turn ceiling like the suspect window.",
+      "help": "Absolute ceiling for UNKNOWN-verdict forbearance (e.g. the extended probably-thinking window). Applies ONLY to UNKNOWN verdicts — never to a WORKING session, which is deferred before this cap is consulted and is therefore bounded only by the turn's own ceiling. Default 1h, clamped against the transport's per-prompt timeout like the suspect window.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 3600.0

--- a/src/kiro_crew/acp/liveness.py
+++ b/src/kiro_crew/acp/liveness.py
@@ -727,9 +727,18 @@ class LivenessOracle:
         Requires (a) the ENTIRE matched subtree flat on CPU+IO across two
         samples, and (b) at least one process blocked reading a tty or its
         stdin pipe. A socket-blocked read is a network wait (not stuck); a
-        futex/lock wait is ambiguous — both return "" (UNKNOWN-ish: the caller
-        treats a live child without stuck evidence as WORKING, and genuinely
-        ambiguous hangs are bounded by the UNKNOWN timeout class elsewhere).
+        futex/lock wait is ambiguous — both return "".
+
+        Returning "" for a LIVE child means the caller reports WORKING, and a
+        WORKING verdict is NOT bounded by the UNKNOWN timeout class: the
+        dispatch loop short-circuits on it (``session_handle`` defers WORKING
+        unconditionally) BEFORE ``tool_stall_suspect_secs`` /
+        ``tool_stall_hard_cap_secs`` are applied. So a genuinely ambiguous hang
+        — a child alive but wedged on a futex, a socket read, or a hung mount —
+        is deferred for as long as the turn's own wall-clock ceiling allows, not
+        for a watchdog window. That is deliberate (a quiet long build must not
+        be cancelled on a timer) but it is the only path with no window of its
+        own, so it is logged with escalating severity rather than capped.
         """
         subtree = iter_descendants(self._proc, pid)
         moved, move_evidence = self._tree_movement(pid, key_prefix="stuck")

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -127,7 +127,7 @@ class WatchdogSettings:
     behaves identically to a default config.
 
     Every idle window must stay strictly inside the turn's own wall-clock
-    ceiling — see :func:`_clamp_to_turn_ceiling` for why and
+    ceiling — see :func:`_clamp_to_prompt_ceiling` for why and
     :data:`_TURN_CEILING_WINDOW_FRACTION` for the enforced headroom."""
 
     check_after_secs: float = 60.0
@@ -1913,10 +1913,15 @@ class AcpSessionHandle:
                     # ── Verdict-driven watchdogs ──
                     # Wellness (the liveness oracle) is the detector; timeouts
                     # govern only the UNKNOWN class. Idle clocks: the stale clock
-                    # folds in the runtime's stderr/keepalive clock (_last_activity
-                    # — kiro streams thinking_tokens on STDERR during reasoning);
-                    # the tool clock keys off session-queue frames only (keepalive
-                    # and progress frames for the session reset last_data_ts, so a
+                    # folds in the runtime's activity clock (_last_activity —
+                    # advanced by stdout lines, outbound requests and
+                    # notifications, and the /api/session-keepalive touch, but
+                    # NOT by a response or error we send back, and NOT by
+                    # stderr: AcpRuntime's stderr drain only rings the
+                    # _stderr_lines buffer, so a kiro-cli reasoning burst on
+                    # stderr does not move this clock); the tool clock keys off
+                    # session-queue frames only (keepalive and progress frames
+                    # for the session reset last_data_ts, so a
                     # legitimately-streaming tool keeps the watchdog satisfied).
                     if self._cancelled:
                         continue

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -5321,8 +5321,12 @@ class WatchdogConfig:
             "for long builds and MCP tools on macOS, where the liveness oracle "
             "degrades (no /proc) and cannot distinguish a live build from a stall, "
             "while still landing inside the turn's own ceiling "
-            "(agent.chat_turn_timeout_secs) so recovery is reachable. A window at or "
-            "past that ceiling is clamped at load with a warning.",
+            "(agent.chat_turn_timeout_secs) so recovery is reachable. Enforcement is "
+            "at handle construction, not config load: a window past the headroom "
+            "fraction of the transport's per-prompt timeout is clamped with a "
+            "warning, while one that merely exceeds agent.chat_turn_timeout_secs is "
+            "warned about but left as set, because the same handle also serves "
+            "callers that pass a larger prompt timeout (review and cron turns).",
         ),
     )
     tool_stall_hard_cap_secs: float = field(
@@ -5331,8 +5335,10 @@ class WatchdogConfig:
             "Hard cap (s)",
             "Absolute ceiling for UNKNOWN-verdict forbearance (e.g. the extended "
             "probably-thinking window). Applies ONLY to UNKNOWN verdicts — never "
-            "to a WORKING session. Default 1h, bounded by the turn ceiling like "
-            "the suspect window.",
+            "to a WORKING session, which is deferred before this cap is consulted "
+            "and is therefore bounded only by the turn's own ceiling. Default 1h, "
+            "clamped against the transport's per-prompt timeout like the suspect "
+            "window.",
         ),
     )
     model_silent_probe_secs: float = field(


### PR DESCRIPTION
## Problem / Motivation

Three statements in the ACP tool-stall watchdog contradict the code they
describe, and each one misdirects a reader trying to understand why a wedged
turn was not recovered:

1. **`acp/liveness.py::_stuck_input_check`** says that when it returns `""` for
   an ambiguous hang, "genuinely ambiguous hangs are bounded by the UNKNOWN
   timeout class elsewhere". They are not bounded at all. Returning `""` for a
   **live** child produces `VERDICT_WORKING` (`liveness.py:604`), and the
   dispatch loop defers `WORKING` with an unconditional `continue`
   (`session_handle.py:1955-1957`) **before** `tool_stall_suspect_secs` and
   `tool_stall_hard_cap_secs` are computed (`:1978`, `:1998`). A child that is
   alive but wedged on a futex, a socket read, or a hung mount is therefore
   deferred up to the turn's own wall-clock ceiling, with no watchdog window
   applying.

   This specific contradiction is already on record as defect 2 of #2368, whose
   closing note states that "nothing about the underlying observation is
   disputed; it is still true on main". This PR corrects the *description* only
   and takes no position on the parked behavioural question — see Related Issues.

2. **`acp/session_handle.py`** says the stale clock "folds in the runtime's
   stderr/keepalive clock (`_last_activity` — kiro streams thinking_tokens on
   STDERR during reasoning)". The keepalive half is correct; the stderr half is
   not. `AcpRuntime._drain_stderr` (`runtime.py:2930-2952`) only appends to the
   `_stderr_lines` ring buffer and logs — it never assigns `_last_activity`. On
   the runtime path that clock is advanced by stdout line reads
   (`runtime.py:1727`), stdin writes (`:2221`, `:2246`, `:2920`), and
   `session_provider.touch_activity()` (`session_provider.py:392-394`, reached
   from `/api/session-keepalive`). Folding stderr into a liveness clock is
   `AcpClient` behaviour (`client.py:2926-2928`) — a different backend — so
   citing it here tells the reader to expect stderr chatter to hold the
   kiro-path clock open, which it cannot.

3. **`WatchdogSettings`** cross-references `:func:`_clamp_to_turn_ceiling``,
   which does not exist anywhere in the tree. The function is
   `_clamp_to_prompt_ceiling` (`session_handle.py:166`, called at `:250`), so
   the single pointer to the headroom rationale was dead — apparently a rename
   that missed the docstring.

Two operator-facing `WatchdogConfig` descriptions are also inaccurate.
`tool_stall_suspect_secs` states that an over-ceiling window "is clamped at load
with a warning". There is no config-load clamp: these fields are floats and so
sit outside the int-only `_SECURITY_BOUNDED_FIELDS` sweep, and no schema or
validation rule covers them. `tool_stall_hard_cap_secs` repeats the same claim.

## Why it matters

These are the comments a reader consults precisely when a turn has hung and they
are trying to work out which window should have fired. Statement 1 asserts a cap
that does not exist, which sends the reader looking for a misconfigured value
instead of at the uncapped `WORKING` path. Statement 2 attributes the stale clock
to a stderr stream that the runtime does not sample, which invites a false theory
that reasoning output on stderr masks the tool watchdog on the kiro path.
Statement 3 leaves the headroom rationale unreachable. The two config
descriptions tell an operator that a bad value self-heals at load, when in fact
enforcement happens later and the chat-ceiling case is deliberately advisory.

Everything here is a documentation defect, so the cost is entirely
wasted-investigation time rather than incorrect runtime behaviour.

## What changed (motivation → approach → change)

Comment, docstring, and config-help text only — no control flow, no constants,
no behaviour change.

- `liveness.py::_stuck_input_check` — replaced the incorrect "bounded by the
  UNKNOWN timeout class" parenthetical with what actually happens: a live child
  without stuck evidence reads `WORKING`, and `WORKING` is deferred before the
  windows are applied, so the bound is the turn ceiling. The docstring now also
  records that this is deliberate (a quiet long build must not be cancelled on a
  timer) and that the path is logged with escalating severity rather than capped,
  so a future reader does not "fix" it by accident.
- `session_handle.py` — corrected the stale-clock comment to name the three
  things that do advance the runtime clock (stdout, stdin, keepalive touch) and
  to state explicitly that stderr does not, with the reason.
- `session_handle.py` — repointed the dead `:func:` reference at
  `_clamp_to_prompt_ceiling`.
- `config/loader.py` — corrected both window descriptions to say enforcement is
  at handle construction rather than config load, and to distinguish the two
  cases that genuinely differ: past the headroom fraction of the transport's
  per-prompt timeout the window is clamped with a warning, whereas merely
  exceeding `agent.chat_turn_timeout_secs` is warned about and left as set,
  because the same handle also serves callers that pass a larger prompt timeout.
  The hard-cap description additionally notes that a `WORKING` session is
  deferred before the cap is consulted.

I deliberately did **not** change any behaviour here. Whether the uncapped
`WORKING` deferral should gain a bound is the parked decision in #2368, and this
PR is written so that it stays correct whichever way that ruling goes: it
describes what the code does today rather than what it ought to do.

## Tests

N/A — no executable behaviour is touched. The change is confined to a docstring,
two comments, and two `_meta()` help strings, none of which are asserted on by
the suite.

## Manual verification

- `python -m ast` parses all three edited files.
- Every claim in the corrected text was read back from source at the commit
  being targeted: the `WORKING` short-circuit ordering
  (`session_handle.py:1955-1957` vs `:1978`/`:1998`), the absence of any
  `_last_activity` assignment in `AcpRuntime._drain_stderr`, the five runtime
  assignment sites, `session_provider.touch_activity`, and the absence of any
  `def _clamp_to_turn_ceiling` in the tree.
- `black`: `src/kiro_crew/acp/liveness.py` and `src/kiro_crew/acp/session_handle.py`
  are already outside the formatting baseline on `main` and this change does not
  alter that (baseline and edited both report one file each);
  `src/kiro_crew/config/loader.py` is clean before and after. No line added here
  exceeds the 100-column limit.

## Screenshots / video

N/A — no user-visible UI change.

## Related Issues

Refs #2368 — deliberately **not** `Fixes`. That issue is a parked architecture
decision (closed as "a parked decision, not a task ... what is missing is a
ruling, not an investigation"), and its defect 2 is the `_stuck_input_check`
docstring corrected here. This PR does not reopen or pre-empt that ruling: it
only stops the comments from describing behaviour the code does not have. If the
delta-vs-state question is later answered in favour of bounding `WORKING`, the
text added here becomes the thing to update, not an obstacle.

Context for reviewers on why this is comment-only: #2368's own routing note
explains that narrowing the shell branch's `WORKING` "changes a deliberate,
documented invariant" and needs a human owner to accept the tradeoff. Correcting
the description carries none of that risk.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [ ] Existing tests pass and new tests added for new functionality — N/A, no
      functionality changed; no new tests warranted for comment text
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (this PR *is* the documentation correction)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- Left as-is: the template marks the CLA wording as a placeholder to be
     supplied by OSPO. Not inventing text here. -->

## Open question for reviewers (not addressed in this PR)

Four modules outside `acp/` pin their own ceilings against
`acp/client.py::_TOOL_STALL_TIMEOUT` (600s) — `dashboard/state.py:5473`
(`_QUESTION_TIMEOUT_MAX = 540`), `messaging/approval.py:61`
(`TEXT_APPROVAL_TIMEOUT_S = 300.0`), `mcp_shared.py:185`, and
`docs/agent-questions.md:71`. Those surfaces serve the dashboard path, which runs
on `session_handle`'s 3600s window rather than the `AcpClient` constant, so the
attribution looks incorrect even though the values remain conservative. I left
them untouched because confirming which watchdog governs each caller needs a
maintainer's read of intent, not just a grep. Happy to fold a correction in if
you confirm the reading.
