### PR TITLE
fix(acp): classify expired-token stderr as auth instead of a session/new timeout

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1054,10 +1054,13 @@ class AcpPromptBusy(AcpError):  # noqa: N818
     """
 
 
-# kiro-cli emits a "not logged in" banner on stderr when the user's session
-# has expired. Detected during spawn/prompt so we can raise AcpAuthRequired
-# (non-retryable) instead of churning through the retry ladder.
-_NOT_LOGGED_IN_RE = re.compile(r"not\s+logged\s+in", re.IGNORECASE)
+# Auth failure on stderr is detected during spawn/prompt so we can raise
+# AcpAuthRequired (non-retryable) instead of churning through the retry ladder.
+# The detector is `is_auth_failure_output` below; there is deliberately no
+# separate "not logged in" pattern here, because having one was the defect —
+# `_RE_SESSION_EXPIRED` already carries that wording alongside the rest of the
+# auth vocabulary, and a second narrower copy is what let the spawn path miss
+# every expiry that does not use the banner's exact words.
 _NOT_LOGGED_IN_MESSAGE = (
     "kiro-cli is not logged in. Run `kiro-cli login` in your terminal, " "then start a new chat."
 )
@@ -1160,6 +1163,34 @@ def _is_session_expired(haystack: str) -> bool:
         or _RE_SESSION_EXPIRED.search(haystack)
         or _RE_INVALID_BEARER.search(haystack)
     )
+
+
+def is_auth_failure_output(haystack: str) -> bool:
+    """True when free-form kiro-cli output reports an auth failure.
+
+    Companion to :func:`_is_session_expired` for output that is NOT a JSON-RPC
+    error frame — i.e. whatever the CLI writes to stderr while starting up. It is
+    the union of the two terminal auth families this module already recognises:
+    ``_is_session_expired`` (401/403, expiry wording, rejected bearer token) and
+    ``_RE_AUTH`` (the named service exceptions, which ``_is_session_expired``
+    deliberately leaves to ``_RE_AUTH``). Both are terminal for the same reason —
+    no retry refreshes a login — so for the single question "is this stderr an
+    auth problem" they belong together.
+
+    This exists because the two auth vocabularies had drifted apart by call path,
+    not by intent. Everything above was reachable only from the error-frame path;
+    the spawn / ``session/new`` path had its own detector matching the single
+    literal banner ``not logged in``. Real expiry output does not use that
+    wording — an expired bearer token produces ``AccessDeniedException: "Invalid
+    token"`` and ``the bearer token included in the request is invalid`` — so the
+    spawn path discarded an auth signal this module could already read, and the
+    operator got a 90-second timeout instead of a sign-in prompt.
+
+    Keeping one detector rather than widening the banner regex is the same
+    anti-drift argument the module makes for its other shared patterns: a second
+    vocabulary is what created the gap.
+    """
+    return bool(_RE_AUTH.search(haystack)) or _is_session_expired(haystack)
 
 
 # Account/plan capacity is EXHAUSTED — terminal. Distinct from a throttle: a

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -40,13 +40,13 @@ from kiro_crew.acp._dispatch import (
     set_mode_params,
 )
 from kiro_crew.acp.client import (
-    _NOT_LOGGED_IN_RE,
     OversizeLineUnrecoverable,
     _drain_oversize_line,
     _get_start_time,
     _KiroExecutableTrustError,
     _resolve_kiro_bin_for_spawn,
     finish_suspended_spawn,
+    is_auth_failure_output,
 )
 from kiro_crew.acp.kas_agents import (
     KasAgentTranslationError,
@@ -795,6 +795,15 @@ class AcpRuntime:
         self._dead = False
         self._last_activity: float = 0.0
         self._stderr_lines: list[str] = []
+        # Latched auth-failure observation. ``_stderr_lines`` is a 20-line ring,
+        # so on a noisy startup the auth line can be evicted before anything asks
+        # about it — and the question is only ever asked LATER, once a request
+        # times out or the runtime dies. Re-scanning a buffer that no longer holds
+        # the evidence answers "no auth problem", which is indistinguishable from
+        # a real negative. Latch on arrival instead: an auth failure observed once
+        # stays observed for the life of this runtime, which is correct because
+        # nothing about a rejected credential un-rejects itself mid-process.
+        self._saw_auth_failure = False
         # Unroutable-frame drop accounting: (sessionId, method) → count since
         # the last flush, plus the monotonic timestamp of that flush (0.0 = no
         # window open yet; the first counted drop opens it). Written ONLY from
@@ -2282,13 +2291,23 @@ class AcpRuntime:
             pass
 
     def saw_not_logged_in(self) -> bool:
-        """True if kiro-cli's 'not logged in' auth-failure appeared on stderr.
+        """True if kiro-cli reported an auth failure on stderr.
 
         Lets callers translate a runtime death into AcpAuthRequired (an
         actionable login prompt) instead of a generic process-death error —
         parity with AcpClient, which inspects stderr the same way.
+
+        That parity is what this now actually delivers. The check used to be a
+        single regex for the literal banner ``not logged in``, while AcpClient's
+        error-frame path recognised the full auth vocabulary; a real expired
+        bearer token writes ``AccessDeniedException: "Invalid token"`` and ``the
+        bearer token included in the request is invalid`` and says ``not logged
+        in`` nowhere, so this returned False on exactly the state it exists to
+        detect, and the operator was shown a ``session/new`` timeout instead.
+
+        Reads the latch, not the ring buffer: see ``_saw_auth_failure``.
         """
-        return any(_NOT_LOGGED_IN_RE.search(line) for line in self._stderr_lines)
+        return self._saw_auth_failure
 
     def _mark_dead(self, reason: str, *, expected: bool = False) -> None:
         """Mark runtime dead, fail all pending requests, poison all session queues.
@@ -3206,6 +3225,18 @@ class AcpRuntime:
                     self._stderr_lines.append(text)
                     if len(self._stderr_lines) > 20:
                         self._stderr_lines = self._stderr_lines[-20:]
+                    # Latch here, at the sink, because this is the only point at
+                    # which every line is guaranteed to have been seen. The
+                    # trim above is what makes it necessary: nobody asks about
+                    # auth until a request has already timed out, by which time a
+                    # chatty startup can have pushed the auth line out of the ring.
+                    # Deliberately does not log: the line below already emits this
+                    # text at debug, so a second record here would add no content
+                    # and only raise arbitrary matched stderr to a default-visible
+                    # level, against this sink's own convention. The condition is
+                    # surfaced where it is actionable instead -- as AcpAuthRequired.
+                    if not self._saw_auth_failure and is_auth_failure_output(text):
+                        self._saw_auth_failure = True
                     logger.debug("stderr: %s", text[:200])
         except asyncio.CancelledError:
             raise

--- a/test/test_acp_auth_failure_on_stderr.py
+++ b/test/test_acp_auth_failure_on_stderr.py
@@ -1,0 +1,157 @@
+"""kiro-cli auth failures on stderr must be classified as auth, not as a timeout.
+
+Two auth classifiers had drifted apart by call path. The JSON-RPC error-frame path
+reached the full vocabulary (`_is_session_expired` plus `_RE_AUTH`). The spawn /
+`session/new` path had its own detector matching one literal banner, `not logged in`.
+
+Real expired-token output does not use that wording -- it reports
+`AccessDeniedException: "Invalid token"` and `the bearer token included in the
+request is invalid` -- so the spawn path discarded an auth signal the codebase
+could already read, and the operator saw `Request session/new timed out after 90s`.
+That is not a cosmetic message problem: `AcpAuthRequired` is explicitly
+non-retryable, so failing to reach it burns the whole retry ladder and the full
+timeout budget per attempt on a credential no retry can fix.
+
+The stderr corpus below is real kiro-cli output captured during an actual token
+expiry, not invented wording.
+
+The first two tests deliberately assert through `AcpRuntime.saw_not_logged_in()`
+rather than through the new helper. That predicate exists in both the fixed and
+the unfixed tree, so on unfixed code these fail with an AssertionError showing the
+real defect -- not with an ImportError showing only that a new function is absent.
+"""
+
+import pytest
+
+# Real kiro-cli stderr during an expired IAM Identity Center bearer token.
+EXPIRED_TOKEN_STDERR = [
+    'GetProfile failed: AccessDeniedException: "Invalid token" (HTTP 400)',
+    "Failed to fetch models from API: service error, using fallback list",
+    "Access denied: The bearer token included in the request is invalid.",
+]
+
+# Ordinary startup chatter from a healthy, logged-in run.
+HEALTHY_STDERR = [
+    "Starting kiro-cli 2.19.1",
+    "INFO listening on stdio",
+    "Loaded 3 MCP servers",
+    "Failed to fetch models from API: service error, using fallback list",
+]
+
+
+class _FakeStream:
+    """Minimal asyncio-stream stand-in yielding fixed stderr lines then EOF."""
+
+    def __init__(self, lines):
+        self._lines = [f"{line}\n".encode() for line in lines]
+
+    async def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class _FakeProcess:
+    def __init__(self, lines):
+        self.stderr = _FakeStream(lines)
+
+
+def _runtime(lines):
+    """An AcpRuntime with only the stderr machinery wired up.
+
+    `_saw_auth_failure` is seeded unconditionally so this helper works against a
+    tree that has no such attribute; the unfixed `saw_not_logged_in` ignores it.
+    """
+    from kiro_crew.acp.runtime import AcpRuntime
+
+    runtime = AcpRuntime.__new__(AcpRuntime)
+    runtime._stderr_lines = []
+    runtime._saw_auth_failure = False
+    runtime._process = _FakeProcess(lines)
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_real_expired_token_stderr_raises_the_auth_predicate():
+    """The defect itself, asserted through the predicate the callers use.
+
+    Drives the real `_drain_stderr` over real expired-token stderr, then asks the
+    question the four `AcpAuthRequired` call sites ask. Fails on unfixed code
+    (`False`), because none of these lines contain the banner wording.
+    """
+    runtime = _runtime(EXPIRED_TOKEN_STDERR)
+    await runtime._drain_stderr()
+    assert runtime.saw_not_logged_in() is True, (
+        "real expired-token stderr was not classified as an auth failure, so the "
+        "caller raises a generic timeout instead of AcpAuthRequired"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_observation_survives_the_stderr_ring_buffer():
+    """The latch, and it is the difference between a real answer and a stale one.
+
+    `_stderr_lines` is a 20-line ring, and nothing asks about auth until a request
+    has already timed out. On a chatty startup the auth line is evicted by then, so
+    a detector that re-scans the buffer answers "no auth problem" -- indistinguishable
+    from a real negative.
+
+    Puts the auth line first, then enough noise to overflow the ring. Fails on any
+    implementation that scans the buffer instead of latching on arrival.
+    """
+    runtime = _runtime([EXPIRED_TOKEN_STDERR[2]] + [f"noise line {i}" for i in range(40)])
+    await runtime._drain_stderr()
+
+    assert len(runtime._stderr_lines) == 20, "precondition: the ring must have trimmed"
+    assert not any(
+        "bearer token" in line for line in runtime._stderr_lines
+    ), "precondition: the auth line must have been evicted, or this proves nothing"
+    assert (
+        runtime.saw_not_logged_in() is True
+    ), "the auth observation was lost when the ring buffer trimmed it"
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_run_never_reports_auth_failure():
+    """No false positives, and the latch is not a stuck bit on ordinary output.
+
+    The corpus includes the fallback-list line, which co-occurs with the real auth
+    failure but carries no auth signal of its own: classifying on co-occurrence
+    rather than on content would flag every degraded-model-fetch run.
+    """
+    runtime = _runtime(HEALTHY_STDERR * 6)
+    await runtime._drain_stderr()
+    assert runtime.saw_not_logged_in() is False
+
+
+def test_the_banner_wording_is_absent_from_the_real_corpus():
+    """The premise of the defect, pinned so it cannot be argued away later.
+
+    If kiro-cli ever does emit `not logged in` alongside these lines, the old
+    narrow detector would have fired and this class of failure would be moot. It
+    does not, and this records that.
+    """
+    joined = "\n".join(EXPIRED_TOKEN_STDERR).lower()
+    assert "not logged in" not in joined
+
+
+@pytest.mark.parametrize("line", [EXPIRED_TOKEN_STDERR[0], EXPIRED_TOKEN_STDERR[2]])
+def test_each_auth_bearing_line_is_recognised(line):
+    """Per-line coverage of the shared detector."""
+    from kiro_crew.acp.client import is_auth_failure_output
+
+    assert is_auth_failure_output(line) is True, f"not recognised: {line!r}"
+
+
+def test_the_legacy_banner_still_classifies():
+    """Widening must not drop what the narrow detector already caught."""
+    from kiro_crew.acp.client import is_auth_failure_output
+
+    assert is_auth_failure_output("kiro-cli: not logged in") is True
+    assert is_auth_failure_output("Not Logged In") is True
+
+
+def test_noise_lines_are_not_flagged_individually():
+    """Each healthy line must be silent on its own, not merely in aggregate."""
+    from kiro_crew.acp.client import is_auth_failure_output
+
+    for line in HEALTHY_STDERR:
+        assert is_auth_failure_output(line) is False, f"false positive on {line!r}"

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -5034,13 +5034,36 @@ async def test_send_command_redacts_output(monkeypatch):
 # ── Round-2 parity fixes: auth detection, exception translation, steer ──
 
 
-def test_saw_not_logged_in_detects_auth_failure():
-    """#1: AcpRuntime.saw_not_logged_in scans captured stderr for kiro-cli's
-    'not logged in' signal so a death can be surfaced as AcpAuthRequired."""
-    rt, _, _ = _make_runtime()
-    rt._stderr_lines = ["startup noise", "error: You are not logged in, please log in"]
+@pytest.mark.asyncio
+async def test_saw_not_logged_in_detects_auth_failure():
+    """#1: AcpRuntime.saw_not_logged_in reports kiro-cli's auth-failure signal on
+    stderr so a death can be surfaced as AcpAuthRequired.
+
+    Drives the real ``_drain_stderr`` rather than assigning ``_stderr_lines``
+    directly. The observation is now latched as each line arrives, because the
+    buffer is a 20-line ring and nothing asks about auth until a request has
+    already timed out -- by which point a chatty startup can have evicted the
+    line. ``_drain_stderr`` is the only production writer of that buffer, so
+    driving it is strictly closer to the real path than the previous assignment
+    was; the two assertions below are unchanged in intent.
+    """
+
+    class _Stderr:
+        def __init__(self, lines):
+            self._lines = [f"{ln}\n".encode() for ln in lines]
+
+        async def readline(self):
+            return self._lines.pop(0) if self._lines else b""
+
+    async def _drain(lines):
+        rt, _, proc = _make_runtime()
+        proc.stderr = _Stderr(lines)
+        await rt._drain_stderr()
+        return rt
+
+    rt = await _drain(["startup noise", "error: You are not logged in, please log in"])
     assert rt.saw_not_logged_in() is True
-    rt._stderr_lines = ["ordinary stderr", "mcp server ready"]
+    rt = await _drain(["ordinary stderr", "mcp server ready"])
     assert rt.saw_not_logged_in() is False
 
 


### PR DESCRIPTION
## Problem / Motivation

Two auth classifiers in the ACP layer had drifted apart by call path. The JSON-RPC error-frame path reached the full vocabulary — `_is_session_expired` (401/403, expiry wording, rejected bearer token) plus `_RE_AUTH` (the named service exceptions). The spawn / `session/new` path had its own detector matching one literal banner, `not logged in`.

Real expired-token output uses none of that wording. Captured from an actual expiry:

```
GetProfile failed: AccessDeniedException: "Invalid token" (HTTP 400)
Failed to fetch models from API: service error, using fallback list
Access denied: The bearer token included in the request is invalid.
```

Driven through the real `_drain_stderr` on the unfixed tree, the two classifiers disagree on that identical text:

```
spawn path  saw_not_logged_in()   = False
frame path  _is_session_expired() = True
```

The signal was **lost, not absent** — the same stderr arriving as an error frame already produces a correct sign-in message. Only this path could not see it, and the operator got `Request session/new timed out after 90s`.

## Why it matters

`AcpAuthRequired` is documented non-retryable, and `client.py` already treats `_RE_AUTH` as terminal specifically so the retry ladder is skipped. Never reaching it means an expired credential burns the whole ladder and the full 90-second budget per attempt on a condition no retry can fix. The timeout string is also produced by at least two unrelated causes, so the operator applies the wrong remediation — and because #4237 enriches this timeout toward MCP reporting, they are actively steered at the wrong subsystem.

## What changed (motivation → approach → change)

Symptom: an auth failure surfaces as a timeout. Root cause: the auth vocabulary was duplicated, and the copy on this path was narrower. So the change removes the duplication rather than widening the copy — widening the banner regex would have preserved the shape of the defect.

- `acp/client.py` gains `is_auth_failure_output`, the union of the two terminal auth families the module already recognises. Grouping them is consistent with existing semantics: `_is_session_expired`'s own comment says it excludes the named exceptions only because `_RE_AUTH` "already owns" them, and both are treated as terminal at the existing call sites.
- `_NOT_LOGGED_IN_RE` is **deleted**. It became dead once the detector was shared, because `_RE_SESSION_EXPIRED` already carries `not\s+logged\s+in` inline. Left in place it would be unreachable code that still looks like the live rule.
- `acp/runtime.py`: `saw_not_logged_in` delegates to the shared detector, and the result is **latched** at the `_drain_stderr` sink.
- The four `AcpAuthRequired` call sites are unchanged — they already raise the right thing once the predicate is right.

The latch is load-bearing, not tidiness. `_stderr_lines` is trimmed to 20 entries and nothing asks about auth until a request has already timed out, so on a chatty startup the auth line is evicted by then; re-scanning the buffer answers "no auth problem", which is indistinguishable from a real negative. `_drain_stderr` is the sole production writer of that buffer (`runtime.py` has only the init, one read for logging, and the two writes inside it), so latching there covers every real path.

## Tests

`test/test_acp_auth_failure_on_stderr.py`. The first two assert through `saw_not_logged_in()` rather than through the new helper, deliberately: that predicate exists in both trees, so on unfixed code they fail with the **defect** rather than with an ImportError proving only that a new function is absent.

| Test | Locks in | Fails unfixed with |
|---|---|---|
| `test_real_expired_token_stderr_raises_the_auth_predicate` | real expiry stderr reaches the auth predicate | `real expired-token stderr was not classified as an auth failure` |
| `test_the_observation_survives_the_stderr_ring_buffer` | the latch: auth line first, then 40 noise lines | `the auth observation was lost when the ring buffer trimmed it` |
| `test_a_healthy_run_never_reports_auth_failure` | no false positives; the latch is not a stuck bit | passes both ways by design — it is the guard, not the proof |
| `test_the_banner_wording_is_absent_from_the_real_corpus` | pins the premise, so it cannot be argued away later | passes both ways |
| `test_each_auth_bearing_line_is_recognised`, `test_the_legacy_banner_still_classifies`, `test_noise_lines_are_not_flagged_individually` | per-line detector behaviour, incl. that widening drops nothing | — |

The no-false-positive guards were checked for vacuity by mutating the detector to return `True` unconditionally; they trip. Without that check they would have looked like coverage while asserting nothing.

`test_acp_runtime.py::test_saw_not_logged_in_detects_auth_failure` assigned `_stderr_lines` directly, bypassing the capture path where classification now happens. It is rewritten to drive `_drain_stderr`, with both original assertions unchanged. Adapted rather than deleted because that buffer has no other production writer, so the direct assignment was a test-only shortcut — not a path this could regress.

Also run: every `test_acp_*.py` plus `test_kiro_prerequisite.py` and `test_token_auth.py` — 1,894 passed, 1 skipped, 0 failed.

## Manual verification

N/A — the behaviour is a predicate over captured stderr, asserted directly against the real `_drain_stderr` by the tests above. Reproducing it live needs a genuinely expired token, which is why the stderr corpus here is captured real output rather than something I generated.

## Screenshots / video

N/A — no user-visible surface changes. The diff touches `acp/client.py` and `acp/runtime.py` only.

## Related Issues

Fixes #6140

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff

Deliberately **out of scope**, flagged so the omission is a choice rather than an oversight: a `doctor` check that validates the token with a real auth-exercising probe instead of trusting `whoami`. I could not verify the premise — `kiro_prerequisite.py` asserts `whoami` is *not* a local read and performs a 12–20s OIDC refresh, which if correct means the gap there is narrower than it looks. Settling that needs a genuinely expired token, so it does not belong in a PR whose other claims are all executed.

## Contribution License Agreement

<!-- PLACEHOLDER per the repo template: the exact CLA wording is to be supplied by OSPO.
     Not inventing text here. Happy to add the standard wording once it lands in the template. -->
