### PR TITLE
perf: backport Windows install and cold-start speedups

### DIFF
--- a/.github/scripts/test-windows-installer.ps1
+++ b/.github/scripts/test-windows-installer.ps1
@@ -1,6 +1,11 @@
+param(
+  [switch]$SkipGatewayValidation
+)
+
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
-$MaxInstallSeconds = 300
+$MaxInstallSeconds = 120
+$MaxGatewayReadySeconds = 30
 
 Add-Type -AssemblyName System.Drawing
 Add-Type -TypeDefinition @"
@@ -46,7 +51,7 @@ function Save-InstallerWindow {
 }
 
 function Find-InstallerRegistrations {
-  param([string]$ProductName)
+  param([string]$ExpectedDisplayName)
 
   $registrations = @()
   foreach ($location in @(
@@ -65,7 +70,7 @@ function Find-InstallerRegistrations {
   )) {
     foreach ($entry in Get-ItemProperty -Path $location.Uninstall -ErrorAction SilentlyContinue) {
       $displayName = $entry.PSObject.Properties["DisplayName"]
-      if ($displayName -and $displayName.Value -like "$ProductName*") {
+      if ($displayName -and $displayName.Value -eq $ExpectedDisplayName) {
         $registrations += [pscustomobject]@{
           Entry = $entry
           InstallRoot = $location.Install
@@ -100,10 +105,15 @@ $productFilename = if ($productFilenameProperty -and $productFilenameProperty.Va
 if (-not $productName -or -not $productFilename) {
   throw "package.json must define an installer product name."
 }
+$expectedDisplayName = "$productName $($package.version)"
 
-# Exercise the install-root ownership boundary with an existing directory. The
-# /D argument must remain last for NSIS to parse it as an install destination.
-$requestedInstallRoot = Join-Path $evidence "existing-install-parent"
+# Exercise the install-root ownership boundary with an existing directory. Keep
+# the install itself on the local temp volume: a synced workspace (OneDrive on a
+# developer machine) can recreate or hold files while NSIS removes them, which
+# tests the sync client rather than the installer. Evidence still lives under
+# the workspace for artifact upload. The /D argument must remain last for NSIS.
+$requestedInstallRoot = Join-Path ([IO.Path]::GetFullPath($env:TEMP)) `
+  "kirocrew-installer-test-$PID"
 $sentinel = Join-Path $requestedInstallRoot "pre-existing-user-file.txt"
 New-Item -ItemType Directory -Path $requestedInstallRoot -Force | Out-Null
 Set-Content -LiteralPath $sentinel -Value "must survive uninstall" -Encoding utf8NoBOM
@@ -173,7 +183,7 @@ if ($env:GITHUB_STEP_SUMMARY) {
 $deadline = [DateTime]::UtcNow.AddSeconds(10)
 $registrations = @()
 do {
-  $registrations = @(Find-InstallerRegistrations $productName)
+  $registrations = @(Find-InstallerRegistrations $expectedDisplayName)
   if ($registrations.Count -eq 0) {
     Start-Sleep -Milliseconds 250
   }
@@ -204,6 +214,111 @@ if (-not (Test-Path -LiteralPath $installedExecutable -PathType Leaf)) {
   throw "The installed application executable is missing: $installedExecutable"
 }
 
+if ($SkipGatewayValidation) {
+  Write-Host "Skipping bundled gateway validation for the synthetic CI backend payload."
+} else {
+# Exercise the same bundled interpreter Electron launches, immediately after
+# installation while Defender's post-install scanning is still active. The
+# Windows package ships checked-hash bytecode for the measured gateway import
+# closure; this catches either those files being filtered out of the artifact or
+# the launcher accidentally redirecting imports into an empty user cache again.
+$backendRoot = Join-Path $installLocation "resources\backend-dist\kirocrew-backend"
+$bundledPython = Join-Path $backendRoot "python.exe"
+if (-not (Test-Path -LiteralPath $bundledPython -PathType Leaf)) {
+  throw "The installed bundled Python is missing: $bundledPython"
+}
+$startupPycCount = @(
+  Get-ChildItem -LiteralPath $backendRoot -Recurse -File -Filter "*.pyc"
+).Count
+if ($startupPycCount -lt 1000) {
+  throw "Expected at least 1000 precompiled startup modules; found $startupPycCount."
+}
+
+$portProbe = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+$portProbe.Start()
+$gatewayPort = ([Net.IPEndPoint]$portProbe.LocalEndpoint).Port
+$portProbe.Stop()
+$gatewayHome = Join-Path $evidence "gateway-home-$PID"
+$gatewayStdout = Join-Path $evidence "gateway-stdout.log"
+$gatewayStderr = Join-Path $evidence "gateway-stderr.log"
+New-Item -ItemType Directory -Path $gatewayHome -Force | Out-Null
+
+$savedGatewayEnv = @{
+  KIROCREW_HOME = $env:KIROCREW_HOME
+  KIROCREW_PROJECT_DIR = $env:KIROCREW_PROJECT_DIR
+  KIRO_HOME = $env:KIRO_HOME
+  PYTHONPYCACHEPREFIX = $env:PYTHONPYCACHEPREFIX
+  PYTHONPATH = $env:PYTHONPATH
+  PYTHONNOUSERSITE = $env:PYTHONNOUSERSITE
+  PYTHONUTF8 = $env:PYTHONUTF8
+  PYTHONIOENCODING = $env:PYTHONIOENCODING
+}
+$gatewayProcess = $null
+$gatewayReady = $false
+$gatewayTimer = [System.Diagnostics.Stopwatch]::StartNew()
+try {
+  $env:KIROCREW_HOME = $gatewayHome
+  $env:KIROCREW_PROJECT_DIR = $installLocation
+  $env:KIRO_HOME = Join-Path $gatewayHome "kiro"
+  $env:PYTHONPYCACHEPREFIX = $null
+  $env:PYTHONPATH = $null
+  $env:PYTHONNOUSERSITE = "1"
+  $env:PYTHONUTF8 = "1"
+  $env:PYTHONIOENCODING = "utf-8:backslashreplace"
+  $gatewayProcess = Start-Process -FilePath $bundledPython -ArgumentList @(
+    "-s", "-m", "kiro_crew", "gateway", "--no-open", "--port", "$gatewayPort"
+  ) -WorkingDirectory $installLocation -RedirectStandardOutput $gatewayStdout `
+    -RedirectStandardError $gatewayStderr -WindowStyle Hidden -PassThru
+
+  do {
+    try {
+      $readyResponse = Invoke-WebRequest -UseBasicParsing `
+        -Uri "http://127.0.0.1:$gatewayPort/api/ready" -TimeoutSec 1
+      $gatewayReady = $readyResponse.StatusCode -eq 200
+    } catch {
+      $gatewayReady = $false
+    }
+    if (-not $gatewayReady) {
+      Start-Sleep -Milliseconds 100
+      $gatewayProcess.Refresh()
+    }
+  } while (
+    -not $gatewayReady -and
+    -not $gatewayProcess.HasExited -and
+    $gatewayTimer.Elapsed.TotalSeconds -lt $MaxGatewayReadySeconds
+  )
+} finally {
+  $gatewayTimer.Stop()
+  if ($null -ne $gatewayProcess -and -not $gatewayProcess.HasExited) {
+    Stop-Process -Id $gatewayProcess.Id -Force -ErrorAction SilentlyContinue
+    $gatewayProcess.WaitForExit()
+  }
+  foreach ($name in $savedGatewayEnv.Keys) {
+    if ($null -eq $savedGatewayEnv[$name]) {
+      Remove-Item -Path "Env:$name" -ErrorAction SilentlyContinue
+    } else {
+      Set-Item -Path "Env:$name" -Value $savedGatewayEnv[$name]
+    }
+  }
+}
+
+$gatewayElapsed = [Math]::Round($gatewayTimer.Elapsed.TotalSeconds, 2)
+Set-Content -Path (Join-Path $evidence "gateway-startup-timing.txt") `
+  -Value "gateway-ready-seconds=$gatewayElapsed" -Encoding utf8NoBOM
+if (-not $gatewayReady) {
+  Write-Host "Gateway stdout tail:"
+  Get-Content -LiteralPath $gatewayStdout -Tail 30 -ErrorAction SilentlyContinue
+  Write-Host "Gateway stderr tail:"
+  Get-Content -LiteralPath $gatewayStderr -Tail 30 -ErrorAction SilentlyContinue
+  throw "Installed gateway was not ready within $MaxGatewayReadySeconds seconds."
+}
+Write-Host "Installed gateway became ready in $gatewayElapsed seconds ($startupPycCount pycs)."
+if ($env:GITHUB_STEP_SUMMARY) {
+  Add-Content -Path $env:GITHUB_STEP_SUMMARY `
+    -Value "Windows installed gateway ready: **$gatewayElapsed seconds** (ceiling: $MaxGatewayReadySeconds seconds)."
+}
+}
+
 $uninstaller = Get-ChildItem -LiteralPath $installLocation -File -Filter "Uninstall*.exe" |
   Select-Object -First 1
 if (-not $uninstaller) {
@@ -222,7 +337,7 @@ if ($uninstallProcess.ExitCode -ne 0) {
 
 $uninstallDeadline = [DateTime]::UtcNow.AddSeconds(30)
 do {
-  $remainingRegistrations = @(Find-InstallerRegistrations $productName)
+  $remainingRegistrations = @(Find-InstallerRegistrations $expectedDisplayName)
   if ($remainingRegistrations.Count -ne 0 -or (Test-Path -LiteralPath $installLocation)) {
     Start-Sleep -Milliseconds 250
   }
@@ -239,6 +354,11 @@ if (Test-Path -LiteralPath $installLocation) {
 if (-not (Test-Path -LiteralPath $sentinel -PathType Leaf)) {
   throw "Silent uninstall removed content from the pre-existing parent directory."
 }
+
+# The sentinel has proved ownership boundaries; leave only reusable evidence,
+# not a temp directory on local developer runs.
+Remove-Item -LiteralPath $sentinel -Force
+Remove-Item -LiteralPath $requestedInstallRoot -Force
 
 if ($elapsed -gt $MaxInstallSeconds) {
   throw "Windows installation took $elapsed seconds, above the $MaxInstallSeconds-second ceiling."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Enforce native installer performance ceiling
         shell: pwsh
         working-directory: website/electron
-        run: '& "$env:GITHUB_WORKSPACE\.github\scripts\test-windows-installer.ps1"'
+        run: '& "$env:GITHUB_WORKSPACE\.github\scripts\test-windows-installer.ps1" -SkipGatewayValidation'
 
       - name: Upload installer timing
         if: always()

--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -63,7 +63,19 @@ Current status:
   Windows' client-area animation setting. The fade contains no timer-driven
   bitmap swap or UI-thread sleep, so extraction keeps the native progress path;
   CI performs a real silent install, records its duration, and fails if it
-  exceeds 5 minutes.
+  exceeds 2 minutes.
+- **Single-pass payload publication** — the differential-aware updater still
+  verifies and fully extracts its 7z payload into a staging directory before it
+  changes the installation. On the normal same-volume per-user Windows layout,
+  the installer then renames Electron's large `resources` and `locales`
+  directories into place instead of asking Defender and the filesystem to
+  process thousands of Python files in a second copy pass. Per-machine installs
+  retain electron-builder's original `CopyFiles` path so the payload inherits
+  the Program Files ACL. A cross-volume temporary directory, occupied
+  destination, or failed rename also falls back to that copy path and its
+  bounded retry prompts. The build-time patch is
+  pinned to the installed app-builder-lib version and fails closed if its NSIS
+  template changes, so an upgrade cannot silently remove that fallback.
 - **Uninstall removes the app and its caches, and keeps your data.** Removed:
   the install directory, the Start Menu shortcut, the uninstall registry key,
   and any “start with Windows” Run entry left by an earlier custom installer,
@@ -92,10 +104,17 @@ Current status:
   open the existing native Electron menus from the left of that row, the command
   palette remains centered on the window, and native minimize/maximize/close
   controls remain on the right.
-- **Cold-start-aware gateway handoff** — a live bundled backend keeps the loading
-  screen and progress updates through the longer Windows import window instead of
-  presenting a false failure that succeeds on Retry. A child exit or spawn error
-  still fails immediately and includes the launch-log cause.
+- **Precompiled Windows gateway startup** — packaging traces the real
+  `kiro_crew.cli_server` import after pruning and ships checked-hash bytecode for
+  that import closure beside its sources. Windows consumes those caches directly,
+  avoiding the thousand-file cache-population burst that otherwise overlaps
+  Defender's post-install scanning. macOS and Linux still redirect bytecode out
+  of the signed/read-only app tree. The loading screen retains its extended
+  Windows handoff window as a slow-machine fallback; a child exit or spawn error
+  still fails immediately and includes the launch-log cause. CI starts the
+  just-installed bundled interpreter against an isolated data home and requires
+  `/api/ready` within 30 seconds, so both the packaged caches and the full gateway
+  handoff are covered rather than only a synthetic import benchmark.
 
 The source install below remains the fully supported path.
 

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -365,10 +365,26 @@ build_backend_windows() {
   ( cd "$out"
     find . -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
     find Lib/site-packages -type d \( -name tests -o -name test \) -prune -exec rm -rf {} + 2>/dev/null || true
-    rm -rf Lib/test Lib/idlelib Lib/tkinter Lib/turtledemo Lib/ensurepip Lib/lib2to3 2>/dev/null || true )
+    rm -rf Lib/test Lib/idlelib Lib/tkinter Lib/turtledemo Lib/ensurepip Lib/lib2to3 \
+           include libs tcl \
+           Lib/site-packages/kiro_crew/_vendor/llama_cpp_libs/linux_aarch64 \
+           Lib/site-packages/kiro_crew/_vendor/llama_cpp_libs/linux_x86_64 \
+           Lib/site-packages/kiro_crew/_vendor/llama_cpp_libs/macos_arm64 \
+           Lib/site-packages/kiro_crew/_vendor/llama_cpp_libs/macos_x86_64 \
+           2>/dev/null || true
+    rm -f DLLs/_tkinter.pyd DLLs/tcl*.dll DLLs/tk*.dll 2>/dev/null || true )
 
   # After pruning, so it validates what actually ships.
   stdlib_probe_gate "$out"
+
+  # Trace the real gateway import after the final prune and ship checked-hash
+  # pycs for exactly that closure. Windows can consume these beside the source
+  # without invalidating an Authenticode signature, avoiding the first launch's
+  # thousand-file cache write while keeping unrelated modules out of the bundle.
+  log "Precompiling Windows gateway startup modules ($(basename "$out"))…"
+  env PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 PYTHONPATH= \
+    "$out/python.exe" -s "$ROOT/packaging/precompile_windows.py" \
+    --root "$out" --module kiro_crew.cli_server
 
   echo "    $(basename "$out") size: $(du -sh "$out" 2>/dev/null | cut -f1)"
 }

--- a/packaging/precompile_windows.py
+++ b/packaging/precompile_windows.py
@@ -1,0 +1,88 @@
+"""Precompile the Windows desktop gateway's measured import closure.
+
+The Windows installer ships a loose Python runtime.  Importing the gateway for
+the first time otherwise creates more than a thousand small ``.pyc`` files
+while antivirus scanning is hottest, turning a few seconds of Python work into
+a long first launch.  This build helper imports the gateway without writing
+bytecode, records only modules actually loaded from the bundled runtime, then
+emits deterministic checked-hash caches beside their sources.
+
+Keeping this as a build helper (rather than runtime bootstrap code) means the
+end user's first launch does no cache-population pass.  Checked-hash pycs remain
+valid when archive extraction changes mtimes, and relative ``co_filename``
+values avoid leaking a CI runner path into tracebacks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import py_compile
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _module_source(module: ModuleType, root: Path) -> Path | None:
+    raw = getattr(module, "__file__", None)
+    if not isinstance(raw, str) or not raw.lower().endswith(".py"):
+        return None
+    source = Path(raw).resolve()
+    try:
+        source.relative_to(root)
+    except ValueError:
+        return None
+    return source if source.is_file() else None
+
+
+def precompile_import_closure(root: Path, module_names: list[str]) -> tuple[int, int]:
+    """Import ``module_names`` and compile loaded sources located under ``root``."""
+
+    root = root.resolve(strict=True)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        importlib.invalidate_caches()
+        for module_name in module_names:
+            importlib.import_module(module_name)
+    finally:
+        sys.dont_write_bytecode = previous
+
+    sources = {
+        source
+        for module in tuple(sys.modules.values())
+        if module is not None and (source := _module_source(module, root)) is not None
+    }
+    if not sources:
+        raise RuntimeError(f"no imported Python sources were found below {root}")
+
+    total_bytes = 0
+    for source in sorted(sources):
+        cache = Path(importlib.util.cache_from_source(str(source)))
+        relative_name = source.relative_to(root).as_posix()
+        py_compile.compile(
+            str(source),
+            cfile=str(cache),
+            dfile=relative_name,
+            doraise=True,
+            optimize=sys.flags.optimize,
+            invalidation_mode=py_compile.PycInvalidationMode.CHECKED_HASH,
+        )
+        total_bytes += cache.stat().st_size
+    return len(sources), total_bytes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--module", action="append", required=True, dest="modules")
+    args = parser.parse_args(argv)
+
+    count, total_bytes = precompile_import_closure(args.root, args.modules)
+    print(f"precompiled {count} startup modules ({total_bytes / 1024 / 1024:.1f} MiB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -2023,8 +2023,12 @@ def _venv_deps_ok(venv_py: Path) -> bool:
     the diagnostic whose job is to catch exactly that install.
     """
     try:
+        # Windows process creation and first-time Defender scans can consume
+        # most of a five-second budget when the host is busy (including during
+        # the parallel test suite). Keep the probe bounded, but allow enough
+        # time for a healthy interpreter to start and import its dependencies.
         proc = dep_sync._probe_interpreter(
-            venv_py, "import websockets, slack_sdk, aiohttp", timeout=5
+            venv_py, "import websockets, slack_sdk, aiohttp", timeout=15
         )
     except Exception:
         return False

--- a/test/requires-real-symlinks.txt
+++ b/test/requires-real-symlinks.txt
@@ -9,6 +9,9 @@ src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py::Te
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pollute.py::TestExcludesAreNarrow::test_a_relative_or_symlinked_exclude_still_matches
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_watchers.py::TestCloneIsolation::test_symlinked_destination_is_refused
 src/kiro_crew/apps/builtins/auto_improvement/tests/test_reconcile_and_publish.py::TestOrphanCloneSweep::test_a_symlink_is_not_followed
+src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_a_claim_through_an_aliased_spelling_is_refused
+src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_a_symlinked_spelling_cannot_record_a_second_answer
+src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_an_unresolvable_directory_keeps_its_normalized_literal_key
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_handoff_refuses_a_symlinked_tasks_file
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_resolved_spec_dir_is_revalidated_for_sensitivity
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_safe_dir_resolves_symlinks_before_checking
@@ -17,6 +20,7 @@ src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_spec_file_re
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_spec_file_refuses_symlink_to_sensitive_target
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_spec_read_refuses_a_symlinked_spec_file
 src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_symlinked_spec_dir_cannot_touch_another_specs_sentinel
+src/kiro_crew/apps/builtins/spec_builder/tests/test_routes.py::test_the_ledger_key_touches_no_filesystem
 test/test_enterprise.py::test_dangling_symlink_config_fails_closed
 test/test_enterprise.py::test_symlink_to_empty_config_stays_default_open
 test/test_external_logout_detection.py::TestIdentityFingerprint::test_missing_and_symlinked_stores_read_as_absent
@@ -69,6 +73,7 @@ test/test_pptx_maker_decks.py::TestListDecks::test_a_symlinked_artifact_subdirec
 test/test_pptx_maker_decks.py::TestListDecks::test_a_symlinked_brief_is_not_followed
 test/test_pptx_maker_decks.py::TestListDecks::test_a_symlinked_deck_is_not_listed_or_read
 test/test_prepare_pr_local_review.py::test_branch_symlink_cannot_redirect_a_reviewers_contract
+test/test_prepare_pr_local_review.py::test_worktree_bootstrap_source_cannot_escape_the_worktree
 test/test_prepare_pr_profiles.py::test_symlinked_config_is_refused
 test/test_prompts.py::TestListAimPrompts::test_sensitive_sop_symlink_skipped
 test/test_pwa_file_symlink.py::test_pwa_file_rejects_traversal

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -1729,7 +1729,7 @@ class TestVenvDepsProbe:
         assert cli_doctor._venv_deps_ok(Path("/v/bin/python")) is True
         assert seen["code"] == "import websockets, slack_sdk, aiohttp"
         assert seen["target"] == Path("/v/bin/python")
-        assert seen["timeout"] == 5
+        assert seen["timeout"] == 15
 
     def test_the_probe_is_wired_into_the_doctor_run(self) -> None:
         """Guards the call site: every other test drives the helper directly,

--- a/test/test_mcp_gateway_session_inject.py
+++ b/test/test_mcp_gateway_session_inject.py
@@ -188,15 +188,36 @@ def test_non_dict_server_entry_is_skipped(tmp_path):
 
 REAL_CLI = shutil.which("kiro-cli")
 
-#: A probe MCP server that records that it launched and then lingers, in place
-#: of ``sh -c "touch X; sleep 20"``. The interpreter is portable where a POSIX
-#: shell is not, and the marker path arrives as ``argv`` so a Windows path's
-#: backslashes never pass through a string literal.
-_PROBE_SNIPPET = (
-    "import pathlib,sys,time;"
-    "pathlib.Path(sys.argv[1]).write_text('x');"
-    "time.sleep(20)"
-)
+#: A tiny, portable MCP server that records that it launched. Older kiro-cli
+#: versions tolerated a process that merely slept after creating the marker;
+#: current versions require the initialize handshake to complete before they
+#: retain the server. Keeping the probe protocol-valid makes this test about
+#: session-injection precedence, not a particular release's failure timing.
+#: The marker path arrives as ``argv`` so Windows backslashes never pass through
+#: a generated string literal.
+_PROBE_SCRIPT = r"""
+import json
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text("x", encoding="utf-8")
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request:
+        continue
+    if request.get("method") == "initialize":
+        params = request.get("params") or {}
+        result = {
+            "protocolVersion": params.get("protocolVersion", "2024-11-05"),
+            "capabilities": {},
+            "serverInfo": {"name": "kirocrew-precedence-probe", "version": "1"},
+        }
+    elif request.get("method") == "tools/list":
+        result = {"tools": []}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}), flush=True)
+"""
 
 _DRIVER = r"""
 import json, os, subprocess, sys, threading, time
@@ -250,7 +271,7 @@ if not _line:
 send({"jsonrpc": "2.0", "id": 2, "method": "session/new",
       "params": {"cwd": w + "/proj", "mcpServers": [
           {"name": "shared", "command": sys.executable,
-           "args": ["-c", sys.argv[2], w + "/marks/INJECTED"], "env": []}]}})
+           "args": [sys.argv[2], w + "/marks/INJECTED"], "env": []}]}})
 # Poll for the marker the injected server writes, with a deadline generous
 # enough for a cold CLI. The old 8s sleep was paid in full on every run.
 deadline = time.time() + 20
@@ -292,6 +313,8 @@ def test_real_kiro_cli_prefers_session_injected_server():
         (root / "khome" / "agents").mkdir(parents=True)
         (root / "proj").mkdir()
         (root / "marks").mkdir()
+        probe = root / "probe.py"
+        probe.write_text(_PROBE_SCRIPT, encoding="utf-8")
         (root / "khome" / "agents" / "pooltest.json").write_text(json.dumps({
             "name": "pooltest",
             "description": "precedence probe",
@@ -300,19 +323,28 @@ def test_real_kiro_cli_prefers_session_injected_server():
             "prompt": "probe",
             "mcpServers": {"shared": {
                 "command": sys.executable,
-                "args": ["-c", _PROBE_SNIPPET, str(root / "marks" / "FROM_SPEC")],
+                "args": [str(probe), str(root / "marks" / "FROM_SPEC")],
             }},
         }), encoding="utf-8")
         driver = root / "drive.py"
         driver.write_text(_DRIVER, encoding="utf-8")
-        subprocess.run([sys.executable, str(driver), str(root), _PROBE_SNIPPET],
-                       capture_output=True, timeout=180, check=False)
+        result = subprocess.run(
+            [sys.executable, str(driver), str(root), str(probe)],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=180,
+            check=False,
+        )
         deadline = time.time() + 5
         while time.time() < deadline and not (root / "marks" / "INJECTED").exists():
             time.sleep(0.2)
         assert (root / "marks" / "INJECTED").exists(), (
             "session/new-injected server never launched — ACP injection is not "
-            "taking effect at all; pooling cannot work through this channel"
+            "taking effect at all; pooling cannot work through this channel\n"
+            f"driver exit: {result.returncode}\n"
+            f"driver stdout: {result.stdout[-2000:]}\n"
+            f"driver stderr: {result.stderr[-2000:]}"
         )
         assert not (root / "marks" / "FROM_SPEC").exists(), (
             "the agent spec's same-named server ALSO launched: session/new "

--- a/test/test_precompile_windows.py
+++ b/test/test_precompile_windows.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import struct
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "packaging" / "precompile_windows.py"
+SPEC = importlib.util.spec_from_file_location("precompile_windows", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+_PREVIOUS_DONT_WRITE_BYTECODE = sys.dont_write_bytecode
+sys.dont_write_bytecode = True
+try:
+    SPEC.loader.exec_module(MODULE)
+finally:
+    sys.dont_write_bytecode = _PREVIOUS_DONT_WRITE_BYTECODE
+
+
+def test_precompiles_import_closure_as_relocatable_checked_hash_pyc(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = tmp_path / "runtime"
+    package = root / "sample_startup"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("from . import dependency\n", encoding="utf-8")
+    (package / "dependency.py").write_text("VALUE = 42\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(root))
+    for name in ("sample_startup", "sample_startup.dependency"):
+        sys.modules.pop(name, None)
+
+    count, total_bytes = MODULE.precompile_import_closure(root, ["sample_startup"])
+
+    assert count == 2
+    assert total_bytes > 0
+    for source in package.glob("*.py"):
+        cache = Path(importlib.util.cache_from_source(str(source)))
+        payload = cache.read_bytes()
+        assert struct.unpack("<I", payload[4:8])[0] == 3  # checked-hash pyc
+        code = importlib.machinery.SourcelessFileLoader(source.stem, str(cache)).get_code(
+            source.stem
+        )
+        assert code is not None
+        assert code.co_filename == source.relative_to(root).as_posix()

--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -95,6 +95,15 @@ Notes:
 - The result is an assisted (non-one-click, per-user) NSIS installer,
   `KiroCrew Setup <version>.exe` (nightly builds:
   `KiroCrew Nightly Setup <version>.exe`), in `website/electron/dist/`.
+- The pinned electron-builder NSIS template is patched during `npm install` to
+  expose Kiro Crew's staged-payload publish hook. On a normal same-volume
+  per-user install it renames the large `resources` / `locales` trees into place
+  and copies only the small root remainder; per-machine installs keep the
+  upstream copy path so files inherit the Program Files ACL. Cross-volume or
+  occupied destinations also retain the upstream copy-and-retry fallback. The
+  Windows backend ships checked-hash
+  bytecode for the measured gateway import closure, so first launch consumes
+  build-time caches rather than generating thousands of files under Defender.
 - The native welcome/finish sidebar and the header used on intermediate pages
   carry the Kiro Crew logo and ghost artwork. The standard NSIS controls and
   localized instructions remain native. Page boundaries use a short Win32

--- a/website/electron/build/installer.nsh
+++ b/website/electron/build/installer.nsh
@@ -244,6 +244,31 @@ FunctionEnd
   !insertmacro MUI_PAGE_FINISH
 !macroend
 
+; app-builder-lib stages the complete differential-aware 7z under $PLUGINSDIR,
+; then normally copies every file into $INSTDIR. The bundled Python runtime is
+; almost entirely under resources, so on the normal same-volume install path a
+; directory rename publishes those thousands of files in one filesystem
+; operation. Rename is attempted only for the two stable Electron directories
+; in per-user installs. Per-machine installs deliberately use CopyFiles so the
+; payload inherits the Program Files ACL instead of retaining the staging
+; user's temporary-directory ACL. CopyFiles also handles root files, future
+; directories, cross-volume TEMP layouts, occupied destinations and retries
+; exactly as upstream does.
+!macro customPublishAppPackage SOURCE DESTINATION
+  ${If} $installMode != "all"
+    ClearErrors
+    Rename "${SOURCE}\resources" "${DESTINATION}\resources"
+    ${If} ${Errors}
+      ClearErrors
+    ${EndIf}
+    Rename "${SOURCE}\locales" "${DESTINATION}\locales"
+    ${If} ${Errors}
+      ClearErrors
+    ${EndIf}
+  ${EndIf}
+  CopyFiles /SILENT "${SOURCE}\*" "${DESTINATION}"
+!macroend
+
 ; Preserve only the install-root ownership guard from the former custom UI.
 ; This runs for silent installs too and does not replace or restyle any page.
 !macro customInit

--- a/website/electron/gateway-env.js
+++ b/website/electron/gateway-env.js
@@ -37,4 +37,26 @@ function buildGatewayEnvironment(baseEnv) {
   };
 }
 
-module.exports = { buildGatewayEnvironment, GATEWAY_UTF8_ENV };
+/**
+ * Keep runtime bytecode outside signed/read-only POSIX app bundles.
+ *
+ * The Windows bundle instead ships checked-hash pycs beside its sources. PE
+ * Authenticode does not seal resource trees the way macOS code signing does,
+ * and using those build-time caches avoids a thousand-file first-launch write
+ * burst. A per-machine install may be read-only to the user; Python can still
+ * consume the shipped caches without needing to update them.
+ */
+function gatewayBytecodeEnvironment(platform, cachePath, isPackaged) {
+  if (platform === "win32" && isPackaged) {
+    // An empty value makes CPython use adjacent __pycache__ files and, unlike
+    // omitting the key, overrides a hostile/inherited cache prefix.
+    return { PYTHONPYCACHEPREFIX: "" };
+  }
+  return { PYTHONPYCACHEPREFIX: cachePath };
+}
+
+module.exports = {
+  buildGatewayEnvironment,
+  gatewayBytecodeEnvironment,
+  GATEWAY_UTF8_ENV,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -7,7 +7,7 @@ const path = require("path");
 const http = require("http");
 
 const { findKirocrewBin } = require("./find-bin");
-const { buildGatewayEnvironment } = require("./gateway-env");
+const { buildGatewayEnvironment, gatewayBytecodeEnvironment } = require("./gateway-env");
 const { resolveGatewayPath } = require("./mac-env");
 const {
   findMissingBundleParts,
@@ -998,17 +998,16 @@ function spawnGateway(resolve) {
             // (two levels up from electron/), so resolve by markers there.
             // macOS/Linux keep the original one-level-up path unchanged.
             KIROCREW_PROJECT_DIR: IS_WIN ? resolveProjectDir() : path.resolve(__dirname, ".."),
-            // Keep CPython bytecode caches OUT of the signed app bundle.
-            // Without this, the embedded interpreter writes __pycache__/*.pyc
-            // next to the bundled sources on first import, breaking the
-            // codesign seal ("a sealed resource is missing or invalid") --
-            // Gatekeeper then fails the installed app, and Squirrel's
-            // installer can trip over the corrupted target during updates.
-            // CPython creates the directory tree on demand (PEP 3147 /
-            // sys.pycache_prefix). Inherited by every Python child the
-            // gateway spawns (app servers run on the same interpreter), so
-            // the whole process tree stays out of the bundle.
-            PYTHONPYCACHEPREFIX: path.join(kirocrewDir, "cache", "pycache"),
+            // macOS code signing seals the app tree and Linux packages may be
+            // read-only, so those platforms redirect runtime bytecode. Windows
+            // consumes checked-hash pycs generated during packaging instead;
+            // avoiding the redirected-cache population is the main cold-start
+            // win on a freshly installed, Defender-scanned bundle.
+            ...gatewayBytecodeEnvironment(
+              process.platform,
+              path.join(kirocrewDir, "cache", "pycache"),
+              app.isPackaged,
+            ),
           }),
         });
         gatewayProcess = child;

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "electron .",
     "test": "node --test test/*.test.js mochi/test/*.test.js crew-companion/test/*.test.js",
+    "postinstall": "node scripts/patch-nsis-template.js",
     "dist": "electron-builder",
     "dist:mac": "electron-builder --mac",
     "dist:linux": "electron-builder --linux"
@@ -215,9 +216,7 @@
         "from": "backend-dist",
         "to": "backend-dist",
         "filter": [
-          "**/*",
-          "!**/__pycache__/**",
-          "!**/*.pyc"
+          "**/*"
         ]
       }
     ],

--- a/website/electron/scripts/patch-nsis-template.js
+++ b/website/electron/scripts/patch-nsis-template.js
@@ -1,0 +1,93 @@
+"use strict";
+
+// electron-builder's differential-aware NSIS path extracts the complete app
+// archive under $PLUGINSDIR and then CopyFiles the whole tree into $INSTDIR.
+// Kiro Crew's bundled Python backend is thousands of small files, so that
+// second pass dominates Windows install/update time (and makes Defender scan
+// the payload twice). electron-builder exposes hooks before and after this
+// operation, but none at the publish boundary itself. Keep the dependency pin
+// and make the smallest possible, fail-closed template patch: custom installers
+// may publish the staged tree efficiently, while every other installer keeps
+// upstream's CopyFiles behavior.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const EXPECTED_APP_BUILDER_VERSION = "26.15.3";
+const HOOK_MARKER = "!ifmacrodef customPublishAppPackage";
+
+const ORIGINAL_LINES = [
+  "    # Attempt to copy files in atomic way",
+  '    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR',
+];
+
+const PATCHED_LINES = [
+  "    # Let a product publish large staged directories without copying every file twice.",
+  `    ${HOOK_MARKER}`,
+  '      !insertmacro customPublishAppPackage "$PLUGINSDIR\\7z-out" "$OUTDIR"',
+  "    !else",
+  "      # Upstream fallback for products without the custom publish hook.",
+  '      CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR',
+  "    !endif",
+];
+
+function patchTemplateText(source) {
+  const eol = source.includes("\r\n") ? "\r\n" : "\n";
+  if (source.includes(HOOK_MARKER)) {
+    const patched = PATCHED_LINES.join(eol);
+    const occurrences = source.split(patched).length - 1;
+    if (occurrences !== 1) {
+      throw new Error(
+        `electron-builder NSIS template drift: publish hook is incomplete or duplicated (${occurrences})`
+      );
+    }
+    return { text: source, changed: false };
+  }
+
+  const original = ORIGINAL_LINES.join(eol);
+  const occurrences = source.split(original).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(
+      `electron-builder NSIS template drift: expected one publish block, found ${occurrences}`
+    );
+  }
+  return {
+    text: source.replace(original, PATCHED_LINES.join(eol)),
+    changed: true,
+  };
+}
+
+function patchInstalledTemplate() {
+  const packageJsonPath = require.resolve("app-builder-lib/package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (packageJson.version !== EXPECTED_APP_BUILDER_VERSION) {
+    throw new Error(
+      `refusing to patch app-builder-lib ${packageJson.version}; expected ${EXPECTED_APP_BUILDER_VERSION}`
+    );
+  }
+
+  const templatePath = path.join(
+    path.dirname(packageJsonPath),
+    "templates",
+    "nsis",
+    "include",
+    "extractAppPackage.nsh"
+  );
+  const result = patchTemplateText(fs.readFileSync(templatePath, "utf8"));
+  if (result.changed) {
+    fs.writeFileSync(templatePath, result.text, "utf8");
+    process.stdout.write("Patched electron-builder's NSIS app publish hook.\n");
+  } else {
+    process.stdout.write("electron-builder's NSIS app publish hook is already patched.\n");
+  }
+}
+
+if (require.main === module) {
+  patchInstalledTemplate();
+}
+
+module.exports = {
+  EXPECTED_APP_BUILDER_VERSION,
+  HOOK_MARKER,
+  patchTemplateText,
+};

--- a/website/electron/test/gateway-env.test.js
+++ b/website/electron/test/gateway-env.test.js
@@ -7,6 +7,7 @@ const path = require("node:path");
 
 const {
   buildGatewayEnvironment,
+  gatewayBytecodeEnvironment,
   GATEWAY_UTF8_ENV,
 } = require("../gateway-env");
 
@@ -45,6 +46,22 @@ test("the gateway UTF-8 contract is explicit and stable", () => {
   });
 });
 
+test("Windows consumes packaged bytecode while POSIX redirects runtime caches", () => {
+  const cache = String.raw`C:\Users\test\.kiro\crew\cache\pycache`;
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("win32", cache, true), {
+    PYTHONPYCACHEPREFIX: "",
+  });
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("win32", cache, false), {
+    PYTHONPYCACHEPREFIX: cache,
+  });
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("darwin", cache, true), {
+    PYTHONPYCACHEPREFIX: cache,
+  });
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("linux", cache, true), {
+    PYTHONPYCACHEPREFIX: cache,
+  });
+});
+
 test("the one desktop gateway spawn uses the hardened environment builder", () => {
   const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
   const gatewaySpawns = [...main.matchAll(/spawn\(spawnBin, spawnArgs,/g)];
@@ -52,7 +69,7 @@ test("the one desktop gateway spawn uses the hardened environment builder", () =
   assert.equal(gatewaySpawns.length, 1, "expected one owned gateway spawn boundary");
   assert.match(
     main,
-    /env:\s*buildGatewayEnvironment\(\{[\s\S]*?PYTHONPYCACHEPREFIX:[\s\S]*?\}\),/,
+    /env:\s*buildGatewayEnvironment\(\{[\s\S]*?gatewayBytecodeEnvironment\([\s\S]*?\}\),/,
     "the owned gateway spawn must pass every initial launch and liveness respawn " +
       "through buildGatewayEnvironment",
   );

--- a/website/electron/test/nsis-template-patch.test.js
+++ b/website/electron/test/nsis-template-patch.test.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  EXPECTED_APP_BUILDER_VERSION,
+  HOOK_MARKER,
+  patchTemplateText,
+} = require("../scripts/patch-nsis-template");
+
+const upstreamBlock = [
+  "!macro extractUsing7za FILE",
+  "    # Attempt to copy files in atomic way",
+  '    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR',
+  "    IfErrors 0 DoneExtract7za",
+  "!macroend",
+].join("\n");
+
+test("the NSIS template patch inserts one guarded publish hook", () => {
+  const result = patchTemplateText(upstreamBlock);
+
+  assert.equal(result.changed, true);
+  assert.equal(result.text.match(new RegExp(HOOK_MARKER, "g")).length, 1);
+  assert.match(
+    result.text,
+    /!insertmacro customPublishAppPackage "\$PLUGINSDIR\\7z-out" "\$OUTDIR"/
+  );
+  assert.match(result.text, /!else[\s\S]*?CopyFiles \/SILENT/);
+  assert.match(result.text, /!endif[\s\S]*?IfErrors 0 DoneExtract7za/);
+});
+
+test("the NSIS template patch is idempotent", () => {
+  const once = patchTemplateText(upstreamBlock);
+  const twice = patchTemplateText(once.text);
+
+  assert.equal(twice.changed, false);
+  assert.equal(twice.text, once.text);
+});
+
+test("the NSIS template patch fails closed when upstream drifts", () => {
+  assert.throws(
+    () => patchTemplateText("!macro extractUsing7za FILE\n!macroend\n"),
+    /template drift/
+  );
+  assert.throws(
+    () => patchTemplateText(`before\n${HOOK_MARKER}\nafter\n`),
+    /incomplete or duplicated/
+  );
+  assert.equal(EXPECTED_APP_BUILDER_VERSION, "26.15.3");
+});
+
+test("directory publication preserves per-machine ACL inheritance", () => {
+  const installer = fs.readFileSync(
+    path.join(__dirname, "..", "build", "installer.nsh"),
+    "utf8"
+  );
+  const publishMacro = installer.match(
+    /!macro customPublishAppPackage[\s\S]*?!macroend/
+  )?.[0];
+
+  assert.ok(publishMacro);
+  const guardStart = publishMacro.indexOf('${If} $installMode != "all"');
+  const resourcesRename = publishMacro.indexOf(
+    'Rename "${SOURCE}\\resources"'
+  );
+  const guardEnd = publishMacro.lastIndexOf("${EndIf}");
+  const fallbackCopy = publishMacro.indexOf("CopyFiles /SILENT");
+  for (const index of [guardStart, resourcesRename, guardEnd, fallbackCopy]) {
+    assert.notEqual(index, -1);
+  }
+  assert.ok(guardStart < resourcesRename);
+  assert.ok(resourcesRename < guardEnd);
+  assert.ok(guardEnd < fallbackCopy);
+});

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -243,10 +243,50 @@ describe("first-download installer design contract", () => {
       "customFinishPage must retain electron-builder's locked StartApp contract"
     );
     assert.match(buildWorkflow, /test-windows-installer\.ps1/);
-    assert.match(runtimeScript, /^\$MaxInstallSeconds = 300$/m);
+    assert.match(runtimeScript, /^\$MaxInstallSeconds = 120$/m);
+    assert.match(runtimeScript, /^\$MaxGatewayReadySeconds = 30$/m);
     assert.match(runtimeScript, /silent-install-seconds=/);
+    assert.match(runtimeScript, /gateway-ready-seconds=/);
+    assert.match(runtimeScript, /startupPycCount -lt 1000/);
+    assert.match(runtimeScript, /\/api\/ready/);
+    assert.match(
+      runtimeScript,
+      /\$env:KIRO_HOME = Join-Path \$gatewayHome "kiro"/
+    );
     assert.match(runtimeScript, /WaitForExit\(\$MaxInstallSeconds \* 1000\)/);
     assert.match(runtimeScript, /native-install-mode\.png/);
+  });
+
+  it("publishes the staged Windows payload without a second small-file copy pass", () => {
+    const patchScript = fs.readFileSync(
+      path.join(ROOT, "scripts", "patch-nsis-template.js"),
+      "utf8"
+    );
+    assert.equal(pkg.scripts.postinstall, "node scripts/patch-nsis-template.js");
+    assert.match(patchScript, /EXPECTED_APP_BUILDER_VERSION = "26\.15\.3"/);
+    assert.match(patchScript, /!ifmacrodef customPublishAppPackage/);
+    assert.match(
+      installer,
+      /!macro customPublishAppPackage SOURCE DESTINATION[\s\S]*?Rename "\$\{SOURCE\}\\resources" "\$\{DESTINATION\}\\resources"[\s\S]*?Rename "\$\{SOURCE\}\\locales" "\$\{DESTINATION\}\\locales"[\s\S]*?CopyFiles \/SILENT "\$\{SOURCE\}\\\*" "\$\{DESTINATION\}"/
+    );
+  });
+
+  it("ships the Windows startup caches generated after the platform prune", () => {
+    const backendResource = pkg.build.extraResources.find(
+      resource => resource.from === "backend-dist"
+    );
+    const buildScript = fs.readFileSync(
+      path.join(REPO_ROOT, "packaging", "build-desktop.sh"),
+      "utf8"
+    );
+    assert.deepEqual(backendResource.filter, ["**/*"]);
+    assert.match(buildScript, /rm -rf[\s\S]*?include libs tcl/);
+    assert.match(buildScript, /llama_cpp_libs\/linux_aarch64/);
+    assert.match(buildScript, /DLLs\/_tkinter\.pyd DLLs\/tcl\*\.dll DLLs\/tk\*\.dll/);
+    assert.match(
+      buildScript,
+      /precompile_windows\.py" \\\r?\n\s*--root "\$out" --module kiro_crew\.cli_server/
+    );
   });
 
   it("keeps install-root ownership and legacy startup cleanup without custom pages", () => {


### PR DESCRIPTION
## Problem / Motivation

Backport the Windows install and cold-start performance fix from merged PR #6047 to `release/0.4.0`. The release branch otherwise retains the NSIS double-copy path that took about 5 minutes 25 seconds and caused the native progress bar to jump, followed by a 44–50 second first gateway start while Defender scanned newly generated bytecode.

## Why it matters

Windows users installing the 0.4.0 release would still see a healthy install look stalled and then wait nearly another minute before the app becomes usable. This backport keeps the measured fix in the active release line.

## What changed (motivation → approach → change)

- Cherry-picked source commit `a2028c2847cbb28dcd40ba189528ce3eb16948ff` from merged PR #6047 with `-x` attribution.
- Same-volume per-user NSIS installs rename the staged `resources` and `locales` directories, retaining upstream `CopyFiles` for the small remainder and every failure/cross-volume fallback. Per-machine installs deliberately retain `CopyFiles` so Program Files ACL inheritance stays correct.
- Windows packaging imports the actual gateway closure after pruning and writes deterministic checked-hash pycs. Packaged Windows launches consume those adjacent pycs; other platforms keep their external runtime cache behavior.
- The electron-builder 26.15.3 template patch is pinned, idempotent, and fails closed on template drift.
- Installer validation now enforces a 120-second install ceiling and, for a real backend payload, a 30-second installed-gateway readiness ceiling.
- Release-specific conflict resolution kept `test/test_ai_review_workflows.py` unchanged because the source hunk only adjusted Bash lookup inside a main-only test block absent from `release/0.4.0`.
- All other changed file blobs match the merged source commit exactly; `website/electron/package.json` differs only by retaining release version `0.4.0-rc.9`.

## Tests

- Targeted Python release coverage: `136 passed, 2 skipped`.
- Full Electron suite: `1,337 passed, 2 skipped, 0 failed`.
- Website production build and TypeScript passed.
- Full backend release run collected 65,618 tests: `63,013 passed, 2,593 skipped, 6 xfailed`; the eight failures caused by a local forced xdist worker cap / high-load browser recording all passed in a clean no-cap rerun (`8 passed`).
- Black baseline gate passed.
- The source PR #6047 was green before merge, including full frontend, static gates, synthetic Windows NSIS build, and real installer validation. This backport PR's CI is authoritative for the release branch.

## Manual verification

The merged source change was verified with the full Windows backend and unsigned x64 NSIS package: 9,449 files / 661.4 MiB installed in 27.48 seconds locally and 59.91 seconds in the CI-equivalent run, both below 120 seconds. The just-installed bundled gateway reached `/api/ready` in 5.05–5.68 seconds, down from 44–50 seconds. Uninstall registration, payload removal, pre-existing sentinel preservation, cache isolation, and cleanup also passed.

<!-- no-visual-delta -->

## Related Issues

no linked issue: this is a release backport of merged PR #6047.

Related PR: #6012 covers visible update progress; #6047 is the complementary install/cold-start performance fix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->