### PR TITLE
fix(chat): remove follow-up options only from generated suffix

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -7862,19 +7862,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 // text so it no longer matches, leave text alone — the chip
                 // still un-highlights for consistency).
                 if (followUpPickedRef.current.has(o)) {
+                  const pickedSuffix = Array.from(followUpPickedRef.current).join(', ')
                   const next = new Set(followUpPickedRef.current); next.delete(o)
+                  const remainingSuffix = Array.from(next).join(', ')
                   followUpPickedRef.current = next
                   setInput(prev => {
-                    // Order matters: try leading ", o" first so "opt, opt" + remove
-                    // last "opt" doesn't match "opt, " and splice the wrong one.
-                    const leading = ', ' + o
-                    let idx = prev.indexOf(leading)
-                    if (idx >= 0) return prev.slice(0, idx) + prev.slice(idx + leading.length)
-                    const trailing = o + ', '
-                    idx = prev.indexOf(trailing)
-                    if (idx >= 0) return prev.slice(0, idx) + prev.slice(idx + trailing.length)
-                    if (prev === o) return ''
-                    return prev  // user edited — leave text, still unmark below
+                    // Options are appended as one ordered suffix. Remove only
+                    // from that complete generated structure: searching for a
+                    // last occurrence still corrupts an earlier ", Go" if the
+                    // user has already deleted the appended ", Go" by hand.
+                    if (prev === pickedSuffix) return remainingSuffix
+                    const delimitedSuffix = ', ' + pickedSuffix
+                    if (!prev.endsWith(delimitedSuffix)) return prev
+                    const draft = prev.slice(0, -delimitedSuffix.length)
+                    return remainingSuffix ? draft + ', ' + remainingSuffix : draft
                   })
                   setFollowUpPicked(next)
                 } else {

--- a/website/src/test/ChatPage.followUpToggle.test.tsx
+++ b/website/src/test/ChatPage.followUpToggle.test.tsx
@@ -220,6 +220,32 @@ describe('ChatPage follow-up option toggle', () => {
     expect(composer().value).toBe('Deploy, Retry')
   })
 
+  it('unselecting removes the appended option, not a matching substring in the draft', async () => {
+    // Regression: `indexOf(', ' + option)` matched the ", Go" inside
+    // "Please, Google" before the option the handler appended at the end.
+    await renderPage('Ready to proceed.\n\n[OPTIONS: Go | Stay]', '', 'Go')
+    fireEvent.change(composer(), { target: { value: 'Please, Google' } })
+    vi.useFakeTimers()
+    await act(async () => { clickOption('Go') })
+    expect(composer().value).toBe('Please, Google, Go')
+    await act(async () => { clickOption('Go') })
+    expect(composer().value).toBe('Please, Google')
+  })
+
+  it('leaves earlier draft text alone when the user already deleted the appended option', async () => {
+    await renderPage('Ready to proceed.\n\n[OPTIONS: Go | Stay]', '', 'Go')
+    fireEvent.change(composer(), { target: { value: 'Discuss, Go home' } })
+    vi.useFakeTimers()
+    await act(async () => { clickOption('Go') })
+    expect(composer().value).toBe('Discuss, Go home, Go')
+
+    // The chip remains selected, but the user removes its generated tail by hand.
+    // Unselecting must not fall back to the earlier ", Go" inside their draft.
+    fireEvent.change(composer(), { target: { value: 'Discuss, Go home' } })
+    await act(async () => { clickOption('Go') })
+    expect(composer().value).toBe('Discuss, Go home')
+  })
+
   it('re-adds the option on a third click', async () => {
     await renderPage()
     vi.useFakeTimers()


### PR DESCRIPTION
## Problem / Motivation

ChatPage's follow-up option toggle used substring search when removing an option. A matching fragment inside the user's draft could be deleted instead of the text generated by the toggle. A simple `lastIndexOf` still corrupts an earlier `, Go` if the user manually removes the generated tail before unselecting the chip.

## Why it matters

Unselecting a suggested answer must never rewrite unrelated draft text. Draft corruption can silently change what the user sends, and the bug becomes especially easy to trigger with short options such as `Go`.

## What changed

- Treat the currently picked options as one ordered, generated suffix.
- Remove an option only when that complete suffix is still present at the end of the composer.
- Rebuild the suffix from the remaining picked options, preserving the user's draft and multi-select order.
- If the user edited the generated structure, only unmark the chip and leave their text untouched.
- Drop the branch's carried backend liveness commit because main already contains the more complete #5929 implementation.

## Tests

- Added a deterministic regression for `Please, Google, Go` unselecting back to `Please, Google`.
- Added the edited-tail negative case: after the user removes the appended option, unselecting leaves `Discuss, Go home` untouched.
- Focused follow-up toggle suite: 12 passed.
- Related ChatPage matrix: 374 passed.
- Typecheck, lint (0 errors), and production build passed.
- The pre-fix `lastIndexOf` implementation was mutation-checked and deterministically failed the edited-tail case.

No retry, sleep, timeout increase, or flaky-test suppression was used.

## Manual verification

N/A — the interaction state machine is covered directly with the real ChatPage component and fake timers.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This fixes composer text mutation without changing rendered layout or styling; the before/after behavior is pinned by the interaction tests above.

## Related Issues

Fixes #5897