### PR TITLE
test(skill-trust): force a distinct inode on the rebind test

### DIFF
--- a/test/test_skill_trust.py
+++ b/test/test_skill_trust.py
@@ -580,9 +580,31 @@ class TestInstanceBinding:
         """
         project = _real_dir(tmp_path, "project")
         skill_trust.grant_project_trust(project)
+
+        # The identity the grant actually bound, captured before the delete.
+        granted_st = os.stat(project)
+        granted_instance = (granted_st.st_dev, granted_st.st_ino)
+
+        # Replace the directory the same way
+        # ``test_a_different_directory_at_the_same_path_is_not_trusted`` does,
+        # and for the same reason: on Linux ``_instance_identity`` is ``dev:ino``
+        # alone (no birth time), so recreating after the delete leaves the
+        # distinctness to the allocator, which is free to hand the just-freed
+        # inode straight back -- and then the untrusted pre-state this rebind is
+        # measured against never holds. Creating the replacement WHILE the
+        # granted directory still exists forces distinct inodes (two live
+        # directories on one device cannot share one), and the rename preserves
+        # the replacement's inode while giving it the granted path.
+        replacement = _real_dir(tmp_path, "replacement-instance")
         os.rmdir(project)
-        _real_dir(tmp_path, "an-intervening-inode")
-        _real_dir(tmp_path, "project")
+        os.rename(replacement, project)
+
+        replacement_st = os.stat(project)
+        assert (replacement_st.st_dev, replacement_st.st_ino) != granted_instance, (
+            "precondition: inode reuse -- the replacement directory was handed "
+            "the granted directory's own (st_dev, st_ino) back, so the untrusted "
+            "pre-state the re-grant below is measured against would not hold"
+        )
         skill_trust.reset_cache_for_tests()
         assert skill_trust.is_project_trusted(project) is False
 


### PR DESCRIPTION
## What

`test/test_skill_trust.py::TestInstanceBinding::test_re_granting_a_replaced_directory_rebinds_it` is a Linux-only flake. It failed on a Backend Tests (3.10) shard in [#5930](https://github.com/kirodotdev/KiroCrew/pull/5930) ([job 98219561678](https://github.com/kirodotdev/KiroCrew/actions/runs/98219561678)) with `AssertionError: assert True is False`, and passes on macOS every time.

## Why it flakes

The test replaced the granted directory by deleting it, creating an intervening directory, then recreating at the same path — relying on the intervening `mkdir` to consume the freed inode:

```python
skill_trust.grant_project_trust(project)
os.rmdir(project)
_real_dir(tmp_path, "an-intervening-inode")   # meant to consume the freed inode
_real_dir(tmp_path, "project")
assert skill_trust.is_project_trusted(project) is False   # coin flip on ext4
```

ext4 makes no such guarantee. `_instance_identity` ([skill_trust.py:153](https://github.com/kirodotdev/KiroCrew/blob/main/src/kiro_crew/skill_trust.py#L153)) binds a directory by `st_dev:st_ino`, folding in `st_birthtime` only where the platform exposes it — and CPython surfaces no birth time on Linux, as its own docstring concedes. So when the recreate is handed the original inode back, the identity matches, and the untrusted pre-state the rebind is measured against never holds. On macOS the birth time is folded in, so the recreate always differs and the test cannot fail there.

This is the same flake [#5932](https://github.com/kirodotdev/KiroCrew/issues/5932) closed in the sibling test `test_a_different_directory_at_the_same_path_is_not_trusted`. That fix (056e768f1) only patched one of the two tests using the pattern; this is the one it missed.

## The fix

The same technique, so both tests now replace a directory the same way: build the replacement **while the granted directory still exists** — two live directories on one device cannot share an `(st_dev, st_ino)`, which makes distinctness a kernel invariant rather than an allocator preference — then `rmdir` the original and `rename` the replacement onto its path, which preserves its distinct inode. The precondition is then asserted explicitly, so if a filesystem ever did violate it the failure names inode reuse instead of `assert True is False`.

All four of the test's assertions, and its docstring, are unchanged. Nothing is skipped, xfailed, rerun, or weakened — per `AGENTS.md` and [testing-conventions § Determinism](https://github.com/kirodotdev/KiroCrew/blob/main/docs/system-specs/common/testing-conventions.md).

## Verification

macOS, Python 3.11 venv:

- `test_skill_trust.py` + `test_skill_trust_store.py` + `test_skill_budget.py` — 188 passed.
- **Linux-shape check.** A local pass proves nothing about the failing platform, since macOS folds in `st_birthtime`. Patching `_instance_identity` to a `dev:ino`-only (Linux-shaped) version and running the new test body 150 times: 150/150 deterministic. For contrast, the old pattern's inode-reuse rate on APFS is 0/400 — which is exactly why this only ever reddened on ext4.
- **Mutation check.** Reintroducing the bug the test exists for (the dedup loop in `grant_project_trust` returning early on a path match) turns it red at `assert skill_trust.is_project_trusted(project) is True`. The test still catches its regression.
- `black --check`, `flake8`, `isort`, the repo black gate, and the brand gate are clean. No `src/` change, so mypy is unaffected.

## Notes

- The third `os.rmdir` in the file is not affected: it deletes without recreating, so it has no inode-allocation dependency.
- No production code changes — the residuals `_instance_identity` documents for Linux (adversarial inode grinding, `st_dev` instability across remounts) are unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
