### PR TITLE
test(i18n): follow the memo ratchet through language wrapper modules

### DIFF
--- a/website/src/test/MemoI18nSubscriptionRatchet.test.ts
+++ b/website/src/test/MemoI18nSubscriptionRatchet.test.ts
@@ -42,6 +42,48 @@
  *    `LanguageProvider` documents why the value must stay identity-fresh.
  *    Forcing `useLanguageGeneration()` onto such a consumer would be redundant.
  *
+ * ## Why the trigger follows imports, and only through hook-free modules
+ *
+ * Language dependence is transitive. `utils/timeAgo.ts` imports the seam and
+ * re-exports its output as a plain function, so a memo boundary that renders
+ * `timeAgo(t)` is exactly as stale as one rendering `fmtRelative(t)` directly --
+ * with no `i18nT(` and no `i18n/format` import for either narrower branch to
+ * see. That is the same "added one innocent import at a time" route the
+ * direct-import branch closed, one module further out (#5922).
+ *
+ * So a module counts as a LANGUAGE WRAPPER when it contains no React hook call
+ * AND it either imports the seam directly or imports another wrapper. The
+ * hook-free half is the load-bearing one, and it is a statement about who CAN
+ * fix the staleness:
+ *
+ *  - A hook-free module cannot subscribe to anything. It is a plain function
+ *    (or a hookless presentational component) reading the active language at
+ *    call time, so the only site where a subscription can exist is the memo
+ *    boundary that calls it. Flagging that caller points at the one fix.
+ *  - A module that already calls hooks owns its own freshness: it can add
+ *    `useLanguageGeneration()` itself, and if it has a memo boundary the two
+ *    branches above already require it. Propagating the trigger to ITS callers
+ *    would red a parent for a child's omission and nudge the fix into the wrong
+ *    file, so the trigger stops at the first hooked module.
+ *
+ * The wrapper set is therefore a CLOSURE over hook-free modules, not a fixed
+ * depth: a hook-free wrapper of a wrapper cannot subscribe either, so capping
+ * the walk at one hop would recreate the same blind spot one module further out
+ * and contradict the rule's own premise. The closure is what makes it
+ * self-consistent, and it costs one loop -- measured at 31 modules reached in 2
+ * rounds, with zero offenders.
+ *
+ * A direct `i18next.language` read is the small sibling of the same gap (e.g.
+ * `components/commandPalette/providers/recentsProvider.ts`): the file reads the
+ * active language with no seam import at all, so it triggers on its own. It is
+ * NOT a wrapper seed -- propagating from it would drag in `LanguageProvider` and
+ * with it most of the tree.
+ *
+ * Both import spellings count. `@/utils/timeAgo` is the same module as
+ * `../utils/timeAgo` (the `@/*` -> `./src/*` alias in `tsconfig.app.json` and
+ * `vite.config.ts`), so resolving only relative specifiers would leave the alias
+ * as a silent bypass of exactly the shape this branch exists to close.
+ *
  * The rule is counted per boundary, not per file: a file with three memo
  * components and one subscription would still leave two subtrees stale, so the
  * number of `useLanguageGeneration()` calls must be at least the number of
@@ -49,7 +91,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, posix } from 'node:path'
 
 const SRC = join(__dirname, '..')
 
@@ -88,12 +130,83 @@ const MEMO_BOUNDARY = /(?<![\w$])(?:React\.)?memo\s*[<(]/g
  */
 const FORMAT_IMPORT = /from\s+['"][^'"]*\bi18n\/format['"]/
 
+/** The locale-formatting seam itself, as a path relative to `src/`. */
+const LANGUAGE_SEAM = 'i18n/format.ts'
+
+/**
+ * A direct read of the active language off the i18next instance -- the same
+ * call-time language dependence as a formatter, with no seam import to see.
+ */
+const I18NEXT_LANGUAGE = /\bi18next\.language\b/
+
+/**
+ * Any React hook CALL. Used to decide whether a module can subscribe to a
+ * language switch on its own; `use` followed by a capital rules out plain
+ * helpers like `useful(` while catching `useState(`, `useLanguage(` and every
+ * custom hook.
+ */
+const HOOK_CALL = /(?<![\w$])use[A-Z]\w*\s*\(/
+
+/**
+ * Import specifiers that can name a file in this tree: relative (`./x`, `../x`)
+ * and alias (`@/x`, the `@/*` -> `./src/*` mapping in `tsconfig.app.json` and
+ * `vite.config.ts`). Covers `from '...'`, bare `import '...'` and `import('...')`.
+ */
+const MODULE_IMPORT = /(?:\bfrom|\bimport)\s*\(?\s*['"]((?:\.|@\/)[^'"]*)['"]/g
+
+/** Specifiers imported by one file that could name a file in this tree. */
+export function importedSpecifiers(src: string): string[] {
+  return [...stripComments(src).matchAll(MODULE_IMPORT)].map(m => m[1])
+}
+
+/**
+ * Resolve one specifier to a path in `known` (all paths relative to `src/`),
+ * trying the extensions and index files a bundler would. `@/` resolves from the
+ * tree root, everything else from the importing file's directory. Returns null
+ * for anything outside the scanned tree (assets, generated files, packages).
+ */
+export function resolveSpecifier(fromRel: string, spec: string, known: Set<string>): string | null {
+  const base = spec.startsWith('@/')
+    ? posix.normalize(spec.slice(2))
+    : posix.normalize(posix.join(posix.dirname(fromRel), spec))
+  for (const cand of [base, `${base}.ts`, `${base}.tsx`, `${base}/index.ts`, `${base}/index.tsx`]) {
+    if (known.has(cand)) return cand
+  }
+  return null
+}
+
+/**
+ * Modules that carry the seam's language-dependent output and cannot subscribe
+ * on their own: no hook call, and either a direct `i18n/format` import or an
+ * import of another such module. Closed to a fixpoint, because a hook-free
+ * wrapper of a wrapper cannot subscribe either -- see the header for why the
+ * walk stops at the first hooked module rather than at a fixed depth.
+ */
+export function languageWrapperModules(sources: Map<string, string>): Set<string> {
+  const known = new Set(sources.keys())
+  const code = new Map([...sources].map(([rel, src]) => [rel, stripComments(src)]))
+  const candidates = [...code].filter(([rel, src]) => rel !== LANGUAGE_SEAM && !HOOK_CALL.test(src))
+  const wrappers = new Set(candidates.filter(([, src]) => FORMAT_IMPORT.test(src)).map(([rel]) => rel))
+  for (;;) {
+    const grew = candidates.filter(([rel, src]) =>
+      !wrappers.has(rel) &&
+      importedSpecifiers(src).some(spec => {
+        const dep = resolveSpecifier(rel, spec, known)
+        return dep !== null && wrappers.has(dep)
+      }),
+    )
+    if (grew.length === 0) return wrappers
+    for (const [rel] of grew) wrappers.add(rel)
+  }
+}
+
 /** Count memo boundaries and subscriptions in one file's source. */
 export function scanFile(src: string): {
   boundaries: number
   subscriptions: number
   usesI18nT: boolean
   importsFormat: boolean
+  readsI18nextLanguage: boolean
   languageContextReads: number
 } {
   const code = stripComments(src)
@@ -101,8 +214,9 @@ export function scanFile(src: string): {
   const subscriptions = [...code.matchAll(/\buseLanguageGeneration\(\)/g)].length
   const usesI18nT = /\bi18nT\(/.test(code)
   const importsFormat = FORMAT_IMPORT.test(code)
+  const readsI18nextLanguage = I18NEXT_LANGUAGE.test(code)
   const languageContextReads = [...code.matchAll(/\buseLanguage\(\)/g)].length
-  return { boundaries, subscriptions, usesI18nT, importsFormat, languageContextReads }
+  return { boundaries, subscriptions, usesI18nT, importsFormat, readsI18nextLanguage, languageContextReads }
 }
 
 function sourceFiles(): string[] {
@@ -112,12 +226,17 @@ function sourceFiles(): string[] {
     .filter(p => !p.startsWith('test/') && !p.includes('__tests__') && !/\.test\.tsx?$/.test(p))
 }
 
+/** Every scanned file's source, read once so the import scan stays one pass. */
+function sourceMap(): Map<string, string> {
+  return new Map(sourceFiles().map(rel => [rel, readFileSync(join(SRC, rel), 'utf8')]))
+}
+
 describe('memo() + i18nT() subscription ratchet', () => {
   it('every memo() boundary in an i18nT()-using file calls useLanguageGeneration()', () => {
     const offenders: string[] = []
-    for (const rel of sourceFiles()) {
+    for (const [rel, src] of sourceMap()) {
       if (EXEMPT.has(rel)) continue
-      const { boundaries, subscriptions, usesI18nT } = scanFile(readFileSync(join(SRC, rel), 'utf8'))
+      const { boundaries, subscriptions, usesI18nT } = scanFile(src)
       if (boundaries === 0 || !usesI18nT) continue
       if (subscriptions < boundaries) {
         offenders.push(`${rel}: ${boundaries} memo() boundaries, ${subscriptions} useLanguageGeneration() calls`)
@@ -131,28 +250,42 @@ describe('memo() + i18nT() subscription ratchet', () => {
     ).toEqual([])
   })
 
-  it('every memo() boundary in a format-consuming file subscribes or reads the language context', () => {
+  it('every memo() boundary in a language-formatting consumer subscribes or reads the language context', () => {
+    const sources = sourceMap()
+    const known = new Set(sources.keys())
+    const wrappers = languageWrapperModules(sources)
     const offenders: string[] = []
-    for (const rel of sourceFiles()) {
+    for (const [rel, src] of sources) {
       if (EXEMPT.has(rel)) continue
-      const { boundaries, subscriptions, importsFormat, languageContextReads } =
-        scanFile(readFileSync(join(SRC, rel), 'utf8'))
-      if (boundaries === 0 || !importsFormat) continue
+      const { boundaries, subscriptions, importsFormat, readsI18nextLanguage, languageContextReads } = scanFile(src)
+      if (boundaries === 0) continue
+      // One hop out: a wrapper's output is the seam's output, and the wrapper
+      // cannot subscribe on its own, so this boundary owns the freshness.
+      const viaWrappers = importedSpecifiers(src)
+        .map(spec => resolveSpecifier(rel, spec, known))
+        .filter((dep): dep is string => dep !== null && wrappers.has(dep))
+      if (!importsFormat && !readsI18nextLanguage && viaWrappers.length === 0) continue
       // useLanguage() consumers re-render THROUGH memo on a switch (context
       // bypasses the props bailout) and format.ts reads the language at call
       // time, so either subscription shape keeps the boundary fresh.
       if (subscriptions + languageContextReads < boundaries) {
+        const via = importsFormat
+          ? 'i18n/format'
+          : viaWrappers.length > 0
+            ? `wrapper ${viaWrappers.join(', ')}`
+            : 'i18next.language'
         offenders.push(
           `${rel}: ${boundaries} memo() boundaries, ${subscriptions} useLanguageGeneration() + ` +
-          `${languageContextReads} useLanguage() calls`,
+          `${languageContextReads} useLanguage() calls (language-dependent via ${via})`,
         )
       }
     }
     expect(
       offenders,
       'src/i18n/format.ts formatters read the active language at call time, so a memoized component ' +
-      'rendering their output goes stale after a language switch exactly like an i18nT() one; each ' +
-      'memo() boundary in a file importing i18n/format must call useLanguageGeneration() or consume ' +
+      'rendering their output goes stale after a language switch exactly like an i18nT() one -- whether ' +
+      'it calls them directly, through a hook-free wrapper module one import hop away, or reads ' +
+      'i18next.language itself. Each such memo() boundary must call useLanguageGeneration() or consume ' +
       'the useLanguage() context (which re-renders through memo), or be exempted here with a reason.',
     ).toEqual([])
   })
@@ -176,6 +309,7 @@ describe('scanFile predicate', () => {
       subscriptions: 0,
       usesI18nT: true,
       importsFormat: false,
+      readsI18nextLanguage: false,
       languageContextReads: 0,
     })
   })
@@ -230,5 +364,112 @@ describe('scanFile predicate', () => {
   it('does not mistake another module for the format seam', () => {
     const r = scanFile(`import { x } from '../i18n/formatters'\nimport { y } from './format'`)
     expect(r.importsFormat).toBe(false)
+  })
+
+  it('flags a direct i18next.language read with no seam import', () => {
+    const r = scanFile(`import i18next from 'i18next'\nexport default memo(() => <a>{i18next.language}</a>)`)
+    expect(r.readsI18nextLanguage).toBe(true)
+    expect(r.importsFormat).toBe(false)
+    expect(r.usesI18nT).toBe(false)
+    expect(r.boundaries).toBe(1)
+  })
+
+  it('does not count an i18next.language mention in a comment', () => {
+    expect(scanFile(`// reads i18next.language at call time\nconst X = memo(() => null)`).readsI18nextLanguage).toBe(false)
+  })
+})
+
+describe('wrapper closure and import resolution', () => {
+  it('collects relative and alias specifiers from every import form, and ignores packages', () => {
+    const specs = importedSpecifiers(
+      `import a from './a'\nimport { b } from '../b'\nimport '../side'\n` +
+      `const c = await import('./c')\nimport d from '@/utils/d'\nimport react from 'react'\n` +
+      `// import x from './commented'`,
+    )
+    expect(specs).toEqual(['./a', '../b', '../side', './c', '@/utils/d'])
+  })
+
+  it('resolves a specifier through .ts, .tsx and index files, and gives up outside the tree', () => {
+    const known = new Set(['utils/timeAgo.ts', 'components/Row.tsx', 'apps/x/index.ts'])
+    expect(resolveSpecifier('pages/ChatPage.tsx', '../utils/timeAgo', known)).toBe('utils/timeAgo.ts')
+    expect(resolveSpecifier('pages/ChatPage.tsx', '../components/Row', known)).toBe('components/Row.tsx')
+    expect(resolveSpecifier('pages/ChatPage.tsx', '../apps/x', known)).toBe('apps/x/index.ts')
+    expect(resolveSpecifier('pages/ChatPage.tsx', '../styles/theme.css', known)).toBeNull()
+  })
+
+  it('resolves the @/ alias from the tree root, to the same file as the relative spelling', () => {
+    const known = new Set(['utils/timeAgo.ts'])
+    // The alias is depth-independent, so it must not be joined with the importer's dir.
+    expect(resolveSpecifier('apps/issue-radar/views/deep/Card.tsx', '@/utils/timeAgo', known)).toBe('utils/timeAgo.ts')
+    expect(resolveSpecifier('App.tsx', '@/utils/timeAgo', known)).toBe('utils/timeAgo.ts')
+  })
+
+  it('treats a hook-free seam importer as a wrapper', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['utils/timeAgo.ts', `import { fmtRelative } from '../i18n/format'\nexport const timeAgo = (t) => fmtRelative(t)`],
+    ]))
+    expect([...wrappers]).toEqual(['utils/timeAgo.ts'])
+  })
+
+  it('does not treat a hooked seam importer as a wrapper: it can subscribe itself', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['components/Row.tsx', `import { fmtDate } from '../i18n/format'\nexport const Row = () => { const [x] = useState(0); return fmtDate(x) }`],
+    ]))
+    expect([...wrappers]).toEqual([])
+  })
+
+  it('never treats the seam itself as a wrapper, and needs a real seam import', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['i18n/format.ts', `export const fmtDate = (d) => String(d)`],
+      ['utils/plain.ts', `export const twice = (n) => n * 2`],
+      ['utils/other.ts', `import { x } from '../i18n/formatters'\nexport const y = () => x`],
+    ]))
+    expect([...wrappers]).toEqual([])
+  })
+
+  it('closes over hook-free wrappers of wrappers, and stops at the first hooked module', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['utils/timeAgo.ts', `import { fmtRelative } from '../i18n/format'\nexport const timeAgo = (t) => fmtRelative(t)`],
+      ['utils/stamp.ts', `import { timeAgo } from './timeAgo'\nexport const stamp = (t) => timeAgo(t)`],
+      ['utils/label.ts', `import { stamp } from '@/utils/stamp'\nexport const label = (t) => stamp(t)`],
+      ['hooks/useStamp.ts', `import { label } from '../utils/label'\nexport const useStamp = (t) => { const [v] = useState(label(t)); return v }`],
+      ['components/Far.tsx', `import { useStamp } from '../hooks/useStamp'\nexport const Far = () => useStamp(1)`],
+    ]))
+    // Three hops of hook-free modules, reached through both spellings.
+    expect([...wrappers].sort()).toEqual(['utils/label.ts', 'utils/stamp.ts', 'utils/timeAgo.ts'])
+    // The hooked module owns its own freshness, so the walk does not continue past it.
+    expect(wrappers.has('hooks/useStamp.ts')).toBe(false)
+    expect(wrappers.has('components/Far.tsx')).toBe(false)
+  })
+
+  it('the defect shape is a memo boundary whose only language input is a wrapper', () => {
+    const sources = new Map([
+      ['utils/timeAgo.ts', `import { fmtRelative } from '../i18n/format'\nexport const timeAgo = (t) => fmtRelative(t)`],
+      ['components/Row.tsx', `import { timeAgo } from '@/utils/timeAgo'\nexport default memo(({ t }) => <a>{timeAgo(t)}</a>)`],
+    ])
+    const wrappers = languageWrapperModules(sources)
+    const row = sources.get('components/Row.tsx')!
+    const r = scanFile(row)
+    // Neither narrower branch sees this file at all.
+    expect(r.usesI18nT).toBe(false)
+    expect(r.importsFormat).toBe(false)
+    expect(r.boundaries).toBe(1)
+    expect(r.subscriptions + r.languageContextReads).toBe(0)
+    const via = importedSpecifiers(row)
+      .map(spec => resolveSpecifier('components/Row.tsx', spec, new Set(sources.keys())))
+      .filter(dep => dep !== null && wrappers.has(dep))
+    expect(via).toEqual(['utils/timeAgo.ts'])
+  })
+
+  it('the live tree still has wrapper modules for the branch to act on', () => {
+    // A regex tightened against the tree could silently empty this set and turn
+    // the widened branch into a no-op, so pin the population and the modules
+    // #5922 enumerated. utils/cronUtils.tsx is deliberately not pinned: it is
+    // the one of the five likeliest to gain a hook legitimately.
+    const wrappers = languageWrapperModules(sourceMap())
+    expect(wrappers.size).toBeGreaterThan(0)
+    for (const rel of ['utils/timeAgo.ts', 'utils/formatCost.ts', 'utils/scheduleCadence.ts', 'apps/issue-radar/lib/format.ts']) {
+      expect(wrappers.has(rel), `expected wrapper: ${rel}`).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
## What is the problem?

The `memo()` + i18n subscription ratchet (`website/src/test/MemoI18nSubscriptionRatchet.test.ts`) decides whether a file is language-dependent by looking one level deep: does it call `i18nT(`, or does it import `i18n/format` directly. Language dependence is transitive, so that misses a whole class of file. Five modules import the seam and re-export its output as plain functions:

- `utils/timeAgo.ts`
- `utils/formatCost.ts`
- `utils/scheduleCadence.ts`
- `utils/cronUtils.tsx`
- `apps/issue-radar/lib/format.ts`

A `memo()` boundary whose only language-dependent input is `timeAgo(t)` renders exactly as stale as one rendering `fmtRelative(t)`, but carries no `i18nT(` and no seam import for either branch to see. A direct `i18next.language` read (for example `components/commandPalette/providers/recentsProvider.ts`) is the small sibling of the same gap.

There are no live offenders today, on this branch or on main. This is a guard gap, not a live defect -- the same status that justified #5545.

## Why this issue matters to the user

The defect the ratchet exists to prevent is a memoized subtree that keeps rendering the previous catalog after a language switch: the user picks a new language, the page repaints, and one card still shows the old dates, costs or cadences until something unrelated moves its props. That is the failure the tree scan was written to make impossible to add by accident.

The gap matters because of how the defect arrives. It is never written deliberately -- it appears one innocent-looking import at a time, which is why the guard reads the tree instead of relying on per-component tests. Leaving the wrapper hop uncovered leaves that exact route open, one module further out than the direct-import branch reached.

## How our fix solves it

The trigger now follows imports, but only through modules that cannot subscribe on their own.

A module counts as a **language wrapper** when it contains no React hook call AND it either imports `i18n/format` directly or imports another wrapper. The hook-free half is the load-bearing part, and it is a statement about who can fix the staleness:

- A hook-free module cannot subscribe to anything. It reads the active language at call time, so the only place a subscription can exist is the `memo()` boundary that calls it. Flagging that caller points at the one possible fix.
- A module that already calls hooks owns its own freshness: it can add `useLanguageGeneration()` itself, and if it has a `memo()` boundary the two existing branches already require that. Propagating the trigger past it would red a parent for a child's omission and push the fix into the wrong file, so the walk stops at the first hooked module.

The wrapper set is therefore a **closure** over hook-free modules, not a fixed depth. A hook-free wrapper *of* a wrapper cannot subscribe either, so capping the walk at one hop would recreate the same blind spot one module further out and contradict the rule's own premise. The closure is what makes it self-consistent, and it costs one loop.

Both import spellings resolve. `@/utils/timeAgo` names the same module as `../utils/timeAgo` (the `@/*` -> `./src/*` alias in `tsconfig.app.json` and `vite.config.ts`, already used in `src/`), so matching only relative specifiers would have left the alias as a silent bypass of exactly the shape this branch closes.

The second branch therefore now fires on three shapes -- a direct `i18n/format` import, a wrapper anywhere in the closure, or a direct `i18next.language` read -- and accepts the same two subscriptions as before (`useLanguageGeneration()` or a `useLanguage()` context read, which re-renders through `memo`). An `i18next.language` reader triggers its own file but is deliberately not a wrapper seed: propagating from it would drag in `LanguageProvider` and with it most of the tree.

This is option (b) from the issue -- the transitive import scan. Option (a), enumerating the five wrapper paths in the trigger list, rots the moment a sixth wrapper is added; option (c), a pragma wrapper authors must remember, fails silently when they forget. The scan detects a new wrapper the moment it is written.

Measured scope on this branch: **31 wrapper modules reached in 2 closure rounds, 13 files newly in scope, 0 new offenders** -- the widening is zero-churn, exactly as the issue predicted.

## What tests we did

Mutation-verified in both directions, with temporary probe files, covering each trigger shape the branch adds:

- Relative spelling, one hop (`export default memo(...)` rendering `timeAgo(t)`, no subscription): **RED**, naming the hop -- `components/MutationProbe.tsx: 1 memo() boundaries, 0 useLanguageGeneration() + 0 useLanguage() calls (language-dependent via wrapper utils/timeAgo.ts)`.
- Alias spelling (`import { timeAgo } from '@/utils/timeAgo'`): **RED**, same finding -- the case that would have escaped before the alias was resolved.
- Second hop (a hook-free `utils/probeStamp.ts` wrapping `timeAgo`, consumed by the memo boundary): **RED**, naming `utils/probeStamp.ts` -- the case a one-hop cap could not have caught.
- Same defect present, main's ratchet at `4c83b6743` restored verbatim into the tree: **12/12 GREEN**. This is the A/B that proves the branch closes a real blind spot rather than restating an existing one.
- Probe with `useLanguageGeneration()` added: **GREEN** -- the intended fix is accepted.
- All probes removed; the tree is green.

The fixture suite grew from 12 to 23 tests, covering the new pure helpers so a regex tightened against the live tree cannot silently stop matching the defect shape: specifier collection across `from`, bare `import` and dynamic `import()` including the alias form (packages and commented-out imports excluded), resolution through `.ts` / `.tsx` / `index.ts` / `index.tsx`, alias resolution from the tree root at two different importer depths, a null for paths outside the tree, wrapper classification (hook-free importer in, hooked importer out, seam itself never a wrapper, `i18n/formatters` not mistaken for the seam), closure behaviour across three hop-free hops with the walk stopping at a hooked module, and the `i18next.language` trigger including its comment-only negative case. One test pins that the live wrapper set is non-empty and still contains the modules #5922 enumerated, so a future tightening cannot turn the branch into a no-op. `utils/cronUtils.tsx` is deliberately left out of that pin: it is the one of the five likeliest to gain a hook legitimately, and pinning it would red an unrelated change.

Gates run locally:

- `vitest run src/test/MemoI18nSubscriptionRatchet.test.ts` -- 23/23 pass.
- Full frontend suite with `I18N_BASE_REF` set to the merge base -- 1553 files, 24312 passed, 1 expected fail, 3 skipped, 0 failures.
- `npm run typecheck` (`tsc -b`) clean; `eslint` on the changed file clean.
- `I18N_BASE_REF=<merge-base> npm run i18n:check` -- all checks OK, including the diff-scoped ones that silently skip without a base ref.
- `npm run jscpd` -- 0 clones.

## Any other suggestions on the work

Two residuals worth stating rather than quietly widening scope for:

1. An unsubscribed *component* is out of scope. If a memoized parent renders a child component that imports the seam and never subscribes, the parent's props bailout does freeze it -- but the correct fix is a subscription in the child, which the two existing branches already require once the child has its own `memo()` boundary. Flagging the parent would point at the wrong file. The wider "propagate through anything that does not subscribe" rule was measured too and also yields 0 offenders (23 files newly in scope), so it remains available if that class ever produces a real bug.
2. `i18next.language` readers stay leaves. Making them wrapper seeds pulls in `LanguageProvider`, which most of the tree imports, and the guard would stop being about a specific defect shape.

Closes #5922
