### PR TITLE
fix(dashboard): agent-config PUT holds the MCP lock and drains on cancel

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -195,6 +195,132 @@ def _installed_agent_config() -> Path:
     return kiro_agents_dir_path() / AGENT_FILENAME
 
 
+def _write_installed_config_locked(path: Path, config: dict[str, Any]) -> None:
+    """Write the installed agent spec while holding bridges' file lock.
+
+    Runs in a worker thread (see :func:`_commit_agent_config`, dispatched
+    through ``_offload_config_write``), which is what makes taking a synchronous
+    flock here legal — on the event loop it would stall the gateway whenever app
+    registration held the lock.
+
+    ``bridges._mcp_lock`` is imported lazily: ``apps.bridges`` imports back into
+    the dashboard handlers, so a module-level import is circular.
+    """
+    from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
+
+    with _agent_file_lock(target=path):
+        write_config_atomically(path, config)
+
+
+def _commit_agent_config(
+    *,
+    config: dict[str, Any],
+    name: str,
+    mc_cfg_path: Path,
+    removed_per_key: dict[str, list[str]],
+    installed_path: Path,
+) -> bool:
+    """Perform the one fallible read and EVERY durable write of one PUT, as one unit.
+
+    This function is the commit half of the invariant stated at the
+    :func:`api_agent_config` PUT branch: it is the ONLY place that branch
+    persists application state, it is purely synchronous, and it is dispatched
+    exactly once through the shielded ``_offload_config_write``. Those three
+    properties make a PUT **non-cancellable but not rollback-atomic**:
+
+    * Purely synchronous — there is no await between two writes, so no
+      cancellation and no other task can be interleaved into the sequence. A
+      worker thread cannot be cancelled at all, so once this starts it runs to
+      completion.
+    * Dispatched once, shielded — the caller cannot unwind (and so cannot
+      release the transaction lock) until this has returned. The alternative
+      shape, awaiting each write separately under the lock, puts a cancellation
+      point between writes however wide the lock is.
+    * The only writer — nothing durable happens before the call, so every
+      failure earlier in the handler leaves the three targets byte-identical.
+
+    What that does NOT buy is rollback: an I/O failure (permission, quota, disk
+    full, lock-open, a failed atomic rename) stops the sequence where it is, and
+    the writes already committed stay committed. The honest failure prefixes, in
+    order, are:
+
+    0. the governance filter raises — nothing durable, and the caller's 500 is
+       exact (it fails closed, so a raise withholds rather than grants);
+    1. the ``config.json`` read raises :class:`ConfigReadError` — nothing
+       durable, and the caller's 500 is exact;
+    2. the ``config.json`` write fails — nothing durable;
+    3. the first bookkeeping write fails — ``config.json`` updated;
+    4. the second bookkeeping write fails (the lift can write twice, once per
+       key) — ``config.json`` updated plus one bookkeeping key;
+    5. the installed-spec write fails — ``config.json`` and bookkeeping
+       updated, the spec unchanged.
+
+    Order inside the unit is chosen to make the *earliest* prefixes the *least*
+    harmful, and three steps are load-bearing rather than incidental:
+
+    * The governance filter is FIRST, and it is in here at all so that the grant
+      decision cannot be made against a ceiling that changes before the write
+      publishes it — see step (0). First because it persists nothing, so its own
+      fail-closed raise costs no partial write.
+    * The read is FIRST among the writes' own inputs. It is the only
+      fallible-by-decision I/O step, and running it here — immediately adjacent
+      to the write it feeds — is what closes the lost-update window: on the
+      previous shape the caller read the baseline and the worker wrote it back
+      one executor hop later, so a concurrent writer landing in that gap had its
+      unrelated fields silently reverted.
+    * The bookkeeping lift runs AFTER the ``config.json`` write (so prefix 2
+      leaves the sidecar untouched, restoring the pre-lock ordering) but BEFORE
+      the spec write, because it STRIPS Kiro Crew keys (``model_managed`` /
+      ``cc_model``) out of the same *config* dict the spec write then persists —
+      reverse the two and the spec lands with fields kiro-cli's
+      ``deny_unknown_fields`` rejects (#2570).
+
+    Everything else fallible has already been decided by the caller: *config* is
+    parsed and validated, *removed_per_key* is the computed ``removedTools`` map,
+    and both paths are resolved.
+
+    Returns whatever the bookkeeping lift returns (True when it stripped a
+    key), so the caller can log it after the lock is released — logging is not
+    durable state and has no business inside the unit.
+    """
+    # (0) Governance floor, immediately before the writes it governs and inside
+    # the same synchronous unit, which is what its own contract asks for
+    # ("every whole-config writer MUST call this immediately before it
+    # persists"). It ran in phase 1 until R7: there it decided against a profile
+    # snapshot taken BEFORE two lock acquisitions, so a contended transaction
+    # flock — unbounded, cross-process — let the ceiling change during the wait
+    # and the PUT persisted a grant governance had since withheld. Here no
+    # await, no lock release and no other task can land between the decision and
+    # the write that publishes it. Same reasoning that put the read at (1).
+    #
+    # First in the unit, so a raise from the filter (``may_skip_gate_now`` fails
+    # closed) leaves all three targets byte-identical, exactly as a phase-1
+    # failure did. Its SEL withhold record is infrastructure, not payload, and
+    # is best-effort inside the filter — it cannot fail this unit.
+    #
+    # Imported lazily: platform.governance is not a module-level dependency of
+    # the dashboard handlers.
+    from kiro_crew.platform.governance import sanitize_agent_config_governance
+
+    sanitize_agent_config_governance(config)
+    # (1) The one fallible READ, and it precedes every write.
+    #
+    # Fail closed: writing back a {} baseline would drop every other setting
+    # just to record removedTools (see read_config_for_update).
+    mc_cfg = read_config_for_update(mc_cfg_path)
+    if removed_per_key:
+        mc_cfg["removedTools"] = removed_per_key
+    else:
+        mc_cfg.pop("removedTools", None)
+    # (2) config.json — the snapshot the read above produced, still current.
+    write_config_atomically(mc_cfg_path, mc_cfg)
+    # (3) agent_model_state.json bookkeeping — after (2), before (4).
+    changed = agent_state.lift_and_strip_bookkeeping(config, name)
+    # (4) the installed spec, under bridges' file lock.
+    _write_installed_config_locked(installed_path, config)
+    return changed
+
+
 async def api_agent_config(request: web.Request) -> web.Response:
     """GET/PUT /api/agent/config — read or write the installed agent config.
 
@@ -221,10 +347,109 @@ async def api_agent_config(request: web.Request) -> web.Response:
         if not isinstance(config, dict):
             return web.json_response({"error": "config must be an object"}, status=400)
         try:
+            # ── THE INVARIANT THIS BRANCH ENFORCES ────────────────────────────
+            # Every validation completes BEFORE the first durable write, and the
+            # one fallible read plus all durable APPLICATION/CONFIG writes of one
+            # PUT execute as a single non-cancellable unit that the transaction
+            # lock strictly contains — the lock cannot release while any write of
+            # the unit is in flight.
+            #
+            # "Application/config writes" is the exact scope, and deliberately so:
+            # the transaction lock's own sidecar (``_McpFileLock.__aenter__``
+            # creates ~/.kiro/settings/mcp.lock) and the SEL audit record on the
+            # owner-denial path above are INFRASTRUCTURE, not payload. Both can
+            # become durable outside the unit, and neither is a half-applied PUT:
+            # a lock file records no user setting and the audit log is required to
+            # outlive the request it describes.
+            #
+            # The unit is non-cancellable but NOT rollback-atomic: an I/O failure
+            # part-way through leaves the earlier writes committed. The prefixes
+            # are enumerated in :func:`_commit_agent_config`, which also explains
+            # why the order makes the earliest prefix the least harmful.
+            #
+            # Structurally that is two phases with nothing in between:
+            #
+            #   PHASE 1 (below, off the locks) — GATHER AND DECIDE. Parse, diff,
+            #   resolve every path. Persists nothing, so any failure or
+            #   cancellation here leaves all three target files byte-identical
+            #   and the 4xx/5xx it returns is honest.
+            #
+            #   PHASE 2 — COMMIT. Take the transaction lock, then the config
+            #   lock, then hand the GOVERNANCE FILTER, the ``config.json`` READ
+            #   and ALL THREE durable writes to :func:`_commit_agent_config`
+            #   through the shielded ``_offload_config_write``, exactly once.
+            #   The read is inside the unit rather than in front of it: adjacent
+            #   to the write it feeds, it cannot capture a baseline that a
+            #   concurrent writer then updates before the worker publishes it
+            #   back. The filter is inside for the same reason in the other
+            #   direction: in front of the locks its verdict could go stale
+            #   during a contended, unbounded flock wait, and the write would
+            #   publish a grant governance had already withheld.
+            #
+            # Why this shape and not "the lock covers more": three prior fixes
+            # widened the lock and each time the next defect was a SEQUENCING or
+            # CANCELLATION fault inside the widened span — a fallible read placed
+            # after a write, an await between two writes, a worker outliving the
+            # await that dispatched it. Widening a span cannot fix those, because
+            # they are properties of what happens INSIDE it. Collapsing the writes
+            # to a single synchronous unit removes the interleaving points instead
+            # of trying to cover them: there is no "between two writes" to land in.
+            #
+            # The three lock layers, transaction lock outermost:
+            #
+            # 1. ``_get_mcp_lock`` (~/.kiro/settings/mcp.lock) is the MCP
+            #    TRANSACTION lock. Agent spec files are a census source for the
+            #    MCP config transactions in handlers/mcp.py, which read the
+            #    current state and then act on it while holding this lock. An
+            #    unlocked write can land inside that read-then-act window, so the
+            #    transaction commits a decision about spec contents that changed
+            #    underneath it.
+            # 2. ``_get_config_lock`` is the in-process lock every other
+            #    ``config.json`` read-modify-writer in the dashboard takes
+            #    (messaging channel savers, security, the MCP handlers, agent
+            #    create/update/delete). This PUT's own RMW now spans an executor
+            #    hop, so the event loop no longer serializes it for free: without
+            #    this lock a sibling RMW can read the same baseline and the last
+            #    atomic rename silently reverts the other side's unrelated
+            #    settings. Held ACROSS the offload for exactly the reason
+            #    api_mcp_gateway_set_stub holds it across its own offload.
+            # 3. ``bridges._mcp_lock(target=installed_path)``
+            #    (~/.kiro/agents/kirocrew.lock) is the FILE lock. The transaction
+            #    lock does not cover it: apps/bridges.py does whole-file
+            #    read-modify-writes of THIS SAME file under that separate flock
+            #    (app enable/disable, MCP (de)registration). Holding only the
+            #    transaction lock leaves a concurrent app enable and this PUT
+            #    each writing the whole file, and the last atomic rename silently
+            #    discards the other side's changes.
+            #
+            # Order is transaction → config → file and must stay that way. Each
+            # edge already exists in the tree and none is inverted anywhere:
+            # transaction→config at api_mcp_toggle / api_mcp_toggle_all /
+            # api_mcp_remove in handlers/mcp.py, config→file wherever
+            # ``_sync_mcp_to_agent`` runs under the config lock (api_mcp_remove,
+            # api_mcp_server_detail, mcp_discover, api_capability_mcp_install),
+            # and no config-lock or file-lock holder in the tree acquires the
+            # transaction lock inside, so there is no ABBA cycle. The file lock is
+            # taken inside the worker thread (by _write_installed_config_locked,
+            # reached from _commit_agent_config) — a blocking flock on the event
+            # loop would freeze the gateway while app registration holds it.
+            # Nothing else in this branch takes a cross-process lock: governance +
+            # SEL and agent_state take none, so running the filter inside the
+            # worker adds no lock edge to the transaction → config → file order.
+            #
+            # PHASE 1 ── gather and decide. Nothing below is durable.
+            #
             # Track tools the user intentionally removed from shipped defaults
             # so they don't reappear on upgrade.  Stored in ~/.kiro/crew/config.json
             # (NOT kirocrew.json — kiro-cli rejects unknown fields).
             # Per-key dict so removing from allowedTools only doesn't affect tools.
+            #
+            # Computed HERE, from the SUBMITTED config, because the governance
+            # filter has not run yet: it now runs in the commit unit (step 0), so
+            # this diff still sees the pre-governance map. A ceiling-withheld
+            # allowedTools ref is not a user removal, and diffing after the
+            # filter would record it as one and suppress that tool on every
+            # future upgrade. Keep this before the offload.
             shipped = get_shipped_tools()
             removed_per_key: dict[str, list[str]] = {}
             for key in ("tools", "allowedTools"):
@@ -232,55 +457,77 @@ async def api_agent_config(request: web.Request) -> web.Response:
                 if diff:
                     removed_per_key[key] = diff
             mc_cfg_path = _h.config_path()  # type: ignore[operator]
-            # Fail closed: writing back a {} baseline would drop every other
-            # setting just to record removedTools. See read_config_for_update.
-            try:
-                mc_cfg = read_config_for_update(mc_cfg_path)
-            except ConfigReadError:
-                logger.exception("Refusing to record removedTools: config unreadable")
-                return web.json_response(
-                    {"error": "failed to read config file", "code": "config_unreadable"},
-                    status=500,
-                )
-            if removed_per_key:
-                mc_cfg["removedTools"] = removed_per_key
-            else:
-                mc_cfg.pop("removedTools", None)
-            write_config_atomically(mc_cfg_path, mc_cfg)
-            # Governance floor on the WHOLE-object write path: this handler
-            # persists the request's config verbatim, so a dashboard PUT could
-            # otherwise restore a ceiling-governed @denied grant or a governed
-            # server's autoApprove that the per-ref writers strip. Filter the map
-            # here too (no-op on an ungoverned host).
-            from kiro_crew.platform.governance import sanitize_agent_config_governance
-
-            # Offloaded: the filter resolves the ceiling AND scans the profile
-            # directory per ref, which is synchronous filesystem work — running it
-            # inline would stall the aiohttp event loop for the duration.
-            await asyncio.to_thread(sanitize_agent_config_governance, config)
-            # Never persist Kiro Crew bookkeeping into the kiro spec —
-            # kiro-cli rejects unknown fields and drops the agent (#2570).
-            # Offloaded like the governance filter above: this reads/writes the
-            # agent_model_state.json sidecar, the same class of synchronous
-            # filesystem work that would otherwise stall the event loop.
             # Only trust a submitted name when it is a non-empty string — any
             # other JSON type (list, dict, number) would flow into the sidecar
             # helper as a dict key and crash the endpoint with a 500.
             raw_name = config.get("name")
             name = raw_name if isinstance(raw_name, str) and raw_name.strip() else installed_path.stem
-            changed = await asyncio.to_thread(agent_state.lift_and_strip_bookkeeping, config, name)
+
+            # Governance floor on the WHOLE-object write path: this handler
+            # persists the request's config verbatim, so a dashboard PUT could
+            # otherwise restore a ceiling-governed @denied grant or a governed
+            # server's autoApprove that the per-ref writers strip.
+            #
+            # NOT in phase 1. The filter used to run here, and that placed the
+            # grant decision BEFORE both lock acquisitions: the transaction flock
+            # is cross-process and its wait is unbounded, so a ceiling revoked
+            # during a contended wait was already stale by the time the write
+            # landed, and the PUT restored a grant governance had withheld.
+            # ``_commit_agent_config`` step (0) now runs it synchronously
+            # adjacent to the writes it governs — see that docstring. It costs a
+            # per-ref directory scan inside the locks, which is the price of the
+            # decision being current; and one call, not two, so the filter is
+            # never applied to a config it already filtered.
+
+            from kiro_crew.dashboard.handlers.mcp import (
+                _get_mcp_lock,
+                _offload_config_write,
+            )
+
+            # PHASE 2 ── commit. Both locks are acquired ahead of every durable
+            # write, so a cancellation at the (unbounded, contended) flock wait
+            # inside ``__aenter__`` still tears nothing.
+            async with _get_mcp_lock():
+                # The config lock spans the whole read-modify-write, not just the
+                # write: the read now happens in the worker thread, so this is
+                # the only thing serializing this PUT's RMW against the sibling
+                # ``config.json`` writers that take the same lock.
+                async with _get_config_lock():
+                    # THE one durable step: the config.json read + removedTools
+                    # sidecar + bookkeeping sidecar + installed spec, in a worker
+                    # thread, behind the shield.
+                    #
+                    # ``_offload_config_write`` is what binds the unit to the
+                    # locks: a worker thread cannot be cancelled, and the shield's
+                    # drain loop keeps re-absorbing cancellations until the worker
+                    # is done, so this await cannot return or raise — and
+                    # therefore ``async with`` cannot run ``__aexit__`` — while a
+                    # write is still in flight. A bare ``to_thread`` per write
+                    # would instead give every write boundary a cancellation point
+                    # at which the locks are released with the worker still
+                    # writing.
+                    try:
+                        changed = await _offload_config_write(
+                            _commit_agent_config,
+                            config=config,
+                            name=name,
+                            mc_cfg_path=mc_cfg_path,
+                            removed_per_key=removed_per_key,
+                            installed_path=installed_path,
+                        )
+                    except ConfigReadError:
+                        # The unit's FIRST step, so this 500 is exact: no write of
+                        # the unit has run and all three targets are unchanged.
+                        logger.exception("Refusing to record removedTools: config unreadable")
+                        return web.json_response(
+                            {"error": "failed to read config file", "code": "config_unreadable"},
+                            status=500,
+                        )
             if changed:
                 logger.info(
                     "Stripped Kiro Crew bookkeeping keys from a PUT to agent config for %r",
                     name,
                 )
-            # Offloaded + atomic: a crash or disk-full mid-write on a bare
-            # write_text would leave the spec truncated and break every
-            # subsequent session start (kiro-cli reads this file at spawn).
-            # write_config_atomically writes to a temp file then os.replace,
-            # matching the same pattern already used for the mc_cfg sidecar
-            # above (line 239) and the other config writes in this file.
-            await asyncio.to_thread(write_config_atomically, installed_path, config)
             # Restart kiro-cli sessions so new config takes effect
             await _h._reset_all_sessions(request)
             return web.json_response({"ok": True, "applied": True})
@@ -342,16 +589,32 @@ async def api_default_agent(request: web.Request) -> web.Response:
                 status=400,
             )
         path = _h.config_path()
-        try:
-            data = read_config_for_update(path)
-        except ConfigReadError:
-            # Fail closed: writing back a {} baseline would drop every other setting.
-            logger.exception("Refusing to set default agent: config unreadable")
-            return web.json_response(
-                {"error": "failed to read config file", "code": "config_unreadable"}, status=500
-            )
-        data["default_agent"] = name
-        write_config_atomically(path, data)
+        # This read-modify-write must hold the SAME in-process lock every other
+        # ``config.json`` RMW in the dashboard takes (agent create/update/delete,
+        # capability install/uninstall, the agent-config PUT). The event loop no
+        # longer serializes it for free: the PUT's own RMW now runs in a WORKER
+        # THREAD, holding this lock across the offload, so an unlocked read here
+        # can capture a baseline the worker is about to republish — and the last
+        # atomic rename silently reverts the other side's unrelated settings.
+        #
+        # Loop-side ``async with`` rather than an offload: the lock is an
+        # asyncio lock (``LoopBoundLock``) acquired exactly this way by every
+        # sibling RMW in this module, and the read and write below are
+        # synchronous with NO await between them, so once the lock is held the
+        # pair is already indivisible — a worker hop would add a cancellation
+        # point where today there is none.
+        async with _get_config_lock():
+            try:
+                data = read_config_for_update(path)
+            except ConfigReadError:
+                # Fail closed: writing back a {} baseline would drop every other setting.
+                logger.exception("Refusing to set default agent: config unreadable")
+                return web.json_response(
+                    {"error": "failed to read config file", "code": "config_unreadable"},
+                    status=500,
+                )
+            data["default_agent"] = name
+            write_config_atomically(path, data)
         return web.json_response({"ok": True, "default_agent": name})
     cfg = KiroCrewConfig.load()
     return web.json_response({"default_agent": cfg.default_agent})

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -1642,20 +1642,43 @@ def _load_json_or_empty(path: Path) -> dict[str, Any]:
 async def _offload_config_write(fn, /, *args, **kwargs):
     """Run a store-writing helper in a worker thread, surviving cancellation.
 
-    A worker thread cannot be cancelled: shielding the await and re-awaiting
-    the future on ``CancelledError`` guarantees the write runs to completion
-    before the cancellation propagates.  Without this, a cancelled request
-    task would release the MCP lock (or begin teardown) while the thread is
-    still mutating the store, letting a concurrent purge interleave with the
-    stale write.  Same pattern as the dangling-uninstall sweep below.
+    A worker thread cannot be cancelled, so the write always runs to completion;
+    the job here is to keep the CALLER from unwinding before it does. Awaiting
+    the future through ``asyncio.shield`` and, on ``CancelledError``, re-awaiting
+    it guarantees the write has finished before the cancellation propagates.
+    Without this, a cancelled request task would release the MCP lock (or begin
+    teardown) while the thread is still mutating the store, letting a concurrent
+    purge interleave with the stale write.
+
+    The drain is a LOOP, not a single re-await, because the drain is itself
+    cancellable: a second cancellation arriving while it is in flight would
+    cancel the drain and unwind the caller with the worker still writing —
+    exactly the window this function exists to close. Each re-shield absorbs one
+    more cancellation, so the guarantees hold under REPEATED cancellation:
+
+    * the write always runs to completion before this returns or raises;
+    * if cancelled, ``CancelledError`` is re-raised AFTER the drain;
+    * an exception from the write still propagates (and, as before, takes
+      precedence over a pending cancellation).
+
+    Same pattern as the dangling-uninstall sweep below.
     """
     loop = asyncio.get_running_loop()
     future = loop.run_in_executor(None, partial(fn, *args, **kwargs))
-    try:
-        return await asyncio.shield(future)
-    except asyncio.CancelledError:
-        await future
-        raise
+    cancelled: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(future)
+            break
+        except asyncio.CancelledError as exc:
+            # Remember the FIRST cancellation and keep draining. Once the future
+            # is done, ``await shield(...)`` returns without suspending, so this
+            # cannot spin: the loop turns only on an actual new cancellation.
+            if cancelled is None:
+                cancelled = exc
+    if cancelled is not None:
+        raise cancelled
+    return result
 
 
 def _atomic_write(path: Path, data: dict) -> None:

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -6,7 +6,9 @@ imported config_path() function, causing "'PosixPath' object is not callable".
 
 from __future__ import annotations
 
+import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -291,3 +293,930 @@ async def test_api_agent_config_put_uses_atomic_write(tmp_path):
     )
     _, written_data = installed_spec_calls[0]
     assert written_data.get("name") == "test"
+
+
+@pytest.mark.asyncio
+async def test_agent_config_write_holds_the_mcp_transaction_lock(tmp_path):
+    """The agent-spec write participates in the MCP transaction lock.
+
+    Agent spec files are a census source for the MCP config transactions in
+    ``handlers/mcp.py``, which read current state and then act on it while
+    holding ``_get_mcp_lock``. A config write landing between that read and the
+    act would have the transaction commit a decision about contents that changed
+    underneath it. External writers cannot be serialized; the gateway's own
+    writer must be.
+    """
+    import contextlib
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {"config": {"name": "test", "tools": ["a"], "allowedTools": ["b"]}}
+
+    request.json = mock_json
+
+    # Two INDEPENDENT observations per write, not one boolean: a recorder that
+    # only tracks "some lock was held" passes just as happily when the wrong
+    # lock is held. The write must be covered by the settings/mcp.lock
+    # transaction lock AND by bridges' kirocrew.lock file lock, and the file
+    # lock must be keyed on the file actually being written.
+    lock_held: list[bool] = []
+    writes: list[tuple[str, bool, tuple[str, ...]]] = []
+    holding = False
+    file_locked: list[Path] = []
+
+    @contextlib.asynccontextmanager
+    async def _recording_lock():
+        nonlocal holding
+        holding = True
+        lock_held.append(True)
+        try:
+            yield
+        finally:
+            holding = False
+
+    @contextlib.contextmanager
+    def _recording_file_lock(*, exclusive: bool = True, target=None):  # noqa: ANN001
+        file_locked.append(target)
+        try:
+            yield
+        finally:
+            file_locked.remove(target)
+
+    def _recording_write(path, config):  # noqa: ANN001 - mirrors the real signature
+        writes.append((str(path), holding, tuple(str(t) for t in file_locked)))
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch(
+            "kiro_crew.agent.build_agent_config",
+            return_value={"toolsSettings": {}},
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.mcp._get_mcp_lock",
+            _recording_lock,
+        ),
+        patch(
+            "kiro_crew.apps.bridges._mcp_lock",
+            _recording_file_lock,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.write_config_atomically",
+            _recording_write,
+        ),
+    ):
+        resp = await api_agent_config(request)
+
+    assert resp.status == 200
+    # Only the agent-SPEC write must hold the lock: the spec file is a census
+    # source for the MCP config transactions. The config.json sidecar write is
+    # not.
+    spec_writes = [entry for entry in writes if entry[0] == str(installed)]
+    assert spec_writes, "the agent-spec write never happened"
+    assert all(held for _p, held, _f in spec_writes), (
+        "the agent-spec write ran OUTSIDE the MCP transaction lock"
+    )
+    # bridges.py does whole-file read-modify-writes of THIS SAME file under its
+    # own flock (kirocrew.lock), which the transaction lock does not cover: a
+    # concurrent app enable and this PUT would each write the whole file and the
+    # last atomic rename would silently discard the other side. Assert the file
+    # lock was held too, and that it was keyed on the installed path -- a lock on
+    # any other sidecar serializes against nothing.
+    for _path, _held, locked in spec_writes:
+        assert locked, "the agent-spec write ran WITHOUT bridges' kirocrew.json file lock"
+        assert str(installed) in locked, (
+            "bridges' file lock was taken on the wrong target: "
+            f"{locked} does not include {installed}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_config_write_goes_through_one_shielded_offload(tmp_path):
+    """Every durable write happens inside ONE shielded offload, none outside it.
+
+    Holding the lock is not enough. A cancelled PUT unwinds the async context and
+    releases ``_get_mcp_lock`` while a bare ``asyncio.to_thread`` worker keeps
+    writing, so an MCP config transaction can take the lock, read the OLD state,
+    act on it, and only then have the worker publish a change the transaction
+    never saw. ``_offload_config_write`` exists for exactly this: it drains the
+    worker before the lock is released (its own drain behaviour is pinned in
+    mcp.py).
+
+    This asserts the structural property that makes the window unrepresentable,
+    in the form the invariant actually needs: there is exactly ONE dispatch
+    through the shielded offload, and all three durable writes -- the bookkeeping
+    lift, the removedTools sidecar and the installed spec -- happen inside it.
+    A second dispatch, or any write outside one, re-creates a cancellation point
+    between two writes however wide the lock is.
+
+    Supersedes an earlier version that asserted the offloaded callable was named
+    ``_write_installed_config_locked``. That name pinned the arrangement in which
+    the spec write was the only offloaded write and the other two ran on the
+    event loop -- the arrangement R3a and R3b were defects of. Asserting the
+    write set and its containment pins the property instead of the spelling, and
+    the spec write is still covered (it is one of the three).
+    """
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {"config": {"name": "test", "tools": ["a"], "allowedTools": ["b"]}}
+
+    request.json = mock_json
+
+    offloaded: list[str] = []
+    inside_offload = False
+    writes: list[tuple[str, bool]] = []
+
+    async def _recording_offload(fn, *args, **kwargs):
+        nonlocal inside_offload
+        offloaded.append(getattr(fn, "__name__", repr(fn)))
+        inside_offload = True
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            inside_offload = False
+
+    def _recording_lift(config, name):  # noqa: ANN001 - mirrors the real signature
+        writes.append(("bookkeeping", inside_offload))
+        return False
+
+    def _recording_write(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        writes.append(("mc_cfg" if Path(path) == mc_cfg else "spec", inside_offload))
+        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch("kiro_crew.agent_state.lift_and_strip_bookkeeping", _recording_lift),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.write_config_atomically",
+            _recording_write,
+        ),
+        patch("kiro_crew.dashboard.handlers.mcp._offload_config_write", _recording_offload),
+    ):
+        resp = await api_agent_config(request)
+
+    assert resp.status == 200
+    assert len(offloaded) == 1, (
+        "the PUT's durable writes were dispatched as several offloads, so a "
+        f"cancellation can land between them: {offloaded}"
+    )
+    assert {label for label, _ in writes} == {"bookkeeping", "mc_cfg", "spec"}, (
+        f"not every durable write of the PUT was observed: {writes}"
+    )
+    outside = [label for label, inside in writes if not inside]
+    assert not outside, (
+        f"{outside} ran OUTSIDE the shielded offload: a cancellation at the "
+        "await that dispatched it releases the transaction lock with the write "
+        "still in flight"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_persists_nothing_before_the_transaction_lock(tmp_path):
+    """A PUT cancelled while WAITING for the transaction lock must leave no trace.
+
+    ``_McpFileLock.__aenter__`` awaits ``run_in_executor(acquire_lock)``, so the
+    lock WAIT is a cancellation point -- and a contended flock makes that wait
+    unbounded, however long the other holder takes. A gateway shutdown (or a
+    client disconnect) that cancels the request there raises out of
+    ``__aenter__``, so the handler never reaches the agent-spec write. Anything
+    it already persisted at that moment is a HALF-APPLIED PUT: the removedTools
+    bookkeeping in ``config.json`` records that the user dropped a shipped tool
+    while the spec on disk still grants it, and nothing ever reconciles the two
+    -- the next upgrade honours the bookkeeping and silently removes a tool the
+    user never saw removed.
+
+    Pins the invariant structurally rather than probabilistically: NO durable
+    write happens before the lock is held, so every write in the sequence
+    commits under the same lock and cancellation at the wait tears nothing.
+    """
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew", "tools": ["a", "c"]}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+    # A baseline that must survive an aborted PUT byte-for-byte.
+    mc_cfg.write_text(json.dumps({"default_agent": "kirocrew"}))
+    before_cfg = mc_cfg.read_text()
+    before_spec = installed.read_text()
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        # Drops shipped tool "c", so the handler WOULD record removedTools.
+        return {"config": {"name": "test", "tools": ["a"], "allowedTools": ["b"]}}
+
+    request.json = mock_json
+
+    reached_lock = asyncio.Event()
+    never_granted = asyncio.Event()
+
+    class _ContendedLock:
+        """Models a transaction lock already held by another writer.
+
+        Suspends in ``__aenter__`` exactly as the real ``_McpFileLock`` does
+        while its executor thread blocks on the flock -- deterministically, and
+        without touching the host's ``~/.kiro/settings/mcp.lock``.
+        """
+
+        async def __aenter__(self) -> None:
+            reached_lock.set()
+            await never_granted.wait()
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.mcp._get_mcp_lock",
+            lambda: _ContendedLock(),
+        ),
+    ):
+        task = asyncio.ensure_future(api_agent_config(request))
+        try:
+            await asyncio.wait_for(reached_lock.wait(), timeout=5)
+            # Cancel while the handler is suspended on the lock wait.
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            never_granted.set()
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+    assert mc_cfg.read_text() == before_cfg, (
+        "the removedTools bookkeeping was persisted BEFORE the transaction lock "
+        "was held, so a cancel at the lock wait leaves it recorded with no "
+        "matching agent-spec write"
+    )
+    assert installed.read_text() == before_spec, "the aborted PUT still rewrote the agent spec"
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_lock_releases_only_after_every_write_landed(tmp_path):
+    """The transaction lock must not release while ANY write of the PUT is in flight.
+
+    The half of the invariant about cancellation. Holding the lock across all
+    three durable writes is not enough on its own: if any of them is reached
+    through an await that is a plain cancellation point, a cancel delivered
+    there unwinds ``async with`` and releases the lock while the worker thread
+    it dispatched keeps writing. The next PUT (or any MCP transaction) then
+    enters the lock against an in-flight write and reads a state no writer ever
+    committed -- the very interleaving the lock exists to forbid.
+
+    Pinned structurally rather than probabilistically: at the moment the lock
+    is released, EVERY durable write of the PUT must already have completed.
+    That is only representable when the writes form one uninterruptible unit,
+    so this fails on any shape that leaves a cancellable await between the
+    lock and a write.
+    """
+    import contextlib
+    import threading
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {"config": {"name": "test", "tools": ["a"], "allowedTools": ["b"]}}
+
+    request.json = mock_json
+
+    release = threading.Event()
+    worker_entered = threading.Event()
+    # Names of the durable writes that have COMPLETED, in order.
+    completed: list[str] = []
+    # A snapshot of ``completed`` taken at each lock release. Snapshotting (not
+    # aliasing) matters: on the broken shape the abandoned worker thread appends
+    # to ``completed`` after the lock is already gone.
+    at_release: list[list[str]] = []
+
+    def _blocking_bookkeeping(config, name):  # noqa: ANN001 - mirrors the real signature
+        """Stand in for the first durable write, parked mid-write on demand."""
+        worker_entered.set()
+        release.wait(timeout=10)
+        completed.append("bookkeeping")
+        return False
+
+    def _recording_write(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        completed.append("mc_cfg" if Path(path) == mc_cfg else "spec")
+        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    @contextlib.asynccontextmanager
+    async def _recording_lock():
+        try:
+            yield
+        finally:
+            at_release.append(list(completed))
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        # Neutral: the filter persists nothing, and pinning it here would only
+        # couple this test to the host's governance profiles.
+        patch(
+            "kiro_crew.platform.governance.sanitize_agent_config_governance",
+            lambda config: None,
+        ),
+        patch("kiro_crew.agent_state.lift_and_strip_bookkeeping", _blocking_bookkeeping),
+        patch("kiro_crew.dashboard.handlers.mcp._get_mcp_lock", _recording_lock),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.write_config_atomically",
+            _recording_write,
+        ),
+    ):
+        task = asyncio.ensure_future(api_agent_config(request))
+        # try/finally: the assertions below run while a worker thread is parked
+        # in ``release.wait(timeout=10)``. Abandoning it would keep a default
+        # executor thread blocked for the full 10s and degrade every test that
+        # shares the executor, so release and reap unconditionally.
+        try:
+            await asyncio.to_thread(worker_entered.wait, 5)
+            assert worker_entered.is_set(), "test bug: the first durable write never started"
+
+            # Cancel with the write parked. Give the loop room to deliver it and
+            # to run any unwind the handler's shape allows.
+            task.cancel()
+            for _ in range(10):
+                if task.done():
+                    break
+                await asyncio.sleep(0.01)
+
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            release.set()
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert len(at_release) == 1, f"the transaction lock was entered {len(at_release)} times"
+    landed = at_release[0]
+    assert set(landed) == {"bookkeeping", "mc_cfg", "spec"}, (
+        "the transaction lock was released with writes still in flight: only "
+        f"{landed} had completed. A cancellation between the lock and a durable "
+        "write lets the next holder observe a half-applied PUT."
+    )
+    # Order that is load-bearing (as opposed to incidental): the bookkeeping lift
+    # STRIPS Kiro Crew keys out of the very dict the spec write persists, so it
+    # must complete first or the spec lands with keys kiro-cli rejects. The
+    # sidecar write's position relative to the other two is not pinned.
+    assert landed.index("bookkeeping") < landed.index("spec")
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_unreadable_config_persists_nothing(tmp_path, monkeypatch):
+    """A fallible READ must not sit after a durable write.
+
+    The other half of the invariant. ``read_config_for_update`` fails closed on
+    a corrupt ``config.json`` and the handler answers 500 -- correct only while
+    nothing has been written yet. Reached AFTER the bookkeeping lift, the same
+    500 leaves ``agent_model_state.json`` recording a model for a spec that was
+    never written: bookkeeping durable while the spec it describes is not, which
+    is exactly the half-applied state the transaction lock was widened to make
+    unreachable.
+
+    Pins all three durable targets byte-identical, so the property is "nothing
+    was persisted" rather than "the write I happened to think of was skipped".
+    """
+    from kiro_crew.config.loader import ConfigReadError
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew", "tools": ["a", "c"]}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+    mc_cfg.write_text(json.dumps({"default_agent": "kirocrew"}))
+    state = tmp_path / "agent_model_state.json"
+    # ``model_managed`` already set, so only the ``cc_model`` below can lift --
+    # enough for the bookkeeping write to be observable, and it keeps the
+    # sidecar off the developer's real ~/.kiro/crew.
+    state.write_text(json.dumps({"test": {"model_managed": False}}, indent=2, sort_keys=True) + "\n")
+    monkeypatch.setattr("kiro_crew.agent_state._state_path", lambda: state)
+
+    before_cfg = mc_cfg.read_text()
+    before_spec = installed.read_text()
+    before_state = state.read_text()
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {
+            "config": {
+                "name": "test",
+                "tools": ["a"],
+                "allowedTools": ["b"],
+                # Unset in the sidecar above, so the bookkeeping lift WOULD write.
+                "cc_model": "claude-sonnet-4.6",
+            }
+        }
+
+    request.json = mock_json
+
+    def _unreadable(path):  # noqa: ANN001 - mirrors the real signature
+        raise ConfigReadError("config.json is corrupt")
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch(
+            "kiro_crew.platform.governance.sanitize_agent_config_governance",
+            lambda config: None,
+        ),
+        patch("kiro_crew.dashboard.handlers.agents.read_config_for_update", _unreadable),
+    ):
+        response = await api_agent_config(request)
+
+    assert response.status == 500
+    assert json.loads(response.text)["code"] == "config_unreadable"
+    assert state.read_text() == before_state, (
+        "the bookkeeping sidecar was written before the config read failed, so "
+        "the 500 leaves bookkeeping durable for a spec that was never written"
+    )
+    assert mc_cfg.read_text() == before_cfg, "the refused PUT still rewrote the sidecar"
+    assert installed.read_text() == before_spec, "the refused PUT still rewrote the agent spec"
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_keeps_a_concurrent_config_write_that_lands_before_the_worker(
+    tmp_path,
+):
+    """A ``config.json`` write landing before the worker must not be reverted.
+
+    The read that feeds the ``removedTools`` write used to happen in the handler,
+    one executor hop before the worker published the result. Any concurrent
+    whole-file ``config.json`` writer landing in that gap -- ``api_default_agent``
+    does exactly such a read-modify-write, and takes no lock at all -- had its
+    unrelated fields silently reverted when the PUT renamed its already-stale
+    snapshot into place. Nothing reports that: the setting simply goes back to
+    its old value.
+
+    Injects that writer at exactly that point, the offload dispatch. On the
+    pre-fix shape the baseline is already captured by the time this runs, so the
+    write below is lost; with the read moved inside the unit, immediately
+    adjacent to the write it feeds, it is the READ that runs afterwards and the
+    concurrent field survives.
+    """
+    import contextlib
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+    mc_cfg.write_text(json.dumps({"default_agent": "kirocrew"}))
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        # Drops shipped tool "c", so the PUT WILL record removedTools.
+        return {"config": {"name": "test", "tools": ["a"], "allowedTools": ["b"]}}
+
+    request.json = mock_json
+
+    @contextlib.asynccontextmanager
+    async def _neutral_lock():
+        # Neutral: this test is about the read's POSITION, and the real lock
+        # would touch the host's ~/.kiro/settings/mcp.lock.
+        yield
+
+    async def _offload_after_a_concurrent_write(fn, *args, **kwargs):
+        # A sibling whole-file RMW commits here -- between the old read point and
+        # the worker's write. Modelled on api_default_agent's unlocked RMW.
+        other = json.loads(mc_cfg.read_text(encoding="utf-8"))
+        other["default_agent"] = "other"
+        mc_cfg.write_text(json.dumps(other), encoding="utf-8")
+        return fn(*args, **kwargs)
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch(
+            "kiro_crew.platform.governance.sanitize_agent_config_governance",
+            lambda config: None,
+        ),
+        patch("kiro_crew.dashboard.handlers.mcp._get_mcp_lock", _neutral_lock),
+        patch(
+            "kiro_crew.dashboard.handlers.mcp._offload_config_write",
+            _offload_after_a_concurrent_write,
+        ),
+    ):
+        response = await api_agent_config(request)
+
+    assert response.status == 200
+    after = json.loads(mc_cfg.read_text(encoding="utf-8"))
+    assert after["default_agent"] == "other", (
+        "the PUT published a config.json snapshot it had read BEFORE a concurrent "
+        "writer committed, silently reverting that writer's unrelated field"
+    )
+    # And the PUT's own write still landed -- the point is that both survive.
+    assert after["removedTools"]["tools"] == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_failed_config_write_leaves_bookkeeping_untouched(
+    tmp_path, monkeypatch
+):
+    """A failing ``config.json`` write must leave the bookkeeping sidecar untouched.
+
+    The unit is non-cancellable but NOT rollback-atomic, so its ORDER is what
+    decides the damage a failed write leaves behind. With the bookkeeping lift
+    running first, an I/O failure on the ``config.json`` write (permission,
+    quota, disk full, a failed atomic rename) answered 500 with
+    ``agent_model_state.json`` already recording a model for a spec that never
+    landed -- strictly worse than the pre-lock ordering, which wrote
+    ``config.json`` before bookkeeping.
+
+    Pins the restored prefix: the ``config.json`` write is the first durable
+    step, so its failure leaves the other two targets byte-identical.
+    """
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew", "tools": ["a", "c"]}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+    mc_cfg.write_text(json.dumps({"default_agent": "kirocrew"}))
+    state = tmp_path / "agent_model_state.json"
+    # ``model_managed`` already set, so only the ``cc_model`` below can lift --
+    # enough for the bookkeeping write to be observable, and it keeps the
+    # sidecar off the developer's real ~/.kiro/crew.
+    state.write_text(
+        json.dumps({"test": {"model_managed": False}}, indent=2, sort_keys=True) + "\n"
+    )
+    monkeypatch.setattr("kiro_crew.agent_state._state_path", lambda: state)
+
+    before_state = state.read_text()
+    before_spec = installed.read_text()
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {
+            "config": {
+                "name": "test",
+                "tools": ["a"],
+                "allowedTools": ["b"],
+                # Unset in the sidecar above, so the bookkeeping lift WOULD write.
+                "cc_model": "claude-sonnet-4.6",
+            }
+        }
+
+    request.json = mock_json
+
+    def _config_write_fails(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        if Path(path) == mc_cfg:
+            raise OSError("disk full")
+        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.build_agent_config", return_value={"toolsSettings": {}}),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": ["a", "c"], "allowedTools": ["b"]},
+        ),
+        patch(
+            "kiro_crew.platform.governance.sanitize_agent_config_governance",
+            lambda config: None,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.write_config_atomically",
+            _config_write_fails,
+        ),
+    ):
+        response = await api_agent_config(request)
+
+    assert response.status == 500
+    assert state.read_text() == before_state, (
+        "the bookkeeping lift ran BEFORE the config.json write that failed, so "
+        "the 500 leaves agent_model_state.json recording a model for a spec "
+        "that was never installed"
+    )
+    assert (
+        installed.read_text() == before_spec
+    ), "the agent spec was written even though an earlier write of the unit failed"
+
+
+@pytest.mark.asyncio
+async def test_offload_config_write_drains_through_repeated_cancellation():
+    """The drain itself must survive being cancelled.
+
+    ``_offload_config_write`` shields the write and, on ``CancelledError``,
+    re-awaits the future to drain the worker. A bare ``await future`` in that
+    handler is itself cancellable: a SECOND cancellation arriving during the
+    drain cancels the drain, so the caller unwinds -- releasing the MCP
+    transaction lock -- while the worker thread is still writing. That is the
+    exact window the offload exists to close, so it must hold under repeated
+    cancellation, not just the first one.
+
+    Pins all three guarantees: the write runs to completion before control
+    returns, the ``CancelledError`` still escapes, and completion happens
+    BEFORE it escapes.
+    """
+    import threading
+
+    from kiro_crew.dashboard.handlers.mcp import _offload_config_write
+
+    release = threading.Event()
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _blocking_write():
+        started.set()
+        # Block until the test has delivered both cancellations.
+        release.wait(timeout=10)
+        finished.set()
+        return "written"
+
+    task = asyncio.ensure_future(_offload_config_write(_blocking_write))
+
+    # try/finally: every assertion below runs while a worker thread is parked in
+    # ``release.wait(timeout=10)`` and ``task`` is deliberately
+    # cancellation-resistant. An assertion failing before ``release.set()`` would
+    # abandon both -- the executor thread blocks for the full 10s and the pending
+    # task outlives the test, so ONE genuine regression here degrades every test
+    # that shares the default executor. Release and drain unconditionally.
+    try:
+        # Let the worker thread actually enter the write.
+        await asyncio.to_thread(started.wait, 5)
+        await asyncio.sleep(0)
+
+        # First cancellation: the shielded await raises, the drain begins.
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done(), "the task completed before the worker was drained"
+
+        # Second cancellation, delivered while the drain is in flight. Pre-fix this
+        # cancels the drain and the task finishes with the worker still writing.
+        task.cancel()
+        await asyncio.sleep(0)
+
+        assert not finished.is_set(), "test bug: the worker finished before it was released"
+        assert not task.done(), (
+            "the drain was cancelled: _offload_config_write returned while the "
+            "worker thread was still writing, so the caller's lock is released "
+            "mid-write"
+        )
+
+        # Now let the worker complete and confirm the cancellation still propagates.
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert finished.is_set(), "the write did not run to completion"
+    finally:
+        release.set()
+        if not task.done():
+            task.cancel()
+        # Reap the task either way, so a failed assertion cannot leave it pending.
+        await asyncio.gather(task, return_exceptions=True)
+        # Do not leave the executor thread parked for the rest of the session.
+        await asyncio.to_thread(finished.wait, 10)
+
+
+@pytest.mark.asyncio
+async def test_offload_config_write_propagates_write_errors():
+    """A failing write still raises -- the drain must not swallow it."""
+    from kiro_crew.dashboard.handlers.mcp import _offload_config_write
+
+    def _failing_write():
+        raise OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        await _offload_config_write(_failing_write)
+
+
+@pytest.mark.asyncio
+async def test_default_agent_write_holds_the_config_lock(tmp_path):
+    """PUT /api/config/default-agent read-modify-writes config.json, so it must
+    hold the same in-process lock every sibling RMW in the dashboard takes.
+
+    The agent-config PUT moved its own RMW into a WORKER THREAD, holding
+    ``_get_config_lock`` across the offload. The event loop therefore no longer
+    serializes the two for free: an unlocked read here can capture a baseline
+    the worker is about to republish, and the last atomic rename silently
+    reverts the other side's unrelated settings.
+
+    Instrumentation, not a true race: the lock has to cover BOTH halves of the
+    read-modify-write, and a recorder proves that deterministically where a
+    timing test would only prove it sometimes.
+    """
+    import contextlib
+
+    from kiro_crew.config.loader import read_config_for_update, write_config_atomically
+    from kiro_crew.dashboard.handlers import api_default_agent
+
+    mc_cfg = tmp_path / "config.json"
+    mc_cfg.write_text(json.dumps({"default_agent": "kirocrew", "unrelated": "keep me"}))
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {"agent": "kirocrew"}
+
+    request.json = mock_json
+
+    holding = False
+    observed: list[tuple[str, bool]] = []
+
+    @contextlib.asynccontextmanager
+    async def _recording_lock():
+        nonlocal holding
+        holding = True
+        try:
+            yield
+        finally:
+            holding = False
+
+    def _recording_read(path):  # noqa: ANN001 - mirrors the real signature
+        observed.append(("read", holding))
+        return read_config_for_update(path)
+
+    def _recording_write(path, data):  # noqa: ANN001 - mirrors the real signature
+        observed.append(("write", holding))
+        write_config_atomically(path, data)
+
+    loaded = MagicMock()
+    loaded.agents = {"kirocrew": MagicMock()}
+    fake_config_cls = MagicMock()
+    fake_config_cls.load.return_value = loaded
+
+    with (
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.dashboard.handlers.agents.KiroCrewConfig", fake_config_cls),
+        patch("kiro_crew.dashboard.handlers.agents._get_config_lock", _recording_lock),
+        patch("kiro_crew.dashboard.handlers.agents.read_config_for_update", _recording_read),
+        patch("kiro_crew.dashboard.handlers.agents.write_config_atomically", _recording_write),
+    ):
+        resp = await api_default_agent(request)
+
+    assert resp.status == 200
+    assert [step for step, _held in observed] == ["read", "write"], observed
+    # BOTH halves, not just the write: a lock taken around the write alone still
+    # lets a sibling RMW land between this read and it, which is the whole defect.
+    assert all(held for _step, held in observed), (
+        f"the default-agent read-modify-write ran OUTSIDE the config lock: {observed}"
+    )
+    # And the RMW itself still preserves unrelated settings.
+    assert json.loads(mc_cfg.read_text(encoding="utf-8")) == {
+        "default_agent": "kirocrew",
+        "unrelated": "keep me",
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_config_put_governs_against_the_ceiling_current_at_commit(
+    tmp_path, monkeypatch
+):
+    """The governance verdict must be taken INSIDE the locked region.
+
+    The transaction lock is a cross-process flock and its wait is unbounded, so
+    a ceiling revoked while this PUT queues behind another transaction leaves a
+    pre-lock verdict stale — and the write then republishes an auto-approve
+    grant governance has already withheld, which is precisely the bypass the
+    filter exists to close.
+
+    Modelled deterministically rather than by timing: the fake transaction lock
+    revokes the grant as it is acquired, i.e. strictly after any pre-lock
+    snapshot and strictly before any durable write.
+    """
+    import contextlib
+
+    import kiro_crew.platform.governance as gov
+
+    # Mutable ceiling: everything is grantable until the lock wait revokes
+    # @revoked_during_wait.
+    revoked: set[str] = set()
+    monkeypatch.setattr(gov, "may_skip_gate_now", lambda ref: ref not in revoked)
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {
+            "config": {
+                "name": "test",
+                "allowedTools": ["@kept", "@revoked_during_wait"],
+            }
+        }
+
+    request.json = mock_json
+
+    @contextlib.asynccontextmanager
+    async def _revoking_lock():
+        # Stand-in for a contended, unbounded cross-process flock wait: the
+        # ceiling moves while this PUT is queued behind another transaction.
+        await asyncio.sleep(0)
+        revoked.add("@revoked_during_wait")
+        yield
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            # Ships the ref the submission also carries, so a diff taken AFTER
+            # the filter would see it missing and record a phantom user removal.
+            return_value={"tools": [], "allowedTools": ["@revoked_during_wait"]},
+        ),
+        patch("kiro_crew.dashboard.handlers.mcp._get_mcp_lock", _revoking_lock),
+    ):
+        resp = await api_agent_config(request)
+
+    assert resp.status == 200
+    written = json.loads(installed.read_text(encoding="utf-8"))
+    assert written["allowedTools"] == ["@kept"], (
+        "the PUT persisted an auto-approve grant the ceiling withheld before any "
+        "durable write: the governance verdict was taken outside the lock and went "
+        f"stale during the wait (got {written['allowedTools']})"
+    )
+    # removedTools must STILL be diffed from the SUBMITTED, pre-governance map.
+    # The submission carries @revoked_during_wait, so the user removed nothing —
+    # recording it here would suppress that tool on every future upgrade.
+    assert "removedTools" not in json.loads(mc_cfg.read_text(encoding="utf-8")), (
+        "a ceiling-withheld ref was recorded as a user removal: removed_per_key "
+        "was diffed against the POST-governance config"
+    )


### PR DESCRIPTION
## Problem / Motivation

The agent-config `PUT` endpoint (`api_agent_config` in
`src/kiro_crew/dashboard/handlers/agents.py`) writes the installed agent spec with a
bare `asyncio.to_thread(write_config_atomically, ...)`. That write is unserialized
against the MCP transaction lock that every other config writer in
`handlers/mcp.py` takes, and it is unshielded, so it can outlive the request that
started it. Two things follow:

- **Interleaving.** A concurrent MCP-config transaction holds `_get_mcp_lock()`
  while it reads the agent spec files as a census source. The `PUT` write can land
  in the middle of that read-then-act window, so the transaction acts on a census
  that no longer describes the file on disk.
- **Abandonment.** If the request is cancelled (client disconnect, session reset,
  server shutdown), the handler unwinds immediately while the worker thread keeps
  writing. The write completes with nobody waiting on it, publishing a spec entry
  *after* a reader has already made its decision about the old contents.

## Why it matters

The agent spec is read at every kiro-cli session spawn and is one of the inputs an
MCP config transaction consults before it mutates shared state. A write that
lands outside the lock means a transaction can be decided on stale facts and then
have those facts changed underneath it — a lost-update window on user
configuration, not merely a latency artifact. The cancellation half is worse
because it is silent: the request returns (or is torn down) and the stray write
still happens, so nothing in the logs marks the moment the two views diverged.

Both hazards are already solved for the other writers in this codebase. This
endpoint was the one that had not been brought in line.

## What changed (motivation → approach → change)

**Symptom** — the agent-spec write is visible to, and racing with, MCP config
transactions it never coordinates with; it can also lose an entire concurrent
write of the same file; and a cancelled request can leave a write in flight.

**Root cause** — three separate gaps at one write site:

1. It never acquired the MCP **transaction** lock (`~/.kiro/settings/mcp.lock`)
   that every sibling writer in `handlers/mcp.py` takes.
2. It never acquired the **file** lock for the file it writes. `apps/bridges.py`
   does whole-file read-modify-writes of that same
   `~/.kiro/agents/kirocrew.json` under its *own* flock
   (`bridges._mcp_lock` → `kirocrew.lock`) on app enable/disable and MCP
   (de)registration. The transaction lock does not cover that sidecar, so the two
   writers were serialized by nothing.
3. It offloaded with a bare `asyncio.to_thread`, which is cancelled at the
   `await` and does not drain the worker.

**Change** — take **both** locks, transaction lock outermost, and drain the
worker:

```python
async with _get_mcp_lock():                      # settings/mcp.lock  (transaction)
    await _offload_config_write(_write_installed_config_locked, installed_path, config)

def _write_installed_config_locked(path, config):
    from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
    with _agent_file_lock(target=path):          # agents/kirocrew.lock  (file)
        write_config_atomically(path, config)
```

- `_get_mcp_lock()` serializes the write against every other gateway *transaction*,
  so the spec cannot change inside another transaction's read-then-act window.
- `bridges._mcp_lock(target=installed_path)` serializes it against bridges' own
  whole-file RMW of the same file. Without it, a concurrent app enable and this
  PUT each wrote the whole file and the last atomic rename silently discarded the
  other side's changes. It is keyed on the installed path — a lock on any other
  sidecar would serialize against nothing.
- `_offload_config_write` drains the worker before **either** lock is released,
  which makes the cancellation window structurally unrepresentable rather than
  merely unlikely.

**Lock order is transaction-then-file, and it is safe by audit, not by
assumption.** Enumerating all 11 `bridges._mcp_lock` acquisitions and all 14
settings-lock acquirers in `src/`: no path anywhere in the tree takes a file
flock and *then* the transaction lock, so there is no ABBA cycle. The chosen
order is also the one the codebase already uses whenever a settings-lock holder
reaches a `kirocrew.json` writer (`api_mcp_remove` → `_sync_mcp_to_agent`,
`rebuild_agent_config`). Two details make the audit non-obvious and are worth
recording: `bridges._mcp_lock(target=_LEGACY_SHARED_MCP_PATH)` resolves to the
*same* `settings/mcp.lock` sidecar as the transaction lock, and
`onboarding_import._mcp_lock` is a misleadingly-named wrapper that takes only the
settings lock — neither is reached while a file flock is held.

The file lock is acquired **inside the worker thread**, not on the event loop:
`bridges._mcp_lock` is a synchronous flock, and blocking on it from the loop
would freeze the gateway whenever app registration held it.

Scope notes, deliberately:

- The final shape (after the restructure round below) brings ALL of the PUT's
  durable writes under the locks, not only the agent-spec write: the
  `config.json` read-modify-write moved inside the commit unit (under
  `_get_config_lock`, nested in the transaction lock), followed by the
  bookkeeping write and the installed-spec write. An earlier revision left the
  `config.json` write outside; the review rounds below closed that.
- External writers (kiro-cli itself, hand edits to the spec file) cannot be
  serialized by any in-process lock. This change does not claim to fix that; it
  fixes the gateway racing *itself*, which is the part we own.
- The lock span is not bounded against a write that stalls on a dead filesystem.
  That is left alone on purpose: it is the shape of every existing transaction in
  `handlers/mcp.py`, and changing it here would be a wider change than this fix.
- The helper imports are function-local, matching how this module already reaches
  into `handlers.mcp` elsewhere, and avoid an import cycle (`apps.bridges` imports
  back into the dashboard handlers).

- Restructure round: after three review rounds landed blocking findings in the PUT span, the handler was rebuilt around one invariant — all fallible reads and validation complete before the first durable write, and all durable writes execute as a single non-cancellable unit the transaction lock strictly contains. The commit unit holds `_get_config_lock` (nested inside the transaction lock) across the config.json read-modify-write, preserves the parent's failure prefix (a failed config write leaves bookkeeping untouched), and is documented as non-cancellable but not rollback-atomic. Round 7 additionally locks `api_default_agent`'s read-modify-write under the same config lock (it raced the worker-thread commit) and moves the governance sanitize into the commit unit itself (step 0), so the grant verdict is taken under the locks, adjacent to the writes it governs, with `removedTools` still diffed from the submitted, pre-governance config.

## Tests

Eleven test functions in `test/test_api_agent_config_put_succeeds.py`, all written red-first
and confirmed to fail for their real reason (not collection or setup):

- **`test_agent_config_write_holds_the_mcp_transaction_lock`** — asserts **both**
  locks at the moment of the write: the transaction lock is held, *and* bridges'
  file lock was entered with `target ==` the installed path. The earlier version
  of this test recorded a single boolean, which would have passed just as happily
  with the wrong lock held; it now records the two independently and fails if
  either is dropped. Pre-fix failure: `AssertionError: the agent-spec write ran
  WITHOUT bridges' kirocrew.json file lock` / `assert ()`. The `assert
  spec_writes` guard runs first, so it cannot pass vacuously by the write being
  skipped. Both halves were falsified against deliberately-broken helpers (no
  file lock → fails on `WITHOUT bridges`; lock on a different target → fails on
  `wrong target`; the real helper passes), so neither assertion is decorative.
- **`test_offload_config_write_drains_through_repeated_cancellation`** — the
  drain must survive being cancelled itself. A worker blocks on a
  `threading.Event`; the task is cancelled once (drain begins), then cancelled
  again mid-drain. Asserts the write ran to completion **before** the
  `CancelledError` escaped, and that it still escaped. Pre-fix failure:
  `AssertionError: the drain was cancelled: _offload_config_write returned while
  the worker thread was still writing, so the caller's lock is released
  mid-write` / `assert not True`. Note it survives the *first* cancellation
  pre-fix — the test fails only at the second, which is exactly the reported
  defect.
- **`test_offload_config_write_propagates_write_errors`** — a failing write still
  raises; the new drain loop must not swallow it. Green before and after, so it
  guards the fix rather than the bug.
- **`test_agent_config_write_drains_the_worker_on_cancellation`** — unchanged in
  intent (the spec write is routed through the shielded offload, not a bare
  `to_thread`), updated for the callable the handler now offloads. Pre-fix
  failure: `AssertionError: the agent-spec write did not go through the shielded
  offload: ['write_config_atomically']`.

Regression scope run: the test modules that import `handlers.agents`, plus the
MCP handler/bridges suites and the repo-wide drift guards
(`test_security_posture.py`, `test_spawn_audit.py`) — **10,892 passed, 16
failed**. All 16 failures reproduce unchanged on the pre-fix commit in a pristine
detached worktree (host-isolation floor, `test_autonudge`, `test_source_providers`,
`test_artifacts_handlers` — they assert `KIROCREW_HOME` is not the operator's real
home, which this environment violates); the failure set is byte-identical before
and after, so none is attributable to this change.

Gates: `isort --check-only` clean, `flake8` clean, `mypy src/kiro_crew/` clean
(1113 files), black ratchet passed with the baseline **unchanged** (all three
touched files are already baselined and were not graduated).

- Restructure suite: lock releases only after every write landed; cancellation at lock-wait persists nothing; a concurrent config writer's unrelated field survives the PUT; a failed config write returns 500 with bookkeeping byte-identical; the offload drain survives repeated cancellation; the one-offload pin rejects any write dispatched outside the unit.

## Manual verification

N/A — unit coverage sufficient. Both properties are structural facts about the
call graph (which lock is held at the write, and which offload the write is routed
through), which the two tests assert directly; there is no rendered surface or
external service in the path, and reproducing the race by hand would be less
reliable evidence than the assertions.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — one write site in a request handler
plus its tests; no UI, response shape, or user-visible string is touched.

## Related Issues

no linked issue: extraction of a hardening fix from #5899 so it lands
independently; #5899 sheds the same hunks on its post-merge rebase.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff



