### PR TITLE
fix(knowledge): non-segment ** in .kiroignore must not cross a path separator

### DIFF
--- a/src/kiro_crew/knowledge/kiroignore.py
+++ b/src/kiro_crew/knowledge/kiroignore.py
@@ -15,7 +15,10 @@ Syntax is a deliberate SUBSET of gitignore. Supported:
 * any other embedded ``/`` -- also anchors at the root (gitignore's rule); a
   pattern with no separator matches that basename at any depth
 * ``*`` (any run of non-separator characters), ``?`` (one non-separator),
-  ``**`` (crosses separators, including the ``**/`` prefix and ``/**`` suffix)
+  ``**`` -- crosses separators ONLY when it is a complete path segment: the
+  ``**/`` prefix, a ``/**`` suffix, or a bare ``**``. A ``**`` that is not
+  segment-aligned on both sides (``logs/**txt``, ``a**b``, ``a**/b``) is treated
+  as two ordinary ``*`` and stays within a single segment.
 * ``!`` negation -- among the rules that match a given path, the LAST one wins
 * trailing whitespace is stripped
 
@@ -71,11 +74,22 @@ def _translate(pattern: str) -> str:
     out: list[str] = []
     i, n = 0, len(pattern)
     while i < n:
-        if pattern.startswith("**/", i):
-            # Zero or more leading path segments.
+        if pattern.startswith("**/", i) and (i == 0 or pattern[i - 1] == "/"):
+            # A ``**`` that forms a COMPLETE leading path segment (left-bounded by
+            # ``/`` or the start, right-bounded by the ``/`` it consumes) matches
+            # zero or more path segments. A ``**/`` that is NOT segment-aligned on
+            # the left (``a**/b``) is not this form -- it falls through so each
+            # ``*`` degrades to the within-segment ``[^/]*``.
             out.append("(?:[^/]+/)*")
             i += 3
-        elif pattern.startswith("**", i):
+        elif pattern.startswith("**", i) and (i == 0 or pattern[i - 1] == "/") and i + 2 == n:
+            # A ``**`` that forms a COMPLETE path segment -- left-bounded by ``/``
+            # or the start AND right-bounded by the end of the pattern (a bare
+            # ``**`` or a segment-final ``logs/**``) -- crosses separators and
+            # matches everything below that point. A ``**`` that starts a segment
+            # without ending one (``logs/**txt``, ``**a``, ``a/**b``) is NOT this
+            # form: it falls through so each ``*`` degrades to the within-segment
+            # ``[^/]*`` and cannot cross a separator.
             out.append(".*")
             i += 2
         elif pattern[i] == "*":

--- a/test/test_knowledge_kiroignore.py
+++ b/test/test_knowledge_kiroignore.py
@@ -85,6 +85,60 @@ class TestKiroIgnoreSyntax:
         assert m.is_ignored("pkg/snap.md", is_dir=False) is True
         assert m.is_ignored("pkg/a/b/snap.md", is_dir=False) is True
 
+    def test_non_segment_double_star_does_not_cross_a_separator(self):
+        """``**`` crosses separators ONLY as a complete path segment. A ``**``
+        with a non-``/`` neighbour (``a**b``) is not segment-bounded, so git
+        treats it as a single ``*`` that stays within one path segment.
+
+        The discriminator is a pattern whose match depends on the ``**`` NOT
+        crossing ``/``: ``a**b`` matches ``axxb`` but must not match ``ax/xb``.
+        (``a**`` alone cannot show this through ``is_ignored`` -- its match
+        ``ax`` is an ancestor directory of ``ax/xb``, and ignoring a directory
+        ignores its whole subtree, so ``ax/xb`` is ignored regardless of how
+        ``**`` translates. ``a**b`` avoids that: no ancestor of ``ax/xb``
+        matches it, so the separator-crossing behaviour is what is tested.)"""
+        m = _rules("a**")
+        assert m.is_ignored("abc", is_dir=False) is True
+        m2 = _rules("a**b")
+        assert m2.is_ignored("axxb", is_dir=False) is True
+        assert m2.is_ignored("ax/xb", is_dir=False) is False
+
+    def test_double_star_that_starts_a_segment_without_ending_one(self):
+        """A ``**`` that is LEFT-bounded (starts a segment) but not RIGHT-bounded
+        (``logs/**txt``, ``x/**y``) is not a complete segment, so it must stay
+        within one path segment rather than degrade to the cross-separator
+        ``.*``. Regression pin for the right-bound gap: without ``i + 2 == n`` on
+        the segment-``**`` branch, ``logs/**txt`` compiled to ``^logs/.*txt$``
+        and wrongly matched ``logs/a/btxt``.
+
+        Discriminator: a match that depends on ``**`` NOT crossing ``/`` where no
+        ANCESTOR of the deep path independently matches (an ancestor match would
+        ignore the whole subtree and mask the separator-crossing behaviour)."""
+        m = _rules("logs/**txt")
+        assert m.is_ignored("logs/atxt", is_dir=False) is True
+        assert m.is_ignored("logs/a/btxt", is_dir=False) is False
+        m2 = _rules("x/**y")
+        assert m2.is_ignored("x/ay", is_dir=False) is True
+        assert m2.is_ignored("x/a/by", is_dir=False) is False
+        # ``a/**b`` is named in the module docstring as a non-segment example;
+        # pin it too (same right-bound gap, one segment deeper).
+        m3 = _rules("a/**b")
+        assert m3.is_ignored("a/xb", is_dir=False) is True
+        assert m3.is_ignored("a/x/b", is_dir=False) is False
+
+    def test_double_star_slash_that_is_not_left_bounded(self):
+        """The ``**/`` branch must ALSO be left-bounded: ``a**/b`` is not a
+        complete leading segment, so it must not emit the cross-separator
+        ``(?:[^/]+/)*``. Regression pin for the ``**/`` left-bound gap.
+
+        ``a**/b`` should behave as ``a`` + two within-segment ``*`` + ``/b``:
+        it matches ``axx/b`` but not ``ax/x/b`` (the middle ``**`` cannot span a
+        separator). No ancestor of ``ax/x/b`` matches ``a**/b``, so the
+        separator-crossing behaviour is what is under test."""
+        m = _rules("a**/b")
+        assert m.is_ignored("axx/b", is_dir=False) is True
+        assert m.is_ignored("ax/x/b", is_dir=False) is False
+
     def test_negation_the_last_matching_rule_wins(self):
         m = _rules("*.md", "!keep.md")
         assert m.is_ignored("note.md", is_dir=False) is True


### PR DESCRIPTION
## Problem / Motivation

A `.kiroignore` pattern whose `**` is **not a complete path segment** was compiled to a regex that crosses `/`, so it silently matched paths in nested directories that gitignore would never match. Concretely: `a**` matched `abc/def`; and after the initial left-bound-only fix, `logs/**txt` still compiled to `^logs/.*txt$` and matched `logs/a/btxt`, `**a` / `a/**b` behaved the same, and `a**/b` still emitted the cross-segment `(?:[^/]+/)*`.

## Why it matters

`kiroignore` is documented as a subset of gitignore semantics, and a knowledge-source scan relies on that behavior to decide which files to index. A pattern that over-matches across directory boundaries silently excludes files the author never intended to exclude — a correctness gap invisible until content goes missing from a scan.

## What changed (motivation → approach → change)

Symptom: a `**` that is not a complete path segment still crossed `/`. Root cause: in `_translate`, the cross-separator branches were not fully segment-bounded — the `**/` branch had no left-bound check, and the bare-`**` branch had a left bound but no right bound.

Change: a `**` emits its cross-separator form **only when it is a complete path segment** — left-bounded (start of pattern or preceded by `/`) AND right-bounded (followed by `/`, or the end of the pattern):
- the `**/` branch now also requires the left bound `(i == 0 or pattern[i - 1] == "/")`, so `a**/b` falls through;
- the bare-`**` branch now also requires the right bound `i + 2 == n`, so it fires only for a segment-final `**` (a bare `**` or a trailing `/**`).

A `**` that is not segment-aligned on both sides falls through to the existing single-`*` handling (`[^/]*` per star), so it stays within one path segment and cannot cross `/`. No change to anchoring, negation, or directory-only handling.

## Tests

`test/test_knowledge_kiroignore.py`:
- `test_double_star_that_starts_a_segment_without_ending_one` — `logs/**txt`, `x/**y`, `a/**b` match within a segment (`logs/atxt` yes, `logs/a/btxt` no).
- `test_double_star_slash_that_is_not_left_bounded` — `a**/b` matches `axx/b` but not `ax/x/b`.
- The existing `test_non_segment_double_star_does_not_cross_a_separator` (`a**`, `a**b`) and the segment-`**` positives (`**/cdk.out/`, `logs/**`, `pkg/**/snap.md`) continue to pass.

Each negative case uses a deep path whose ancestors do not independently match, so the assertion pins the separator-crossing behavior rather than being masked by the excluded-subtree rule. All new assertions were verified to fail against the pre-fix source (they discriminate the fix). Full file: 35 passing.

## Manual verification

N/A — unit coverage sufficient. `_translate` is a pure function; the added tests exercise the exact input→output the fix changes, and the pre-existing `**` tests pin that segment-bounded behavior is unchanged.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a glob→regex translator that gives `**` a cross-separator meaning must require the `**` to be a COMPLETE path segment — bounded on BOTH sides (start/`/` on the left AND `/`/end on the right) — before emitting the separator-crossing form; a `**` bounded on only one side must degrade to a within-segment `*`. Guarding one side only (as the first pass here did) leaves the mirror case open. Applies to any gitignore-style matcher.

## Related Issues

no linked issue: found via a source audit of the gitignore-pattern translation; there is no tracked issue for it.
