### PR TITLE
fix(core): route the two residual kill-then-bare-wait reap sites through kill_and_reap

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -630,16 +630,15 @@ async def _read_stream_limited(stream: asyncio.StreamReader, limit: int, label: 
 
 
 async def _terminate_process(proc: asyncio.subprocess.Process) -> None:
-    """Kill and reap a provider process tree after timeout, overflow, or cancellation."""
-    if proc.returncode is None:
-        try:
-            platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
-        except (OSError, ValueError):
-            # Best-effort PID fallback if group lookup races with launcher exit.
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-    with contextlib.suppress(ProcessLookupError):
-        await proc.wait()
+    """Kill and reap a provider process tree after timeout, overflow, or cancellation.
+
+    The reap is bounded and drains the pipes: this path is reached with the
+    stdout/stderr readers already cancelled by ``wait_for``, so a killed child
+    blocked writing into a full pipe -- or a surviving descendant still holding
+    the pipes open -- would make a bare ``await proc.wait()`` hang the calling
+    task forever.
+    """
+    await platform_compat.kill_and_reap(proc)
 
 
 async def _collect_process_output(

--- a/src/kiro_crew/mcp_gateway/resolve_once.py
+++ b/src/kiro_crew/mcp_gateway/resolve_once.py
@@ -76,7 +76,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
-from kiro_crew.platform_compat import SIGKILL, kill_process_tree_async
+from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 
 logger = logging.getLogger(__name__)
@@ -575,11 +575,14 @@ async def _reap_install_tree(proc: "asyncio.subprocess.Process") -> None:
     Escalates straight to SIGKILL: this path is only reached when the install has
     already blown its deadline or the broker is going away, so there is nothing
     left to salvage by asking politely.
+
+    The reap is bounded and drains the pipes. This path is reached with the
+    ``_drain_capped`` reader already cancelled by ``wait_for`` (timeout) or by
+    broker shutdown (cancellation), so the stdout pipe is undrained: npm blocked
+    writing into a full pipe -- or a lifecycle-script grandchild still holding it
+    open -- would make a bare ``await proc.wait()`` hang forever.
     """
-    with contextlib.suppress(ProcessLookupError, OSError, ValueError):
-        await kill_process_tree_async(proc.pid, SIGKILL)
-    with contextlib.suppress(Exception):
-        await proc.wait()
+    await kill_and_reap(proc)
 
 
 async def _rmtree_off_loop(path: str) -> None:

--- a/test/test_mcp_resolve_once.py
+++ b/test/test_mcp_resolve_once.py
@@ -695,7 +695,9 @@ class TestInstall:
         unbounded background process.
         """
         killed: list[tuple[int, int]] = []
-        real_kill = R.kill_process_tree_async
+        from kiro_crew import platform_compat
+
+        real_kill = platform_compat.kill_process_tree_async
 
         async def fake_kill_tree(pid, sig):
             # Record AND actually kill: a recording-only spy would leave the stub
@@ -704,7 +706,7 @@ class TestInstall:
             killed.append((pid, sig))
             return await real_kill(pid, sig)
 
-        monkeypatch.setattr(R, "kill_process_tree_async", fake_kill_tree)
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", fake_kill_tree)
         home = str(tmp_path / "home")
         spec = R.NpmSpec(package="foo@1.0.0", passthrough=())
         # A stub that never exits on its own, so the deadline is what ends it.
@@ -714,7 +716,7 @@ class TestInstall:
         rec = await R.install(home, spec, npm=str(sleeper), timeout_secs=0.4)
         assert rec is None
         # The GROUP was signalled, not just the pid.
-        assert killed and killed[0][1] == R.SIGKILL
+        assert killed and killed[0][1] == platform_compat.SIGKILL
 
     async def test_the_install_is_spawned_in_its_own_process_group(self) -> None:
         # Reaping the tree is only possible if the tree is a group of its own;
@@ -939,3 +941,58 @@ class TestSubstitutionActuallyHappens:
         inner = ("npx", ["-y", "foo@1.0.0"], dict(os.environ), "/tmp")
         resolver = G.resolve_once_resolver(lambda _key: inner)
         assert resolver(SimpleNamespace(server_name="s")) == inner
+
+
+class _ReapProbe:
+    """An install-tree child double that records how it is reaped.
+
+    ``_reap_install_tree`` runs on the timeout and cancellation arms with the
+    ``_drain_capped`` reader already cancelled, so the stdout pipe is undrained:
+    a killed npm blocked writing into a full pipe -- or a lifecycle-script
+    grandchild still holding it open -- makes a bare ``await proc.wait()`` hang
+    forever (#6005). The bounded reap must drain via ``communicate()`` and never
+    touch ``wait()``.
+    """
+
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+        self.returncode: "int | None" = None
+        self.kill_calls = 0
+        self.wait_calls = 0
+        self.communicate_calls = 0
+
+    async def communicate(self):
+        self.communicate_calls += 1
+        self.returncode = -9
+        return b"", b""
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        return -9
+
+
+class TestReapInstallTree:
+    @pytest.mark.asyncio
+    async def test_reaps_via_communicate_not_wait(self, monkeypatch) -> None:
+        """The reap must go through the bounded, pipe-draining ``kill_and_reap``,
+        never a bare ``await proc.wait()`` that a full pipe can hang (#6005)."""
+        from kiro_crew import platform_compat
+
+        proc = _ReapProbe()
+        tree_kills: "list[tuple[int, int]]" = []
+
+        async def _fake_tree(pid, sig):
+            tree_kills.append((pid, sig))
+            return True
+
+        # Fake pid + patched tree kill so no test can reach a real killpg.
+        monkeypatch.setattr(platform_compat, "kill_process_tree_async", _fake_tree)
+
+        await R._reap_install_tree(proc)
+
+        assert proc.communicate_calls == 1
+        assert proc.wait_calls == 0
+        assert tree_kills and tree_kills[0][0] == proc.pid

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -654,6 +654,13 @@ async def test_run_json_kills_process_tree_when_stdout_exceeds_limit(monkeypatch
             self.returncode = -9
             self.done.set()
 
+        async def communicate(self):
+            # The bounded reap drains the pipes via communicate() rather than a
+            # bare wait() that a full pipe could hang.
+            self.returncode = -9
+            self.done.set()
+            return b"", b""
+
     proc = FakeProcess()
     spawn_kwargs = {}
 
@@ -661,26 +668,26 @@ async def test_run_json_kills_process_tree_when_stdout_exceeds_limit(monkeypatch
         spawn_kwargs.update(kwargs)
         return proc
 
-    def kill_tree(pid, sig):
-        assert pid == proc.pid
-        assert sig == source.platform_compat.SIGKILL
+    tree_kills: list[tuple[int, int]] = []
+
+    async def kill_tree(pid, sig):
+        tree_kills.append((pid, sig))
         proc.returncode = -sig
         proc.done.set()
         return True
 
-    tree_kill = MagicMock(side_effect=kill_tree)
     monkeypatch.setattr(source, "_resolve_provider_executable", lambda _name: "/usr/bin/gh")
     monkeypatch.setattr(
         source,
         "sandboxed_spawn_argv",
         lambda argv, **kwargs: (argv, kwargs["env"], None),
     )
-    monkeypatch.setattr(source.platform_compat, "kill_process_tree", tree_kill)
+    monkeypatch.setattr(source.platform_compat, "kill_process_tree_async", kill_tree)
     monkeypatch.setattr(source.asyncio, "create_subprocess_exec", fake_create)
     with pytest.raises(source.SourceProviderError, match="response was too large"):
         await source._run_json("gh", "api", "repos/acme/repo", max_output_bytes=4)
-    tree_kill.assert_called_once_with(proc.pid, source.platform_compat.SIGKILL)
-    assert proc.killed is False
+    # The whole tree is SIGKILLed through the bounded reap (kill_and_reap).
+    assert tree_kills == [(proc.pid, source.platform_compat.SIGKILL)]
     assert spawn_kwargs["env"]["GH_HOST"] == "github.com"
     assert spawn_kwargs["start_new_session"] is source.platform_compat.IS_POSIX
     assert spawn_kwargs["creationflags"] == source.platform_compat.CREATE_NEW_PROCESS_GROUP
@@ -7837,3 +7844,62 @@ class TestJiraLinkedChanges:
         assert result[1]["issueKey"] == "B-2"
         assert result[1]["relation"] == "is duplicated by"
         assert result[1]["state"] == "closed"
+
+
+class _ReapProbe:
+    """A PIPE-stdio child double that records how it is reaped.
+
+    A killed child blocked writing into a full pipe -- or a surviving
+    descendant still holding the pipes open -- makes a bare ``await
+    proc.wait()`` hang the caller forever (#6005). The bounded reap must
+    therefore drain the pipes via ``communicate()`` and must never touch
+    ``wait()``.
+    """
+
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+        self.returncode: "int | None" = None
+        self.kill_calls = 0
+        self.wait_calls = 0
+        self.communicate_calls = 0
+
+    async def communicate(self):
+        self.communicate_calls += 1
+        self.returncode = -9
+        return b"", b""
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        return -9
+
+
+@pytest.mark.asyncio
+async def test_terminate_process_reaps_via_communicate_not_wait(monkeypatch):
+    """``_terminate_process`` must route through the bounded, pipe-draining
+    ``kill_and_reap`` -- a bare ``await proc.wait()`` here can hang the gateway
+    task forever when the child is killed with a full pipe (#6005)."""
+    from kiro_crew import platform_compat
+
+    proc = _ReapProbe()
+    tree_kills: "list[tuple[int, int]]" = []
+
+    async def _fake_tree(pid, sig):
+        tree_kills.append((pid, sig))
+        return True
+
+    # Fake pid + patched tree kill so no test can reach a real killpg. Both the
+    # async helper (used by kill_and_reap) and the legacy sync entry point are
+    # patched so the pin stays safe even when run against unmodified code.
+    monkeypatch.setattr(platform_compat, "kill_process_tree_async", _fake_tree)
+    monkeypatch.setattr(
+        platform_compat, "kill_process_tree", lambda *a, **k: tree_kills.append(a)
+    )
+
+    await source._terminate_process(proc)
+
+    assert proc.communicate_calls == 1
+    assert proc.wait_calls == 0
+    assert tree_kills and tree_kills[0][0] == proc.pid


### PR DESCRIPTION
## Problem / Motivation

Two sites kill a PIPE-stdio child's process tree and then reap it with a bare,
unbounded `await proc.wait()`:

- `src/kiro_crew/dashboard/handlers/source_providers.py` `_terminate_process`
  — reached on provider timeout, output overflow, and cancellation, with the
  stdout/stderr readers already cancelled by `wait_for`.
- `src/kiro_crew/mcp_gateway/resolve_once.py` `_reap_install_tree` — reached on
  the timeout and cancellation arms of a cancelled npm-install drain, whose
  `preinstall`/`postinstall` grandchildren can hold the pipes open.

A killed child blocked writing into a full pipe — or a surviving descendant
still holding the pipes open — can hang the calling task forever. The
`contextlib.suppress` wrapped around each `wait()` swallows exceptions but does
not bound a hang.

## Why it matters

Both paths run inside the gateway process, on its event loop, and both are on
teardown-shaped paths (a provider request timing out, a broker shutdown
cancelling a prefetch). An unbounded `wait()` there wedges the calling task —
and on the shutdown arm, the whole teardown — behind a child that will never be
reaped. This is the exact defect class already fixed for eight other sites in
#5989 by PR #6003; these two are the residual siblings that PR did not touch.

## What changed (motivation → approach → change)

Symptom: a timed-out/cancelled reap can hang forever. Root cause: `proc.wait()`
does not drain the pipes, so a killed child blocked on a full pipe (or a
descendant holding it open) never lets `wait()` return, and the reap is
unbounded. Change: route both sites through the shared
`platform_compat.kill_and_reap(proc)` (public on main since PR #6003) — tree
kill + pid-scoped fallback + a bounded, pipe-draining `communicate()` reap, all
cancellation-shielded. The now-unused `SIGKILL` / `kill_process_tree_async`
import in `resolve_once.py` is dropped in favour of `kill_and_reap`.

Scope — the third bare `await proc.wait()` in `resolve_once.py` `_drain_capped`
is deliberately left unchanged. It is not a kill-then-wait site: it drains
stdout to EOF *first* (the read loop exits only on EOF, i.e. every write end
including grandchildren is closed) and only then waits for the exit status, and
the whole `_drain_capped` call is itself wrapped in `asyncio.wait_for(...,
timeout_secs)`. With no pipe left undrained, no process is blocked on a pipe
write, so that `wait()` cannot hang on the defect this issue describes. It is a
post-EOF exit-status wait — the same class PR #6003 also left alone.

## Tests

Following PR #6003's regression-pin pattern (a reap probe that records whether
the reap drains via `communicate()` or falls back to a bare `wait()`):

- `test/test_source_providers.py::test_terminate_process_reaps_via_communicate_not_wait`
  — asserts `_terminate_process` drains via `communicate()`, never awaits
  `wait()`, and SIGKILLs the whole tree.
- `test/test_mcp_resolve_once.py::TestReapInstallTree::test_reaps_via_communicate_not_wait`
  — the same contract for `_reap_install_tree`.

Both were proven to FAIL on the unmodified production code (reverting only the
two production hunks: 2 failed → 2 passed after restoring the fix). Both patch
`kiro_crew.platform_compat.kill_process_tree_async` with a fake pid so no test
reaches a real `killpg`.

Two pre-existing tests pinned the old kill mechanism and are updated to the new
`kill_and_reap` contract (async tree kill + `communicate()` reap), not weakened:
- `test_mcp_resolve_once.py::TestInstall::test_a_timeout_reaps_the_whole_process_tree`
- `test_source_providers.py::test_run_json_kills_process_tree_when_stdout_exceeds_limit`

## Manual verification

N/A — unit coverage sufficient. The change substitutes one internal reap helper
for a bare `wait()` on two teardown paths; the regression tests exercise both
arms and the whole affected test files (534 tests) pass.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no user-visible UI is touched.

## Related Issues

Closes #6005
