### PR TITLE
fix(dashboard): take startup restore reads off the event loop (#895)

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -37,6 +37,7 @@ from kiro_crew.dashboard.state import (
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
     SLOT_OWNED_META_KEYS,
+    ConversationLog,
     _archive_lines,
     carry_provenance,
     carry_unowned_metadata,
@@ -251,26 +252,133 @@ def _build_kiro_model_map() -> dict[str, str]:
     return out
 
 
-def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
-    """Drive the open-tab restore one tab at a time, yielding the running count.
+def _load_restore_cfg() -> "KiroCrewConfig | None":
+    """Load the config the restore paths read, tolerating a broken file.
 
-    Exposed as a generator so the same logic serves both a plain synchronous
-    caller (:func:`restore_open_slots`) and an event-loop-friendly one
-    (:func:`restore_open_slots_async`) that awaits between tabs. See
-    :func:`restore_open_slots` for the behavioural contract.
+    Factored out so the async drivers can hoist it into a worker thread —
+    ``KiroCrewConfig.load()`` reads and parses ``config.json`` from disk, which
+    is exactly the kind of blocking I/O that must not run on the event loop
+    during startup restore.
     """
-    if not state.conversation_log:
-        return
+    try:
+        return KiroCrewConfig.load()
+    except Exception:
+        return None
+
+
+def _read_open_slots_keys() -> list[object]:
+    """Read and parse ``open_slots.json``, returning its raw ``keys`` list.
+
+    Pure disk work with no slot state touched, so the async driver can hoist the
+    whole thing into ``asyncio.to_thread``: the read plus the JSON parse were
+    running on the event loop during startup (#895).
+
+    Entries are returned UNVALIDATED — the file is attacker-writable, so every
+    caller must pass each one through :func:`_sanitize_open_slot_key` before it
+    reaches path construction. Returns ``[]`` for a missing, unreadable or
+    malformed file, which is the documented no-op.
+    """
     path = config_dir() / "open_slots.json"
     if not path.exists():
-        return
+        return []
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         logger.debug("open_slots.json unreadable; skipping", exc_info=True)
-        return
+        return []
     keys = data.get("keys") if isinstance(data, dict) else None
     if not isinstance(keys, list):
+        return []
+    return list(keys)
+
+
+def _sanitize_open_slot_key(raw: object) -> str | None:
+    """Fold one ``open_slots.json`` entry to a canonical slot key, or reject it.
+
+    Single home for the screen both restore drivers apply, so the sync and async
+    paths cannot drift on the security check.
+
+    Defense-in-depth: slot keys flow into ``_history_key_for()`` -> filesystem
+    path construction. ``open_slots.json`` is 0o600 so the threat is small, but a
+    key smuggled in (symlink attack at write time or a separate vuln) could
+    escape the sessions directory (e.g. ``"../../etc/passwd"``). Live-gateway
+    slot keys never contain path separators; reject any that do and warn so an
+    attempted breakout is visible, leaving the caller to restore the rest.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    if "/" in raw or "\\" in raw:
+        logger.warning(
+            "restore_open_slots: rejecting key with path separators: %r", raw
+        )
+        return None
+    # Fold to the canonical (filename-charset) key. Snapshots written before
+    # slot-key normalization landed may carry a raw display-style key (e.g.
+    # "Artifact: My Doc") alongside its sanitized twin — after folding, the
+    # second form hits the caller's dedup guard instead of restoring a duplicate
+    # sidebar session backed by the same transcript.
+    return _normalize_slot_key(raw)
+
+
+def _prefetch_rehydrate_inputs(
+    conv_log: ConversationLog,
+    history_key: str,
+    *,
+    adopt_closed: bool = False,
+    kiro_model_map: dict[str, str] | None = None,
+    with_status: bool = False,
+) -> tuple[dict, bool, list[dict] | None, dict[str, str] | None]:
+    """Read everything :func:`_rehydrate_slot_from_history` needs, off the loop.
+
+    The one prefetch seam shared by every async restore path — the metadata line,
+    the chained message walk and (when the caller has no shared copy) the
+    agent→model map. All three are blocking disk work; none of them touches slot
+    state, so the whole function is safe to hand to ``asyncio.to_thread`` while
+    the loop-affine slot mutation stays on the event loop. See
+    :func:`rehydrate_slot_from_history_async` for why that split is mandatory
+    rather than merely nice.
+
+    *with_status* selects ``get_metadata_status`` over ``get_metadata`` so the
+    open-tab restore keeps the readability signal it needs: ``get_metadata``
+    reports ``{}`` for both "never persisted" and "could not be read after
+    retries", and treating the second as the first is what silently discards a
+    live tab.
+
+    Returns ``(meta, readable, messages, model_map)``. *messages* and *model_map*
+    are ``None`` when there is nothing to build — no metadata, an unreadable
+    read, or a session closed with ✕ that the caller did not opt to adopt — so a
+    caller can decide without a second disk round trip.
+    """
+    if with_status:
+        meta, readable = conv_log.get_metadata_status(history_key)
+    else:
+        meta, readable = conv_log.get_metadata(history_key), True
+    if not readable or not meta or (meta.get("closed") and not adopt_closed):
+        return meta or {}, readable, None, None
+    return (
+        meta,
+        readable,
+        conv_log.read_messages_chained(history_key),
+        kiro_model_map if kiro_model_map is not None else _build_kiro_model_map(),
+    )
+
+
+def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
+    """Drive the open-tab restore one tab at a time, yielding the running count.
+
+    Exposed as a generator so a plain synchronous caller
+    (:func:`restore_open_slots`) can spin through it. The event-loop path does
+    NOT drive this generator: it needs each per-tab disk read hoisted into a
+    worker thread, which a synchronous generator cannot express, so
+    :func:`restore_open_slots_async` runs its own prefetch-then-apply loop over
+    the same shared helpers (:func:`_read_open_slots_keys`,
+    :func:`_sanitize_open_slot_key`, :func:`_prefetch_rehydrate_inputs`). See
+    :func:`restore_open_slots` for the behavioural contract.
+    """
+    if not state.conversation_log:
+        return
+    keys = _read_open_slots_keys()
+    if not keys:
         return
     restored = 0
     # Rebound each pass so it reflects only THIS restore: a key that becomes
@@ -281,72 +389,191 @@ def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
     # Built once and shared across every tab — it is identical per slot.
     kiro_model_map = _build_kiro_model_map()
     for raw in keys:
-        if not isinstance(raw, str) or not raw:
-            continue
-        # Defense-in-depth: slot keys flow into _history_key_for() ->
-        # filesystem path construction. open_slots.json is 0o600 so the threat
-        # is small, but a key smuggled in (symlink attack at write time or a
-        # separate vuln) could escape the sessions directory (e.g.
-        # "../../etc/passwd"). Live-gateway slot keys never contain path
-        # separators; reject any that do, warn so an attempted breakout is
-        # visible, and keep restoring the rest.
-        if "/" in raw or "\\" in raw:
-            logger.warning(
-                "restore_open_slots: rejecting key with path separators: %r", raw
-            )
-            continue
-        # Fold to the canonical (filename-charset) key. Snapshots written
-        # before slot-key normalization landed may carry a raw display-style
-        # key (e.g. "Artifact: My Doc") alongside its sanitized twin — after
-        # folding, the second form hits the dedup guard below instead of
-        # restoring a duplicate sidebar session backed by the same transcript.
-        raw = _normalize_slot_key(raw)
-        if raw in state._slots:
+        key = _sanitize_open_slot_key(raw)
+        if key is None or key in state._slots:
             continue
         try:
             # Ask whether the metadata READ succeeded, not just whether it came
-            # back empty. get_metadata() reports {} for both "never persisted"
-            # and "could not be read after retries", and treating the second as
-            # the first is what silently discards a live tab. Key it exactly as
-            # _rehydrate_slot_from_history does, so the prefetch below is a hit.
+            # back empty (``with_status``) — see _prefetch_rehydrate_inputs.
             #
-            # This read MUST stay inside the per-tab guard. restore_open_slots_async
-            # has no except at its call site, so anything escaping here aborts
-            # dashboard startup and costs every LATER tab too, not just this one.
-            meta, readable = state.conversation_log.get_metadata_status(
-                slot_transcript_key(raw)
+            # These reads MUST stay inside the per-tab guard. The async driver
+            # has no except at its call site either, so anything escaping here
+            # aborts dashboard startup and costs every LATER tab too.
+            meta, readable, messages, model_map = _prefetch_rehydrate_inputs(
+                state.conversation_log,
+                slot_transcript_key(key),
+                kiro_model_map=kiro_model_map,
+                with_status=True,
             )
-            if readable:
-                slot = _rehydrate_slot_from_history(
-                    state, raw, kiro_model_map=kiro_model_map, _prefetched_meta=meta
-                )
-                if slot is not None:
-                    restored += 1
-            else:
-                unrestored.add(raw)
-                logger.warning(
-                    "restore_open_slots: metadata unreadable for %s; keeping it "
-                    "in the reopen seed for the next restore instead of "
-                    "dropping it",
-                    raw,
-                )
+            restored += _apply_restored_open_slot(
+                state,
+                key,
+                meta=meta,
+                readable=readable,
+                messages=messages,
+                model_map=model_map,
+                unrestored=unrestored,
+            )
         except Exception:
-            logger.debug("restore_open_slots: rehydrate failed for %s", raw, exc_info=True)
+            logger.debug("restore_open_slots: rehydrate failed for %s", key, exc_info=True)
             # Same epistemic position as an unreadable read: the session was not
             # shown to be gone, so keep its key rather than erasing the seed.
-            unrestored.add(raw)
+            unrestored.add(key)
             # No rollback here: _rehydrate_slot_from_history undoes its own
             # partial slot and restricted key, so every caller gets it rather
             # than only the ones that remembered to compensate.
         # One yield point per tab, reached on EVERY outcome. A failing tab still
-        # costs real I/O (the metadata read retries, and _pause_for_transient_retry
-        # deliberately does not sleep while on the loop), so a run of failing tabs
-        # that skipped the yield would monopolise the loop and feed the stall
-        # watchdog. The async driver turns this into a real event-loop yield; the
-        # sync driver just spins through it.
+        # costs real I/O, so a run of failing tabs that skipped the yield would
+        # monopolise the loop and feed the stall watchdog. The sync driver just
+        # spins through it; the async driver has its own per-tab yield.
         yield restored
     if restored:
         logger.info("Restored %d open tab(s) from open_slots.json", restored)
+
+
+def _deletion_during_read(
+    conv_log: ConversationLog,
+    history_key: str,
+    pre_meta: dict,
+    pre_messages: list[dict] | None,
+) -> str | None:
+    """Was *history_key* deleted (or deleted-and-recreated) during a prefetch?
+
+    Returns a short reason for logging, or ``None`` when it is safe to build.
+
+    Offloading a transcript read (#895) opened a window that did not exist when
+    read-then-build ran atomically on the loop: ``ConversationLog.delete_session``
+    leaves **no tombstone** — its own docstring notes that once the delete
+    releases the lock "a concurrent writer can recreate the session" — so a slot
+    published from content we already hold rewrites, on its next flush, a file
+    the user permanently deleted. The dashboard's HTTP listener is bound before
+    startup restore runs (``_start_site`` precedes it in ``start_dashboard``), so
+    a user delete really can land inside this window.
+
+    This is the guard the chat-resume handler already applies after its own read
+    for exactly this reason; the logic is mirrored here rather than reinvented, so
+    both surfaces refuse on the same evidence.
+
+    MUST be called synchronously, on the loop, with no suspension point between
+    it and the build it gates — an await in between would reopen the window it
+    closes.
+
+    Two arms, and the asymmetry in each is deliberate:
+
+    * **absence** — ``get_metadata_status``, never ``get_metadata``: the latter
+      returns ``{}`` for both "deleted" and "unreadable", and reading an
+      unreadable metadata line as a deletion would discard a LIVE session. On an
+      unreadable read this returns ``None`` (build), because refusing is the
+      destructive direction here.
+    * **identity** — the delete leaves no tombstone, so a delete-then-RECREATE
+      inside the window leaves a NON-EMPTY metadata dict belonging to a NEW
+      conversation. Existence alone reads that as "still here" and would publish
+      a slot holding the OLD transcript, whose flush overwrites a session the
+      user is actively using — worse than the first arm, because the data
+      destroyed is live. ``created_at`` is the discriminator: every path that
+      MINTS a metadata line stamps it, while a rewrite/compaction carries it
+      through verbatim, so this does not fire on a legitimate rewrite.
+
+    ``created_at`` ABSENT on either side falls through to building rather than
+    refusing: refusing would reject every transcript whose metadata predates the
+    field, a visible break for real users, to close a narrow race.
+
+    The existence witness is the UNION of the pre-read metadata and the
+    transcript, so a metadata-only session (a metadata line with no messages,
+    which ``update_metadata`` creates on upsert) is not silently unguarded.
+    """
+    post_meta, readable = conv_log.get_metadata_status(history_key)
+    if not readable:
+        return None
+    if not (pre_meta or pre_messages):
+        # Never existed when we looked — an absent key is a new conversation,
+        # not a deletion.
+        return None
+    if not post_meta:
+        return "deleted"
+    pre_identity = pre_meta.get("created_at")
+    post_identity = post_meta.get("created_at")
+    if pre_identity and post_identity and pre_identity != post_identity:
+        return "deleted and recreated"
+    return None
+
+
+def _apply_restored_open_slot(
+    state: DashboardState,
+    key: str,
+    *,
+    meta: dict,
+    readable: bool,
+    messages: list[dict] | None,
+    model_map: dict[str, str] | None,
+    unrestored: set[str],
+    conv_log: ConversationLog | None = None,
+    started: float | None = None,
+) -> int:
+    """Turn one prefetched open-tab read into a slot; return 1 if it restored.
+
+    LOOP-AFFINE — slot construction broadcasts through
+    ``asyncio.Queue.put_nowait`` / ``Event.set``, so this half must run on the
+    event loop even when the read that fed it did not. Shared by both drivers so
+    the "unreadable metadata keeps its reopen seed" rule has one definition.
+
+    *conv_log* and *started* together opt into the POST-HOP re-checks and are
+    passed only by the async driver, whose read happened in a worker thread. The
+    synchronous generator reads inline with no suspension point, so its pre-read
+    answers cannot have gone stale and it would only pay for redundant work.
+    """
+    if not readable:
+        unrestored.add(key)
+        logger.warning(
+            "restore_open_slots: metadata unreadable for %s; keeping it "
+            "in the reopen seed for the next restore instead of dropping it",
+            key,
+        )
+        return 0
+    if messages is None:
+        # No metadata (never persisted) or the user closed the tab with ✕. Both
+        # are confident answers, so the key is NOT carried as unrestored — the
+        # synchronous helper's own guards reached the same verdict before.
+        return 0
+    if started is not None and slot_closed_since(state, key, started):
+        # TAB-CLOSE RACE, same window ``rehydrate_slot_from_history_async`` and
+        # the recent-sessions driver already guard. The user can click ✕ while
+        # the transcript is in flight: the close pops the slot and records the
+        # tombstone synchronously on the loop, but persists the ``closed`` flag
+        # only after its own awaits — so the metadata read above still says open.
+        # Rebuilding from it re-creates a tab the user dismissed, and the restored
+        # slot's next flush writes metadata WITHOUT ``closed``, erasing the close
+        # itself. The tombstone is the authoritative signal in this window.
+        logger.info(
+            "restore_open_slots: session %s was closed while its transcript "
+            "loaded; not restoring a tab the user dismissed",
+            key,
+        )
+        # A confident answer, like closed-on-disk — do NOT carry the key.
+        return 0
+    if conv_log is not None:
+        # Synchronous and immediately before the build: no await may separate the
+        # two (see _deletion_during_read).
+        gone = _deletion_during_read(
+            conv_log, slot_transcript_key(key), meta, messages
+        )
+        if gone is not None:
+            logger.info(
+                "restore_open_slots: session %s was %s while its transcript "
+                "loaded; refusing to restore a tab whose flush would rewrite it",
+                key,
+                gone,
+            )
+            # A confident answer, like closed/absent — do NOT carry the key.
+            return 0
+    slot = _rehydrate_slot_from_history(
+        state,
+        key,
+        kiro_model_map=model_map,
+        _prefetched_meta=meta,
+        _prefetched_messages=messages,
+    )
+    return 1 if slot is not None else 0
 
 
 def restore_open_slots(state: DashboardState) -> int:
@@ -378,7 +605,7 @@ def restore_open_slots(state: DashboardState) -> int:
 
 
 async def restore_open_slots_async(state: DashboardState) -> int:
-    """:func:`restore_open_slots`, yielding to the event loop between tabs.
+    """:func:`restore_open_slots`, with the disk reads off the loop (#895).
 
     Restoring a tab reads and redacts a transcript, so a user with many large
     tabs can spend tens of seconds in here. Doing that synchronously monopolizes
@@ -386,24 +613,83 @@ async def restore_open_slots_async(state: DashboardState) -> int:
     ``LoopStallWatchdog`` *from a coroutine*, a blocked loop cannot pet it. The
     watchdog's 25s ``exit_after`` timer then fires, dumps thread stacks and
     ``_exit``s the gateway, which is exactly the observed startup crash-loop: the
-    app never finished booting. Yielding per tab lets the heartbeat run, so a slow
-    restore degrades into "the sidebar fills in progressively" rather than "the
-    gateway dies".
+    app never finished booting.
 
-    Stays ON the loop rather than moving to a worker thread because creating a
-    slot broadcasts via ``asyncio.Queue.put_nowait`` / ``asyncio.Event.set``,
-    neither of which is thread-safe.
+    Yielding between tabs (the ``sleep(0)`` below) was the first fix and is kept:
+    it bounds how long any ONE tab can hold the loop. But it only ever moved the
+    boundary — the whole per-tab read still ran ON the loop, so a single large
+    transcript could stall it for seconds before the next yield arrived. So the
+    reads themselves now move: ``open_slots.json``, the agent→model map, and each
+    tab's metadata + chained transcript walk are hoisted into
+    ``asyncio.to_thread``, and only the slot mutation stays here.
+
+    That mutation cannot follow them. Creating a slot broadcasts via
+    ``asyncio.Queue.put_nowait`` / ``asyncio.Event.set``, neither of which is
+    thread-safe, and ``_spawn_ws_send``'s ``ensure_future`` raises off-loop into
+    a broad ``except`` that marks every connected dashboard client dead and drops
+    it *without a close frame* — browsers then never reconnect. So this driver
+    runs its own prefetch-then-apply loop (the shape
+    ``rehydrate_slot_from_history_async`` established) rather than driving
+    :func:`_restore_open_slots_steps`, whose reads are inline by construction.
+    The generator stays for the synchronous callers.
 
     Because this yields, the 5s periodic flush (already running by this point)
     can interleave — so ``restoring_open_slots`` is held for the duration to stop
     it snapshotting a half-restored slot set over open_slots.json.
     """
+    if not state.conversation_log:
+        return 0
     restored = 0
     state.restoring_open_slots = True
     try:
-        for restored in _restore_open_slots_steps(state):
+        keys = await asyncio.to_thread(_read_open_slots_keys)
+        if not keys:
+            return 0
+        # Rebound only once there is a snapshot to restore FROM, matching the
+        # generator: a missing/malformed file must not clear a carried set.
+        unrestored: set[str] = set()
+        state.unrestored_slot_keys = unrestored
+        conv_log = state.conversation_log
+        kiro_model_map = await asyncio.to_thread(_build_kiro_model_map)
+        for raw in keys:
+            key = _sanitize_open_slot_key(raw)
+            if key is None or key in state._slots:
+                continue
+            try:
+                started = time.time()
+                meta, readable, messages, model_map = await asyncio.to_thread(
+                    _prefetch_rehydrate_inputs,
+                    conv_log,
+                    slot_transcript_key(key),
+                    kiro_model_map=kiro_model_map,
+                    with_status=True,
+                )
+                restored += _apply_restored_open_slot(
+                    state,
+                    key,
+                    meta=meta,
+                    readable=readable,
+                    messages=messages,
+                    model_map=model_map,
+                    unrestored=unrestored,
+                    # Opts into the post-hop re-checks (close tombstone +
+                    # deletion): this driver's read ran in a worker thread, so
+                    # its answers can have gone stale.
+                    conv_log=conv_log,
+                    started=started,
+                )
+            except Exception:
+                logger.debug(
+                    "restore_open_slots: rehydrate failed for %s", key, exc_info=True
+                )
+                unrestored.add(key)
             # sleep(0) yields to the ready queue without adding wall-clock delay.
+            # Reached on EVERY outcome, including a failing tab (see the
+            # generator's note) — and still needed with the reads offloaded,
+            # because the apply half above runs here.
             await asyncio.sleep(0)
+        if restored:
+            logger.info("Restored %d open tab(s) from open_slots.json", restored)
     finally:
         # Always clear, even if a rehydrate raises — a stuck flag would silently
         # disable open-tab persistence for the rest of the process's life.
@@ -481,10 +767,7 @@ def _rehydrate_slot_from_history(
     # ever asking for that.
     if meta.get("closed") and not adopt_closed:
         return None
-    try:
-        _restore_cfg = KiroCrewConfig.load()
-    except Exception:
-        _restore_cfg = None
+    _restore_cfg = _load_restore_cfg()
     # Same kiro-agent model map as restore_recent_sessions so legacy sessions
     # without a persisted `model` still resolve correctly. Reuse the caller's
     # when bulk-restoring — it is identical for every slot.
@@ -794,9 +1077,18 @@ async def rehydrate_slot_from_history_async(
     receiving frames until a manual reload. ``restore_open_slots_async``
     documents the same invariant.
 
-    So only the two reads move: the metadata line and the chained message walk,
-    which on a large session are tens of MB of read plus JSON parse. Everything
-    that touches slot state runs on the loop, as the synchronous callers do.
+    So only the reads move: the metadata line, the chained message walk (tens of
+    MB of read plus JSON parse on a large session) and the agent→model map.
+    Everything that touches slot state runs on the loop, as the synchronous
+    callers do. The reads are shared with the two bulk restore drivers via
+    :func:`_prefetch_rehydrate_inputs`, so all three prefetch identically.
+
+    Because the read is offloaded, the state it observed can be stale by the time
+    the build runs. Both post-hop windows are re-checked below, synchronously and
+    immediately before the build so no await can reopen them: the close tombstone
+    (a ✕ during the read) and :func:`_deletion_during_read` (the session deleted,
+    or deleted and recreated, during the read). Returning ``None`` for either is
+    part of the contract — the callers already handle a ``None`` result.
     """
     if not state.conversation_log:
         return None
@@ -806,20 +1098,19 @@ async def rehydrate_slot_from_history_async(
     history_key = slot_transcript_key(slot_name)
     conv_log = state.conversation_log
 
-    def _read() -> tuple[dict | None, list[dict] | None, dict[str, str] | None]:
-        meta = conv_log.get_metadata(history_key)
-        if not meta or (meta.get("closed") and not adopt_closed):
-            return None, None, None
-        return (
-            meta,
-            conv_log.read_messages_chained(history_key),
-            kiro_model_map if kiro_model_map is not None else _build_kiro_model_map(),
-        )
-
     started = time.time()
-    meta, messages, model_map = await asyncio.to_thread(_read)
-    if meta is None or messages is None:
+    _meta, _readable, messages, model_map = await asyncio.to_thread(
+        _prefetch_rehydrate_inputs,
+        conv_log,
+        history_key,
+        adopt_closed=adopt_closed,
+        kiro_model_map=kiro_model_map,
+    )
+    # ``messages is None`` covers both "never persisted" and "closed with ✕"
+    # — the prefetch already applied the same guards the synchronous form does.
+    if messages is None:
         return None
+    meta = _meta
     # Tab-close race. The user can click ✕ while the read above is in flight.
     # The close pops the slot and records a tombstone synchronously on the loop,
     # but persists the ``closed`` flag only after its own awaits — so the
@@ -836,6 +1127,28 @@ async def rehydrate_slot_from_history_async(
             slot_name,
         )
         return None
+    # DELETION race, the same window and the same remedy the two bulk restore
+    # drivers apply. This wrapper's read has always been offloaded, so the window
+    # predates #895 — the guard is folded in here anyway rather than left as the
+    # one uncovered instance, because a class of defect fixed at two of three
+    # call sites simply returns through the third.
+    #
+    # NOT gated on ``adopt_closed``: that opt-in is about the ``closed`` FLAG (an
+    # app-owned worker slot whose lifecycle belongs to the app), not about the
+    # session having been permanently deleted. Nothing wants to resurrect a
+    # deleted transcript.
+    #
+    # Synchronous and immediately before the build, so no await can reopen the
+    # window it closes.
+    gone = _deletion_during_read(conv_log, history_key, meta, messages)
+    if gone is not None:
+        logger.info(
+            "Rehydration abandoned: session %s was %s while its transcript "
+            "loaded; refusing to rebuild a slot whose flush would rewrite it",
+            slot_name,
+            gone,
+        )
+        return None
     return _rehydrate_slot_from_history(
         state,
         slot_name,
@@ -846,202 +1159,284 @@ async def rehydrate_slot_from_history_async(
     )
 
 
+def _recent_session_slot_name(key: str) -> str | None:
+    """Map a ``list_sessions()`` key to its dashboard slot name, or skip it.
+
+    Returns ``None`` for a key this restore path does not own. Channel-born
+    sessions are restored by ``channel_slot_reconciler``, which reads their
+    transcripts in an executor — pulling them in here would put a large
+    transcript's read in front of the whole gateway at startup.
+    """
+    if key.startswith("dashboard:"):
+        return key.removeprefix("dashboard:")
+    if key.startswith("dashboard_"):
+        return key.removeprefix("dashboard_")
+    return None
+
+
+def _prefetch_recent_session(
+    conv_log: ConversationLog,
+    key: str,
+    session: dict,
+    *,
+    folders_only: bool,
+    cutoff: float | None,
+) -> tuple[dict | None, list[dict] | None]:
+    """Read one candidate session's metadata + transcript, off the loop (#895).
+
+    Applies the selection filters BETWEEN the two reads so a session that is
+    going to be skipped never pays for its transcript walk — the metadata read is
+    what the filters need, and it is the cheap one.
+
+    Returns ``(None, None)`` for a session this pass must skip (not folder'd /
+    pinned under ``folders_only``, closed with ✕, or outside the mtime window).
+    Pure disk work: no slot state is touched, so the whole function is safe in
+    ``asyncio.to_thread`` while the loop-affine apply half stays on the loop.
+    """
+    meta = conv_log.get_metadata(key)
+    if not meta:
+        # No metadata line at all. ``list_sessions()`` is a SNAPSHOT, and since
+        # #895 it is taken one thread hop before this read, so a session can be
+        # deleted in between and still appear in the list — or the read itself
+        # came back empty. Either way there is nothing to build from, and
+        # building anyway is destructive rather than merely useless: an empty
+        # ``meta`` sails past the folder/pin/closed/cutoff filters below (all of
+        # which read falsy), reaches ``get_or_create_slot``, and registers a
+        # PHANTOM slot whose next flush RECREATES the transcript the user
+        # deleted. ``_rehydrate_slot_from_history`` already refuses on empty
+        # metadata for exactly this reason ("don't create a phantom slot"); this
+        # makes the recent-sessions path agree with it.
+        return None, None
+    has_folder = bool(meta.get("folder_id"))
+    has_pin = bool(meta.get("pinned"))
+    if folders_only and not has_folder and not has_pin:
+        return None, None
+    if meta.get("closed"):
+        return None, None
+    if not has_folder and not has_pin:
+        if cutoff is not None and session.get("modified", 0) < cutoff:
+            return None, None
+    return meta, conv_log.read_messages_chained(key)
+
+
+def _apply_recent_session(
+    state: DashboardState,
+    key: str,
+    slot_name: str,
+    session: dict,
+    meta: dict,
+    messages: list[dict],
+    *,
+    conv_log: "ConversationLog",
+    kiro_model_map: dict[str, str],
+    restore_cfg: "KiroCrewConfig | None",
+) -> None:
+    """Build the slot for one prefetched recent session.
+
+    LOOP-AFFINE — everything here mutates slot state, and slot creation
+    broadcasts through ``asyncio.Queue.put_nowait`` / ``Event.set`` (neither
+    thread-safe). Split out of :func:`_restore_recent_sessions_steps` so the
+    synchronous generator and :func:`restore_recent_sessions_async` share one
+    definition of the build while differing only in where the reads that feed it
+    happen.
+    """
+    _restore_cfg = restore_cfg
+    slot = state.get_or_create_slot(
+        slot_name,
+        app=meta.get("app", ""),
+        # No channel_origin here: the caller skips every non-dashboard key, so a
+        # channel-born session never reaches this — ``channel_slot_reconciler``
+        # owns surfacing those.
+        # Restore the persisted origin. Re-deriving it here would relabel
+        # every rehydrated slot on restart, so a cron slot would come back
+        # as USER (leak) and a real user slot as untagged (silently
+        # dropping `slots:user` for apps that legitimately hold it).
+        origin=str(meta.get("origin", "")),
+    )
+    # Titles can be LLM-generated (auto-title) and are surfaced on the
+    # dashboard — apply the same redaction as assistant content. Matches
+    # the treatment in _rehydrate_slot_from_history above.
+    raw_title = session.get("title", slot_name)
+    _rehydrate_slot_title(
+        slot,
+        raw_title,
+        titled=bool(session.get("title")),
+        metadata=meta,
+    )
+    if meta.get("created_at"):
+        slot.created_at = meta["created_at"]
+    if meta.get("agent"):
+        slot.agent = meta["agent"]
+    if meta.get("model"):
+        # Canonicalize a pre-migration claude_code provider id to the
+        # canonical dropdown key (no-op for other providers); reuse the
+        # already-loaded _restore_cfg provider.
+        _prov = _restore_cfg.agent.provider if _restore_cfg else ""
+        slot.model = model_registry.canonicalize_for_provider(
+            _normalize_model(meta["model"]), _prov
+        )
+    elif slot.agent:
+        try:
+            mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
+            kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
+            slot.model = kiro_model_map.get(kiro_name, "")
+        except Exception:
+            logger.debug(
+                "Failed to resolve model for restored slot %s", slot_name, exc_info=True
+            )
+    if meta.get("reasoning_effort"):
+        slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
+    if meta.get("workspace"):
+        slot.workspace = meta["workspace"]
+    if meta.get("project"):
+        slot.project = meta["project"]
+    if meta.get("mode"):
+        slot.mode = meta["mode"]
+    if meta.get("folder_id"):
+        slot.folder_id = meta["folder_id"]
+    if meta.get("channel_folder_filed"):
+        slot._channel_folder_filed = True
+    if meta.get("app"):
+        slot._app = meta["app"]
+    # Same tamper gate as _rehydrate_slot_from_history: re-validate the
+    # companion binding against the slug grammar before it reaches
+    # to_dict()/WS broadcasts.
+    _artifact_meta = meta.get("artifact")
+    if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
+        slot._artifact = _artifact_meta
+    if meta.get("pinned"):
+        slot.pinned = True
+    if meta.get("color_index") is not None:
+        slot.color_index = meta["color_index"]
+    _ch = meta.get("color_hex")
+    if isinstance(_ch, str) and COLOR_HEX_RE.match(_ch):
+        slot.color_hex = _ch.lower()
+    if meta.get("color_theme"):
+        slot.color_theme = meta["color_theme"]
+    raw_tags = meta.get("tags")
+    if isinstance(raw_tags, list):
+        slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+        # Prune ids missing from the vocabulary: tag deletion commits the
+        # vocab write first (crash-atomic), so a crash mid-delete can
+        # leave dangling ids on the persisted slot line. load_tags() runs
+        # before any slot restore, so state._tags is authoritative here.
+        # FAIL-OPEN only when the vocabulary is UNKNOWN (tags.json parse
+        # or I/O failure): pruning then would wipe EVERY assignment and
+        # the next save persists the loss. A legitimately-empty vocabulary
+        # (user deleted the last tag) IS authoritative and must prune —
+        # otherwise a crash mid-delete resurrects the dangling id forever.
+        if getattr(state, "_tags_authoritative", True):
+            known = {t.get("id") for t in state._tags}
+            slot.tags = [t for t in slot.tags if t in known]
+    if meta.get("auto_tagged"):
+        slot._auto_tagged = True
+    if meta.get("human_seen"):
+        # Attendance survives the restart, so an app-owned tab a person has
+        # been working in keeps the full approval window instead of silently
+        # dropping to the unattended deny-fast (state._ChatSlot.unattended).
+        slot._human_seen = True
+    mm = meta.get("memory_mode", "persistent")
+    slot.memory_mode = mm
+    if mm != "persistent":
+        state._restricted_keys.add(f"dashboard:{slot_name}")
+    if meta.get("forked_from") is not None:
+        slot.forked_from = meta["forked_from"]
+    if meta.get("linked_session_key"):
+        slot.linked_session_key = str(meta["linked_session_key"])
+    elif is_channel_session_key(key) and state.sessions:
+        # First time this thread is surfaced: bind it to the session the
+        # channel itself runs. Resolved from the session map, never derived
+        # from the filename — the ``:``-to-``_`` fold is not reversible, so
+        # a guess could point the tab at a session the channel never reads.
+        real_key = state.sessions.channel_key_for_stem(key)
+        if real_key:
+            slot.linked_session_key = real_key
+    tab_id = meta.get("tab_id")
+    if not tab_id:
+        tab_id = uuid.uuid4().hex[:12]
+        # restore_recent_sessions runs during on_startup (event loop live)
+        # — keep the _locked flock/os.close off the loop via the off-loop
+        # backfill helper. Dispatched AFTER the transcript read above (the
+        # caller prefetches messages first) so its os.replace() cannot race
+        # the read of the same file — see the equivalent note in
+        # _rehydrate_slot_from_history.
+        update_metadata_off_loop(conv_log, key, {"tab_id": tab_id})
+    slot._tab_id = tab_id
+    slot._disk_older_count = max(0, len(messages) - 500)
+    for m in messages[-500:]:
+        role = m.get("role", "assistant")
+        cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
+        content = m.get("content", "")
+        # CONTENT is redacted on load; META is deferred to the emit sites.
+        # See the equivalent loop in _rehydrate_slot_from_history for the
+        # measured rationale (content ~0.4s / ~204 readers, meta ~5.5s /
+        # 31 readers that touch only control fields outside the emit sites).
+        if role != "user":
+            content, _ = redact_exfiltration_urls(content)
+            content, _ = redact_credentials(content)
+        slot.append(
+            role,
+            content,
+            cls,
+            ts=m.get("ts", ""),
+            broadcast=False,
+            meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
+        )
+        # See the equivalent call in _rehydrate_slot_from_history.
+        carry_provenance(slot.messages[-1], m)
+        _attach_variants(slot, m)
+    slot.drain()
+    slot._resumed_count = len(slot.messages)
+    # Loaded window is the on-disk window region; older lines (counted in
+    # _disk_older_count above) are the frozen prefix saves never rewrite.
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+    logger.info("Restored session %s (%s)", slot_name, slot.title)
+
+
 def _restore_recent_sessions_steps(
     state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
 ) -> "Iterator[int]":
     """Drive :func:`restore_recent_sessions` one session at a time.
 
-    Generator for the same reason as :func:`_restore_open_slots_steps`: it lets
-    the startup path yield to the event loop between sessions. This path restores
+    Generator so a plain synchronous caller can spin through it. The event-loop
+    path does NOT drive this one either: it needs ``list_sessions()`` and each
+    per-session read hoisted into a worker thread, which a synchronous generator
+    cannot express, so :func:`restore_recent_sessions_async` runs its own
+    prefetch-then-apply loop over the same shared helpers. This path restores
     every folder'd/pinned session regardless of the mtime window, so it can be
     just as slow as the open-tab restore — measured at 13.6s for 76 sessions.
     """
     if not state.conversation_log:
         return
+    conv_log = state.conversation_log
     cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
     restored = 0
 
     kiro_model_map = _build_kiro_model_map()
-    try:
-        _restore_cfg = KiroCrewConfig.load()
-    except Exception:
-        _restore_cfg = None
-    for s in state.conversation_log.list_sessions():
+    _restore_cfg = _load_restore_cfg()
+    for s in conv_log.list_sessions():
         key = s.get("key", "")
-        if key.startswith("dashboard:"):
-            slot_name = key.removeprefix("dashboard:")
-        elif key.startswith("dashboard_"):
-            slot_name = key.removeprefix("dashboard_")
-        else:
-            # Channel-born sessions are restored by ``channel_slot_reconciler``,
-            # which reads their transcripts in an executor. This loop runs ON the
-            # event loop between yields, so pulling them in here would put a
-            # large transcript's read in front of the whole gateway at startup.
+        slot_name = _recent_session_slot_name(key)
+        if slot_name is None or slot_name in state._slots:
             continue
-        if slot_name in state._slots:
+        meta, messages = _prefetch_recent_session(
+            conv_log, key, s, folders_only=folders_only, cutoff=cutoff
+        )
+        if meta is None or messages is None:
             continue
-        meta = state.conversation_log.get_metadata(key)
-        has_folder = bool(meta.get("folder_id"))
-        has_pin = bool(meta.get("pinned"))
-        if folders_only and not has_folder and not has_pin:
-            continue
-        if meta.get("closed"):
-            continue
-        if not has_folder and not has_pin:
-            if cutoff is not None and s.get("modified", 0) < cutoff:
-                continue
-        slot = state.get_or_create_slot(
+        _apply_recent_session(
+            state,
+            key,
             slot_name,
-            app=meta.get("app", ""),
-            # No channel_origin here: this loop `continue`s above for every
-            # non-dashboard key, so a channel-born session never reaches it --
-            # ``channel_slot_reconciler`` owns surfacing those.
-            # Restore the persisted origin. Re-deriving it here would relabel
-            # every rehydrated slot on restart, so a cron slot would come back
-            # as USER (leak) and a real user slot as untagged (silently
-            # dropping `slots:user` for apps that legitimately hold it).
-            origin=str(meta.get("origin", "")),
+            s,
+            meta,
+            messages,
+            conv_log=conv_log,
+            kiro_model_map=kiro_model_map,
+            restore_cfg=_restore_cfg,
         )
-        # Titles can be LLM-generated (auto-title) and are surfaced on the
-        # dashboard — apply the same redaction as assistant content. Matches
-        # the treatment in _rehydrate_slot_from_history above.
-        raw_title = s.get("title", slot_name)
-        _rehydrate_slot_title(
-            slot,
-            raw_title,
-            titled=bool(s.get("title")),
-            metadata=meta,
-        )
-        if meta.get("created_at"):
-            slot.created_at = meta["created_at"]
-        if meta.get("agent"):
-            slot.agent = meta["agent"]
-        if meta.get("model"):
-            # Canonicalize a pre-migration claude_code provider id to the
-            # canonical dropdown key (no-op for other providers); reuse the
-            # already-loaded _restore_cfg provider.
-            _prov = _restore_cfg.agent.provider if _restore_cfg else ""
-            slot.model = model_registry.canonicalize_for_provider(
-                _normalize_model(meta["model"]), _prov
-            )
-        elif slot.agent:
-            try:
-                mc = _restore_cfg.agents.get(slot.agent) if _restore_cfg else None
-                kiro_name = mc.kiro_agent if mc and mc.kiro_agent else slot.agent
-                slot.model = kiro_model_map.get(kiro_name, "")
-            except Exception:
-                logger.debug(
-                    "Failed to resolve model for restored slot %s", slot_name, exc_info=True
-                )
-        if meta.get("reasoning_effort"):
-            slot.reasoning_effort = _validate_reasoning_effort(meta["reasoning_effort"])
-        if meta.get("workspace"):
-            slot.workspace = meta["workspace"]
-        if meta.get("project"):
-            slot.project = meta["project"]
-        if meta.get("mode"):
-            slot.mode = meta["mode"]
-        if meta.get("folder_id"):
-            slot.folder_id = meta["folder_id"]
-        if meta.get("channel_folder_filed"):
-            slot._channel_folder_filed = True
-        if meta.get("app"):
-            slot._app = meta["app"]
-        # Same tamper gate as _rehydrate_slot_from_history: re-validate the
-        # companion binding against the slug grammar before it reaches
-        # to_dict()/WS broadcasts.
-        _artifact_meta = meta.get("artifact")
-        if isinstance(_artifact_meta, str) and ARTIFACT_SLUG_RE.match(_artifact_meta):
-            slot._artifact = _artifact_meta
-        if meta.get("pinned"):
-            slot.pinned = True
-        if meta.get("color_index") is not None:
-            slot.color_index = meta["color_index"]
-        _ch = meta.get("color_hex")
-        if isinstance(_ch, str) and COLOR_HEX_RE.match(_ch):
-            slot.color_hex = _ch.lower()
-        if meta.get("color_theme"):
-            slot.color_theme = meta["color_theme"]
-        raw_tags = meta.get("tags")
-        if isinstance(raw_tags, list):
-            slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
-            # Prune ids missing from the vocabulary: tag deletion commits the
-            # vocab write first (crash-atomic), so a crash mid-delete can
-            # leave dangling ids on the persisted slot line. load_tags() runs
-            # before any slot restore, so state._tags is authoritative here.
-            # FAIL-OPEN only when the vocabulary is UNKNOWN (tags.json parse
-            # or I/O failure): pruning then would wipe EVERY assignment and
-            # the next save persists the loss. A legitimately-empty vocabulary
-            # (user deleted the last tag) IS authoritative and must prune —
-            # otherwise a crash mid-delete resurrects the dangling id forever.
-            if getattr(state, "_tags_authoritative", True):
-                known = {t.get("id") for t in state._tags}
-                slot.tags = [t for t in slot.tags if t in known]
-        if meta.get("auto_tagged"):
-            slot._auto_tagged = True
-        if meta.get("human_seen"):
-            # Attendance survives the restart, so an app-owned tab a person has
-            # been working in keeps the full approval window instead of silently
-            # dropping to the unattended deny-fast (state._ChatSlot.unattended).
-            slot._human_seen = True
-        mm = meta.get("memory_mode", "persistent")
-        slot.memory_mode = mm
-        if mm != "persistent":
-            state._restricted_keys.add(f"dashboard:{slot_name}")
-        if meta.get("forked_from") is not None:
-            slot.forked_from = meta["forked_from"]
-        if meta.get("linked_session_key"):
-            slot.linked_session_key = str(meta["linked_session_key"])
-        elif is_channel_session_key(key) and state.sessions:
-            # First time this thread is surfaced: bind it to the session the
-            # channel itself runs. Resolved from the session map, never derived
-            # from the filename — the ``:``-to-``_`` fold is not reversible, so
-            # a guess could point the tab at a session the channel never reads.
-            real_key = state.sessions.channel_key_for_stem(key)
-            if real_key:
-                slot.linked_session_key = real_key
-        tab_id = meta.get("tab_id")
-        if not tab_id:
-            tab_id = uuid.uuid4().hex[:12]
-            # restore_recent_sessions runs during on_startup (event loop live)
-            # — keep the _locked flock/os.close off the loop via the off-loop
-            # backfill helper.
-            update_metadata_off_loop(
-                state.conversation_log, key, {"tab_id": tab_id}
-            )
-        slot._tab_id = tab_id
-        messages = state.conversation_log.read_messages_chained(key)
-        slot._disk_older_count = max(0, len(messages) - 500)
-        for m in messages[-500:]:
-            role = m.get("role", "assistant")
-            cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
-            content = m.get("content", "")
-            # CONTENT is redacted on load; META is deferred to the emit sites.
-            # See the equivalent loop in _rehydrate_slot_from_history for the
-            # measured rationale (content ~0.4s / ~204 readers, meta ~5.5s /
-            # 31 readers that touch only control fields outside the emit sites).
-            if role != "user":
-                content, _ = redact_exfiltration_urls(content)
-                content, _ = redact_credentials(content)
-            slot.append(
-                role,
-                content,
-                cls,
-                ts=m.get("ts", ""),
-                broadcast=False,
-                meta=(m["meta"] if isinstance(m.get("meta"), dict) else None),
-            )
-            # See the equivalent call in _rehydrate_slot_from_history.
-            carry_provenance(slot.messages[-1], m)
-            _attach_variants(slot, m)
-        slot.drain()
-        slot._resumed_count = len(slot.messages)
-        # Loaded window is the on-disk window region; older lines (counted in
-        # _disk_older_count above) are the frozen prefix saves never rewrite.
-        slot._disk_window_len = len(slot.messages)
-        slot._dirty = False
         restored += 1
-        logger.info("Restored session %s (%s)", slot_name, slot.title)
         # One yield point per restored session (see _restore_open_slots_steps).
         yield restored
     _sync_dashboard_slots(state)
@@ -1065,20 +1460,113 @@ def restore_recent_sessions(
 async def restore_recent_sessions_async(
     state: DashboardState, window_minutes: int = 30, *, folders_only: bool = False
 ) -> int:
-    """:func:`restore_recent_sessions`, yielding to the event loop per session.
+    """:func:`restore_recent_sessions`, with the disk reads off the loop (#895).
 
     Same rationale as :func:`restore_open_slots_async` — keeps the stall-watchdog
     heartbeat alive while a large restore proceeds, and holds
     ``restoring_open_slots`` so an interleaved flush cannot snapshot a partial
     slot set (this path adds slots to the same sidebar).
+
+    Everything blocking is hoisted into ``asyncio.to_thread``: ``list_sessions()``
+    (which globs + stats + reads the first line of EVERY session file), the
+    agent→model map, the config load, and each candidate's metadata + chained
+    transcript walk. Only :func:`_apply_recent_session` stays on the loop,
+    because slot construction is loop-affine for the reasons
+    :func:`rehydrate_slot_from_history_async` documents.
+
+    Yielding per session is kept alongside the offload: the apply half still runs
+    here, so the loop must get a turn between sessions.
     """
+    if not state.conversation_log:
+        return 0
     restored = 0
     state.restoring_open_slots = True
     try:
-        for restored in _restore_recent_sessions_steps(
-            state, window_minutes, folders_only=folders_only
-        ):
+        conv_log = state.conversation_log
+        cutoff = time.time() - (window_minutes * 60) if window_minutes > 0 else None
+        sessions = await asyncio.to_thread(conv_log.list_sessions)
+        kiro_model_map = await asyncio.to_thread(_build_kiro_model_map)
+        _restore_cfg = await asyncio.to_thread(_load_restore_cfg)
+        for s in sessions:
+            key = s.get("key", "")
+            slot_name = _recent_session_slot_name(key)
+            if slot_name is None or slot_name in state._slots:
+                continue
+            started = time.time()
+            meta, messages = await asyncio.to_thread(
+                _prefetch_recent_session,
+                conv_log,
+                key,
+                s,
+                folders_only=folders_only,
+                cutoff=cutoff,
+            )
+            if meta is None or messages is None:
+                continue
+            # POST-HOP REVALIDATION. Before the reads were offloaded, each item's
+            # check-then-apply ran atomically on the loop — nothing could get
+            # between them. The read window is now seconds wide, so the pre-hop
+            # answers are stale and BOTH must be asked again here, on the loop,
+            # before anything mutates slot state:
+            #
+            #   * the slot may now EXIST (a resume, a nudge, or the user opening
+            #     the tab published it while the transcript loaded).
+            #     ``_apply_recent_session`` calls ``get_or_create_slot``, which
+            #     returns that live slot, and the replay below would then append
+            #     500 on-disk messages onto state that already has them and
+            #     persist the duplicates.
+            #   * the tab may have been CLOSED with ✕. The close pops the slot and
+            #     records a tombstone synchronously, but persists the ``closed``
+            #     flag only after its own awaits — so the metadata just read still
+            #     says open, and rebuilding from it would resurrect a dismissed
+            #     tab and then fire a nudge turn into it. The tombstone is the
+            #     authoritative signal in that window.
+            #
+            # ``rehydrate_slot_from_history_async`` guards the same two windows
+            # after its own hop, and the open-tab driver inherits the ``_slots``
+            # half from ``_rehydrate_slot_from_history``'s internal re-check. This
+            # is the one converted surface that has to spell both out.
+            if slot_name in state._slots:
+                logger.debug(
+                    "Restore skipped: session %s was published while its "
+                    "transcript loaded",
+                    slot_name,
+                )
+                continue
+            if slot_closed_since(state, slot_name, started):
+                logger.info(
+                    "Restore abandoned: session %s was closed while its "
+                    "transcript loaded",
+                    slot_name,
+                )
+                continue
+            # Third window: the session may have been permanently DELETED (or
+            # deleted and recreated) during the read. Synchronous and last, so no
+            # await separates it from the build it gates.
+            gone = _deletion_during_read(conv_log, key, meta, messages)
+            if gone is not None:
+                logger.info(
+                    "Restore abandoned: session %s was %s while its transcript "
+                    "loaded; refusing to restore a slot whose flush would "
+                    "rewrite it",
+                    slot_name,
+                    gone,
+                )
+                continue
+            _apply_recent_session(
+                state,
+                key,
+                slot_name,
+                s,
+                meta,
+                messages,
+                conv_log=conv_log,
+                kiro_model_map=kiro_model_map,
+                restore_cfg=_restore_cfg,
+            )
+            restored += 1
             await asyncio.sleep(0)
+        _sync_dashboard_slots(state)
     finally:
         state.restoring_open_slots = False
     return restored

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -5336,15 +5336,15 @@ class ConversationLog:
     def _pause_for_transient_retry(self) -> None:
         """Pause briefly before retrying a transient read, but ONLY off the loop.
 
-        Shared by :meth:`_read_metadata` and :meth:`_read_messages`. Both are
-        reached ON the event loop by ``restore_open_slots_async`` (which keeps
-        the whole restore on the loop deliberately: creating a slot broadcasts
-        through ``asyncio.Queue.put_nowait`` / ``Event.set``, neither
-        thread-safe). A kernel sleep there stops ``_loop_heartbeat`` from petting
-        the LoopStallWatchdog -- whose ``exit_after`` timer then kills the
-        gateway, the exact crash-loop the async restore exists to prevent. So
-        sleep only when NOT on a running loop; on the loop the retry is
-        immediate (a stat plus an open -- cheap enough to be worth taking).
+        Shared by :meth:`_read_metadata` and :meth:`_read_messages`. Since #895
+        the startup restore prefetches both in ``asyncio.to_thread``, so the
+        common bulk-restore caller lands here OFF the loop and gets the patient
+        path. On-loop callers remain (any read reached directly from a coroutine),
+        and for them a kernel sleep stops ``_loop_heartbeat`` from petting the
+        LoopStallWatchdog -- whose ``exit_after`` timer then kills the gateway,
+        the exact crash-loop the async restore exists to prevent. So sleep only
+        when NOT on a running loop; on the loop the retry is immediate (a stat
+        plus an open -- cheap enough to be worth taking).
         """
         on_loop = True
         try:

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1441,3 +1443,539 @@ def test_non_object_metadata_line_does_not_abort_the_whole_restore(
     state2._persist_open_slots()
     persisted = set(json.loads((tmp_path / "open_slots.json").read_text())["keys"])
     assert persisted == {"chat-0-ok", "chat-2-ok"}
+
+
+# ── Startup must not READ on the event loop either (#895) ──
+#
+# The per-tab yield above bounded how long ONE tab could hold the loop, but the
+# per-tab WORK still ran on it: get_metadata_status plus a chained
+# read_messages_chained walk on a multi-megabyte transcript is seconds of loop
+# time *between* yields, and the ``open_slots.json`` read plus the agent→model
+# map glob were on-loop before the first yield ever arrived. So the reads now
+# move into asyncio.to_thread and only the slot mutation stays on the loop --
+# the same prefetch-then-apply split rehydrate_slot_from_history_async
+# established, and for the same non-negotiable reason (slot construction
+# broadcasts through asyncio.Queue.put_nowait / Event.set, neither thread-safe).
+
+
+def _record_restore_threads(monkeypatch, state):
+    """Instrument one state's restore so each half's thread is observable.
+
+    Returns a dict of thread-name lists, filled in as the restore runs:
+
+    * ``walk`` — ``read_messages_chained``, the expensive half. Must NEVER run on
+      the loop thread; this is the property #895 is about.
+    * ``prefetch`` — ``_prefetch_rehydrate_inputs``, the offloaded read bundle.
+    * ``recheck`` — ``_deletion_during_read``, the post-hop deletion guard, which
+      must run ON the loop *by design*: it gates the build and no suspension point
+      may separate the two. So it is asserted separately rather than lumped in
+      with the reads.
+    * ``build`` — ``_rehydrate_slot_from_history``, loop-affine.
+    * ``snapshot`` — the ``open_slots.json`` read.
+
+    Wraps the REAL implementations so the restore still completes end to end and
+    the assertions are about placement, not about a stub's behaviour.
+    """
+    from kiro_crew.dashboard import chat_persistence
+
+    log = state.conversation_log
+    assert log is not None
+    seen: dict[str, list[str]] = {
+        "walk": [],
+        "prefetch": [],
+        "recheck": [],
+        "build": [],
+        "snapshot": [],
+    }
+
+    real_chained = log.read_messages_chained
+    real_prefetch = chat_persistence._prefetch_rehydrate_inputs
+    real_recheck = chat_persistence._deletion_during_read
+    real_build = chat_persistence._rehydrate_slot_from_history
+    real_keys = chat_persistence._read_open_slots_keys
+
+    def _chained(key):
+        seen["walk"].append(threading.current_thread().name)
+        return real_chained(key)
+
+    def _prefetch(*a, **kw):
+        seen["prefetch"].append(threading.current_thread().name)
+        return real_prefetch(*a, **kw)
+
+    def _recheck(*a, **kw):
+        seen["recheck"].append(threading.current_thread().name)
+        return real_recheck(*a, **kw)
+
+    def _build(*a, **kw):
+        seen["build"].append(threading.current_thread().name)
+        return real_build(*a, **kw)
+
+    def _keys():
+        seen["snapshot"].append(threading.current_thread().name)
+        return real_keys()
+
+    monkeypatch.setattr(log, "read_messages_chained", _chained)
+    monkeypatch.setattr(chat_persistence, "_prefetch_rehydrate_inputs", _prefetch)
+    monkeypatch.setattr(chat_persistence, "_deletion_during_read", _recheck)
+    monkeypatch.setattr(chat_persistence, "_rehydrate_slot_from_history", _build)
+    monkeypatch.setattr(chat_persistence, "_read_open_slots_keys", _keys)
+    return seen
+
+
+def test_restore_open_slots_async_reads_off_the_loop(tmp_path, monkeypatch):
+    """Every per-tab disk read must run in a worker thread, not on the loop.
+
+    This is the assertion the yield-only fix could not make: it passes only when
+    the metadata read and the chained transcript walk have actually left the
+    event-loop thread. Driving the synchronous generator (the previous shape)
+    fails it on the first tab.
+
+    The post-hop deletion re-check is deliberately excluded and asserted to be ON
+    the loop instead — see the sibling test below.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-offloop" for i in range(3)]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen = _record_restore_threads(monkeypatch, state2)
+
+    main = threading.current_thread().name
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == len(keys)
+    assert set(state2._slots) == set(keys)
+    assert seen["walk"], "no transcript was read — the test would not detect the bug"
+    assert all(t != main for t in seen["walk"]), (
+        "a transcript walk ran ON the event-loop thread; a large transcript "
+        f"there stalls the stall-watchdog heartbeat (threads: {sorted(set(seen['walk']))})"
+    )
+    assert seen["prefetch"] and all(t != main for t in seen["prefetch"]), (
+        f"the prefetch bundle ran on the loop (threads: {sorted(set(seen['prefetch']))})"
+    )
+    assert seen["snapshot"] and all(t != main for t in seen["snapshot"]), (
+        "open_slots.json was read on the event loop before the first yield"
+    )
+    assert seen["build"] == [main] * len(keys), (
+        "slot construction left the event-loop thread; it broadcasts through "
+        "asyncio.Queue.put_nowait / Event.set, neither of which is thread-safe "
+        f"(threads: {seen['build']})"
+    )
+
+
+def test_the_deletion_recheck_runs_on_the_loop_next_to_the_build(tmp_path, monkeypatch):
+    """The guard must NOT be offloaded — that would reopen the window it closes.
+
+    ``_deletion_during_read`` gates the build, so an await between the two would
+    let a delete land in the gap. It is one mtime-cached metadata line, which is
+    why paying for it on the loop is the right trade.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-gated")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-gated"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen = _record_restore_threads(monkeypatch, state2)
+
+    main = threading.current_thread().name
+    assert asyncio.run(restore_open_slots_async(state2)) == 1
+    assert seen["recheck"] == [main], (
+        "the deletion re-check must run on the loop, immediately before the "
+        f"build it gates (threads: {seen['recheck']})"
+    )
+    assert seen["build"] == [main]
+
+
+def test_restore_open_slots_sync_driver_still_reads_inline(tmp_path, monkeypatch):
+    """The synchronous caller keeps its inline reads — no loop to offload to.
+
+    Guards the split from being "fixed" by making the sync path spawn threads it
+    has no reason to: with no running loop, ``_locked`` already takes the patient
+    path and a thread hop would only add latency. It also must not pay for the
+    post-hop deletion re-check, since its read has no suspension point to go
+    stale across.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-inline")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-inline"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    seen = _record_restore_threads(monkeypatch, state2)
+
+    main = threading.current_thread().name
+    assert restore_open_slots(state2) == 1
+    assert seen["walk"] and all(t == main for t in seen["walk"])
+    assert seen["build"] == [main]
+    assert seen["recheck"] == [], (
+        "the sync driver paid for a post-hop re-check it cannot need"
+    )
+
+
+def test_async_restore_keeps_an_unreadable_tab_in_the_reopen_seed(tmp_path, monkeypatch):
+    """The offloaded read must still distinguish "unreadable" from "gone".
+
+    ``get_metadata`` reports ``{}`` for both, and treating the second as the
+    first is what silently drops a live tab (the Windows sharing-violation
+    shape). Moving the read into a worker thread must not lose the
+    ``get_metadata_status`` readability flag that carries the difference.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-ok", "chat-2-unreadable"]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_status = log.get_metadata_status
+
+    def _status(key):
+        if key.endswith("unreadable"):
+            return {}, False
+        return real_status(key)
+
+    monkeypatch.setattr(log, "get_metadata_status", _status)
+
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 1
+    assert "chat-1-ok" in state2._slots
+    assert "chat-2-unreadable" not in state2._slots
+    assert "chat-2-unreadable" in state2.unrestored_slot_keys, (
+        "an unreadable tab was dropped from the reopen seed instead of carried"
+    )
+
+
+def test_async_restore_does_not_carry_a_confidently_absent_tab(tmp_path, monkeypatch):
+    """A readable-but-empty metadata read is a confident answer, not a retry.
+
+    Companion to the test above: carrying every miss would resurrect keys for
+    sessions that genuinely no longer exist, forever.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-present")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-present", "chat-2-absent"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 1
+    assert "chat-2-absent" not in state2.unrestored_slot_keys
+
+
+def test_async_restore_rejects_a_path_separator_key(tmp_path, monkeypatch):
+    """The path-traversal screen must survive the driver rewrite.
+
+    ``open_slots.json`` is attacker-writable in the threat model the screen
+    exists for, and the async driver no longer shares the generator's body — so
+    the screen is asserted on the driver that startup actually runs.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-clean")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps(
+            {"keys": ["../../etc/passwd", "..\\..\\windows", "chat-1-clean"], "ts": 0.0}
+        )
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 1
+    assert set(state2._slots) == {"chat-1-clean"}
+
+
+def test_async_restore_leaves_a_carried_seed_alone_when_there_is_no_snapshot(
+    tmp_path, monkeypatch
+):
+    """A missing snapshot is a no-op — including for ``unrestored_slot_keys``.
+
+    The set is rebound per restore so a key that becomes readable stops being
+    carried. Rebinding it when there is nothing to restore FROM would instead
+    erase a seed the previous boot deliberately kept.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    carried = {"chat-7-carried"}
+    state.unrestored_slot_keys = carried
+
+    assert asyncio.run(restore_open_slots_async(state)) == 0
+    assert state.unrestored_slot_keys is carried
+    assert state.restoring_open_slots is False
+
+
+# ── Deletion during the offloaded read (#895 round 3) ──
+#
+# ``ConversationLog.delete_session`` leaves NO tombstone — its own docstring
+# notes that once the delete releases the lock "a concurrent writer can recreate
+# the session". Offloading the transcript read opened a window where the user can
+# permanently delete a session while restore holds its content, and the published
+# slot would rewrite the deleted file on its next flush. The dashboard's HTTP
+# listener is bound BEFORE startup restore runs (``_start_site`` precedes it in
+# ``start_dashboard``), so this is reachable, not theoretical.
+#
+# The chat-resume handler already guards its own read this way; the restore paths
+# mirror it rather than reinventing it. Raised as blocking by GPT 5.6 review.
+
+
+def test_a_session_deleted_during_the_read_is_not_restored(tmp_path, monkeypatch):
+    """A tab whose session vanished mid-read must not be rebuilt from stale bytes."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-keep", "chat-2-deleted"]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_chained = log.read_messages_chained
+
+    def _delete_then_read(key):
+        msgs = real_chained(key)
+        if "chat-2-deleted" in key:
+            # The user hits Delete while this transcript is in flight.
+            log.delete_session(key)
+        return msgs
+
+    monkeypatch.setattr(log, "read_messages_chained", _delete_then_read)
+
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 1
+    assert set(state2._slots) == {"chat-1-keep"}, (
+        "restored a tab for a session the user permanently deleted; its next "
+        "flush would rewrite the deleted transcript"
+    )
+    # A confident answer, not a retry — the key must not be carried forward.
+    assert "chat-2-deleted" not in state2.unrestored_slot_keys
+
+
+def test_a_session_recreated_during_the_read_is_not_overwritten(tmp_path, monkeypatch):
+    """Delete-then-recreate leaves metadata PRESENT but belonging to a new chat.
+
+    Existence alone reads that as "still here" and would publish a slot holding
+    the OLD transcript, whose flush overwrites a conversation the user is actively
+    using — worse than the plain-delete arm, because the destroyed data is live.
+    ``created_at`` is the discriminator.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-swapped")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-swapped"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_chained = log.read_messages_chained
+
+    def _swap_then_read(key):
+        msgs = real_chained(key)
+        if "swapped" in key:
+            log.delete_session(key)
+            log.append(key, "user", "a brand new conversation")
+            log.update_metadata(key, {"created_at": "2099-01-01T00:00:00"})
+        return msgs
+
+    monkeypatch.setattr(log, "read_messages_chained", _swap_then_read)
+
+    assert asyncio.run(restore_open_slots_async(state2)) == 0
+    assert "chat-1-swapped" not in state2._slots
+    # The replacement conversation is intact on disk.
+    assert [m.get("content") for m in log.read_messages_chained(
+        _history_key_for("chat-1-swapped")
+    )] == ["a brand new conversation"]
+
+
+def test_an_unreadable_recheck_still_restores_the_tab(tmp_path, monkeypatch):
+    """Refusing is the destructive direction on doubt, so unreadable != deleted.
+
+    ``get_metadata`` returns ``{}`` for both "deleted" and "could not be read",
+    and treating an unreadable line as a deletion would silently discard a LIVE
+    tab — the Windows sharing-violation shape again. The guard must fall through
+    to restoring.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-flaky")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-flaky"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_status = log.get_metadata_status
+    calls = {"n": 0}
+
+    def _status(key):
+        calls["n"] += 1
+        # First call is the prefetch (must succeed); the post-hop re-check reads
+        # back unreadable.
+        if calls["n"] > 1:
+            return {}, False
+        return real_status(key)
+
+    monkeypatch.setattr(log, "get_metadata_status", _status)
+
+    assert asyncio.run(restore_open_slots_async(state2)) == 1
+    assert "chat-1-flaky" in state2._slots
+    assert calls["n"] >= 2, "the post-hop re-check never ran"
+
+
+def test_a_rewrite_that_preserves_created_at_is_not_refused(tmp_path, monkeypatch):
+    """A compaction/rewrite carries ``created_at`` through, so it must not fire.
+
+    Guards the identity arm from being a blanket "anything changed" refusal,
+    which would drop tabs on ordinary housekeeping.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-rewritten")
+    log0 = state.conversation_log
+    key0 = _history_key_for("chat-1-rewritten")
+    log0.update_metadata(key0, {"created_at": "2026-01-01T00:00:00"})
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-rewritten"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_chained = log.read_messages_chained
+
+    def _touch_then_read(key):
+        msgs = real_chained(key)
+        if "rewritten" in key:
+            # Metadata churn that keeps identity — the rewrite case.
+            log.update_metadata(key, {"title": "renamed by housekeeping"})
+        return msgs
+
+    monkeypatch.setattr(log, "read_messages_chained", _touch_then_read)
+
+    assert asyncio.run(restore_open_slots_async(state2)) == 1
+    assert "chat-1-rewritten" in state2._slots
+
+
+def test_missing_created_at_falls_through_to_restoring(tmp_path, monkeypatch):
+    """Pre-``created_at`` transcripts must stay restorable.
+
+    Refusing when the discriminator is absent on either side would reject every
+    session whose metadata predates the field — a visible break for real users —
+    to close a narrow race. The residual (an undetected recreate of such a
+    transcript) is accepted and documented; the durable fix is a tombstone in
+    ``history.delete_session``, which is out of scope.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-legacy")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-legacy"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    key = _history_key_for("chat-1-legacy")
+    from kiro_crew.dashboard import chat_persistence as cp
+
+    # The session is PRESENT (so the absence arm cannot fire) and the pre-read
+    # metadata carries no ``created_at`` — the legacy-transcript shape. The
+    # identity arm needs two DIFFERING stamps, so one missing side falls through.
+    assert cp._deletion_during_read(log, key, {"title": "legacy"}, []) is None
+    # And with both sides present but equal, it also falls through.
+    live_meta = log.get_metadata(key)
+    assert live_meta.get("created_at"), "fixture no longer stamps created_at"
+    assert cp._deletion_during_read(log, key, live_meta, []) is None
+
+    assert asyncio.run(restore_open_slots_async(state2)) == 1
+    assert "chat-1-legacy" in state2._slots
+
+
+def test_a_never_persisted_key_is_not_treated_as_a_deletion(tmp_path, monkeypatch):
+    """An absent key is a new conversation, not something that was deleted."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    from kiro_crew.dashboard import chat_persistence as cp
+
+    assert cp._deletion_during_read(
+        state.conversation_log, "dashboard:never-existed", {}, None
+    ) is None
+
+
+def test_a_tab_closed_during_the_open_slot_read_is_not_restored(tmp_path, monkeypatch):
+    """The open-tab driver needs the SAME tombstone re-check as its siblings.
+
+    ``rehydrate_slot_from_history_async`` and the recent-sessions driver both
+    consult the close tombstone after their thread hop; this driver was the one
+    converted surface still missing it (GPT 5.6 review, round 3). The close pops
+    the slot and records the tombstone synchronously, but persists the ``closed``
+    flag only after its own awaits — so the metadata read mid-flight still says
+    open. Restoring from it re-creates a dismissed tab, and worse, the restored
+    slot's next flush writes metadata WITHOUT ``closed``, erasing the close.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-1-stays", "chat-2-dismissed"]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    real_chained = log.read_messages_chained
+
+    from kiro_crew.dashboard import channel_slots
+
+    def _close_then_read(key):
+        if "chat-2-dismissed" in key:
+            # The user clicks ✕ while this transcript is in flight.
+            channel_slots.note_slot_closed(state2, "chat-2-dismissed")
+        return real_chained(key)
+
+    monkeypatch.setattr(log, "read_messages_chained", _close_then_read)
+
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == 1
+    assert set(state2._slots) == {"chat-1-stays"}, (
+        "restored a tab the user dismissed mid-read; its flush would also clear "
+        "the closed marker"
+    )
+    # A confident answer, not a retry — the key must not be carried forward.
+    assert "chat-2-dismissed" not in state2.unrestored_slot_keys
+
+
+def test_an_older_close_does_not_block_an_open_slot_restore(tmp_path, monkeypatch):
+    """Negative control: only a close DURING the read is the race.
+
+    Without the ``>= started`` comparison the guard would make a reopened tab
+    un-restorable for the tombstone's whole lifetime.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-reopened")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-reopened"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    from kiro_crew.dashboard import channel_slots
+
+    channel_slots.note_slot_closed(state2, "chat-1-reopened")  # then reopened
+    time.sleep(0.01)
+
+    assert asyncio.run(restore_open_slots_async(state2)) == 1
+    assert "chat-1-reopened" in state2._slots

--- a/test/test_persist_off_loop.py
+++ b/test/test_persist_off_loop.py
@@ -451,3 +451,144 @@ def test_a_corrupt_ts_is_skipped_not_ranked(bad: str) -> None:
 def test_all_candidates_corrupt_yields_no_floor(bad: str) -> None:
     """No usable floor means None -- never a bogus value the stamper will drop."""
     assert latest_transcript_ts(bad, bad) is None
+
+
+# ── Restore-read tier: no startup restore read is INLINED on the loop (#895) ──
+#
+# Same failure family as the persist gate above, opposite direction: a READ this
+# time, and the cost is not a dropped write but a stalled event loop. The startup
+# restore drivers call list_sessions() (a glob + stat + first-line read of EVERY
+# session file) and, per session, a metadata read plus a chained transcript walk.
+# On a real home that measured ~13.6s for 76 sessions — and because
+# _loop_heartbeat pets the LoopStallWatchdog FROM A COROUTINE, a blocked loop
+# cannot pet it: the 25s exit_after timer fires, dumps thread stacks and _exit()s
+# the gateway before it ever finishes booting.
+#
+# SCOPE, stated plainly: this gate is SHAPE cover, not the proof. It flags a read
+# spelled directly inside an `async def` body in chat_persistence.py. It would
+# NOT have caught #895's original form, where the async driver drove a synchronous
+# GENERATOR and the reads sat one hop away inside it — and it deliberately does not
+# chase that hop, because following module-local calls transitively lands in
+# _rehydrate_slot_from_history's read fallback (dead when a caller prefetches) and
+# buys false positives that would get suppressed rather than obeyed.
+#
+# What actually pins the property is behavioural, in
+# test_open_slots_persistence.py::test_restore_open_slots_async_reads_off_the_loop
+# and test_session_restore.py's off-loop class: they record the thread each half
+# ran on and fail on the base shape. This gate is the cheap companion that stops
+# a future edit from re-inlining a read straight into a driver.
+#
+# The offloaded shape passes for free — `asyncio.to_thread(_prefetch_recent_session, …)`
+# passes the function as a bare Name, which is not a call at that point.
+#
+# Scoped to chat_persistence.py deliberately. Repo-wide these three methods have
+# many legitimate on-loop callers reading one small metadata line; the invariant
+# being pinned is about the BULK restore path, and a gate that fires everywhere
+# would be turned off rather than obeyed.
+
+_RESTORE_READS = frozenset({"list_sessions", "read_messages_chained", "get_metadata_status"})
+
+
+def find_restore_read_violations(source: str, path: str = "<source>") -> list[tuple[str, int]]:
+    """Return ``(path, lineno)`` for on-loop bulk-restore reads.
+
+    Matches the ATTRIBUTE form only (``conv_log.read_messages_chained(key)``),
+    which is how every real call site spells it — the methods live on
+    ``ConversationLog``, so there is no bare-name form to evade through. A
+    trailing ``# loop-ok: <reason>`` comment suppresses a line that is genuinely
+    safe, and every suppression must state its reason.
+    """
+    tree = ast.parse(source)
+    suppressed = _suppressed_lines(source)
+    out: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for call in _scope_calls(node):
+            func = call.func
+            if not (isinstance(func, ast.Attribute) and func.attr in _RESTORE_READS):
+                continue
+            span = range(call.lineno, (call.end_lineno or call.lineno) + 1)
+            if any(ln in suppressed for ln in span):
+                continue
+            out.append((path, call.lineno))
+    return out
+
+
+def test_no_startup_restore_read_runs_on_the_event_loop() -> None:
+    """chat_persistence's async drivers must prefetch, never read inline."""
+    target = _src_root() / "dashboard" / "chat_persistence.py"
+    assert target.exists(), f"chat_persistence.py not found at {target}"
+    violations = find_restore_read_violations(
+        target.read_text(encoding="utf-8"), str(target)
+    )
+    if violations:
+        detail = "\n".join(f"  {path}:{lineno}" for path, lineno in violations)
+        raise AssertionError(
+            "a bulk-restore disk read is called directly inside an `async def` "
+            "body in chat_persistence.py.\n\n"
+            "list_sessions() scans every session file; read_messages_chained() "
+            "walks a whole transcript across forks. On the event loop that "
+            "starves the LoopStallWatchdog heartbeat, whose exit_after timer "
+            "then kills the gateway mid-boot (#895). Hoist the read:\n"
+            "    meta, msgs = await asyncio.to_thread(_prefetch_recent_session, …)\n"
+            "and keep only the slot mutation on the loop (slot creation "
+            "broadcasts through asyncio.Queue.put_nowait / Event.set, neither "
+            "thread-safe).\n"
+            "If an on-loop read is genuinely correct, add a trailing "
+            "'# loop-ok: <reason>' comment.\n\n"
+            f"{detail}"
+        )
+
+
+def test_restore_read_detector_flags_an_inline_walk() -> None:
+    src = (
+        "async def f(log, key):\n"
+        "    msgs = log.read_messages_chained(key)\n"
+        "    return msgs\n"
+    )
+    assert [v[1] for v in find_restore_read_violations(src)] == [2]
+
+
+def test_restore_read_detector_flags_an_inline_session_scan() -> None:
+    src = "async def f(log):\n    return log.list_sessions()\n"
+    assert [v[1] for v in find_restore_read_violations(src)] == [2]
+
+
+def test_restore_read_detector_accepts_the_offloaded_form() -> None:
+    """``to_thread`` passes the callable as a bare Name — not a call yet."""
+    src = (
+        "import asyncio\n"
+        "async def f(log):\n"
+        "    return await asyncio.to_thread(log.list_sessions)\n"
+    )
+    assert find_restore_read_violations(src) == []
+
+
+def test_restore_read_detector_ignores_a_sync_helper() -> None:
+    """The prefetch helpers themselves are sync — that is the whole point."""
+    src = (
+        "def _prefetch(log, key):\n"
+        "    return log.get_metadata_status(key), log.read_messages_chained(key)\n"
+    )
+    assert find_restore_read_violations(src) == []
+
+
+def test_restore_read_detector_ignores_a_nested_sync_scope() -> None:
+    """A closure handed to a worker thread is a different execution frame."""
+    src = (
+        "import asyncio\n"
+        "async def f(log, key):\n"
+        "    def _read():\n"
+        "        return log.read_messages_chained(key)\n"
+        "    return await asyncio.to_thread(_read)\n"
+    )
+    assert find_restore_read_violations(src) == []
+
+
+def test_restore_read_detector_honors_a_loop_ok_suppression() -> None:
+    src = (
+        "async def f(log, key):\n"
+        "    return log.list_sessions()  # loop-ok: two entries, fixture only\n"
+    )
+    assert find_restore_read_violations(src) == []

--- a/test/test_rehydrate_async.py
+++ b/test/test_rehydrate_async.py
@@ -34,6 +34,7 @@ class _Log:
         self._meta = meta
         self._messages = messages or []
         self.read_threads: list[str] = []
+        self.recheck_threads: list[str] = []
 
     def get_metadata(self, key: str) -> dict | None:
         self.read_threads.append(threading.current_thread().name)
@@ -42,6 +43,17 @@ class _Log:
     def read_messages_chained(self, key: str) -> list[dict]:
         self.read_threads.append(threading.current_thread().name)
         return self._messages
+
+    def get_metadata_status(self, key: str) -> tuple[dict, bool]:
+        """The post-hop deletion re-check reads through here.
+
+        Recorded SEPARATELY from ``read_threads``: this one runs ON the loop by
+        design (it gates the build, so no await may separate the two), while
+        every entry in ``read_threads`` must have left the loop. Lumping them
+        together would make the off-loop assertions unsatisfiable.
+        """
+        self.recheck_threads.append(threading.current_thread().name)
+        return self._meta or {}, True
 
 
 def _state(log: _Log) -> MagicMock:
@@ -169,3 +181,227 @@ async def test_no_conversation_log_returns_none() -> None:
     state = MagicMock()
     state.conversation_log = None
     assert await cp.rehydrate_slot_from_history_async(state, "chat-1-x") is None
+
+
+# ── The shared prefetch seam (#895) ──
+#
+# The wrapper's read half is now a named module-level function so the two bulk
+# startup restore drivers can hoist the SAME reads into a worker thread instead
+# of each growing its own copy. These tests pin the contract the drivers depend
+# on, which the wrapper's own tests above do not reach: the readability flag, and
+# not paying for a transcript walk that will be thrown away.
+
+
+class _StatusLog(_Log):
+    """``_Log`` plus the ``get_metadata_status`` form the open-tab restore needs."""
+
+    def __init__(self, meta: dict | None, messages: list[dict] | None, readable: bool) -> None:
+        super().__init__(meta, messages)
+        self._readable = readable
+
+    def get_metadata_status(self, key: str) -> tuple[dict, bool]:
+        self.read_threads.append(threading.current_thread().name)
+        return self._meta or {}, self._readable
+
+
+def test_prefetch_reports_an_unreadable_metadata_read() -> None:
+    """``with_status`` must carry the difference ``get_metadata`` cannot express.
+
+    ``{}`` means both "never persisted" and "could not be read after retries",
+    and the open-tab restore does something destructive with the second reading:
+    it drops a live tab. So the flag must survive the trip through the prefetch.
+    """
+    log = _StatusLog({}, [], readable=False)
+    meta, readable, messages, model_map = cp._prefetch_rehydrate_inputs(
+        log, "dashboard:chat-1-x", with_status=True
+    )
+    assert meta == {}
+    assert readable is False
+    assert messages is None, "an unreadable session must not report a transcript"
+    assert model_map is None
+
+
+def test_prefetch_skips_the_transcript_walk_for_an_absent_session() -> None:
+    """No metadata → no transcript read. The walk is the expensive half."""
+    log = _StatusLog({}, [{"role": "user", "content": "hi"}], readable=True)
+    meta, readable, messages, _ = cp._prefetch_rehydrate_inputs(
+        log, "dashboard:chat-1-x", with_status=True
+    )
+    assert (meta, readable, messages) == ({}, True, None)
+    # Only the metadata line was read — one recorded read, not two — even though
+    # the stub has a transcript sitting there ready to hand over.
+    assert len(log.read_threads) == 1
+
+
+def test_prefetch_skips_the_transcript_walk_for_a_closed_session() -> None:
+    """A session closed with ✕ is not rebuilt, so its transcript is dead weight."""
+    log = _Log({"closed": True}, [{"role": "user", "content": "hi"}])
+    _meta, _readable, messages, model_map = cp._prefetch_rehydrate_inputs(
+        log, "dashboard:chat-1-closed"
+    )
+    assert messages is None
+    assert model_map is None
+    # Only the metadata line was read — one recorded read, not two.
+    assert len(log.read_threads) == 1
+
+
+def test_prefetch_adopts_a_closed_session_on_request() -> None:
+    """``adopt_closed`` callers (app-owned worker slots) still get the walk."""
+    log = _Log({"closed": True}, [{"role": "user", "content": "hi"}])
+    _meta, _readable, messages, _ = cp._prefetch_rehydrate_inputs(
+        log, "dashboard:chat-1-closed", adopt_closed=True, kiro_model_map={}
+    )
+    assert messages == [{"role": "user", "content": "hi"}]
+
+
+def test_prefetch_reuses_a_callers_model_map() -> None:
+    """A bulk caller builds the agent→model map once; the prefetch must not re-glob.
+
+    Rebuilding it per slot re-globs and re-parses every agent JSON to produce a
+    byte-identical dict — O(N) directory scans for one boot.
+    """
+    log = _Log({"title": "x"}, [])
+    shared = {"kirocrew": "sonnet"}
+    called = False
+
+    def _boom() -> dict[str, str]:
+        nonlocal called
+        called = True
+        return {}
+
+    original = cp._build_kiro_model_map
+    cp._build_kiro_model_map = _boom  # type: ignore[assignment]
+    try:
+        _m, _r, _msgs, model_map = cp._prefetch_rehydrate_inputs(
+            log, "dashboard:chat-1-x", kiro_model_map=shared
+        )
+    finally:
+        cp._build_kiro_model_map = original  # type: ignore[assignment]
+
+    assert model_map is shared
+    assert called is False, "the prefetch rebuilt a map the caller already had"
+
+
+# ── Deletion during the wrapper's own read (#895 round 4) ──
+#
+# This wrapper's read has ALWAYS been offloaded, so its delete-during-read window
+# predates #895 — but a class of defect fixed at two of three prefetch-then-apply
+# call sites just returns through the third, so the guard is folded in here too.
+# Its three production callers (the Slack gateway's AutoNudge dashboard fire, the
+# spec-builder route, and the issue-radar crew runtime) already handle a ``None``
+# return, which is what a refusal looks like.
+
+
+@pytest.mark.asyncio
+async def test_a_deletion_during_the_read_abandons_rehydration(monkeypatch) -> None:
+    """A session deleted mid-read must not be rebuilt from the stale snapshot.
+
+    ``delete_session`` leaves no tombstone, so the rebuilt slot's next flush
+    recreates the transcript the user permanently deleted.
+    """
+    log = _Log(
+        {"title": "Doomed", "created_at": "2026-01-01T00:00:00"},
+        [{"role": "user", "content": "hi"}],
+    )
+    state = _state(log)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(
+        cp,
+        "_rehydrate_slot_from_history",
+        lambda *a, **k: pytest.fail("rebuilt a slot for a deleted session"),
+    )
+    # The post-hop re-check sees the session gone.
+    monkeypatch.setattr(log, "get_metadata_status", lambda key: ({}, True))
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-doomed") is None
+
+
+@pytest.mark.asyncio
+async def test_a_recreate_during_the_read_abandons_rehydration(monkeypatch) -> None:
+    """Delete-then-recreate leaves metadata present but under a new identity.
+
+    Rebuilding would publish a slot holding the OLD transcript, whose flush
+    overwrites the conversation the user is now using.
+    """
+    log = _Log(
+        {"title": "Swapped", "created_at": "2026-01-01T00:00:00"},
+        [{"role": "user", "content": "hi"}],
+    )
+    state = _state(log)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(
+        cp,
+        "_rehydrate_slot_from_history",
+        lambda *a, **k: pytest.fail("rebuilt a slot over a replacement session"),
+    )
+    monkeypatch.setattr(
+        log, "get_metadata_status", lambda key: ({"created_at": "2099-01-01T00:00:00"}, True)
+    )
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-swapped") is None
+
+
+@pytest.mark.asyncio
+async def test_the_deletion_guard_applies_even_to_adopt_closed(monkeypatch) -> None:
+    """``adopt_closed`` opts into the closed FLAG, never into resurrection.
+
+    App-owned worker slots may legitimately restore a session carrying ``closed``,
+    because their lifecycle belongs to the app. Nothing wants a permanently
+    DELETED transcript back.
+    """
+    log = _Log(
+        {"closed": True, "created_at": "2026-01-01T00:00:00"}, [{"role": "user", "content": "hi"}]
+    )
+    state = _state(log)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(
+        cp,
+        "_rehydrate_slot_from_history",
+        lambda *a, **k: pytest.fail("resurrected a deleted app-owned session"),
+    )
+    monkeypatch.setattr(log, "get_metadata_status", lambda key: ({}, True))
+
+    assert (
+        await cp.rehydrate_slot_from_history_async(state, "chat-1-worker", adopt_closed=True)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_intact_session_still_rehydrates(monkeypatch) -> None:
+    """Negative control: the guard must not refuse an untouched session."""
+    log = _Log(
+        {"title": "Fine", "created_at": "2026-01-01T00:00:00"}, [{"role": "user", "content": "hi"}]
+    )
+    state = _state(log)
+    sentinel = MagicMock(name="slot")
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(cp, "_rehydrate_slot_from_history", lambda *a, **k: sentinel)
+
+    assert await cp.rehydrate_slot_from_history_async(state, "chat-1-fine") is sentinel
+
+
+@pytest.mark.asyncio
+async def test_the_deletion_recheck_runs_on_the_loop(monkeypatch) -> None:
+    """The guard must stay ON the loop — offloading it reopens the window.
+
+    ``_deletion_during_read`` gates the build; an await between the two would let
+    a delete land in the gap. One mtime-cached metadata line is the price.
+    """
+    log = _Log(
+        {"title": "Fine", "created_at": "2026-01-01T00:00:00"}, [{"role": "user", "content": "hi"}]
+    )
+    state = _state(log)
+    monkeypatch.setattr(cp, "_build_kiro_model_map", lambda: {})
+    monkeypatch.setattr(cp, "_rehydrate_slot_from_history", lambda *a, **k: MagicMock())
+
+    main = threading.current_thread().name
+    await cp.rehydrate_slot_from_history_async(state, "chat-1-fine")
+
+    assert log.recheck_threads == [main], (
+        "the deletion re-check must run on the loop, immediately before the "
+        f"build it gates (threads: {log.recheck_threads})"
+    )
+    assert log.read_threads and all(
+        t != main for t in log.read_threads
+    ), "the prefetch reads must still be off the loop"

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -1169,3 +1169,421 @@ class TestPartialRehydrateRollsBack:
             "restore_open_slots re-grew its own rollback: two copies of the same "
             "undo will drift, and the callee's is the one every caller reaches"
         )
+
+
+# ── restore_recent_sessions_async: the reads must leave the loop (#895) ──
+#
+# This driver is the slower of the two startup restores: it calls list_sessions()
+# (a glob + stat + first-line read of EVERY session file) and then per selected
+# session a get_metadata plus a chained transcript walk — measured at 13.6s for
+# 76 sessions, all of it on the event loop between per-session yields. The yield
+# bounded one session's share; it did not stop a single large transcript from
+# stalling the stall-watchdog heartbeat. So every read is hoisted into
+# asyncio.to_thread and only the slot build stays on the loop, which is
+# mandatory: slot creation broadcasts through asyncio.Queue.put_nowait /
+# Event.set, neither of which is thread-safe.
+
+
+class TestAsyncRestoreRecentSessionsOffLoop:
+    @pytest.mark.asyncio
+    async def test_matches_the_sync_driver(self, tmp_path, monkeypatch):
+        """Parity guard: the two drivers no longer share a generator body."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        for name in ("dashboard_par1", "dashboard_par2"):
+            _write_session(
+                tmp_path,
+                name,
+                [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+                meta={"title": name, "agent": "kirocrew"},
+            )
+            (tmp_path / f"{name}.jsonl").touch()
+
+        sync_state = _make_state(tmp_path)
+        async_state = _make_state(tmp_path)
+        sync_n = restore_recent_sessions(sync_state, window_minutes=60)
+        async_n = await restore_recent_sessions_async(async_state, window_minutes=60)
+
+        assert sync_n == async_n == 2
+        assert set(sync_state._slots) == set(async_state._slots) == {"par1", "par2"}
+        assert [m["content"] for m in async_state._slots["par1"].messages] == ["hi"]
+
+    @pytest.mark.asyncio
+    async def test_every_read_runs_off_the_loop_and_the_build_runs_on_it(
+        self, tmp_path, monkeypatch
+    ):
+        """list_sessions, get_metadata and the transcript walk must all be offloaded."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard import chat_persistence
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        for i in range(3):
+            name = f"dashboard_off{i}"
+            _write_session(
+                tmp_path,
+                name,
+                [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+                meta={"title": name},
+            )
+            (tmp_path / f"{name}.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        reads: list[str] = []
+        builds: list[str] = []
+
+        real_list = log.list_sessions
+        real_meta = log.get_metadata
+        real_chained = log.read_messages_chained
+        real_apply = chat_persistence._apply_recent_session
+
+        def _list():
+            reads.append(threading.current_thread().name)
+            return real_list()
+
+        def _meta(key):
+            reads.append(threading.current_thread().name)
+            return real_meta(key)
+
+        def _chained(key):
+            reads.append(threading.current_thread().name)
+            return real_chained(key)
+
+        def _apply(*a, **kw):
+            builds.append(threading.current_thread().name)
+            return real_apply(*a, **kw)
+
+        monkeypatch.setattr(log, "list_sessions", _list)
+        monkeypatch.setattr(log, "get_metadata", _meta)
+        monkeypatch.setattr(log, "read_messages_chained", _chained)
+        monkeypatch.setattr(chat_persistence, "_apply_recent_session", _apply)
+
+        main = threading.current_thread().name
+        restored = await restore_recent_sessions_async(state, window_minutes=60)
+
+        assert restored == 3
+        assert reads, "nothing was read — the test would not detect the bug"
+        assert all(t != main for t in reads), (
+            "a startup restore read ran ON the event-loop thread "
+            f"(threads seen: {sorted(set(reads))})"
+        )
+        assert builds == [main] * 3, (
+            "slot construction left the event-loop thread; it broadcasts through "
+            f"asyncio.Queue.put_nowait / Event.set (threads seen: {builds})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_skipped_session_never_pays_for_its_transcript(
+        self, tmp_path, monkeypatch
+    ):
+        """The filters run BETWEEN the two reads, on the cheap one.
+
+        Reading a multi-megabyte transcript and then discarding it because the
+        session is closed or outside the window is pure waste, and it is the read
+        that dominates startup.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_keep",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "keep"},
+        )
+        _write_session(
+            tmp_path,
+            "dashboard_shut",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "shut", "closed": True},
+        )
+        for name in ("dashboard_keep", "dashboard_shut"):
+            (tmp_path / f"{name}.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        walked: list[str] = []
+        real_chained = log.read_messages_chained
+
+        def _chained(key):
+            walked.append(key)
+            return real_chained(key)
+
+        monkeypatch.setattr(log, "read_messages_chained", _chained)
+
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 1
+        assert set(state._slots) == {"keep"}
+        assert not any("shut" in k for k in walked), (
+            f"read the transcript of a session it then skipped: {walked}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_restoring_guard_is_released_even_on_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """A stuck flag silently disables open-tab persistence for the process."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        state = _make_state(tmp_path)
+        with patch.object(
+            state.conversation_log, "list_sessions", side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError):
+                await restore_recent_sessions_async(state, window_minutes=60)
+        assert state.restoring_open_slots is False
+
+    @pytest.mark.asyncio
+    async def test_a_channel_born_session_is_left_to_the_reconciler(
+        self, tmp_path, monkeypatch
+    ):
+        """Non-dashboard keys stay out of this path — the reconciler owns them."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "slack_1712793600.123456",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "thread"},
+        )
+        (tmp_path / "slack_1712793600.123456.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 0
+        assert state._slots == {}
+
+    @pytest.mark.asyncio
+    async def test_a_slot_published_during_the_read_is_not_replayed_over(
+        self, tmp_path, monkeypatch
+    ):
+        """Post-hop re-check: the pre-hop ``_slots`` answer is seconds stale.
+
+        Offloading the reads opened a window that did not exist before — the
+        check and the apply used to run atomically on the loop. If a resume, a
+        nudge or the user opening the tab publishes the slot while its transcript
+        loads, ``_apply_recent_session`` -> ``get_or_create_slot`` returns that
+        LIVE slot and the replay appends the on-disk messages a second time, then
+        persists the duplicates. Flagged as blocking by GPT 5.6 review and by
+        Design review on the first CI round.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_racy",
+            [
+                {"role": "user", "content": "first", "ts": "2026-03-23T10:00:00"},
+                {"role": "assistant", "content": "reply", "ts": "2026-03-23T10:00:01"},
+            ],
+            meta={"title": "Racy"},
+        )
+        (tmp_path / "dashboard_racy.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        real_chained = log.read_messages_chained
+
+        def _publish_then_read(key):
+            # Stand in for a resume publishing the slot mid-read: the live slot
+            # already holds the transcript, which is exactly the state a replay
+            # would double.
+            if "racy" in key and "racy" not in state._slots:
+                live = state.get_or_create_slot("racy")
+                live.append("user", "first", "msg msg-u", ts="2026-03-23T10:00:00")
+                live.append("assistant", "reply", "msg msg-a", ts="2026-03-23T10:00:01")
+                live.drain()
+            return real_chained(key)
+
+        monkeypatch.setattr(log, "read_messages_chained", _publish_then_read)
+
+        restored = await restore_recent_sessions_async(state, window_minutes=60)
+
+        assert restored == 0, "restored a session that was already live"
+        assert [m["content"] for m in state._slots["racy"].messages] == [
+            "first",
+            "reply",
+        ], "the transcript was replayed onto a live slot — duplicated history"
+
+    @pytest.mark.asyncio
+    async def test_a_tab_closed_during_the_read_is_not_resurrected(
+        self, tmp_path, monkeypatch
+    ):
+        """✕ clicked mid-read must win over the metadata snapshot.
+
+        The close pops the slot and records a tombstone synchronously, but
+        persists the ``closed`` flag only after its own awaits — so the metadata
+        read before the click still says open. Rebuilding from it would re-create
+        a dismissed tab and then fire a nudge turn into it. Mirrors the guard
+        ``rehydrate_slot_from_history_async`` applies after its own hop.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard import channel_slots
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_dismissed",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Dismissed"},
+        )
+        (tmp_path / "dashboard_dismissed.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        real_chained = log.read_messages_chained
+
+        def _close_then_read(key):
+            channel_slots.note_slot_closed(state, "dismissed")
+            return real_chained(key)
+
+        monkeypatch.setattr(log, "read_messages_chained", _close_then_read)
+
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 0
+        assert "dismissed" not in state._slots, "resurrected a tab the user closed"
+
+    @pytest.mark.asyncio
+    async def test_an_older_tombstone_does_not_block_a_reopened_tab(
+        self, tmp_path, monkeypatch
+    ):
+        """Only a close DURING the read is the race; older tombstones are inert.
+
+        Without the ``>= started`` comparison the guard would make a reopened tab
+        un-restorable for the tombstone's whole lifetime.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard import channel_slots
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_reopened",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Reopened"},
+        )
+        (tmp_path / "dashboard_reopened.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        channel_slots.note_slot_closed(state, "reopened")  # then reopened
+        time.sleep(0.01)
+
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 1
+        assert "reopened" in state._slots
+
+    @pytest.mark.asyncio
+    async def test_a_session_deleted_during_the_read_is_not_restored(
+        self, tmp_path, monkeypatch
+    ):
+        """Third post-hop window: permanent deletion during the offloaded read.
+
+        ``delete_session`` leaves no tombstone, so a slot published from content
+        already in hand rewrites the deleted file on its next flush. The
+        dashboard's listener is bound before startup restore runs, so a user
+        delete really can land here. Raised as blocking by GPT 5.6 review.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_doomed",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Doomed", "created_at": "2026-03-23T10:00:00"},
+        )
+        (tmp_path / "dashboard_doomed.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        real_chained = log.read_messages_chained
+
+        def _delete_then_read(key):
+            msgs = real_chained(key)
+            log.delete_session(key)
+            return msgs
+
+        monkeypatch.setattr(log, "read_messages_chained", _delete_then_read)
+
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 0
+        assert "doomed" not in state._slots, (
+            "restored a slot for a permanently deleted session; its flush would "
+            "rewrite the deleted transcript"
+        )
+        assert not (tmp_path / "dashboard_doomed.jsonl").exists(), (
+            "the deleted transcript came back"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_intact_session_is_not_refused_by_the_deletion_guard(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative control: the guard must not refuse an untouched session."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_intact",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Intact", "created_at": "2026-03-23T10:00:00"},
+        )
+        (tmp_path / "dashboard_intact.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        assert await restore_recent_sessions_async(state, window_minutes=60) == 1
+        assert "intact" in state._slots
+
+    @pytest.mark.asyncio
+    async def test_a_session_deleted_before_its_metadata_read_builds_no_phantom(
+        self, tmp_path, monkeypatch
+    ):
+        """An empty metadata line must skip, not build a phantom slot.
+
+        ``list_sessions()`` is a snapshot taken one thread hop earlier, so a
+        session deleted in that gap still appears in the list while its metadata
+        reads back ``{}``. An empty dict sails past every filter (folder, pin,
+        closed, cutoff all read falsy) and used to reach ``get_or_create_slot`` —
+        registering a phantom slot whose flush RECREATES the deleted transcript.
+        Raised as blocking by GPT 5.6 review, round 3.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
+
+        _write_session(
+            tmp_path,
+            "dashboard_vanished",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Vanished", "created_at": "2026-03-23T10:00:00"},
+        )
+        _write_session(
+            tmp_path,
+            "dashboard_survivor",
+            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Survivor", "created_at": "2026-03-23T10:00:00"},
+        )
+        for name in ("dashboard_vanished", "dashboard_survivor"):
+            (tmp_path / f"{name}.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        real_list = log.list_sessions
+
+        def _list_then_delete():
+            listed = real_list()
+            # The delete lands after the snapshot, before the per-session read.
+            log.delete_session("dashboard:vanished")
+            return listed
+
+        monkeypatch.setattr(log, "list_sessions", _list_then_delete)
+
+        restored = await restore_recent_sessions_async(state, window_minutes=60)
+
+        assert restored == 1
+        assert set(state._slots) == {"survivor"}, (
+            "built a phantom slot for a deleted session; its flush would "
+            f"recreate the transcript (slots: {sorted(state._slots)})"
+        )
+        assert not (tmp_path / "dashboard_vanished.jsonl").exists(), (
+            "the deleted transcript came back"
+        )


### PR DESCRIPTION
Closes #895 (Stage 1 only — Stage 2 is filed as #6144).

## Problem

Both startup restore drivers already yielded to the event loop between items — but they did all their **work** on it. The yield bounded how long any *one* tab could hold the loop; it never stopped a single large transcript from stalling it for seconds, and the reads that happen *before* the first yield were never covered at all.

That matters because `_loop_heartbeat` pets the `LoopStallWatchdog` **from a coroutine**. A blocked loop cannot pet it, so the 25s `exit_after` timer fires, dumps thread stacks and `_exit`s the gateway — the app never finishes booting.

On-loop before this change:

| Path | On-loop work |
|---|---|
| `restore_open_slots_async` | `open_slots.json` read + parse, agent→model map glob, then per tab `get_metadata_status` + `read_messages_chained` |
| `restore_recent_sessions_async` | `list_sessions()` (a glob + stat + first-line read of **every** session file), the config load, then per session `get_metadata` + `read_messages_chained` |

`restore_recent_sessions_async` measured ~13.6s for 76 sessions.

## Fix

Every read moves into `asyncio.to_thread`; only the slot mutation stays on the loop.

The split is not optional in the other direction. Slot construction reaches `get_or_create_slot` → `push_slots_update` → `_broadcast`, which uses `asyncio.Queue.put_nowait` and `Event.set` (neither thread-safe) and `ensure_future` (off-loop it raises into a broad `except` that marks every connected dashboard client dead and drops it *without a close frame*, so browsers never reconnect). So this reuses the prefetch-then-apply shape `rehydrate_slot_from_history_async` already established — via one shared reader, `_prefetch_rehydrate_inputs`, that all three paths now call.

The async drivers no longer drive the synchronous generators: a sync generator cannot express a per-item thread hop. The generators stay for the synchronous callers, and everything both sides need is factored out so the two paths cannot drift on it — `_read_open_slots_keys`, `_sanitize_open_slot_key` (the path-traversal screen), `_apply_restored_open_slot` (the unreadable-vs-absent rule), `_recent_session_slot_name`, `_prefetch_recent_session`, `_apply_recent_session`.

One behavioural improvement falls out: for recent sessions the selection filters now run **between** the two reads, on the cheap one, so a session that is closed or outside the mtime window never pays for its transcript walk.

## Revalidation after the hop

Offloading a read widens the window between *deciding* to restore an item and *mutating* slot state. That used to be atomic on the loop, and the dashboard's HTTP listener is **already bound** when startup restore runs (`_start_site` at `server.py:3250`, ~340 lines before the restore), so the window is reachable by real user actions.

Three windows, all re-checked **synchronously with no await separating the check from the build it gates**:

- **The slot may now exist** — a resume, a nudge, or the user opening the tab published it mid-read. `get_or_create_slot` returns that live slot and the replay appends its on-disk messages a second time, then persists the duplicates.
- **The tab may have been closed with ✕** — the close records a tombstone synchronously but persists `closed` only after its own awaits, so the metadata just read still says open. Rebuilding re-creates a dismissed tab, and the restored slot's next flush writes metadata *without* `closed`, erasing the close itself.
- **The session may have been deleted, or deleted and recreated** — `delete_session` leaves no tombstone (its own docstring notes a concurrent writer can recreate the session once the delete releases the lock), so a slot published from content already in hand rewrites the deleted file on its next flush, and in the recreate case overwrites a conversation the user is actively using.

New `_deletion_during_read` mirrors the guard the chat-resume handler (`chat_handlers.py:5187`) already applies after its own read rather than inventing a second rule: `get_metadata_status` (never `get_metadata`, which cannot tell "deleted" from "unreadable") for the absence arm, and a `created_at` identity comparison for the recreate arm. **Both fail open on doubt** — an unreadable re-check or a missing stamp on either side falls through to restoring, because refusing is the destructive direction and would drop live or pre-`created_at` sessions.

`_prefetch_recent_session` additionally refuses an **empty metadata line**. `list_sessions()` is a snapshot taken one thread hop earlier, so a session deleted in that gap still appears in the list while its metadata reads back `{}` — and `{}` sails past every filter (folder, pin, closed, cutoff all read falsy), reaches `get_or_create_slot`, and registers a phantom slot whose flush *recreates the deleted transcript*. `_rehydrate_slot_from_history` already refuses on empty metadata for exactly this reason; the recent path now agrees with it.

The guards live at the shared apply chokepoint so all three prefetch-then-apply paths get them from one definition, and are opt-in (`conv_log` / `started`) so the synchronous generator — which has no suspension point to go stale across — pays for none of it:

| Path | `_slots` | close tombstone | deletion / recreate |
|---|---|---|---|
| `restore_open_slots_async` | via `_rehydrate_slot_from_history` | ✅ | ✅ |
| `restore_recent_sessions_async` | ✅ | ✅ | ✅ + empty-`meta` skip |
| `rehydrate_slot_from_history_async` | ✅ *(pre-existing)* | ✅ *(pre-existing)* | ✅ |

The last row's window **predates this PR** (that wrapper's read was already offloaded). It is included because a class of defect fixed at two of three call sites simply returns through the third — which is exactly what happened across review rounds 2, 3 and 4 here.

## Preserved deliberately

- The `restoring_open_slots` flush guard — an interleaved 5s flush must not snapshot a half-restored slot set over `open_slots.json`.
- The per-item `sleep(0)` — the apply half still runs on the loop, so it still needs a turn. Not deleted; re-measure before proposing that.
- The `get_metadata_status` **readability flag** — the difference between "never persisted" and "could not be read after retries". Losing it in the thread hop would silently drop a live tab (the Windows sharing-violation shape).
- `_restricted_keys` seeding by restore (the privacy seam).
- Read-before-`tab_id`-backfill ordering, which keeps the file quiescent for the read on Windows.
- The path-traversal screen, now asserted on the driver startup actually runs.

## Tests

- **Thread-recording cover on all three paths**: each expensive read must leave the loop thread, each build must stay on it. Red on the base shape — `AssertionError: read ran ON the loop thread: ['MainThread']`. Companions assert the deletion re-check runs **on** the loop, next to the build it gates, because offloading it would reopen the window it closes.
- **Every post-hop window has a test that is red without its guard**, each paired with a negative control: older tombstone (both drivers), a rewrite that preserves `created_at`, a missing `created_at`, an unreadable re-check, an intact session, and `adopt_closed` still refused on deletion.
- Parity: async driver vs sync driver restore the same slots (they no longer share a generator body).
- The rewritten open-slots driver re-pins: unreadable tab stays in the reopen seed, a confidently-absent tab does not, path-separator keys are rejected, a missing snapshot leaves a carried seed alone.
- Recent sessions: a skipped session never pays for its transcript, the restoring guard releases on failure, channel-born keys stay with the reconciler.
- Prefetch-seam unit tests (readability flag, closed/absent short-circuit, `adopt_closed`, caller's model map reused).
- An AST gate in `test_persist_off_loop.py` against re-inlining a restore read into an `async def`. Its header states plainly that it is *shape* cover and would **not** have caught #895's original generator-hop form — the behavioural tests are the proof; the gate stops a future re-inline. Same pattern and `# loop-ok:` convention as the existing `test_no_turn_is_persisted_on_the_event_loop` in that file.

## Out of scope

- **Stage 2** (lazy sidebar projection) — filed as #6144.
- `src/kiro_crew/dashboard/handlers/sessions.py` — the sibling API-handler `list_sessions()` offload, under separate change in #5938. Untouched here.
- Residual, documented in-code: a delete-then-recreate of a transcript whose metadata predates `created_at` stays undetected. The durable fix is a tombstone in `history.delete_session` — the same residual the chat-resume handler already records.

## Verification

- **Full backend suite run against a pristine `9057fcf84` worktree after every round.** Final: **65,225 passed**, and the FAILED+ERROR lists are **byte-identical** to base (101 failed + 2 errors, all `AF_UNIX path too long` sandbox-environment noise). Zero regressions attributable to this change, three rounds running.
- 1,480 pass across the touched suites plus every downstream caller of `rehydrate_slot_from_history_async` (Slack gateway / AutoNudge, spec-builder routes, issue-radar crew runtime).
- `flake8`, `isort`, `mypy src/kiro_crew/dashboard/`, and the baselined black gate all clean.
- Single commit, per the repo rule.
