### PR TITLE
fix(dashboard): enforce the session byte cap on the whole-file save path

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -39,7 +39,21 @@ injected into every component.
 Per-thread JSONL files at `~/.kiro/crew/sessions/{safe_key}.jsonl`. First line is metadata, subsequent lines are messages with `role`, `content`, `ts`, `tools`, `source_thread`, `source_user`. A writer can also supply `cls` (presentation class) and `mid` — persisted as `meta.mid`, the same field shape the dashboard slot save writes, so a dual-write injector's durable copy carries the SAME delivery identity as its in-memory window copy and a bounded slot-detail read reconciles the two as one message instead of re-appending the injection. A row appended without an id carries no `meta` at all (the pre-id shape readers keep an id-less fallback for; existing transcripts are never migrated).
 
 - Append-only for LLM cache efficiency
-- Rotation at 2MB (keeps metadata + last 200 messages, atomic write)
+- Rotation at 2MB (keeps metadata + last 200 messages, atomic write). Two callers:
+  `ConversationLog.append` (uncapped) and the dashboard whole-file save
+  (`_save_slot_to_history`), which passes `_maybe_rotate(max_drop=...)` to cap the
+  drop at the **frozen prefix**. That save rewrites the file as
+  `meta + frozen_prefix + serialize(window)`, so a line dropped from the window
+  region is one the slot still holds in memory: the next save re-emits it,
+  rotation drops it again, and the two churn indefinitely. Capping the drop keeps
+  the window's head as the file's first message line — the only state the
+  frozen-prefix + window model can express (there is no representable state with a
+  hole at the front of the window). The cost is that a session whose whole
+  transcript is still its live window — no memory trim has run, so no prefix
+  exists — stays over the cap until the trim supplies a prefix or an `append`
+  writer rotates it uncapped. Unbounded growth is unaffected: the live window is
+  capped at `_MAX_SLOT_MESSAGES`, so every byte a long session accumulates beyond
+  that lands in the prefix, which is exactly what the save path can reclaim.
 - **Cache-fill staleness guard** — mtime-keyed memos cannot trust "same mtime == same content": housekeeping rewrites (compaction / rotation / metadata edits / `mark_consolidated`) restore the pre-write mtime via `_restore_mtime`, so a fill spanning one would park pre-rewrite data under an mtime the file still has — undetectably, for the life of the process. Two mechanisms close the fill window, by cache: `_meta_cache` and `_recent_cache` publish through a per-key invalidation **generation** (`_invalidate_cache` bumps the counter BEFORE dropping entries; each fill snapshots it before its `stat` and re-checks it around the publish via `_publish_if_current`, discarding the fill if it moved — lock-free on read paths reachable on the event loop, a discarded fill costs one re-read), while `_folded_cache`/`_snippet_cache` serialize the whole stat → read → store under `_file_lock` (`_folded_content`), and `_msg_cache` uses that same double-checked miss-only locking whose unlocked on-loop fallback publishes under the generation plus a cross-process flock-hold witness (`_read_messages`, below). The generation table is process-wide (class-level, keyed by transcript dir + sanitized stem — see `_read_messages` below for why instance scope is not enough), and generations, invalidation, and the pops all cover every cache-key spelling of one session — logical key, sanitized `path.stem`, and the canonical/legacy Slack aliases in both directions (`_cache_key_identities`) — because `list_sessions` keys its fills by stem while most writers invalidate under the logical key. `_meta_cache`, `_folded_cache`, and `_snippet_cache` entries ALSO record the generation they were filled under and a warm hit requires both the mtime and the generation to match, with the store routed through `_publish_if_current`: the fold's `_file_lock` is process-wide and path-keyed, so it orders fills against every in-process writer regardless of instance — but `_invalidate_cache`'s pops reach only the writer's own instance's caches, so an entry already sitting warm in ANOTHER instance survives a preserved-mtime rewrite, and the generation clause on the hit (backed by the process-wide table) is what unhits it. The store-side guard is generation-stamp hygiene — the lock already covers the fill window in-process; unlike `_read_messages`' flock-hold witness, the search memos have no cross-process witness, so a preserved-mtime rewrite from a different PROCESS remains a known residual gap for them.
 - `recent(key)` — last 20 messages for context injection
 - `recent_with_provenance(key)` — entries with source citations
@@ -511,7 +525,11 @@ archived instead of being permanently deleted:
 - **Triggers**: `_rotate()` (>2MB), `rewrite_session()` (compact), and the
   dashboard rewrite path (`_save_slot_to_history` with a snapshot /
   `rewrite=True` / `_pending_rewrite` → `_archive_dropped_lines`). The default
-  frozen-prefix dashboard save drops nothing, so it does not archive.
+  frozen-prefix dashboard save archives nothing of its OWN — its payload is a
+  superset of what is on disk — but it does call `_maybe_rotate` (capped at the
+  frozen prefix, above), so on an over-cap transcript it archives via that path.
+  Reaching the steady state costs at most one such rotation: the drop is capped at
+  lines the slot does not hold, so nothing it re-emits can be dropped again.
 - **Atomic writes**: exclusive-create (`open mode 'x'`) avoids TOCTOU clobber
 - **Retention**: configurable via `session.archive_retention_days` (default 30
   days; `-1` or `null` disables cleanup so the user manages deletion manually).

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2885,7 +2885,69 @@ def _save_slot_to_history(
             # from ``existing_meta`` when present), so the delete-won guard can
             # recognize a file recreated by another writer after a permanent
             # delete on the NEXT save.
+            #
+            # Read before the rotation below, but valid after it either way:
+            # rotation rewrites the meta line to stamp ``rotated_at`` and
+            # preserves every other field, so ``created_at`` — the only field
+            # this identity depends on — survives a rotation unchanged.
             slot._disk_meta_created_at = str(meta_line.get("created_at") or "")
+            # Enforce the session byte cap on THIS path too, against the FROZEN
+            # PREFIX. ``_maybe_rotate`` used to have exactly one caller
+            # (``ConversationLog.append``), so a transcript written only through
+            # this whole-file save was never size-checked while the documented cap
+            # said otherwise. The prefix is also the part that actually grows
+            # without bound: the live window is capped at ``_MAX_SLOT_MESSAGES``,
+            # so every byte a long session accumulates beyond that lands in the
+            # prefix, and the prefix is what this save re-emits verbatim forever.
+            #
+            # ``max_drop`` is the whole reason this call is safe. This save writes
+            # ``meta + frozen_prefix + serialize(window)``, so a line rotation
+            # drops from the WINDOW region is one the slot still holds in
+            # ``slot.messages`` — the next save re-emits it, rotation drops it
+            # again, and the two churn forever. Measured on the unbounded call at
+            # 30 x 100 KB with no frozen prefix: rotation dropped 10 window rows,
+            # and each of the next 5 ordinary saves resurrected and re-dropped the
+            # same 10 (5 rotations, 50 re-archived lines). Capping the drop at the
+            # prefix leaves the window's head as the file's first message line,
+            # which is the only state the frozen-prefix + window model can
+            # express; there is no representable state with a hole at the front of
+            # the window.
+            #
+            # Deliberately NOT closed by trimming ``slot.messages`` instead: this
+            # runs in the flush executor thread (see the snapshot rationale at the
+            # top of this function), where every other window mutation in the
+            # dashboard is loop-only, and it would delete messages out from under
+            # an open tab. The cost of the cap is that a session whose entire
+            # transcript is still its live window stays oversized until the memory
+            # trim gives it a prefix, or until an ``append`` writer rotates it
+            # uncapped. Oversized is recoverable; churn and lost rows are not.
+            #
+            # The ceiling is counted off the prefix bytes actually written, not
+            # ``disk_older``: on a short/truncated file the prefix carries fewer
+            # lines than the counter claims, and ``count("\n")`` is the count that
+            # matches how rotation will re-split the file.
+            #
+            # Called INSIDE ``_locked`` and after the mtime restore, so rotation
+            # cannot race another writer and cannot resurrect an mtime the close
+            # path deliberately rewound.
+            dropped = state.conversation_log._maybe_rotate(
+                path, history_key, max_drop=frozen_prefix.count("\n")
+            )
+            if dropped:
+                # Rotation removed leading messages, which moves the frozen-prefix
+                # boundary this slot is holding. Reconcile it: without this, every
+                # later save rebuilds its payload from ``body[:disk_older]`` — a
+                # floor that no longer exists — RESURRECTING the dropped messages,
+                # which rotation then drops again.
+                #
+                # A plain subtraction, because ``max_drop`` above guarantees
+                # ``dropped`` came entirely from the prefix. ``_disk_window_len``
+                # is deliberately left alone: it is a PREFIX length over the
+                # window ("``messages[:n]`` are on disk"), so there is no value it
+                # could take to describe a window whose head is missing from disk —
+                # which is exactly why rotation is not allowed to create that
+                # state.
+                slot._disk_older_count = max(0, slot._disk_older_count - dropped)
             # Record the post-write mtime in the frozen-prefix cache (even when
             # there is no frozen prefix, ``disk_older == 0``). The cache doubles
             # as the "did another process touch this file since we last wrote
@@ -2898,17 +2960,28 @@ def _save_slot_to_history(
             # the on-disk window region (after the frozen prefix), and because
             # ``disk_older`` is unchanged a bare frozen+window rebuild on the next
             # save would otherwise silently delete them.
-            try:
-                _st = path.stat()
-                slot._frozen_prefix_cache = (
-                    _st.st_mtime,
-                    _st.st_size,
-                    disk_older,
-                    frozen_prefix,
-                    foreign_lines,
-                )
-            except OSError:
+            #
+            # After a rotation the cached tuple would be stale on the two fields
+            # that matter: ``disk_older`` and ``frozen_prefix`` describe the
+            # pre-rotation file. Caching it is worse than caching nothing,
+            # because the next save trusts the cache instead of re-reading and so
+            # re-emits the dropped rows. Drop the cache and let that save pay one
+            # O(file) re-read against the reconciled counts above; rotation is
+            # rare, so this costs nothing on the steady path.
+            if dropped:
                 slot._frozen_prefix_cache = None
+            else:
+                try:
+                    _st = path.stat()
+                    slot._frozen_prefix_cache = (
+                        _st.st_mtime,
+                        _st.st_size,
+                        disk_older,
+                        frozen_prefix,
+                        foreign_lines,
+                    )
+                except OSError:
+                    slot._frozen_prefix_cache = None
             state.conversation_log._invalidate_cache(history_key)
             state.conversation_log.note_tab_id(history_key, tab_id)
             return True

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2664,5 +2664,5 @@ class ConversationLog:
     def _rewrite_session_locked(self, key: str, messages: list[dict]) -> None:
         self._rewrite_coordinator._rewrite_session_locked(key, messages)
 
-    def _maybe_rotate(self, path: Path, key: str) -> None:
-        self._rewrite_coordinator._maybe_rotate(path, key)
+    def _maybe_rotate(self, path: Path, key: str, *, max_drop: int | None = None) -> int:
+        return self._rewrite_coordinator._maybe_rotate(path, key, max_drop=max_drop)

--- a/src/kiro_crew/history_rewrite.py
+++ b/src/kiro_crew/history_rewrite.py
@@ -139,18 +139,45 @@ class HistoryRewriteCoordinator:
         _history_facade()._restore_mtime(path, prev_mtime)
         self._log._invalidate_cache(key)
 
-    def _maybe_rotate(self, path: Path, key: str) -> None:
+    def _maybe_rotate(self, path: Path, key: str, *, max_drop: int | None = None) -> int:
         """Rotate an oversized transcript while its facade lock is held.
 
         ``key`` is the logical spelling used by cache readers.  The path stem is
         lossy, so invalidation must use ``key`` even though archive filenames
         continue to use ``path.stem`` for byte-compatible behavior.
+
+        Returns the number of leading MESSAGE lines dropped, and ``0`` when
+        nothing was rotated. The count is what a whole-file writer needs to stay
+        consistent with the file afterwards: such a writer tracks how many
+        leading on-disk messages form a prefix it never rewrites, and rotation
+        moves that boundary underneath it. Returning ``None`` — which was
+        adequate while ``append`` was the only caller — would force any second
+        caller to re-read the whole file just to learn how far the floor moved.
+
+        *max_drop* caps how many leading message lines rotation may drop
+        (``None`` = uncapped, the ``append`` behaviour). It exists for a caller
+        that does not merely APPEND to the file but REWRITES it from an
+        in-memory copy of the tail. For such a caller a dropped line its copy
+        still holds is not actually gone: the next rewrite re-emits it, rotation
+        drops it again, and the two churn forever — an O(window) steady state
+        turned into O(file) work with unbounded archive growth. Capping the drop
+        at the leading lines the caller does NOT hold keeps the file and that
+        caller's model in agreement. When the retained tail still exceeds the
+        budget at the cap, rotation drops what it may and leaves the file
+        oversized, exactly as it already does for a single unsplittable message
+        larger than the whole budget — an oversized file is recoverable, a line
+        dropped out from under the writer that still holds it is not.
+
+        Archiving the dropped lines is a PRECONDITION of the rewrite, not a
+        best-effort side effect: this file is their only copy until the archive
+        write lands, so a failed archive returns ``0`` with the transcript
+        untouched rather than committing a rewrite that deletes them.
         """
         try:
             if path.stat().st_size <= _facade_session_max_bytes():
-                return
+                return 0
         except OSError:
-            return
+            return 0
 
         # Rotation follows a genuine append.  Keep that append's mtime instead
         # of restamping the session when the retained tail is rewritten.
@@ -159,7 +186,7 @@ class HistoryRewriteCoordinator:
         metadata_line = lines[0] if lines and '"_type"' in lines[0] else ""
         message_lines = lines[1:] if metadata_line else lines[:]
         if not message_lines:
-            return
+            return 0
         metadata_bytes = len(metadata_line.encode("utf-8"))
 
         def kept_bytes(count: int) -> int:
@@ -167,15 +194,23 @@ class HistoryRewriteCoordinator:
                 len(line.encode("utf-8")) for line in message_lines[-count:]
             )
 
+        # The fewest messages rotation is ALLOWED to retain. Uncapped that is 1
+        # (keep at least the newest turn); ``max_drop`` raises the floor so the
+        # lines above it are untouchable. Both the starting point and the shrink
+        # loop respect it, so a cap of 0 makes this a no-op rather than a rewrite
+        # that keeps every line.
+        keep_floor = 1 if max_drop is None else max(1, len(message_lines) - max_drop)
         # First apply the line cap, then shrink the tail until it also fits the
         # byte budget.  This handles sessions made of a few very large rows.
-        keep_count = min(_facade_session_keep_lines(), len(message_lines))
-        while keep_count > 1 and kept_bytes(keep_count) > _facade_session_max_bytes():
+        keep_count = max(min(_facade_session_keep_lines(), len(message_lines)), keep_floor)
+        while keep_count > keep_floor and kept_bytes(keep_count) > _facade_session_max_bytes():
             keep_count -= 1
         if keep_count >= len(message_lines):
-            # A single unsplittable message may exceed the complete budget.
-            # Rewriting would drop nothing, so leave the transcript intact.
-            return
+            # Keeping every message would drop nothing — either a single
+            # unsplittable message exceeds the complete budget, or ``max_drop``
+            # left nothing droppable. Rewriting would drop nothing, so leave the
+            # transcript intact.
+            return 0
 
         kept = message_lines[-keep_count:]
         dropped = message_lines[:-keep_count]
@@ -187,11 +222,24 @@ class HistoryRewriteCoordinator:
                 base=self._log._dir,
             )
         except Exception:
+            # Fail CLOSED. The rewrite below is what removes these lines, and
+            # until the archive write lands this transcript is their only copy,
+            # so archiving best-effort and rewriting anyway turns a recoverable
+            # unwritable archive directory into permanent transcript loss. Same
+            # trade as ``max_drop`` above, for the same reason: an oversized file
+            # is recoverable, a dropped row is not.
+            #
+            # Reported as 0 dropped rather than raised, because rotation is
+            # housekeeping that runs after somebody else's write and a full
+            # archive directory must not become a failed append. The file is
+            # untouched here, so a caller's prefix bookkeeping and the read cache
+            # both stay accurate with no invalidation.
             _HISTORY_LOGGER.warning(
-                "Failed to archive rotated lines for %s",
+                "Declining to rotate %s: archiving the dropped lines failed",
                 path.stem,
                 exc_info=True,
             )
+            return 0
 
         # Retained row offsets have changed.  Reset consolidation progress and
         # advance the content identity so any in-flight consolidation or derived
@@ -217,6 +265,7 @@ class HistoryRewriteCoordinator:
             len(lines),
             len(kept) + (1 if metadata_line else 0),
         )
+        return len(dropped)
 
 
 __all__ = ["HistoryRewriteCoordinator"]

--- a/test/test_dashboard_save_enforces_session_cap.py
+++ b/test/test_dashboard_save_enforces_session_cap.py
@@ -1,0 +1,421 @@
+"""The dashboard whole-file save must honour the session byte cap.
+
+``_SESSION_MAX_BYTES`` was enforced in exactly one place, ``ConversationLog.append``,
+which calls ``_maybe_rotate``. ``_save_slot_to_history`` rewrites the whole file
+through ``atomic_write`` and never reached that check, so a transcript written only
+by the dashboard grew without bound while ``docs/system-specs/modules/history.md``
+documents the cap unqualified.
+
+The enforcement is deliberately scoped to the FROZEN PREFIX, and the scope is the
+substance of these tests rather than a caveat on them. The save writes
+``meta + frozen_prefix + serialize(window)``, so a line rotation drops from the
+window region is one the slot still holds in ``slot.messages``: the next save
+re-emits it, rotation drops it again, and the pair churns forever. The prefix is
+also where unbounded growth actually lives — the live window is capped at
+``_MAX_SLOT_MESSAGES``, so every byte a long session accumulates beyond that is
+prefix, re-emitted verbatim by every later save.
+
+So there are two contracts to hold, and a test for each:
+
+* rotation DOES reclaim the prefix (``..._rotates_the_frozen_prefix...``), and
+* rotation DECLINES rather than dropping a row the window still holds
+  (``..._declines_to_drop_rows_the_live_window_holds``) — the load-bearing one,
+  because the failure it guards is invisible in a single save and only shows up
+  as repeated work across later ones.
+"""
+
+from chat_test_helpers import _make_state
+
+from kiro_crew.history import _SESSION_MAX_BYTES
+
+
+def _transcript(state, slot):
+    from kiro_crew.dashboard.chat_persistence import slot_history_key
+
+    return state.conversation_log._path(slot_history_key(slot))
+
+
+def _disk_message_rows(path):
+    """On-disk MESSAGE lines (metadata line excluded)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return lines[1:] if lines and '"_type"' in lines[0] else lines
+
+
+def _count_rotations(monkeypatch):
+    """Instrument rotation + archiving. Returns ``(rotations, archived)`` lists.
+
+    ``_maybe_rotate`` takes a keyword-only ``max_drop``; the wrapper forwards
+    ``**kw`` rather than naming it, so this keeps working if the signature grows.
+    """
+    import kiro_crew.history as history_mod
+    from kiro_crew.history import ConversationLog
+
+    rotations: list[int] = []
+    archived: list[int] = []
+    real_rotate = ConversationLog._maybe_rotate
+    real_archive = history_mod._archive_lines
+
+    def _counting_rotate(self, rot_path, key, **kw):
+        result = real_rotate(self, rot_path, key, **kw)
+        rotations.append(result or 0)
+        return result
+
+    def _counting_archive(stem, lines, reason=None, base=None):
+        archived.append(len(lines))
+        return real_archive(stem, lines, reason=reason, base=base)
+
+    monkeypatch.setattr(ConversationLog, "_maybe_rotate", _counting_rotate)
+    monkeypatch.setattr(history_mod, "_archive_lines", _counting_archive)
+    return rotations, archived
+
+
+def _fold_window_into_prefix(slot, fold):
+    """Emulate the memory trim that creates a frozen prefix, as state.py does it.
+
+    ``_disk_older_count`` only grows when memory trimming folds persisted window
+    messages into it, at ``_MAX_SLOT_MESSAGES`` (10,000) messages — which the
+    few-large-messages shape that triggers a byte-cap rotation never reaches. So a
+    test that needs a prefix has to build one, byte for byte the way the trim does.
+    """
+    del slot.messages[:fold]
+    slot._resumed_count = max(0, slot._resumed_count - fold)
+    persisted_trim = min(fold, slot._disk_window_len)
+    slot._disk_older_count += persisted_trim
+    slot._disk_window_len = max(0, slot._disk_window_len - fold)
+
+
+def test_dashboard_save_rotates_the_frozen_prefix_down_to_the_byte_cap(tmp_path, monkeypatch):
+    """A save whose oversize lives in the frozen prefix must rotate it away.
+
+    This is the enforcement the save path was missing: on unfixed code
+    ``_maybe_rotate`` had a single caller (``append``), so this file crossed the
+    cap and stayed there with ``rotated_at`` absent from the metadata line -- i.e.
+    rotation was never consulted, rather than consulted and declined.
+
+    The prefix is also the only part that can be reclaimed safely, so the
+    reconciled counter is asserted alongside the size: rotation moved the
+    frozen-prefix boundary, and a save that shrinks the file without lowering
+    ``_disk_older_count`` has simply deferred the corruption to the next save.
+    """
+    from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("capsession")
+    path = _transcript(state, slot)
+
+    # Stay UNDER the cap so this first save cannot rotate; the prefix has to exist
+    # before rotation, or there is nothing for rotation to reclaim.
+    body = "z" * 100_000
+    for i in range(15):
+        slot.append("user" if i % 2 == 0 else "assistant", f"pre{i}:{body}", "msg")
+    slot.drain()
+    _save_slot_to_history(state, slot, force=True)
+    assert path.stat().st_size <= _SESSION_MAX_BYTES, "setup must not rotate yet"
+
+    _fold_window_into_prefix(slot, 10)
+    older_before = slot._disk_older_count
+    assert older_before > 0, "the frozen prefix is the precondition"
+
+    # Now cross the cap. The oversize is in the prefix, so rotation can clear it.
+    for i in range(15):
+        slot.append("user" if i % 2 == 0 else "assistant", f"post{i}:{body}", "msg")
+    slot.drain()
+    _save_slot_to_history(state, slot, force=True)
+
+    size = path.stat().st_size
+    assert size <= _SESSION_MAX_BYTES, (
+        f"dashboard save left {size:,} bytes on disk, over the {_SESSION_MAX_BYTES:,} "
+        "cap, with the oversize sitting in the reclaimable frozen prefix"
+    )
+    first_line = path.read_text(encoding="utf-8").splitlines()[0]
+    assert "rotated_at" in first_line, (
+        "the file fits the cap but carries no rotation stamp, so it was never "
+        "rotated -- assert on the mechanism, not just the size"
+    )
+    assert slot._disk_older_count < older_before, (
+        f"rotation shrank the file but left _disk_older_count at {older_before}; "
+        "the next save would rebuild its payload from a prefix that is no longer "
+        "on disk"
+    )
+
+
+def test_dashboard_save_declines_to_drop_rows_the_live_window_holds(tmp_path, monkeypatch):
+    """30 large messages with NO frozen prefix: nothing is safely droppable.
+
+    This is the natural shape for a byte-cap rotation, not an edge case: a
+    frozen prefix only appears once memory trimming folds window rows into it at
+    ``_MAX_SLOT_MESSAGES`` (10,000), and a session of a few large messages blows
+    the 2 MB budget thousands of messages earlier. So on this path
+    ``_disk_older_count`` is 0 and EVERY line rotation would drop is a line
+    ``slot.messages`` still holds.
+
+    Measured on unfixed code (uncapped ``_maybe_rotate``): the rotating save
+    dropped 10 window rows from disk while all 30 stayed in memory, and each of
+    the next 5 ordinary saves resurrected and re-dropped the same 10 --
+    ``rotations=[10, 10, 10, 10, 10]``, 50 re-archived lines, an O(window) steady
+    state turned into O(file) with unbounded archive growth.
+
+    Asserted as data preservation rather than as a size bound, because the size
+    bound is what unfixed code satisfies. The invariant is that the file agrees
+    with the window the slot holds: all 30 rows are on disk, and no later save
+    has anything left to rotate. Declining costs an oversized file until the
+    memory trim supplies a prefix or an ``append`` writer rotates it uncapped;
+    oversized is recoverable, and a row dropped from under its holder is not.
+    """
+    from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("churnsession")
+    path = _transcript(state, slot)
+
+    body = "z" * 100_000
+    for i in range(30):
+        slot.append("user" if i % 2 == 0 else "assistant", f"{i}:{body}", "msg")
+    slot.drain()
+    _save_slot_to_history(state, slot, force=True)
+
+    assert slot._disk_older_count == 0, "this shape must have no frozen prefix"
+    assert len(_disk_message_rows(path)) == 30, (
+        f"rotation dropped {30 - len(_disk_message_rows(path))} row(s) that "
+        "slot.messages still holds; the next save will re-emit them and rotation "
+        "will drop them again"
+    )
+    assert "rotated_at" not in path.read_text(encoding="utf-8").splitlines()[0], (
+        "the transcript carries a rotation stamp, so rotation ran on a file whose "
+        "every line is live-window content -- it must decline instead"
+    )
+
+    # From here on, ordinary saves must be steady: nothing left to rotate, and
+    # nothing re-archived. This is the assertion that fails on unfixed code.
+    rotations, archived = _count_rotations(monkeypatch)
+    for n in range(5):
+        slot.append("user", f"tick{n}", "msg")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+    assert rotations == [0, 0, 0, 0, 0], (
+        f"post-save rotations {rotations}: rotation is dropping live-window rows, "
+        "so each save resurrects them from memory and rotation drops them again"
+    )
+    assert sum(archived) == 0, (
+        f"post-save archiving {archived} ({sum(archived)} line(s)): the same rows "
+        "are being archived on every save -- unbounded archive growth"
+    )
+    rows = _disk_message_rows(path)
+    assert len(rows) == 35, (
+        f"{len(rows)} row(s) on disk after 30 + 5 messages; the transcript no "
+        "longer agrees with the window the slot holds"
+    )
+
+
+def test_saves_after_a_rotation_settle_instead_of_re_rotating(tmp_path, monkeypatch):
+    """A rotation that DID reclaim prefix must not make every later save re-rotate.
+
+    Guards the regression that enforcing the cap introduces. Rotation removes
+    leading messages, which moves the frozen-prefix boundary the slot is holding.
+    If that boundary is not reconciled, each later save rebuilds the payload from
+    a prefix that is no longer on disk, RESURRECTING the dropped messages, and
+    rotation drops them again.
+
+    The failure is invisible in the file: measured over 5 ordinary post-rotation
+    saves, reconciled and unreconciled runs leave byte-identical transcripts with
+    no duplicated rows, because rotation re-trims what the stale prefix
+    resurrected. What differs is that the unreconciled run rotates on all 5 saves
+    and re-archives the same lines each time -- unbounded archive growth and
+    O(file) work on a path whose steady state is meant to be O(window). So this
+    asserts on rotation and archive activity, not on content; an earlier version
+    asserted "no duplicate rows" and passed against the unreconciled code while
+    appearing to guard it.
+    """
+    from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("dupsession")
+    path = _transcript(state, slot)
+
+    body = "z" * 100_000
+    for i in range(15):
+        slot.append("user" if i % 2 == 0 else "assistant", f"pre{i}:{body}", "msg")
+    slot.drain()
+    _save_slot_to_history(state, slot, force=True)
+    assert path.stat().st_size <= _SESSION_MAX_BYTES, "setup must not rotate yet"
+
+    _fold_window_into_prefix(slot, 10)
+    assert slot._disk_older_count > 0, "the frozen prefix is the precondition"
+
+    for i in range(15):
+        slot.append("user" if i % 2 == 0 else "assistant", f"post{i}:{body}", "msg")
+    slot.drain()
+    _save_slot_to_history(state, slot, force=True)
+    assert path.stat().st_size <= _SESSION_MAX_BYTES, "the rotating save must fit the cap"
+
+    rotations, archived = _count_rotations(monkeypatch)
+    for n in range(5):
+        slot.append("user", f"tick{n}", "msg")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+    assert rotations == [0, 0, 0, 0, 0], (
+        f"post-rotation saves re-rotated {rotations}; the frozen-prefix boundary "
+        "was not reconciled, so each save resurrects the dropped messages and "
+        "rotation drops them again"
+    )
+    assert sum(archived) == 0, (
+        f"post-rotation saves re-archived {sum(archived)} line(s) ({archived}); "
+        "the same dropped messages are being archived repeatedly"
+    )
+    assert (
+        path.stat().st_size <= _SESSION_MAX_BYTES
+    ), "the follow-up saves must also respect the cap"
+
+
+def test_maybe_rotate_reports_how_many_lines_it_dropped(tmp_path):
+    """``_maybe_rotate`` returns the dropped count, and 0 when it does nothing.
+
+    The count is the contract the dashboard save relies on to reconcile its
+    prefix boundary without re-reading the file. A ``None`` return -- what this
+    had while ``append`` was the only caller -- cannot express "nothing moved".
+    """
+    from kiro_crew.history import ConversationLog
+
+    log = ConversationLog(tmp_path / "logs")
+    key = "dashboard:rotate-return"
+
+    log.append(key, "user", "small")
+    assert (
+        log._maybe_rotate(log._path(key), key) == 0
+    ), "an under-cap file must report zero dropped lines, not None"
+
+    body = "z" * 100_000
+    for i in range(30):
+        log.append(key, "user", f"{i}:{body}")
+    # ``append`` already rotates, so the file is at or under the cap here; the
+    # return value is exercised on the path above and by the dashboard tests.
+    assert log._path(key).stat().st_size <= _SESSION_MAX_BYTES
+
+
+def test_maybe_rotate_never_drops_more_than_max_drop(tmp_path):
+    """``max_drop`` is a hard ceiling, and ``0`` makes rotation a no-op.
+
+    The dashboard save's safety rests entirely on this bound, so it is asserted
+    directly rather than only through the save path. The ``0`` case matters most:
+    the shrink loop starts from ``min(_SESSION_KEEP_LINES, len(msg_lines))``, so
+    without raising the loop's floor a cap of 0 would still rewrite the file down
+    to the line cap -- dropping every line it was forbidden to touch.
+    """
+    from kiro_crew.history import ConversationLog
+
+    log = ConversationLog(tmp_path / "logs")
+    body = "z" * 100_000
+
+    def _oversized(key):
+        """Write an oversized transcript directly.
+
+        ``append`` rotates as it goes, so it cannot leave an oversized file
+        behind to rotate; the fixture has to be built under the cap and then
+        overwritten.
+        """
+        log.append(key, "user", "seed")
+        path = log._path(key)
+        meta = path.read_text(encoding="utf-8").splitlines(keepends=True)[0]
+        rows = [f'{{"role": "user", "content": "{i}:{body}"}}\n' for i in range(30)]
+        path.write_text(meta + "".join(rows), encoding="utf-8")
+        assert path.stat().st_size > _SESSION_MAX_BYTES, "the fixture must be oversized"
+        return path
+
+    # ``max_drop=0``: oversized, but nothing may be dropped.
+    key0 = "dashboard:maxdrop-zero"
+    path0 = _oversized(key0)
+    assert log._maybe_rotate(path0, key0, max_drop=0) == 0, "max_drop=0 must drop nothing"
+    assert len(_disk_message_rows(path0)) == 30, "max_drop=0 must not rewrite the file"
+
+    # A positive cap is honoured exactly: uncapped rotation on this same fixture
+    # would drop far more than 3 lines to reach the byte budget.
+    key3 = "dashboard:maxdrop-three"
+    path3 = _oversized(key3)
+    dropped = log._maybe_rotate(path3, key3, max_drop=3)
+    assert dropped == 3, f"max_drop=3 allowed {dropped} line(s) to be dropped"
+    assert len(_disk_message_rows(path3)) == 27, "exactly the capped number must be gone"
+    assert (
+        log._maybe_rotate(path3, key3, max_drop=0) == 0
+    ), "a still-oversized file must stay put once the cap is exhausted"
+
+    # Uncapped rotation on the identical fixture is the control: it drops far
+    # more, which is what makes the cap above a real constraint rather than a
+    # restatement of what rotation would have done anyway.
+    keyu = "dashboard:maxdrop-none"
+    pathu = _oversized(keyu)
+    assert log._maybe_rotate(pathu, keyu) > 3, (
+        "uncapped rotation dropped <= 3 lines on this fixture, so the capped "
+        "assertions above prove nothing"
+    )
+
+
+def test_maybe_rotate_declines_to_rewrite_when_archiving_fails(tmp_path, monkeypatch):
+    """A failed archive must abort the rewrite instead of deleting what it lost.
+
+    Rotation's own rewrite is what removes the dropped lines, and until the
+    archive write lands this transcript is their only copy. So archiving
+    best-effort and rewriting anyway converts a recoverable "archive directory is
+    unwritable" into permanent transcript loss. The dashboard save makes it
+    reachable for the FROZEN PREFIX specifically -- the region ``slot.messages``
+    does not hold, so no later save can re-emit what rotation deleted.
+
+    Declining leaves the file oversized, which is the trade ``max_drop`` already
+    makes on this path: oversized is recoverable, a dropped row is not.
+    """
+    import kiro_crew.history as history_mod
+    from kiro_crew.history import ConversationLog
+
+    log = ConversationLog(tmp_path / "logs")
+    real_archive = history_mod._archive_lines
+    body = "z" * 100_000
+
+    def _oversized(key):
+        """Write an oversized transcript directly.
+
+        ``append`` rotates as it goes, so it cannot leave an oversized file
+        behind; the fixture has to be built under the cap and then overwritten.
+        """
+        log.append(key, "user", "seed")
+        path = log._path(key)
+        meta = path.read_text(encoding="utf-8").splitlines(keepends=True)[0]
+        rows = [f'{{"role": "user", "content": "{i}:{body}"}}\n' for i in range(30)]
+        path.write_text(meta + "".join(rows), encoding="utf-8")
+        assert path.stat().st_size > _SESSION_MAX_BYTES, "the fixture must be oversized"
+        return path
+
+    key = "dashboard:archive-raises"
+    path = _oversized(key)
+    before = path.read_text(encoding="utf-8")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(history_mod, "_archive_lines", _boom)
+
+    assert log._maybe_rotate(path, key) == 0, (
+        "rotation reported dropped lines after archiving raised, so it committed "
+        "the rewrite and the only copy of those lines is gone"
+    )
+    assert path.read_text(encoding="utf-8") == before, (
+        "the transcript was rewritten even though archiving raised; the dropped "
+        "lines existed nowhere else"
+    )
+    assert "rotated_at" not in path.read_text(encoding="utf-8").splitlines()[0], (
+        "the file carries a rotation stamp, so rotation committed despite the " "failed archive"
+    )
+
+    # Control on an identical fixture with archiving healthy: this one MUST
+    # rotate. Without it the assertions above would also pass on a file rotation
+    # simply had nothing to do with.
+    monkeypatch.setattr(history_mod, "_archive_lines", real_archive)
+    key_ok = "dashboard:archive-succeeds"
+    path_ok = _oversized(key_ok)
+    assert log._maybe_rotate(path_ok, key_ok) > 0, (
+        "rotation declined on the healthy-archive fixture too, so the decline "
+        "above is not attributable to the archive failure"
+    )


### PR DESCRIPTION
## Problem / Motivation

`_SESSION_MAX_BYTES` (2 MB) was enforced in exactly one place — `ConversationLog.append`, which calls `_maybe_rotate`. The dashboard persists a slot by rewriting the whole transcript through `atomic_write` in `_save_slot_to_history`, which never reached that check, so a transcript written only by the dashboard grew without bound.

Measured before this change, same workload through both writers:

```
_SESSION_MAX_BYTES = 2097152

append   : 2,001,763 bytes   rotated_at set,     under cap
dashboard: 3,005,449 bytes   rotated_at absent,  OVER cap
dashboard: 6,010,744 bytes   after one more save = 2.87x the cap
```

`rotated_at` was never set, so rotation was not consulted and declined — it was never consulted.

## Why it matters

`docs/system-specs/modules/history.md` stated the cap unqualified, so anything relying on a bounded session file was relying on a guarantee the dashboard path did not provide. Dashboard sessions are the common case, and the file is read back on resume and by session search, so an unbounded transcript is unbounded read cost on those paths as well as unbounded disk.

`_MAX_SLOT_MESSAGES` in `dashboard/state.py` does not cover this: it bounds the in-memory window, and trimmed rows become frozen-prefix bytes on disk. That is also where the growth lives — every byte a long session accumulates past the window lands in the prefix, and the dashboard save re-emits that prefix verbatim forever.

## What changed (motivation → approach → change)

Symptom: a dashboard-written transcript exceeds a documented cap. Root cause: the cap's only enforcement point is on a writer this path does not use. So the change routes the existing enforcement onto the missing writer rather than adding a second size mechanism — and bounds what that writer is allowed to reclaim, because the two writers do not have the same relationship to the file.

**Where the code lives.** Rebased onto the upstream history split (#6920, `history.py` 7612 → 2668 lines): `_maybe_rotate`'s implementation is in `src/kiro_crew/history_rewrite.py`, and `history.py` keeps a two-line facade delegation, widened to forward `max_drop` and return the count. `append`'s call site is unchanged and still uncapped.

**`_maybe_rotate(path, key, *, max_drop: int | None = None) -> int`.**

- It now returns the number of leading message lines it dropped, and `0` when it does nothing. It returned `None` while `append` was its only caller; a second caller needs the count to stay consistent with the file, and existing callers that discard the return are unaffected.
- `max_drop` caps how many leading message lines rotation may drop. `None` = uncapped, i.e. exactly the old `append` behaviour.

**`max_drop` is the central mechanism, and it is why calling rotation from this path is safe at all.** The dashboard save writes `meta + frozen_prefix + serialize(window)`. A line rotation drops from the *window* region is one the slot still holds in `slot.messages`: the next save re-emits it from memory, rotation drops it again, and the two churn indefinitely. Measured on the uncapped call at 30 × 100 KB with no frozen prefix — the natural shape, since a prefix only appears once memory trimming folds window rows in at `_MAX_SLOT_MESSAGES` (10,000) and a few large messages blow the 2 MB budget thousands of messages earlier — rotation dropped 10 window rows while all 30 stayed in memory, and each of the next 5 saves resurrected and re-dropped the same 10: 5 rotations, 50 re-archived lines, an O(window) steady state turned into O(file) with unbounded archive growth.

So the save passes `max_drop=frozen_prefix.count("\n")` — the prefix bytes actually written, not `_disk_older_count`, because on a short or truncated file the prefix carries fewer lines than the counter claims. That keeps the window's head as the file's first message line, which is the only state the frozen-prefix + window model can express: there is no representable state with a hole at the front of the window.

**Honest cost, stated rather than hidden.** A session whose entire transcript is still its live window has no frozen prefix, so `max_drop` is `0` and this path **declines to rotate** — that file stays over the cap until the memory trim supplies a prefix or an `append` writer rotates it uncapped. **This PR bounds growth — the frozen prefix, where a long session's bytes actually go — not every file at every instant.** Unbounded growth is closed; instantaneous compliance is not claimed. An oversized file is recoverable; a row dropped from under the writer that still holds it is not. Trimming `slot.messages` instead was rejected: this runs in the flush executor thread, where every other window mutation in the dashboard is loop-only, and it would delete messages out from under an open tab.

**Archiving now fails closed.** The rewrite is what removes the dropped lines, and until the archive write lands this transcript is their only copy. A failed archive therefore returns `0` with the transcript untouched instead of committing a rewrite that deletes them — previously it logged a warning and rewrote anyway, turning a recoverable unwritable archive directory into permanent transcript loss. Reported as `0` dropped rather than raised, because rotation is housekeeping that runs after somebody else's write and a full archive directory must not become a failed append.

**Reconciliation on the caller side.** When `dropped` is non-zero, the save subtracts it from `slot._disk_older_count` and drops `slot._frozen_prefix_cache`. Without the first, every later save rebuilds its payload from `body[:disk_older]` — a floor no longer on disk — resurrecting the dropped messages so rotation drops them again. A plain subtraction is correct precisely because `max_drop` guarantees `dropped` came entirely from the prefix. `_disk_window_len` is **deliberately not reconciled**: it is a prefix length over the window (`messages[:n]` are on disk), so no value could describe a window whose head is missing from disk — which is exactly why rotation is not allowed to create that state. The cache is dropped rather than rewritten because after a rotation its `disk_older` and `frozen_prefix` fields describe the pre-rotation file, and a stale prefix is worse than no cache: the next save would trust it instead of re-reading. Rotation is rare, so the one O(file) re-read costs nothing on the steady path.

Called inside the existing `_locked` block and after the mtime restore, so rotation cannot race another writer and cannot resurrect an mtime the close path deliberately rewound.

## Tests

`test/test_dashboard_save_enforces_session_cap.py`, **six** tests, each verified to fail without the corresponding part of the change:

| Test | Locks in | Fails without the fix at |
|---|---|---|
| `test_dashboard_save_rotates_the_frozen_prefix_down_to_the_byte_cap` | the save reclaims frozen-prefix bytes and stamps `rotated_at` | no rotation at all — the cap was never consulted on this writer |
| `test_dashboard_save_declines_to_drop_rows_the_live_window_holds` | with no frozen prefix, rotation **declines**; all 30 rows stay on disk, no `rotated_at` stamp, later saves steady | `"rotation dropped 10 row(s) that slot.messages still holds"`, then `rotations=[10, 10, 10, 10, 10]` with 50 re-archived lines |
| `test_saves_after_a_rotation_settle_instead_of_re_rotating` | a rotation that *did* reclaim prefix does not make every later save re-rotate | rotations `[10, 10, 10, 10, 10]` against rotation-without-reconciliation |
| `test_maybe_rotate_reports_how_many_lines_it_dropped` | the `0`-not-`None` return contract | `assert None == 0` |
| `test_maybe_rotate_never_drops_more_than_max_drop` | the ceiling itself, including `max_drop=0` as a no-op | `TypeError: unexpected keyword argument 'max_drop'` |
| `test_maybe_rotate_declines_to_rewrite_when_archiving_fails` | fail-closed: a raising archive leaves the transcript byte-identical and returns `0` | the rewrite commits and the dropped lines are gone with no copy anywhere |

**The second test is the one to read.** It asserts data preservation, **not** a size bound, because the size bound is what *unfixed* code satisfies here: uncapped rotation happily pulls the file under 2 MB by deleting rows the open tab still holds. The invariant that distinguishes fixed from unfixed is that the file agrees with the window — so this test asserts the file stays oversized and intact. Anyone reading the earlier revision of this description will find it claimed the opposite (that the 3 MB file ends under the cap); that claim was wrong about what ships, and this table now matches the assertions.

The third test constructs its precondition deliberately, which is worth flagging for review: `_disk_older_count` only grows when memory trimming folds persisted window messages into it at `_MAX_SLOT_MESSAGES` (10,000), which the few-large-messages shape that triggers a byte-cap rotation never reaches. So it emulates that fold exactly as `state.py` performs it. An earlier version omitted the fold, had no frozen prefix, and therefore passed against the unreconciled code while appearing to guard it — caught by mutating the fix rather than by observing the pass.

Also run: full regression sweep, **3092 passed, 0 failed**.

## Manual verification

N/A — the behaviour is a file size, a row count, and an archive/rotation count, all asserted directly by the automated tests above.

## Screenshots / video

N/A — no user-visible surface changes. The diff touches `history.py`, `history_rewrite.py`, `dashboard/chat_persistence.py`, and `docs/system-specs/modules/history.md`; the observable effects are a file size and a rotation/archive count, both asserted directly by the tests above.

## Related Issues

Fixes #6128

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/modules/history.md` now names which writers enforce the cap and states the frozen-prefix bound
- [x] No secrets, credentials, or internal references in the diff

On docs: `docs/system-specs/modules/history.md` is updated in this diff so the cap is no longer stated unqualified. One adjacent doc defect is left alone to keep the diff to the behaviour — `history.py`'s module docstring says the session cap is 512 KB while the constant is 2 MB. Happy to fold that in if you would rather they ship together.

## Contribution License Agreement

<!-- PLACEHOLDER per the repo template: the exact CLA wording is to be supplied by OSPO.
     Not inventing text here. Happy to add the standard wording once it lands in the template. -->
