### PR TITLE
refactor(messaging): flatten the options-cap separator ternary

### DIFF
--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -206,8 +206,9 @@ def _default_redactor(text: str) -> str:
     """The same pair ``TurnDriver`` streams provider text through.
 
     Module scope on purpose: ``security`` is a pure-regex module with no vendor
-    dependencies, and ``messaging.driver`` already imports it from here, so this
-    adds no import-time cost and nothing that could touch an event loop.
+    dependencies -- the same module ``messaging.driver`` imports directly for its
+    own stream redaction -- so this adds no import-time cost and nothing that
+    could touch an event loop.
     """
     out, _ = redact_exfiltration_urls(text or "")
     out, _ = redact_credentials(out)
@@ -302,8 +303,8 @@ def apply_options_cap(
     Returns ``(body, kept_choices)``: the first ``max_buttons`` choices are kept
     for the widget and the remainder is appended to ``body`` as a numbered text
     list, numbering continued after the widget slots, rather than dropped — so
-    the user still learns those choices exist. A list that fits is a
-    byte-identical pass-through.
+    the user still learns those choices exist. A list that fits leaves ``body``
+    byte-identical; the kept choices are still redacted (see below).
 
     ``max_buttons <= 0`` needs no branch of its own: :func:`cap_choices` keeps
     nothing and overflows everything, so a button-less channel is the
@@ -313,14 +314,13 @@ def apply_options_cap(
     offered.
 
     **The KEPT choices are redacted, not just the overflow.** A choice label is
-    LLM-authored text rendered into a channel, exactly like the overflow list, and
-    the overflow was the only half that ran through :func:`display_safe`. So a
-    markup-split credential inside a label rendered intact on the button -- and again
-    in the press echo, which quotes the label back -- while the same string in the
-    overflow list was redacted. On a forum Topic that is every allow-listed
-    participant. Slack redacts at this same point (``slack/format.py``'s
-    ``_redact_choices``); this closes the gap for every widget channel at once
-    rather than per renderer, so a channel added later cannot miss it.
+    LLM-authored text rendered into a channel, exactly like the overflow list, so
+    redacting only the overflow half would leave a markup-split credential intact
+    on the button -- and again in the press echo, which quotes the label back. On a
+    forum Topic that is every allow-listed participant. Slack redacts at this same
+    point (``slack/format.py``'s ``_redact_choices``); doing it here covers every
+    widget channel at once rather than per renderer, so a channel added later
+    cannot miss it.
 
     Both halves go through :func:`display_safe_for` rather than :func:`display_safe`,
     so the mention defang honours ``capabilities.mention_grammars`` -- which this
@@ -335,7 +335,12 @@ def apply_options_cap(
     if not overflow:
         return body, kept
     lines = format_overflow(overflow, start=len(kept), capabilities=capabilities)
-    sep = "" if not body else ("\n" if body.endswith("\n") else "\n\n")
+    if not body:
+        sep = ""
+    elif body.endswith("\n"):
+        sep = "\n"
+    else:
+        sep = "\n\n"
     return f"{body}{sep}{lines}", kept
 
 
@@ -343,11 +348,10 @@ def split_options_trailer(text: str, *, hide_partial: bool = False) -> tuple[str
     """Split a trailing ``[OPTIONS:]`` marker off *text* into ``(body, choices)``.
 
     The ONE parse of that marker. Widget-capable renderers need both halves and
-    :func:`render_options_as_text` returns only the body, so before this existed
-    every channel carried the same eight lines: search the shared trailer regex,
-    ``rstrip`` the body, split the group on ``|``, drop the blanks, and decide what
-    to do with an unfinished marker. Six copies of it, three of them (Discord,
-    Telegram, Teams) identical down to the comment -- and a parse duplicated per
+    :func:`render_options_as_text` returns only the body, so both reach the marker
+    through here rather than every caller repeating the same steps: search the
+    shared trailer regex, ``rstrip`` the body, split the group on ``|``, drop the
+    blanks, and decide what to do with an unfinished marker. A parse duplicated per
     channel is a parse that drifts per channel, silently, because each copy looks
     right in isolation.
 


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/messaging/renderer.py` carried the module-simplification detector's
last remaining actionable site in `messaging/`: a chained conditional expression in
`apply_options_cap` that picks the separator between the message body and the
numbered overflow list.

```python
sep = "" if not body else ("\n" if body.endswith("\n") else "\n\n")
```

It is one three-way decision written so that a reader has to unwind it
right-to-left to see the branch order, in the middle of the function that enforces
`capabilities.max_buttons` and redacts every choice label before it reaches a chat
platform.

Reading the file to make that change surfaced two docstring claims that are
factually wrong about the code beside them, and two more that narrate a past state
instead of stating the current one:

- `_default_redactor` says "`messaging.driver` already imports it from here".
  `messaging/driver.py:48` imports `redact_credentials` / `redact_exfiltration_urls`
  straight from `kiro_crew.security`, and never imports `_default_redactor` at all.
- `apply_options_cap` says "A list that fits is a byte-identical pass-through".
  Only `body` is. The kept choices go through `display_safe_for` unconditionally at
  line 334, *above* the `if not overflow` early return, so the tuple's second
  element is never a pass-through — which is the whole point of the
  "**The KEPT choices are redacted**" paragraph three paragraphs further down.

## Why it matters

A stale comment on a redaction sink is worse than no comment. The
"byte-identical pass-through" line tells a caller it may keep the original choice
labels or compare `kept is choices`; doing either reintroduces the exact hole the
function exists to close (a markup-split credential rendered intact on a button,
and again in the press echo that quotes the label back). The `_default_redactor`
line sends the next reader looking for an import that is not there when they try to
judge whether module scope is still free.

The ternary itself costs nothing at runtime — it costs the reader, in a function
where the ordering of the redaction steps is load-bearing.

## What changed (motivation → approach → change)

Nested conditional expression → `if`/`elif`/`else`, so the branch order is on the
page in the order it is evaluated. The truth table is unchanged and exhaustive:

| `body` | `sep` |
|---|---|
| `""` (falsy) | `""` — `body.endswith` still not evaluated |
| non-empty, ends `"\n"` | `"\n"` |
| non-empty, otherwise | `"\n\n"` |

This trades one line for six, which is the intended direction for this class: the
campaign targets chained ternaries for *branch legibility*, not line count.

Four docstrings in the same file are restated in the present tense per the
`AGENTS.md` comment rule. Two are the factual corrections above. The other two drop
a past-tense account of a fixed bug ("the overflow **was** the only half that ran
through `display_safe`") and a per-channel copy count ("Six copies of it, three of
them … identical down to the comment"), keeping every reason each carried — the
press-echo hazard, the forum-Topic blast radius, `slack/format.py`'s
`_redact_choices`, and why a per-channel parse drifts.

Scope held deliberately narrow, per this campaign's prohibitions:

- **No import added, deleted, moved or hoisted.** An AST dump of every
  `Import`/`ImportFrom` node is byte-identical to the base, line *and* column — so
  the two in-function `kiro_crew.messaging.split` imports in `chunk_for_transport`
  are still lazy.
- **No security control reshaped.** The sequence in `apply_options_cap` is still
  `cap_choices` → unconditional `display_safe_for` over every kept choice → early
  return on no overflow → `format_overflow(..., capabilities=capabilities)` →
  concatenate. `renderer.py` is not in the detector's keystone set and is not in
  `no-new-work-on-gateway-boot-path`'s `file-patterns`.
- **No spec update owed.** No signature, schema, or documented behaviour changes;
  `docs/system-specs/modules/messaging.md` describes these helpers independently
  and none of its text is invalidated.

## Tests

No test added or changed — this is a behaviour-preserving refactor, and all three
separator outcomes already have *discriminating* pins in
`test/test_options_cap_contract.py`: `"\n\n"` at :162/:170/:183, `"\n"` at :184
(`"Pick.\n"` → `"Pick.\n\n1. A"`, which a `"\n\n"` separator would render as three
newlines), and `""` at :188 (body `"1. A\n2. B"` with no leading blank line).

Equivalence was proved rather than asserted: the base and head modules were exec'd
side by side in one process over 1,932 `(body × choices × capabilities)` triples
through `apply_options_cap` and 120 `render_options_as_text` pairs — including
`"[OPTIONS: ]"`, `"see the [OPTIONS section"`, zero and negative `max_buttons`, and
`mention_grammars` both ways — with zero divergence in value or in exception type.
With docstrings stripped, the base→head `ast.dump` diff is confined entirely to the
`sep` statement.

Run on the Python 3.12 CI-parity venv: `flake8`, `isort --check-only`, `mypy`,
`check_black_formatting`, `check_subprocess_encoding`, `check_brand_name`,
`check_harness_parity`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history` — all exit 0. 1,465 tests across every test module
that imports `messaging.renderer` or one of these helpers pass (`test_options_cap_contract`,
`test_capability_ledger`, `test_messaging_driver`, `test_messaging_dispatch`,
`test_slack_render_pipeline`, `test_security_posture`, and the discord / telegram /
teams / webex / wecom / weixin / whatsapp / imessage renderer suites). Gates and
tests were re-run after the rebase onto `b783441d4`.

## Manual verification

N/A — unit coverage sufficient. The changed statement is a pure string selection
with all three outcomes pinned by discriminating assertions, and the differential
execution above covers the input space directly.

## Screenshots / video

<!-- no-visual-delta -->

Backend-only diff: one Python file under `src/kiro_crew/messaging/`, nothing under
`website/`, so there is no rendered surface to capture. (The `changes` job will
report `only_backend=true`, which is why the frontend suites were not run locally.)

## Related Issues

no linked issue: this is a scheduled module-simplification sweep item, taken from the
detector's own queue (`messaging` was the smallest module with an actionable site)
rather than from a reported bug.

---

### Pre-open review fleet

Five read-only reviewers ran on the finished diff before this PR was opened, each
with its own lens: AUTOSDE blocking rules + the `code-review.yml` deterministic
greps; behaviour preservation; import semantics and symbol binding; the security
keystone and boot path; comment accuracy.

**One finding survived and was acted on.** The comment-accuracy reviewer flagged
that my rewrite of `split_options_trailer`'s docstring said the helper exists
"instead of each channel repeating the same steps", which reads as an inventory
claim over all channels — and `slack/format.py::extract_options` does keep its own
choice split. Verified against the code: the substance holds, because that parse is
a *different grammar* (`OPTIONS_RE_LINE`, end-of-line, MULTILINE) and the repo's own
ratchet — `test/test_options_cap_contract.py::TestOnlyOneTrailerParseExists`, whose
docstring says Slack "is deliberately NOT in scope" — enforces exactly the
end-of-buffer trailer invariant the docstring claims. So the phrase was tightened to
"every caller" rather than adding a Slack exception sentence to an untouched claim
the ratchet already documents where it belongs.

**Dropped as out of scope, not refuted** — two AGENTS.md comment violations the
fleet found in `test/test_options_cap_contract.py` (a past-tense account of the
fixed bug at :890, and a `Regression (review round 3):` marker at :645). Both are
real, both are in a different file from the one this PR edits for a structural
reason, and folding them in is the "while I'm here" widening this campaign
excludes. Also dropped: two pre-existing `LOW` coverage gaps in the same test file
(no pin for a multi-newline body, and none for the `sep == "\n"` branch on the
widget path specifically) — adding tests to raise coverage is explicitly its own
PR, and every branch this diff touches is already pinned.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
