### PR TITLE
fix(apps): app hooks can import siblings, and a failed wire-up is visible

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -296,6 +296,24 @@ root (validated against `HooksConfig._HOOK_PATH_RE`).
 `on_app_enable`, also re-run at gateway startup via `on_gateway_startup`), so
 they go live without waiting for a Gateway restart.
 
+**Importing your own modules.** Hook entry files are loaded from their file path
+into a synthetic package named after the app, never via `sys.path`, so use a
+**relative** import to reach a sibling module:
+
+```python
+# backend/routes.py
+from . import config          # backend/config.py
+from .render import to_html   # backend/render.py
+```
+
+A relative import resolves inside the app's own directory tree and cannot walk
+above the app root (`from ... import x` is refused). It is not a sandbox: app
+Python already runs in the Gateway process with full filesystem access, so a
+symlinked sibling resolves wherever it points. Do not use a bare
+`import config`: `sys.modules["config"]` is process-global, so two apps each
+shipping a `config.py` would end up sharing one module. `from kiro_crew...`
+absolute imports are for built-in apps only.
+
 ## Permissions
 
 ### `permissions` — Declared Capabilities

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -22,7 +22,7 @@ from kiro_crew.apps.bridges import (
     disarm_app_crons_for_execution,
     register_app_crons_with_service,
 )
-from kiro_crew.apps.context import build_app_context
+from kiro_crew.apps.context import AppContext, build_app_context
 from kiro_crew.apps.cron_sdk import CronSDK
 from kiro_crew.apps.execution import (
     app_execution_denied,
@@ -39,6 +39,40 @@ logger = logging.getLogger(__name__)
 # Module-level singletons (initialized at gateway startup)
 _route_registry: RouteRegistry | None = None
 _lifecycle_dispatcher: LifecycleDispatcher | None = None
+
+# Last hook-wiring health per app, for apps whose hooks did NOT come up clean.
+# ``AppHealthStatus`` lives on the AppContext, which both wiring paths drop as
+# soon as they finish, so the reason a hook failed had no reader on the startup
+# path -- an app that failed to load was indistinguishable from one that was
+# never installed. Published here so ``GET /api/apps`` can report it under the
+# same ``hooks.health_status`` spelling the enable response already uses.
+_hook_health: dict[str, dict[str, Any]] = {}
+
+
+def _publish_hook_health(app_name: str, ctx: AppContext) -> dict[str, Any] | None:
+    """Record (or clear) one app's hook-wiring health and return the snapshot.
+
+    Both wiring paths funnel through here so they cannot drift: whatever
+    ``register_app_routes`` and the lifecycle dispatcher marked on the context is
+    what an operator reads back. A healthy wire-up clears any earlier entry, so a
+    fixed app stops reporting a stale failure after a re-enable.
+    """
+    if ctx.health.status == "healthy":
+        _hook_health.pop(app_name, None)
+        return None
+    snapshot = ctx.health.to_dict()
+    _hook_health[app_name] = snapshot
+    return snapshot
+
+
+def clear_hook_health(app_name: str) -> None:
+    """Forget an app's recorded hook health (disable / teardown)."""
+    _hook_health.pop(app_name, None)
+
+
+def get_all_hook_health() -> dict[str, dict[str, Any]]:
+    """Return every recorded non-healthy hook-wiring snapshot, by app name."""
+    return {name: dict(snapshot) for name, snapshot in _hook_health.items()}
 
 
 def init_hooks_system(
@@ -212,8 +246,9 @@ async def on_app_enable(
         result["hooks_startup"] = "ok" if success else "failed"
 
     # Report health status
-    if ctx.health.status != "healthy":
-        result["health_status"] = ctx.health.to_dict()
+    health_snapshot = _publish_hook_health(app_name, ctx)
+    if health_snapshot:
+        result["health_status"] = health_snapshot
 
     sel().log_api_access(
         caller="gateway",
@@ -303,6 +338,10 @@ async def on_app_disable(
     # Deregister routes
     if _route_registry:
         _route_registry.deregister_app_routes(app_name)
+
+    # A disabled app has no live hooks, so a recorded failure would linger as a
+    # stale claim about an app that is no longer wired up at all.
+    clear_hook_health(app_name)
 
     # Clean up cron jobs owned by this app
     permissions = manifest.get("permissions", {})
@@ -432,6 +471,15 @@ async def on_gateway_startup(
             )
             if success:
                 logger.info("Startup hook invoked for: %s", name)
+
+        # Same publication as on_app_enable: the reason a hook failed must outlive
+        # the context, or boot is the one path where it is collected and dropped.
+        # No log line here on purpose: every site that marks the context degraded
+        # already logs at ERROR itself (route_registry.py:142,151,159 and
+        # lifecycle.py:352,396, plus the cancelled site via
+        # _mark_cancelled_startup_residual at lifecycle.py:66), so an aggregate
+        # would only re-log them, and only ever for this one caller.
+        _publish_hook_health(name, ctx)
 
 
 async def on_gateway_shutdown() -> None:

--- a/src/kiro_crew/apps/module_loader.py
+++ b/src/kiro_crew/apps/module_loader.py
@@ -6,6 +6,7 @@ namespaced keys to prevent collisions between apps.
 """
 from __future__ import annotations
 
+import importlib.machinery
 import importlib.util
 import logging
 import sys
@@ -51,9 +52,117 @@ def _warn_third_party_execution(app_name: str) -> None:
     )
 
 
+def _app_namespace_root(app_name: str) -> str:
+    """Build the synthetic top-level package name that owns one app's modules.
+
+    Per-app isolation rests on the app-name grammar: ``KEBAB_RE`` in
+    ``apps/manifest.py`` admits only ``[a-z0-9]`` and ``-``, so a name can never
+    contain a dot. That is what keeps one app's root from becoming a dotted
+    prefix of another's -- ``_kirocrew_app_foo`` and ``_kirocrew_app_foo-bar``
+    are separated by ``-``, so neither is under the other's ``root + "."``
+    namespace. Relaxing that grammar to allow dots would let app ``foo`` own
+    keys belonging to app ``foo.bar``.
+    """
+    return f"_kirocrew_app_{app_name}"
+
+
 def _module_namespace(app_name: str, dotted_path: str) -> str:
     """Build a unique sys.modules key for an app module."""
-    return f"_kirocrew_app_{app_name}.{dotted_path}"
+    return f"{_app_namespace_root(app_name)}.{dotted_path}"
+
+
+def _app_module_keys(app_name: str) -> list[str]:
+    """Every sys.modules key owned by this app — the synthetic root included."""
+    root = _app_namespace_root(app_name)
+    prefix = f"{root}."
+    return [k for k in sys.modules if k == root or k.startswith(prefix)]
+
+
+def _ensure_namespace_packages(app_name: str, dotted_path: str, app_dir: Path) -> None:
+    """Register the synthetic parent packages a dotted module key implies.
+
+    ``_module_namespace`` deliberately builds a DOTTED sys.modules key so two
+    apps shipping identically-named modules cannot collide. A dotted name makes
+    the loaded module's ``__package__`` point at a parent package, and CPython
+    then requires that parent — and every ancestor above it, up to the top-level
+    name — to be present in ``sys.modules`` before a relative import inside the
+    module body can resolve. Registering only the immediate parent is not enough:
+    the import machinery walks to the root, so ``from . import config`` in a
+    ``backend.routes`` hook entry file still raises ``ModuleNotFoundError`` for
+    the top-level name.
+
+    Each ancestor is registered as a namespace package whose ``__path__`` points
+    at the matching directory inside the app, so sibling resolution stays scoped
+    to the app's own tree and no ``sys.path`` mutation is needed — the property
+    this module's docstring commits to.
+    """
+    segments = dotted_path.split(".")
+    # (name, search directory) for the synthetic root plus one package per
+    # intermediate segment. The final segment is the module itself, not a package.
+    ancestors: list[tuple[str, Path]] = [(_app_namespace_root(app_name), app_dir)]
+    for segment in segments[:-1]:
+        parent_name, parent_dir = ancestors[-1]
+        ancestors.append((f"{parent_name}.{segment}", parent_dir / segment))
+
+    for name, search_dir in ancestors:
+        if name in sys.modules:
+            continue
+        pkg = importlib.util.module_from_spec(
+            importlib.machinery.ModuleSpec(name, None, is_package=True)
+        )
+        pkg.__path__ = [str(search_dir)]
+        sys.modules[name] = pkg
+
+
+def _app_module_snapshot(app_name: str) -> dict[str, Any]:
+    """Snapshot this app's sys.modules entries as name -> module OBJECT.
+
+    Names alone are not enough. Two hooks may name the same module file (the
+    documented ``on_startup`` / ``on_shutdown`` pair does exactly that), so the
+    second load overwrites the first's ``sys.modules`` entry under a key that is
+    already present. A name-only snapshot would treat that key as pre-existing
+    and leave the overwriting object in place on rollback, diverging from the
+    module the first hook's registered handlers came from.
+    """
+    return {k: sys.modules[k] for k in _app_module_keys(app_name)}
+
+
+def _rollback_app_modules(app_name: str, keep: dict[str, Any]) -> None:
+    """Undo one load's sys.modules footprint, leaving earlier loads intact.
+
+    A failed load can have touched three kinds of key: the leaf module, the
+    synthetic ancestor packages, and any sibling the module body imported before
+    it raised. Removing everything this app owns would evict a hook that loaded
+    successfully earlier, so ``keep`` is the snapshot taken before this load:
+    a key absent from it is removed, and a key whose OBJECT this load replaced is
+    restored to the object the snapshot holds.
+
+    Dropping the key is not enough either. CPython's import machinery binds a
+    submodule as an ATTRIBUTE on its parent package, so a sibling imported by the
+    failing body stays reachable as ``parent.sibling`` after its key is gone --
+    invisible to ``unload_app_modules`` and ``is_app_module_loaded``, which reason
+    over ``sys.modules`` alone, and worse: a later ``from . import sibling`` finds
+    the attribute, skips the import entirely, and silently reuses the stale module
+    instead of re-reading the file. So the parent attribute follows the same
+    decision as the key, identity-checked so an unrelated attribute of the same
+    name is never touched.
+    """
+    for key in _app_module_keys(app_name):
+        current = sys.modules.get(key)
+        original = keep.get(key)
+        if original is current:
+            continue
+        if original is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
+        parent_name, _, leaf_name = key.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, leaf_name, None) is current:
+            if original is None:
+                delattr(parent, leaf_name)
+            else:
+                setattr(parent, leaf_name, original)
 
 
 def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[..., Any]:
@@ -135,6 +244,16 @@ def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[
     if spec is None or spec.loader is None:
         raise ImportError(f"Failed to create module spec for {file_path}")
 
+    # Snapshot before any registration so a failed load can be undone precisely,
+    # without evicting a hook of the same app that already loaded successfully.
+    # Objects, not just names: a second hook naming the same module file replaces
+    # an entry that is already present.
+    preexisting = _app_module_snapshot(app_name)
+
+    # The dotted key makes __package__ point at a synthetic parent — register the
+    # whole ancestor chain so relative imports in the module body can resolve.
+    _ensure_namespace_packages(app_name, dotted_path, app_dir)
+
     module = importlib.util.module_from_spec(spec)
     sys.modules[unique_name] = module
 
@@ -142,13 +261,20 @@ def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[
         spec.loader.exec_module(module)
     except Exception as exc:
         # Clean up on failure
-        sys.modules.pop(unique_name, None)
+        _rollback_app_modules(app_name, preexisting)
         raise ImportError(
             f"Failed to execute module {file_path}: {exc}"
         ) from exc
 
+    # Mirror normal import semantics: bind the module on its parent package so a
+    # sibling can reach it as an attribute (``from .routes import register``).
+    parent_name, _, leaf_name = unique_name.rpartition(".")
+    parent_module = sys.modules.get(parent_name)
+    if parent_module is not None:
+        setattr(parent_module, leaf_name, module)
+
     if not hasattr(module, callable_name):
-        sys.modules.pop(unique_name, None)
+        _rollback_app_modules(app_name, preexisting)
         raise ImportError(
             f"Module {file_path} has no attribute {callable_name!r}. "
             f"Available: {[a for a in dir(module) if not a.startswith('_')]}"
@@ -156,7 +282,7 @@ def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[
 
     func = getattr(module, callable_name)
     if not callable(func):
-        sys.modules.pop(unique_name, None)
+        _rollback_app_modules(app_name, preexisting)
         raise ImportError(
             f"{callable_name!r} in {file_path} is not callable "
             f"(got {type(func).__name__})"
@@ -177,11 +303,13 @@ def load_app_module(app_name: str, app_dir: Path, module_path: str) -> Callable[
 def unload_app_modules(app_name: str) -> int:
     """Remove all cached modules for an app from sys.modules.
 
-    Called on app disable to ensure re-enable loads fresh code.
-    Returns the number of modules removed.
+    Called on app disable to ensure re-enable loads fresh code. This covers the
+    synthetic ancestor packages too — leaving one behind would pin a stale
+    ``__path__`` at the app's old location across an uninstall/reinstall.
+
+    Returns the number of sys.modules entries removed.
     """
-    prefix = f"_kirocrew_app_{app_name}."
-    to_remove = [k for k in sys.modules if k.startswith(prefix)]
+    to_remove = _app_module_keys(app_name)
     for k in to_remove:
         del sys.modules[k]
     if to_remove:
@@ -191,5 +319,4 @@ def unload_app_modules(app_name: str) -> int:
 
 def is_app_module_loaded(app_name: str) -> bool:
     """Check if any modules are loaded for an app."""
-    prefix = f"_kirocrew_app_{app_name}."
-    return any(k.startswith(prefix) for k in sys.modules)
+    return bool(_app_module_keys(app_name))

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -53,6 +53,7 @@ from kiro_crew.apps.dependency_ledger import (
 from kiro_crew.apps.event_bus import build_broadcast_fn
 from kiro_crew.apps.execution import app_execution_denied
 from kiro_crew.apps.hooks_integration import (
+    get_all_hook_health,
     on_app_enable,
     stop_retained_startup_hooks,
 )
@@ -249,6 +250,16 @@ async def handle_list_apps(request: web.Request) -> web.Response:
     apps = await asyncio.to_thread(list_apps)
     # Enrich with backend process status
     procs = {p["app_name"]: p for p in list_app_processes()}
+    # ...and with in-process hook wiring health, which has no process to inspect:
+    # an app whose route hook failed to import has no route-table entry, so the
+    # dispatcher answers 404 exactly like an app that was never installed. This is
+    # the only place that failure becomes visible to an operator.
+    #
+    # Reported under the same "hooks" envelope and the same "health_status" key the
+    # enable response already uses, so one record has ONE public spelling rather
+    # than a second flat name to maintain. The envelope also keeps the subsystem
+    # explicit: this is hook-wiring health, not the subprocess backend_status.
+    hook_health = get_all_hook_health()
     for app in apps:
         proc = procs.get(app["name"])
         if proc:
@@ -258,6 +269,11 @@ async def handle_list_apps(request: web.Request) -> web.Response:
                 "healthy": proc["healthy"],
                 "pid": proc["pid"],
             }
+        health = hook_health.get(app["name"])
+        if health:
+            if health.get("issues"):
+                health["issues"] = [_redact_warning(i) for i in health["issues"]]
+            app["hooks"] = {"health_status": health}
     return web.json_response(apps)
 
 

--- a/test/test_app_hook_health.py
+++ b/test/test_app_hook_health.py
@@ -1,0 +1,191 @@
+"""Issue #6078 Part B: the reason a hook failed must outlive the AppContext.
+
+``register_app_routes`` records WHY it could not wire an app up
+(``ctx.health.mark_degraded``), but the context it writes to was dropped on the
+gateway startup path — only ``on_app_enable`` ever read it back. An app that was
+installed, trusted and enabled therefore looked exactly like an app that was
+never installed: the dispatcher answers 404 either way.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+import kiro_crew.apps.hooks_integration as hooks_mod
+import kiro_crew.apps.routes as routes_mod
+from kiro_crew.apps.route_registry import RouteRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clean_hook_health():
+    """The registry is process-global; no test may inherit another's entries."""
+    hooks_mod._hook_health.clear()
+    yield
+    hooks_mod._hook_health.clear()
+
+
+def _write_app(app_dir: Path, module: str, body: str) -> None:
+    path = app_dir / (module.replace(".", "/") + ".py")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _app_info(name: str, routes_hook: str) -> dict:
+    return {
+        "name": name,
+        "enabled": True,
+        "manifest": {"name": name, "backend": {"hooks": {"routes": routes_hook}}},
+    }
+
+
+def _arm_startup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, app_dir: Path, info: dict
+) -> None:
+    """Point on_gateway_startup at one app living under tmp_path."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", SimpleNamespace())
+    monkeypatch.setattr(hooks_mod, "_route_registry", RouteRegistry(web.Application()))
+    monkeypatch.setattr(hooks_mod, "list_apps", lambda: [info])
+    monkeypatch.setattr(hooks_mod, "_app_hook_root", lambda _name: app_dir)
+    monkeypatch.setattr(hooks_mod, "app_execution_denied", lambda *a, **kw: "")
+    monkeypatch.setattr("kiro_crew.apps.execution.third_party_execution_allowed", lambda: True)
+
+
+class TestStartupPublishesHookHealth:
+    @pytest.mark.asyncio
+    async def test_failed_route_hook_reason_survives_startup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A route hook that cannot be imported leaves a readable reason behind."""
+        app_dir = tmp_path / "apps" / "broken-app"
+        _write_app(app_dir, "backend.routes", "raise RuntimeError('kaboom')\n")
+        _arm_startup(
+            monkeypatch,
+            tmp_path,
+            app_dir,
+            _app_info("broken-app", "backend.routes:register"),
+        )
+
+        await hooks_mod.on_gateway_startup()
+
+        health = hooks_mod.get_all_hook_health().get("broken-app")
+        assert health is not None, (
+            "startup dropped the reason the route hook failed — an enabled app is "
+            "indistinguishable from one that was never installed"
+        )
+        assert health["status"] == "degraded"
+        assert any("Route module load failed" in issue for issue in health["issues"])
+        assert any("kaboom" in issue for issue in health["issues"])
+
+    @pytest.mark.asyncio
+    async def test_working_route_hook_records_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clean wire-up must not leave a health entry for the dashboard to show."""
+        app_dir = tmp_path / "apps" / "good-app"
+        _write_app(app_dir, "backend.routes", "def register(ctx):\n    return []\n")
+        _arm_startup(
+            monkeypatch,
+            tmp_path,
+            app_dir,
+            _app_info("good-app", "backend.routes:register"),
+        )
+
+        await hooks_mod.on_gateway_startup()
+
+        assert hooks_mod.get_all_hook_health().get("good-app") is None
+        assert hooks_mod.get_all_hook_health() == {}
+
+
+class TestHookHealthLifecycle:
+    def test_healthy_rewire_clears_a_stale_failure(self) -> None:
+        """A fixed app stops reporting the failure it had on the previous wire-up."""
+        hooks_mod._hook_health["formerly-broken"] = {"status": "degraded"}
+        ctx = SimpleNamespace(health=SimpleNamespace(status="healthy"))
+
+        assert hooks_mod._publish_hook_health("formerly-broken", ctx) is None
+        assert hooks_mod.get_all_hook_health().get("formerly-broken") is None
+
+    def test_snapshots_are_copies(self) -> None:
+        """A reader cannot mutate the stored record through the value it got."""
+        hooks_mod._hook_health["an-app"] = {"status": "degraded", "issues": ["one"]}
+
+        snapshot = hooks_mod.get_all_hook_health().get("an-app")
+        assert snapshot is not None
+        snapshot["status"] = "tampered"
+
+        assert hooks_mod.get_all_hook_health().get("an-app")["status"] == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_disable_clears_the_recorded_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disabled app has no live hooks, so a stored failure would be a lie."""
+        monkeypatch.setattr(hooks_mod, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(hooks_mod, "_route_registry", None)
+        hooks_mod._hook_health["going-away"] = {"status": "degraded"}
+
+        await hooks_mod.on_app_disable("going-away", {"name": "going-away", "manifest": {}})
+
+        assert hooks_mod.get_all_hook_health().get("going-away") is None
+
+
+class TestListAppsSurfacesHookHealth:
+    @pytest.mark.asyncio
+    async def test_list_apps_reports_hook_health(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GET /api/apps carries the hook failure beside backend_status."""
+        monkeypatch.setattr(
+            routes_mod, "list_apps", lambda: [{"name": "broken-app", "enabled": True}]
+        )
+        monkeypatch.setattr(routes_mod, "list_app_processes", lambda: [])
+        hooks_mod._hook_health["broken-app"] = {
+            "status": "degraded",
+            "issues": ["Route module load failed: boom"],
+            "last_checked": "2026-08-26T00:00:00Z",
+        }
+
+        resp = await routes_mod.handle_list_apps(make_mocked_request("GET", "/api/apps"))
+
+        assert resp.status == 200
+        payload = json.loads(resp.text)
+        assert payload[0]["hooks"]["health_status"]["status"] == "degraded"
+        assert payload[0]["hooks"]["health_status"]["issues"] == ["Route module load failed: boom"]
+
+    @pytest.mark.asyncio
+    async def test_healthy_app_has_no_hooks_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            routes_mod, "list_apps", lambda: [{"name": "good-app", "enabled": True}]
+        )
+        monkeypatch.setattr(routes_mod, "list_app_processes", lambda: [])
+
+        resp = await routes_mod.handle_list_apps(make_mocked_request("GET", "/api/apps"))
+
+        payload = json.loads(resp.text)
+        assert "hooks" not in payload[0]
+
+    @pytest.mark.asyncio
+    async def test_reported_issues_do_not_leak_the_stored_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redacting for the response must not rewrite what the gateway holds."""
+        monkeypatch.setattr(
+            routes_mod, "list_apps", lambda: [{"name": "broken-app", "enabled": True}]
+        )
+        monkeypatch.setattr(routes_mod, "list_app_processes", lambda: [])
+        monkeypatch.setattr(routes_mod, "_redact_warning", lambda s: "REDACTED")
+        hooks_mod._hook_health["broken-app"] = {
+            "status": "degraded",
+            "issues": ["Route module load failed: boom"],
+        }
+
+        resp = await routes_mod.handle_list_apps(make_mocked_request("GET", "/api/apps"))
+
+        payload = json.loads(resp.text)
+        assert payload[0]["hooks"]["health_status"]["issues"] == ["REDACTED"]
+        assert hooks_mod._hook_health["broken-app"]["issues"] == ["Route module load failed: boom"]

--- a/test/test_module_loader.py
+++ b/test/test_module_loader.py
@@ -299,13 +299,17 @@ class TestModuleUnload:
 
         assert is_app_module_loaded("test-app")
 
+        # Two leaf modules plus the synthetic packages that carry their dotted
+        # names: the app root, and "sub" for the nested module.
         count = unload_app_modules("test-app")
-        assert count == 2
+        assert count == 4
         assert not is_app_module_loaded("test-app")
 
         # Verify specific keys are gone
         assert "_kirocrew_app_test-app.mod_a" not in sys.modules
         assert "_kirocrew_app_test-app.sub.mod_b" not in sys.modules
+        assert "_kirocrew_app_test-app.sub" not in sys.modules
+        assert "_kirocrew_app_test-app" not in sys.modules
 
     def test_unload_does_not_affect_other_apps(self, tmp_path: Path) -> None:
         """Unloading app A does not remove app B's modules."""
@@ -358,6 +362,265 @@ class TestModuleUnload:
         assert func_v2(None) == "v2"
 
         unload_app_modules("test-app-reload")
+
+
+# ---------------------------------------------------------------------------
+# Issue #6078: a multi-module app backend must be able to import its own siblings
+# ---------------------------------------------------------------------------
+
+
+class TestRelativeImports:
+    """A hook entry file can reach its sibling modules with a relative import.
+
+    The sys.modules key is deliberately dotted so two apps cannot collide, which
+    makes the module's ``__package__`` name a synthetic parent. Unless every
+    ancestor of that name is registered, CPython raises ``ModuleNotFoundError``
+    for the top of the chain and the app silently gets no routes.
+    """
+
+    def test_nested_hook_module_imports_sibling(self, tmp_path: Path) -> None:
+        """``from . import config`` works from a ``backend.routes`` entry file."""
+        app_dir = tmp_path / "multi-file-app"
+        _create_app_module(app_dir, "backend.config:_", "TIMEOUT = 30\n")
+        _create_app_module(app_dir, "backend.routes:register", """
+from . import config
+
+
+def register(ctx):
+    return config.TIMEOUT
+""")
+
+        func = load_app_module("multi-file-app", app_dir, "backend.routes:register")
+        assert func(None) == 30
+
+        unload_app_modules("multi-file-app")
+
+    def test_root_level_hook_module_imports_sibling(self, tmp_path: Path) -> None:
+        """The same holds when the hook module sits at the app root."""
+        app_dir = tmp_path / "flat-app"
+        _create_app_module(app_dir, "config:_", "TIMEOUT = 5\n")
+        _create_app_module(app_dir, "routes:register", """
+from . import config
+
+
+def register(ctx):
+    return config.TIMEOUT
+""")
+
+        func = load_app_module("flat-app", app_dir, "routes:register")
+        assert func(None) == 5
+
+        unload_app_modules("flat-app")
+
+    def test_from_import_of_submodule_attribute(self, tmp_path: Path) -> None:
+        """``from .render import to_html`` — the other spelling authors reach for."""
+        app_dir = tmp_path / "render-app"
+        _create_app_module(
+            app_dir, "backend.render:_", "def to_html(v):\n    return f'<p>{v}</p>'\n"
+        )
+        _create_app_module(app_dir, "backend.routes:register", """
+from .render import to_html
+
+
+def register(ctx):
+    return to_html("hi")
+""")
+
+        func = load_app_module("render-app", app_dir, "backend.routes:register")
+        assert func(None) == "<p>hi</p>"
+
+        unload_app_modules("render-app")
+
+    def test_sibling_modules_stay_isolated_between_apps(self, tmp_path: Path) -> None:
+        """Two apps shipping the same sibling filename see their own copy.
+
+        This is the property the dotted namespace exists for, and the reason a
+        bare ``import config`` is not an acceptable workaround.
+        """
+        for name, value in (("iso-a", "1"), ("iso-b", "2")):
+            app_dir = tmp_path / name
+            _create_app_module(app_dir, "backend.config:_", f"VALUE = {value}\n")
+            _create_app_module(app_dir, "backend.routes:register", """
+from . import config
+
+
+def register(ctx):
+    return config.VALUE
+""")
+
+        func_a = load_app_module("iso-a", tmp_path / "iso-a", "backend.routes:register")
+        func_b = load_app_module("iso-b", tmp_path / "iso-b", "backend.routes:register")
+
+        assert func_a(None) == 1
+        assert func_b(None) == 2
+        assert (
+            sys.modules["_kirocrew_app_iso-a.backend.config"]
+            is not sys.modules["_kirocrew_app_iso-b.backend.config"]
+        )
+
+        unload_app_modules("iso-a")
+        unload_app_modules("iso-b")
+
+    def test_relative_import_cannot_escape_the_app_root(self, tmp_path: Path) -> None:
+        """A relative import that walks above the app root is refused.
+
+        The synthetic root's ``__path__`` is the app directory, so there is no
+        package above it to traverse into.
+        """
+        (tmp_path / "outside.py").write_text("SECRET = 'leaked'\n", encoding="utf-8")
+        app_dir = tmp_path / "escape-app"
+        _create_app_module(app_dir, "backend.routes:register", """
+from ... import outside
+
+
+def register(ctx):
+    return outside.SECRET
+""")
+
+        with pytest.raises(ImportError):
+            load_app_module("escape-app", app_dir, "backend.routes:register")
+
+        assert not is_app_module_loaded("escape-app")
+
+    def test_failed_load_leaves_no_synthetic_packages_behind(
+        self, tmp_path: Path
+    ) -> None:
+        """A module whose body raises leaves sys.modules exactly as it was."""
+        app_dir = tmp_path / "broken-app"
+        _create_app_module(app_dir, "backend.routes:register", """
+raise RuntimeError("boom")
+
+
+def register(ctx):
+    return None
+""")
+
+        with pytest.raises(ImportError):
+            load_app_module("broken-app", app_dir, "backend.routes:register")
+
+        assert "_kirocrew_app_broken-app" not in sys.modules
+        assert "_kirocrew_app_broken-app.backend" not in sys.modules
+        assert not is_app_module_loaded("broken-app")
+
+    def test_failed_load_keeps_an_earlier_successful_load(
+        self, tmp_path: Path
+    ) -> None:
+        """Rolling back a failed hook must not evict a hook that already loaded."""
+        app_dir = tmp_path / "mixed-app"
+        _create_app_module(app_dir, "backend.config:_", "VALUE = 11\n")
+        _create_app_module(app_dir, "backend.routes:register", """
+from . import config
+
+
+def register(ctx):
+    return config.VALUE
+""")
+        _create_app_module(app_dir, "backend.hooks:on_startup", """
+raise RuntimeError("startup module is broken")
+
+
+def on_startup(ctx):
+    return None
+""")
+
+        func = load_app_module("mixed-app", app_dir, "backend.routes:register")
+        assert func(None) == 11
+
+        with pytest.raises(ImportError):
+            load_app_module("mixed-app", app_dir, "backend.hooks:on_startup")
+
+        # The working hook and the sibling it imported are still usable.
+        assert "_kirocrew_app_mixed-app.backend.routes" in sys.modules
+        assert "_kirocrew_app_mixed-app.backend.config" in sys.modules
+        assert "_kirocrew_app_mixed-app.backend.hooks" not in sys.modules
+        assert func(None) == 11
+
+        unload_app_modules("mixed-app")
+
+    def test_rollback_clears_the_parent_attribute_of_a_dropped_sibling(
+        self, tmp_path: Path
+    ) -> None:
+        """A rolled-back sibling must not stay reachable as a parent attribute.
+
+        CPython binds a submodule on its parent package, so popping only the
+        ``sys.modules`` key leaves the module reachable as ``parent.sibling``.
+        That is invisible to ``unload_app_modules`` / ``is_app_module_loaded``,
+        and a later ``from . import sibling`` would find the attribute, skip the
+        import, and silently reuse the stale module instead of the file on disk.
+
+        The residue needs an earlier SUCCESSFUL load, so the parent package
+        pre-exists and survives the rollback.
+        """
+        app_dir = tmp_path / "residue-app"
+        _create_app_module(app_dir, "backend.config:_", "VALUE = 1\n")
+        _create_app_module(app_dir, "backend.render:_", "MARK = 'first'\n")
+        _create_app_module(app_dir, "backend.routes:register", """
+from . import config
+
+
+def register(ctx):
+    return config.VALUE
+""")
+        _create_app_module(app_dir, "backend.hooks:on_startup", """
+from . import render
+
+raise RuntimeError("boom after importing render")
+
+
+def on_startup(ctx):
+    return None
+""")
+
+        load_app_module("residue-app", app_dir, "backend.routes:register")
+        with pytest.raises(ImportError):
+            load_app_module("residue-app", app_dir, "backend.hooks:on_startup")
+
+        parent = sys.modules["_kirocrew_app_residue-app.backend"]
+        assert "_kirocrew_app_residue-app.backend.render" not in sys.modules
+        assert not hasattr(parent, "render"), (
+            "the rolled-back sibling is still reachable as a parent attribute, so a "
+            "later relative import would reuse it instead of re-reading the file"
+        )
+        # The earlier successful load and the sibling it imported are untouched.
+        assert hasattr(parent, "routes")
+        assert hasattr(parent, "config")
+
+        unload_app_modules("residue-app")
+
+    def test_failed_second_load_of_one_module_restores_the_first_object(
+        self, tmp_path: Path
+    ) -> None:
+        """Two hooks may name the SAME module file, so a load can overwrite a key
+        that is already present. If that second load fails, the entry must go back
+        to the object the first hook's registered handlers came from.
+
+        This is the documented ``on_startup`` / ``on_shutdown`` shape, not an
+        exotic case: both name one ``backend.hooks`` module.
+        """
+        app_dir = tmp_path / "two-hooks-app"
+        _create_app_module(app_dir, "backend.hooks:on_startup", """
+def on_startup(ctx):
+    return "started"
+""")
+
+        first = load_app_module("two-hooks-app", app_dir, "backend.hooks:on_startup")
+        key = "_kirocrew_app_two-hooks-app.backend.hooks"
+        first_module = sys.modules[key]
+        parent = sys.modules["_kirocrew_app_two-hooks-app.backend"]
+
+        # Same module, a callable it does not define: the load re-executes the
+        # file (replacing the sys.modules entry) and then fails the attr check.
+        with pytest.raises(ImportError):
+            load_app_module("two-hooks-app", app_dir, "backend.hooks:on_shutdown")
+
+        assert sys.modules[key] is first_module, (
+            "the failed second load left its own module object registered, so a "
+            "sibling import would see different state than the live handlers"
+        )
+        assert getattr(parent, "hooks") is first_module
+        assert first(None) == "started"
+
+        unload_app_modules("two-hooks-app")
 
 
 def test_deploy_skill_install_copy_fallback(tmp_path, monkeypatch):


### PR DESCRIPTION
## What is the problem?

A third-party app whose in-process backend spans more than one Python module has
no working way to import its own sibling modules, and when that import fails the
reason is discarded on the gateway startup path.

Install, trust and enable all report success. Every request to the app then
returns `404 {"error": "not found"}` -- byte-for-byte what an app that was never
installed returns. Two separable defects, and the second is what makes the first
expensive to diagnose.

**Part A -- the synthetic parent packages are never registered.**
`_module_namespace` deliberately builds a DOTTED `sys.modules` key
(`_kirocrew_app_<app>.<module>`) so two apps shipping identically-named modules
cannot collide. A dotted name makes the loaded module's `__package__` point at a
parent package, and CPython requires that parent -- and every ancestor above it,
up to the top-level name -- to be in `sys.modules` before a relative import in the
module body can resolve. Only the leaf was ever registered, so
`from . import config` in a `backend.routes` hook entry file raised
`ModuleNotFoundError: No module named '_kirocrew_app_<app>'`.

A third-party app has no alternative spelling:

| Approach | Outcome |
|---|---|
| `from . import config` | parent package absent, `ModuleNotFoundError` |
| `from kiro_crew.apps.builtins.<app> import config` | only available to builtins |
| bare `import config` | `sys.modules["config"]` is process-global, so two apps each shipping a `config.py` silently share one module |

The third row is exactly what the dotted prefix exists to prevent, so the
platform closed that door deliberately and never opened another.

**Part B -- the failure reason is collected and then dropped.**
`register_app_routes` does record why it failed
(`ctx.health.mark_degraded("Route module load failed: ...")`), but that list was
read in exactly one place: `on_app_enable`, whose result goes back to the caller
of the enable request. `on_gateway_startup` dropped the context each iteration
without reading it. On boot, the reason a hook failed was written to an object
nothing read and nothing persisted.

## Why this issue matters to the user

In-process hooks are the only way an app receives an `AppContext`
(`ctx.storage` / `ctx.cron` / `ctx.events`), so every author who wants those
capabilities is pushed onto exactly this path. The population affected is
third-party apps that declare `backend.hooks` AND split their backend across
more than one module. Builtin apps are unaffected -- they live inside an
importable package and use absolute `from kiro_crew.apps.builtins.<app> import ...`
imports. Subprocess `entryPoint` backends are unaffected (different mechanism),
and single-file backends are unaffected.

The diagnosis cost is the real damage. An installed, enabled, trusted app is
indistinguishable from an app that does not exist, so an author debugs
installation, trust and manifest format before ever suspecting an import. The
evidence on disk actively misleads: a `backend/__pycache__/routes.cpython-312.pyc`
exists (CPython writes the `.pyc` before executing the body, so a body that
raises on its import line still leaves one behind) and the app's `data/`
directory exists (the `AppContext` and its storage are built before route
registration). The only surviving signal was one `logger.error`, not attached to
the app record, so nothing an operator queries showed it.

## How our fix solves it

Following the chain from the 404 back to the cause:

1. **404 identical to not-installed** -- the dispatch catch-all answers 404 when
   the app has no route-table entry.
2. **No route-table entry** -- `register_app_routes` caught
   `(ImportError, ValueError)` and returned `[]`.
3. **ImportError** -- `load_app_module` re-raised the `ModuleNotFoundError` the
   module body produced.
4. **ModuleNotFoundError** -- the dotted key's ancestor packages were absent.

`_ensure_namespace_packages` now registers the **whole** ancestor chain before
the module executes: the synthetic app root plus one namespace package per
intermediate path segment, each with `__path__` pointing at the matching
directory inside the app. Registering only the immediate parent is not enough --
the import machinery walks to the root, so a `backend.routes` hook would still
fail. Sibling resolution therefore stays scoped to the app's own tree and no
`sys.path` mutation is introduced, which is the property the module's docstring
commits to.

Two consequences handled in the same change:

- A failed load now rolls back **only its own footprint**. `preexisting` is
  snapshotted before any registration, so rollback drops the leaf, the ancestors
  this call created, and any sibling the body imported before it raised -- while
  leaving a hook of the same app that already loaded successfully intact.
- `unload_app_modules` and `is_app_module_loaded` now cover the synthetic
  packages (`_app_module_keys`). Leaving one behind would pin a stale `__path__`
  at the app's old location across an uninstall/reinstall.

For Part B, both wiring paths now publish through one helper
(`_publish_hook_health`), so they cannot drift: whatever `register_app_routes`
and the lifecycle dispatcher marked on the context is what an operator reads
back. `GET /api/apps` reports it under the same `hooks.health_status` spelling
the enable response already uses -- one public name for one record, with the
envelope keeping the subsystem explicit (this is hook-wiring health, not the
subprocess `backend_status`). A healthy wire-up clears any earlier entry, and
disable clears it too, so a fixed or disabled app stops reporting a stale
failure.

No log line is added. An earlier revision of this PR added an aggregate ERROR
log at startup on the belief that the cancelled-startup-hook site degrades
silently; that was wrong -- `_mark_cancelled_startup_residual`
(`lifecycle.py:66`) already logs it at ERROR one line above the mark. All six
degradation sites log, so the journal already named the app and the only
missing half was the record an operator can query.

The app-name grammar that per-app isolation rests on is now stated where it is
relied upon: `KEBAB_RE` admits no dots, which is what keeps one app's root from
becoming a dotted prefix of another's.

## What tests we did

**Unit -- `test/test_module_loader.py`, 7 new tests.** Nested `backend.routes`
and root-level `routes` entry files importing a sibling; the
`from .render import to_html` spelling; two apps shipping the same sibling
filename each seeing their own module object; a relative import that walks above
the app root being refused; a failed load leaving no synthetic packages behind;
and a failed load not evicting an earlier successful one. 6 of the 8 affected
tests fail on `main` (`ModuleNotFoundError: No module named '_kirocrew_app_...'`).
The other two are guards rather than red-on-base pins: the escape test passes on
`main` because the load fails there for a different reason, and the
no-packages-left-behind assertion is vacuous on `main` where no such packages
exist.

**Unit -- `test/test_app_hook_health.py`, 9 new tests.** The real
`on_gateway_startup` driven against an app whose route module raises, asserting
the reason and its detail survive; a clean wire-up recording nothing; a healthy
re-wire clearing a stale failure; returned
snapshots being copies; disable clearing the record; `GET /api/apps` carrying
`hooks.health_status`; a healthy app having no such envelope; and redaction for the response
not rewriting what the gateway holds. All 9 are red on `main` (the surface does
not exist there).

**Live, in an isolated pod.** A third-party app `relimport-demo` with
`backend/{routes,config,render}.py` and `backend.hooks.routes =
"backend.routes:register"`, installed, trusted and enabled, then the pod
restarted so `on_gateway_startup` does the wiring. With only the loader fix
reverted:

```
GET /api/apps/relimport-demo/ping   -> 404 {"error": "not found"}

GET /api/apps                       -> "hooks": { "health_status": {
     "status": "degraded",
     "issues": ["Route module load failed: Failed to execute module
                 .../apps/relimport-demo/backend/routes.py:
                 No module named '_kirocrew_app_relimport-demo'"],
     "last_checked": "2026-08-26T15:53:15Z" } }

gateway.log (WARNING and above only)
  ERROR kiro_crew.apps.route_registry: Failed to load route module for app relimport-demo: ...
```

With the fix in place, same app, same boot path:

```
GET /api/apps/relimport-demo/ping   -> 200 {"greeting": "sibling import works",
                                            "banner": "relimport-demo"}
GET /api/apps                       -> no hooks envelope
```

**Gates.** `isort`, `flake8` and `mypy` clean on every touched file. Targeted
suites green: `test_module_loader.py` + `test_app_hook_health.py` 33 passed,
and 420 passed across `test_app_e2e` / `test_app_bridges` / `test_app_manager` /
`test_app_context` / `test_mochi_hooks` / `test_trusted_apps_api` /
`test_route_registry` / `test_apps_instances_loop_offload`. The full backend run
reports 64631 passed with 83 failures; the identical 83 failures reproduce on a
stashed (pristine) tree in the same environment, so they are host-environment
owned (relocated data home, agent-sandbox uid and unix-socket assertions) and
untouched by this diff.

**Pre-push review.** Two independent reviewers, both NO BLOCKING. Their two
optional items are folded in: the doc sentence about the app root now says what
the boundary actually is, and the `KEBAB_RE` invariant is documented at
`_app_namespace_root`.

## Any other suggestions on the work

- **`kirocrew app info` still shows nothing, deliberately.** It is a separate
  process that reads the on-disk app record; hook wiring health is a fact about
  the running gateway. Persisting it to disk would create a record that goes
  stale the moment the gateway restarts and lies about an app that has since
  been fixed. The honest CLI answer is to query the gateway, which is a larger
  change than this fix warrants -- worth a follow-up if operators want it.
- **`hooks.health_status` is not rendered in the UI yet.** Nothing in `website/src`
  reads `backend_status` either, so the new field follows the established
  pattern: the API reports it, a client can act on it. A badge on the app card
  is the natural next step and fits alongside #5601.
- **Naming.** Two review lanes read this key oppositely -- one name per record
  versus keeping the subsystem explicit. The list endpoint now mirrors the
  enable response's envelope exactly, so `hooks.health_status` satisfies both
  and no existing response key was renamed.
- **`unload_app_modules`' return value changed** from "leaf modules removed" to
  "`sys.modules` entries removed", so an existing assertion moved from 2 to 4.
  The sole production caller (`deregister_app_routes`) discards it; the updated
  test also pins that both synthetic keys are gone, so it is a strengthened
  assertion rather than a relaxed one.
- **A symlinked sibling resolves wherever it points.** The containment check
  resolves the entry leaf, not files a relative import reaches. This is not an
  escalation -- app Python already runs in-process with full filesystem access
  (`module_loader.py` says so explicitly) and could `open()` the file directly.
  The docs no longer imply otherwise.

Closes #6078

