### PR TITLE
feat: file new sessions into a sidebar folder at creation (#6118)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -857,7 +857,6 @@ test/test_mcp_cron_orphan_validation.py
 test/test_mcp_cron_persistent_session.py
 test/test_mcp_cron_security.py
 test/test_mcp_custom_api.py
-test/test_mcp_dashboard_folders.py
 test/test_mcp_dashboard_registration.py
 test/test_mcp_discovery.py
 test/test_mcp_gateway_apps_spool.py

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -16,7 +16,7 @@ unreachable in production because the caller's `X-Internal-Secret` is ignored.
 
 | Tool | Route | What it does |
 |------|-------|--------------|
-| `session_create` | `POST /api/session-control/create` | Open a new, empty session in the caller's workspace |
+| `session_create` | `POST /api/session-control/create` | Open a new, empty session in the caller's workspace, optionally filed into a sidebar folder at creation |
 | `session_stop` | `POST /api/session-control/stop` | Stop another session's in-flight turn |
 | `session_close` | `POST /api/session-control/close` | Close (archive) another session, as the tab ✕ does — heavier than stop, and recoverable rather than a delete |
 | `session_send` | `POST /api/session-control/send` | Deliver a message that another session runs as its next turn |
@@ -46,6 +46,24 @@ hand the person a key they can read and stop. Without it the person does that by
 hand -- new tab, retype the title, pick the agent -- and the two observation verbs
 have nothing to point at that the agent itself put there. It deliberately does
 NOT seed a first message: that would be delivery.
+
+`session_create` also takes an optional `folder` — a folder id or `/`-separated
+human path, resolved with `chat_folder_create`'s `parent` semantics (missing
+segments created, behind the same tree-shaping gate) — and files the slot as
+part of creation (#6118). Filing used to be a second call
+(`chat_folder_move_session`), and the window between the two was a real defect
+path: a folder deleted in between left the session unfiled with the create
+already done. The handler assigns `folder_id` inside the same synchronous window
+that configures the slot, holds `suspend_slots_push` across the whole
+allocation-to-persist span (so the slot's first broadcast frame already shows it
+filed, and a slot whose birth write fails is never broadcast at all), and
+carries the placement in the persist-at-birth metadata, so no caller or client
+ever observes an unfiled session and the placement survives a restart.
+An unresolvable folder refuses the whole create — nothing exists yet, so refusal
+loses nothing — existence is confirmed read-only under the folder-store lock
+(`read_folders`) before the allocation, and the move path's Model-B un-hide runs
+only after the filing has landed, so a refused create leaves no folder-tree
+mutation behind.
 
 `kirocrew-dashboard` rather than `kirocrew-core`, because these tools are not a
 capability every session should carry. That server is an **assignable set**: it

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -98,40 +98,23 @@ beats more parallelism: every open item is a session the user may have to read.
 
 ### Dispatch a round
 
-**Before the round: the goal's folder must exist.** Once per goal, ahead of the
-FIRST `session_create` you ever make for it, call `chat_folder_tree` and then
-`chat_folder_create` for the goal if it is not already there. Keep the returned
-folder id — every session for this goal is filed there.
+For each item in the round:
 
-`session_create` has no `folder` argument, so filing is a separate call and
-therefore easy to skip. Do not skip it. **A `session_create` for this goal
-before its folder exists is a defect, not a shortcut**: the sessions land loose
-at the sidebar's top level, the user cannot tell which goal they belong to, and
-there is no grouping to clean up by when the goal ends. If `chat_folder_create`
-fails, say so and stop — do not dispatch into no folder.
-
-Then for each item in the round:
-
-1. `session_create` with a title that says what the item is FOR, and `agent` set
-   to the crew that fits. Call `select_crew` first and pass the agent it names —
+1. `session_create` with a title that says what the item is FOR, `folder` set to
+   the goal's folder (missing path segments are created automatically, and the
+   session is filed as part of creation — there is no separate move step and no
+   window where the folder can vanish between the two), and `agent` set to the
+   crew that fits. Call `select_crew` first and pass the agent it names —
    the matched crew when the item is clearly a specialist's job, otherwise the
    `default_agent` it returns. **Do NOT leave `agent` unset to "inherit the
    default":** the value inherited is YOUR agent, `kirocrew-conductor`, whose
    spec deliberately has no `fs_write` — so the child could not write a file even
    though writing one is the work you dispatched it to do, and the item would
    look stalled rather than misconfigured.
-2. `chat_folder_move_session` to file the new session under the goal's folder.
-   Do this immediately after the create, before the seed — an unfiled session
-   that then starts working is one the user has to hunt for. **If the move
-   fails, stop this item before the seed** and say so: the folder can be gone
-   by now even though you created it (the user can delete it mid-round), and
-   seeding anyway is exactly the unfiled-session outcome the precondition above
-   exists to prevent — except worse, because the session is now also doing work.
-   Recreate the folder and retry the move, or leave the item undispatched.
-3. `session_send` the seed prompt into the new session — the item's goal, its
+2. `session_send` the seed prompt into the new session — the item's goal, its
    acceptance condition, and where to report. The seed is the item's whole
    contract: the child session gets no other context from you.
-4. `session_ledger_record` the item: its goal text, the round number, and — in
+3. `session_ledger_record` the item: its goal text, the round number, and — in
    `artifacts`, under an `item-<n>` key — the durable item entry carrying its
    acceptance spec, session key, round, status and read cursor. **Never
    hand-write the entry value: encode it with the bundled codec**
@@ -366,13 +349,13 @@ watches, and that cost grows with the loop's own history.
 - **Reads and creates do not prompt; anything that touches another session does.**
   Auto-approved by name: `chat_folder_tree`, `chat_folder_create`,
   `session_create`, `session_read_message` — so a patrol cycle that wakes on a
-  nudge with nobody at the keyboard never blocks. **`chat_folder_move_session`,
-  `session_send` and `session_stop` are deliberately NOT auto-approved**, because
-  each writes to a session that is not yours: filing rewrites another session's
-  folder, a seed runs as the target's own turn, and a stop discards the target's
-  in-flight work. You ingest external content by design, so the prompt is the only
-  call-time check on all three. Expect an approval per item at dispatch (one to
-  file it, one to seed it) and one if you ever stop an item — all of which happen
+  nudge with nobody at the keyboard never blocks, and filing rides the create
+  itself (the `folder` argument), so it costs no extra approval. **`session_send`
+  and `session_stop` are deliberately NOT auto-approved**, because each writes to
+  a session that is not yours: a seed runs as the target's own turn, and a stop
+  discards the target's in-flight work. You ingest external content by design, so
+  the prompt is the only call-time check on both. Expect one approval per item at
+  dispatch (the seed) and one if you ever stop an item — all of which happen
   right after the user approved a plan, not mid-patrol. `execute_bash` also still
   prompts, so **each patrol cycle blocks on one approval for the
   `accept_eval.py` invocation** plus one per codec call. Size the nudge interval

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -2540,6 +2540,155 @@ def _save_slot_to_history(
             note_auth_key,
         )
     if not window:
+        if force or closed:
+            # A FORCED (or closing) save of a message-less slot is a metadata
+            # mutation (folder filing/unfiling, a tag assignment, a pin, a
+            # pinned title, a mode switch, a close) -- the full save below has no window to
+            # write, but the mutation still has to reach disk. This became
+            # reachable when `session_create` started persisting `folder_id`
+            # at birth (#6118): an empty newborn HAS a metadata line, so any
+            # acknowledged metadata change before its first message must
+            # overwrite that line, or a restart resurrects the birth state the
+            # user already changed. The merge carries every slot-owned field a
+            # force/closed save is responsible for -- not just `folder_id`:
+            # the tag routes, the pin route, the recreate PATCH (folder or
+            # pinned title) and the close path all persist ONLY through this
+            # save, so a folder-only merge would silently drop their
+            # acknowledged writes on restart. Merged ONLY into an existing
+            # line: a slot with no line at all does not survive a restart, so
+            # there is nothing to reconcile, and materializing files for every
+            # empty tab here would create transcripts nothing else expects.
+            # The existence guard runs INSIDE the same cross-process lock as
+            # the merge (`update_metadata_if`): the plain update is an upsert,
+            # so a checked-then-written pair would let a permanent deletion
+            # land between the two and be resurrected as a fresh file.
+            # Clearable fields are written even when empty -- the merge cannot
+            # delete a key, and rehydrate treats a falsy value as cleared
+            # (unfiled / untagged / unpinned / untitled / default mode). Fails
+            # closed on an unreadable record, per `update_metadata_if`'s own
+            # contract.
+            def _fresh_fields() -> dict:
+                # Mirrors the FULL save's slot-owned enumeration (the
+                # ``meta_line`` construction below), so a forced save of an
+                # empty slot persists exactly what a forced save of a
+                # non-empty slot would persist for the metadata line -- the
+                # invariant that keeps this branch from silently dropping
+                # whichever acknowledged mutation a route happens to persist
+                # through it (folder, tags, pin, title, mode, project,
+                # artifact binding, ...). Two write classes, matching
+                # rehydrate's semantics:
+                # - CLEARABLE fields are written even when empty (the merge
+                #   cannot delete a key; rehydrate treats a falsy value as
+                #   cleared: unfiled / untagged / unpinned / untitled /
+                #   default mode / unbound artifact / uncolored).
+                # - IDENTITY and MONOTONIC fields are written only when
+                #   truthy, exactly like the full save (origin's fail-closed
+                #   sentinel and the once-flags must never be erased by a
+                #   writer that has not learned them).
+                fields: dict = {
+                    "folder_id": slot.folder_id or "",
+                    "tags": list(slot.tags),
+                    "pinned": bool(slot.pinned),
+                    "mode": slot.mode or "",
+                    "artifact": slot._artifact or "",
+                    "reasoning_effort": slot.reasoning_effort or "",
+                    "color_index": slot.color_index,
+                    "color_hex": slot.color_hex or "",
+                    "color_theme": slot.color_theme or "",
+                    "memory_mode": slot.memory_mode,
+                    "model": slot.model,
+                }
+                if slot.title and slot.title != slot.key:
+                    fields["title"] = slot.title
+                    # Persist the title's provenance next to it (mirrors the
+                    # full save): without it rehydration conservatively
+                    # re-classifies an auto title as "user" and locks the
+                    # refresh out.
+                    _origin = getattr(slot, "_title_origin", "")
+                    if _origin:
+                        fields["title_origin"] = _origin
+                    _mark = getattr(slot, "_title_refresh_mark", 0)
+                    if _mark:
+                        fields["title_refresh_mark"] = _mark
+                else:
+                    fields["title"] = ""
+                if slot.agent:
+                    fields["agent"] = slot.agent
+                if slot.workspace:
+                    fields["workspace"] = slot.workspace
+                if slot.project:
+                    fields["project"] = slot.project
+                if slot._app:
+                    fields["app"] = slot._app
+                if slot._origin:
+                    fields["origin"] = slot._origin
+                if slot.linked_session_key:
+                    fields["linked_session_key"] = slot.linked_session_key
+                if getattr(slot, "channel_origin", False):
+                    fields["channel_origin"] = True
+                if slot.forked_from is not None:
+                    fields["forked_from"] = slot.forked_from
+                if getattr(slot, "_tab_id", None):
+                    fields["tab_id"] = slot._tab_id
+                if getattr(slot, "_auto_tagged", False):
+                    # Once-flag, monotonic (see the full save): written when
+                    # set, never cleared.
+                    fields["auto_tagged"] = True
+                if getattr(slot, "_human_seen", False):
+                    fields["human_seen"] = True
+                if slot._channel_folder_filed:
+                    # Sticky like the full save; the disk-carry half is
+                    # inherent here since a merge never deletes a key.
+                    fields["channel_folder_filed"] = True
+                if closed:
+                    # Without this a closed empty newborn's line stays
+                    # open-shaped and the next restart resurrects a tab the
+                    # user dismissed.
+                    fields["closed"] = True
+                    fields["closed_at"] = closed_at if closed_at is not None else time.time()
+                return fields
+
+            # The slot fields are read INSIDE the guard, which
+            # `update_metadata_if` evaluates under the cross-process lock at
+            # write time -- exactly the contract that method exists for ("the
+            # decision is re-made here rather than trusted from before the
+            # lock"). A dict snapshotted before the lock could commit out of
+            # order: a tag save that snapshotted `pinned=False` before a
+            # concurrent pin request committed `pinned=True` would land its
+            # stale aggregate second and silently revert the acknowledged pin.
+            # The full save has the same shape -- it builds its metadata line
+            # from slot state inside the locked block -- so whichever writer
+            # commits last writes the newest slot state.
+            merged_fields: dict = {}
+            guard_state = {"ran": False}
+
+            def _refresh_under_lock(meta: dict) -> bool:
+                guard_state["ran"] = True
+                if not meta:
+                    return False
+                merged_fields.clear()
+                merged_fields.update(_fresh_fields())
+                return True
+
+            applied = state.conversation_log.update_metadata_if(
+                history_key,
+                merged_fields,
+                _refresh_under_lock,
+            )
+            if not applied and not guard_state["ran"]:
+                # `update_metadata_if` fails CLOSED on an unreadable record
+                # WITHOUT invoking the guard -- that is a failed write, not the
+                # by-design skip for a line-less tab (where the guard runs and
+                # sees an empty record). Returning True here would report a
+                # merge that never happened as durable: a close would remove
+                # the tab while the on-disk line stays open-shaped and the
+                # next restart resurrects it. Raise instead, matching the save
+                # contract: best-effort callers log + mark the slot dirty, and
+                # archival callers (close, best_effort=False) roll back and
+                # keep the slot.
+                raise OSError(
+                    f"empty-window metadata merge skipped: record unreadable for {history_key}"
+                )
         return True
     # Skip a pure no-op: a freshly resumed slot with no new AND no edited
     # messages. ``slot._dirty`` is set by both append and in-place edits

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -129,6 +129,7 @@ async def api_session_control_create(request: web.Request) -> web.Response:
             caller_session_key=_read_session_key(request),
             title=str(body.get("title") or ""),
             agent=str(body.get("agent") or ""),
+            folder_id=str(body.get("folder_id") or ""),
         )
     except sc.SessionControlError as exc:
         return _refusal(exc)

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -43,10 +43,16 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.dashboard.chat_delivery import sanitize_outbound
+from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
 from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.create_rate_limit import SESSION_CREATE, allow_create
-from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, MAX_SLOTS_PER_CREATOR, SlotOrigin
+from kiro_crew.dashboard.state import (
+    MAX_LIVE_SLOTS,
+    MAX_SLOTS_PER_CREATOR,
+    SlotOrigin,
+    _safe_folder_tree,
+)
 from kiro_crew.dashboard.stop_retry import allow_escalation
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
@@ -593,6 +599,7 @@ async def create_session(
     caller_session_key: str,
     title: str = "",
     agent: str = "",
+    folder_id: str = "",
 ) -> dict[str, Any]:
     """Open a new session in the caller's workspace, persisted at birth.
 
@@ -606,6 +613,21 @@ async def create_session(
     there is no target yet), and the child inherits the caller's workspace. Both
     matter because a caller refusal missing here, or a workspace not inherited,
     would hand back a session outside the boundary the other verbs enforce.
+
+    ``folder_id`` files the slot as part of creation (#6118): it is assigned in
+    the same synchronous window that configures the slot, the whole
+    allocation-to-persist span runs under ``suspend_slots_push`` so the slot's
+    first broadcast frame already shows it filed, and the placement rides in the
+    persist-at-birth metadata so it survives a restart. An unknown folder
+    refuses the whole create -- nothing exists yet, so refusal loses nothing,
+    matching the move path's posture -- and existence is confirmed READ-ONLY
+    under the folder-store lock (``read_folders``) before the allocation; the
+    Model-B un-hide runs only after the filing has landed, so a refused create
+    leaves no folder-tree mutation behind. Authorization needs no new path: the
+    folder tree cannot be reshaped from here (the id must already exist), and
+    every caller class the move path's app-ownership rule exists to stop is
+    already refused above it -- an app-scoped caller cannot create a session at
+    all (`app_scoped_caller`).
     """
     if not session_control_enabled():
         raise SessionControlError(
@@ -736,10 +758,28 @@ async def create_session(
     # can see and take over the work. SYSTEM-origin slots fall outside the
     # `slots:user` WS scope, which would hide it from the sidebar.
 
+    if folder_id:
+        # Confirmed under the folder-store lock -- the only place existence
+        # cannot go stale against a concurrent delete (see `read_folders`) --
+        # and READ-ONLY on purpose: the Model-B un-hide is a durable mutation,
+        # and it runs only after the filing actually lands (below, after the
+        # persist), so a create the re-gate refuses leaves no folder-tree state
+        # behind. Placed BEFORE the re-gate so the last suspension this
+        # coroutine takes is here: after the re-gate nothing suspends until the
+        # slot is fully configured, so the folder confirmed here cannot be
+        # deleted before the assignment lands (folder mutations run on this
+        # loop).
+        def _exists(folders: list[dict[str, Any]]) -> bool:
+            return any(str(f.get("id") or "") == folder_id for f in _safe_folder_tree(folders))
+
+        if not await state.read_folders(_exists):
+            raise SessionControlError("folder not found", code="folder_not_found")
+
     # Re-resolved and re-gated HERE, adjacent to the allocation, because every
-    # decision above was made before this coroutine suspended -- twice, for the
-    # project directory and the config load -- and the inputs to those decisions are
-    # live state that can flip inside either window.
+    # decision above was made before this coroutine suspended -- for the
+    # project directory, the config load, and the folder confirmation -- and the
+    # inputs to those decisions are live state that can flip inside any of those
+    # windows.
     #
     # Re-reading the slot TABLE is the part that matters most: closing the caller's
     # tab removes its slot, and a Python reference to the removed object stays
@@ -807,86 +847,141 @@ async def create_session(
     # the same reason: it decides which workspace actually EXECUTES the turn, so it
     # must never be observable as empty. Everything after this point is synchronous
     # until the slot is fully configured.
-    slot = state.get_or_create_slot(
-        None, agent=agent_name, workspace=workspace, origin=SlotOrigin.USER
-    )
-    # Attribute the slot to the caller that asked for it, which is what makes the
-    # per-creator ceiling above countable. Written here, inside the synchronous
-    # window that follows the mint, so no suspension point separates the cap test
-    # from this write -- otherwise two concurrent creates could both pass a ceiling
-    # that one of them had already filled. Only this entry point sets it: a
-    # person's own tab and a fork reach `get_or_create_slot` directly and stay
-    # unattributed, so ordinary human use never consumes an automated caller's
-    # share.
-    slot._created_by = caller_key
-    # cwd must follow the workspace too, or file search and project-scoped agents
-    # resolve against a directory the slot does not claim -- the same
-    # authorization-vs-execution split as the agent binding, one layer down.
-    if not slot.project:
-        slot.project = project_dir
-    if title.strip():
-        slot.title = sanitize_outbound(title.strip())[:200]
-        slot._titled = True
-    # Persist at birth. `save_slot_off_loop` cannot do this: the save it wraps
-    # returns early on an empty message window -- before its `force` check -- so a
-    # freshly created session, which has no messages by definition, would write
-    # nothing at all. The tool would then hand back a session that does not survive
-    # a restart.
     #
-    # Awaited, and a failure RETRACTS the slot rather than merely propagating: an
-    # unpersisted slot stays in the table, usable in memory and addressable by its
-    # creator, then vanishes on restart. Reporting the failure while leaving that
-    # behind is the worse of the two outcomes, because the caller sees an error and
-    # the session exists anyway. Same retraction the fork path uses on a failed
-    # build.
-    try:
-        await asyncio.to_thread(
-            log.update_metadata,
-            slot_history_key(slot),
-            {
-                "_type": "metadata",
-                # The slot's OWN durable identity, and its origin, both of which
-                # the normal save path writes -- but a slot created here may never
-                # reach that path: `_save_slot_to_history` returns early on an
-                # empty message window, so for a session that is created and then
-                # sits idle THIS dict is the only record on disk. Omitting `origin`
-                # is silently destructive on the next restart: rehydrate falls back
-                # to the fail-closed empty sentinel, so a session opened as USER
-                # comes back unattributed and `slots:user` subscribers stop seeing
-                # it. Checked field-by-field against the save path; these are the
-                # only fields a slot carries at birth that it does not already
-                # write.
-                "tab_id": slot._tab_id,
-                "origin": slot._origin,
-                "created_at": metadata_now_iso(),
-                "workspace": slot.workspace,
-                "agent": slot.agent or "",
-                "project": slot.project or "",
-                "title": slot.title or "",
-                "memory_mode": getattr(slot, "memory_mode", "persistent"),
-            },
+    # The whole allocation-to-persist span runs under `suspend_slots_push`:
+    # `get_or_create_slot` broadcasts on a leading edge, so without the suspend an
+    # idle gateway serializes and sends the new slot BEFORE `folder_id` is
+    # assigned -- every client (and any app on `slots:user`) would render the
+    # session at the top level for a frame, the observable unfiled state #6118
+    # exists to remove. It also covers the persist and its failure retraction, so
+    # a slot whose birth write fails is never broadcast at all. Same pattern the
+    # move path uses ("file the slot before the coalesced broadcast").
+    with state.suspend_slots_push():
+        slot = state.get_or_create_slot(
+            None, agent=agent_name, workspace=workspace, origin=SlotOrigin.USER
         )
-    except Exception:
-        # Retract, but never at the cost of work already in flight. The slot is
-        # addressable from the moment `get_or_create_slot` publishes it, which is
-        # before this await, so a turn can have started on it while the write was
-        # in the worker thread. Popping the slot then would leave that turn running
-        # with nothing pointing at it -- unreachable, unstoppable, and invisible to
-        # the stop verb. A phantom session that vanishes on the next restart is the
-        # lesser harm, so liveness wins over tidiness and the slot stays.
-        if not slot.running and not slot.messages:
-            state._slots.pop(slot.key, None)
+        # Attribute the slot to the caller that asked for it, which is what makes the
+        # per-creator ceiling above countable. Written here, inside the synchronous
+        # window that follows the mint, so no suspension point separates the cap test
+        # from this write -- otherwise two concurrent creates could both pass a ceiling
+        # that one of them had already filled. Only this entry point sets it: a
+        # person's own tab and a fork reach `get_or_create_slot` directly and stay
+        # unattributed, so ordinary human use never consumes an automated caller's
+        # share.
+        slot._created_by = caller_key
+        # cwd must follow the workspace too, or file search and project-scoped agents
+        # resolve against a directory the slot does not claim -- the same
+        # authorization-vs-execution split as the agent binding, one layer down.
+        if not slot.project:
+            slot.project = project_dir
+        if folder_id:
+            # Filed inside the same synchronous window that configures the slot, so
+            # the session is never observable unfiled -- the atomicity #6118 exists
+            # for. Existence was confirmed under the store lock above, and folder
+            # mutations run on this loop, so the folder cannot have been deleted
+            # between that check and this assignment. No `_folder_changed` flag: the
+            # slot's first turn carries the armed first-turn breadcrumb injection
+            # (`is_new` in chat_runner), so the [FOLDER] line reaches the model
+            # without it.
+            slot.folder_id = folder_id
+        if title.strip():
+            slot.title = sanitize_outbound(title.strip())[:200]
+            slot._titled = True
+        # Persist at birth. `save_slot_off_loop` cannot do this: the save it wraps
+        # returns early on an empty message window -- a full save has nothing to
+        # write -- so a freshly created session, which has no messages by
+        # definition, would write nothing at all. The tool would then hand back a
+        # session that does not survive a restart.
+        #
+        # Awaited, and a failure RETRACTS the slot rather than merely propagating: an
+        # unpersisted slot stays in the table, usable in memory and addressable by its
+        # creator, then vanishes on restart. Reporting the failure while leaving that
+        # behind is the worse of the two outcomes, because the caller sees an error and
+        # the session exists anyway. Same retraction the fork path uses on a failed
+        # build.
+        try:
+            await asyncio.to_thread(
+                log.update_metadata,
+                slot_history_key(slot),
+                {
+                    "_type": "metadata",
+                    # The slot's OWN durable identity, and its origin, both of which
+                    # the normal save path writes -- but a slot created here may never
+                    # reach that path: `_save_slot_to_history` runs a full save only
+                    # when the window has messages, so for a session that is created
+                    # and then sits idle THIS dict is the only record on disk.
+                    # Omitting `origin` is silently destructive on the next restart:
+                    # rehydrate falls back to the fail-closed empty sentinel, so a
+                    # session opened as USER comes back unattributed and `slots:user`
+                    # subscribers stop seeing it. Checked field-by-field against the
+                    # save path; these are the only fields a slot carries at birth
+                    # that it does not already write.
+                    "tab_id": slot._tab_id,
+                    "origin": slot._origin,
+                    "created_at": metadata_now_iso(),
+                    "workspace": slot.workspace,
+                    "agent": slot.agent or "",
+                    "project": slot.project or "",
+                    "title": slot.title or "",
+                    "memory_mode": getattr(slot, "memory_mode", "persistent"),
+                    # Only when filed, mirroring the normal save path, which omits
+                    # `folder_id` from the metadata line when empty. Without this
+                    # the filing would not survive a restart: for an idle newborn
+                    # THIS dict is the only record of the placement on disk.
+                    **({"folder_id": slot.folder_id} if slot.folder_id else {}),
+                },
+            )
+        except Exception:
+            # Retract, but never at the cost of work already in flight. The slot is
+            # addressable from the moment `get_or_create_slot` publishes it, which is
+            # before this await, so a turn can have started on it while the write was
+            # in the worker thread. Popping the slot then would leave that turn running
+            # with nothing pointing at it -- unreachable, unstoppable, and invisible to
+            # the stop verb. A phantom session that vanishes on the next restart is the
+            # lesser harm, so liveness wins over tidiness and the slot stays.
+            if not slot.running and not slot.messages:
+                state._slots.pop(slot.key, None)
+            state.push_slots_update()
+            raise
+        if slot.folder_id:
+            # Model-B un-hide, applied only NOW that the filing has actually
+            # landed -- running it any earlier persists `hidden = False` for a
+            # create a later gate can still refuse, durably reversing a choice
+            # the user made for a call that failed. The move path holds the same
+            # order (assign, confirm, then un-hide). If the folder was deleted
+            # while the persist was in the worker thread, the delete's own sweep
+            # already unfiled this slot (it is published), so the guard reads
+            # the fresh value and skips; the metadata line can then briefly
+            # carry a dangling folder_id, the same accepted residual a move
+            # racing a delete leaves, and readers fall back to "(unfiled)".
+            #
+            # Best-effort: the create is already COMMITTED (slot published,
+            # persisted at birth), so a folder-store write failure here must not
+            # propagate -- the request would report failure for a session that
+            # exists, and the caller's retry would create a duplicate. A folder
+            # left hidden with a session inside is the recoverable lesser harm.
+            try:
+                await _unhide_folder(state, slot.folder_id)
+            except Exception:
+                logger.warning(
+                    "create_session: filing committed for %s but un-hiding folder %s failed",
+                    slot.key,
+                    slot.folder_id,
+                    exc_info=True,
+                )
         state.push_slots_update()
-        raise
-    state.push_slots_update()
     _audit(
         caller_session_key=caller_key,
         operation="create",
         slot_key=slot.key,
         outcome="allowed",
-        detail={"agent": slot.agent or ""},
+        detail={"agent": slot.agent or "", "folder_id": slot.folder_id or ""},
     )
-    return {"ok": True, "target": slot.key, "title": slot.title or slot.key}
+    return {
+        "ok": True,
+        "target": slot.key,
+        "title": slot.title or slot.key,
+    }
 
 
 def authorize_target(

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -248,6 +248,15 @@ def _tool_definitions() -> list[dict[str, Any]]:
                             "Agent to bind the session to. Omit to use the default agent."
                         ),
                     },
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Sidebar folder to file the new session into, atomically with "
+                            "creation — a folder id or a '/'-separated human path. Missing "
+                            "path segments are created (mkdir -p), like chat_folder_create's "
+                            "`parent`. Omit to leave the session at the top level."
+                        ),
+                    },
                 },
                 "required": [],
             },
@@ -892,15 +901,68 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
 
     if name == "session_create":
         args = validate_tool_args(args, SESSION_CREATE_SCHEMA)
+        payload: dict[str, Any] = {"title": args.get("title", ""), "agent": args.get("agent", "")}
+        folder_ref = str(args.get("folder") or "")
+        folder_label = ""
+        made_note = ""
+        if folder_ref:
+            # Filing at creation resolves the reference with
+            # ``chat_folder_create``'s `parent` semantics — missing path segments
+            # are CREATED — and creating folders is tree shaping, so the same
+            # gate applies rather than a second authorization path: a caller
+            # that could not reshape the tree by creating a folder must not
+            # reach the same write by naming the path here (#6118). The gate's
+            # verified key is what the segment creation writes under, per its
+            # own contract.
+            gate_key, gate = _refuse_tree_shaping_if_unverifiable(
+                "filing a new session at creation"
+            )
+            if gate:
+                return gate
+            # An app-scoped caller may create folders, but it can NEVER complete
+            # session_create (the endpoint refuses `app_scoped_caller`), so
+            # resolving the folder for it would only leave created path
+            # segments behind for a call that cannot succeed. This is a
+            # side-effect guard, not a second authorization home: the
+            # endpoint's refusal stays authoritative for the create itself.
+            scope_rows, scope_err = _get_rows("/api/chat/slots")
+            if scope_err:
+                return redact(f"Error: {scope_err}")
+            if _caller_app_scope(gate_key, scope_rows):
+                return (
+                    "Error: an app-scoped session cannot create sessions, so there is "
+                    "nothing to file — folder resolution is refused before it would "
+                    "create path segments for a create that cannot succeed."
+                )
+            chat_folders, folders_err = _get_rows("/api/chat/folders")
+            if folders_err:
+                return redact(f"Error: {folders_err}")
+            fld_id, created_segments, fld_err = _ensure_chat_folder_path(
+                folder_ref, chat_folders, session_key=gate_key
+            )
+            if created_segments:
+                made_note = f" (created folder path: {'/'.join(created_segments)})"
+            if fld_err:
+                # Refuse the whole create: the caller asked for a session filed
+                # in this folder, and "created but unfiled" would silently honor
+                # half of that. No SESSION exists yet; path segments the mkdir -p
+                # walk already created DO persist and are reported in
+                # `made_note` — the same partial-report posture
+                # chat_folder_create takes, since folder deletion is
+                # deliberately not a capability this server has.
+                return redact(f"Error: {fld_err}{made_note}")
+            payload["folder_id"] = fld_id
+            folder_label = _chat_folder_paths(chat_folders).get(fld_id, fld_id)
         resp = _post(
             "/api/session-control/create",
-            {"title": args.get("title", ""), "agent": args.get("agent", "")},
+            payload,
             session_key=caller_key,
         )
         if resp.get("error"):
-            return f"Error: could not create a session: {resp['error']}"
-        return (
-            f"\U0001f195 Opened `{resp.get('target')}` ({resp.get('title')}). "
+            return redact(f"Error: could not create a session: {resp['error']}{made_note}")
+        filed = f" filed in `{folder_label}`" if folder_label else ""
+        return redact(
+            f"\U0001f195 Opened `{resp.get('target')}` ({resp.get('title')}){filed}.{made_note} "
             "It is empty and waiting in the user's sidebar; watch it with "
             "session_read_message."
         )

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2653,6 +2653,13 @@ SESSION_CREATE_SCHEMA = ToolSchema(
     fields=[
         FieldSpec("title", str, required=False, default="", max_len=200),
         FieldSpec("agent", str, required=False, default="", max_len=MAX_SHORT_STRING),
+        # A sidebar-folder reference — a folder id OR a ``/``-separated human
+        # path, the same shape ``chat_folder_move_session.folder`` takes — so
+        # filing is atomic with creation instead of a create-then-move pair a
+        # folder delete can land between (#6118). Bounded like every other
+        # folder reference; the two readings share no charset, so only the
+        # length is checked here.
+        FieldSpec("folder", str, required=False, default="", max_len=_ARTIFACT_FOLDER_REF_MAX),
     ],
 )
 

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -397,26 +397,6 @@ class TestConductorInstaller:
         # And a goal that already authorizes execution must not be re-gated.
         assert "Skip the gate when the user already gave one" in text
 
-    def test_skill_requires_the_goal_folder_before_the_first_session(self):
-        """Folder creation is a round-level PRECONDITION, not a per-item step.
-
-        ``session_create`` has no ``folder`` argument, so filing a session is a
-        separate call — and when the instruction sat inside the per-item loop
-        worded "once per goal (skip if it exists)" the first live run dropped it
-        and every dispatched session landed loose at the sidebar's top level,
-        with nothing tying it to the goal it belongs to.
-        """
-        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
-        assert "Before the round: the goal's folder must exist" in text
-        # The create must be named as a defect, not merely discouraged, and the
-        # failure path must stop rather than dispatch into no folder.
-        assert "before its folder exists is a defect" in text
-        # Creating the folder is not sufficient on its own: the user can delete
-        # it mid-round, so a FAILED move must stop the item before the seed —
-        # otherwise the session is both unfiled and already doing work, which is
-        # strictly worse than the outcome the precondition exists to prevent.
-        assert "If the move\n   fails, stop this item before the seed" in text
-
     def test_skill_states_the_real_approval_cost(self):
         """The cost note must match the spec, or patrol plans for wrong prompts.
 
@@ -427,7 +407,7 @@ class TestConductorInstaller:
         """
         text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
         assert "Reads and creates do not prompt" in text
-        assert "`chat_folder_move_session`,\n  `session_send` and `session_stop`" in text
+        assert "`session_send`\n  and `session_stop` are deliberately NOT auto-approved" in text
         assert "accept_eval.py` invocation" in text
 
     def test_skill_documents_artifacts_as_a_string_map(self):
@@ -478,6 +458,26 @@ class TestConductorInstaller:
         assert SKILL_DIR.is_dir()
         assert not (_BUILTIN_SKILLS_DIR / "conductor").exists()
         assert "name: goal-conductor" in (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_skill_files_the_session_at_creation_not_by_a_move(self):
+        """Dispatch passes ``folder`` to ``session_create``; no move step exists.
+
+        ``session_create`` files the slot atomically at creation (#6118), which
+        is what closed the create-then-move window a folder delete could land
+        in. The instruction layer must not resurrect the workaround: a separate
+        ``chat_folder_create`` precondition or ``chat_folder_move_session`` step
+        reopens exactly the non-atomic window the tool argument removed. Pinned
+        as a doc ratchet because the instruction, not the code, is what would
+        drift back.
+        """
+        text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        assert "1. `session_create`" in text, "dispatch must open with the atomic create"
+        assert "`folder`" in text, "dispatch must name the folder argument at create"
+        assert "chat_folder_move_session" not in text, "the move workaround must stay deleted"
+        # Scoped to the dispatch STEP, not the whole document: a future
+        # legitimate mention of the tool elsewhere in the skill must not fail a
+        # pin whose intent is only that the precreation step stay deleted.
+        assert "1. `chat_folder_create`" not in text, "no folder-precreation dispatch step"
 
 
 def _load_evaluator():

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -135,9 +135,10 @@ class TestFolderTree:
 class TestFolderCreate:
     def test_creates_subfolder_under_existing_parent_path(self) -> None:
         made = {"id": "dddddddddddd", "name": "0812", "parent_id": "aaaaaaaaaaaa"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", return_value=made
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "0812", "parent": "kirocrew"})
         path, body = mock_post.call_args.args
         assert path == "/api/chat/folders"
@@ -146,17 +147,19 @@ class TestFolderCreate:
 
     def test_accepts_parent_by_id(self) -> None:
         made = {"id": "dddddddddddd", "name": "x", "parent_id": "bbbbbbbbbbbb"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", return_value=made
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": "x", "parent": "bbbbbbbbbbbb"})
         assert mock_post.call_args.args[1]["parent_id"] == "bbbbbbbbbbbb"
 
     def test_top_level_when_parent_omitted(self) -> None:
         made = {"id": "eeeeeeeeeeee", "name": "Solo", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", return_value=made
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": "Solo"})
         assert mock_post.call_args.args[1] == {"name": "Solo", "parent_id": ""}
 
@@ -191,8 +194,9 @@ class TestFolderCreate:
 
         secret = "AKIAIOSFODNN7EXAMPLE"
         args = {"name": "leaf", "parent": f"keys-{secret}"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post),
         ):
             _call_tool_inner("chat_folder_create", args)
             before = len(posts)
@@ -210,9 +214,11 @@ class TestFolderCreate:
         redacted form — so a segment that only overruns AFTER redaction must
         still be refused, or it comes back truncated and unmatchable."""
         seg = "k" * 95
-        with patch("kiro_crew.mcp_dashboard.redact", side_effect=lambda s: s + "x" * 20), patch(
-            "kiro_crew.mcp_dashboard._get", side_effect=_rows
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard.redact", side_effect=lambda s: s + "x" * 20),
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": seg})
         assert "too long" in out
         mock_post.assert_not_called()
@@ -224,11 +230,11 @@ class TestFolderCreate:
         during redaction would be persisted truncated — unmatchable by any later
         path, the same mismatch the segment walk refuses.
         """
-        with patch(
-            "kiro_crew.mcp_dashboard.redact", side_effect=lambda s: s + "x" * 30
-        ), patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard.redact", side_effect=lambda s: s + "x" * 30),
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "k" * 90})
         assert "too long after redaction" in out
         mock_post.assert_not_called()
@@ -244,8 +250,9 @@ class TestFolderCreate:
                 "parent_id": body["parent_id"],
             }
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post),
         ):
             out = _call_tool_inner(
                 "chat_folder_create", {"name": "week1", "parent": "kirocrew/2026/august"}
@@ -268,8 +275,9 @@ class TestFolderCreate:
                 return {"id": "new000000001", "name": body["name"], "parent_id": ""}
             return {"error": "name required"}
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post),
         ):
             out = _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": "new/deeper"})
         assert out.startswith("Error:")
@@ -281,12 +289,11 @@ class TestFolderCreate:
         Treating it as a path segment would create a folder literally named
         after the hex id.
         """
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
-            out = _call_tool_inner(
-                "chat_folder_create", {"name": "x", "parent": "0123456789ab"}
-            )
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
+            out = _call_tool_inner("chat_folder_create", {"name": "x", "parent": "0123456789ab"})
         assert out.startswith("Error:") and "folder not found" in out
         mock_post.assert_not_called()
 
@@ -318,20 +325,20 @@ class TestAmbiguousFolderPaths:
         return [{"key": "chat-1-100", "title": "S", "folder_id": ""}]
 
     def test_create_refuses_an_ambiguous_parent_path(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
-            out = _call_tool_inner(
-                "chat_folder_create", {"name": "x", "parent": "kirocrew/0811"}
-            )
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._get),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
+            out = _call_tool_inner("chat_folder_create", {"name": "x", "parent": "kirocrew/0811"})
         assert out.startswith("Error:")
         assert "bbbbbbbbbbbb" in out and "cccccccccccc" in out
         mock_post.assert_not_called()
 
     def test_move_refuses_an_ambiguous_destination_path(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._get),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew", "new_parent": "kirocrew/0811"}
             )
@@ -339,9 +346,10 @@ class TestAmbiguousFolderPaths:
         mock_patch.assert_not_called()
 
     def test_session_move_refuses_an_ambiguous_destination_path(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._get),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-1-100", "folder": "kirocrew/0811"},
@@ -351,9 +359,10 @@ class TestAmbiguousFolderPaths:
 
     def test_an_id_still_addresses_one_of_the_duplicates(self) -> None:
         """The refusal must leave a way through: the id is unambiguous."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._get),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-1-100", "folder": "cccccccccccc"},
@@ -362,9 +371,10 @@ class TestAmbiguousFolderPaths:
         assert mock_patch.call_args.args[1] == {"folder_id": "cccccccccccc"}
 
     def test_mkdir_p_does_not_add_a_third_duplicate_sibling(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._get), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._get),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner(
                 "chat_folder_create", {"name": "leaf", "parent": "kirocrew/0811/deeper"}
             )
@@ -400,9 +410,10 @@ class TestSlashBearingFolderNames:
         return _get
 
     def test_the_literal_folder_wins_when_no_nested_pair_exists(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
             )
@@ -411,18 +422,20 @@ class TestSlashBearingFolderNames:
 
     def test_create_under_a_literal_slash_name_does_not_build_a_nested_pair(self) -> None:
         made = {"id": "dddddddddddd", "name": "leaf", "parent_id": "aaaaaaaaaaaa"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)), patch(
-            "kiro_crew.mcp_dashboard._post", return_value=made
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.LITERAL)),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": "A/B"})
         # Exactly one POST: the leaf. No "A" and no "B" were manufactured.
         assert mock_post.call_count == 1
         assert mock_post.call_args.args[1] == {"name": "leaf", "parent_id": "aaaaaaaaaaaa"}
 
     def test_collision_between_the_two_readings_is_refused(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
             )
@@ -444,9 +457,10 @@ class TestSlashBearingFolderNames:
             {"id": "bbbbbbbbbbbb", "name": "A", "parent_id": ""},
             {"id": "cccccccccccc", "name": " B", "parent_id": "bbbbbbbbbbbb"},
         ]
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(padded)), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(padded)),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-1-100", "folder": "A/B"}
             )
@@ -455,9 +469,10 @@ class TestSlashBearingFolderNames:
         mock_patch.assert_not_called()
 
     def test_an_id_resolves_either_way(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._getter(self.BOTH)),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-1-100", "folder": "cccccccccccc"},
@@ -471,9 +486,10 @@ class TestSlashBearingFolderNames:
         The sidebar keeps its freedom — a human may still name a folder ``A/B``;
         this only stops the agent adding more unaddressable-by-path names.
         """
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Projects/Web"})
         assert out.startswith("Error:") and "cannot contain '/'" in out
         mock_post.assert_not_called()
@@ -489,10 +505,13 @@ class TestFolderNameRedaction:
     LEAKY = "AKIAIOSFODNN7EXAMPLE"
 
     def test_leaf_name_is_redacted_before_the_write(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post",
-            return_value={"id": "dddddddddddd", "name": "x", "parent_id": ""},
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._post",
+                return_value={"id": "dddddddddddd", "name": "x", "parent_id": ""},
+            ) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": self.LEAKY})
         assert self.LEAKY not in mock_post.call_args.args[1]["name"]
 
@@ -507,8 +526,9 @@ class TestFolderNameRedaction:
                 "parent_id": body["parent_id"],
             }
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", side_effect=_post
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post),
         ):
             out = _call_tool_inner(
                 "chat_folder_create", {"name": "leaf", "parent": f"kirocrew/{self.LEAKY}"}
@@ -519,10 +539,13 @@ class TestFolderNameRedaction:
 
 class TestFolderMove:
     def test_reparents_by_path(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch",
-            return_value={"id": "cccccccccccc", "name": "Travel", "parent_id": "aaaaaaaaaaaa"},
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._patch",
+                return_value={"id": "cccccccccccc", "name": "Travel", "parent_id": "aaaaaaaaaaaa"},
+            ) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "Travel", "new_parent": "kirocrew"}
             )
@@ -532,10 +555,13 @@ class TestFolderMove:
         assert "kirocrew/Travel" in out
 
     def test_move_to_root(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch",
-            return_value={"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": ""},
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._patch",
+                return_value={"id": "bbbbbbbbbbbb", "name": "0811", "parent_id": ""},
+            ) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "root"}
             )
@@ -543,17 +569,21 @@ class TestFolderMove:
         assert "0811" in out
 
     def test_root_is_not_a_movable_subject(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner("chat_folder_move", {"folder": "root"})
         assert out.startswith("Error:")
         mock_patch.assert_not_called()
 
     def test_cycle_verdict_comes_from_the_endpoint(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch",
-            return_value={"error": "cannot move a folder into its own descendant"},
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._patch",
+                return_value={"error": "cannot move a folder into its own descendant"},
+            ),
         ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew", "new_parent": "kirocrew/0811"}
@@ -562,9 +592,11 @@ class TestFolderMove:
 
     def test_unknown_folder_errors(self) -> None:
         """Move RESOLVES a folder; it must never create one on the way."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post, patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner("chat_folder_move", {"folder": "Nope/Missing"})
         assert out.startswith("Error:") and "folder not found" in out
         mock_post.assert_not_called()
@@ -581,9 +613,11 @@ class TestFolderMove:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in dupes] if path == "/api/chat/folders" else _slots_with_caller()
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post, patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner("chat_folder_move", {"folder": "kirocrew/0811/deeper"})
         assert out.startswith("Error:") and "share the same parent" in out
         assert "bbbbbbbbbbbb" in out and "cccccccccccc" in out
@@ -599,9 +633,11 @@ class TestFolderMoveSession:
         all, where it reads as the unconfined dashboard user — so the write is
         refused here rather than sent with an authority nobody can name.
         """
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""
-        ), patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-3-300", "folder": "kirocrew/0811"},
@@ -617,12 +653,14 @@ class TestFolderMoveSession:
         with no matching row is the closed-tab race and is refused, so an absent
         one would exercise that refusal instead of the pass-through.
         """
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-2-200",
-        ), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-2-200",
+            ),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-3-300", "folder": "kirocrew/0811"},
@@ -630,9 +668,13 @@ class TestFolderMoveSession:
         assert mock_patch.call_args.kwargs["session_key"] == "dashboard:chat-2-200"
 
     def test_moves_by_slot_key_into_a_path(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": "bbbbbbbbbbbb"}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._patch",
+                return_value={"ok": True, "folder_id": "bbbbbbbbbbbb"},
+            ) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-3-300", "folder": "kirocrew/0811"},
@@ -643,9 +685,10 @@ class TestFolderMoveSession:
         assert "kirocrew/0811" in out
 
     def test_accepts_a_dashboard_session_key(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "dashboard:chat-1-100", "folder": "Travel"},
@@ -653,9 +696,10 @@ class TestFolderMoveSession:
         assert mock_patch.call_args.args[0] == "/api/chat/slots/chat-1-100/folder"
 
     def test_accepts_an_exact_unique_title(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             _call_tool_inner(
                 "chat_folder_move_session", {"session": "folder mcp", "folder": "Travel"}
             )
@@ -670,9 +714,10 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else dupes
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "Same", "folder": "Travel"}
             )
@@ -680,9 +725,10 @@ class TestFolderMoveSession:
         mock_patch.assert_not_called()
 
     def test_partial_title_is_not_a_match(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "Folder", "folder": "Travel"}
             )
@@ -710,9 +756,10 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "dashboard:chat-9-999", "folder": "Travel"},
@@ -730,9 +777,10 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-1-100", "folder": "Travel"}
             )
@@ -749,9 +797,10 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "dashboard:chat-1-100", "folder": "Travel"},
@@ -760,17 +809,21 @@ class TestFolderMoveSession:
         assert mock_patch.call_args.args[0] == "/api/chat/slots/chat-1-100/folder"
 
     def test_unfile_to_top_level(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch(
+                "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}
+            ) as mock_patch,
+        ):
             out = _call_tool_inner("chat_folder_move_session", {"session": "chat-1-100"})
         assert mock_patch.call_args.args[1] == {"folder_id": ""}
         assert "top level" in out
 
     def test_unknown_destination_folder_never_reaches_the_endpoint(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-1-100", "folder": "Nope"}
             )
@@ -784,9 +837,10 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else odd
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True}
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             _call_tool_inner(
                 "chat_folder_move_session", {"session": "Artifact: My Doc", "folder": "Travel"}
             )
@@ -805,8 +859,9 @@ class TestFolderMoveSession:
         def _get(path: str) -> list[dict]:
             return [dict(f) for f in _FOLDERS] if path == "/api/chat/folders" else rows
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_get), patch(
-            "kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_get),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True, "folder_id": ""}),
         ):
             out = _call_tool_inner("chat_folder_move_session", {"session": leaky})
         assert leaky not in out
@@ -848,18 +903,20 @@ class TestNamesTheEndpointWouldTruncate:
     LONG = "x" * 101
 
     def test_the_schema_refuses_an_overlong_leaf_name(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             with pytest.raises(ValidationError):
                 _call_tool_inner("chat_folder_create", {"name": self.LONG})
         mock_post.assert_not_called()
 
     def test_a_parent_segment_is_refused_before_any_write(self) -> None:
         """The schema's 4096-char path bound cannot see a per-segment overrun."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post"
-        ) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner(
                 "chat_folder_create", {"name": "leaf", "parent": f"Travel/{self.LONG}"}
             )
@@ -877,9 +934,10 @@ class TestNamesTheEndpointWouldTruncate:
         error in ``redact()`` and would mask an unredacted message.
         """
         leaky = "AKIAIOSFODNN7EXAMPLE" + "z" * 90
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner("chat_folder_move", {"folder": f"Travel/{leaky}"})
         assert "too long" in out
         assert "AKIAIOSFODNN7EXAMPLE" not in out
@@ -889,12 +947,11 @@ class TestNamesTheEndpointWouldTruncate:
         """Exactly at the limit round-trips, so the guard is off-by-one clean."""
         at_limit = "y" * 100
         made = {"id": "ffffffffffff", "name": at_limit, "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows), patch(
-            "kiro_crew.mcp_dashboard._post", return_value=made
-        ) as mock_post:
-            out = _call_tool_inner(
-                "chat_folder_create", {"name": "leaf", "parent": at_limit}
-            )
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
+            out = _call_tool_inner("chat_folder_create", {"name": "leaf", "parent": at_limit})
         assert not out.startswith("Error:")
         assert mock_post.call_count == 2  # the parent segment, then the leaf
 
@@ -918,9 +975,12 @@ class TestASubagentCannotOutrankItsParent:
         ]
 
     def test_a_subagent_is_shown_no_sessions(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="subagent:abc123",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="subagent:abc123",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert out.startswith("Error:")
@@ -928,20 +988,28 @@ class TestASubagentCannotOutrankItsParent:
         assert "Radar run" not in out and "Raymond's own" not in out
 
     def test_a_subagent_cannot_reshape_the_tree(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="subagent:abc123",
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="subagent:abc123",
+            ),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Output"})
         assert out.startswith("Error:")
         mock_post.assert_not_called()
 
     def test_a_subagent_cannot_file_a_session(self) -> None:
         """The resolver reads the withheld list, so the write is refused too."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="subagent:abc123",
-        ), patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="subagent:abc123",
+            ),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-1-100", "folder": "kirocrew/0811"},
@@ -951,19 +1019,26 @@ class TestASubagentCannotOutrankItsParent:
 
     def test_an_app_cron_is_shown_no_sessions(self) -> None:
         """A cron can be app-created, so a cron key can carry an app's reach."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="cron:job-abc123",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="cron:job-abc123",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert out.startswith("Error:")
         assert "Radar run" not in out and "Raymond's own" not in out
 
     def test_a_cron_cannot_reshape_the_tree(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="cron:job-abc123",
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="cron:job-abc123",
+            ),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Output"})
         assert out.startswith("Error:")
         mock_post.assert_not_called()
@@ -989,19 +1064,26 @@ class TestASubagentCannotOutrankItsParent:
         app-owned session's agent can outlive its own row. Reading that absence
         as "no app" would hand it the authority the app does not have.
         """
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-gone-999",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-gone-999",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert out.startswith("Error:")
         assert "Radar run" not in out and "Raymond's own" not in out
 
     def test_a_vanished_dashboard_caller_cannot_reshape_the_tree(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-gone-999",
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-gone-999",
+            ),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Output"})
         assert out.startswith("Error:")
         mock_post.assert_not_called()
@@ -1023,9 +1105,12 @@ class TestASubagentCannotOutrankItsParent:
 
     def test_a_slack_or_channel_caller_is_still_unscoped(self) -> None:
         """The exemption covers delegated callers only — these have no app."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="slack:T1:C1:1777",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="slack:T1:C1:1777",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert not out.startswith("Error:")
@@ -1042,9 +1127,12 @@ class TestASubagentCannotOutrankItsParent:
                 {"key": "chat-2-200", "title": "Other app", "folder_id": "", "app": "spec-builder"},
             ]
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=_rows_with_sub), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="subagent:abc123",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows_with_sub),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="subagent:abc123",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert not out.startswith("Error:")
@@ -1080,18 +1168,22 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
     def test_an_apps_create_reaches_the_endpoint(self) -> None:
         """Previously refused here outright; the endpoint now stamps the owner."""
         made = {"id": "new000000001", "name": "Radar output", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Radar output"})
         assert not out.startswith("Error:")
         assert mock_post.called
 
     def test_an_apps_move_reaches_the_endpoint(self) -> None:
         moved = {"id": "fldr00000002", "name": "0811", "parent_id": "fldr00000003"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
             )
@@ -1102,9 +1194,11 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         """The tool must report the endpoint's verdict rather than pre-judging
         it — that is what keeps one rule in one place."""
         denied = {"error": "this app does not own that folder", "code": "folder_not_owned"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._patch", return_value=denied):
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._patch", return_value=denied),
+        ):
             out = _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
             )
@@ -1112,9 +1206,11 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         assert "does not own that folder" in out
 
     def test_an_app_can_still_file_its_own_session(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "chat-1-100", "folder": "kirocrew/0811"},
@@ -1123,9 +1219,7 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         assert mock_patch.called
 
     def test_an_app_can_still_read_the_tree(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ):
+        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as("chat-1-100"):
             out = _call_tool_inner("chat_folder_tree", {})
         assert not out.startswith("Error:")
         assert "kirocrew" in out
@@ -1134,17 +1228,21 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         """Reorganising sessions is the point of the tools — an unscoped caller
         is the person's own agent and is not confined."""
         made = {"id": "new000000001", "name": "Q3", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-3-300"
-        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-3-300"),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Q3"})
         assert not out.startswith("Error:")
         assert mock_post.called
 
     def test_an_unverifiable_caller_cannot_reshape_it_either(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Q3"})
         assert out.startswith("Error:")
         assert "cannot verify which session is calling" in out
@@ -1169,10 +1267,14 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
                 }
             ]
 
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=rows), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="channel:C123",
-        ), patch("kiro_crew.mcp_dashboard._post") as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=rows),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="channel:C123",
+            ),
+            patch("kiro_crew.mcp_dashboard._post") as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Runs"})
         assert out.startswith("Error:")
         assert "channel- or schedule-bound" in out
@@ -1188,10 +1290,14 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
             return [{"key": "chat-5-500", "title": "Mine", "folder_id": "", "app": ""}]
 
         made = {"id": "new000000001", "name": "Runs", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=rows), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="slack:T1/C1",
-        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=rows),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="slack:T1/C1",
+            ),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             out = _call_tool_inner("chat_folder_create", {"name": "Runs"})
         assert not out.startswith("Error:")
         assert mock_post.called
@@ -1222,18 +1328,22 @@ class TestEveryFolderWriteCarriesTheVerifiedKey:
 
     def test_create_sends_the_verified_key(self) -> None:
         made = {"id": "new000000001", "name": "Runs", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": "Runs"})
         assert mock_post.call_args.kwargs["session_key"] == "dashboard:chat-1-100"
 
     def test_mkdir_p_segments_are_created_under_the_verified_key(self) -> None:
         """The intermediate segments are real folders, so each write needs it too."""
         made = {"id": "new000000001", "name": "seg", "parent_id": ""}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
+        ):
             _call_tool_inner("chat_folder_create", {"name": "Leaf", "parent": "Fresh/Deep"})
         assert mock_post.call_count > 1
         for call in mock_post.call_args_list:
@@ -1241,9 +1351,11 @@ class TestEveryFolderWriteCarriesTheVerifiedKey:
 
     def test_move_sends_the_verified_key(self) -> None:
         moved = {"id": "fldr00000002", "name": "0811", "parent_id": "fldr00000003"}
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), self._as(
-            "chat-1-100"
-        ), patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            self._as("chat-1-100"),
+            patch("kiro_crew.mcp_dashboard._patch", return_value=moved) as mock_patch,
+        ):
             _call_tool_inner(
                 "chat_folder_move", {"folder": "kirocrew/0811", "new_parent": "Travel"}
             )
@@ -1268,9 +1380,12 @@ class TestTheSessionListIsScopedToTheCaller:
         ]
 
     def test_an_app_sees_only_its_own_sessions(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-1-100",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-1-100",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert "Radar run" in out
@@ -1279,16 +1394,20 @@ class TestTheSessionListIsScopedToTheCaller:
 
     def test_the_user_sees_every_session(self) -> None:
         """An unscoped caller is the person's own agent — the point of the tools."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-3-300",
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-3-300",
+            ),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert "Radar run" in out and "Spec draft" in out and "Raymond's own work" in out
 
     def test_an_unverifiable_caller_is_shown_nothing(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert out.startswith("Error:")
@@ -1297,10 +1416,14 @@ class TestTheSessionListIsScopedToTheCaller:
 
     def test_an_app_cannot_resolve_a_foreign_session_by_title(self) -> None:
         """The resolver reads the same filtered list, so scope covers writes too."""
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
-            return_value="dashboard:chat-1-100",
-        ), patch("kiro_crew.mcp_dashboard._patch") as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                return_value="dashboard:chat-1-100",
+            ),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session",
                 {"session": "Spec draft", "folder": "Work"},
@@ -1321,9 +1444,24 @@ class TestPrivateSessionsAreInvisible:
         if path == "/api/chat/folders":
             return [dict(f) for f in _FOLDERS]
         return [
-            {"key": "chat-1-100", "title": "Public work", "folder_id": "", "memory_mode": "persistent"},
-            {"key": "chat-9-900", "title": "Secret thing", "folder_id": "", "memory_mode": "incognito"},
-            {"key": "chat-8-800", "title": "Scratch pad", "folder_id": "", "memory_mode": "temporary"},
+            {
+                "key": "chat-1-100",
+                "title": "Public work",
+                "folder_id": "",
+                "memory_mode": "persistent",
+            },
+            {
+                "key": "chat-9-900",
+                "title": "Secret thing",
+                "folder_id": "",
+                "memory_mode": "incognito",
+            },
+            {
+                "key": "chat-8-800",
+                "title": "Scratch pad",
+                "folder_id": "",
+                "memory_mode": "temporary",
+            },
         ]
 
     def test_no_archived_count_is_rendered(self) -> None:
@@ -1355,9 +1493,10 @@ class TestPrivateSessionsAreInvisible:
         assert "Scratch pad" not in out and "chat-8-800" not in out
 
     def test_one_cannot_be_moved_by_key(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "chat-9-900", "folder": "Work"}
             )
@@ -1365,9 +1504,10 @@ class TestPrivateSessionsAreInvisible:
         mock_patch.assert_not_called()
 
     def test_one_cannot_be_moved_by_title(self) -> None:
-        with patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed), patch(
-            "kiro_crew.mcp_dashboard._patch"
-        ) as mock_patch:
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
+            patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
+        ):
             out = _call_tool_inner(
                 "chat_folder_move_session", {"session": "Secret thing", "folder": "Work"}
             )
@@ -1388,27 +1528,34 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
     VERIFIED = "dashboard:chat-verified"
 
     def test_create_carries_the_verified_key(self):
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-        ), patch(
-            "kiro_crew.mcp_dashboard._post", return_value={"target": "chat-2", "title": "w"}
-        ) as post:
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch(
+                "kiro_crew.mcp_dashboard._post", return_value={"target": "chat-2", "title": "w"}
+            ) as post,
+        ):
             _call_tool_inner("session_create", {"title": "worker"})
         assert post.call_args.kwargs["session_key"] == self.VERIFIED
 
     def test_stop_carries_the_verified_key(self):
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-        ), patch("kiro_crew.mcp_dashboard._post", return_value={"ok": True}) as post:
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch("kiro_crew.mcp_dashboard._post", return_value={"ok": True}) as post,
+        ):
             _call_tool_inner("session_stop", {"target": "peer"})
         assert post.call_args.kwargs["session_key"] == self.VERIFIED
 
     def test_read_carries_the_verified_key(self):
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-        ), patch(
-            "kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 0}
-        ) as get:
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch("kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 0}) as get,
+        ):
             _call_tool_inner("session_read_message", {"target": "peer"})
         # `_get` takes the key positionally, matching its signature.
         assert get.call_args.args[1] == self.VERIFIED
@@ -1469,11 +1616,14 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
 
         Mutation guard: returning only the head line and "No messages" fails here.
         """
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-        ), patch(
-            "kiro_crew.mcp_dashboard._get",
-            return_value={"messages": [], "total": 7, "next_since": 7},
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch(
+                "kiro_crew.mcp_dashboard._get",
+                return_value={"messages": [], "total": 7, "next_since": 7},
+            ),
         ):
             out = _call_tool_inner("session_read_message", {"target": "peer"})
         assert "since=7" in out, "an empty window must still carry next_since"
@@ -1485,21 +1635,22 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         this pins the renderer's defensive behaviour for a cursor-less
         response shape, whatever produces one.
         """
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-        ), patch(
-            "kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 7}
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch("kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 7}),
         ):
             out = _call_tool_inner("session_read_message", {"target": "peer"})
         assert "since=" not in out, "no cursor may be invented once rows are trimmed"
 
     def test_an_unverifiable_caller_never_reaches_the_request(self):
         """The refusal must precede the call, not merely alter its key."""
-        with patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""
-        ), patch("kiro_crew.mcp_dashboard._post") as post, patch(
-            "kiro_crew.mcp_dashboard._get"
-        ) as get:
+        with (
+            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_dashboard._post") as post,
+            patch("kiro_crew.mcp_dashboard._get") as get,
+        ):
             for tool, args in (
                 ("session_create", {"title": "worker"}),
                 ("session_stop", {"target": "peer"}),
@@ -1509,6 +1660,151 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
                 assert "cannot be identified" in out
         post.assert_not_called()
         get.assert_not_called()
+
+
+class TestSessionCreateFolder:
+    """`session_create.folder` — filing atomic with creation (#6118).
+
+    The reference resolves with `chat_folder_create`'s `parent` semantics
+    (missing segments created), which is tree shaping — so the SAME gate
+    applies, not a second authorization path. The endpoint receives the
+    resolved id and re-confirms it in the create's own synchronous window;
+    these cases cover the MCP half: gate, resolution, payload shape, refusal.
+    """
+
+    CREATED = {"target": "chat-9-900", "title": "worker", "folder_id": "bbbbbbbbbbbb"}
+
+    def test_files_at_creation_with_the_resolved_id(self) -> None:
+        """One POST, to the create route, already carrying the folder id."""
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", return_value=dict(self.CREATED)) as post,
+        ):
+            out = _call_tool_inner("session_create", {"title": "worker", "folder": "kirocrew/0811"})
+        assert post.call_count == 1, "filing must not be a second call after the create"
+        path, body = post.call_args.args
+        assert path == "/api/session-control/create"
+        assert body["folder_id"] == "bbbbbbbbbbbb"
+        assert "kirocrew/0811" in out
+
+    def test_missing_segments_are_created_like_a_parent_ref(self) -> None:
+        """mkdir -p over the reference, then the create rides the new leaf id."""
+        made = {"id": "dddddddddddd", "name": "fresh", "parent_id": "aaaaaaaaaaaa"}
+
+        def _post_route(path, body, **kwargs):
+            if path == "/api/chat/folders":
+                return dict(made)
+            assert path == "/api/session-control/create"
+            return {**self.CREATED, "folder_id": body["folder_id"]}
+
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post_route) as post,
+        ):
+            out = _call_tool_inner(
+                "session_create", {"title": "worker", "folder": "kirocrew/fresh"}
+            )
+        create_call = post.call_args_list[-1]
+        assert create_call.args[0] == "/api/session-control/create"
+        assert create_call.args[1]["folder_id"] == "dddddddddddd"
+        assert "created folder path" in out
+
+    def test_an_unresolvable_folder_refuses_the_whole_create(self) -> None:
+        """No session may exist when the filing half cannot be honored.
+
+        An id-shaped reference that does not exist is a lookup failure even
+        under mkdir -p (ids are minted server-side), and 'created but unfiled'
+        would silently honor half the request — so the create POST never fires.
+        """
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as post,
+        ):
+            out = _call_tool_inner("session_create", {"title": "worker", "folder": "ffffffffffff"})
+        assert out.startswith("Error:")
+        assert "folder not found" in out
+        post.assert_not_called()
+
+    def test_folder_resolution_rides_the_tree_shaping_gate(self) -> None:
+        """A caller the gate refuses cannot file-by-naming at create time.
+
+        Resolution can CREATE folders, so it is tree shaping: reusing the gate —
+        rather than a second authorization path — is what keeps 'could not
+        reshape the tree by creating a folder' and 'cannot reach the same write
+        through session_create' the same statement.
+        """
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._refuse_tree_shaping_if_unverifiable",
+                return_value=("", "Error: refused by the tree-shaping gate"),
+            ),
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post") as post,
+        ):
+            out = _call_tool_inner("session_create", {"title": "worker", "folder": "kirocrew/0811"})
+        assert out == "Error: refused by the tree-shaping gate"
+        post.assert_not_called()
+
+    def test_no_folder_means_no_gate(self) -> None:
+        """A plain create is not tree shaping and must not grow that refusal."""
+        with (
+            patch("kiro_crew.mcp_dashboard._refuse_tree_shaping_if_unverifiable") as gate,
+            patch(
+                "kiro_crew.mcp_dashboard._post", return_value={"target": "chat-9", "title": "w"}
+            ) as post,
+        ):
+            _call_tool_inner("session_create", {"title": "worker"})
+        gate.assert_not_called()
+        assert post.call_count == 1
+        assert "folder_id" not in post.call_args.args[1]
+
+    def test_an_app_scoped_caller_cannot_leave_folder_segments_behind(self) -> None:
+        """The endpoint refuses `app_scoped_caller`, so resolution must not run.
+
+        An app may create folders in its own subtree, but it can never complete
+        session_create — resolving (and mkdir -p creating) the folder for it
+        would leave path segments behind for a call that cannot succeed. The
+        refusal here is a side-effect guard; the endpoint's own refusal stays
+        authoritative.
+        """
+
+        def _rows_with_app(path: str) -> list[dict]:
+            if path == "/api/chat/slots":
+                return [{"key": "chat-1-100", "title": "Caller", "app": "some-app"}]
+            return _rows(path)
+
+        with (
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows_with_app),
+            patch("kiro_crew.mcp_dashboard._post") as post,
+        ):
+            out = _call_tool_inner(
+                "session_create", {"title": "worker", "folder": "kirocrew/fresh"}
+            )
+        assert out.startswith("Error:")
+        assert "app-scoped" in out
+        post.assert_not_called()
+
+    def test_segment_creation_writes_under_the_gates_verified_key(self) -> None:
+        """The gate's returned key is what the folder writes carry — its contract."""
+        made = {"id": "dddddddddddd", "name": "fresh", "parent_id": "aaaaaaaaaaaa"}
+
+        def _post_route(path, body, **kwargs):
+            if path == "/api/chat/folders":
+                return dict(made)
+            return dict(self.CREATED)
+
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._refuse_tree_shaping_if_unverifiable",
+                return_value=("dashboard:gate-key", None),
+            ),
+            patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
+            patch("kiro_crew.mcp_dashboard._post", side_effect=_post_route) as post,
+        ):
+            _call_tool_inner("session_create", {"title": "worker", "folder": "kirocrew/fresh"})
+        folder_call = post.call_args_list[0]
+        assert folder_call.args[0] == "/api/chat/folders"
+        assert folder_call.kwargs["session_key"] == "dashboard:gate-key"
 
 
 class TestAdvertisedSet:

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -2123,6 +2123,484 @@ def test_created_session_gets_its_workspace_project_dir(tmp_path):
     assert child.project == loader.default_project_dir(child.workspace)
 
 
+# ── session_create: filing at birth (#6118) ─────────────────────────────────
+
+
+def test_create_schema_bounds_the_folder_reference():
+    """`folder` takes an id OR a human path, bounded like every folder ref.
+
+    The two readings share no charset, so the schema checks only the length --
+    the same contract `chat_folder_move_session.folder` carries. Over-length is
+    refused at validation, before any resolution work.
+    """
+    from kiro_crew.validation import SESSION_CREATE_SCHEMA, ValidationError, validate_tool_args
+
+    out = validate_tool_args({"folder": "aaaaaaaaaaaa"}, SESSION_CREATE_SCHEMA)
+    assert out["folder"] == "aaaaaaaaaaaa", "an id-shaped reference must pass"
+    out = validate_tool_args({"folder": "Goals/Q3 push"}, SESSION_CREATE_SCHEMA)
+    assert out["folder"] == "Goals/Q3 push", "a '/'-separated human path must pass"
+    out = validate_tool_args({}, SESSION_CREATE_SCHEMA)
+    assert out["folder"] == "", "omitted means unfiled, not an error"
+    with pytest.raises(ValidationError):
+        validate_tool_args({"folder": "x" * 4097}, SESSION_CREATE_SCHEMA)
+
+
+def _folder(state, fid: str, name: str, **extra):
+    row = {"id": fid, "name": name, "parent_id": "", **extra}
+    state._folders.append(row)
+    return row
+
+
+def test_create_files_the_slot_at_birth(tmp_path):
+    """A named folder is applied at creation AND rides the birth metadata.
+
+    The disk half is the load-bearing one: the normal save path returns early on
+    an empty message window, so for a created-then-idle session the birth
+    metadata line is the only durable record of the placement. Dropping
+    `folder_id` from that dict files the session in memory and loses it on the
+    next restart.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+
+    child = state.get_slot(created["target"])
+    assert child is not None
+    assert child.folder_id == "fold00000001", "the slot must be filed, not left for a move"
+    written = state.conversation_log.get_metadata(slot_history_key(child))
+    assert written.get("folder_id") == "fold00000001", (
+        "the placement must reach the persist-at-birth metadata -- the save path "
+        "writes nothing for an empty session, so this line is the only record"
+    )
+
+
+def test_create_refuses_an_unknown_folder(tmp_path):
+    """An unresolvable folder refuses the WHOLE create, allocating nothing.
+
+    The caller asked for a session filed in this folder; 'created but unfiled'
+    would silently honor half of that. No session exists yet, so refusal loses
+    nothing -- the same posture the move path takes on an unknown folder.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = state.live_slot_count()
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(
+            sc.create_session(state, caller_session_key=_key(caller), folder_id="nope00000000")
+        )
+
+    assert exc.value.code == "folder_not_found"
+    assert state.live_slot_count() == before, "a refused create must not leave a slot behind"
+
+
+def test_a_folder_deleted_mid_create_is_refused_under_the_lock(tmp_path, monkeypatch):
+    """Folder existence is decided under the folder-store lock, late.
+
+    `create_session` suspends before the allocation (project dir, config load),
+    and a folder delete can land in those windows. Existence is therefore
+    confirmed READ-ONLY under the folder-store lock (`state.read_folders`) as
+    the last suspension before the re-gate. Simulated by deleting the folder
+    inside the project-dir resolution. Mutation guard: a check that reads the
+    unlocked list before those awaits would let this create succeed into a
+    folder that is already gone.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    def _delete_folder_then_resolve(_workspace):
+        # Stand in for the interleaving: the delete lands while the project
+        # directory is still being resolved off-loop.
+        state._folders[:] = [f for f in state._folders if f["id"] != "fold00000001"]
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _delete_folder_then_resolve)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(
+            sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+        )
+    assert exc.value.code == "folder_not_found"
+
+
+def test_filing_at_birth_unhides_the_folder_like_a_move(tmp_path):
+    """Model-B semantics apply at create exactly as they do on a move.
+
+    Moving a session into a hidden folder un-hides it (`_unhide_folder`), so a
+    session filed at creation must not land invisibly inside a folder the user
+    cannot see -- that would be a session the sidebar hides by construction.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    row = _folder(state, "fold00000001", "Goal", hidden=True)
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+
+    assert state.get_slot(created["target"]).folder_id == "fold00000001"
+    assert row["hidden"] is False, "filing into a hidden folder must un-hide it"
+
+
+def test_a_folder_cannot_smuggle_creation_past_the_caller_refusals(tmp_path):
+    """Caller eligibility precedes every folder consideration.
+
+    The move path's app-ownership rule never has to run here because an
+    app-scoped caller cannot create a session at all -- that refusal is the
+    guard the filing inherits, and it must keep firing FIRST so the folder
+    argument cannot become a probe for folder existence.
+    """
+    state = _make_state(tmp_path)
+    app_caller = _slot(state, "chat-app")
+    app_caller._app = "some-app"
+    _folder(state, "fold00000001", "Goal")
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(
+            sc.create_session(state, caller_session_key=_key(app_caller), folder_id="fold00000001")
+        )
+    assert (
+        exc.value.code == "app_scoped_caller"
+    ), "the caller refusal must precede folder handling -- not folder_not_found"
+
+
+def test_a_refused_create_leaves_a_hidden_folder_hidden(tmp_path, monkeypatch):
+    """No durable folder-tree mutation may survive a refused create.
+
+    The Model-B un-hide persists `hidden = False` to the folder store, and the
+    re-gate can still refuse AFTER the folder was confirmed -- so un-hiding
+    early would durably reverse a choice the user made, for a call that failed.
+    Simulated with the caller closing mid-create (the same interleaving the
+    re-gate exists for). Mutation guard: moving the un-hide back before the
+    re-gate flips the folder visible here.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    row = _folder(state, "fold00000001", "Goal", hidden=True)
+
+    def _close_caller_then_resolve(_workspace):
+        state._slots.pop(caller.key, None)
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _close_caller_then_resolve)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(
+            sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+        )
+    assert exc.value.code == "caller_not_open"
+    assert row["hidden"] is True, "a refused create must not un-hide the folder"
+
+
+def test_moving_an_empty_newborn_before_its_first_message_survives_a_restart(tmp_path):
+    """A filed-at-birth session that is re-filed while still empty persists it.
+
+    Birth metadata made empty sessions durable, which made the save path's
+    empty-window early return newly consequential: the folder PATCH route and
+    the folder-delete sweep persist via `save_slot_off_loop(force=True)`, whose
+    full save has no window to write for a message-less slot -- without the
+    metadata merge, a restart would resurrect the BIRTH placement the user
+    already changed (or point at a folder they deleted).
+    """
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+    _folder(state, "fold00000002", "Other")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    # The user drags it into another folder before any message lands.
+    child.folder_id = "fold00000002"
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+    moved = state.conversation_log.get_metadata(slot_history_key(child))
+    assert moved.get("folder_id") == "fold00000002", "the move must overwrite the birth filing"
+
+    # And unfiling durably clears it (a falsy value reads as unfiled).
+    child.folder_id = ""
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+    unfiled = state.conversation_log.get_metadata(slot_history_key(child))
+    assert not unfiled.get("folder_id"), "unfiling must not resurrect the birth filing"
+
+    # An ordinary empty tab has no metadata line, and a forced save must not
+    # materialize one -- a session with no line does not survive a restart, so
+    # there is nothing to reconcile.
+    plain = _slot(state, "chat-plain")
+    asyncio.run(save_slot_off_loop(state, plain, force=True))
+    meta, readable = state.conversation_log.get_metadata_status(slot_history_key(plain))
+    assert readable and not meta, "no metadata line may be invented for a plain empty tab"
+
+
+def test_metadata_mutations_on_an_empty_newborn_survive_a_restart(tmp_path):
+    """Tags and a pin acknowledged before the first message persist.
+
+    The tag routes and the pin route persist ONLY through
+    ``save_slot_off_loop(force=True)`` -- for a message-less newborn that is
+    the empty-window merge, so a folder-only merge would acknowledge the
+    mutation and then silently drop it on restart. Clears must be explicit:
+    the merge cannot delete a key, so untag/unpin write falsy values that
+    rehydrate reads as cleared.
+    """
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    # The user tags, pins, mode-switches, and binds it before any message lands.
+    child.tags = ["tag00000001"]
+    child.pinned = True
+    child.mode = "orchestrator"
+    child._artifact = "my-artifact"
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+    meta = state.conversation_log.get_metadata(slot_history_key(child))
+    assert meta.get("tags") == ["tag00000001"], "an acknowledged tag must reach disk"
+    assert meta.get("pinned") is True, "an acknowledged pin must reach disk"
+    assert meta.get("mode") == "orchestrator", "an acknowledged mode switch must reach disk"
+    assert meta.get("artifact") == "my-artifact", "an acknowledged binding must reach disk"
+    assert meta.get("folder_id") == "fold00000001", "the merge must not drop the birth filing"
+
+    # And the clears are explicit -- a restart must not resurrect them.
+    child.tags = []
+    child.pinned = False
+    child.mode = ""
+    child._artifact = ""
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+    meta = state.conversation_log.get_metadata(slot_history_key(child))
+    assert meta.get("tags") == [], "untagging must overwrite the persisted tags"
+    assert not meta.get("pinned"), "unpinning must overwrite the persisted pin"
+    assert not meta.get("mode"), "a mode reset must overwrite the persisted mode"
+    assert not meta.get("artifact"), "an unbind must overwrite the persisted binding"
+
+
+def test_the_empty_window_merge_mirrors_the_full_saves_slot_owned_fields(tmp_path):
+    """Drift guard: every restart-relevant slot-owned field survives the merge.
+
+    The empty-window merge must persist what the FULL save's metadata line
+    would persist, or whichever route happens to flow through it silently
+    drops an acknowledged mutation on restart. Keyed to
+    ``SLOT_OWNED_META_KEYS`` so a field added to the full save later fails
+    here instead of regressing quietly. Exclusions are the history-layer /
+    conditional-identity keys the merge legitimately writes only when the
+    slot carries them.
+    """
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+    from kiro_crew.history import SLOT_OWNED_META_KEYS
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    child.tags = ["tag00000001"]
+    child.pinned = True
+    child.mode = "orchestrator"
+    child._artifact = "my-artifact"
+    child.reasoning_effort = "high"
+    child.color_index = 3
+    child.title = "Pinned title"
+    child._titled = True
+    child._title_origin = "user"
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+    meta = state.conversation_log.get_metadata(slot_history_key(child))
+
+    # History-layer bookkeeping the merge must NOT touch, the closed pair
+    # (exercised by its own test), and identity fields a plain user newborn
+    # does not carry.
+    excluded = {
+        "_type",
+        "created_at",
+        "last_consolidated",
+        "closed",
+        "closed_at",
+        "app",
+        "forked_from",
+        "linked_session_key",
+    }
+    for key in sorted(SLOT_OWNED_META_KEYS - excluded):
+        assert key in meta, f"slot-owned field {key!r} missing after an empty-window forced save"
+    assert meta.get("artifact") == "my-artifact"
+    assert meta.get("reasoning_effort") == "high"
+    assert meta.get("color_index") == 3
+    assert meta.get("title") == "Pinned title"
+    assert meta.get("title_origin") == "user"
+
+
+def test_the_empty_window_merge_reads_slot_state_at_write_time(tmp_path):
+    """The merged fields are evaluated under the history lock, not snapshotted.
+
+    Two concurrent force-saves of the same empty newborn can commit in either
+    order; a dict snapshotted before the lock would let the older save land
+    second and silently revert an acknowledged newer mutation (a tag save
+    restoring ``pinned=False`` over a pin that already committed). Pinning the
+    guard-time read: a slot mutation landing after the save call but before
+    the locked write must be what reaches disk.
+    """
+    from unittest.mock import patch
+
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    real = state.conversation_log.update_metadata_if
+
+    def _mutate_then_write(key, fields, guard):
+        # Simulates a concurrent pin committing between this save's call and
+        # its locked write: the merge must pick up the NEW value.
+        child.pinned = True
+        return real(key, fields, guard)
+
+    child.pinned = False
+    with patch.object(state.conversation_log, "update_metadata_if", _mutate_then_write):
+        asyncio.run(save_slot_off_loop(state, child, force=True))
+    meta = state.conversation_log.get_metadata(slot_history_key(child))
+    assert meta.get("pinned") is True, "the merge must write the slot state current at lock time"
+
+
+def test_closing_an_empty_newborn_does_not_resurrect_it_open(tmp_path):
+    """A close acknowledged for a message-less newborn persists to its line.
+
+    Birth metadata made empty sessions durable -- without the closed merge the
+    line stays open-shaped and the next restart resurrects a tab the user
+    dismissed.
+    """
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    asyncio.run(save_slot_off_loop(state, child, closed=True, closed_at=123.0))
+    meta = state.conversation_log.get_metadata(slot_history_key(child))
+    assert meta.get("closed") is True, "the close must reach the birth metadata line"
+    assert meta.get("closed_at") == 123.0, "the close instant must be the caller-supplied one"
+
+
+def test_an_unreadable_record_fails_the_empty_window_merge_loudly(tmp_path):
+    """A merge skipped because the record could not be READ must raise.
+
+    ``update_metadata_if`` fails closed on an unreadable record without
+    invoking the guard; swallowing that would report the save as durable -- a
+    close would remove the tab while the on-disk line stays open-shaped, and
+    the next restart resurrects it. The by-design skip (guard ran, record
+    empty: a line-less plain tab) must stay silent.
+    """
+    from unittest.mock import patch
+
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+
+    def _unreadable(key, fields, guard):
+        # Mirrors update_metadata_if's fail-closed path: guard NOT invoked.
+        return False
+
+    with patch.object(state.conversation_log, "update_metadata_if", _unreadable):
+        with pytest.raises(Exception):
+            asyncio.run(save_slot_off_loop(state, child, closed=True, best_effort=False))
+
+    # The by-design skip stays silent: a plain empty tab has no metadata line,
+    # the guard runs, sees an empty record, and refuses without error.
+    plain = _slot(state, "chat-plain2")
+    assert asyncio.run(save_slot_off_loop(state, plain, force=True, best_effort=False)) is True
+
+
+def test_an_unhide_failure_does_not_fail_a_committed_create(tmp_path, monkeypatch):
+    """The Model-B un-hide is best-effort once the create has committed.
+
+    By the time it runs, the slot is published and persisted at birth -- a
+    folder-store write failure propagating from here would return 500 for a
+    session that EXISTS, and the caller's natural retry would create a
+    duplicate. Mutation guard: letting the exception escape fails this create.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal", hidden=True)
+
+    async def _boom(_state, _fid):
+        raise RuntimeError("folder store write failed")
+
+    monkeypatch.setattr(sc, "_unhide_folder", _boom)
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+
+    child = state.get_slot(created["target"])
+    assert child is not None, "the committed create must be reported as a success"
+    assert child.folder_id == "fold00000001"
+    written = state.conversation_log.get_metadata(slot_history_key(child))
+    assert written.get("folder_id") == "fold00000001", "the filing itself must have landed"
+
+
+def test_the_empty_window_merge_cannot_resurrect_a_deleted_session(tmp_path):
+    """The existence guard and the merge run under ONE lock.
+
+    The plain metadata update is an upsert, so a checked-then-written pair
+    would let a permanent deletion land between the read and the write and be
+    recreated as a fresh file. `update_metadata_if` re-makes the decision inside
+    the cross-process lock; a session file deleted before the forced save stays
+    deleted.
+    """
+    from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _folder(state, "fold00000001", "Goal")
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), folder_id="fold00000001")
+    )
+    child = state.get_slot(created["target"])
+    history_key = slot_history_key(child)
+    path = state.conversation_log._path(history_key)
+    assert path.exists(), "birth metadata must be on disk before the deletion"
+
+    # A permanent deletion lands, then the racing forced save arrives.
+    path.unlink()
+    child.folder_id = ""
+    asyncio.run(save_slot_off_loop(state, child, force=True))
+
+    assert not path.exists(), "the merge must not resurrect a deleted session file"
+
+
 def test_every_session_control_refusal_is_audited_as_failed():
     """A refused tool call must not be recorded as a completed one.
 
@@ -2484,6 +2962,43 @@ def test_nothing_suspends_while_the_created_slot_is_half_configured():
     assert "await" not in src[reresolve:publish], (
         "an await between re-resolving the caller and allocating the slot makes "
         "every re-read decision stale again"
+    )
+    # The folder confirmation is a suspension (it takes the folder-store lock),
+    # so it must sit BEFORE the re-resolve: after it, nothing suspends until the
+    # slot is configured, which is what makes "confirmed under the lock" still
+    # true at the assignment (folder mutations run on this loop).
+    exists_check = src.index("await state.read_folders(")
+    assert exists_check < reresolve, (
+        "the folder existence check suspends, so it must precede the caller "
+        "re-resolve -- after the re-gate nothing may suspend"
+    )
+    # And the filing itself happens inside the synchronous configuration window,
+    # so no caller ever observes the published slot unfiled -- the atomicity
+    # #6118 exists for.
+    filed = src.index("slot.folder_id = folder_id")
+    assert publish < filed < configured, (
+        "the folder must be assigned between publishing the slot and the end of "
+        "its synchronous configuration, or a caller can observe it unfiled"
+    )
+    # The Model-B un-hide is a DURABLE folder-store mutation, so it may run only
+    # after the filing actually landed: before the persist, any of the re-gate's
+    # refusals (or the write itself failing) would leave a folder the user hid
+    # permanently visible for a call that failed.
+    unhide = src.index("await _unhide_folder(")
+    persist = src.index("log.update_metadata")
+    assert persist < unhide, (
+        "un-hiding must follow the persist -- a refused create must leave no "
+        "durable folder-tree mutation behind"
+    )
+    # The allocation-to-persist span is broadcast-atomic: `get_or_create_slot`
+    # broadcasts on a leading edge, so without the suspend an idle gateway sends
+    # the new slot to every client BEFORE folder_id is assigned -- the session
+    # renders at the top level for a frame, the observable unfiled state this
+    # feature removes. Same pattern the move path pins for its own filing.
+    suspend = src.index("with state.suspend_slots_push():")
+    assert gate < suspend < publish, (
+        "the slot allocation must sit inside suspend_slots_push, so the slot's "
+        "first broadcast frame already shows it filed"
     )
 
 


### PR DESCRIPTION
## Summary

`session_create` had no folder argument, so a caller that wanted a session filed in a sidebar folder had to make two calls (`session_create` then `chat_folder_move_session`). The window between the two was a real defect path: a folder deleted in between left the session created but unfiled — PR #6109 hardened the goal-conductor skill's instructions around it but explicitly could not close that case, and both the Design Review and First Principles lanes there named the missing field as the root cause.

This PR adds an optional `folder` to `session_create` (a folder id or `/`-separated human path, resolved with `chat_folder_create`'s `parent` semantics — missing segments created behind the existing tree-shaping gate) and files the slot as part of creation, then deletes the instruction-layer workaround.

Closes #6118

## What changed

- **`validation.py`** — `SESSION_CREATE_SCHEMA` gains `folder`, bounded like every other folder reference (`_ARTIFACT_FOLDER_REF_MAX`).
- **`mcp_dashboard.py`** — `session_create` resolves the reference through `_refuse_tree_shaping_if_unverifiable` + `_ensure_chat_folder_path` (the same gate folder creation already rides, not a second authorization path) and posts the resolved `folder_id` to the create route.
- **`dashboard/session_control.py`** — `create_session` confirms folder existence read-only under the folder-store lock (`read_folders`) as the last suspension before the re-gate, assigns `folder_id` inside the same synchronous window that configures the slot, holds `suspend_slots_push` across the whole allocation-to-persist span (the slot's first broadcast frame already shows it filed; a slot whose birth write fails is never broadcast), carries the placement in the persist-at-birth metadata, and applies the move path's Model-B un-hide only after the filing has landed.
- **`dashboard/chat_persistence.py`** — a forced save of a message-less slot now merges `folder_id` into an *existing* metadata line. Birth metadata made empty sessions durable, which made the save path's empty-window early return newly consequential: without the merge, moving/unfiling an empty newborn (or deleting its folder) would not persist, and a restart would resurrect the birth placement. No line is ever invented for a plain empty tab.
- **`goal-conductor/SKILL.md`** — the `chat_folder_create` precondition step and the separate `chat_folder_move_session` step are deleted; dispatch passes `folder` at `session_create`.
- **Docs** — `docs/system-specs/modules/session-control.md` updated in the same commit.

## Failure semantics (decision, per the issue)

An unresolvable or mid-create-deleted folder **refuses the whole create** (`folder_not_found`): the caller asked for a session filed in this folder, "created but unfiled" would silently honor half of that, and no session exists yet so refusal loses nothing — matching the move path's posture. Path segments already created by the mkdir-p walk persist on a refused create and are reported in the error (`created folder path: …`), the same partial-report posture `chat_folder_create` takes, since folder deletion is deliberately not a capability this server has.

Authorization adds no new path: app-scoped callers are refused before any folder handling (`app_scoped_caller`, strictly stronger than the move path's app-ownership rule at this entry point), and unverifiable/delegated callers are refused by the tree-shaping gate plus the session-control strict-identity check.

## Pre-push review

Two blind model-pinned lanes (mirroring the CI reviewers) ran before the PR: both blocked on real defects, all fixed with pinning tests —
1. Broadcast atomicity: `get_or_create_slot` broadcasts on a leading edge, so the new slot could render unfiled for a frame → allocation-to-persist now runs under `suspend_slots_push` (the move path's own pattern).
2. Refusal side effects: the Model-B un-hide ran before the re-gate, so a refused create could durably un-hide a folder the user hid → existence check is now read-only (`read_folders`); un-hide runs only after the filing lands.
3. Empty-newborn durability: see `chat_persistence.py` above.

One advisory rebutted with evidence: the success message's folder label resolves correctly for freshly created segments because `_ensure_chat_folder_path` appends created rows into the folder list in place before the path render.

## Testing

- Schema: id form, path form, omitted default, over-length rejection.
- Endpoint: filed at birth + metadata round-trip; unknown folder refused with nothing allocated; folder deleted mid-create refused under the lock; refused create leaves a hidden folder hidden; filing un-hides like a move; app-scoped caller refused before folder handling; empty-newborn move/unfile survives restart; no metadata line invented for a plain empty tab.
- Structural pins: folder confirmation is the last suspension before the re-gate; filing inside the synchronous configuration window; un-hide after persist; allocation inside `suspend_slots_push`.
- MCP: one POST carrying the resolved id; mkdir-p segment creation under the gate's verified key; unresolvable folder refuses before the create POST; no gate consulted when `folder` is omitted.
- Local gates: isort, flake8, mypy (0 issues, 1113 files), black gate (3 graduated baseline entries pruned per the gate's instruction), targeted pytest 361 passed across session-control, MCP folders, conductor, persistence suites.
