### PR TITLE
docs: add the Android OS-magnify route to the mobile fallback (#6108)

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -614,9 +614,10 @@ bugs:
   symptom is [issue #1828](https://github.com/kirodotdev/KiroCrew/issues/1828).
 - **Pinch zoom is off.** The installed app behaves like an application, not a
   web page: two-finger pinch and double-tap no longer scale the shell. **To
-  magnify, use the OS Display Zoom setting** (iOS: Settings → Display &
-  Brightness → Display Zoom), which still enlarges everything; in a browser tab
-  Safari's Aa text-size control works too, but it is **not** reachable from the
+  magnify, use the OS display-zoom setting** (iOS: Settings → Display &
+  Brightness → Display Zoom; Android: Settings → Display → Display size and
+  text), which still enlarges everything; in a browser tab Safari's Aa
+  text-size control works too, but it is **not** reachable from the
   installed app, which has no Safari toolbar. Pinch is off because magnifying a
   fixed-height layout whose scrollers are all inner leaves no way to reach the
   topbar and composer it pushes off-screen. The surfaces that need magnifying


### PR DESCRIPTION
## Problem / Motivation

`docs/guides/remote-and-mobile.md`'s pinch-zoom fallback bullet tells a user
whose pinch just stopped working how to magnify instead -- and named only the
iOS route (Settings > Display & Brightness > Display Zoom). An Android install
user following that bullet lands nowhere.

## Why it matters

The reader of this bullet is by definition someone who just lost a gesture and
needs a substitute now. Android users are hit hardest: Chromium and Firefox
Mobile honour `maximum-scale`, so page zoom is genuinely capped there, whereas
iOS ignores the viewport keys (covered by the `gesturestart` suppression). A
substitute they cannot find is worth nothing. This is also the third instance
of the same defect class in this one bullet across #6000's review rounds.

## What changed (motivation -> approach -> change)

Symptom: the fallback names one platform on a doc that covers two. Root cause:
the bullet was written with the iOS setting's proper name ("Display Zoom")
doing double duty as the generic term. Change: name both routes in the
parenthetical (Android 12+: Settings > Display > Display size and text) and
make the bolded label generic ("the OS display-zoom setting"), since Display
Zoom is iOS-specific terminology and Android's control is named Display size.
Action-first ordering (substitute before rationale) from #6000's round-6
review finding is preserved.

Scope notes: `website/docs/page-layout.md` states the fallback generically
with no platform path, so it strands nobody and is left untouched;
`website/index.html` is a pointer to it. The `noPageZoom.test.ts` assertion
rider mentioned in the issue is unrelated to this defect and is not included.

Pre-push review: GPT (gpt-5.6-sol) and Opus (claude-opus-5) lanes both ran;
their converged finding (the originally-proposed "Display size / Font size"
path is stale for Android 12+, the slash alternation is screen-reader-hostile,
and Font size alone does not "enlarge everything") is folded into this head.

## Tests

N/A -- docs-only prose change; no behavior to lock in. `scripts/docs-lint.sh`
and `scripts/check_brand_name.py` pass.

## Manual verification

Re-read the rendered bullet in context (lines 615-624): the route reads
action-first, both platform paths are current, markdown and ~80-col wrapping
match the file.

Closes #6108
