### PR TITLE
ci: stop dispatching PR readiness on workflow-run creation

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -36,17 +36,35 @@ on:
       - Fork Design Review
       - Fork UX Review
       - Fork First Principles Review
-    # `completed` publishes the real verdict. `requested`/`in_progress` exist so
-    # a monitored workflow flipping BACK to running -- most commonly a re-run of
-    # a reviewer (e.g. Opus 4.8 re-run after a human override) -- re-triggers this
-    # job WHILE it runs, instead of leaving the label frozen at the previous
-    # commit's verdict until the re-run completes. On re-evaluation that workflow
-    # is queried live as `in_progress`, buckets into `pending`, and the label
-    # drops from a stale `action required` (red) back to `checking` (yellow) --
-    # an honest "recomputing" signal. Cheap: the in_progress path has pending>0,
-    # and the pr+sha concurrency group (cancel-in-progress) collapses the burst
-    # of near-simultaneous requested/in_progress fires into one live evaluation.
-    types: [requested, in_progress, completed]
+    # `completed` publishes the real verdict. `in_progress` is kept as a merge
+    # guard, and `requested` is deliberately absent.
+    #
+    # Why `requested` carries nothing: it fires when a run is CREATED, which on
+    # a head update happens for all 14 workflows above before any of them can
+    # have a verdict -- and readiness has already published `checking` for that
+    # revision via the `pull_request_target: synchronize` path. Its only other
+    # occasion is a brand-new run, whose eventual `completed` is the fire that
+    # actually decides anything. Listing it cost a third of this workflow's
+    # dispatch to re-publish a `pending` that was already pending.
+    #
+    # Why `in_progress` is load-bearing and NOT a cosmetic: it is the only type
+    # that observes a monitored workflow going BACK to running. A re-run reuses
+    # the same workflow run and increments its attempt rather than creating a
+    # new one, so `requested` does not fire for it -- `in_progress` does. That
+    # matters for a re-run of an already-GREEN lane: without it, readiness holds
+    # the pre-re-run `success` for the whole re-run, and since this status is
+    # the branch-protection handle for the entire fan-out, armed auto-merge can
+    # merge a revision whose lane is at that moment failing. Dropping it would
+    # trade a merge-safety guard for dispatch, which is the wrong direction.
+    #
+    # The dispatch problem this addresses: every type fires once per monitored
+    # workflow per revision, so all three dispatched up to 42 readiness runs per
+    # head update and made this workflow the majority of the repository's run
+    # creation. Two types put the ceiling at 28. The per-revision concurrency
+    # group below collapses the burst for EXECUTION, but a collapsed run has
+    # already consumed its dispatch slot, so the group never bounded this cost.
+    # Measurements and the queue-saturation mechanism: docs/ci/ci-and-reviews.md.
+    types: [in_progress, completed]
   workflow_dispatch:
     inputs:
       pr:

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -528,13 +528,21 @@ commit status plus one `readiness:` label**.
 
 Two subtleties:
 
-- **It refreshes while a workflow is re-running.** It triggers on `workflow_run`
-  `requested` and `in_progress` as well as `completed`, so when a monitored workflow
-  flips back to running (most often a reviewer re-run after a human override) the
-  live query buckets it into `pending` and the label honestly drops from a stale
-  `action required` back to `checking`, instead of freezing on the previous commit's
-  verdict. The `pr+sha` concurrency group collapses the resulting burst into one
-  evaluation.
+- **It refreshes while a workflow is re-running, but not when one starts.** It triggers
+  on `workflow_run` `in_progress` and `completed`, not on `requested`. `in_progress` is a
+  merge guard, not a cosmetic: it is the only type that sees a monitored workflow go back
+  to running, because a re-run reuses the same run and increments its attempt instead of
+  creating a new one. Without it, a re-run of an already-green lane would leave readiness
+  publishing the pre-re-run `success` for the whole re-run -- and since that status is the
+  branch-protection handle for the entire fan-out, armed auto-merge could merge a revision
+  whose lane is failing at that moment. `requested` is the type that carries nothing: it
+  fires at run CREATION, when no lane can have a verdict yet and readiness has already
+  published `checking` from the `pull_request_target` path. Since every type fires once per
+  monitored workflow per revision, listing all three dispatched up to 42 readiness runs per
+  head update and made readiness ~67% of every workflow run this repository created; two
+  types put the ceiling at 28. The `pr+sha` concurrency group collapses the burst for
+  execution, but a collapsed run has already consumed its dispatch slot, so the group does
+  not bound that cost.
 - **A `pull_request_target` run gets its own isolated concurrency group.** Those are
   the only readiness runs that surface as a CheckRun in the PR's rollup, and GitHub
   marks any superseded run "cancelled" whichever way `cancel-in-progress` is set, so


### PR DESCRIPTION
## Problem / Motivation

`PR Readiness` listens on `workflow_run` for `requested`, `in_progress` **and** `completed` across 14 monitored workflows. Every type fires once per monitored workflow per revision, so one head update dispatches up to **42** readiness runs.

Measured on this repository over one hour:

| slice | runs | share |
|---|---|---|
| **PR Readiness** (`workflow_run`) | **673** | 67% |
| all `pull_request` lanes combined | 221 | 22% |
| fork-repo runs (any workflow) | 75 | 7.5% |
| scheduled sweeps | 4 | 0.4% |

1250 runs created in 60 minutes, 401 sitting in `queued` against 26 `in_progress`.

## Why it matters

GitHub defers workflow-run **creation** once the account's queue saturates. The observable effect is a 10-16 minute gap between a push and its own CI: on `5efecf8b`, CodeQL's `dynamic` run was created at 16:18:59 and every `pull_request` lane at 16:34:53. CodeQL appears to "go first" only because Default Setup dispatches outside that queue.

So the workflow whose job is to report when the other lanes finish was itself the largest reason they started late.

## What changed (motivation → approach → change)

Symptom: readiness runs outnumber the lanes they observe by ~3:1, and PR lanes are created minutes after their push.

Root cause: the three listed types are not equally informative, but they cost the same. The scarce resource is dispatch, and the existing per-revision `concurrency` group with `cancel-in-progress` does not protect it — it collapses the burst for **execution**, by which point each run has already consumed its slot.

Change: `on.workflow_run.types` becomes `[in_progress, completed]`. One line, plus the comments and the doc paragraph that describe it.

**`requested` is what carries nothing.** It fires when a run is *created* — on a head update that means all 14 workflows fire it before any of them can have a verdict, and readiness has already published `checking` for that revision from the `pull_request_target: synchronize` path. Its only other occasion is a genuinely new run, whose eventual `completed` is the fire that decides anything. Dropping it puts the ceiling at 28 per head update.

**`in_progress` is retained deliberately**, and this is a correction to this PR's first revision (`48e48789b`), which dropped it. It is the only type that observes a monitored workflow going *back* to running: a re-run reuses the same workflow run and increments its attempt rather than creating a new one, so `requested` does not fire for it.

### Why the retained guard is load-bearing: the auto-merge path

`PR Readiness` is the **only** required status check on `main` (enforced by the `protected-branches` ruleset — note the legacy `branches/main/protection` API reports an empty `contexts` list, so the requirement is invisible there). Everything that lands on this repository therefore lands on the strength of this one status.

That makes a stale `success` the single unsafe direction, and it is not a hypothetical race here. The repository's PR triage pipeline arms GitHub auto-merge (`gh pr merge --squash --auto`) and approves as its **normal operation** — hourly, 100+ PRs merged that way. Its own gates cannot cover the window:

- it decides whether to arm from the `readiness: passed` **label**, at scan time;
- GitHub decides when to merge from the `PR Readiness` **status**, at a later instant;
- its signal-freshness gate binds signals to the head SHA, but a re-run involves **no new commit**, so the label's timestamp still reads fresh;
- `CI` and `Build` are not among the five reviewer checks that gate enumerates, so a re-run of either is invisible to it.

So for a re-run of an already-green lane, the only thing that withdraws the green before GitHub acts is readiness observing `in_progress` and republishing `pending`. `pr-readiness-sweep.yml` does not substitute for it: the sweep detects stale `pending` and stale `failure`, not stale `success`. Trading that guard for dispatch volume would put a live automated merge path behind a status that can outlive the truth, so only the uninformative type is removed.

Expected effect: ~673 → ~449 readiness runs/hour, roughly 18% off total run creation for this repository.

## Tests

No test asserts the trigger list (`grep -rln 'pr-readiness' tests/` is empty), so nothing needed updating.

- `python3 scripts/docs_lint.py` → pass, 235 markdown files scanned
- `python3 scripts/docs_lint.py --test` is the CI self-test and runs in the Docs Lint lane

## Manual verification

- Parsed the workflow with `js-yaml`: `on.workflow_run.types == ["in_progress", "completed"]`, `workflows` length 14, `pull_request_target.types` unchanged.
- Confirmed the count of 14 against the file rather than trusting the original comment, and corrected the stale figures in both the comment and the doc.
- Confirmed via the `protected-branches` ruleset that `PR Readiness` is the sole required status check for `main`.
- Read the triage pipeline's execute phase to confirm it never merges directly and never reads a commit status: every path is `gh pr merge --squash --auto`, `gh pr review`, or `gh pr comment`, with `--admin` and `gh api` merges forbidden as invariants.
- Confirmed the stale-label reset for a new revision is independent of these types by reading the label-strip step, which runs on the `pull_request_target` path.
- Verified against GitHub's re-run documentation that a re-run reuses the run and increments its attempt (capped at 50), which is why `requested` cannot observe one and `in_progress` can.
- Verified `check_suite: completed` is not a usable alternative join: events raised by the Actions app never trigger workflows, by design, to prevent recursion.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow trigger configuration and documentation prose only — no frontend path is touched and nothing renders.

## Related Issues

no linked issue: found by measuring this repository's own run-creation volume while diagnosing unrelated CI latency, not filed beforehand.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
