### PR TITLE
fix: count survey sessions only on human opt-in paths (#6139)

### DIFF
--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -545,6 +545,9 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
         mode=mode_override if mode_override is not None else slot.mode,
         app=request_app,
         origin=request_slot_origin(request_app),
+        # Human request-layer path: a person forking a conversation. The
+        # origin conjunct in state.py still excludes app-token callers.
+        count_user_session=True,
     )
     new_slot.forked_from = effective_session_key(slot)
     new_slot.reasoning_effort = slot.reasoning_effort

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -243,6 +243,9 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
             origin=request_slot_origin(request.get("app", "")),
             mode=requested_mode,
             memory_mode=requested_memory_mode,
+            # Human request-layer path: a person sending a chat message. The
+            # origin conjunct in state.py still excludes app-token callers.
+            count_user_session=True,
         )
     except ValueError as exc:
         sel().log_api_access(
@@ -1863,6 +1866,9 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
                 ephemeral=body.get("ephemeral"),
                 app=request.get("app", ""),
                 origin=request_slot_origin(request.get("app", "")),
+                # Human request-layer path: the dashboard new-chat tab. The
+                # origin conjunct in state.py still excludes app-token callers.
+                count_user_session=True,
             )
         except ValueError as exc:
             return web.json_response({"error": str(exc)}, status=409)

--- a/src/kiro_crew/dashboard/session_pulse_counter.py
+++ b/src/kiro_crew/dashboard/session_pulse_counter.py
@@ -2,9 +2,12 @@
 
 Gates the session-pulse survey's "new user" window: the survey must not appear
 until this install has started at least ``NEW_USER_SESSION_THRESHOLD`` genuine
-user chats (``SlotOrigin.USER``). Counting only user-origin sessions -- not
-cron, app, system, or restored-untagged slots -- keeps the gate a measure of
-real human engagement, matching the only surface the survey ever shows on.
+user chats (``SlotOrigin.USER``). Counting only user-origin sessions whose
+creation path opts in via ``count_user_session`` -- not cron, app, system,
+restored-untagged slots, or agent-driven session-control creates (which mint
+USER-origin slots for privacy semantics but are not a person chatting, #6139)
+-- keeps the gate a measure of real human engagement, matching the only
+surface the survey ever shows on.
 
 The count is persisted next to the other dashboard state files via
 ``config_dir()`` so it honors ``KIROCREW_HOME`` and survives restarts. The
@@ -106,8 +109,8 @@ def increment_user_session_count_off_loop() -> None:
     """Count one user session without doing its disk I/O on the event loop.
 
     ``get_or_create_slot`` is synchronous and runs on the gateway loop for every
-    request-layer slot birth -- a new chat tab, a fork, and the session-control
-    create verb all reach it -- so doing this module's read, ``mkdir``, tempfile
+    request-layer slot birth -- the chat-send auto-create, a new chat tab, and a
+    fork all reach it -- so doing this module's read, ``mkdir``, tempfile
     write and ``os.replace`` inline stalls the whole loop on slow or contended
     storage.
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6732,6 +6732,19 @@ class DashboardState:
         linked_session_key: str = "",
         channel_origin: bool = False,
         origin: str | None = None,
+        *,
+        # Opt-in for the survey's "new user" session counter, DISTINCT from the
+        # origin tag: ``SlotOrigin.USER`` carries the ``slots:user`` privacy
+        # semantics and is deliberately set by non-human paths too (the
+        # session-control create verb mints USER slots so agent-created
+        # sessions stay app-invisible), so origin alone cannot mean "a person
+        # started this chat". Only the human request-layer paths (chat-send
+        # auto-create, new-chat tab, fork) pass True. Default False is the
+        # chosen fail direction, matching
+        # the counter's own philosophy below: a future missed opt-in only
+        # delays the survey (lost signal); defaulting to count would let
+        # unattended agent activity satisfy the gate (corrupted signal).
+        count_user_session: bool = False,
     ) -> _ChatSlot:
         """Return existing slot or create a new one.
 
@@ -6814,12 +6827,18 @@ class DashboardState:
         # SlotOrigin.USER), so a caller that forgets to declare loses
         # visibility instead of leaking — the direction this has to fail in.
         slot._origin = origin or (SlotOrigin.APP if app else "")
-        if minted_new and slot._origin == SlotOrigin.USER:
+        if minted_new and count_user_session and slot._origin == SlotOrigin.USER:
             # Count only genuine, newly-minted user chats toward the survey's
             # "new user" window (session_pulse_counter). `minted_new` excludes
             # restore/rehydrate (which passes the persisted key as name) and
-            # get-existing, so a restart never re-counts already-seen sessions;
-            # only the request layer ever supplies origin=USER. Best-effort:
+            # get-existing, so a restart never re-counts already-seen sessions.
+            # `count_user_session` carries the human-started signal: only the
+            # request-layer paths a person actually drives (chat-send
+            # auto-create, new-chat tab, fork) opt in, so agent-minted USER
+            # slots (the session-control create verb) do not satisfy the
+            # survey gate on their own (#6139). The
+            # origin conjunct stays as the invariant floor: a caller can never
+            # count a non-USER slot, flag or not. Best-effort:
             # the helper swallows its own I/O errors and never raises into
             # slot creation.
             #

--- a/test/test_session_pulse_session_count.py
+++ b/test/test_session_pulse_session_count.py
@@ -2,13 +2,17 @@
 
 ``DashboardState.get_or_create_slot`` is the sole place a brand-new slot is
 minted. This asserts the durable session-pulse counter goes up by one only when
-the new slot's origin is ``SlotOrigin.USER`` (a person starting a dashboard
-chat), and stays put for cron / app / system / untagged origins and for
-get_or_create calls that return an EXISTING slot.
+the caller both opts in via ``count_user_session=True`` (the human request-layer
+paths: chat-send auto-create, new-chat tab, fork) AND the new slot's origin is
+``SlotOrigin.USER``. Either conjunct alone must not count: origin=USER without
+the flag is the agent-driven session-control create verb (#6139), and the flag
+without USER origin is an app/cron/system slot the survey must never see.
 """
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,6 +21,16 @@ from chat_test_helpers import _make_ready_kiro_prerequisite
 from kiro_crew.dashboard import session_pulse_counter as spc
 from kiro_crew.dashboard.state import DashboardState, SlotOrigin
 from kiro_crew.history import ConversationLog
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+# Origin shapes that must never count, flag or not.
+_NON_USER_KWARGS = (
+    {"origin": SlotOrigin.CRON},
+    {"origin": SlotOrigin.SYSTEM},
+    {"app": "some-app"},  # resolves to APP origin
+    {},  # untagged (origin="")
+)
 
 
 @pytest.fixture(autouse=True)
@@ -48,24 +62,42 @@ def _make_state(tmp_path) -> DashboardState:
     return state
 
 
-def test_user_origin_new_chat_increments(tmp_path) -> None:
+def test_user_origin_new_chat_with_flag_increments(tmp_path) -> None:
     state = _make_state(tmp_path)
     assert spc.get_user_session_count() == 0
-    state.get_or_create_slot(origin=SlotOrigin.USER)
+    state.get_or_create_slot(origin=SlotOrigin.USER, count_user_session=True)
     assert spc.get_user_session_count() == 1
-    state.get_or_create_slot(origin=SlotOrigin.USER)
+    state.get_or_create_slot(origin=SlotOrigin.USER, count_user_session=True)
     assert spc.get_user_session_count() == 2
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"origin": SlotOrigin.CRON},
-        {"origin": SlotOrigin.SYSTEM},
-        {"app": "some-app"},  # resolves to APP origin
-        {},  # untagged (origin="")
-    ],
-)
+def test_user_origin_without_flag_does_not_increment(tmp_path) -> None:
+    # THE regression pinned by #6139: the session-control create verb mints
+    # brand-new slots with origin=SlotOrigin.USER (the tag carries slots:user
+    # privacy semantics and cannot change) but does NOT opt in to the counter.
+    # An agent opening sessions unattended must not satisfy the survey's
+    # eligibility window on its own. This is exactly the session-control call
+    # shape: unnamed slot, origin=USER, flag left at its default.
+    state = _make_state(tmp_path)
+    state.get_or_create_slot(None, agent="some-agent", origin=SlotOrigin.USER)
+    assert spc.get_user_session_count() == 0
+    # Mutation guard: dropping the ``count_user_session`` conjunct from the
+    # increment condition in state.py makes this fail.
+    state.get_or_create_slot(origin=SlotOrigin.USER)
+    assert spc.get_user_session_count() == 0
+
+
+@pytest.mark.parametrize("kwargs", _NON_USER_KWARGS)
+def test_flag_without_user_origin_does_not_increment(tmp_path, kwargs) -> None:
+    # The origin conjunct is the invariant floor: a caller can never count a
+    # non-USER slot, even when it passes the flag. Mutation guard: dropping the
+    # ``slot._origin == SlotOrigin.USER`` conjunct makes this fail.
+    state = _make_state(tmp_path)
+    state.get_or_create_slot(count_user_session=True, **kwargs)
+    assert spc.get_user_session_count() == 0
+
+
+@pytest.mark.parametrize("kwargs", _NON_USER_KWARGS)
 def test_non_user_origins_do_not_increment(tmp_path, kwargs) -> None:
     state = _make_state(tmp_path)
     state.get_or_create_slot(**kwargs)
@@ -77,10 +109,75 @@ def test_restore_shape_named_user_slot_does_not_increment(tmp_path) -> None:
     # `name` and origin=USER. That must NOT count -- otherwise every gateway
     # restart re-counts each restored user session. Regression for the GPT
     # blocking finding "restoring sessions corrupts the durable session count".
+    # The flag does not override this: even an opted-in caller addressing a
+    # named (non-minted) slot stays uncounted.
     state = _make_state(tmp_path)
-    slot = state.get_or_create_slot(name="chat-9-1786589233", origin=SlotOrigin.USER)
+    slot = state.get_or_create_slot(
+        name="chat-9-1786589233", origin=SlotOrigin.USER, count_user_session=True
+    )
     assert spc.get_user_session_count() == 0
     # Returning the now-existing slot also does not count.
-    again = state.get_or_create_slot(name="chat-9-1786589233", origin=SlotOrigin.USER)
+    again = state.get_or_create_slot(
+        name="chat-9-1786589233", origin=SlotOrigin.USER, count_user_session=True
+    )
     assert again is slot
     assert spc.get_user_session_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Structural pins on the call sites. The behavioral tests above exercise
+# get_or_create_slot directly; these pin WHICH callers opt in, so mutating a
+# call site (e.g. passing True at the session-control create verb, or dropping
+# the flag from a human path) fails a test without needing a full HTTP stack.
+# ---------------------------------------------------------------------------
+
+
+def _opted_in_call_counts() -> dict[str, int]:
+    """Map of module path (relative to src/kiro_crew) -> number of
+    ``get_or_create_slot(...)`` calls passing a truthy ``count_user_session``,
+    swept over the whole package so a new opt-in anywhere is caught."""
+    counts: dict[str, int] = {}
+    for path in sorted(_SRC.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "count_user_session" not in text:
+            continue
+        tree = ast.parse(text)
+        n = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name != "get_or_create_slot":
+                continue
+            for kw in node.keywords:
+                if kw.arg == "count_user_session" and not (
+                    isinstance(kw.value, ast.Constant) and kw.value.value is False
+                ):
+                    n += 1
+        if n:
+            # as_posix() so the keys are stable across OSes (Windows yields
+            # backslashes from relative_to + str).
+            counts[path.relative_to(_SRC).as_posix()] = n
+    return counts
+
+
+def test_only_human_request_paths_opt_in() -> None:
+    # Exactly the three human request-layer paths carry the flag: the chat-send
+    # auto-create and the new-chat tab (chat_handlers.py), and fork
+    # (chat_fork.py). This sweeps every module under src/kiro_crew, so an
+    # opt-in appearing anywhere else -- most importantly the session-control
+    # create verb, whose absence IS the fix for #6139 -- or disappearing from
+    # these two files is a deliberate decision: update this pin alongside it.
+    assert _opted_in_call_counts() == {
+        "dashboard/chat_handlers.py": 2,
+        "dashboard/chat_fork.py": 1,
+    }
+
+
+def test_session_control_create_does_not_opt_in() -> None:
+    # The named regression for #6139, kept explicit even though the sweep above
+    # subsumes it: the session-control create verb mints USER-origin slots
+    # (privacy semantics) but must not count toward the survey. Passing
+    # count_user_session=True there re-introduces the bug.
+    assert "dashboard/session_control.py" not in _opted_in_call_counts()


### PR DESCRIPTION
## Summary

The session-pulse counter that gates the new-user feedback survey (`NEW_USER_SESSION_THRESHOLD` in `handlers/feedback.py`) incremented on every newly minted `SlotOrigin.USER` slot. But the session-control create verb (`session_control.py`) also mints USER-origin slots — deliberately, since that tag carries the `slots:user` privacy semantics and cannot change. Result: agent-created sessions counted as human chats, so an agent opening sessions unattended could satisfy the survey's eligibility window on its own (#6139).

## Fix

Decouple the counter from the origin tag with a dedicated opt-in, leaving `SlotOrigin` semantics untouched:

- `get_or_create_slot` gains a **keyword-only** `count_user_session: bool = False` parameter (keyword-only keeps every existing positional caller safe).
- The increment condition becomes `minted_new and count_user_session and slot._origin == SlotOrigin.USER`. The origin conjunct stays as the invariant floor: a caller can never count a non-USER slot, flag or not.
- Only the three human request-layer paths opt in: chat-send auto-create + new-chat tab (`chat_handlers.py`) and fork (`chat_fork.py`).
- `session_control.py` stays at the default — that absence IS the fix.
- Default-not-count is the chosen fail direction, matching the counter's documented philosophy: a future missed opt-in only delays the survey (lost signal); defaulting to count lets unattended agent activity defeat the gate (corrupted signal).
- `session_pulse_counter.py` docstrings updated in the same commit so the module owning the counter's contract no longer documents the fixed bug as current behavior.

## Tests

`test/test_session_pulse_session_count.py`:
- Behavioral: flag+USER counts; USER without flag (the exact session-control shape) does not; flag without USER origin does not; named/restore shape never counts.
- Structural: an `ast`-based sweep over all of `src/kiro_crew` asserts the opted-in call set is exactly `{dashboard/chat_handlers.py: 2, dashboard/chat_fork.py: 1}`, plus an explicit named pin that `session_control.py` does not opt in.
- Mutation-verified: passing `count_user_session=True` at the session-control site, dropping the flag conjunct, and dropping the origin conjunct each fail tests.

Local gates: isort / flake8 / mypy clean; full pytest 69747 passed (86 failures + 2 errors are host-env, verified identical on unmodified base); diff-scoped black gate green.

Pre-push review lanes: GPT PASS (0 findings); Opus PASS with 6 advisories, all adopted (docstring sync, three-path prose, whole-package structural sweep replacing an enumerated denylist, `ast` parsing replacing regex heuristics, shared parametrize constant). On the fork-counting product note: fork opting in follows the task spec and the gate's "chat births a person drove" reading; an app-token fork still cannot count because of the origin conjunct.

## Impact

Survey timing only — no data loss, no crash, no privacy-semantics change. `slots:user` visibility is untouched.

Closes #6139
