### PR TITLE
ci(fork-review): allow-list fork actors on claude-code-action lanes

### DIFF
--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -263,6 +263,11 @@ jobs:
           # Inference via Amazon Bedrock (region from the AWS creds step above).
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow-list the fork actor so claude-code-action >=1.0.194 does not
+          # abort before the model call (issue #6116). Setting this input
+          # auto-enables the action's subprocess secret-scrub + bubblewrap
+          # isolation, which covers this lane's Bash(git diff/gh pr) grants.
+          allowed_non_write_users: "*"
           # Fable 5's BARE, REGIONAL (`us.`) Bedrock inference-profile id, with an
           # Opus 4.8 overload fallback — matches design-review.yml exactly.
           claude_args: |

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -387,6 +387,12 @@ jobs:
           # Read/Grep/Glob.
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # workflow_run runs as the fork contributor, who lacks repo write;
+          # claude-code-action >=1.0.194 rejects that actor before the model
+          # call unless allow-listed here. Read-only lane (Read,Grep,Glob);
+          # setting this input auto-enables subprocess secret-scrub +
+          # bubblewrap isolation. See issue #6116.
+          allowed_non_write_users: "*"
           claude_args: |
             --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -291,6 +291,13 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # workflow_run runs as the fork contributor, who lacks repo write;
+          # claude-code-action >=1.0.194 rejects that actor before the model
+          # call unless it is allow-listed here. The review is read-only
+          # (Read,Grep,Glob) and posts only a check-run/comment, and setting
+          # this input auto-enables the action's subprocess secret-scrub +
+          # bubblewrap isolation. See issue #6116.
+          allowed_non_write_users: "*"
           # No Bash: the diff is pre-fetched by the job itself with `git diff`
           # against the trusted base tree (NOT the compare API, which truncates
           # very large diffs -- see the fetch step above), so the reviewer needs
@@ -369,6 +376,10 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # See the discovery step above: allow-list the fork actor so
+          # claude-code-action >=1.0.194 does not abort before the model call
+          # (issue #6116).
+          allowed_non_write_users: "*"
           claude_args: |
             --model us.anthropic.claude-opus-4-8
             --max-turns 120

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -306,6 +306,11 @@ jobs:
           # (they appear in the diff as binary markers) and are judged from code.
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow-list the fork actor so claude-code-action >=1.0.194 does not
+          # abort before the model call (issue #6116). Setting this input
+          # auto-enables the action's subprocess secret-scrub + bubblewrap
+          # isolation, which covers this lane's Bash(git diff/gh pr) grants.
+          allowed_non_write_users: "*"
           claude_args: |
             --model us.anthropic.claude-fable-5
             --fallback-model us.anthropic.claude-opus-4-8


### PR DESCRIPTION
## Problem / Motivation

Fixes #6116. The dependency bump #4717 (`anthropics/claude-code-action` 1.0.183 → 1.0.194, commit `be7b93b1…` → `459ad358…`) tightened the action's actor-write permission gate. On `workflow_run` events the action now checks `workflow_run.actor.login` — the fork PR author — in addition to the workflow actor, and aborts *before any model call* when that actor lacks repo write:

```
##[error]Action failed with error: Actor does not have write permissions to the repository
##[error]Process completed with exit code 1
```

This broke the four Claude-backed fork Stage-2 review lanes (**Opus 4.8**, **First Principles / Fable 5**, **Design**, **UX**) on every contributor fork PR. The GPT lane is unaffected because it runs `@openai/codex`, which has no such gate. Because **Opus 4.8 is a blocking input to `PR Readiness`**, contributor-authored fork PRs are frozen at `readiness: action required` with no path to green.

Regression is log-confirmed on run `32997574511` (fork actor `rnoack1`, no write) and pins to the bump commit: fork-opus-review failure rate went 3.3% (before 2026-08-25 19:43Z) → 58% (after) → 73% (next day), split categorically by author association (COLLABORATOR 51/0 vs CONTRIBUTOR 0/137).

## Why it matters

Every external contributor's fork PR is un-mergeable-ready regardless of code quality — a repo-wide throughput block, not a single-PR defect. A re-run cannot clear it (the replayed `workflow_run` payload carries the same fork actor).

## What changed (motivation → approach → change)

The action ships a first-class, documented bypass for exactly this `workflow_run` scenario: the `allowed_non_write_users` input (effective only when `github_token` is passed as an input, which all five fork-lane invocations already do). This change adds `allowed_non_write_users: "*"` to the five `anthropics/claude-code-action` steps across the four fork lanes:

- `.github/workflows/fork-opus-review.yml` (discovery + validation invocations)
- `.github/workflows/fork-first-principles-review.yml`
- `.github/workflows/fork-design-review.yml`
- `.github/workflows/fork-ux-review.yml`

`"*"` is the operative value because the population needing the bypass is "every external contributor," which a named allowlist cannot track. Setting this input auto-enables the action's subprocess secret-scrub and, on Linux runners with bubblewrap available, PID-namespace isolation — so the credential-exposure surface of the two Bash-granting lanes (Design/UX) is mitigated by the action itself.

No workflow permissions are broadened; job `permissions:` blocks are unchanged (each stays `checks:write`, `pull-requests:write`, `contents:read`, `actions:read`, `id-token:write`). The pin is not reverted.

**Security posture (maintainer call):** relaxing this gate is the vendor's documented forward fix but is labelled "RISKY" in the action's `security.md`; the residual risk is prompt-injection of a review-only agent (no `contents: write`; output is comments/check-runs only). If a narrower posture is preferred, applying the input to only the two read-only lanes (Opus + First Principles) still fully clears the blocking impact since only Opus feeds `PR Readiness`, leaving Design/UX as a separate decision. Happy to reshape to whatever posture the maintainers want.

## Tests

CI / lint on this PR. No unit-testable code changed (workflow YAML only); `yaml.safe_load` parses all four files. End-to-end validation is only possible after merge, because `workflow_run` fork lanes always execute the default-branch copy of the workflow — this PR's own fork lanes run the pre-merge (broken) definition and cannot self-validate.

## Manual verification

- Confirmed the pin at all five fork-lane call sites is `459ad358…` (1.0.194) and that `allowed_non_write_users` is currently absent from every workflow.
- Verified in the action source (`src/github/validation/permissions.ts` at `459ad358`) that `getActorsToCheck` adds `workflow_run.actor.login`, and that the `allowed_non_write_users` bypass is gated on the token being provided as an input (satisfied here).
- After merge, every currently-stuck fork PR clears on its next CI completion — no rebase or reopen needed.

## Screenshots / video

<!-- CI/workflow-only change; no user-visible UI. -->
N/A — CI workflow change, no user-visible UI.

## Related Issues

Fixes #6116. Related: #5822 (finalize helper hides the underlying error), #5957 (readiness freezes on an unsatisfiable lane), #6031 (first-principles finalize stderr).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm this contribution is made under the terms of the project's Contribution License Agreement.
