### PR TITLE
fix(acp): honor identity-scoped trust grants for subagent MCP calls

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -510,7 +510,6 @@ test/test_auto_research_handlers_coverage.py
 test/test_auto_research_onloop_db.py
 test/test_autonudge_dashboard_fire.py
 test/test_autonudge_stop_auth.py
-test/test_background_approval_routing.py
 test/test_bang_command_catchall.py
 test/test_beacon.py
 test/test_beacon_status_endpoint.py

--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -85,7 +85,15 @@ consuming it, so a repeated permission frame for the same `toolCallId` keeps the
 original tool-call arguments authoritative instead of falling back to the
 permission frame's agent-authored inline input. A genuine miss may carry inline
 data for display, but both provenance flags remain false and consumers that
-need trusted arguments fail closed.
+need trusted arguments fail closed. One identity-scoped carve-out exists
+(`AcpEvent.child_identity_trusted`): a remote MCP tool whose initial
+`tool_call` streams an empty/absent `rawInput` can never resolve args
+provenance, but its engine-authored `_meta.kiro` identity
+(`mcp_server_name`/`tool_name`) is cached independently of the args — so
+grants that authorize BY IDENTITY (trust-all/YOLO, a non-shell trusted
+pattern, the subagent parent policy) honor a child request whose non-shell
+identity resolved, while argument-derived gates (hook auto-approve,
+trust-reads) keep failing closed on `child_low_fidelity`.
 
 The host always sends one-shot approvals (`always=False`, the default). KiroCrew — not the agent — owns the trust scope (`slot._trust`, `slot._trust_reads`, `slot._trusted_patterns`, `safety_override`, `channel.trusted`, parent session `approval_policy`). Per-call `session/request_permission` is required so KiroCrew's PreToolUse hooks (`auto_deny_tools`, sensitive-path checks, credential redaction) fire on every tool invocation. The `always=True` path is reserved for a future "skip KiroCrew hooks for this exact tool" feature; no caller passes it today.
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -80,10 +80,20 @@ When a subagent's tool call triggers `EVENT_PERMISSION_REQUEST`, approval
 is decided in strict priority order:
 
 1. **Hook deny** — `hooks.on_tool_call()` returns `TOOL_DENY` → reject
-2. **YOLO mode** — `is_yolo()` (live check) → auto-approve
-3. **Parent policy** — `parent_policy == "auto"` (snapshot at spawn) → auto-approve
-4. **Interactive callback** — `on_tool_approval` (races dashboard + Slack, 2h timeout)
-5. **Deny by default** — none of the above matched → reject
+2. **Child fidelity gate** — a child request (`sub_session_id`) whose
+   security context never reached the caches (`child_low_fidelity`) skips
+   every auto-approve step below: it is handed to an interactive approver
+   with an "UNVERIFIED" annotation, or rejected when the consumer is
+   headless. One identity-scoped carve-out (#6163): a non-shell child whose
+   engine-authored MCP identity resolved (`child_identity_trusted`) flows
+   on to steps 3–5 — those grants authorize by identity, not by arguments —
+   while the argument-derived hook auto-approve stays gated on full
+   fidelity, and any interactive approver it reaches still sees an
+   arguments-unverified annotation.
+3. **YOLO mode** — `is_yolo()` (live check) → auto-approve
+4. **Parent policy** — `parent_policy == "auto"` (snapshot at spawn) → auto-approve
+5. **Interactive callback** — `on_tool_approval` (races dashboard + Slack, 2h timeout)
+6. **Deny by default** — none of the above matched → reject
 
 `parent_policy` is resolved once when `_run_inner` starts, using this chain:
 1. Read from parent session via `get_approval_policy(parent_session_key)`

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -628,6 +628,36 @@ class AcpEvent:
             return True
         return False
 
+    @property
+    def child_identity_trusted(self) -> bool:
+        """True for a child event whose non-shell MCP identity is VERIFIED.
+
+        ``child_low_fidelity`` conflates two distinct provenance failures:
+        unverified ARGUMENTS (``raw_params_trusted`` — the tool_call frame's
+        ``rawInput`` never reached the cache) and unverified IDENTITY. For a
+        remote MCP tool the backend's initial ``tool_call`` streams an
+        empty/absent ``rawInput``, so args provenance can never resolve — but
+        the engine-authored ``_meta.kiro`` identity (``mcp_server_name`` /
+        ``tool_name``, cached independently of the args) resolves fine.
+
+        Identity-scoped grants — trust-all / YOLO, a non-shell trusted
+        pattern, the subagent parent policy — authorize BY IDENTITY, not by
+        arguments, exactly as they do for the main agent. A verified identity
+        is therefore sufficient authority for THOSE grants even while the
+        arguments stay unverified. Requiring ``shell_classified`` keeps shell
+        fail-closed: a shell-cache MISS defaults ``is_shell`` to False, so
+        without a resolved classification "non-shell" is a guess, not a fact.
+        Argument-derived gates (hook auto-approve, trust-reads, path scoping)
+        must keep consulting ``child_low_fidelity`` and never this property.
+        """
+        return (
+            bool(self.sub_session_id)
+            and not self.is_shell
+            and self.shell_classified
+            and bool(self.mcp_server_name)
+            and bool(self.tool_name)
+        )
+
 
 @dataclass
 class AcpPromptStats:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -6397,6 +6397,28 @@ async def _run_chat(
                 # to the interactive card. A child WITH full context takes the
                 # same branches as the main agent (mode parity).
                 _child_low_fidelity = event.child_low_fidelity
+                # Identity-scoped carve-out (issue #6163): a child whose args
+                # provenance is absent but whose engine-authored MCP identity
+                # resolved from the caches may still take the IDENTITY-scoped
+                # grants below (trusted patterns, trust-all/YOLO) — those
+                # grants authorize by identity, never by arguments, exactly as
+                # they do for the main agent. Argument-derived gates (hook
+                # auto-approve, trust-reads) keep consulting
+                # _child_low_fidelity alone and stay fail-closed.
+                _child_identity_trusted = event.child_identity_trusted
+                if _child_low_fidelity:
+                    # The downgrade itself must be observable (#6163: nothing
+                    # was logged on this path, making per-call prompts in a
+                    # trusted session undiagnosable from logs).
+                    logger.info(
+                        "child permission request low-fidelity: args_trusted=%s "
+                        "identity_trusted=%s server=%r tool=%r request_id=%s",
+                        event.raw_params_trusted,
+                        _child_identity_trusted,
+                        event.mcp_server_name,
+                        event.tool_name,
+                        event.request_id,
+                    )
                 # DISPLAY-ONLY warning for the interactive card: the human
                 # must know the title is ALL there is (the params the gates
                 # would verify are absent, so the displayed text is
@@ -6407,9 +6429,17 @@ async def _run_chat(
                 # TrustDropdown derives its learned patterns from the title,
                 # and a mutated title would store junk pattern entries for
                 # exactly the requests that need the clearest presentation.
+                # When the tool IDENTITY did verify, say so — conflating
+                # "identity unknown" with "arguments unverified" overstates
+                # the risk and trains users to ignore the warning.
                 _child_lf_warning = (
-                    "⚠️ UNVERIFIED child request (security context "
-                    "missing — title is agent-authored): "
+                    (
+                        "⚠️ UNVERIFIED child request arguments (tool identity "
+                        "verified — argument values are agent-authored): "
+                        if _child_identity_trusted
+                        else "⚠️ UNVERIFIED child request (security context "
+                        "missing — title is agent-authored): "
+                    )
                     if _child_low_fidelity
                     else ""
                 )
@@ -6644,9 +6674,8 @@ async def _run_chat(
                 # parent turn. Deny-by-default (CWE-1188): with no active crew this
                 # predicate is False no matter the trust flags, so the tool falls
                 # through to the normal interactive/trust gate below.
-                if (
-                    _native_crew_should_auto_approve(_native_tracker, state, slot)
-                    and not _child_low_fidelity
+                if _native_crew_should_auto_approve(_native_tracker, state, slot) and (
+                    not _child_low_fidelity or _child_identity_trusted
                 ):
                     logger.debug(
                         "Native crew auto-approve: %r (request_id=%s)",
@@ -6689,7 +6718,7 @@ async def _run_chat(
                 # or collapsed redaction marker could authorize a different tool.
                 if (
                     slot._trusted_patterns
-                    and not _child_low_fidelity
+                    and (not _child_low_fidelity or _child_identity_trusted)
                     and not event.tool_input_redacted
                 ):
                     _tp_command = approval_command(
@@ -6815,8 +6844,14 @@ async def _run_chat(
                 # bytes never reached the caches) are excluded from every
                 # auto-approve path and fall through to the interactive card;
                 # children WITH cached bytes take these branches exactly like
-                # the main agent (mode parity).
-                if (slot_trusted or yolo_active) and not _child_low_fidelity:
+                # the main agent (mode parity). One carve-out (#6163): a
+                # non-shell child whose engine-authored MCP identity resolved
+                # (child_identity_trusted) may take this grant — trust-all
+                # authorizes by identity, not by arguments, so unverified
+                # args do not change what the grant asserts.
+                if (slot_trusted or yolo_active) and (
+                    not _child_low_fidelity or _child_identity_trusted
+                ):
                     try:
                         validated_tool = _validate_tool_name(event.title, is_shell=event.is_shell)
                     except ValueError as e:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1749,6 +1749,17 @@ class GatewayOrchestrator:
             # or a foreign event type) must not accidentally enter the
             # restricted path on a truthy non-bool.
             _child_lf = getattr(event, "child_low_fidelity", False) is True
+            # Identity-scoped carve-out (#6163), mirroring chat_runner: the
+            # blanket grants below (auto_approve_sources, --approval yolo,
+            # YOLO override, slot trust, the no-UI default) authorize by
+            # IDENTITY, never by arguments, so a child whose engine-authored
+            # non-shell MCP identity resolved (child_identity_trusted) may
+            # take them even while its arguments stay unverified.
+            # Title/argument-derived shortcuts (--approval reads) keep gating
+            # on _child_lf alone and stay fail-closed. Strict ``is True`` for
+            # the same reason as _child_lf.
+            _child_identity_ok = getattr(event, "child_identity_trusted", False) is True
+            _child_blocked = _child_lf and not _child_identity_ok
             # Background callers pass the authoritative parent session key. Prefer it
             # over a request-ID resolver because tool permission IDs are opaque UUIDs,
             # unlike spawn approvals (``spawn:<agent_id>``). Treating a tool request ID
@@ -1786,7 +1797,7 @@ class GatewayOrchestrator:
 
             # Per-source auto-approve (e.g. cron, taskrunner, subagent)
             if source in self._cfg.hooks.get("auto_approve_sources", []):
-                if _child_lf:
+                if _child_blocked:
                     # The operator explicitly configured this source to run
                     # UNATTENDED — nobody is watching the interactive window,
                     # so parking a low-fidelity child request there would
@@ -1806,7 +1817,12 @@ class GatewayOrchestrator:
             # CLI --approval flag override (composable test mode).
             # 'yolo' auto-approves all; 'reads' auto-approves read-only tools;
             # 'interactive' falls through to the standard flow.
-            if self._approval_mode in ("yolo", "reads") and not _child_lf:
+            # 'yolo' is identity-scoped (approve everything) so it honors the
+            # identity carve-out; 'reads' classifies by the model-authored
+            # title (_is_read_only_tool), so it stays gated on _child_lf.
+            if self._approval_mode in ("yolo", "reads") and (
+                not _child_lf or (self._approval_mode == "yolo" and _child_identity_ok)
+            ):
                 approve = self._approval_mode == "yolo" or (
                     self._approval_mode == "reads" and _is_read_only_tool(event.title or "")
                 )
@@ -1829,7 +1845,7 @@ class GatewayOrchestrator:
                     return True
 
             # Check both YOLO sources: Slack handler (!yolo on) and dashboard UI
-            if safety_override().is_active() and not _child_lf:
+            if safety_override().is_active() and not _child_blocked:
                 return True
 
             if self.dashboard_state:
@@ -1859,7 +1875,7 @@ class GatewayOrchestrator:
 
                 if _parent_slot_key:
                     _ps = (self.dashboard_state._slots or {}).get(_parent_slot_key)
-                    if _ps and _ps._trust and _child_lf:
+                    if _ps and _ps._trust and _child_blocked:
                         # Slot IS trusted; the fidelity gate is what blocks
                         # the auto-approve. A distinct audit reason — an
                         # auditor reading "not_trusted" for a trusted slot
@@ -2052,7 +2068,7 @@ class GatewayOrchestrator:
                     slot=approval_slot,
                     is_background=is_background,
                 )
-            if _child_lf:
+            if _child_blocked:
                 # No human surface answered and none of the (skipped)
                 # shortcuts may speak for an agent-authored request:
                 # fail closed.

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -6029,7 +6029,7 @@ class SubagentManager:
                         client, event.request_id, session_key, event, error="hook_deny"
                     )
                     continue
-                if event.child_low_fidelity:
+                if event.child_low_fidelity and not event.child_identity_trusted:
                     # Backend-internal child origin whose SECURITY context is
                     # absent (structured params missing, unresolved shell
                     # classification, or shell without a recoverable command —
@@ -6042,6 +6042,23 @@ class SubagentManager:
                     # decision to it: that is a human/host judgment, the same
                     # downgrade the dashboard's card provides. Only a truly
                     # headless consumer fails closed.
+                    #
+                    # Identity carve-out (#6163): a non-shell child whose
+                    # engine-authored MCP identity resolved from the caches
+                    # (child_identity_trusted) is NOT downgraded — it flows
+                    # to the ordinary branches below, where identity-scoped
+                    # policy (TOOL_AUTO_APPROVE, parent_policy=auto)
+                    # authorizes by identity exactly as for a full-context
+                    # child. Its arguments remain unverified, which those
+                    # grants never consult.
+                    logger.info(
+                        "child permission request downgraded (low fidelity): "
+                        "args_trusted=%s server=%r tool=%r request_id=%s",
+                        event.raw_params_trusted,
+                        event.mcp_server_name,
+                        event.tool_name,
+                        event.request_id,
+                    )
                     _child_fallback = self._on_tool_approval
                     if self._on_tool_approval_factory or _child_fallback is not None:
                         # The human must know the title is ALL there is: the
@@ -6102,7 +6119,7 @@ class SubagentManager:
                         error="child_origin_no_command_context",
                     )
                     continue
-                if tool_result.action == TOOL_AUTO_APPROVE:
+                if tool_result.action == TOOL_AUTO_APPROVE and not event.child_low_fidelity:
                     await self._approve_and_log(
                         client,
                         event.request_id,
@@ -6122,6 +6139,19 @@ class SubagentManager:
                         info=info,
                     )
                     continue
+                if event.child_low_fidelity and event.child_identity_trusted:
+                    # Identity-trusted fall-through (#6163) headed to an
+                    # INTERACTIVE approver: the ARGUMENTS are still
+                    # unverified, so the human must know the argument values
+                    # are agent-authored. Annotated here — after the
+                    # identity-scoped auto-approve branches — so the SEL
+                    # audit rows those branches write keep the clean
+                    # cache-resolved tool identity, never this prose.
+                    event.title = (
+                        "⚠️ UNVERIFIED child request arguments (tool identity "
+                        f"verified — argument values are agent-authored): "
+                        f"{event.title or '<unknown tool>'}"
+                    )
                 if self._on_tool_approval_factory:
                     approve_cb = self._on_tool_approval_factory(info)
                     info._awaiting_approval = True

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6679,6 +6679,131 @@ def test_child_low_fidelity_requires_structured_security_context():
     assert ev.child_low_fidelity is False
 
 
+def test_child_identity_trusted_gates_on_resolved_nonshell_identity():
+    """#6163: the identity carve-out fires ONLY for a child whose non-shell
+    MCP identity resolved from the engine-authored caches. Shell, an
+    unresolved shell classification, a missing identity, and non-child
+    events all stay outside it."""
+    from kiro_crew.acp.types import AcpEvent
+
+    # The #6163 shape: remote MCP call, args provenance absent, identity
+    # resolved → low-fidelity BUT identity-trusted.
+    ev = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        is_shell=False,
+        shell_classified=True,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+        raw_tool_params={"itemId": "item-0001"},
+        raw_params_trusted=False,
+    )
+    assert ev.child_low_fidelity is True
+    assert ev.child_identity_trusted is True
+    # Shell tool → never identity-trusted (fail-closed path unchanged).
+    ev = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        is_shell=True,
+        shell_classified=True,
+        mcp_server_name="example-server",
+        tool_name="run",
+    )
+    assert ev.child_identity_trusted is False
+    # Unresolved shell classification: is_shell=False is the MISS default,
+    # not a fact — "non-shell" cannot be asserted, so no carve-out.
+    ev = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        is_shell=False,
+        shell_classified=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    assert ev.child_identity_trusted is False
+    # Missing either identity half → no carve-out.
+    ev = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        is_shell=False,
+        shell_classified=True,
+        mcp_server_name="",
+        tool_name="get-item",
+    )
+    assert ev.child_identity_trusted is False
+    ev = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        is_shell=False,
+        shell_classified=True,
+        mcp_server_name="example-server",
+        tool_name="",
+    )
+    assert ev.child_identity_trusted is False
+    # Non-child events: the property is child-scoped.
+    ev = AcpEvent(
+        kind="permission_request",
+        is_shell=False,
+        shell_classified=True,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    assert ev.child_identity_trusted is False
+
+
+def test_remote_mcp_empty_rawinput_yields_identity_trusted_event():
+    """#6163 end-to-end dispatch regression: a child tool_call streaming
+    EMPTY rawInput (the remote-MCP shape) followed by a permission frame
+    with agent-authored inline input produces an event that is low-fidelity
+    (args unverified) yet identity-trusted (engine-authored _meta.kiro
+    resolved) — the input the trust-all/trusted-pattern carve-out keys on."""
+    from kiro_crew.acp._dispatch import build_permission_event, parse_session_update
+
+    caches: dict = {
+        "tool_input_cache": {},
+        "shell_cache": {},
+        "raw_params_cache": {},
+        "mcp_server_name_cache": {},
+        "tool_name_cache": {},
+    }
+    parse_session_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tc-6163",
+            "title": "@example-server/get-item",
+            "kind": "other",
+            "rawInput": {},
+            "_meta": {"kiro": {"mcpServerName": "example-server", "toolName": "get-item"}},
+        },
+        cache_scope="child-a",
+        **caches,
+    )
+
+    class _Msg:
+        id = 90
+        method = "session/request_permission"
+        params = {
+            "sessionId": "child-a",
+            "toolCall": {
+                "toolCallId": "tc-6163",
+                "title": "@example-server/get-item",
+                "input": {"itemId": "item-0001"},
+            },
+            "options": [
+                {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+                {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+            ],
+        }
+
+    event, _ = build_permission_event(_Msg(), cache_scope="child-a", **caches)
+    event.sub_session_id = "child-a"
+    assert event.raw_params_trusted is False
+    assert event.child_low_fidelity is True
+    assert event.mcp_server_name == "example-server"
+    assert event.tool_name == "get-item"
+    assert event.child_identity_trusted is True
+
+
 @pytest.mark.asyncio
 async def test_between_turns_child_permission_is_answered_not_queued():
     """With no in-flight prompt nothing consumes the slot queue until the next

--- a/test/test_background_approval_routing.py
+++ b/test/test_background_approval_routing.py
@@ -223,9 +223,7 @@ class TestOwnedApprovalStillRoutesToItsSlot:
         gateway.dashboard_state._slots = {"slot-other": _slot(running=True)}
 
         with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
-            approve_fn = gateway._interactive_approval(
-                "subagent", slot_resolver=lambda _rid: ""
-            )
+            approve_fn = gateway._interactive_approval("subagent", slot_resolver=lambda _rid: "")
             await approve_fn(_event("req-owned-4"), "")
 
         assert _requested_slot(gateway) == ""
@@ -278,9 +276,7 @@ class TestLowFidelityChildNeverAutoApproved:
         gateway = _make_gateway()
         gateway.dashboard_state._slots = {"slot-1": _slot(running=True, trust=True)}
         gateway.sessions.get_pid = MagicMock(return_value=None)
-        approve_fn = gateway._interactive_approval(
-            "subagent", slot_resolver=lambda _rid: "slot-1"
-        )
+        approve_fn = gateway._interactive_approval("subagent", slot_resolver=lambda _rid: "slot-1")
         assert await approve_fn(_child_lf_event()) is True
         gateway.dashboard_state.request_approval.assert_awaited_once()
 
@@ -299,3 +295,74 @@ class TestLowFidelityChildNeverAutoApproved:
         assert await approve_fn(_event()) is True
         # Parent event: the yolo shortcut answered, no prompt raised.
         gateway.dashboard_state.request_approval.assert_not_awaited()
+
+
+def _child_identity_event(request_id: str = "req-child-id-1") -> LLMEvent:
+    """An identity-trusted CHILD permission event (#6163): args provenance
+    absent (child_low_fidelity) but the engine-authored non-shell MCP
+    identity resolved — the shape a remote-MCP tool_call with empty
+    ``rawInput`` produces."""
+    ev = LLMEvent(
+        kind="permission_request",
+        request_id=request_id,
+        title="@example-server/get-item",
+        sub_session_id="child-a",
+        is_shell=False,
+        shell_classified=True,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    assert ev.child_low_fidelity
+    assert ev.child_identity_trusted
+    return ev
+
+
+class TestIdentityTrustedChildTakesIdentityScopedGrants:
+    """#6163: identity-scoped grants (auto_approve_sources, --approval yolo,
+    slot trust, the no-UI default) authorize by identity, so an
+    identity-trusted child takes them like a full-context event — while the
+    title-derived --approval reads shortcut stays gated on child_low_fidelity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_sources_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway._cfg.hooks.get = MagicMock(return_value=["cron"])
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_yolo_approval_mode_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway._approval_mode = "yolo"
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True
+        # The yolo shortcut answered — no interactive prompt raised.
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reads_approval_mode_still_gated_for_identity_trusted_child(self) -> None:
+        """'reads' classifies by the model-authored title, so identity trust
+        is NOT sufficient — the request falls through to the prompt."""
+        gateway = _make_gateway()
+        gateway._approval_mode = "reads"
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_slot_trust_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-1": _slot(running=True, trust=True)}
+        gateway.sessions.get_pid = MagicMock(return_value=None)
+        approve_fn = gateway._interactive_approval("subagent", slot_resolver=lambda _rid: "slot-1")
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_ui_default_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway.dashboard_state = None
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True

--- a/test/test_promise_only_autoapprove_parity.py
+++ b/test/test_promise_only_autoapprove_parity.py
@@ -61,10 +61,14 @@ def test_downgrade_gate_covers_every_approval_grant_source() -> None:
     source = _RUNNER.read_text(encoding="utf-8")
 
     # The tool-event branch that auto-approves without human confirmation.
+    # The child gate carries the #6163 identity carve-out, so the branch
+    # spans two lines: `if (<grants>) and (not _child_low_fidelity or
+    # _child_identity_trusted):`.
     approval = re.search(
-        r"^\s*if \((?P<cond>[^)]*yolo_active[^)]*)\) and not _child_low_fidelity:",
+        r"^\s*if \((?P<cond>[^)]*yolo_active[^)]*)\) and \(\s*"
+        r"not _child_low_fidelity or _child_identity_trusted\s*\):",
         source,
-        re.MULTILINE,
+        re.MULTILINE | re.DOTALL,
     )
     assert approval, "could not locate the auto-approve tool branch; update this test"
     granting = {name for name in ("slot_trusted", "yolo_active") if name in approval.group("cond")}

--- a/test/test_unattended_slot_guardrails.py
+++ b/test/test_unattended_slot_guardrails.py
@@ -867,8 +867,10 @@ class TestScopedGrantIsNeverPersisted:
         assert "slot_trusted = _slot_is_trusted(slot)" in src
         # The trust/YOLO gate still branches on _slot_is_trusted's verdict; the
         # low-fidelity qualifier only excludes backend-subagent events whose
-        # command bytes never reached the caches (see chat_runner).
-        assert "if (slot_trusted or yolo_active) and not _child_low_fidelity:" in src
+        # command bytes never reached the caches, with the #6163 carve-out for
+        # a child whose non-shell MCP identity resolved (see chat_runner).
+        assert "if (slot_trusted or yolo_active) and (" in src
+        assert "not _child_low_fidelity or _child_identity_trusted" in src
 
     def test_the_runner_writes_the_policy_through_the_helper(self) -> None:
         """Pins the call site, not just the helper.


### PR DESCRIPTION
<!-- no-visual-delta --> Backend-only permission-gating change; no UI surface is touched, so no screenshots are required.

## Problem / Motivation

Subagent remote-MCP tool calls always prompt interactively — even when the session has an active trust-all grant. Every child MCP call surfaces a "⚠️ UNVERIFIED child request (security context missing — title is agent-authored)" card, so a read-only 8-evaluator fan-out costs on the order of 100 manual approvals, and the log shows nothing explaining why the auto-approve was skipped.

Root mechanism: the backend's initial `tool_call` frame for a remote MCP tool streams an empty/absent `rawInput`, so the raw-params cache is never written, `raw_params_trusted` stays `False`, and `AcpEvent.child_low_fidelity` becomes `True` — which skips every auto-approve branch.

## Why it matters

Trust-all exists precisely so an attended fan-out does not require per-call clicking. With this bug, any subagent workload that touches remote MCP tools degrades to one interactive prompt per call, which in practice makes MCP-heavy subagent fan-outs unusable — users either babysit approvals or (worse) reach for blanket YOLO overrides. The silent downgrade (no log line) also made the behavior undiagnosable.

## What changed (motivation → approach → change)

Observed symptom → root cause: `child_low_fidelity` conflates two distinct provenance failures — unverified **arguments** (`raw_params_trusted`, which for remote MCP can never resolve because the engine does not deliver params on a trusted frame) and unverified **identity**. But the engine-authored `_meta.kiro` identity (`mcp_server_name`/`tool_name`) is cached independently of the args and *does* resolve on these frames.

Approach chosen: separate verified identity from verified arguments (direction 2 in the issue) rather than trying to restore args provenance (direction 1) — there is no evidence the backend ever delivers remote-MCP params on a trusted frame, permission frames carry no `_meta`, and inline fields are model-influenced by design. Writing `{}` into the cache was rejected as ambiguous: it would assert "engine said no args" when the backend may stream a placeholder.

The change:

- **`AcpEvent.child_identity_trusted`** (`acp/types.py`): true only for a child event that is non-shell, has a *resolved* shell classification, and has both cache-resolved identity halves. Requiring `shell_classified` keeps shell fail-closed — a shell-cache miss defaults `is_shell=False`, so without a resolved classification "non-shell" is a guess, not a fact.
- **`chat_runner.py`**: the trust-all/YOLO and trusted-patterns guards honor the carve-out — these grants authorize *by identity*, never by arguments, exactly as they do for the main agent. Argument-derived gates (hook auto-approve, trust-reads) still consult `child_low_fidelity` alone and stay fail-closed. The previously-silent downgrade now logs (args-trusted/identity-trusted/server/tool/request-id), and the interactive card warning now distinguishes "identity verified, arguments unverified" from fully-unverified requests.
- **`subagent.py`**: identity-trusted events skip the low-fidelity downgrade and flow to the ordinary `parent_policy`/interactive branches; the arg-derived hook `TOOL_AUTO_APPROVE` is explicitly kept gated on full fidelity. The arguments-unverified title annotation is applied only on the interactive-approver path, after the auto-approve branches, so SEL audit rows keep the clean cache-resolved tool identity.
- **`slack/gateway.py` + native-crew (completeness, from First Principles review)**: the sibling identity-scoped grant sites in the gateway approval callback — `auto_approve_sources`, `--approval yolo`, the YOLO safety override, slot trust, and the no-UI default — plus the native-crew auto-approve in `chat_runner.py` honor the same carve-out, so an identity-trusted child that reaches the gateway (the subagent interactive fall-through routes exactly there) is covered by the same grants. `--approval reads` is deliberately NOT widened: it classifies by the model-authored title, so it stays gated on `child_low_fidelity` like every argument/title-derived gate.
- **Docs**: `docs/system-specs/modules/acp-client.md` (provenance section) and `docs/system-specs/modules/subagent.md` (Tool Approval Cascade) updated to describe the gate and the carve-out.

`child_low_fidelity` itself is unchanged — everything argument-shaped keeps failing closed.

## Tests

- `test_child_identity_trusted_gates_on_resolved_nonshell_identity` (`test/test_acp_runtime.py`): the property matrix — true for the #6163 shape (non-shell child, args untrusted, identity resolved); false for shell, unresolved shell classification, either identity half missing, and non-child events.
- `test_remote_mcp_empty_rawinput_yields_identity_trusted_event` (`test/test_acp_runtime.py`): end-to-end dispatch regression encoding the exact failing frame sequence — a child `tool_call` with empty `rawInput` + `_meta.kiro`, followed by a permission frame with agent-authored inline input — asserting the event is low-fidelity yet identity-trusted.
- `TestIdentityTrustedChildTakesIdentityScopedGrants` (`test/test_background_approval_routing.py`): the gateway callback's identity-scoped grants (`auto_approve_sources`, `--approval yolo`, slot trust, no-UI default) approve an identity-trusted child without prompting, while `--approval reads` still falls through to the prompt — mirroring the existing `TestLowFidelityChildNeverAutoApproved` class, whose shell-shaped events keep failing closed.
- `test/test_promise_only_autoapprove_parity.py` and `test/test_unattended_slot_guardrails.py`: source-pinned assertions updated to the new two-line guard shape, so a future grant-source change still fails loudly.
- Full consumer suites green: `test_acp_runtime.py`, `test_acp_provider.py`, `test_background_approval_routing.py`, `test_hang_resilience_metrics.py`, `test_promise_only_autoapprove_parity.py`, `test_unattended_slot_guardrails.py` (368 passed) plus `test_subagent.py` approval/child selection (24 passed). black / isort / flake8 / black-ratchet clean; the single mypy hit is the pre-existing Linux-only `PidfdChildWatcher` report in the untouched `cli.py`.

## Manual verification

Reproduced the issue's probe locally against this branch's source: scenario A (params on the frame) stays full-fidelity; scenarios B (empty `rawInput`) and C (absent `rawInput`) are `child_low_fidelity=True` with `shell_classified=True`, resolved identity, and `child_identity_trusted=True` — the exact input the widened guards key on. The dispatch-level regression test now encodes the same sequence.

## Related Issues

Fixes #6163

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
