### PR TITLE
fix(chat): surface a leaked tool call instead of landing it silently

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -114,6 +114,30 @@ send time.
   pending synthesis, and the tag is merge-breaking so a nudge is never folded
   into a `[N queued messages merged]` user turn. At `_prompt_depth > 0` the ladder is disabled entirely (terminal
   notice on the first empty) to prevent nested-turn re-queue loops.
+- **Leaked tool-call notice** (dashboard chat runner, depth-0 turns only,
+  issue #6112): a turn that ends normally with an invoke block emitted as
+  TEXT and zero tool calls executed — the model wrote its invocation into the
+  prose channel instead of dispatching it (observed with deferred MCP tools
+  whose schema is not yet bound, and with large nested arguments) — surfaces
+  a visible notice card and is marked un-landed (no success recording, no
+  budget reset, no consolidation), so an unattended monitor/autonudge cycle
+  that leaked never lands silently. Detection is machine-shaped
+  (`chat_utils.has_leaked_tool_call`): an unquoted invoke open tag plus a
+  parameter or close tag, with fenced code blocks and inline code spans
+  stripped first so a pasted transcript or explained example never matches;
+  the gate (`should_notice_leaked_tool_call`) is claimed ahead of the
+  promise-only guard and excludes stage-execution turns (the orchestrator's
+  stage loop reads the turn result for stage accounting). Deliberately **notice-only** — no continuation is
+  queued, because an injected "re-issue that call" would carry runtime
+  authority into sessions where the call auto-approves (slot trust, global
+  yolo, or a static agent tool allowlist, the last invisible at the runner
+  layer, so no fail-closed downgrade condition exists) and the leaked block
+  may be untrusted external content the model merely reproduced. A loop loses
+  one cycle, visibly, and retries on its own schedule. Scope limit: the
+  notice/un-landing applies only to ZERO-tool-call turns — a mixed turn that
+  executed tools and then leaked its final dispatch as text lands normally
+  (un-landing a turn whose earlier calls had real side effects would
+  misdescribe it) and is logged at WARNING as a diagnostic instead.
 - **Context compaction**: at ≥ configured threshold (`session.autocompact_pct`, default 70%, valid 5–90), compacts **in place** on both
   backends: kiro-cli via a `/compact` **prompt** (`session/prompt` +
   `_kiro.dev/compaction/status` watch — never the string form of

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -255,11 +255,13 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     SUBAGENT_COMPLETION_KIND,
     SYNTHETIC_RECOVERY_KIND,
     RecoveryPayload,
+    has_leaked_tool_call,
     is_promise_only_terminal,
     is_synthetic_payload_item,
     is_synthetic_recovery_item,
     mint_options_token,
     payload_for_replay,
+    should_notice_leaked_tool_call,
     should_recover_promise_only,
 )
 
@@ -4706,6 +4708,11 @@ async def _run_chat(
     # continuation (see the promise-only guard near turn completion). Like
     # _retrying_empty it suppresses success-recording for this non-landing turn.
     _recovering_promise = False
+    # Set when the turn ended with a tool-call block leaked into its text and
+    # the notice was surfaced (#6112). Same un-landed semantics as
+    # _recovering_promise: the turn announced work it never did, so it must not
+    # be recorded as a success or reset the retry budgets.
+    _noticed_leak = False
     # Whether THIS turn consumed the one-shot post-compaction re-injection flag.
     # Bound at turn scope, not at the consume site: the consume lives inside the
     # context-builder leg, and the probe/base legs skip it entirely — reading an
@@ -8009,6 +8016,67 @@ async def _run_chat(
                 slot._stage_titles, slot._plan_goal, slot._stage_descriptions = (
                     _extract_and_redact_plan_metadata(_orch_plan_buf)
                 )
+        # Leaked tool-call notice (#6112): the turn ended NORMALLY with an
+        # invoke block emitted as TEXT and zero tool calls — the model wrote
+        # the invocation into the prose channel instead of executing it, so
+        # nothing ran and, in a monitor/autonudge loop, the session silently
+        # stalls. Surface a visible notice and mark the turn un-landed.
+        # NOTICE-ONLY by design — no continuation is queued, because an
+        # injected "re-issue that call" carries runtime authority into
+        # sessions where the call auto-approves (slot trust, yolo, or a static
+        # agent tool allowlist — the last invisible at this layer, so no
+        # fail-closed downgrade condition exists), and the leaked block may be
+        # untrusted external content the model merely reproduced. Rationale in
+        # full: should_notice_leaked_tool_call's docstring. Checked BEFORE the
+        # promise-only guard: a leaked block is machine syntax, not a promise
+        # sentence, and the more specific detector must own the turn.
+        if not _armed_final and should_notice_leaked_tool_call(
+            stop_reason=_stop_reason,
+            end_turn_reason=STOP_REASON_END_TURN,
+            final_segment_text=assistant_text,
+            prompt_depth=_prompt_depth,
+            is_cancelled=(_stop_reason == STOP_REASON_CANCELLED),
+            refusal_reasons=_refusal_reasons,
+            turn_tool_calls=_turn_tool_calls,
+            # A stage-execution turn must not be un-landed from here: the
+            # orchestrator's stage loop reads this turn's result for stage
+            # accounting, and the leak mark would let it record an unfinished
+            # stage as complete (same exclusion as the promise-only guard).
+            in_stage_execution=slot._in_stage_execution,
+        ):
+            logger.warning(
+                "Leaked tool call for slot %s — the final message contained an "
+                "invoke block as text with no tool call executed (credits=%.4f)",
+                slot.key,
+                _turn_credits,
+            )
+            slot.append(
+                "notice",
+                "ℹ️ A tool call leaked into the reply text instead of executing — "
+                "nothing was run. Re-send your request to retry (an active monitor "
+                "loop retries on its next cycle).",
+                "msg msg-info",
+            )
+            _noticed_leak = True
+        elif (
+            _turn_tool_calls > 0
+            and _stop_reason == STOP_REASON_END_TURN
+            and _prompt_depth == 0
+            and has_leaked_tool_call(assistant_text)
+        ):
+            # MIXED-TURN diagnostic (advisory gap named by review): the turn
+            # executed tools and THEN leaked a final dispatch as text. The
+            # notice/un-landing path deliberately excludes this shape —
+            # un-landing a turn whose earlier tool calls had real side effects
+            # would misdescribe it — but the stall must stay diagnosable, so
+            # log it. No notice card, no un-landing, no behavior change.
+            logger.warning(
+                "Leaked tool call alongside %d executed tool call(s) for slot %s "
+                "— the final segment contains an invoke block as text; the turn "
+                "lands normally (diagnostic only)",
+                _turn_tool_calls,
+                slot.key,
+            )
         # Promise-only guard (#2686): the turn ended NORMALLY with visible text
         # whose FINAL segment only ANNOUNCES an immediate action ("I'll do that
         # now") without making the tool call, so the work never happened yet the
@@ -8020,7 +8088,9 @@ async def _run_chat(
         # (the [OPTION] gate is the action), so it is excluded. Bounded to one
         # attempt via slot._promise_only_retries; a second promise-only ending
         # falls through and lands normally rather than looping.
-        if not _armed_final and should_recover_promise_only(
+        # Chained as `elif` off the leaked-tool-call notice above: at most one
+        # of the two unacted-turn paths may claim a turn.
+        elif not _armed_final and should_recover_promise_only(
             stop_reason=_stop_reason,
             end_turn_reason=STOP_REASON_END_TURN,
             # `_produced_visible_output` is set True ONLY on the paths that reset
@@ -8191,11 +8261,11 @@ async def _run_chat(
             await save_slot_off_loop(state, slot)
         # Reset ALL retry budgets once the cycle completes (success OR the
         # terminal second-empty error) so each new user turn gets fresh budgets.
-        # Guarded by _retrying_empty AND _recovering_promise: neither a re-queue
-        # nor a promise-only recovery is a landed turn, so both must preserve the
-        # counters (a promise-only turn that reset budgets would also mask the
-        # transient-failure retry accounting).
-        if not _retrying_empty and not _recovering_promise:
+        # Guarded by _retrying_empty, _recovering_promise and _noticed_leak:
+        # neither a re-queue nor an unacted turn is a landed turn, so all must
+        # preserve the counters (an unacted turn that reset budgets would also
+        # mask the transient-failure retry accounting).
+        if not _retrying_empty and not _recovering_promise and not _noticed_leak:
             # A non-zero stall budget reaching this reset on an OK turn is a
             # COMPLETED recovery cycle: the stall branches return early, so the
             # only way here with an armed budget is the synthetic recovery turn
@@ -8256,7 +8326,7 @@ async def _run_chat(
 
         if _stop_reason == STOP_REASON_CANCELLED:
             logger.info("Turn cancelled by user for slot %s", slot.key)
-        elif not _retrying_empty and not _recovering_promise:
+        elif not _retrying_empty and not _recovering_promise and not _noticed_leak:
             _maybe_consolidate(state, slot)
         state.sessions.check_context_usage(session_key, client)
         pct = client.context_usage_pct()
@@ -8265,11 +8335,13 @@ async def _run_chat(
             _stop_reason != STOP_REASON_CANCELLED
             and not _retrying_empty
             and not _recovering_promise
+            and not _noticed_leak
         ):
-            # A promise-only turn is deliberately NOT recorded as a landed success:
-            # it announced work it never did, so counting it would tell the
+            # An unacted turn (promise-only, or a tool call leaked as text) is
+            # deliberately NOT recorded as a landed success: it announced or
+            # serialized work it never did, so counting it would tell the
             # reliability metrics (and the poisoned-conversation one-shot) the turn
-            # succeeded. The single injected continuation gets its own turn; if THAT
+            # succeeded. The promise-only continuation gets its own turn; if THAT
             # lands, it records success normally.
             state.sessions.record_success(session_key)
             # A LANDED turn breaks the pre-stream-exhaustion streak and

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1687,6 +1687,189 @@ def is_promise_only_terminal(final_segment_text: str) -> bool:
     return bool(_PROMISE_NOW_RE.search(text))
 
 
+# Fenced code blocks (``` or ~~~, any length ≥3) and inline code spans (a
+# backtick run closed by an equal-length run on the same line) are QUOTED
+# content: a user pasting a leak transcript, or the model explaining tool
+# syntax, legitimately shows an invoke block inside them. Both are stripped
+# before the leak scan so quoted machine syntax never triggers the notice.
+# Only PAIRED delimiters are removed — an unpaired fence or tick run inside a
+# genuinely leaked payload leaves the surrounding invoke tags visible (failure
+# direction: a missed notice, never a suppressed one).
+#
+# LINEAR BY CONSTRUCTION, deliberately. The scan runs on the event loop at
+# every turn completion over model-authored text, so it must stay linear on
+# ADVERSARIAL input too: a variable-length backreference pattern like
+# ``(`{3,}|~{3,}).*?(?P=fence)`` backtracks over every possible delimiter
+# split, and a few thousand consecutive backticks stall the loop for tens of
+# seconds — long enough for the liveness watchdog to kill the gateway. So the
+# delimiters are tokenized with a fixed-alternative regex (no backreferences)
+# and paired in one forward pass.
+_CODE_DELIM_RE = re.compile(r"`+|~{3,}")
+
+
+def _strip_quoted_code(text: str) -> str:
+    """*text* with paired code fences and inline code spans removed, linearly.
+
+    One forward pass over the delimiter tokens:
+
+    * A run of ≥3 backticks or ≥3 tildes OPENS a fence; the next run of the
+      same character AT LEAST AS LONG (CommonMark's closer rule) CLOSES it,
+      and everything between is dropped — so a four-backtick quote can carry
+      triple-backtick content without being cut short. Delimiters of the
+      other kind, and shorter runs of the same kind, inside an open fence are
+      content.
+    * Outside a fence, a backtick run of length L opens an inline span; the
+      next run of exactly length L on the SAME line closes it. A newline
+      discards all pending span opens (spans cannot contain newlines), and a
+      pending open that never closes is emitted as literal text.
+
+    Every token is visited once and every output chunk is appended/discarded
+    at most once, so the pass is linear whatever the input shape.
+    """
+    out: list[str] = []
+    # Pending inline-span opens: run length -> index in ``out`` where the
+    # opening run was appended. Cleared on every newline and on fence entry.
+    span_open_at: dict[int, int] = {}
+    fence_char = ""  # non-empty while inside an open fence
+    fence_open_len = 0
+    fence_open_out_idx = 0
+    pos = 0
+    for tok in _CODE_DELIM_RE.finditer(text):
+        seg = text[pos : tok.start()]
+        delim = tok.group()
+        pos = tok.end()
+        if fence_char:
+            # Inside a fence: append tentatively — the content is dropped only
+            # when a closer actually arrives, so an UNPAIRED fence leaves every
+            # byte in place (fail toward detection, never suppression).
+            out.append(seg)
+            if delim[0] == fence_char and len(delim) >= fence_open_len:
+                del out[fence_open_out_idx:]  # drop the fence and its content
+                fence_char = ""
+            else:
+                out.append(delim)
+            continue
+        out.append(seg)
+        if "\n" in seg:
+            span_open_at.clear()
+        if len(delim) >= 3:
+            # Fence opener (either character). Tentatively append; the closer
+            # (if any) truncates back to this index.
+            fence_open_out_idx = len(out)
+            out.append(delim)
+            fence_char = delim[0]
+            fence_open_len = len(delim)
+            span_open_at.clear()
+            continue
+        opened = span_open_at.pop(len(delim), None)
+        if opened is not None:
+            del out[opened:]  # drop the span, its delimiters, and its content
+            # Pending opens recorded INSIDE the just-dropped span went with it;
+            # keeping their indices would point past the truncated output.
+            span_open_at = {ln: i for ln, i in span_open_at.items() if i < opened}
+        else:
+            span_open_at[len(delim)] = len(out)
+            out.append(delim)
+    # An unpaired fence needs no special handling here: its tentatively-
+    # appended delimiter is already in ``out`` as literal text.
+    out.append(text[pos:])
+    return "".join(out)
+
+
+# The leaked block's signature: an invoke open tag with a name attribute
+# (optionally namespace-prefixed the way some harnesses emit it). MACHINE-SHAPED
+# on purpose — unlike the promise-only detector this is not a natural-language
+# inference, so the false-positive surface is quoted syntax (handled by the
+# stripping above), not phrasing.
+_LEAKED_INVOKE_OPEN_RE = re.compile(
+    r"<(?:[A-Za-z][\w.-]*:)?invoke\s+name\s*=\s*[\"'][^\"'<>]+[\"']"
+)
+# Corroboration: the block must also carry a parameter tag or its own close tag,
+# so a lone stray open tag in prose (a truncated quote, a typo'd example) does
+# not read as a full leaked invocation.
+_LEAKED_INVOKE_BODY_RE = re.compile(r"<(?:[A-Za-z][\w.-]*:)?(?:parameter\b|/invoke\s*>)")
+
+
+def has_leaked_tool_call(text: str) -> bool:
+    """True when *text* contains a tool invocation emitted as PROSE — an
+    unquoted invoke-block open tag with a parameter or close tag (issue #6112:
+    the model writes the call into the text channel instead of executing it,
+    the turn ends with zero tool calls, and the session silently stalls).
+
+    Quoted syntax is excluded structurally: fenced code blocks and inline code
+    spans are stripped before the scan, so a pasted bug report or an explained
+    example never matches. The caller must additionally require
+    ``turn_tool_calls == 0`` — a turn that executed tools and ALSO printed a
+    block is not the leak shape.
+    """
+    if not text:
+        return False
+    stripped = _strip_quoted_code(text)
+    opener = _LEAKED_INVOKE_OPEN_RE.search(stripped)
+    if not opener:
+        return False
+    # Corroboration must FOLLOW the opener: a parameter/close tag sitting
+    # before a lone opener is unrelated markup, not this invocation's body.
+    return bool(_LEAKED_INVOKE_BODY_RE.search(stripped, opener.end()))
+
+
+def should_notice_leaked_tool_call(
+    *,
+    stop_reason: str,
+    end_turn_reason: str,
+    final_segment_text: str,
+    prompt_depth: int,
+    is_cancelled: bool,
+    refusal_reasons: list,
+    turn_tool_calls: int = 0,
+    in_stage_execution: bool = False,
+) -> bool:
+    """Decide whether to surface the leaked-tool-call NOTICE (issue #6112).
+
+    The defect: the model emits an invoke block into its TEXT channel instead
+    of executing it (observed when the target is a deferred MCP tool whose
+    schema is not yet bound, and with large nested arguments), the turn then
+    ends with zero tool calls, and the session idles — in a monitor/autonudge
+    loop this is a silent stall the user only discovers by noticing nothing
+    happened.
+
+    NOTICE-ONLY, deliberately. An injected "re-issue that call" continuation
+    would carry runtime authority into a session where the call can execute
+    with no human gate — slot trust, global yolo, OR a static agent tool
+    allowlist all auto-approve it, and the last of these is invisible at this
+    layer, so no downgrade condition can be written here that fails closed.
+    The leaked block is also not proof of the model's own intent: untrusted
+    external content (a pasted issue, a fetched page quoting a leak) can carry
+    an unfenced block the model merely reproduces. So the turn is marked
+    un-landed and the user gets a visible card naming what happened; nothing
+    is queued and nothing can execute. An unattended loop loses one cycle and
+    retries on its own schedule — visibly, which is the half of #6112 this
+    layer can fix honestly.
+
+    Gates: the turn ended NORMALLY (cancel/refusal/error paths own their own
+    reporting), made ZERO tool calls (a turn that executed tools and also
+    printed a block is not the leak shape), is top-level, is NOT a
+    stage-execution turn (the orchestrator's stage loop reads the turn result
+    for stage accounting, and un-landing a stage turn from here would let the
+    loop record an unfinished stage as complete — same exclusion as the
+    promise-only guard), and its final segment carries the machine-shaped
+    leak (:func:`has_leaked_tool_call`). No one-shot budget: nothing is
+    re-queued, so there is no loop to bound, and every leaked turn deserves
+    its own visible mark.
+    """
+    if is_cancelled or refusal_reasons:
+        return False
+    if turn_tool_calls != 0:
+        return False
+    if in_stage_execution:
+        return False
+    if stop_reason != end_turn_reason:
+        return False
+    if prompt_depth != 0:
+        return False
+    return has_leaked_tool_call(final_segment_text)
+
+
 def should_recover_promise_only(
     *,
     stop_reason: str,

--- a/test/test_leaked_toolcall_notice.py
+++ b/test/test_leaked_toolcall_notice.py
@@ -1,0 +1,236 @@
+"""Acceptance tests for the leaked tool-call notice (#6112).
+
+The bug: the model emits an invoke-block tool invocation into its TEXT channel
+instead of executing it (observed when the target is a deferred MCP tool whose
+schema is not bound, and with large nested arguments), the turn ends with zero
+tool calls, and the session silently stalls — in a monitor/autonudge loop the
+user only discovers it by noticing nothing happened.
+
+The fix is NOTICE-ONLY, deliberately: an injected "re-issue that call"
+continuation would carry runtime authority into sessions where the call
+auto-approves (slot trust, global yolo, or a static agent tool allowlist — the
+last invisible at the runner layer, so no fail-closed downgrade condition
+exists), and the leaked block may be untrusted external content the model
+merely reproduced. So the leaked turn is marked un-landed and the user gets a
+visible card; nothing is queued and nothing can execute.
+
+These tests exercise the pure detector (``has_leaked_tool_call``) and the
+gating decision (``should_notice_leaked_tool_call``) directly, matching the
+sibling promise-only suite.
+
+The machine-syntax fixtures are ASSEMBLED from fragments rather than written
+as literals: a raw invoke block in this file is exactly the byte sequence
+agent tool-call parsers trip over (the defect under test), so spelling it out
+verbatim makes the file itself hazardous to quote.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN
+from kiro_crew.dashboard.chat_utils import (
+    has_leaked_tool_call,
+    should_notice_leaked_tool_call,
+)
+
+_END = STOP_REASON_END_TURN
+
+# Tag fragments, assembled at import time (see module docstring).
+_INV_OPEN = "<" + 'invoke name="spawn_run">'
+_INV_OPEN_SQ = "<" + "invoke name='spawn_run'>"
+_INV_CLOSE = "</" + "invoke>"
+_INV_OPEN_NS = "<" + 'antml:invoke name="spawn_run">'
+_INV_CLOSE_NS = "</" + "antml:invoke>"
+
+
+def _param(name: str, value: str) -> str:
+    return "<" + f'parameter name="{name}">' + value + "</" + "parameter>"
+
+
+# The issue's verbatim leak shape: the invocation written into the reply text.
+_LEAK = (
+    "call "
+    + _INV_OPEN
+    + " "
+    + _param("__tool_use_purpose", "Loop cycle 5: reconcile the CR queue ...")
+    + " "
+    + _param("agent", "btdocs-ops")
+    + " "
+    + _param("task", "Oncall reconciliation pass ...")
+    + " "
+    + _INV_CLOSE
+)
+
+
+def _notice(**over):
+    """should_notice_leaked_tool_call with leak-firing defaults, so each test
+    flips exactly the one field it is about."""
+    kw = dict(
+        stop_reason=_END,
+        end_turn_reason=_END,
+        final_segment_text=_LEAK,
+        prompt_depth=0,
+        is_cancelled=False,
+        refusal_reasons=[],
+        turn_tool_calls=0,
+    )
+    kw.update(over)
+    return should_notice_leaked_tool_call(**kw)
+
+
+# ── Detector: what must match ──
+
+
+def test_verbatim_issue_leak_is_detected():
+    assert has_leaked_tool_call(_LEAK)
+    assert _notice() is True
+
+
+def test_multiline_leak_with_nested_arguments_is_detected():
+    # The reported leaks carried large multi-paragraph task arguments with
+    # URLs, ids, and bulleted instructions of their own.
+    text = (
+        "I'll dispatch the swarm.\n\n"
+        + _INV_OPEN
+        + "\n"
+        + _param(
+            "task",
+            "Review PR #123:\n- read the diff\n- check CI\nURLs: https://example.test/pr/123",
+        )
+        + "\n"
+        + _INV_CLOSE
+        + "\n"
+    )
+    assert has_leaked_tool_call(text)
+
+
+def test_namespace_prefixed_and_single_quoted_forms_are_detected():
+    assert has_leaked_tool_call(_INV_OPEN_NS + _param("task", "x") + _INV_CLOSE_NS)
+    assert has_leaked_tool_call(_INV_OPEN_SQ + _param("task", "x") + _INV_CLOSE)
+
+
+def test_open_tag_with_close_but_no_parameter_is_detected():
+    # A zero-argument call still leaks as an open+close pair.
+    assert has_leaked_tool_call("run it: " + _INV_OPEN + _INV_CLOSE)
+
+
+# ── Detector: what must NOT match ──
+
+
+def test_fenced_code_block_is_quoted_content_not_a_leak():
+    # A user pasting a leak transcript (or the model explaining the bug) puts
+    # the block in a fence; that is quoted syntax, never a dispatch intent.
+    assert not has_leaked_tool_call("Here is the leak I saw:\n\n```\n" + _LEAK + "\n```\n")
+
+
+def test_tilde_fence_and_long_backtick_fence_are_quoted_content():
+    # Markdown accepts ~~~ fences and fences longer than three backticks; both
+    # are quoting, same as the plain triple-backtick form.
+    assert not has_leaked_tool_call("Quoted:\n~~~\n" + _LEAK + "\n~~~\n")
+    assert not has_leaked_tool_call("Quoted:\n````\n" + _LEAK + "\n````\n")
+
+
+def test_longer_fence_carries_shorter_fence_content():
+    # CommonMark: a closer must be at least as long as its opener. With a
+    # SINGLE shorter run inside the quote, a wrong ">=3 closes anything"
+    # pairing would end the fence at the inner run and expose the quoted
+    # leak after it as unfenced text — the false-notice shape.
+    text = "Quoted:\n````\nan inner ``` run, then the pasted leak:\n" + _LEAK + "\n````\ntail"
+    assert not has_leaked_tool_call(text)
+
+
+def test_corroboration_before_the_opener_does_not_count():
+    # A stray parameter/close tag BEFORE a lone opener is unrelated markup,
+    # not this invocation's body — corroboration must follow the opener.
+    stray_close = "</" + "invoke>"
+    assert not has_leaked_tool_call(stray_close + " earlier markup, then " + _INV_OPEN)
+
+
+def test_multi_backtick_inline_span_is_quoted_content():
+    # An inline span delimited by a matching run of 2+ backticks (the escape
+    # for content that itself contains a backtick) is quoting too.
+    assert not has_leaked_tool_call(
+        "The model printed `` " + _INV_OPEN + _INV_CLOSE + " `` as text."
+    )
+
+
+def test_inline_code_span_is_quoted_content_not_a_leak():
+    assert not has_leaked_tool_call("The model printed `" + _INV_OPEN + _INV_CLOSE + "` as text.")
+
+
+def test_lone_open_tag_without_body_is_not_a_leak():
+    # A truncated quote or typo'd example: no parameter tag, no close tag.
+    assert not has_leaked_tool_call("it emitted " + _INV_OPEN + " and stopped")
+
+
+def test_prose_and_empty_text_are_not_leaks():
+    assert not has_leaked_tool_call("")
+    assert not has_leaked_tool_call("I'll invoke the tool now.")
+    assert not has_leaked_tool_call("Use spawn_run with name=spawn_run to dispatch.")
+
+
+def test_unpaired_fence_fails_toward_detection_not_suppression():
+    # Only PAIRED fences are stripped: an unpaired fence inside a genuinely
+    # leaked payload must not hide the surrounding invoke tags.
+    text = _INV_OPEN + _param("task", "```py\nprint(1)") + _INV_CLOSE
+    assert has_leaked_tool_call(text)
+
+
+def test_leak_after_an_unpaired_giant_delimiter_run_is_still_detected():
+    # An unpaired run of any length is literal text; the leak after it must
+    # stay visible (the linear scanner keeps unclosed-fence content in place).
+    assert has_leaked_tool_call("`" * 5000 + "\n" + _LEAK)
+    assert has_leaked_tool_call("~" * 5000 + "\n" + _LEAK)
+
+
+def test_adversarial_delimiter_runs_scan_in_linear_time():
+    # The scan runs on the event loop at every turn completion, so it must
+    # stay linear on ADVERSARIAL model-authored text: the previous
+    # backreference regex took seconds at a few thousand consecutive
+    # backticks (superlinear backtracking) — long enough for the liveness
+    # watchdog to kill the gateway. The ceiling is generous by orders of
+    # magnitude for a linear pass (microseconds); only a reintroduced
+    # backtracking pattern can approach it (the old regex needed >6s at
+    # 8k characters and grew ~8x per doubling).
+    import time
+
+    for payload in (
+        "`" * 50_000,
+        "`` " * 20_000,
+        ("`a" * 30_000),
+        ("```x~~~y" * 10_000),
+    ):
+        start = time.perf_counter()
+        has_leaked_tool_call(payload + " tail text")
+        assert time.perf_counter() - start < 2.0
+
+
+# ── Gates (each test flips exactly one) ──
+
+
+def test_a_turn_that_made_tool_calls_never_notices():
+    # A turn that executed tools and also printed a block is not the leak shape.
+    assert _notice(turn_tool_calls=1) is False
+
+
+def test_cancelled_and_refused_turns_never_notice():
+    assert _notice(is_cancelled=True, stop_reason=STOP_REASON_CANCELLED) is False
+    assert _notice(refusal_reasons=["blocked"]) is False
+
+
+def test_non_end_turn_stop_reasons_never_notice():
+    # Error/stall exits own their own reporting paths.
+    assert _notice(stop_reason="error: tool stall") is False
+
+
+def test_nested_prompts_never_notice():
+    assert _notice(prompt_depth=1) is False
+
+
+def test_stage_execution_turns_never_notice():
+    # The orchestrator's stage loop reads the turn result for stage accounting;
+    # un-landing a stage turn would record an unfinished stage as complete.
+    assert _notice(in_stage_execution=True) is False
+
+
+def test_non_leak_text_never_notices():
+    assert _notice(final_segment_text="All done — the queue is empty.") is False


### PR DESCRIPTION
## What

A turn can end with the model writing its tool invocation into the TEXT channel as an invoke-shaped block instead of executing it — observed when the target is a deferred MCP tool whose schema is not yet bound (MCP Tool Search), and with large, heavily nested arguments. The turn then has **zero tool calls** and lands silently as an apparent success, so an unattended monitor/autonudge loop stalls with no visible signal (field diagnosis on the issue: ~4 of 7 loop cycles leaked, cadence slipped from 10 to ~35 minutes, work sat unhandled until a human noticed).

This detects the leak at turn completion and **fails loudly**: a visible notice card, and the leaked turn is marked un-landed — not recorded as a success, retry budgets preserved, no consolidation. A monitor loop loses one cycle *visibly* and retries on its own schedule. Issue #6112 names "raise a visible error" as an accepted fix shape alongside recovery.

## Why notice-only (design decision)

Earlier revisions of this PR injected a bounded "re-issue that call" continuation (mirroring the promise-only guard #2686, first unconditionally, then with the yolo/slot-trust downgrade). Both were correctly blocked by the GPT lane, and the second block generalizes:

- An injected continuation carries **runtime authority**: in the very sessions this bug bites (unattended loops), the re-issued call auto-approves — via slot trust, global yolo, **or a static agent tool allowlist**. The allowlist is invisible at the runner layer, so no downgrade condition can be written there that fails closed.
- The leaked block is **not proof of the model's own intent**: untrusted external content (a pasted issue, a fetched page quoting a leak) can carry an unfenced invoke block the model merely reproduces in its reply. Executing a reproduction is an injection vector.

So nothing is queued and nothing can execute. The loop-level cost is one visible lost cycle; the loop's next cycle retries by construction.

## How

- **Detector (`has_leaked_tool_call`, `chat_utils.py`)** — machine-shaped, not NL inference: an unquoted invoke open tag corroborated by a parameter or close tag. Fenced code blocks and inline code spans are stripped first, so a pasted bug report or an explained example never matches; only paired fences are stripped, so an unpaired fence inside a genuinely leaked payload fails toward detection, never suppression.
- **Gate (`should_notice_leaked_tool_call`)** — normal `end_turn`, zero tool calls, top-level turn, no cancel/refusal; claimed ahead of the promise-only guard (a leaked block is machine syntax, and the more specific detector owns the turn).
- **Runner (`chat_runner.py`)** — notice card + un-landed marking (`_noticed_leak` joins the `_retrying_empty`/`_recovering_promise` gates on success-recording, budget reset, and consolidation). No new prefix, no injected message, no frontend change.
- **Spec** — documented beside the empty-response recovery ladder in `docs/system-specs/modules/session.md`, same commit.

## Tested

- 14 tests in `test/test_leaked_toolcall_notice.py`: the issue's verbatim leak text, the multiline nested-argument shape, namespace-prefixed and single-quoted tag forms, fenced/inline-code negatives, the lone-open-tag negative, the unpaired-fence direction, and one flip per gate.
- **Mutation-verified**: removing fence-stripping and removing body corroboration each turn a test red; restored green.
- Recovery-family suites (promise-only, card/marker parity), chat_runner/chat_utils consumer suites: 328 tests green; mypy clean; black/isort/flake8/docs-lint green.

## Not covered (follow-up candidates)

- Mixed-turn scope limit: the notice/un-landing applies only to zero-tool-call turns. A turn that executed tools and then leaked its final dispatch as text lands normally (un-landing a turn whose earlier calls had real side effects would misdescribe it) and is logged at WARNING as a diagnostic instead — documented in session.md.

- Cause-side fix: auto-loading deferred tools named in an armed loop instruction (issue suggestion 3 — a tool-search-subsystem change).
- In-turn self-healing recovery would require an approval-aware injection the runner layer cannot express today (it cannot see agent tool allowlists); if wanted, that is a design question for the approval subsystem, not a patch here.

Closes #6112

