### PR TITLE
fix(chat): fold a long tool-call title to one line while collapsed

### DIFF
--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -63,6 +63,25 @@ const foldedDiffCards = new Set<string>()
 const SLIDE_DURATION = 0.22
 const SLIDE_EASE = [0.4, 0, 0.2, 1] as const
 
+// ── Collapsed label clamp ──
+// A tool title is whatever the transport hands us, and for a shell call that is
+// the WHOLE command — an inline heredoc or a chained one-liner is routinely
+// several kB. Rendered with `break-words` that wrapped to forty-odd lines, so a
+// single folded tool row could be taller than the answer it belongs to, and the
+// reader had to scroll a wall of quoting to reach the next message.
+//
+// A collapsed row is a STATUS line, exactly like ThinkingBlock's folded
+// "Thought process": it says which tool is running and that it is running, and
+// nothing more. So the collapsed label is pinned to one line with an ellipsis
+// and the full text lives one click away in ToolDetails, which already renders
+// the verbatim input. Expanding restores wrapping — the user asked to see it.
+//
+// `truncate` (not `line-clamp-1`) because the label is a plain flex child:
+// line-clamp would force `display: -webkit-box` on it and drop the flex
+// alignment the icon's centering depends on.
+const LABEL_COLLAPSED_CLASS = 'truncate'
+const LABEL_EXPANDED_CLASS = 'break-words'
+
 /**
  * A tool row's secondary status line (shell elapsed time, `wait` countdown).
  *
@@ -662,6 +681,9 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   // ignores it while pending.
   const effectivelyExpanded = expanded || hasPendingPerm
 
+  // One line while folded, full wrap once opened. See LABEL_COLLAPSED_CLASS.
+  const labelWrapClass = effectivelyExpanded ? LABEL_EXPANDED_CLASS : LABEL_COLLAPSED_CLASS
+
   // Stable per-instance fallback id for framer-motion's `LayoutGroup`. When a
   // pre-persistence historical message has neither `effectiveId` nor
   // `toolCallId`, multiple pills would otherwise share `tool-detail-` and the
@@ -792,11 +814,12 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
         {/* Deterministic vertical centering: the label spans pin leading-5
             (20px), so the 12px icon centers on the first line at exactly
             (20 − 12) / 2 = 4px. items-start keeps the icon on the first line
-            when the label wraps. */}
+            when the label wraps, which only an EXPANDED row now does. */}
         <Icon size={12} className={`shrink-0 ${iconClass}`} style={{ marginTop: '4px' }} />
         {isShimmering ? (
           <motion.span
-            className="break-words min-w-0 leading-5 bg-clip-text"
+            data-testid="tool-pill-label"
+            className={`${labelWrapClass} min-w-0 leading-5 bg-clip-text`}
             style={{
               backgroundImage: `linear-gradient(90deg, ${shimmerBase} 0%, ${shimmerBase} 40%, ${shimmerHighlight} 50%, ${shimmerBase} 60%, ${shimmerBase} 100%)`,
               backgroundSize: '300% 100%',
@@ -807,7 +830,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
             transition={{ duration: 2.4, repeat: Infinity, ease: 'linear' }}
           >{displayLabel}</motion.span>
         ) : (
-          <span className="break-words min-w-0 leading-5 text-muted hover:text-text transition-colors">{displayLabel}</span>
+          <span data-testid="tool-pill-label" className={`${labelWrapClass} min-w-0 leading-5 text-muted hover:text-text transition-colors`}>{displayLabel}</span>
         )}
       </button>
 

--- a/website/src/test/ToolCallLine.labelClamp.test.tsx
+++ b/website/src/test/ToolCallLine.labelClamp.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * A FOLDED tool row is a status line, not a payload dump.
+ *
+ * The transport hands us the tool title verbatim, and for a shell call that is
+ * the entire command. A chained one-liner with an inline heredoc is routinely
+ * several kB, and rendering it with `break-words` wrapped it to forty-odd lines
+ * — one folded tool row taller than the answer it belonged to, with the reader
+ * scrolling a wall of shell quoting to reach the next message.
+ *
+ * The contract this pins: collapsed clamps to one line (`truncate`), expanded
+ * wraps (`break-words`). Nothing is lost by clamping — ToolDetails already
+ * renders the verbatim input, which for a shell call IS the command.
+ *
+ * jsdom does no layout, so the ellipsis itself is unobservable here; the class
+ * is the observable proxy, and the toggle across the click is what makes the
+ * assertion load-bearing rather than a spelling test.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders, createTestStore } from './helpers'
+import ToolCallLine from '../pages/chat/ToolCallLine'
+import type { RootState } from '../store'
+import type { ChatMessage } from '../types'
+
+type ChatState = RootState['chat']
+
+const LS_KEY = 'mc-chat-config'
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  // Raw titles, so the label under test is the command rather than a purpose.
+  localStorage.setItem(LS_KEY, JSON.stringify({ simplifiedToolNames: false }))
+})
+
+/** Shaped like the row in the report: a chained command carrying a heredoc. */
+const LONG_CMD = `cd /tmp/kc-1429 && sed -i 's/${'a'.repeat(40)}/${'b'.repeat(40)}/g' prbody.md && python3 - <<'EOF'\n${'x'.repeat(2000)}\nEOF`
+
+function longToolMsg(): ChatMessage {
+  return { role: 'tool', content: `🔧 ${LONG_CMD}`, cls: '', meta: { tool_call_id: 'tc_long' } }
+}
+
+function storeFor(msg: ChatMessage, running: boolean) {
+  return createTestStore({
+    chat: {
+      messages: [msg],
+      // `output` is OMITTED while running, not set to '': ToolCallLine reads
+      // completion as `output != null`, so an empty string would mark the call
+      // done and route the label through the settled (non-shimmer) branch.
+      toolLog: [{
+        type: 'tool', text: LONG_CMD, tool_call_id: 'tc_long', is_shell: true,
+        input: LONG_CMD, ts: 1, ...(running ? {} : { output: 'done' }),
+      }],
+      slotRunning: running,
+    } as unknown as ChatState,
+  })
+}
+
+const labelClass = () => screen.getByTestId('tool-pill-label').className
+
+describe('ToolCallLine collapsed label clamp', () => {
+  it('clamps a kB-long shell title to one line while folded, and wraps once opened', () => {
+    const msg = longToolMsg()
+    renderWithProviders(<ToolCallLine message={msg} running={false} />, { store: storeFor(msg, false) })
+
+    expect(labelClass()).toContain('truncate')
+    expect(labelClass()).not.toContain('break-words')
+
+    // The whole point of clamping: the text is still THERE, just not laid out
+    // across forty lines — so opening the row must reveal it, not re-fetch it.
+    fireEvent.click(screen.getByRole('button', { expanded: false }))
+    expect(labelClass()).toContain('break-words')
+    expect(labelClass()).not.toContain('truncate')
+  })
+
+  it('clamps the shimmering label too, so a RUNNING row cannot be the tall one', () => {
+    // The running row is exactly the one the report caught, and it renders
+    // through the motion.span shimmer branch — a different element from the
+    // settled span, so the settled test above does not cover it.
+    const msg = longToolMsg()
+    renderWithProviders(<ToolCallLine message={msg} running={true} />, { store: storeFor(msg, true) })
+
+    expect(labelClass()).toContain('truncate')
+    expect(labelClass()).toContain('bg-clip-text') // proves we are on the shimmer branch
+  })
+})


### PR DESCRIPTION
## Problem

A tool row's title is whatever the transport hands us, and for a shell call that is the **entire command**. A chained one-liner carrying an inline heredoc is routinely several kB, and the collapsed pill rendered it with `break-words` — so one *folded* tool row wrapped to forty-odd lines and stood taller than the answer it belonged to. The reader had to scroll a wall of shell quoting to reach the next message.

Reported from a live session: a single `execute_bash` row filled the entire viewport while the turn was still streaming.

## Approach

A collapsed row is a **status line**. It exists to say which tool ran and whether it is still running — the same contract `ThinkingBlock`'s folded "Thought process" row already keeps, and the reason both rows share `rowPill.ts` geometry in the first place.

So the collapsed label is pinned to one line with an ellipsis, and the full text stays one click away in `ToolDetails`, which already renders the verbatim input — for a shell call, that **is** the command. Nothing becomes unreachable. Expanding restores wrapping, because at that point the reader has asked to see it.

`truncate` rather than `line-clamp-1`: the label is a plain flex child, and line-clamp would force `display: -webkit-box` on it, dropping the flex alignment the leading icon's deterministic `marginTop: 4px` centering depends on.

## Change

- `ToolCallLine.tsx` — `LABEL_COLLAPSED_CLASS` / `LABEL_EXPANDED_CLASS`, selected by `effectivelyExpanded`, applied to **both** label branches: the settled `span` and the shimmering `motion.span` a running row renders.
- No new state, no new machinery. The `min-w-0` / `max-w-full` chain already present on the wrapper and the button is what gives the truncation something to resolve against.
- A pending-approval row is `effectivelyExpanded` by construction, so the input a user is being asked to approve is never the thing that gets clamped.

The running row keeps its existing streaming signal untouched — accent shimmer on the label plus the spinner icon — so a folded row still reads as in-progress.

## Tests

`website/src/test/ToolCallLine.labelClamp.test.tsx` (new, 2 cases):

- a kB-long shell title is `truncate` while folded and `break-words` after the click — asserting the **flip across the toggle**, so the test fails on a broken toggle rather than merely pinning a spelling;
- the shimmering branch is clamped too (asserted via `bg-clip-text` to prove the test is really on that branch), because a *running* row is exactly the one the report caught, and it renders a different element from the settled one.

Revert-verified: setting `LABEL_COLLAPSED_CLASS = 'break-words'` fails both cases; restoring it passes. `106` existing `ToolCallLine` / `ThinkingBlock` / `TurnBlock` tests unaffected. `tsc --noEmit` and `eslint` clean.

## Manual verification

Measured in real Chromium at a 700px message column, with the command from the report: **140px (7 lines) → 20px (1 line)**. A short label (`Running: echo hello`) picks up no ellipsis — `scrollWidth === clientWidth`.
