### PR TITLE
fix(conductor): one plan gate, required goal folder, rate-bounded dashboard trust

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4423,6 +4423,103 @@ in-flight item, which you handle immediately.
 """
 
 
+#: The dashboard verbs the conductor may call WITHOUT an approval prompt, named one
+#: by one rather than as the whole ``@kirocrew-dashboard`` server.
+#:
+#: THE INVARIANT, so a later reader extends this by rule and not by taste. A
+#: granted verb must satisfy BOTH halves:
+#:
+#: 1. It may CREATE something new or READ. It may never MUTATE user-visible
+#:    workspace state that already exists and is not the conductor's own — a
+#:    session's contents or liveness, or the arrangement the person made of their
+#:    sessions and folders.
+#: 2. Its worst case, called in a loop, must be BOUNDED BY THE SERVER — and
+#:    bounded so the resource stays reachable by everyone else.
+#:
+#: The conductor ingests untrusted text by design — its charter's worked example is
+#: "resolve this repo's open issues", and it holds ``web_fetch`` for exactly that —
+#: so every granted verb is reachable by content it read, with no human in the loop
+#: on a nudge-driven patrol cycle. Per-call approval was the only thing
+#: rate-limiting a granted verb, and ``allowedTools`` has no argument or rate
+#: matching to replace it, so the bound cannot live in this list: it has to live in
+#: the endpoint. Half 2 is not a restatement of half 1 — an unbounded create is how
+#: a create does damage without mutating anything.
+#:
+#: Half 1 names user-visible workspace state deliberately, rather than "any
+#: pre-existing resource", because a create ALWAYS writes some shared bookkeeping —
+#: the slot table, the folder index, the session-pulse counter below — and a literal
+#: reading would forbid every create and decide nothing. What it protects is state
+#: the person arranged and would have to reconstruct by hand. Creation is otherwise
+#: recoverable clutter; mutation of what the user arranged is not.
+#:
+#: Both granted creation verbs earn half 2 from a server ceiling, and BOTH ceilings
+#: were added by this change — neither verb was safe to auto-approve as the code
+#: stood:
+#:
+#: * ``chat_folder_create`` had no bound at all, so a loop grew durable on-disk
+#:   state without limit. Now ``MAX_CHAT_FOLDERS``, tested under the folder lock.
+#: * ``session_create`` had a GLOBAL ceiling (``MAX_LIVE_SLOTS``) but no
+#:   distribution: one caller could hold all 500, and every later create — the
+#:   person opening a chat tab included — got the 429. A bounded resource that one
+#:   caller can exhaust is not bounded from anybody else's point of view. Now
+#:   ``MAX_SLOTS_PER_CREATOR`` bounds what a single caller holds, leaving 450 slots
+#:   reachable no matter what the conductor does.
+#:
+#: Every verb this server exposes, against that rule:
+#:
+#: * ``chat_folder_tree`` — READ of the caller's visible tree. GRANTED.
+#: * ``chat_folder_create`` — creates a NEW folder, and
+#:   ``_refuse_tree_shaping_if_unverifiable`` refuses an unverifiable caller and
+#:   keeps an app agent out of the person's own folders. Touches nothing that
+#:   already existed, and bounded by ``MAX_CHAT_FOLDERS``. GRANTED.
+#: * ``session_create`` — creates a NEW session in the caller's workspace, bounded
+#:   both globally (``MAX_LIVE_SLOTS``, 429 on breach) and per caller
+#:   (``MAX_SLOTS_PER_CREATOR``), and visible in the sidebar. GRANTED.
+#:   One known side effect, recorded because it is the closest thing to an
+#:   exception here: ``create_session`` mints its slot with
+#:   ``origin=SlotOrigin.USER`` (it is a first-class user-owned session, which is
+#:   what keeps it correctly private), and ``get_or_create_slot`` increments the
+#:   session-pulse counter on exactly that origin — so conductor-created sessions
+#:   count toward the feedback survey's "10 genuine user chats" window. That is a
+#:   pre-existing conflation in the counter, not something this grant introduces:
+#:   the counter uses the ownership tag as a proxy for "a person started a chat",
+#:   and it miscounts for every caller of the session-control create verb. Filed
+#:   as issue #6139 rather than point-fixed here, because the correct fix is a
+#:   fail-open/fail-closed decision about which call sites opt in, inside the
+#:   session-pulse surface. Consequence if it drifts: a survey prompt appears
+#:   earlier than the product intended. No workspace state is altered.
+#: * ``session_read_message`` — read-only, and the verb the patrol loop actually
+#:   needs on a cycle with nobody at the keyboard. GRANTED.
+#: * ``chat_folder_move_session`` — WITHHELD. It writes another session's
+#:   ``folder_id``: the PATCH goes to ``/api/chat/slots/<target>/folder`` where the
+#:   target is the session named in the ARGUMENTS, and the strictly-resolved
+#:   caller key is only the authority header. ``mcp_dashboard`` calls it "the one
+#:   tool here that writes to a session OTHER than the caller's". Auto-approving it
+#:   would let ingested content silently refile or unfile any persistent
+#:   same-workspace session, losing filing the user did by hand.
+#: * ``chat_folder_move`` — WITHHELD. Reparents an existing folder tree, and no
+#:   conductor step needs it.
+#: * ``session_send`` — WITHHELD. Runs text as another session's user-role turn
+#:   under that target's own grants. The server-side gates bound WHICH target is
+#:   reachable; nothing bounds WHAT is sent.
+#: * ``session_stop`` — WITHHELD. Ends another session's in-flight turn and
+#:   DISCARDS its work (``stop_target``: "A first call cancels cooperatively;
+#:   calling again while that is pending escalates to a hard kill").
+#:
+#: Every withheld verb stays MOUNTED (``@kirocrew-dashboard`` is still in
+#: ``tools``) — it just passes through ``hooks.on_tool_call`` like any ungranted
+#: tool. The cost is an approval when a round files a session, seeds a child, or
+#: stops one; all three happen right after a human approved the plan, while the
+#: unattended patrol cycle needs none of them. Issue #6118 (a ``folder`` argument
+#: on ``session_create``) would remove the filing call altogether.
+_CONDUCTOR_DASHBOARD_GRANTS: tuple[str, ...] = (
+    "@kirocrew-dashboard/chat_folder_tree",
+    "@kirocrew-dashboard/chat_folder_create",
+    "@kirocrew-dashboard/session_create",
+    "@kirocrew-dashboard/session_read_message",
+)
+
+
 def _install_conductor_agent() -> None:
     """Generate and install the kirocrew-conductor agent config.
 
@@ -4438,11 +4535,28 @@ def _install_conductor_agent() -> None:
     the explicit per-agent assignment that set requires — it is deliberately
     absent from the default agent's spec.
 
-    ``@kirocrew-dashboard`` is NOT added to ``allowedTools``: its calls must
-    keep passing through ``hooks.on_tool_call`` where the deny floor and
-    governance ceiling apply, so every session-control call prompts. Neither is
-    ``execute_bash``, for the same reason — the evaluator run prompts too, which
-    is what actually bounds what an acceptance spec can execute.
+    ``@kirocrew-dashboard`` is MOUNTED whole but auto-approved only verb by verb,
+    via ``_CONDUCTOR_DASHBOARD_GRANTS`` (see its comment for the per-verb
+    reasoning). Both backends honour a per-tool reference, so the narrowing is
+    real rather than cosmetic: kiro-cli's ``is_tool_in_allowlist`` checks
+    ``@server`` and then ``@server/<tool>``, and ``allowed_tools_to_permissions``
+    maps the same entry to an exact KAS ``server/tool`` resource match.
+
+    The line the split follows is stated as an invariant on that tuple, not as a
+    taste call: a granted verb may CREATE or READ, never MUTATE something that
+    already exists and is not the conductor's own. Reads and creates are granted
+    because the patrol loop is nudge-driven and must not block on an approval
+    nobody is there to give. ``session_stop`` (discards a peer's in-flight turn),
+    ``session_send`` (runs text as a peer's turn) and ``chat_folder_move_session``
+    (writes a peer session's ``folder_id``) are withheld, because the conductor
+    ingests untrusted content by design and the server-side gates bound which
+    target is reachable, not what is done to it.
+
+    ``execute_bash`` is withheld for a different reason that is worth keeping
+    distinct: ``allowedTools`` is name-scoped with no argument matching, so
+    trusting the two bundled scripts cannot be told apart from trusting arbitrary
+    shell. There is no per-argument form of that grant the way there is a per-tool
+    form of the MCP one.
 
     The operating procedure ships as the ``goal-conductor`` builtin skill, NOT
     ``conductor``: that skill name is owned by the generated delegation skill
@@ -4490,7 +4604,7 @@ def _install_conductor_agent() -> None:
     # then applies the ceiling's per-tool rule with the real arguments.
     granted: list[str] = []
     withheld: list[str] = []
-    for ref in ("session", "report", "@kirocrew-core"):
+    for ref in ("session", "report", "@kirocrew-core", *_CONDUCTOR_DASHBOARD_GRANTS):
         (granted if _may_auto_approve(ref) else withheld).append(ref)
     config["allowedTools"] = granted
     if withheld:

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -65,11 +65,28 @@ Worked example — goal "resolve this repo's open issues":
 
 ## The loop
 
-### Round 0 — agree the plan
+### Round 0 — one plan, one gate
 
-Restate the goal, list the work items with their acceptance conditions, and say
-how many you will run per round. Wait for the user. Do not dispatch on a plan
-they have not seen.
+Your FIRST reply to a goal is the plan itself — never a round of questions.
+Restate the goal, list the work items with their acceptance conditions, name the
+concurrency, and list your assumptions as **Assumptions** the user can correct
+in the same breath. Then stop and wait for exactly one go-ahead.
+
+**Decide, do not ask.** Anything you can settle yourself is an assumption, not a
+question: which repo, how many items per round, which crew, how to phrase an
+acceptance condition, what to do about an ambiguous candidate. Pick the sensible
+default, write it under Assumptions, and let the user overrule it. A question is
+warranted only when a wrong guess is unrecoverable AND no default exists —
+credentials, spend, deleting or overwriting someone's work, or a goal so
+underspecified you cannot name a single work item. At most **one** such question,
+folded into the plan message, never a separate turn.
+
+**Skip the gate when the user already gave one.** If the goal message itself
+authorizes execution — "just do it", "go ahead", "don't ask me", a re-send of a
+plan you already showed — dispatch round 1 immediately and report the plan as
+part of that same turn. Do not re-ask for permission you already hold. Otherwise
+one confirmation is all you get: after the go-ahead, run rounds without
+re-gating each one.
 
 **Respect existing ownership signals during triage.** Other automation shares
 your work pool — Issue Radar crews label issues `claimed`, humans assign
@@ -81,11 +98,21 @@ beats more parallelism: every open item is a session the user may have to read.
 
 ### Dispatch a round
 
-For each item in the round:
+**Before the round: the goal's folder must exist.** Once per goal, ahead of the
+FIRST `session_create` you ever make for it, call `chat_folder_tree` and then
+`chat_folder_create` for the goal if it is not already there. Keep the returned
+folder id — every session for this goal is filed there.
 
-1. `chat_folder_create` once per goal (skip if it exists) so every session for
-   this goal lands in one place.
-2. `session_create` with a title that says what the item is FOR, and `agent` set
+`session_create` has no `folder` argument, so filing is a separate call and
+therefore easy to skip. Do not skip it. **A `session_create` for this goal
+before its folder exists is a defect, not a shortcut**: the sessions land loose
+at the sidebar's top level, the user cannot tell which goal they belong to, and
+there is no grouping to clean up by when the goal ends. If `chat_folder_create`
+fails, say so and stop — do not dispatch into no folder.
+
+Then for each item in the round:
+
+1. `session_create` with a title that says what the item is FOR, and `agent` set
    to the crew that fits. Call `select_crew` first and pass the agent it names —
    the matched crew when the item is clearly a specialist's job, otherwise the
    `default_agent` it returns. **Do NOT leave `agent` unset to "inherit the
@@ -93,11 +120,18 @@ For each item in the round:
    spec deliberately has no `fs_write` — so the child could not write a file even
    though writing one is the work you dispatched it to do, and the item would
    look stalled rather than misconfigured.
-3. `chat_folder_move_session` to file the new session under the goal's folder.
-4. `session_send` the seed prompt into the new session — the item's goal, its
+2. `chat_folder_move_session` to file the new session under the goal's folder.
+   Do this immediately after the create, before the seed — an unfiled session
+   that then starts working is one the user has to hunt for. **If the move
+   fails, stop this item before the seed** and say so: the folder can be gone
+   by now even though you created it (the user can delete it mid-round), and
+   seeding anyway is exactly the unfiled-session outcome the precondition above
+   exists to prevent — except worse, because the session is now also doing work.
+   Recreate the folder and retry the move, or leave the item undispatched.
+3. `session_send` the seed prompt into the new session — the item's goal, its
    acceptance condition, and where to report. The seed is the item's whole
    contract: the child session gets no other context from you.
-5. `session_ledger_record` the item: its goal text, the round number, and — in
+4. `session_ledger_record` the item: its goal text, the round number, and — in
    `artifacts`, under an `item-<n>` key — the durable item entry carrying its
    acceptance spec, session key, round, status and read cursor. **Never
    hand-write the entry value: encode it with the bundled codec**
@@ -329,17 +363,23 @@ watches, and that cost grows with the loop's own history.
   defaults to OFF and fails closed — every session tool answers
   `session_control_disabled` until the user sets it to `true` in config.json.
   If you see that error, say which switch to flip; do not retry.
-- **Every dashboard tool call prompts for approval, and so does every bundled
-  script run.** That is deliberate: both `@kirocrew-dashboard` and `execute_bash`
-  are withheld from auto-approve so their calls still pass through the tool-call
-  hook where the deny floor and governance ceiling apply. The steady-state cost is
-  concrete and worth planning for: **each patrol cycle blocks on one approval for
-  the `accept_eval.py` invocation** plus one per codec call, and one per
-  session-control call in a dispatch round. Patrol is therefore
-  attended-unattended — the loop wakes itself, but a cycle that finds nobody at
-  the keyboard waits rather than proceeding. Size the nudge interval for that,
-  and prefer batched calls — one evaluator call per cycle carrying every open
-  item, one codec call per map-wide operation — over one call per item.
+- **Reads and creates do not prompt; anything that touches another session does.**
+  Auto-approved by name: `chat_folder_tree`, `chat_folder_create`,
+  `session_create`, `session_read_message` — so a patrol cycle that wakes on a
+  nudge with nobody at the keyboard never blocks. **`chat_folder_move_session`,
+  `session_send` and `session_stop` are deliberately NOT auto-approved**, because
+  each writes to a session that is not yours: filing rewrites another session's
+  folder, a seed runs as the target's own turn, and a stop discards the target's
+  in-flight work. You ingest external content by design, so the prompt is the only
+  call-time check on all three. Expect an approval per item at dispatch (one to
+  file it, one to seed it) and one if you ever stop an item — all of which happen
+  right after the user approved a plan, not mid-patrol. `execute_bash` also still
+  prompts, so **each patrol cycle blocks on one approval for the
+  `accept_eval.py` invocation** plus one per codec call. Size the nudge interval
+  for that, and batch: one evaluator call per cycle carrying every open item, one
+  codec call per map-wide operation. On a host with a governance ceiling even the
+  granted verbs prompt; if you see approvals where this says you should not, that
+  is why.
 - **`session_send` reports delivery, not completion.** `started: true` means the
   target began a turn on your message; `started: false` means it queued. Neither
   says the work succeeded — acceptance is still the domain assertion's job.

--- a/src/kiro_crew/dashboard/chat_folders.py
+++ b/src/kiro_crew/dashboard/chat_folders.py
@@ -14,6 +14,7 @@ from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.create_rate_limit import FOLDER_CREATE, allow_create
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot, derive_caller_app
 from kiro_crew.executors import subprocess_executor
@@ -23,6 +24,19 @@ from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exf
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
+
+#: The ceiling on chat folders, the folder-tree counterpart to
+#: :data:`~kiro_crew.dashboard.state.MAX_LIVE_SLOTS`. Folder creation had no bound
+#: at all: every other create path in the dashboard tests a ceiling, so an
+#: automated caller looping on this one was the single way to grow durable
+#: on-disk state without limit.
+#:
+#: Chosen to sit far above any hand-built tree -- a person organizing chats works
+#: in tens of folders, not hundreds -- so the only thing that ever reaches it is a
+#: runaway loop. Tested under ``mutate_folders``, not before it: the count is only
+#: authoritative while the lock is held, which is the same reason the parent is
+#: re-checked and ``order`` recounted there.
+MAX_CHAT_FOLDERS = 500
 
 _folder_icon_lock = LoopBoundLock()
 
@@ -389,6 +403,29 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     if (refusal := _refuse_unattributable_caller(state, request)) is not None:
         return refusal
+    # Rate-limit INTERNAL callers only. This endpoint is mixed-path: the browser's
+    # own "new folder" control posts here too, and a person organizing their chats
+    # can legitimately create a dozen in one sitting, so throttling them would be a
+    # regression with no security value. The threat is an automated loop on an
+    # auto-approved verb, and `_audit_origin` already tells the two apart -- a
+    # request without the internal secret is the browser.
+    #
+    # Keyed on the VALIDATED caller name, not the session key. The session key would
+    # give finer granularity but is partly caller-supplied:
+    # `_refuse_unattributable_caller` only refuses a `dashboard:` key naming a dead
+    # slot, so a caller could present rotating non-dashboard keys and earn a fresh
+    # budget for each. The caller name is checked against `_KNOWN_INTERNAL_CALLERS`,
+    # so it cannot be varied to escape the bucket. The cost is that internal callers
+    # share one folder budget, which is acceptable when a goal needs exactly one.
+    rl_source, rl_caller = _audit_origin(request)
+    if rl_source != "dashboard" and not allow_create(FOLDER_CREATE, rl_caller):
+        return web.json_response(
+            {
+                "error": "too many folders created recently; retry shortly",
+                "code": "create_rate_limited",
+            },
+            status=429,
+        )
     try:
         body = await request.json()
     except Exception:
@@ -441,6 +478,12 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
         parent = next((f for f in folders if f["id"] == parent_id), None) if parent_id else None
         if parent_id and parent is None:
             return False, "parent_not_found"
+        # The ceiling is tested here, under the lock, for the same reason the parent
+        # is re-checked here: `len(folders)` is only authoritative while the lock is
+        # held, so a pre-lock test lets concurrent creators each pass a cap that is
+        # already full.
+        if len(folders) >= MAX_CHAT_FOLDERS:
+            return False, "folder_cap_reached"
         # Nesting into a folder writes to THAT folder's child list, so an app may
         # only nest under one of its own. The top level is not a folder row and
         # so has no owner to violate — that is where an app's own tree starts.
@@ -453,6 +496,14 @@ async def api_chat_folder_create(request: web.Request) -> web.Response:
         return True, ""
 
     create_err = await state.mutate_folders(_append)
+    if create_err == "folder_cap_reached":
+        return web.json_response(
+            {
+                "error": f"folder cap reached ({MAX_CHAT_FOLDERS})",
+                "code": "folder_cap_reached",
+            },
+            status=429,
+        )
     if create_err == "parent_not_found":
         # The parent was deleted while this request waited for the lock.
         return web.json_response(

--- a/src/kiro_crew/dashboard/create_rate_limit.py
+++ b/src/kiro_crew/dashboard/create_rate_limit.py
@@ -1,0 +1,125 @@
+"""Per-caller rate limiting for the dashboard's *creation* verbs.
+
+The capacity ceilings elsewhere (``MAX_LIVE_SLOTS``, ``MAX_SLOTS_PER_CREATOR``,
+``MAX_CHAT_FOLDERS``) bound how much of a resource can exist at once. They do not
+bound the RATE, and rate is the property that matters for an auto-approved verb: a
+caller whose approval prompt has been waived has nothing throttling a loop, so the
+only cost of attempting exhaustion is time.
+
+This is the primary control for that, and it is deliberately the one that needs no
+durable state. A lifetime quota has to survive restarts to mean anything -- every
+path that rehydrates a session would have to carry its attribution, and there are
+27 such call sites -- whereas a window measured in minutes is not meaningfully
+resettable: a restart buys the caller one window, not a clean slate. So the guard
+that has to hold under adversarial conditions is the one with no persistence
+requirement, and the capacity ceilings sit behind it as secondary bounds.
+
+Why this cannot live in the agent's own instructions: the conductor reads untrusted
+text by design, and content that can drive it into a creation loop can equally
+override a "create at most N per round" line in its skill. Self-restraint is a
+convention; this is a control. It is enforced here, for every caller, so it holds
+regardless of which agent is calling or what it was told.
+
+Budgets are per (verb, caller) so a folder burst cannot consume a caller's session
+budget, and they are sized to leave honest work untouched: a decomposed goal files
+one folder and opens on the order of ten sessions in its dispatch round, which fits
+inside a single window with headroom. At the session rate, filling
+``MAX_LIVE_SLOTS`` from empty takes over two hours of uninterrupted looping, every
+step of it visible in the sidebar -- which converts a silent exhaustion into
+something a person watching the dashboard sees long before it lands.
+
+Follows ``handlers/auth_refresh.py``'s bucket shape rather than
+``notifications.rate_limit.AppRateLimiter``: that limiter never evicts, which is
+sound for a bounded set of installed app names but would leak here, where the key
+space is session keys that churn for the gateway's lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+#: Window both budgets are measured over.
+WINDOW_SECS = 300.0
+
+#: Creates allowed per window, per caller, per verb. Sessions get the larger budget
+#: because a dispatch round opens one per work item; a goal needs exactly one folder,
+#: so that budget only has to absorb retries and a nested tree.
+MAX_SESSION_CREATES_PER_WINDOW = 20
+MAX_FOLDER_CREATES_PER_WINDOW = 10
+
+#: How often stale buckets are swept, so the map cannot grow without bound across
+#: the many distinct session keys a long-lived gateway sees.
+_SWEEP_INTERVAL_SECS = 60.0
+
+_lock = threading.Lock()
+_buckets: dict[tuple[str, str], deque[float]] = {}
+_last_sweep = 0.0
+
+SESSION_CREATE = "session_create"
+FOLDER_CREATE = "folder_create"
+
+_BUDGETS = {
+    SESSION_CREATE: MAX_SESSION_CREATES_PER_WINDOW,
+    FOLDER_CREATE: MAX_FOLDER_CREATES_PER_WINDOW,
+}
+
+
+def _sweep(now: float, *, force: bool = False) -> None:
+    """Drop buckets whose every timestamp has aged out. Caller holds ``_lock``."""
+    global _last_sweep
+    if not force and now - _last_sweep < _SWEEP_INTERVAL_SECS:
+        return
+    _last_sweep = now
+    cutoff = now - WINDOW_SECS
+    stale: list[tuple[str, str]] = []
+    for key, bucket in _buckets.items():
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if not bucket:
+            stale.append(key)
+    for key in stale:
+        _buckets.pop(key, None)
+
+
+def allow_create(verb: str, caller_key: str, *, now: float | None = None) -> bool:
+    """Consume one unit of *caller_key*'s budget for *verb*.
+
+    Returns ``False`` when the caller is over its budget for the current window,
+    which the endpoint renders as a 429.
+
+    Fails CLOSED on an unknown verb or an empty caller key. An empty key means the
+    request cannot be attributed and therefore cannot be rate-limited at all;
+    bucketing those together under one sentinel would still let the whole budget
+    through on a key an attacker can trivially blank, so the request is refused
+    instead. Every caller this guards resolves its identity strictly before
+    reaching here, so this denies no legitimate traffic.
+    """
+    budget = _BUDGETS.get(verb)
+    if budget is None or not caller_key:
+        return False
+    if now is None:
+        now = time.monotonic()
+    cutoff = now - WINDOW_SECS
+    key = (verb, caller_key)
+    with _lock:
+        _sweep(now)
+        bucket = _buckets.get(key)
+        if bucket is None:
+            bucket = deque()
+            _buckets[key] = bucket
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= budget:
+            return False
+        bucket.append(now)
+        return True
+
+
+def reset_for_tests() -> None:
+    """Clear all buckets. Test-only: module state would otherwise leak across tests."""
+    global _last_sweep
+    with _lock:
+        _buckets.clear()
+        _last_sweep = 0.0

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -42,7 +42,8 @@ from kiro_crew.config.loader import (
 from kiro_crew.dashboard.chat_delivery import sanitize_outbound
 from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
 from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
-from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, SlotOrigin
+from kiro_crew.dashboard.create_rate_limit import SESSION_CREATE, allow_create
+from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, MAX_SLOTS_PER_CREATOR, SlotOrigin
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
 from kiro_crew.sel import sel
@@ -766,10 +767,35 @@ async def create_session(
             code="caller_workspace_changed",
         )
     _refuse_ineligible_creator(state, live_caller)
+    # The RATE guard, ahead of the capacity ceilings below. Those bound how many
+    # sessions can exist; this bounds how fast one caller may open them, which is
+    # the property an auto-approved verb loses -- a waived prompt leaves a loop
+    # nothing to push back on. Deliberately the control that needs no durable
+    # state: a lifetime quota means nothing across a restart unless every
+    # rehydrate path carries its attribution, while a five-minute window buys a
+    # restart one window rather than a clean slate.
+    if not allow_create(SESSION_CREATE, caller_key):
+        raise SessionControlError(
+            "too many sessions created recently; retry shortly",
+            code="create_rate_limited",
+            status=429,
+        )
     if state.live_slot_count() >= MAX_LIVE_SLOTS:
         raise SessionControlError(
             f"slot cap reached ({MAX_LIVE_SLOTS})",
             code="slot_cap_reached",
+            status=429,
+        )
+    # Then the per-creator sub-ceiling. The global cap above bounds the TOTAL but
+    # not the distribution, so without this one caller can hold all 500 and the
+    # person's own next chat tab gets the 429 -- the resource is bounded, but not
+    # from anyone else's point of view. This is the bound that makes the verb safe
+    # to auto-approve: the worst case of an automated creator looping on it is its
+    # own 50 slots, not everyone's 500.
+    if state.creator_slot_count(caller_key) >= MAX_SLOTS_PER_CREATOR:
+        raise SessionControlError(
+            f"per-caller slot cap reached ({MAX_SLOTS_PER_CREATOR})",
+            code="creator_slot_cap_reached",
             status=429,
         )
 
@@ -780,6 +806,15 @@ async def create_session(
     slot = state.get_or_create_slot(
         None, agent=agent_name, workspace=workspace, origin=SlotOrigin.USER
     )
+    # Attribute the slot to the caller that asked for it, which is what makes the
+    # per-creator ceiling above countable. Written here, inside the synchronous
+    # window that follows the mint, so no suspension point separates the cap test
+    # from this write -- otherwise two concurrent creates could both pass a ceiling
+    # that one of them had already filled. Only this entry point sets it: a
+    # person's own tab and a fork reach `get_or_create_slot` directly and stay
+    # unattributed, so ordinary human use never consumes an automated caller's
+    # share.
+    slot._created_by = caller_key
     # cwd must follow the workspace too, or file search and project-scoped agents
     # resolve against a directory the slot does not claim -- the same
     # authorization-vs-execution split as the agent binding, one layer down.

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -92,6 +92,23 @@ logger = logging.getLogger(__name__)
 #: point can silently drift to a different limit.
 MAX_LIVE_SLOTS = 500
 
+#: The most live slots ONE creator may hold, as a sub-ceiling under
+#: :data:`MAX_LIVE_SLOTS`. The global ceiling alone bounds the total but not the
+#: distribution, so a single automated creator working through a nudge loop can
+#: reach 500 on its own and every later create -- including the person opening a
+#: new chat tab -- gets the 429. That is the availability half of the cap: a
+#: bounded resource that one caller may exhaust entirely is not bounded from
+#: anybody else's point of view.
+#:
+#: Deliberately far above real use and far below the global ceiling: a decomposed
+#: goal runs on the order of ten concurrent sessions, so 50 never binds honest
+#: work, while 450 slots stay reachable by everyone else no matter what one
+#: caller does. Enforced in ``session_control.create_session``, which is the only
+#: entry point that creates on some OTHER caller's behalf; a person's own new tab
+#: and a fork are attributed to nobody and so are bounded by the global ceiling
+#: alone.
+MAX_SLOTS_PER_CREATOR = 50
+
 #: Return type of a mutate_folders callback.
 _T = TypeVar("_T")
 
@@ -2664,6 +2681,7 @@ class _ChatSlot:
         "_summary_turn_mark",
         "_detail_render_lock",
         "_last_stop_reason",
+        "_created_by",
         "_artifact",
         "_channel_folder_filed",
         "_resumed_count",
@@ -2876,6 +2894,11 @@ class _ChatSlot:
         # finish, and deriving anything from it would describe work that was
         # interrupted mid-flight as if it had concluded.
         self._last_stop_reason: str = ""
+        #: The resolved slot key of the caller that asked for this session via the
+        #: session-control create verb, or "" for a slot nobody asked for -- a
+        #: person's own tab, a fork, a restore. Read by
+        #: ``DashboardState.creator_slot_count`` for ``MAX_SLOTS_PER_CREATOR``.
+        self._created_by: str = ""
         # Artifact companion binding: set when this slot is a
         # companion chat session for an artifact (slug). At most one
         # non-archived slot per slug by convention — the frontend flow
@@ -6936,6 +6959,26 @@ class DashboardState:
         each slip past a cap that is already full.
         """
         return len(self._slots) + len(self._slots_under_construction)
+
+    def creator_slot_count(self, creator_key: str) -> int:
+        """Live slots that *creator_key* asked for, for :data:`MAX_SLOTS_PER_CREATOR`.
+
+        Counts only slots carrying the attribution ``create_session`` writes, so a
+        person's own tab and a fork -- which name no creator -- are never charged to
+        anyone and stay bounded by :data:`MAX_LIVE_SLOTS` alone.
+
+        Unlike :meth:`live_slot_count` this does NOT add the under-construction set:
+        attribution is written just after the slot is minted, with no suspension
+        between the caller's cap test and that write, so a slot mid-construction has
+        no creator to compare and adding the set would charge one caller for
+        another's in-flight create. An empty ``creator_key`` counts nothing rather
+        than matching every unattributed slot.
+        """
+        if not creator_key:
+            return 0
+        return sum(
+            1 for slot in self._slots.values() if getattr(slot, "_created_by", "") == creator_key
+        )
 
     def begin_slot_construction(self, key: str) -> None:
         """Mark *key* as allocated-but-unpublished.

--- a/test/test_chat_folder_cap.py
+++ b/test/test_chat_folder_cap.py
@@ -1,0 +1,168 @@
+"""The bounds on chat-folder creation: a global ceiling and a per-caller rate.
+
+Folder creation was the one create path in the dashboard with no bound at all, so an
+automated caller looping on it could grow durable on-disk state without limit. Two
+guards now: ``MAX_CHAT_FOLDERS`` bounds how many can exist, tested where the count is
+authoritative (under the folder lock), and a per-caller rate bounds how fast one
+caller may make them. The rate applies to INTERNAL callers only -- this endpoint also
+serves the browser's own control, and throttling a person organizing their chats
+would be a regression with no security value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard import create_rate_limit
+from kiro_crew.dashboard.chat_folders import MAX_CHAT_FOLDERS, api_chat_folder_create
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+
+def _folders(count: int) -> list[dict[str, Any]]:
+    return [
+        {"id": f"fldr{i:04d}", "name": f"F{i}", "parent_id": None, "order": i} for i in range(count)
+    ]
+
+
+def _state(folders: list[dict[str, Any]], *, on_mutate: Any = None) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state._folders = folders
+    slot = _ChatSlot("chat-1-100")
+    state._slots = {slot.key: slot}
+    state.push_slots_update = MagicMock()
+    state.conversation_log = None
+
+    async def _mutate(fn: Any) -> Any:
+        # The real store runs the callback while holding the lock and hands back
+        # its second element. `on_mutate` stands in for a concurrent creator that
+        # won the lock first, so the callback sees a list that grew after the
+        # request was admitted.
+        if on_mutate is not None:
+            on_mutate(state._folders)
+        _changed, value = fn(state._folders)
+        return value
+
+    state.mutate_folders = _mutate
+    return state
+
+
+def _make_app(state: DashboardState) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+
+    @web.middleware
+    async def _publish_app(request: web.Request, handler: Any) -> Any:
+        request["app"] = ""
+        return await handler(request)
+
+    app.middlewares.append(_publish_app)
+    app.router.add_post("/api/chat/folders", api_chat_folder_create)
+    return app
+
+
+async def _create(state: DashboardState, name: str = "New") -> tuple[int, dict[str, Any]]:
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post(
+            "/api/chat/folders",
+            json={"name": name},
+            headers={"X-Session-Key": "dashboard:chat-1-100"},
+        )
+        return resp.status, await resp.json()
+
+
+@pytest.mark.asyncio
+async def test_creation_is_refused_at_the_ceiling() -> None:
+    """Mutation guard: remove the check and this returns 201 forever."""
+    status, body = await _create(_state(_folders(MAX_CHAT_FOLDERS)))
+
+    assert status == 429, "a cap breach is a 429, not a 500 and not a silent success"
+    assert body["code"] == "folder_cap_reached"
+    assert str(MAX_CHAT_FOLDERS) in body["error"], "the refusal should name the ceiling"
+
+
+@pytest.mark.asyncio
+async def test_the_last_folder_under_the_ceiling_is_still_allowed() -> None:
+    """The boundary, so an off-by-one cannot cost the user their final folder."""
+    folders = _folders(MAX_CHAT_FOLDERS - 1)
+    status, _body = await _create(_state(folders))
+
+    assert status == 201
+    assert len(folders) == MAX_CHAT_FOLDERS
+
+
+@pytest.mark.asyncio
+async def test_an_internal_caller_is_rate_limited_at_the_endpoint() -> None:
+    """The MCP path is throttled, which is what bounds an auto-approved loop.
+
+    Mutation guard: drop the `allow_create` call and the burst all returns 201.
+    """
+    create_rate_limit.reset_for_tests()
+    try:
+        state = _state(_folders(0))
+        headers = {
+            "X-Session-Key": "dashboard:chat-1-100",
+            "X-Internal-Secret": "s3cret",
+            "X-Internal-Caller": "kirocrew-dashboard",
+        }
+        async with TestClient(TestServer(_make_app(state))) as client:
+            allowed = 0
+            for i in range(create_rate_limit.MAX_FOLDER_CREATES_PER_WINDOW + 3):
+                resp = await client.post(
+                    "/api/chat/folders", json={"name": f"F{i}"}, headers=headers
+                )
+                if resp.status == 201:
+                    allowed += 1
+                else:
+                    body = await resp.json()
+                    assert resp.status == 429
+                    assert body["code"] == "create_rate_limited"
+        assert allowed == create_rate_limit.MAX_FOLDER_CREATES_PER_WINDOW
+    finally:
+        create_rate_limit.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_the_browser_is_not_rate_limited() -> None:
+    """The person's own "new folder" control posts to this same endpoint, and someone
+    organizing their chats can legitimately create more than the agent budget in one
+    sitting. Throttling them would be a regression with no security value.
+
+    Mutation guard: apply the limiter unconditionally and this starts 429ing.
+    """
+    create_rate_limit.reset_for_tests()
+    try:
+        state = _state(_folders(0))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            for i in range(create_rate_limit.MAX_FOLDER_CREATES_PER_WINDOW + 3):
+                resp = await client.post(
+                    "/api/chat/folders",
+                    json={"name": f"F{i}"},
+                    headers={"X-Session-Key": "dashboard:chat-1-100"},
+                )
+                assert resp.status == 201, "a browser create must never be throttled"
+    finally:
+        create_rate_limit.reset_for_tests()
+
+    """`len(folders)` is only authoritative while the lock is held.
+
+    A pre-lock test lets two concurrent creators each pass a cap that one of them
+    has already filled -- the same pre-lock/post-lock gap the parent re-check and
+    the `order` recount exist to close.
+
+    Mutation guard: hoist the check above `mutate_folders` and this returns 201,
+    landing folder 501.
+    """
+
+    def _fill(folders: list[dict[str, Any]]) -> None:
+        folders.extend(_folders(MAX_CHAT_FOLDERS)[len(folders) :])
+
+    # Admitted while the tree was empty; the lock winner filled it meanwhile.
+    status, body = await _create(_state([], on_mutate=_fill))
+
+    assert status == 429
+    assert body["code"] == "folder_cap_reached"

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -63,13 +63,15 @@ class TestConductorInstaller:
         assert data["name"] == "kirocrew-conductor"
         assert "work item" in data["prompt"]
 
-    def test_no_write_tool_and_dashboard_not_preapproved(self, tmp_path, monkeypatch):
-        """The two deliberate security properties of the spec.
+    def test_no_write_tool_and_shell_not_preapproved(self, tmp_path, monkeypatch):
+        """The security properties of the spec, in one place.
 
         No ``fs_write``: the conductor cannot do a work item's work itself.
-        ``@kirocrew-dashboard`` and ``execute_bash`` reachable but NOT in
-        ``allowedTools``: their calls must keep passing through the tool-call
-        hook where the deny floor and governance ceiling apply.
+        ``@kirocrew-dashboard`` is MOUNTED whole but never granted whole — the
+        auto-approve list names verbs, so the destructive ones keep prompting.
+        ``execute_bash`` is mounted and never granted, because ``allowedTools``
+        has no argument matching and trusting the two bundled scripts cannot be
+        told apart from trusting arbitrary shell.
         """
         data = self._install(tmp_path, monkeypatch)
         assert "fs_write" not in data["tools"]
@@ -77,6 +79,60 @@ class TestConductorInstaller:
         assert "@kirocrew-dashboard" not in data["allowedTools"]
         assert "execute_bash" in data["tools"]
         assert "execute_bash" not in data["allowedTools"]
+
+    def test_only_create_and_read_verbs_are_auto_approved(self, tmp_path, monkeypatch):
+        """The grant invariant: create or read, never mutate someone else's thing.
+
+        Every auto-approved verb is reachable by content the conductor ingested
+        (its charter reads issue text; it holds ``web_fetch`` for that), with no
+        human in the loop on a nudge-driven cycle. So a granted verb may make a
+        NEW folder or session, or read — never write a resource the user already
+        arranged, because that destroys state no prompt asked about.
+
+        Pinned as literal names rather than by importing the tuple: the point is
+        that WIDENING the tuple fails a test, which a tautological assertion
+        against the tuple itself could never catch. Each withheld verb below is
+        withheld for a reason recorded next to it in ``agent.py``:
+        ``chat_folder_move_session`` PATCHes another session's ``folder_id``
+        (target comes from the arguments, not the caller), ``session_send`` runs
+        text as a peer's turn, ``session_stop`` discards a peer's in-flight work,
+        and ``chat_folder_move`` reparents an existing tree.
+        """
+        granted = self._install(tmp_path, monkeypatch)["allowedTools"]
+        for verb in (
+            "chat_folder_move_session",
+            "chat_folder_move",
+            "session_send",
+            "session_stop",
+        ):
+            assert f"@kirocrew-dashboard/{verb}" not in granted, verb
+        for verb in (
+            "chat_folder_tree",
+            "chat_folder_create",
+            "session_create",
+            "session_read_message",
+        ):
+            assert f"@kirocrew-dashboard/{verb}" in granted, verb
+
+    def test_no_dashboard_verb_is_granted_outside_the_named_set(self, tmp_path, monkeypatch):
+        """Nothing reaches ``allowedTools`` that the audit above did not rule on.
+
+        Guards the gap the per-verb lists cannot: a NEW tool added to the
+        dashboard server, or a stray entry added to the grant tuple, would
+        otherwise be auto-approved without anyone deciding it should be. The
+        expected set is spelled out so adding a grant is a deliberate edit here.
+        """
+        granted = self._install(tmp_path, monkeypatch)["allowedTools"]
+        dashboard = {g for g in granted if g.startswith("@kirocrew-dashboard")}
+        assert dashboard == {
+            "@kirocrew-dashboard/chat_folder_tree",
+            "@kirocrew-dashboard/chat_folder_create",
+            "@kirocrew-dashboard/session_create",
+            "@kirocrew-dashboard/session_read_message",
+        }
+        # The bare server must never appear: it would grant every verb, including
+        # the four the test above withholds.
+        assert "@kirocrew-dashboard" not in granted
 
     def test_mounts_no_tool_the_charter_never_names(self, tmp_path, monkeypatch):
         """An unused grant is surface the charter cannot account for.
@@ -160,26 +216,63 @@ class TestConductorInstaller:
         )
         assert "@kirocrew-core" in data["tools"]
         assert "@kirocrew-core" not in data["allowedTools"]
-        assert data["allowedTools"] == ["session", "report"]
+        assert data["allowedTools"] == [
+            "session",
+            "report",
+            "@kirocrew-dashboard/chat_folder_tree",
+            "@kirocrew-dashboard/chat_folder_create",
+            "@kirocrew-dashboard/session_create",
+            "@kirocrew-dashboard/session_read_message",
+        ]
 
     def test_kas_permissions_are_derived_from_the_filtered_grants(self, tmp_path, monkeypatch):
         """The KAS block is derived, not restated — so the ceiling reaches it too.
 
-        Ungoverned: the ``@kirocrew-core`` grant projects to an ``mcp`` allow
-        rule. Governed: the grant is gone, so the rule is too — and the key is
-        still present, because its mere presence is what makes KAS load the spec.
+        Ungoverned: the per-tool dashboard grants project to EXACT ``server/tool``
+        resources rather than a ``kirocrew-dashboard/*`` wildcard, which is what
+        makes the narrowing real on the KAS backend as well as on kiro-cli — a
+        wildcard here would re-grant the ``session_stop`` / ``session_send`` that
+        ``allowedTools`` deliberately withholds. Governed against
+        ``@kirocrew-core``: that pattern is gone while the dashboard ones survive,
+        which is the property a rule list restated as a literal would have lost.
         """
+        dashboard_resources = [
+            "kirocrew-dashboard/chat_folder_create",
+            "kirocrew-dashboard/chat_folder_tree",
+            "kirocrew-dashboard/session_create",
+            "kirocrew-dashboard/session_read_message",
+        ]
         data = self._install(tmp_path, monkeypatch)
         assert data["permissions"] == {
-            "rules": [{"capability": "mcp", "match": ["kirocrew-core/*"], "effect": "allow"}]
+            "rules": [
+                {
+                    "capability": "mcp",
+                    "match": ["kirocrew-core/*", *dashboard_resources],
+                    "effect": "allow",
+                }
+            ]
         }
+        assert "kirocrew-dashboard/*" not in data["permissions"]["rules"][0]["match"]
 
         governed = self._install(
             tmp_path,
             monkeypatch,
             may_auto_approve=lambda ref: ref != "@kirocrew-core",
         )
-        assert governed["permissions"] == {"rules": []}
+        assert governed["permissions"] == {
+            "rules": [{"capability": "mcp", "match": dashboard_resources, "effect": "allow"}]
+        }
+
+    def test_a_fully_governed_host_still_emits_the_permissions_key(self, tmp_path, monkeypatch):
+        """``{"rules": []}`` when nothing qualifies — the key's PRESENCE loads the spec.
+
+        Split from the test above once the dashboard grant meant a ceiling on
+        ``@kirocrew-core`` alone no longer empties the rule list: without this,
+        the empty-policy branch would have silently lost its coverage.
+        """
+        data = self._install(tmp_path, monkeypatch, may_auto_approve=lambda ref: False)
+        assert data["permissions"] == {"rules": []}
+        assert data["allowedTools"] == []
 
     def test_withholding_a_grant_is_audit_logged(self, tmp_path, monkeypatch):
         """A withheld grant is a permission DECISION and must leave a record.
@@ -225,7 +318,63 @@ class TestConductorInstaller:
         data = self._install(
             tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core"
         )
-        assert data["allowedTools"] == ["session", "report"]
+        assert data["allowedTools"] == [
+            "session",
+            "report",
+            "@kirocrew-dashboard/chat_folder_tree",
+            "@kirocrew-dashboard/chat_folder_create",
+            "@kirocrew-dashboard/session_create",
+            "@kirocrew-dashboard/session_read_message",
+        ]
+
+    def test_skill_gates_the_plan_once_instead_of_interrogating(self):
+        """Round 0 must be ONE plan message, not a round of questions.
+
+        The first live run opened with a clarification round: the previous
+        wording ("restate the plan, wait for the user") left room for one ahead
+        of the plan, and every question spent there is latency on work the
+        conductor could have assumed and let the user correct. Pinned as a doc
+        ratchet because the instruction, not the code, is what would drift.
+        """
+        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        # What the conductor can settle itself is an assumption, not a question.
+        assert "Decide, do not ask" in text
+        assert "Assumptions" in text
+        # And a goal that already authorizes execution must not be re-gated.
+        assert "Skip the gate when the user already gave one" in text
+
+    def test_skill_requires_the_goal_folder_before_the_first_session(self):
+        """Folder creation is a round-level PRECONDITION, not a per-item step.
+
+        ``session_create`` has no ``folder`` argument, so filing a session is a
+        separate call — and when the instruction sat inside the per-item loop
+        worded "once per goal (skip if it exists)" the first live run dropped it
+        and every dispatched session landed loose at the sidebar's top level,
+        with nothing tying it to the goal it belongs to.
+        """
+        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert "Before the round: the goal's folder must exist" in text
+        # The create must be named as a defect, not merely discouraged, and the
+        # failure path must stop rather than dispatch into no folder.
+        assert "before its folder exists is a defect" in text
+        # Creating the folder is not sufficient on its own: the user can delete
+        # it mid-round, so a FAILED move must stop the item before the seed —
+        # otherwise the session is both unfiled and already doing work, which is
+        # strictly worse than the outcome the precondition exists to prevent.
+        assert "If the move\n   fails, stop this item before the seed" in text
+
+    def test_skill_states_the_real_approval_cost(self):
+        """The cost note must match the spec, or patrol plans for wrong prompts.
+
+        The granted verbs run silently while `session_send` / `session_stop` and
+        the bundled scripts prompt, so a skill that claimed either "everything
+        prompts" or "nothing prompts" would have the conductor sizing its nudge
+        interval around approvals it does not pay — or walking into ones it does.
+        """
+        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert "Reads and creates do not prompt" in text
+        assert "`chat_folder_move_session`,\n  `session_send` and `session_stop`" in text
+        assert "accept_eval.py` invocation" in text
 
     def test_skill_documents_artifacts_as_a_string_map(self):
         """The ledger's ``artifacts`` values MUST be JSON-serialized strings.

--- a/test/test_create_rate_limit.py
+++ b/test/test_create_rate_limit.py
@@ -1,0 +1,96 @@
+"""Per-caller rate limiting on the dashboard's creation verbs.
+
+This is the primary guard on an auto-approved create: the capacity ceilings bound
+how much can exist, this bounds how fast one caller may make it. It is also the
+guard that has to hold without durable state, so the window semantics and the
+fail-closed paths are pinned here rather than left to the call sites.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.dashboard import create_rate_limit as rl
+
+
+@pytest.fixture(autouse=True)
+def _clean_buckets():
+    rl.reset_for_tests()
+    yield
+    rl.reset_for_tests()
+
+
+def test_a_caller_gets_its_budget_and_then_is_refused() -> None:
+    """Mutation guard: drop the length test and the last call still returns True."""
+    for i in range(rl.MAX_SESSION_CREATES_PER_WINDOW):
+        assert rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0), f"call {i} in budget"
+
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0) is False
+
+
+def test_the_budget_refills_as_the_window_slides() -> None:
+    """A refused caller must recover, or one burst disables the verb for good."""
+    for _ in range(rl.MAX_SESSION_CREATES_PER_WINDOW):
+        rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0)
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0) is False
+
+    # One tick past the window, every timestamp has aged out.
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0 + rl.WINDOW_SECS + 1) is True
+
+
+def test_one_caller_exhausting_its_budget_does_not_refuse_another() -> None:
+    """Buckets are per caller; a shared bucket would let one agent mute everyone."""
+    for _ in range(rl.MAX_SESSION_CREATES_PER_WINDOW):
+        rl.allow_create(rl.SESSION_CREATE, "chat-hog", now=1000.0)
+
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-hog", now=1000.0) is False
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-other", now=1000.0) is True
+
+
+def test_the_two_verbs_have_separate_budgets() -> None:
+    """A folder burst must not consume the caller's session budget, or filing a
+    goal's folder could stop it opening the sessions that goal needs."""
+    for _ in range(rl.MAX_FOLDER_CREATES_PER_WINDOW):
+        rl.allow_create(rl.FOLDER_CREATE, "chat-1", now=1000.0)
+
+    assert rl.allow_create(rl.FOLDER_CREATE, "chat-1", now=1000.0) is False
+    assert rl.allow_create(rl.SESSION_CREATE, "chat-1", now=1000.0) is True
+
+
+def test_an_empty_caller_key_is_refused() -> None:
+    """Fails closed. An unattributable request cannot be rate-limited at all, and
+    bucketing those under one sentinel would still pass a whole budget on a key an
+    attacker can blank."""
+    assert rl.allow_create(rl.SESSION_CREATE, "", now=1000.0) is False
+
+
+def test_an_unknown_verb_is_refused() -> None:
+    """Fails closed, so a future verb wired up with a typo'd name is throttled to
+    zero rather than silently unlimited."""
+    assert rl.allow_create("session_delete", "chat-1", now=1000.0) is False
+
+
+def test_a_dispatch_round_for_a_real_goal_fits_in_one_window() -> None:
+    """The budgets must not bind honest work: a decomposed goal files one folder and
+    opens roughly ten sessions in its dispatch round.
+
+    Mutation guard: lower MAX_SESSION_CREATES_PER_WINDOW under ~12 and this fails,
+    which is the signal that the limit has been tightened into the legitimate path.
+    """
+    assert rl.allow_create(rl.FOLDER_CREATE, "chat-conductor", now=1000.0) is True
+    for i in range(12):
+        assert rl.allow_create(
+            rl.SESSION_CREATE, "chat-conductor", now=1000.0 + i
+        ), "a 12-item goal must dispatch without being throttled"
+
+
+def test_stale_buckets_are_swept_so_the_map_cannot_grow_without_bound() -> None:
+    """Session keys churn for the gateway's lifetime, so buckets must be evicted --
+    the reason this does not reuse the never-evicting AppRateLimiter."""
+    for i in range(50):
+        rl.allow_create(rl.SESSION_CREATE, f"chat-{i}", now=1000.0)
+    assert len(rl._buckets) == 50
+
+    # A call a full window later sweeps every aged-out bucket, keeping only its own.
+    rl.allow_create(rl.SESSION_CREATE, "chat-late", now=1000.0 + rl.WINDOW_SECS + 1)
+    assert len(rl._buckets) == 1, "aged-out buckets must not accumulate"

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -1962,6 +1962,78 @@ def test_the_slot_cap_is_re_checked_after_the_await(tmp_path, monkeypatch):
     assert err.value.code == "slot_cap_reached"
 
 
+def test_a_created_slot_records_the_caller_that_asked_for_it(tmp_path, monkeypatch):
+    """Attribution is what makes the per-creator ceiling countable at all.
+
+    Mutation guard: drop the ``_created_by`` write and every caller's count stays
+    0, so ``MAX_SLOTS_PER_CREATOR`` can never be reached and the cap is decorative.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller.agent = "researcher"
+    _agent_resolves(monkeypatch, "default")
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    child = state.get_slot(created["target"])
+    assert child is not None
+    # The resolved slot key, which is the identity `create_session` also audits --
+    # not the history key the caller presents. Write and count must agree, or the
+    # ceiling silently never binds.
+    assert getattr(child, "_created_by", "") == caller.key
+    assert state.creator_slot_count(caller.key) == 1
+
+
+def test_one_caller_cannot_consume_everybody_elses_slots(tmp_path, monkeypatch):
+    """The per-creator ceiling bounds the DISTRIBUTION, not just the total.
+
+    The global cap alone leaves an automated creator on a nudge loop able to hold
+    all ``MAX_LIVE_SLOTS`` itself, after which every later create -- the person
+    opening a new chat tab included -- gets the 429. A resource one caller can
+    exhaust is not bounded from anybody else's point of view, so this is the half
+    of the bound that keeps the verb safe to auto-approve.
+
+    Mutation guard: test the caller's count against ``MAX_LIVE_SLOTS`` instead of
+    ``MAX_SLOTS_PER_CREATOR`` and the first assertion stops refusing.
+    """
+    state = _make_state(tmp_path)
+    hog = _slot(state, "chat-hog")
+    hog.agent = "researcher"
+    other = _slot(state, "chat-other")
+    other.agent = "researcher"
+    _agent_resolves(monkeypatch, "default")
+
+    # Exactly what create_session writes, without paying for 50 real creates.
+    for i in range(sc.MAX_SLOTS_PER_CREATOR):
+        _slot(state, f"held-{i}")._created_by = hog.key
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(hog)))
+    assert err.value.code == "creator_slot_cap_reached"
+    assert err.value.status == 429, "a cap breach is a 429, not a 500"
+
+    # The global ceiling is nowhere near full, which is the point: the refusal came
+    # from this caller's own share, and everyone else still has room.
+    assert state.live_slot_count() < sc.MAX_LIVE_SLOTS
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(other)))
+    assert created["ok"] is True, "one caller's full share must not starve another"
+
+
+def test_slots_nobody_asked_for_are_charged_to_nobody(tmp_path):
+    """A person's own tab and a fork reach ``get_or_create_slot`` unattributed.
+
+    Two failure modes this pins at once: charging those to a caller would let
+    ordinary human use burn an automated caller's budget, and counting an empty
+    creator key would make every unattributed slot match at once -- so the first
+    ``create_session`` call would refuse on a tree the conductor never touched.
+    """
+    state = _make_state(tmp_path)
+    person = _slot(state, "chat-person")
+
+    assert state.creator_slot_count("") == 0, "an empty key must match nothing"
+    assert state.creator_slot_count(person.key) == 0
+
+
 def test_creation_never_loads_the_config_on_the_event_loop():
     """A cache miss reads and validates the config file, stalling every task.
 


### PR DESCRIPTION
## Problem / Motivation

Three defects observed on the first real run of the `kirocrew-conductor` agent
against a live goal:

1. **It interrogated the user before doing any work.** The goal-conductor skill's
   Round 0 said "restate the goal, list the work items, wait for the user", which
   left room for a clarification round *ahead* of the plan. The run spent its
   opening turns asking questions rather than proposing a plan.
2. **It created sessions with no folder.** `chat_folder_create` was step 1 *inside*
   the per-item dispatch loop, worded "once per goal (skip if it exists)". The run
   skipped it entirely and every dispatched session landed loose at the sidebar's
   top level.
3. **Every session-control call stopped for an approval.** `@kirocrew-dashboard`
   was withheld from the conductor agent's `allowedTools`, so `session_create`,
   `session_send`, `chat_folder_*` and the rest each prompted.

## Why it matters

Each one lands on the conductor's core loop rather than an edge:

1. The conductor exists to take a goal off the user's hands. A round of questions
   before the plan inverts that, and every question about something the conductor
   could have assumed is latency on work it could already have started.
2. Sessions with no folder have nothing tying them to the goal they belong to.
   With two or three items per round the user cannot tell which sidebar entries
   are this goal's, and there is no grouping to close the goal out by.
3. The patrol loop is `monitor_start`-driven: it wakes *itself* on a nudge
   interval. A cycle that blocks on an approval blocks on a person who is not at
   the keyboard, so the loop stalls rather than patrols — the skill's own "Known
   limits" section had to describe patrol as "attended-unattended" because of it.

## What changed (motivation → approach → change)

**1. Round 0 is now one plan message with one gate.** The wording that permitted a
question round is replaced by an explicit rule: the first reply *is* the plan, and
anything the conductor can settle itself becomes a stated **Assumption** the user
can overrule in the same breath (which repo, items per round, which crew, how to
phrase an acceptance condition). A question is permitted only when a wrong guess is
unrecoverable *and* no default exists — credentials, spend, destroying someone's
work, or a goal too vague to name a single work item — capped at one and folded
into the plan message. A goal message that already authorizes execution ("just do
it", "go ahead", a re-send of a plan already shown) dispatches round 1 in that same
turn instead of re-asking for permission the conductor already holds.

**2. The goal folder is a round-level precondition, not a per-item step.**
`session_create` has no `folder` argument (`SESSION_CREATE_SCHEMA` at
`src/kiro_crew/validation.py:2628` carries only `title` and `agent`), so filing is
a second call — which is exactly why an optional-sounding instruction inside the
loop got dropped. **That second call is an earlier design choice, not a
constraint**: adding a `folder` field would make filing atomic with creation and
delete this whole choreography. Doing that is wider than this fix, so it is
deferred to #6118 and the instruction layer is hardened in the meantime. It is hoisted above
the loop as a precondition ahead of the *first* `session_create` for the goal,
`session_create`-before-folder is named as a defect rather than discouraged, and a
failed `chat_folder_create` stops the round instead of dispatching into no folder.
The local GPT review lane then caught the sibling gap: creating the folder is not
sufficient, because the user can delete it mid-round, so a failed
`chat_folder_move_session` now also stops the item *before* the seed — seeding
anyway produces a session that is both unfiled and already doing work, strictly
worse than the outcome the precondition prevents.

**3. Dashboard verbs are auto-approved BY NAME, under one invariant.** The
dashboard server joins the same `_may_auto_approve` ceiling filter as `session`,
`report` and `@kirocrew-core`, so a governed host still withholds it (with the
existing `mcp_auto_approve_withheld` SEL audit) and the derived KAS `permissions`
block picks the change up automatically rather than restating it.

But the grant names **verbs, not the server**, because the first attempt at this
granted `@kirocrew-dashboard` whole and that was wrong. `allowedTools` is the one
path that never reaches `hooks.on_tool_call`, and the conductor ingests untrusted
text by design — its charter's worked example is "resolve this repo's open issues"
and it holds `web_fetch` for exactly that. So every auto-approved verb is
reachable by content the conductor read, with no human in the loop on a
nudge-driven cycle. The rule that decides each verb, recorded on
`_CONDUCTOR_DASHBOARD_GRANTS` so the next reader extends it by rule:

> A granted verb must satisfy **both** halves:
> 1. It may **create** something new or **read**. It may never **mutate**
>    user-visible workspace state that already exists and is not the conductor's
>    own — a session's contents or liveness, or the arrangement the person made of
>    their sessions and folders.
> 2. Its worst case, called in a loop, must be **bounded by the server** — and
>    bounded so the resource stays reachable by everyone else.

Half 2 is the one the review process forced, and it is not a restatement of half 1:
an unbounded create does damage without mutating anything. Per-call approval was
the only thing rate-limiting a granted verb, and `allowedTools` has no argument or
rate matching to replace it, so waiving the prompt removes the only brake on a loop.
The brake has to live in the endpoint, and it comes in two layers.

**The primary guard is a per-caller RATE on both creation verbs**
(`dashboard/create_rate_limit.py`): 20 sessions and 10 folders per caller per
5-minute sliding window, refused with a 429. It is deliberately the guard that needs
**no durable state**. A lifetime quota means nothing across a restart unless every
path that rehydrates a session carries its attribution, and there are 27
`get_or_create_slot` call sites across 12 modules; a five-minute window is not
meaningfully resettable — a restart buys a caller one window, not a clean slate. At
the session rate, filling `MAX_LIVE_SLOTS` from empty takes **over two hours of
uninterrupted looping**, every step visible in the sidebar, which turns a silent
exhaustion into something a person watching the dashboard sees before it lands.

This cannot live in the conductor's own instructions. It reads untrusted text by
design, and content that can drive it into a creation loop can equally override a
"create at most N per round" line in its skill. Self-restraint is a convention; this
is a control, enforced for every caller regardless of which agent is calling.

Two details in that guard are load-bearing, and both are pinned by tests:

- **Folders are rate-limited for INTERNAL callers only.** The endpoint is
  mixed-path: the browser's own "new folder" control posts to it, and a person
  organizing their chats can legitimately create a dozen in one sitting, so
  throttling them would be a regression with no security value. `_audit_origin`
  already distinguishes the two — a request without the internal secret is the
  browser.
- **The bucket keys on the validated caller name, not the session key.** The session
  key would give finer granularity but is partly caller-supplied:
  `_refuse_unattributable_caller` refuses a `dashboard:` key naming a dead slot, but
  not a rotating non-dashboard key, so keying on it would let a caller earn a fresh
  budget per spelling. The caller name is checked against `_KNOWN_INTERNAL_CALLERS`.
  The cost is that internal callers share one folder budget, acceptable when a goal
  needs exactly one.

**Behind the rate guard sit two capacity ceilings**, both added here because neither
resource had an adequate one:

- **`chat_folder_create` had no bound at all.** Every other allocation path in the
  dashboard tests a ceiling; this one did not, so a loop could grow durable on-disk
  state without limit. Now `MAX_CHAT_FOLDERS = 500`, tested *inside*
  `mutate_folders` — `len(folders)` is only authoritative while the lock is held,
  which is the same reason the parent is re-checked and `order` recounted there.
- **`session_create` had a global ceiling but no distribution.** `MAX_LIVE_SLOTS =
  500` bounds the total, so one caller could hold all 500 and every later create —
  the person opening a new chat tab included — got the 429. Now
  `MAX_SLOTS_PER_CREATOR = 50` bounds what a single caller holds, with slots created
  through the verb attributed to their caller (`_created_by`); a person's own tab and
  a fork are attributed to nobody and stay bounded by the global ceiling alone, so
  ordinary human use never consumes an automated caller's share. That attribution is
  in-memory and resets on restart, which is precisely why the rate guard — not this
  ceiling — is the control that has to hold adversarially.

Half 1 names that resource class on purpose rather than saying "any pre-existing
resource". A create always writes *some* shared bookkeeping — the slot table, the
folder index, the session-pulse counter — so a literal reading would forbid every
create and decide nothing. What it protects is state the person arranged and would
have to rebuild by hand.

| Verb | Verdict | Why |
|---|---|---|
| `chat_folder_tree` | granted | read of the caller's visible tree |
| `chat_folder_create` | granted | new folder; `_refuse_tree_shaping_if_unverifiable` refuses an unverifiable caller, and bounded by the new `MAX_CHAT_FOLDERS` |
| `session_create` | granted | new session, bounded globally by `MAX_LIVE_SLOTS` and per caller by the new `MAX_SLOTS_PER_CREATOR`. One recorded side effect: it mints with `origin=SlotOrigin.USER`, which is what keeps the session correctly private, and the session-pulse counter increments on that tag — so conductor sessions count toward the survey's "10 genuine user chats" window. A pre-existing conflation in the counter (it miscounts for every caller of the verb, including a hand-approved one), deferred as #6139 |
| `session_read_message` | granted | read-only, and the verb an unattended patrol cycle actually needs |
| `chat_folder_move_session` | **withheld** | writes another session's `folder_id` — the PATCH targets the session named in the *arguments*; the strict caller key is only the authority header. `mcp_dashboard` calls it "the one tool here that writes to a session OTHER than the caller's" |
| `chat_folder_move` | **withheld** | reparents an existing tree; no conductor step needs it |
| `session_send` | **withheld** | runs text as a peer's user-role turn under that target's grants |
| `session_stop` | **withheld** | ends a peer's in-flight turn and *discards its work* |

Every withheld verb stays **mounted** (`@kirocrew-dashboard` is still in `tools`)
— it just passes through `hooks.on_tool_call` like any ungranted tool. The cost is
an approval when a round files a session, seeds a child, or stops one.

**Being precise about when that cost lands, because the obvious framing overstates
the fix:** on round 1 those prompts follow the human's plan approval, so someone is
present. On a multi-round goal they are not — round N+1 dispatches *from the patrol
loop* as items complete, so a filing or seeding prompt can land mid-patrol with
nobody there, which is the same stall shape defect 3 describes. So this PR reduces
the unattended-patrol stall rather than ending it: the read-only patrol cycle
(`chat_folder_tree`, `session_read_message`) no longer prompts, and #6118 removes the
filing call, but a mid-patrol *dispatch* still blocks until then.

**The same honesty applies to the evaluator.** `execute_bash` stays ungranted, and
the conductor's acceptance check runs `accept_eval.py` through it, so **every** patrol
cycle still pays one approval regardless of anything in this diff — the skill's own
cost note says so. Ending the per-cycle stall means giving the evaluator a non-shell
entry point (tracked in #6160), not widening this grant list.

The narrowing is real on both backends, not cosmetic — this was verified before
relying on it, since a per-tool ref that matched nothing would silently grant
nothing: kiro-cli's `is_tool_in_allowlist` checks `@server` and then builds
`@{server}/{tool}` and matches that (`tool_permission_checker.rs`), and
`allowed_tools_to_permissions` maps the same entry to an exact KAS `server/tool`
resource. No `kirocrew-dashboard/*` wildcard is emitted, so nothing re-grants the
withheld verbs through the KAS path.

`execute_bash` stays ungranted for a different reason worth keeping distinct:
`allowedTools` is name-scoped with no argument matching, so trusting the two
bundled scripts (`accept_eval.py`, `ledger_entry.py`) cannot be distinguished from
trusting arbitrary shell. There is no per-argument form of that grant the way there
is a per-tool form of the MCP one. The installer's docstring and the skill's cost
note both state what the code now does.

## Tests

All in `test/test_conductor_agent.py`, which already owned this installer's
contract — four of its existing tests failed against the permission change and were
updated rather than worked around:

**The rate guard** (`test/test_create_rate_limit.py`, new — 8 tests):

- budget-then-refuse, and refill as the window slides (a refused caller must recover,
  or one burst disables the verb permanently)
- per-caller buckets: one caller exhausting its budget must not refuse another
- separate budgets per verb, so filing a goal's folder cannot consume the session
  budget that same goal needs
- fail-closed on an empty caller key and on an unknown verb, so a future verb wired
  up with a typo'd name is throttled to zero rather than silently unlimited
- `test_a_dispatch_round_for_a_real_goal_fits_in_one_window` — the limits must not
  bind honest work: one folder plus twelve sessions in a window. Lowering the session
  budget under ~12 fails this, which is the signal the limit has been tightened into
  the legitimate path.
- stale-bucket sweep, since session keys churn for the gateway's lifetime — the
  reason this does not reuse the never-evicting `AppRateLimiter`

**The two ceilings and the endpoint wiring** (`test/test_chat_folder_cap.py`, new, and
additions to `test/test_session_control.py`):

- `test_creation_is_refused_at_the_ceiling` / `test_the_last_folder_under_the_ceiling_is_still_allowed`
  — the refusal and the boundary, so an off-by-one cannot cost the user their last
  folder.
- `test_the_ceiling_is_tested_under_the_lock` — a concurrent creator fills the tree
  *inside* the `mutate_folders` callback; hoisting the check above the lock makes this
  land folder 501.
- `test_an_internal_caller_is_rate_limited_at_the_endpoint` and
  `test_the_browser_is_not_rate_limited` — both directions of the mixed-path split.
  Applying the limiter unconditionally makes the second one 429.
- `test_a_created_slot_records_the_caller_that_asked_for_it` — attribution, without
  which every caller's count stays 0 and the per-creator ceiling is decorative.
- `test_one_caller_cannot_consume_everybody_elses_slots` — the hog is refused at its
  own share while the global ceiling is nowhere near full, and a *second* caller still
  succeeds.
- `test_slots_nobody_asked_for_are_charged_to_nobody` — pins both directions: a
  person's tab must not burn an automated caller's budget, and an empty creator key
  must not match every unattributed slot.

**The grant surface** (`test/test_conductor_agent.py`, 29 tests):

- `test_only_create_and_read_verbs_are_auto_approved` — pins the invariant by
  literal verb name in both directions: the four withheld verbs absent, the four
  granted present. Deliberately not asserted against `_CONDUCTOR_DASHBOARD_GRANTS`
  itself, which would be tautological and could never catch a widening.
- `test_no_dashboard_verb_is_granted_outside_the_named_set` — asserts the granted
  dashboard set is *exactly* those four and that the bare server never appears.
  This is the guard the per-verb lists cannot give: a NEW tool added to the
  dashboard server, or a stray tuple entry, fails here instead of being
  auto-approved without anyone ruling on it.
- `test_no_write_tool_and_shell_not_preapproved` — no `fs_write`, and
  `execute_bash` mounted but never granted.
- `test_grants_pass_through_the_governance_ceiling` — a ceiling opinion on
  `@kirocrew-core` strips that grant while leaving the ref mounted; the expected
  list carries the four per-verb dashboard grants.
- `test_kas_permissions_are_derived_from_the_filtered_grants` — the dashboard
  grants project to EXACT `server/tool` resources, plus an explicit assertion that
  no `kirocrew-dashboard/*` wildcard appears. That wildcard is what would silently
  re-grant the withheld verbs on the KAS backend, so it is pinned rather than
  assumed.
- `test_a_fully_governed_host_still_emits_the_permissions_key` — the `{"rules": []}`
  branch, whose mere presence is what makes KAS load the spec, kept its coverage
  when a ceiling on `@kirocrew-core` alone stopped emptying the rule list.
- `test_audit_failure_does_not_break_the_install` — the spec still lands when the
  SEL sink raises.
- `test_skill_gates_the_plan_once_instead_of_interrogating`,
  `test_skill_requires_the_goal_folder_before_the_first_session`,
  `test_skill_states_the_real_approval_cost` — doc ratchets in the same style as
  the file's existing `test_skill_documents_artifacts_as_a_string_map`, because for
  a skill it is the *instruction*, not the code, that regresses. The folder one also
  pins the failed-move stop path; the cost one pins which verbs prompt, so the
  skill and the spec cannot drift apart.

1986 tests pass across the changed surfaces (`test_session_control.py`,
`test_chat_folder_cap.py`, `test_chat_folder_ownership.py`,
`test_chat_folder_app_isolation.py`, `test_chat_folder_store_shape.py`,
`test_chat_slot_create_folder.py`, `test_dashboard_chat.py`, `test_agent.py`,
`test_kas_permissions.py`, `test_session_pulse_session_count.py` and
`test_conductor_agent.py`).

## Manual verification

N/A for the behavioural half — the fixes are instructions the model follows, and
exercising them means handing a live conductor a real goal, which is the reporter's
next step rather than something a unit test can stand in for.

Verified by hand for the permission half, in the direction that could have made the
narrowing a lie: per-tool refs are honoured on both backends, checked in source
before relying on them (`is_tool_in_allowlist` in kiro-cli's
`tool_permission_checker.rs`, `_mcp_pattern` in `acp/kas_permissions.py`). There is
no precedent in this repo for a per-tool `allowedTools` entry — every prior MCP
grant is whole-server — so a ref that matched nothing would have shipped "no grant
at all" while the description claimed a narrowed one.

Also verified the claim the withheld list turns on: `chat_folder_move_session`
PATCHes `/api/chat/slots/{target}/folder` where the target comes from
`_resolve_chat_slot_key(args["session"], ...)`, not from the caller.

The installed `~/.kiro/agents/kirocrew-conductor.json` was updated by hand to the
same result this installer produces, so the reporter can test on their current
install without waiting for a rebuild.

Local gates green on the pushed head: `test/test_conductor_agent.py`, isort,
flake8, mypy, `check_black_formatting.py`, `docs_lint.py`, `check_brand_name.py`,
`check_harness_parity.py`, `check_changelog_history.py`, `check_focus_cue.py`,
`check_loop_bound_locks.py`. Local review ran both profile reviewers against their
extracted CI contracts on each revision.

## Related Issues

no linked issue: reported directly from a live conductor run, not filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
