### PR TITLE
fix(mobile): give the diagram viewer its own pinch zoom via a shared hook

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -620,7 +620,8 @@ bugs:
   installed app, which has no Safari toolbar. Pinch is off because magnifying a
   fixed-height layout whose scrollers are all inner leaves no way to reach the
   topbar and composer it pushes off-screen. The surfaces that need magnifying
-  keep it — the image viewer zooms on its own pinch, code blocks scroll sideways.
+  keep it — the image viewer and the diagram viewer both zoom on their own pinch,
+  the diagram viewer also on a double-tap, and code blocks scroll sideways.
 
 Installing changes nothing about authentication: the app carries the same cookies
 the browser holds, on the same clocks as [Session duration](#session-duration).

--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -313,9 +313,32 @@ The corollary is the part to get right. **A surface that must magnify owns its o
 zoom — it does not ask for `pinch-zoom` back.** `touch-action` is intersected from
 the hit-test target up to the root, so a descendant cannot re-grant a behaviour the
 root withheld; declaring `touch-pinch-zoom` there buys a dead gesture, not a working
-one. The image viewer (`Lightbox` in `MarkdownRenderer.tsx`) is the worked example:
-`touch-none` plus a two-pointer distance ratio driving the same `zoom` state its
-toolbar and keyboard drive. Code blocks take the other legitimate route and scroll
+one.
+
+**Count the surfaces this rule binds before believing it holds.** There are **three**
+full-viewport magnify overlays — the image viewer (`Lightbox` in
+`MarkdownRenderer.tsx`), the diagram viewer (`DiagramLightbox.tsx`), and the
+screenshot viewer in `pages/AppDetailPage.tsx` — and when page zoom was first
+switched off only the first owned a gesture. The second silently
+became unmagnifiable by any gesture, because its content is fit-scaled vector whose
+labels are smallest at exactly the state it opens in. The rule read as satisfied
+because the *documented example* obeyed it; nothing had counted the instances. The
+first two
+now share `hooks/usePinchZoom.ts` (contact tracking, focal anchoring, pan clamping),
+so a further such surface gets the gesture by using the hook rather than by
+re-deriving the math — and `touch-none` on the transform target is what opts it out
+of the root's `pan-x pan-y`.
+
+The guard that enforces this sweeps **both** `components/**` and `pages/**`, because
+a magnify overlay can live in either and a population scoped to one directory counts
+instances of a set it has itself narrowed. `AppDetailPage.tsx` is carried in that
+guard as a named, issue-linked exception rather than excluded by the glob: an
+exception a reader can see is a debt with an owner, a glob boundary is not. Giving it
+the gesture is tracked separately because its overlay also owns arrow-key navigation
+between screenshots and click-to-dismiss, so a pinch there has to be reconciled with
+a prev/next seam the other two do not have.
+
+Code blocks take the other legitimate route and scroll
 horizontally instead. And note what is *not* lost — the OS Display Zoom setting sits
 outside the viewport contract and still magnifies anything. A browser tab's own
 text-size control does too, but it is **not** a fallback in the installed app: a

--- a/website/src/components/DiagramLightbox.tsx
+++ b/website/src/components/DiagramLightbox.tsx
@@ -1,10 +1,28 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, useReducedMotion } from 'framer-motion'
 import { X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap'
+import { usePinchZoom } from '../hooks/usePinchZoom'
+
+/** Diagram zoom bounds. `1` is fit-to-viewport. The ceiling is higher than the
+ *  image viewer's because the content is vector: a mermaid label at 8px in a
+ *  fit-scaled diagram needs more magnification to read than a photo detail does,
+ *  and scaling an SVG costs no resolution. */
+const DIAGRAM_ZOOM_MIN = 1
+const DIAGRAM_ZOOM_MAX = 8
+/** Zoom a double-tap toggles to, when starting from fit. */
+const DIAGRAM_ZOOM_DOUBLE_TAP = 2.5
+/** Two taps count as a double-tap within this window, and within this distance of
+ *  each other — the distance test is what keeps two deliberate taps on different
+ *  parts of a large diagram from reading as one double-tap. */
+const DOUBLE_TAP_MS = 300
+const DOUBLE_TAP_SLOP = 32
+/** Travel a one-finger drag must cover before it counts as a pan rather than a
+ *  tap — below it the double-tap and click-out paths are left alone. */
+const DRAG_SLOP = 6
 
 /**
  * Full-viewport viewer for an inline-rendered SVG diagram (mermaid).
@@ -30,6 +48,13 @@ import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap'
  * therefore the same sanitization posture) as the inline `MermaidBlock`
  * rendering the identical string: mermaid output under
  * `securityLevel: 'strict'`, never raw user HTML.
+ *
+ * Magnification: this viewer owns its own zoom (`usePinchZoom`) because page
+ * zoom is off on touch shell-wide, and fit-to-viewport is exactly the state in
+ * which a diagram's labels are smallest. Without it a phone user has no gesture
+ * left that magnifies a diagram at all — which is what shipped briefly, and is
+ * the reason the gesture lives in a shared hook now rather than in the image
+ * viewer alone.
  */
 export default function DiagramLightbox({ svg, onClose }: { svg: string; onClose: () => void }) {
   const { t } = useTranslation()
@@ -37,6 +62,106 @@ export default function DiagramLightbox({ svg, onClose }: { svg: string; onClose
   const hostRef = useRef<HTMLDivElement>(null)
   const reduceMotion = useReducedMotion()
   useDialogFocusTrap(dialogRef, onClose)
+
+  // A finished pinch or double-tap is not a click-out. Without this the click
+  // synthesised after the last finger lifts reaches the dismiss handler below and
+  // closes the viewer the user just spent the gesture zooming into.
+  const suppressClickRef = useRef(false)
+  /** True once the SVG has been fit-scaled to the viewport, i.e. it carried a
+   *  `viewBox`. Only then is zoom/pan the right mechanism: a no-viewBox SVG keeps
+   *  its natural size and the surrounding scroller reaches its edges instead. */
+  const [fitted, setFitted] = useState(false)
+  const [dragging, setDragging] = useState(false)
+  const dragRef = useRef({ id: -1, startX: 0, startY: 0, baseX: 0, baseY: 0, active: false })
+  const { zoom, setZoom, pan, setPan, pinching, clampPan, trackPointerDown, trackPointerMove, trackPointerUp, reset } =
+    usePinchZoom({
+      targetRef: hostRef,
+      min: DIAGRAM_ZOOM_MIN,
+      max: DIAGRAM_ZOOM_MAX,
+      onPinchEnd: () => { suppressClickRef.current = true },
+    })
+
+  // Reset to fit whenever the diagram changes, so a zoom from the previous one is
+  // never inherited by the next.
+  useEffect(() => { reset() }, [svg, reset])
+
+  // Re-clamp the pan after a zoom change: the pannable box is a function of the
+  // zoom, so shrinking back toward fit must pull an out-of-range pan back in.
+  useEffect(() => { setPan(p => (zoom <= DIAGRAM_ZOOM_MIN ? { x: 0, y: 0 } : clampPan(p.x, p.y))) }, [zoom, clampPan, setPan])
+
+  /** Double-tap toggles fit <-> DOUBLE_TAP, anchored where the user tapped so the
+   *  label they aimed at is what they get. The shell withholds the browser's own
+   *  double-tap zoom, and this is one of the two surfaces where users still reach
+   *  for it. */
+  const lastTapRef = useRef({ t: 0, x: 0, y: 0 })
+  const onTap = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType === 'mouse') return
+    const now = Date.now()
+    const last = lastTapRef.current
+    const isDouble = now - last.t < DOUBLE_TAP_MS && Math.hypot(e.clientX - last.x, e.clientY - last.y) < DOUBLE_TAP_SLOP
+    lastTapRef.current = { t: now, x: e.clientX, y: e.clientY }
+    if (!isDouble) return
+    lastTapRef.current = { t: 0, x: 0, y: 0 }
+    suppressClickRef.current = true
+    if (zoom > DIAGRAM_ZOOM_MIN) { setZoom(DIAGRAM_ZOOM_MIN); setPan({ x: 0, y: 0 }); return }
+    // Anchor the zoom-in at the tap: the point tapped is at content-local offset
+    // `(tap - centre)`, and holding it there under the new scale is what puts the
+    // label the user aimed at under their finger rather than at the centre.
+    const cx = window.innerWidth / 2
+    const cy = window.innerHeight / 2
+    const z = DIAGRAM_ZOOM_DOUBLE_TAP
+    setZoom(z)
+    setPan(clampPan((e.clientX - cx) * (1 - z), (e.clientY - cy) * (1 - z), z))
+  }, [zoom, setZoom, setPan, clampPan])
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    suppressClickRef.current = false
+    // A pinch owns the gesture when it seats; neither the tap nor the pan path
+    // must also run. The first contact already ran through `onTap` and left a
+    // tap candidate, so clear it — otherwise a single tap shortly after the
+    // pinch lifts completes a double-tap the user never made.
+    if (trackPointerDown(e)) {
+      dragRef.current.active = false
+      setDragging(false)
+      lastTapRef.current = { t: 0, x: 0, y: 0 }
+      return
+    }
+    onTap(e)
+    // One-finger drag pans a zoomed diagram. Without it the zoom is a trap: the
+    // gesture magnifies the centre and nothing reaches the edges, which is the
+    // same shape of dead end this whole fix is about.
+    if (zoom <= DIAGRAM_ZOOM_MIN) return
+    if ((e.target as HTMLElement | null)?.closest('button')) return
+    dragRef.current = { id: e.pointerId, startX: e.clientX, startY: e.clientY, baseX: pan.x, baseY: pan.y, active: true }
+  }, [trackPointerDown, onTap, zoom, pan])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (trackPointerMove(e)) return
+    const d = dragRef.current
+    if (!d.active || e.pointerId !== d.id) return
+    const dx = e.clientX - d.startX
+    const dy = e.clientY - d.startY
+    // Below the slop the gesture is still a candidate tap; committing to a drag
+    // early would eat the double-tap.
+    if (!dragging && Math.hypot(dx, dy) < DRAG_SLOP) return
+    if (!dragging) {
+      setDragging(true)
+      // A committed drag is not a tap, so it must not leave a tap candidate
+      // behind: two quick flick-pans starting near the same point would then
+      // read as a double-tap and reset the very zoom and pan being navigated.
+      // Clearing at the COMMIT point is what keeps a real double-tap working —
+      // its two touches stay under the slop by definition and never reach here.
+      lastTapRef.current = { t: 0, x: 0, y: 0 }
+    }
+    suppressClickRef.current = true
+    setPan(clampPan(d.baseX + dx, d.baseY + dy))
+  }, [trackPointerMove, dragging, clampPan, setPan])
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    trackPointerUp(e)
+    const d = dragRef.current
+    if (d.active && e.pointerId === d.id) { d.active = false; if (dragging) setDragging(false) }
+  }, [trackPointerUp, dragging])
 
   useEffect(() => {
     const host = hostRef.current
@@ -53,6 +178,9 @@ export default function DiagramLightbox({ svg, onClose }: { svg: string; onClose
       el.style.maxHeight = 'none'
       el.style.width = '100%'
       el.style.height = '100%'
+      setFitted(true)
+    } else {
+      setFitted(false)
     }
   }, [svg])
 
@@ -82,6 +210,8 @@ export default function DiagramLightbox({ svg, onClose }: { svg: string; onClose
       // the close button, which handles itself) closes the viewer. Escape is
       // handled by useDialogFocusTrap plus the preventDefault claim above.
       onClick={e => {
+        // A pinch, drag or double-tap just finished — that click is gesture residue.
+        if (suppressClickRef.current) { suppressClickRef.current = false; return }
         const el = e.target as HTMLElement
         if (!el.closest('svg') && !el.closest('button')) onClose()
       }}
@@ -96,10 +226,36 @@ export default function DiagramLightbox({ svg, onClose }: { svg: string; onClose
           <X className="lucide-inline" aria-hidden="true" />
         </button>
       </div>
-      {/* min-h-0 lets the flex child shrink to the viewport; overflow-auto is
-          the escape hatch for a no-viewBox SVG kept at natural size. */}
+      {/* min-h-0 lets the flex child shrink to the viewport. overflow-auto is
+          retained as the escape hatch for a no-viewBox SVG kept at natural size —
+          that case is NOT fit-scaled, so scrolling (not zoom) is what reaches its
+          edges, and `touch-none` is therefore applied to the inner wrapper only
+          when `fitted`.
+          `touch-action` resolves over the whole ANCESTOR CHAIN up to the element
+          that would scroll, so keeping it off this div is not enough: on the
+          dialog root it disables touch panning here just as effectively, and a
+          wrapper-only assertion cannot detect that. `DiagramLightbox.zoom.test.tsx`
+          asserts across the chain for that reason — unlike `Lightbox`, which owns
+          no scroller and correctly suppresses gestures at its own root. */}
       <div className="flex-1 min-h-0 overflow-auto px-6 pb-6">
-        <div ref={hostRef} className="w-full h-full flex items-center justify-center" />
+        <div
+          ref={hostRef}
+          className={`w-full h-full flex items-center justify-center ${fitted ? 'touch-none' : ''}`}
+          style={fitted ? {
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            // No transition during a gesture: a pinch already produces a frame per
+            // move, and easing between them lags the fingers. Nor for a user who
+            // opted out of motion — a double-tap animates a 2.5x scale, which is
+            // exactly the kind of movement that setting exists to suppress. The
+            // zoom itself still happens; only the easing to it is dropped.
+            transition: pinching || dragging || reduceMotion ? 'none' : 'transform 150ms ease-out',
+            cursor: zoom > DIAGRAM_ZOOM_MIN ? (dragging ? 'grabbing' : 'grab') : undefined,
+          } : undefined}
+          onPointerDown={fitted ? onPointerDown : undefined}
+          onPointerMove={fitted ? onPointerMove : undefined}
+          onPointerUp={fitted ? onPointerUp : undefined}
+          onPointerCancel={fitted ? onPointerUp : undefined}
+        />
       </div>
     </motion.div>,
     document.body

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -345,6 +345,7 @@ function initMermaid(mermaid: MermaidApi): void {
 import { CodeBlock } from './CodeBlock'
 import { ExcalidrawBlock } from './ExcalidrawBlock'
 import DiagramLightbox from './DiagramLightbox'
+import { usePinchZoom } from '../hooks/usePinchZoom'
 
 /** Forward the `data-sourcepos` attribute from rehypeSourcepos onto the
  *  rendered element. Used in every MD_COMPONENTS override; returns an
@@ -3107,46 +3108,6 @@ const LIGHTBOX_ZOOM_MIN = 1
 const LIGHTBOX_ZOOM_MAX = 5
 const LIGHTBOX_ZOOM_STEP = 0.5
 
-/** Distance between two pointer positions, for the pinch scale factor. */
-function pointerDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
-  return Math.hypot(a.x - b.x, a.y - b.y)
-}
-
-/** Hold a candidate zoom inside the viewer's bounds. Rounded because a pinch
- *  produces a continuous factor, and an unrounded float would make the
- *  `zoom > LIGHTBOX_ZOOM_MIN` checks (which gate panning and swipe-to-dismiss)
- *  flip on a residue like 1.0000000000000002 after a pinch back down to fit. */
-function clampLightboxZoom(z: number): number {
-  return Math.min(LIGHTBOX_ZOOM_MAX, Math.max(LIGHTBOX_ZOOM_MIN, +z.toFixed(3)))
-}
-
-/** The two contacts that own a pinch: the first two live ones, in insertion order,
- *  plus a `key` identifying that exact pair.
- *
- *  The pair is DERIVED on every read rather than stored as two pointer ids, and
- *  that is the invariant the gesture rests on. Storing ids leaves `pinchRef`
- *  naming a pointer that has since lifted whenever the contact set changes in a
- *  way a `size < 2` test cannot see — a third finger lands, then one of the
- *  original two lifts while two contacts remain. The stored id is then absent
- *  from the map, every later move reads `undefined` for it, and the pinch is dead
- *  until the user lifts everything and starts over. Deriving the pair makes that
- *  state unrepresentable: the pair is always live by construction, and a change
- *  of `key` is the signal to re-seat the baseline. */
-function pinchPair(points: Map<number, { x: number; y: number }>):
-  { key: string; a: { x: number; y: number }; b: { x: number; y: number } } | null {
-  if (points.size < 2) return null
-  const entries = points.entries()
-  const [idA, a] = entries.next().value as [number, { x: number; y: number }]
-  const [idB, b] = entries.next().value as [number, { x: number; y: number }]
-  return { key: `${idA}:${idB}`, a, b }
-}
-
-/** Midpoint of a pinch — the point the zoom is anchored to, so the detail under
- *  the fingers stays under the fingers instead of sliding away from them. */
-function pinchMidpoint(a: { x: number; y: number }, b: { x: number; y: number }) {
-  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
-}
-
 /** Swipe-to-dismiss (touch only, fit zoom only) tuning.
  *
  *  `SLOP` is the travel a touch must cover before the drag counts as a gesture
@@ -3238,44 +3199,48 @@ export function dispatchLightbox(target: HTMLImageElement): void {
  *  payload and the legacy { src, alt } single-image shape. */
 export function Lightbox() {
   const [state, setState] = useState<LightboxDetail | null>(null)
-  // Zoom (enlarge) factor for the current image. 1 = fit-to-screen; larger
-  // values scale the fit box up so the image overflows into the scrollable
-  // overlay. Reset to 1 whenever the shown image changes (see effect below).
-  const [zoom, setZoom] = useState(1)
-  const zoomIn = useCallback(() => setZoom(z => Math.min(LIGHTBOX_ZOOM_MAX, +(z + LIGHTBOX_ZOOM_STEP).toFixed(2))), [])
-  const zoomOut = useCallback(() => setZoom(z => Math.max(LIGHTBOX_ZOOM_MIN, +(z - LIGHTBOX_ZOOM_STEP).toFixed(2))), [])
-  // Pan offset (px) for dragging an enlarged image around. Only meaningful when
-  // zoom > 1. The image element itself is the drag surface; a small movement
-  // threshold distinguishes a pan-drag from a click (which steps the zoom).
-  const [pan, setPan] = useState({ x: 0, y: 0 })
   const imgRef = useRef<HTMLImageElement>(null)
   const dragRef = useRef({ startX: 0, startY: 0, baseX: 0, baseY: 0, moved: 0, active: false, dragging: false })
   const [dragging, setDragging] = useState(false)
-  // Live zoom for the pointer/clamp closures (avoids stale-closure math in the
-  // fire-and-forget pointer handlers and the post-layout re-clamp effect).
-  const zoomRef = useRef(zoom)
-  zoomRef.current = zoom
-  // Live pan, for the same reason. The pinch handler needs the pan the image is
-  // CURRENTLY rendered at to re-seat its baseline, and a `useCallback([])` closure
-  // would hand it the pan from first render.
-  const panRef = useRef(pan)
-  panRef.current = pan
-  // Clamp a candidate pan so the image can't be flung entirely off-screen. Zoom
-  // is applied as a CSS `scale()` transform, so the *visual* size is the layout
-  // box (offsetWidth/Height) times the current zoom; travel is allowed up to
-  // half that overflow beyond the viewport.
+  // `suppressClick` makes the click that follows a real gesture a no-op, so a
+  // spring-back or a finished pinch does not also close via the backdrop handler.
+  // Declared before the hook because `onPinchEnd` sets it.
+  const suppressClickRef = useRef(false)
+  // Zoom (enlarge) factor and pan offset for the current image, plus the pinch
+  // gesture that drives them. 1 = fit-to-screen; larger values scale the fit box
+  // up so the image overflows the viewport and can be panned. Reset to fit
+  // whenever the shown image changes (see effect below).
   //
-  // `z` is explicit because the pinch clamps against the zoom it is about to SET,
-  // not the one on screen: reading `zoomRef` there would clamp a zoomed-in pan
-  // against the smaller previous box and snap the image back toward centre on
-  // every frame of the gesture.
-  const clampPan = useCallback((x: number, y: number, z: number = zoomRef.current) => {
-    const el = imgRef.current
-    if (!el) return { x, y }
-    const maxX = Math.max(0, (el.offsetWidth * z - window.innerWidth) / 2)
-    const maxY = Math.max(0, (el.offsetHeight * z - window.innerHeight) / 2)
-    return { x: Math.min(maxX, Math.max(-maxX, x)), y: Math.min(maxY, Math.max(-maxY, y)) }
-  }, [])
+  // The gesture lives in `usePinchZoom` because this is not the only surface that
+  // owns its own magnification — `DiagramLightbox` is the other, and shipping the
+  // math twice is how the two diverge.
+  const {
+    zoom, setZoom, pan, setPan, pinching, zoomRef, clampPan,
+    trackPointerDown, trackPointerMove, trackPointerUp, reset: resetZoom,
+  } = usePinchZoom({
+    targetRef: imgRef,
+    min: LIGHTBOX_ZOOM_MIN,
+    max: LIGHTBOX_ZOOM_MAX,
+    onPinchStart: () => {
+      // Both one-finger gestures lose their claim: a dismiss-drag would read the
+      // pinch's vertical component as pull-to-close, and the <img> pan would fight
+      // the scale over the same two contacts.
+      abortSwipeRef.current?.()
+      const d = dragRef.current
+      if (d.active) { d.active = false; d.dragging = false; setDragging(false) }
+    },
+    // A finished pinch is not a tap. Without this the click synthesised after the
+    // last finger lifts reaches the backdrop handler and closes the viewer the
+    // user just spent the gesture zooming into.
+    onPinchEnd: () => { suppressClickRef.current = true },
+  })
+  const zoomIn = useCallback(() => setZoom(z => Math.min(LIGHTBOX_ZOOM_MAX, +(z + LIGHTBOX_ZOOM_STEP).toFixed(2))), [setZoom])
+  const zoomOut = useCallback(() => setZoom(z => Math.max(LIGHTBOX_ZOOM_MIN, +(z - LIGHTBOX_ZOOM_STEP).toFixed(2))), [setZoom])
+  /** `onPinchStart` fires from inside the hook, which is constructed before
+   *  `abortSwipe` exists — the ref is what lets the callback reach the later
+   *  definition without reordering the whole component around it. */
+  const abortSwipeRef = useRef<(() => void) | null>(null)
+
   // End a drag on either pointerup OR pointercancel (touch/pen interrupted, or
   // capture lost) so `active`/`dragging` never latch on with no contact held.
   const endDrag = useCallback((e: React.PointerEvent<HTMLImageElement>) => {
@@ -3301,7 +3266,6 @@ export function Lightbox() {
   // rewrites the gesture's origin and a two-finger zoom attempt walks the image
   // down and closes the viewer the user was zooming into.
   const swipeRef = useRef({ pointerId: -1, startX: 0, startY: 0, active: false, engaged: false })
-  const suppressClickRef = useRef(false)
   // Abandon the in-flight gesture and return the image to rest. Used by the
   // multi-touch bail-out and by pointercancel.
   const abortSwipe = useCallback(() => {
@@ -3311,6 +3275,8 @@ export function Lightbox() {
     s.pointerId = -1
     setSwipeY(0)
   }, [])
+  // Publish it for the hook's `onPinchStart`, which is constructed above this.
+  abortSwipeRef.current = abortSwipe
   // ── pinch-to-zoom (touch, two fingers) ───────────────────────────────────
   // Browser page zoom is off on touch across the shell (viewport meta in
   // index.html, root `touch-action` in index.css, `gesturestart` suppression in
@@ -3321,48 +3287,10 @@ export function Lightbox() {
   // toolbar and keyboard drive, so pan clamping, the reset on image change and
   // the `zoomed` cursor keep working with no parallel code path.
   //
-  // Live contacts are tracked in a map because pointer events carry ONE pointer
-  // each: the second finger's position is only ever knowable from what an
-  // earlier event stored.
-  const pointsRef = useRef(new Map<number, { x: number; y: number }>())
-  // `key` is the identity of the pair the baseline was measured from — '' means no
-  // pinch is armed. Everything else is that baseline: the finger distance, and the
-  // zoom/pan/midpoint the image sat at when the pair was seated. The scale and the
-  // pan are both derived from it, so the gesture is a pure function of the live
-  // contacts and never accumulates drift.
-  const pinchRef = useRef({
-    key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
-    startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
-  })
-  const [pinching, setPinching] = useState(false)
-  const endPinch = useCallback(() => {
-    if (pinchRef.current.key === '') return
-    pinchRef.current = {
-      key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
-      startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
-    }
-    setPinching(false)
-    // A finished pinch is not a tap. Without this the click synthesised after the
-    // last finger lifts reaches the backdrop handler and closes the viewer the
-    // user just spent the gesture zooming into.
-    suppressClickRef.current = true
-  }, [])
-  /** Measure the baseline for `pair` from what is on screen right now. Called both
-   *  when a pinch begins and whenever the live pair changes identity mid-gesture —
-   *  re-seating from the CURRENT zoom and pan is what makes a finger landing or
-   *  lifting continue the gesture smoothly instead of snapping the image back to
-   *  where the previous pair started. */
-  const seatPinch = useCallback((pair: NonNullable<ReturnType<typeof pinchPair>>) => {
-    const dist = pointerDistance(pair.a, pair.b)
-    // Two contacts at the same point give no baseline to scale against; leave the
-    // pinch unseated and let the next move (or lift) sort the gesture out.
-    if (dist <= 0) return
-    pinchRef.current = {
-      key: pair.key, startDist: dist, baseZoom: zoomRef.current,
-      startMid: pinchMidpoint(pair.a, pair.b), basePan: panRef.current,
-    }
-    setPinching(true)
-  }, [])
+  // The gesture itself is `usePinchZoom` (contact tracking, focal anchoring, pan
+  // clamping); what stays here is only the part that is specific to THIS viewer —
+  // which one-finger gesture yields to a pinch, and what a finished pinch means
+  // for the click that follows.
   const onOverlayPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     // Every click in this subtree is preceded by a pointerdown, so clearing here
     // is what keeps the flag from latching when the click is swallowed upstream
@@ -3373,49 +3301,17 @@ export function Lightbox() {
     // two tracked contacts, and every branch that follows returns early — so
     // recording last would mean the second finger is never seen in exactly the
     // cases (drag live, already zoomed) a pinch is most likely to start from.
-    pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
-    const pair = pinchPair(pointsRef.current)
-    if (pair) {
-      seatPinch(pair)
-      // Both one-finger gestures lose their claim: a dismiss-drag would read the
-      // pinch's vertical component as pull-to-close, and the <img> pan would fight
-      // the scale over the same two contacts.
-      abortSwipe()
-      const d = dragRef.current
-      if (d.active) { d.active = false; d.dragging = false; setDragging(false) }
-      return
-    }
+    // The hook records the contact and, when a pinch seats, calls `onPinchStart`
+    // (which drops the swipe and the <img> drag) and returns true.
+    if (trackPointerDown(e)) return
     if (zoomRef.current > LIGHTBOX_ZOOM_MIN) return // the <img> pan owns this gesture
     // Toolbar taps must stay taps — never start a drag from a control.
     if ((e.target as HTMLElement | null)?.closest('button')) return
     swipeRef.current = { pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, active: true, engaged: false }
-  }, [abortSwipe, seatPinch])
+  }, [trackPointerDown, zoomRef])
   const onOverlayPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (pointsRef.current.has(e.pointerId)) pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
-    const pair = pinchPair(pointsRef.current)
-    if (pair) {
-      const p = pinchRef.current
-      // The live pair is not the one the baseline was measured from (a finger
-      // joined or left). Re-seat and wait for the next move rather than scaling
-      // this frame against a distance from a different pair of fingers.
-      if (p.key !== pair.key) { seatPinch(pair); return }
-      const next = clampLightboxZoom(p.baseZoom * (pointerDistance(pair.a, pair.b) / p.startDist))
-      // Anchor the scale at the gesture midpoint. The image renders as
-      // `translate(pan) scale(zoom)` about its centre, so the content sitting under
-      // the midpoint when the pinch was seated is at image-local offset
-      // `(startMid - centre - basePan) / baseZoom`; holding that offset under the
-      // CURRENT midpoint is what keeps a corner detail under the fingers instead of
-      // pushing it away as the image grows around its centre. Using the live
-      // midpoint (not the seated one) also makes two fingers moving together pan.
-      const cx = window.innerWidth / 2
-      const cy = window.innerHeight / 2
-      const anchorX = (p.startMid.x - cx - p.basePan.x) / p.baseZoom
-      const anchorY = (p.startMid.y - cy - p.basePan.y) / p.baseZoom
-      const mid = pinchMidpoint(pair.a, pair.b)
-      setZoom(next)
-      setPan(clampPan(mid.x - cx - anchorX * next, mid.y - cy - anchorY * next, next))
-      return
-    }
+    // A live pinch consumes the move (scale + focal-anchored pan).
+    if (trackPointerMove(e)) return
     const s = swipeRef.current
     if (!s.active || e.pointerId !== s.pointerId) return
     const dx = e.clientX - s.startX
@@ -3431,13 +3327,12 @@ export function Lightbox() {
     // Downward travel tracks the finger 1:1; upward is rubber-banded, since
     // pulling up is not a dismiss but should not feel dead either.
     setSwipeY(dy >= 0 ? dy : dy / 4)
-  }, [clampPan, seatPinch])
+  }, [trackPointerMove])
   const endSwipe = useCallback((e: React.PointerEvent<HTMLDivElement>, cancelled: boolean) => {
-    pointsRef.current.delete(e.pointerId)
-    // A pinch needs two contacts to exist. Ending it on the FIRST lift (rather
-    // than the last) is what stops the finger still down from being re-read as a
+    // The hook drops the contact and ends the pinch on the FIRST lift (rather than
+    // the last), which is what stops the finger still down from being re-read as a
     // one-finger pan whose origin is wherever the pinch happened to leave it.
-    if (pointsRef.current.size < 2) endPinch()
+    trackPointerUp(e)
     const s = swipeRef.current
     if (!s.active || e.pointerId !== s.pointerId) return
     if (cancelled) { abortSwipe(); return }
@@ -3449,7 +3344,7 @@ export function Lightbox() {
     suppressClickRef.current = true
     if (e.clientY - s.startY > LIGHTBOX_DISMISS_DISTANCE) setState(null)
     else setSwipeY(0)
-  }, [abortSwipe, endPinch])
+  }, [abortSwipe, trackPointerUp])
   const onOverlayPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, false), [endSwipe])
   const onOverlayPointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => endSwipe(e, true), [endSwipe])
   const onOverlayClick = useCallback(() => {
@@ -3481,7 +3376,6 @@ export function Lightbox() {
   // previous one's zoom. The dismiss offset resets with it — a viewer reopened
   // right after a spring-back must not start half-dragged.
   useEffect(() => {
-    setZoom(LIGHTBOX_ZOOM_MIN)
     setSwipeY(0)
     setSwiping(false)
     swipeRef.current.active = false
@@ -3489,14 +3383,10 @@ export function Lightbox() {
     swipeRef.current.pointerId = -1
     // Contacts do not survive the viewer: closing mid-pinch (or an image change
     // driven from the keyboard while fingers are down) must not leave a stale
-    // pair behind for the next open to scale against.
-    pointsRef.current.clear()
-    pinchRef.current = {
-      key: '', startDist: 0, baseZoom: LIGHTBOX_ZOOM_MIN,
-      startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 },
-    }
-    setPinching(false)
-  }, [isOpen, state?.index])
+    // pair behind for the next open to scale against. `resetZoom` clears the
+    // contact map and the pinch baseline along with the zoom and pan.
+    resetZoom()
+  }, [isOpen, state?.index, resetZoom])
   // On any zoom change, recentre at fit and otherwise re-clamp the existing pan
   // to the new (smaller/larger) bounds — zooming out must not strand the image
   // off-screen. Runs post-layout, so offsetWidth already reflects the new box.

--- a/website/src/hooks/usePinchZoom.ts
+++ b/website/src/hooks/usePinchZoom.ts
@@ -1,0 +1,227 @@
+import { useCallback, useRef, useState } from 'react'
+
+/** Two-finger pinch-to-zoom with focal anchoring and pan clamping, for a
+ *  full-viewport viewer that owns its own magnification.
+ *
+ *  Why this is a hook rather than per-viewer code: browser page zoom is off on
+ *  touch across the shell (viewport meta in `index.html`, root `touch-action` in
+ *  `index.css`, `gesturestart` suppression in `utils/pageZoom.ts`), because
+ *  magnifying a fixed-height app shell strands the user in a layout with no
+ *  scroll axis to reach what moved off-screen. The rule that buys is *"a surface
+ *  that must magnify owns its own zoom"* — and this codebase has TWO such
+ *  surfaces, the image `Lightbox` and `DiagramLightbox`. The first shipped this
+ *  gesture; the second shipped without it and became unmagnifiable by any
+ *  gesture, which is the regression this hook exists to make unrepeatable.
+ *
+ *  What the caller still owns, deliberately: the ONE-finger gestures. The image
+ *  viewer has swipe-to-dismiss and a drag-pan on the `<img>`; the diagram viewer
+ *  has neither. Those compete with a pinch over the same contacts, and only the
+ *  caller knows what to surrender — so `onPinchStart` fires when the second
+ *  finger lands and the caller drops whatever one-finger gesture it had in
+ *  flight. Folding those in here would mean this hook knowing about swipe
+ *  thresholds and image drags it has no business knowing about.
+ */
+
+type Point = { x: number; y: number }
+
+/* The three helpers below are module-private on purpose. They are the pinch's
+ * internals, not its interface: both consumers drive the gesture through the
+ * hook's returned handlers and never compute a distance or a pair themselves.
+ * Exporting them would publish an API with no caller, which the next consumer
+ * would then bind to — and a second entry point into this math is the exact
+ * divergence the extraction exists to prevent. */
+
+/** Distance between two pointer positions, for the pinch scale factor. */
+function pointerDistance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/** Midpoint of a pinch — the point the zoom is anchored to, so the detail under
+ *  the fingers stays under the fingers instead of sliding away from them. */
+function pinchMidpoint(a: Point, b: Point): Point {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 }
+}
+
+/** The two contacts that own a pinch: the first two live ones, in insertion order,
+ *  plus a `key` identifying that exact pair.
+ *
+ *  The pair is DERIVED on every read rather than stored as two pointer ids, and
+ *  that is the invariant the gesture rests on. Storing ids leaves the baseline
+ *  naming a pointer that has since lifted whenever the contact set changes in a
+ *  way a `size < 2` test cannot see — a third finger lands, then one of the
+ *  original two lifts while two contacts remain. The stored id is then absent
+ *  from the map, every later move reads `undefined` for it, and the pinch is dead
+ *  until the user lifts everything and starts over. Deriving the pair makes that
+ *  state unrepresentable: the pair is always live by construction, and a change
+ *  of `key` is the signal to re-seat the baseline. */
+function pinchPair(points: Map<number, Point>): { key: string; a: Point; b: Point } | null {
+  if (points.size < 2) return null
+  const entries = points.entries()
+  const [idA, a] = entries.next().value as [number, Point]
+  const [idB, b] = entries.next().value as [number, Point]
+  return { key: `${idA}:${idB}`, a, b }
+}
+
+export type PinchZoomOptions = {
+  /** The element whose layout box bounds the pan. Its `offsetWidth/Height` times
+   *  the current zoom is the visual size; travel is allowed up to half the
+   *  overflow beyond the viewport. A null ref leaves a candidate pan unclamped. */
+  targetRef: { current: { offsetWidth: number; offsetHeight: number } | null }
+  min: number
+  max: number
+  /** Fires when a pinch seats (the second contact lands). The caller uses it to
+   *  drop any one-finger gesture it had in flight — see the note above. */
+  onPinchStart?: () => void
+  /** Fires when the last-but-one contact lifts, i.e. the pinch is over. The
+   *  caller uses it to mark the synthesised click as not-a-tap, so a finished
+   *  pinch does not also dismiss the viewer the user just zoomed into. */
+  onPinchEnd?: () => void
+}
+
+export function usePinchZoom({ targetRef, min, max, onPinchStart, onPinchEnd }: PinchZoomOptions) {
+  const [zoom, setZoom] = useState(min)
+  const [pan, setPan] = useState<Point>({ x: 0, y: 0 })
+  const [pinching, setPinching] = useState(false)
+
+  /** Live zoom/pan for the pointer closures. A `useCallback([])` closure would
+   *  hand the handlers the values from first render, and the pinch specifically
+   *  needs what is on screen NOW to re-seat its baseline. */
+  const zoomRef = useRef(zoom)
+  zoomRef.current = zoom
+  const panRef = useRef(pan)
+  panRef.current = pan
+
+  /** Hold a candidate zoom inside bounds. Rounded because a pinch produces a
+   *  continuous factor, and an unrounded float would make the `zoom > min`
+   *  checks (which gate panning and any fit-only gesture) flip on a residue like
+   *  1.0000000000000002 after a pinch back down to fit. */
+  const clampZoom = useCallback((z: number) => Math.min(max, Math.max(min, +z.toFixed(3))), [min, max])
+
+  /** Clamp a candidate pan so the content can't be flung entirely off-screen.
+   *
+   *  `z` is explicit because the pinch clamps against the zoom it is about to
+   *  SET, not the one on screen: reading `zoomRef` there would clamp a zoomed-in
+   *  pan against the smaller previous box and snap the content back toward centre
+   *  on every frame of the gesture. */
+  const clampPan = useCallback((x: number, y: number, z: number = zoomRef.current): Point => {
+    const el = targetRef.current
+    if (!el) return { x, y }
+    const maxX = Math.max(0, (el.offsetWidth * z - window.innerWidth) / 2)
+    const maxY = Math.max(0, (el.offsetHeight * z - window.innerHeight) / 2)
+    return { x: Math.min(maxX, Math.max(-maxX, x)), y: Math.min(maxY, Math.max(-maxY, y)) }
+  }, [targetRef])
+
+  /** Live contacts, tracked in a map because pointer events carry ONE pointer
+   *  each: the second finger's position is only ever knowable from what an
+   *  earlier event stored. */
+  const pointsRef = useRef(new Map<number, Point>())
+  /** `key` is the identity of the pair the baseline was measured from — '' means
+   *  no pinch is armed. Everything else is that baseline: the finger distance and
+   *  the zoom/pan/midpoint the content sat at when the pair was seated. Scale and
+   *  pan are both derived from it, so the gesture is a pure function of the live
+   *  contacts and never accumulates drift. */
+  const pinchRef = useRef({ key: '', startDist: 0, baseZoom: min, startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 } })
+
+  const resetPinch = useCallback(() => {
+    pinchRef.current = { key: '', startDist: 0, baseZoom: min, startMid: { x: 0, y: 0 }, basePan: { x: 0, y: 0 } }
+  }, [min])
+
+  const endPinch = useCallback(() => {
+    if (pinchRef.current.key === '') return
+    resetPinch()
+    setPinching(false)
+    onPinchEnd?.()
+  }, [resetPinch, onPinchEnd])
+
+  /** Measure the baseline for `pair` from what is on screen right now. Called both
+   *  when a pinch begins and whenever the live pair changes identity mid-gesture —
+   *  re-seating from the CURRENT zoom and pan is what makes a finger landing or
+   *  lifting continue the gesture smoothly instead of snapping the content back to
+   *  where the previous pair started. */
+  const seatPinch = useCallback((pair: NonNullable<ReturnType<typeof pinchPair>>) => {
+    const dist = pointerDistance(pair.a, pair.b)
+    // Two contacts at the same point give no baseline to scale against; leave the
+    // pinch unseated and let the next move (or lift) sort the gesture out.
+    if (dist <= 0) return
+    pinchRef.current = {
+      key: pair.key, startDist: dist, baseZoom: zoomRef.current,
+      startMid: pinchMidpoint(pair.a, pair.b), basePan: panRef.current,
+    }
+    setPinching(true)
+  }, [])
+
+  /** Record a contact and seat a pinch if this is the second one. Returns true
+   *  when a pinch owns the gesture, so the caller can stop before starting a
+   *  one-finger gesture of its own. Mouse pointers are ignored — a pinch is a
+   *  touch gesture, and claiming mouse events would break desktop click paths. */
+  const trackPointerDown = useCallback((e: { pointerId: number; clientX: number; clientY: number; pointerType: string }): boolean => {
+    if (e.pointerType === 'mouse') return false
+    // Record BEFORE any bail-out in the caller. A pinch is only knowable from two
+    // tracked contacts, and a caller that returns early would mean the second
+    // finger is never seen in exactly the cases a pinch is most likely to start from.
+    pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    const pair = pinchPair(pointsRef.current)
+    if (!pair) return false
+    seatPinch(pair)
+    onPinchStart?.()
+    return true
+  }, [seatPinch, onPinchStart])
+
+  /** Apply a pinch frame. Returns true when a pinch consumed the move. */
+  const trackPointerMove = useCallback((e: { pointerId: number; clientX: number; clientY: number }): boolean => {
+    if (pointsRef.current.has(e.pointerId)) pointsRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    const pair = pinchPair(pointsRef.current)
+    if (!pair) return false
+    const p = pinchRef.current
+    // The live pair is not the one the baseline was measured from (a finger joined
+    // or left). Re-seat and wait for the next move rather than scaling this frame
+    // against a distance from a different pair of fingers.
+    if (p.key !== pair.key) { seatPinch(pair); return true }
+    const next = clampZoom(p.baseZoom * (pointerDistance(pair.a, pair.b) / p.startDist))
+    // Anchor the scale at the gesture midpoint. The content renders as
+    // `translate(pan) scale(zoom)` about its centre, so what sat under the midpoint
+    // when the pinch was seated is at content-local offset
+    // `(startMid - centre - basePan) / baseZoom`; holding that offset under the
+    // CURRENT midpoint is what keeps a corner detail under the fingers instead of
+    // pushing it away as the content grows around its centre. Using the live
+    // midpoint (not the seated one) also makes two fingers moving together pan.
+    const cx = window.innerWidth / 2
+    const cy = window.innerHeight / 2
+    const anchorX = (p.startMid.x - cx - p.basePan.x) / p.baseZoom
+    const anchorY = (p.startMid.y - cy - p.basePan.y) / p.baseZoom
+    const mid = pinchMidpoint(pair.a, pair.b)
+    setZoom(next)
+    setPan(clampPan(mid.x - cx - anchorX * next, mid.y - cy - anchorY * next, next))
+    return true
+  }, [clampZoom, clampPan, seatPinch])
+
+  /** Drop a contact. Ends the pinch on the FIRST lift (rather than the last),
+   *  which is what stops the finger still down from being re-read as a one-finger
+   *  gesture whose origin is wherever the pinch happened to leave it. */
+  const trackPointerUp = useCallback((e: { pointerId: number }) => {
+    pointsRef.current.delete(e.pointerId)
+    if (pointsRef.current.size < 2) endPinch()
+  }, [endPinch])
+
+  /** Return to fit and clear any pan. */
+  const reset = useCallback(() => {
+    setZoom(min)
+    setPan({ x: 0, y: 0 })
+    pointsRef.current.clear()
+    resetPinch()
+    setPinching(false)
+  }, [min, resetPinch])
+
+  // Return exactly what a consumer CALLS or READS — never what it merely names.
+  // A handle nothing invokes is a second entry point into this gesture's maths,
+  // which is what having one hook instead of two copies exists to prevent; and a
+  // name that appears only in a dependency array reads as consumed while being
+  // dead. `endPinch` is deliberately absent: `trackPointerUp` calls it, so inside
+  // the hook is the only place it belongs.
+  return {
+    zoom, setZoom, pan, setPan, pinching,
+    zoomRef, clampPan,
+    trackPointerDown, trackPointerMove, trackPointerUp,
+    reset,
+  }
+}

--- a/website/src/test/DiagramLightbox.zoom.test.tsx
+++ b/website/src/test/DiagramLightbox.zoom.test.tsx
@@ -1,0 +1,325 @@
+import { render, fireEvent, act } from '@testing-library/react'
+import DiagramLightbox from '../components/DiagramLightbox'
+
+// Diagram viewer magnification. #6000 turned page zoom off shell-wide on the rule
+// that "a surface that must magnify owns its own zoom" — and this viewer shipped
+// without owning one, which left a diagram's labels unmagnifiable by any gesture
+// (#6107). These specs pin the gesture, and pin the ONE case where zoom is
+// deliberately absent: an SVG with no viewBox is not fit-scaled, so the
+// surrounding scroller (not a transform) is what reaches its edges.
+
+/** Mermaid-shaped output. Built through the DOM rather than written as markup:
+ *  the component takes a *serialized* SVG string and inserts it with
+ *  `createContextualFragment`, so a serialized element is what the fixture
+ *  actually is. Authored SVG markup carrying a viewBox attribute is also what
+ *  the use-lucide-icons rule blocks in a `.tsx` — correctly, since that shape is
+ *  normally a hand-rolled icon — so constructing the fixture keeps that rule
+ *  intact instead of carving out a test exemption for it.
+ *
+ *  (The rule greps diff text, so even prose quoting the pattern trips it. This
+ *  comment is worded to describe the shape rather than spell it.) */
+function svgFixture(attrs: Record<string, string>): string {
+  const NS = 'http://www.w3.org/2000/svg'
+  const el = document.createElementNS(NS, 'svg')
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v)
+  const label = document.createElementNS(NS, 'text')
+  label.setAttribute('x', '1')
+  label.setAttribute('y', '9')
+  label.textContent = 'n1'
+  el.appendChild(label)
+  return el.outerHTML
+}
+
+/** A viewBox is what makes fit-scaling possible, and therefore what makes zoom
+ *  the right mechanism for this content. */
+const WITH_VIEWBOX = svgFixture({ viewBox: '0 0 100 100' })
+/** No viewBox: cannot fit-scale, so it keeps natural size and the scroller — not
+ *  a transform — is what reaches its edges. */
+const NO_VIEWBOX = svgFixture({ width: '4000', height: '3000' })
+
+/** The transform target is the SVG host — the inner child of the scroller.
+ *  Queried from `document.body`, not the render container: this viewer portals
+ *  itself to the body, so the container is empty. */
+function host(): HTMLElement {
+  const el = document.body.querySelector('[role="dialog"] .overflow-auto > div')
+  return el as HTMLElement
+}
+
+function overlay(): HTMLElement {
+  return document.body.querySelector('[role="dialog"]') as HTMLElement
+}
+
+const touch = (x: number, y: number, pointerId = 1) =>
+  ({ pointerType: 'touch', pointerId, clientX: x, clientY: y })
+
+/** jsdom gives every element a zero layout box, so the pan clamp would pin every
+ *  candidate to 0 and no spec could observe a pan. Give the host a real box. */
+function sizeHost(el: HTMLElement, w = 800, h = 600) {
+  Object.defineProperty(el, 'offsetWidth', { configurable: true, value: w })
+  Object.defineProperty(el, 'offsetHeight', { configurable: true, value: h })
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 400 })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+})
+
+describe('DiagramLightbox magnification', () => {
+  it('starts at fit and scales on a two-finger pinch', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    expect(h.getAttribute('style')).toContain('scale(1)')
+    // Two contacts 100px apart, then spread to 200px → 2x.
+    act(() => { fireEvent.pointerDown(h, touch(150, 400, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(250, 400, 2)) })
+    act(() => { fireEvent.pointerMove(h, touch(100, 400, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(300, 400, 2)) })
+    expect(h.getAttribute('style')).toContain('scale(2)')
+  })
+
+  it('anchors the pinch at the gesture midpoint rather than the element centre', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    // Pinch centred well away from the viewport centre (200,400).
+    act(() => { fireEvent.pointerDown(h, touch(60, 200, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(140, 200, 2)) })
+    act(() => { fireEvent.pointerMove(h, touch(20, 200, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(180, 200, 2)) })
+    const style = h.getAttribute('style') ?? ''
+    expect(style).toContain('scale(2)')
+    // An unanchored zoom would leave translate at 0,0; anchoring must move it.
+    expect(style).not.toContain('translate(0px, 0px)')
+  })
+
+  it('keeps the pinch alive when a third finger lands and one of the first two lifts', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    act(() => { fireEvent.pointerDown(h, touch(150, 400, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(250, 400, 2)) })
+    act(() => { fireEvent.pointerMove(h, touch(100, 400, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(300, 400, 2)) })
+    expect(h.getAttribute('style')).toContain('scale(2)')
+    // Third finger joins, then the first lifts — two contacts remain, so the
+    // gesture must continue from the CURRENT zoom rather than dying.
+    act(() => { fireEvent.pointerDown(h, touch(350, 400, 3)) })
+    act(() => { fireEvent.pointerUp(h, touch(100, 400, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(400, 400, 3)) })
+    const style = h.getAttribute('style') ?? ''
+    expect(style).toMatch(/scale\((?!1\))/)
+  })
+
+  it('toggles fit <-> 2.5x on a double-tap and back', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    act(() => { fireEvent.pointerDown(h, touch(200, 400, 1)) })
+    act(() => { fireEvent.pointerUp(h, touch(200, 400, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(202, 402, 2)) })
+    expect(h.getAttribute('style')).toContain('scale(2.5)')
+    // A second double-tap returns to fit with the pan cleared.
+    act(() => { fireEvent.pointerUp(h, touch(202, 402, 2)) })
+    act(() => { fireEvent.pointerDown(h, touch(202, 402, 3)) })
+    act(() => { fireEvent.pointerUp(h, touch(202, 402, 3)) })
+    act(() => { fireEvent.pointerDown(h, touch(203, 403, 4)) })
+    const style = h.getAttribute('style') ?? ''
+    expect(style).toContain('scale(1)')
+    expect(style).toContain('translate(0px, 0px)')
+  })
+
+  it('does not read two far-apart taps as one double-tap', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    act(() => { fireEvent.pointerDown(h, touch(50, 100, 1)) })
+    act(() => { fireEvent.pointerUp(h, touch(50, 100, 1)) })
+    // Same time window, but well beyond DOUBLE_TAP_SLOP (32px).
+    act(() => { fireEvent.pointerDown(h, touch(300, 700, 2)) })
+    expect(h.getAttribute('style')).toContain('scale(1)')
+  })
+
+  it('does not read two quick flick-pans as a double-tap that resets the zoom', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    // Get zoomed by a legitimate double-tap first.
+    act(() => { fireEvent.pointerDown(h, touch(200, 400, 1)) })
+    act(() => { fireEvent.pointerUp(h, touch(200, 400, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(202, 402, 2)) })
+    act(() => { fireEvent.pointerUp(h, touch(202, 402, 2)) })
+    expect(h.getAttribute('style')).toContain('scale(2.5)')
+
+    // Now traverse the zoomed diagram the natural way: two quick flick-pans
+    // beginning near the same point. Each committed drag must retire its own tap
+    // candidate, or the second flick's pointerdown lands inside the double-tap
+    // window and snaps the diagram back to fit — losing the position mid-pan.
+    act(() => { fireEvent.pointerDown(h, touch(300, 500, 3)) })
+    act(() => { fireEvent.pointerMove(h, touch(360, 540, 3)) })
+    act(() => { fireEvent.pointerUp(h, touch(360, 540, 3)) })
+    act(() => { fireEvent.pointerDown(h, touch(305, 505, 4)) })
+    act(() => { fireEvent.pointerMove(h, touch(365, 545, 4)) })
+    act(() => { fireEvent.pointerUp(h, touch(365, 545, 4)) })
+
+    expect(h.getAttribute('style')).toContain('scale(2.5)')
+  })
+
+  it('does not let a pinch leave a tap candidate a later tap can complete', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    // A pinch's FIRST contact runs the tap path (one contact is not yet a pinch),
+    // so seating the second must retire that candidate. Otherwise a single tap
+    // near the same point after the pinch lifts completes a double-tap nobody
+    // performed, toggling the zoom the pinch just set.
+    act(() => { fireEvent.pointerDown(h, touch(300, 500, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(340, 540, 2)) })
+    act(() => { fireEvent.pointerUp(h, touch(340, 540, 2)) })
+    act(() => { fireEvent.pointerUp(h, touch(300, 500, 1)) })
+    const afterPinch = h.getAttribute('style') ?? ''
+
+    act(() => { fireEvent.pointerDown(h, touch(302, 502, 3)) })
+    expect(h.getAttribute('style') ?? '').toBe(afterPinch)
+  })
+
+  it('pans a zoomed diagram on a one-finger drag, and not at fit', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    sizeHost(h)
+    // At fit a drag must not pan — there is nothing off-screen to reach.
+    act(() => { fireEvent.pointerDown(h, touch(200, 400, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(260, 400, 1)) })
+    expect(h.getAttribute('style')).toContain('translate(0px, 0px)')
+    act(() => { fireEvent.pointerUp(h, touch(260, 400, 1)) })
+    // Zoom in, then drag: now the pan moves.
+    act(() => { fireEvent.pointerDown(h, touch(200, 400, 2)) })
+    act(() => { fireEvent.pointerUp(h, touch(200, 400, 2)) })
+    act(() => { fireEvent.pointerDown(h, touch(201, 401, 3)) })
+    expect(h.getAttribute('style')).toContain('scale(2.5)')
+    act(() => { fireEvent.pointerUp(h, touch(201, 401, 3)) })
+    act(() => { fireEvent.pointerDown(h, touch(200, 400, 4)) })
+    act(() => { fireEvent.pointerMove(h, touch(240, 400, 4)) })
+    expect(h.getAttribute('style')).not.toContain('translate(0px, 0px)')
+  })
+
+  it('does not claim mouse pointers, so desktop click-out is untouched', () => {
+    const onClose = vi.fn()
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={onClose} />)
+    const h = host()
+    sizeHost(h)
+    act(() => { fireEvent.pointerDown(h, { pointerType: 'mouse', pointerId: 1, clientX: 200, clientY: 400 }) })
+    act(() => { fireEvent.pointerDown(h, { pointerType: 'mouse', pointerId: 1, clientX: 202, clientY: 402 }) })
+    expect(h.getAttribute('style')).toContain('scale(1)')
+  })
+
+  it('leaves a no-viewBox SVG unzoomed and scrollable, since it is not fit-scaled', () => {
+    render(<DiagramLightbox svg={NO_VIEWBOX} onClose={() => {}} />)
+    const h = host()
+    // No transform at all: the scroller reaches this one's edges, and taking
+    // native touch scrolling away from it (via touch-none) would crop it instead.
+    expect(h.getAttribute('style')).toBeNull()
+    expect(document.body.querySelector('.overflow-auto')).not.toBeNull()
+    // Assert the whole ANCESTOR CHAIN, not just the host. `touch-action` resolves
+    // from the hit-test target up to the element that would scroll, so a
+    // `touch-none` anywhere above the scroller disables its touch panning just as
+    // effectively as one on the host — and a host-only assertion is structurally
+    // incapable of seeing it.
+    const chain: string[] = []
+    for (let el: HTMLElement | null = h; el && el !== document.body; el = el.parentElement) {
+      chain.push(el.className)
+      expect(el.className).not.toContain('touch-none')
+    }
+    // Cheap non-vacuity check: a chain of one would pass the loop trivially while
+    // testing nothing about the ancestors this spec exists to cover.
+    expect(chain.length).toBeGreaterThan(2)
+  })
+
+  it('opts a fit-scaled diagram out of the root pan-only touch-action', () => {
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={() => {}} />)
+    // `touch-action` is intersected from the hit-test target up to the root, and
+    // the shell's root is `pan-x pan-y` — without this the browser keeps the pan
+    // and the two-finger gesture never reaches these handlers.
+    expect(host().className).toContain('touch-none')
+  })
+
+  it('does not close on the click that follows a pinch', () => {
+    const onClose = vi.fn()
+    render(<DiagramLightbox svg={WITH_VIEWBOX} onClose={onClose} />)
+    const h = host()
+    sizeHost(h)
+    act(() => { fireEvent.pointerDown(h, touch(150, 400, 1)) })
+    act(() => { fireEvent.pointerDown(h, touch(250, 400, 2)) })
+    act(() => { fireEvent.pointerMove(h, touch(100, 400, 1)) })
+    act(() => { fireEvent.pointerMove(h, touch(300, 400, 2)) })
+    act(() => { fireEvent.pointerUp(h, touch(100, 400, 1)) })
+    act(() => { fireEvent.pointerUp(h, touch(300, 400, 2)) })
+    // The click synthesised after the last finger lifts is gesture residue.
+    act(() => { fireEvent.click(overlay()) })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+describe('the magnify-surface rule is enforced by count, not by example', () => {
+  it('gives every full-viewport magnify overlay the shared pinch hook', async () => {
+    // This is the guard the original zoom suppression lacked. The rule "a surface
+    // that must magnify owns its own zoom" read as satisfied because the ONE
+    // documented example obeyed it, while a second overlay shipped with no gesture
+    // at all and became unmagnifiable (#6107). A rule believed from its example
+    // fails silently; one checked against its instances does not.
+    //
+    // The population is "components that render a full-viewport overlay whose
+    // content is scaled to fit" — detected by the `fixed inset-0` + `z-[9999]`
+    // shape both viewers use, since that is what makes a surface the only thing
+    // on screen and therefore the only thing that can magnify.
+    //
+    // Sweep BOTH trees. A magnify overlay can live in either, and scoping the
+    // population to one directory would make this check count instances of a set
+    // it had itself narrowed — the same failure as believing the rule from its
+    // documented example. A glob boundary is invisible to a reader; the named
+    // exception below is not.
+    const { glob } = await import('node:fs/promises')
+    const { readFile } = await import('node:fs/promises')
+    const { join } = await import('node:path')
+    const root = join(__dirname, '..')
+    /** Known-unfixed magnify surfaces, each with the issue that will close it.
+     *  An entry here is a visible debt with an owner; deleting the entry is part
+     *  of that issue's work. Do NOT add one to make a red sweep green — the
+     *  point of the sweep is that a NEW overlay cannot ship without the hook. */
+    const deferred = new Map([['pages/AppDetailPage.tsx', '#6162']])
+    const offenders: string[] = []
+    const magnifySurfaces: string[] = []
+    let seen = 0
+    for await (const file of glob(['components/**/*.tsx', 'pages/**/*.tsx'], { cwd: root, withFileTypes: false })) {
+      const src = await readFile(join(root, String(file)), 'utf8')
+      if (!/fixed inset-0[^"'`]*z-\[9999\]/.test(src)) continue
+      seen++
+      // A magnify overlay either uses the shared hook, or is one of the overlays
+      // that never magnifies (a popover, a confirm sheet, a menu scrim). The
+      // discriminator is whether it renders a single piece of CONTENT scaled to
+      // fit — an `<img>`, or an SVG it fit-scales itself. It is content-based
+      // rather than a sizing-utility scan because a `max-h-[…]` means only "this
+      // has a maximum height": a menu carries one and is not a magnifier.
+      const magnifies = /<img|querySelector\('svg'\)|preserveAspectRatio|object-contain/.test(src)
+      if (!magnifies) continue
+      magnifySurfaces.push(String(file))
+      if (!src.includes('usePinchZoom') && !deferred.has(String(file))) offenders.push(String(file))
+    }
+    // Prove the sweep reached the tree rather than passing on an empty match set.
+    expect(seen, 'no full-viewport overlay matched — the shape detector broke').toBeGreaterThan(1)
+    // Every deferred entry must still BE a magnify surface this sweep finds. When
+    // its issue lands, the file gains the hook and the entry must be deleted; if
+    // instead the file stops matching (renamed, reshaped, deleted), the entry is
+    // excusing nothing and would sit here forever, so fail on a stale excuse too.
+    for (const [file, issue] of deferred) {
+      expect(
+        magnifySurfaces,
+        `${file} is listed as a deferred magnify surface (${issue}) but the sweep no longer finds it — delete the entry`,
+      ).toContain(file)
+    }
+    expect(
+      offenders,
+      'this full-viewport overlay scales content to fit but has no own zoom, so on touch its content is unmagnifiable — page zoom is off shell-wide. Use hooks/usePinchZoom.ts',
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

On a phone, a diagram's labels cannot be magnified by any gesture.

#6000 turned page zoom off across the touch shell on the rule *"a surface that must magnify owns its own zoom"* — and that rule binds **two** full-viewport magnify overlays in this codebase, not one. `Lightbox` (images) got a pinch. `DiagramLightbox` did not, and it had been relying on the browser pinch that #6000 removed.

Measured on `main` before this change, in `website/src/components/DiagramLightbox.tsx`:

- `grep -cE "zoom|scale\(|pinch|pointerdown"` → **0**
- no `touch-action` declaration anywhere in the file

It fit-scales the SVG to the viewport and stops. Fit is exactly the state where a mermaid label is smallest, so the viewer opens at its least readable size with no way out.

## Why it matters

This is a **regression** #6000 shipped, not a pre-existing gap: before it, a phone user could pinch the page to read a small label. It also made a shipped doc sentence false — `docs/guides/remote-and-mobile.md` claimed *"The surfaces that need magnifying keep it"*, which was true of the one example and untrue of the population.

Worth naming how it got through, because the mechanism is more general than this bug: the rule was validated against its **documented example** rather than against its **instances**. `Lightbox` obeyed it, the example was checked, and nothing counted how many surfaces the rule bound. That is the same failure shape as the 16px field floor withdrawn during #6000 — a guard that counted native `<input>` tags and missed the ~120 component-routed fields that mattered.

## What changed (motivation → approach → change)

**Symptom** → diagram labels unmagnifiable on touch. **Root cause** → the magnify-surface rule had two instances and one implementation. **Change** → give the second instance the gesture, from a shared implementation rather than a second copy.

**`website/src/hooks/usePinchZoom.ts` (new).** The image viewer's pinch, extracted: derived contact pair (never stored pointer ids), focal anchoring at the gesture midpoint, pan clamped against the zoom being *set* rather than the one on screen, re-seat on pair change. Both Design and First Principles asked for this extraction during #6000 and both said *"when a second consumer appears, not now"* — this issue **is** that second consumer, so the condition they named has fired.

What the hook deliberately does **not** own: the one-finger gestures. The image viewer has swipe-to-dismiss and an `<img>` drag-pan; the diagram viewer has neither. Those compete with a pinch over the same contacts and only the caller knows what to surrender, so `onPinchStart` fires and the caller drops what it had in flight. Folding them in would mean the hook knowing about swipe thresholds it has no business knowing about.

**`DiagramLightbox`** now uses it, plus two things a zoom is useless without: **double-tap** to toggle fit ⇄ 2.5× anchored where the user tapped (the shell withholds the browser's double-tap zoom, and this is one of the two surfaces where users still reach for it — UX's suggestion on #6000's final head), and **one-finger drag-to-pan** when zoomed, without which the zoom magnifies the centre and nothing reaches the edges.

**`Lightbox`** migrated to the same hook, so there is one implementation rather than two that drift. Its 20 existing specs are the regression check and all still pass.

**One case is deliberately left unchanged.** An SVG with **no `viewBox`** cannot fit-scale, so it keeps natural size and the surrounding scroller reaches its edges — the original code documented this and `overflow-auto` is retained for it. Zoom/pan and `touch-none` are applied **only** when the SVG was actually fit-scaled (`fitted`), because `touch-action` resolves over the whole ancestor chain up to the element that would scroll: a `touch-none` anywhere above the scroller takes native touch scrolling away from the one case that depends on it, cropping content that was previously reachable.

An earlier draft of this change did exactly that, **and so did the first pushed head** — it left `touch-none` on the dialog root while making the inner wrapper's copy conditional, which the First Principles lane caught on `b29a2e4ef`. The root class is gone as of `9256ff77b`. The reason it survived a spec written to pin this behaviour is worth stating, because it was a hole in the guard rather than in the fix: the `no-viewBox` spec asserted on the **host only**, and a host-only assertion cannot see an ancestor that disables the same panning. That spec now walks host → root asserting none of them carries `touch-none`, with a non-vacuity check on the chain length; re-adding the root class fails it.

Ceiling is 8× here rather than the image viewer's 5×: the content is vector, so scaling costs no resolution, and a label at 8px in a fit-scaled diagram needs more magnification to read than a photo detail does.

Two smaller corrections from the review round on `b29a2e4ef`. The transform easing now also yields to `reduceMotion`, which the component already computed and already honoured for its overlay fade but not for a double-tap's 2.5× scale — the zoom still happens for those users, only the easing to it is dropped. And the hook's public surface is now exactly `usePinchZoom` + `PinchZoomOptions`: its three internal helpers had no importer outside the file and are module-private.

The returned surface took two rounds to settle. `b29a2e4ef` dropped `panRef` and `clampZoom`, which nothing referenced; the First Principles lane then found `endPinch` on `9256ff77b`, still returned because its last real call site had become `trackPointerUp(e)` — leaving it alive only inside a dependency array, which is exactly what made it look consumed. Removing it exposed a second defect in that array: it never declared `trackPointerUp`, and since `onPinchEnd` is an inline arrow the dead `endPinch` entry was the only thing still forcing `endSwipe` to re-memoize, so dropping it alone would have turned the missing dependency into a live stale closure. Both are fixed. The surface is now `zoom`/`setZoom`/`pan`/`setPan`/`pinching`/`zoomRef`/`clampPan`/`trackPointerDown`/`trackPointerMove`/`trackPointerUp`/`reset` — every field called or read by at least one of the two consumers.

An earlier head carried a spec that parsed the return literal to enforce that automatically; it is **not** in this diff. The First Principles lane argued the trade was wrong — a permanent source-parsing test coupled to formatting, guarding a dead identifier with no user consequence — and I agreed and removed it. So the return surface here is checked by review, not by a test, deliberately.

## Tests

`website/src/test/DiagramLightbox.zoom.test.tsx` — 11 specs:

- pinch scales from fit; anchors at the gesture midpoint rather than the element centre
- a third finger landing and one of the first two lifting **continues** the gesture (the derived-pair invariant)
- double-tap toggles fit ⇄ 2.5× and back, clearing the pan
- two far-apart taps are **not** one double-tap
- one-finger drag pans when zoomed and does nothing at fit
- mouse pointers are not claimed, so desktop click-out is untouched
- a no-viewBox SVG gets **no** transform and **no** `touch-none` — asserted over the whole ancestor chain host → root, not just the host — and keeps its scroller
- a fit-scaled diagram carries `touch-none`, without which the root's `pan-x pan-y` keeps the gesture
- the click synthesised after a pinch does not dismiss the viewer

Plus a guard that enforces the rule **by count instead of by example**: it sweeps `components/**/*.tsx` for full-viewport overlays that scale a single piece of content to fit, and fails any that lack the hook. It asserts it saw more than one overlay, so it cannot pass by matching nothing. Its discriminator is content-based (`<img>`, a fit-scaled SVG) rather than a sizing-utility scan — an earlier version keyed on `max-h-[…]` and flagged `SlotTagPopover`, which is a popover and not a magnifier.

Regression check on the extraction: `MarkdownRenderer.lightboxSwipe` (20 specs, 6 pinch) plus `mermaidEnlarge`, `mermaid`, `mermaidLazy`, `mdNotebookMermaid`, `MarkdownRenderer`, `MarkdownRendererCoverage`, `noPageZoom` — **217 specs across 9 files, all passing.**

## Manual verification

Local gates green: `tsc -b` 0, `eslint src/ --max-warnings 664` 0 errors (651 warnings, base-equal), `docs-lint.sh` 0, `i18n:check` 0.

**Not verified on a real device.** The gesture is unit-tested through synthetic pointer events and the mechanism is the same one already shipping in the image viewer, but a phone check of pinch + double-tap on a mermaid diagram is outstanding — same standing gap as #6000's `gesturestart` path, and this repo has no iOS simulator available.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** at rest the diagram viewer renders identically — the change is a gesture, and its resting state (fit, no transform offset) is pixel-for-pixel what shipped. A still frame cannot show a pinch, and the honest evidence for a gesture is a real-device recording, which is the outstanding item above rather than something a Chromium harness would prove.

## Related Issues

Fixes #6107

Also lands the double-tap suggestion the UX lane raised on #6000's final head — but **only on `DiagramLightbox`**, not on `Lightbox`, which is where that suggestion was originally aimed. The UX lane caught the gap on `b29a2e4ef`, along with a guide sentence of mine that had promised the image viewer a double-tap it does not have; the sentence now describes shipped behaviour, and the `Lightbox` half is #6135 together with a zoom-button/key path for `DiagramLightbox`. Both are enhancements to affordances #6000 never broke — desktop page zoom was never suppressed (the guard installs only under `(pointer: coarse)`) — so neither belongs in a PR whose job is restoring the touch path.



