### PR TITLE
fix(knowledge): reap the LLM pool worker's process tree, not just its pid

### DIFF
--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -15,6 +15,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
 from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort
 from kiro_crew.sandbox import (
@@ -455,6 +456,21 @@ class CCWorker(Worker):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            # Own process group, so the worker's descendants are reachable as a tree.
+            # `claude -p` forks helpers (see spine/agent_runner.py's _terminate_group),
+            # and without this the child lands in the gateway's OWN group -- which is
+            # the one case platform_compat.kill_and_reap deliberately skips its group
+            # kill for, so the reap below would degrade to a pid-scoped kill and
+            # re-parent those helpers to init.
+            #
+            # BOTH args, spelled out explicitly, per the recipe in platform_compat:
+            # on POSIX start_new_session calls setsid (so killpg reaps the group) and
+            # creationflags=0 is a no-op; on Windows start_new_session is silently
+            # ignored and CREATE_NEW_PROCESS_GROUP is what makes the child tree
+            # `taskkill /T`-reapable. Not **unpacked from a dict -- that defeats
+            # mypy's Popen overload resolution on the build fleet.
+            start_new_session=platform_compat.IS_POSIX,
+            creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
         )
         self._event_queue = asyncio.Queue()
         self._reader_task = asyncio.create_task(self._stdout_reader())
@@ -527,8 +543,7 @@ class CCWorker(Worker):
             self._reader_task = None
         if self._proc is not None:
             try:
-                self._proc.kill()
-                await self._proc.wait()
+                await platform_compat.kill_and_reap(self._proc)
             except Exception:
                 logger.debug("CCWorker shutdown error", exc_info=True)
             self._proc = None
@@ -547,8 +562,7 @@ class CCWorker(Worker):
         await self._spawn()
         if old is not None and old is not self._proc:
             try:
-                old.kill()
-                await old.wait()
+                await platform_compat.kill_and_reap(old)
             except Exception:
                 logger.debug("CCWorker: stale process reap failed", exc_info=True)
         self.calls_since_reset = 0

--- a/test/test_llm_pool.py
+++ b/test/test_llm_pool.py
@@ -1293,3 +1293,153 @@ class TestWorkerConversationRecycle:
         client.last_prompt_stats.context_pct = 63.5
         worker._client = client
         assert worker.context_pct() == 63.5
+
+
+class _ReapProbe:
+    """A PIPE-stdio child double that records how it is reaped.
+
+    Mirrors the pin ``test_source_providers`` uses for the same class. A killed
+    child blocked writing into a full pipe -- or a surviving descendant still
+    holding the pipes open -- makes a bare ``await proc.wait()`` hang the caller
+    forever, so the bounded reap must drain via ``communicate()`` and never touch
+    ``wait()``.
+    """
+
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+        self.returncode: "int | None" = None
+        self.kill_calls = 0
+        self.wait_calls = 0
+        self.communicate_calls = 0
+
+    async def communicate(self):
+        self.communicate_calls += 1
+        self.returncode = -9
+        return b"", b""
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        return -9
+
+
+def _patch_tree_kill(monkeypatch, sink):
+    """Fake pid + patched tree kill so no test can reach a real killpg.
+
+    Both the async helper (used by ``kill_and_reap``) and the legacy sync entry
+    point are patched, so the pin stays safe even when run against unmodified
+    code that never calls either.
+    """
+    from kiro_crew import platform_compat
+
+    async def _fake_tree(pid, sig):
+        sink.append((pid, sig))
+        return True
+
+    monkeypatch.setattr(platform_compat, "kill_process_tree_async", _fake_tree)
+    monkeypatch.setattr(
+        platform_compat, "kill_process_tree", lambda *a, **k: sink.append(a)
+    )
+    # The child must not look like it shares this process's group, or
+    # kill_and_reap correctly skips the tree kill.
+    monkeypatch.setattr(platform_compat, "IS_POSIX", True, raising=False)
+    monkeypatch.setattr(
+        platform_compat.os, "getpgid", lambda pid: 999_000 + pid, raising=False
+    )
+
+
+class TestCCWorkerReapsTheProcessTree:
+    """``claude -p`` forks helpers, so a pid-scoped kill re-parents them to init.
+
+    ``spine/agent_runner.py``'s ``_terminate_group`` already records this for the
+    same argv ("agents kept costing money after Stop"), and
+    ``apps/registry.py``'s ``_communicate_with_timeout`` states the rule that a
+    caller MUST spawn with ``start_new_session`` for the group signal to land.
+    These pin both halves: without the spawn flag the child shares the gateway's
+    group and ``kill_and_reap`` deliberately skips its tree kill, so the flag is
+    load-bearing rather than cosmetic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_spawn_requests_its_own_session(self):
+        from kiro_crew import platform_compat
+
+        captured: "dict[str, object]" = {}
+
+        async def _fake_spawn(*argv, **kwargs):
+            captured.update(kwargs)
+            return _ReapProbe()
+
+        worker = CCWorker()
+        worker._claude_bin = "/usr/bin/true"
+        # `**k` is required, not defensive: _spawn reaches wrap_argv through
+        # sandbox.wrap_argv_async, which forwards its sandbox options (always at
+        # least `mode`) into the `_prepare` seam. A positional-only stub raises
+        # TypeError from inside wrap_argv_async instead of exercising the spawn.
+        with patch("kiro_crew.knowledge.llm_pool.wrap_argv", lambda cmd, **k: (cmd, None)), \
+             patch("kiro_crew.knowledge.llm_pool.cgroup_scope_argv", lambda argv: argv), \
+             patch(
+                 "kiro_crew.knowledge.llm_pool.create_subprocess_limited",
+                 _fake_spawn,
+             ):
+            await worker._spawn()
+            worker._reader_task.cancel()
+
+        # Both halves of the platform_compat recipe, asserted the way
+        # test_source_providers does: the POSIX flag is IS_POSIX (not an
+        # unconditional True -- on Windows setsid does not exist and the value is
+        # legitimately False), and the Windows flag is what makes the child tree
+        # `taskkill /T`-reapable there. Asserting membership separately keeps this
+        # load-bearing on Windows too, where `is IS_POSIX` alone would also be
+        # satisfied by the kwarg being absent.
+        assert "start_new_session" in captured and "creationflags" in captured, (
+            "the worker must be spawned with process-group isolation, or its forked "
+            "helpers are unreachable as a tree and get re-parented to init on cleanup"
+        )
+        assert captured["start_new_session"] is platform_compat.IS_POSIX
+        assert captured["creationflags"] == platform_compat.CREATE_NEW_PROCESS_GROUP
+
+    @pytest.mark.asyncio
+    async def test_shutdown_reaps_the_tree_via_communicate_not_wait(self, monkeypatch):
+        tree_kills: "list[tuple]" = []
+        _patch_tree_kill(monkeypatch, tree_kills)
+
+        worker = CCWorker()
+        proc = _ReapProbe()
+        worker._proc = proc
+
+        await worker.shutdown()
+
+        assert tree_kills and tree_kills[0][0] == proc.pid
+        assert proc.communicate_calls == 1
+        assert proc.wait_calls == 0
+        assert worker._proc is None
+
+    @pytest.mark.asyncio
+    async def test_reset_conversation_reaps_the_stale_tree(self, monkeypatch):
+        tree_kills: "list[tuple]" = []
+        _patch_tree_kill(monkeypatch, tree_kills)
+
+        worker = CCWorker()
+        old = _ReapProbe(pid=5150)
+        worker._proc = old
+
+        replacement = _ReapProbe(pid=5151)
+
+        async def _fake_respawn():
+            worker._proc = replacement
+            worker._event_queue = asyncio.Queue()
+
+        monkeypatch.setattr(worker, "_spawn", _fake_respawn)
+
+        await worker.reset_conversation()
+
+        assert tree_kills and tree_kills[0][0] == old.pid, (
+            "the stale worker's whole tree must be reaped on recycle"
+        )
+        assert old.communicate_calls == 1
+        assert old.wait_calls == 0
+        assert replacement.kill_calls == 0
+        assert worker.calls_since_reset == 0


### PR DESCRIPTION
## Problem / Motivation

`knowledge/llm_pool.py`'s `CCWorker` spawns `claude -p` with PIPE stdio and **no**
`start_new_session`, then cleans up with `proc.kill()` followed by an unbounded
`await proc.wait()` — in both `shutdown()` and `reset_conversation()`.

Two failures follow, and the first causes the second:

1. **Leak.** `proc.kill()` signals one pid, so the helpers `claude -p` forks survive and are
   re-parented to init.
2. **Hang.** Those survivors inherited the stdout/stderr pipe write ends, and asyncio's
   `Process.wait()` does not complete until every pipe disconnects — so the unbounded
   `wait()` never returns.

Measured against the real `CCWorker`, with a stand-in `claude` on PATH that forks one child
and then lingers (survival read from `/proc/<pid>/stat`, never from a `kill()` return value):

| arm | cleanup returned? | elapsed | survivors at ppid 1 |
|---|---|---|---|
| `shutdown()` | **no** | 20.1 s (hit a 20 s bound) | **1** |
| `reset_conversation()` | **no** | 20.1 s | **1** |
| this PR | yes | 0.0 s | 0 |

## Why it matters

`shutdown()` runs on pool teardown; `reset_conversation()` runs on every
`calls_since_reset` rollover, i.e. routinely during a large ingestion. Each one currently
leaves a live `claude -p --permission-mode bypassPermissions` subtree with no gateway-side
handle on it — the "kept costing money after Stop" symptom `agent_runner` already recorded for
this same binary — and, because of the pipe-holding survivor, can wedge the calling task
instead of returning.

## What changed (motivation → approach → change)

**Root cause, measured rather than inferred:** `child_pgid == own_pgid == 19046` in both defect
arms. The worker shares the gateway's own process group, which is exactly the case
`platform_compat.kill_and_reap` *deliberately* skips its group kill for:

> A child sharing the caller's own process group (spawned without `start_new_session`) has no
> tree of its own to signal — the group kill is skipped for it and the pid-scoped `kill()`
> below covers it

So **converting the call alone would not have fixed this.** The spawn flag is load-bearing.

**Approach:** use the two mechanisms this repo already has, rather than adding any.
`apps/registry.py:2793` states the rule ("Callers MUST spawn the child with
`start_new_session`"), and `spine/agent_runner.py:653` records the identical argv and symptom
and fixed it with a tree kill. This brings the knowledge pool in line with both.

**Change** (one source file + its test, +164/−4):

- Both spawn args from the recipe in `platform_compat.py:143-153`, passed explicitly rather
  than `**`-unpacked (unpacking defeats mypy's `Popen` overload resolution on the build
  fleet): `start_new_session=platform_compat.IS_POSIX` so setsid runs on POSIX and killpg
  reaps the group, and `creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP` because on
  Windows `start_new_session` is silently ignored and that flag is what makes the child tree
  `taskkill /T`-reapable. `creationflags` is `0` on POSIX, so it is a no-op there.
- Both cleanup paths route through `platform_compat.kill_and_reap` — tree kill, pid fallback,
  bounded pipe-draining `communicate()` reap, cancellation-shielded — the same helper #6003
  introduced and #6005 converted its sites to. This removes the bare unbounded `wait()`.

Considered and rejected: calling `kill_process_tree` directly. `kill_and_reap` is the shared
helper for a PIPE-stdio child and additionally bounds the reap, which is the half that fixes
the hang; open-coding it here would be a third spelling of a rule that already has one.

## Tests

Three pins in `test/test_llm_pool.py`, following #6005's pattern (a probe that counts
`wait()` calls, plus a patched `kill_process_tree_async` and a fake pid so no test can reach a
real `killpg`). **All three fail on unmodified code**, with the fix reverted and the tests
kept:

- `test_spawn_requests_its_own_session` — the spawn must pass `start_new_session=True`.
  Fails as `assert None is True`.
- `test_shutdown_reaps_the_tree_via_communicate_not_wait` — `shutdown()` must reach the
  tree-kill helper for the worker's pid, drain via `communicate()`, and never touch `wait()`.
  Fails as `assert ([])`.
- `test_reset_conversation_reaps_the_stale_tree` — the recycle path must reap the *stale*
  worker's tree and leave the replacement untouched. Fails as `assert ([])`.

`test/test_llm_pool.py`: 91 passed. Targeted gate over `test_llm_pool.py`,
`test_platform_compat_coverage.py`, `test_source_providers.py` and
`test_knowledge_effort_pools.py`: 850 passed, 2 skipped. black / isort / flake8 / mypy
(1113 files) all clean. That is 4 of 1664 test files, so it does not predict the full CI
suite — as the first revision demonstrated.

**Revision 2 — a genuine gap the Windows shard caught.** Revision 1 passed only the POSIX
half, and `Backend Tests (Windows) (2)` went red: `1 failed, 16306 passed`, with the captured
kwargs shown as `{'start_new_session': False, ...}`. Two things were wrong and the log
distinguished them. The assertion was `is True`, which cannot hold on Windows where
`IS_POSIX` is legitimately `False` — now `is platform_compat.IS_POSIX` plus an explicit
membership check, matching `test_source_providers.py:692`, so it stays load-bearing on both
platforms. More importantly the *fix* was incomplete: `platform_compat`'s own recipe asks for
two args, and without `CREATE_NEW_PROCESS_GROUP` the Windows tree is not reliably
`taskkill /T`-reapable. The new pin fails against revision 1, not just against `main`.

## Manual verification

Beyond the unit pins, the real `CCWorker` was driven end to end through both cleanup paths
before and after the change (the table under "Problem / Motivation"). Before: helper pid 19083
moved from `ppid 19081` to `ppid 1` while the call failed to return inside a 20 s bound.
After: every arm returns in 0.0 s with zero survivors and zero processes re-parented to init.

One limitation stated plainly: the host used for that measurement returns `EPERM` for
`unshare(CLONE_NEWUSER)`, so `wrap_argv` returned argv unmodified and the sandbox-launcher
layer was not exercised. On Linux that launcher itself forks (`sandbox.py:2057`,
`sandbox.py:1584`), which puts one *more* process between `proc.pid` and the tool — so the
numbers above are a conservative lower bound, not a best case.

## Screenshots / video

N/A — no user-visible UI change; the diff is process-lifecycle code in the knowledge worker
pool.

## Related Issues

Fixes #6124

Same defect class as #5989 → #6003 → #6005. #6005's body names this mechanism ("or a
surviving descendant holding the pipes — can hang the calling task indefinitely") but its site
enumeration lists only `source_providers.py` and `resolve_once.py`; these two sites were not
enumerated, and they carry the extra defect that the tree is never killed at all. The linked
issue also inventories the other sites the same audit found, for triage as a class.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe this path
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm that this contribution is made under the terms of the project's license and that I
have the right to submit it.
