### PR TITLE
fix: carry caller session bounds into tailnet QR mint

### DIFF
--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -6,6 +6,7 @@ import fnmatch
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
@@ -20,6 +21,11 @@ from kiro_crew.agent_discovery import (
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.dashboard.state import VALID_MEMORY_MODES, DashboardState
+from kiro_crew.dashboard.token_auth import (
+    MAX_SESSION_TTL_SECS,
+    _b64url_decode,
+    _cookie_port_from_host,
+)
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.messaging.privacy_mode import hydrate as _hydrate_conv_flags
 from kiro_crew.messaging.privacy_mode import is_incognito as is_thread_incognito
@@ -1496,6 +1502,68 @@ def _read_session_key(request: "Any") -> str:
     slot lookup (CWE-178/180 — inconsistent normalization in an auth context).
     """
     return request.headers.get("X-Session-Key", "").strip()
+
+
+def _caller_bounds(request: web.Request) -> tuple[dict[str, str], int]:
+    """Read the caller's own session bounds from the token that authenticated it.
+
+    Shared by every handler that mints a NEW credential on the authority of an
+    existing dashboard session (the mobile login link and the tailnet QR mint),
+    so the two mint surfaces cannot drift apart on the invariant: the minted
+    credential must never out-scope the session authorizing it.
+
+    Returns ``(carried_claims, ttl_ceiling_seconds)``. ``ttl_ceiling`` is ``0``
+    when the caller has no lifetime left to lend, which the handler refuses
+    rather than minting against. Claims are carried, never re-derived: ``boot``
+    copied verbatim (same rule as the link→session exchange in ``token_auth``),
+    ``no_refresh`` copied so the recipient session never grows a refresh chain,
+    and the remaining ``session_exp`` becomes the TTL ceiling so a short-lived
+    caller cannot mint a longer-lived credential. Fail-closed on an unreadable
+    payload: a caller whose bounds cannot be established gets a bounded
+    (no-refresh, default-TTL-capped) link rather than an unbounded one.
+
+    **Extraction order must mirror the middleware's, query param before cookie.**
+    Only the credential the middleware actually validated has a verified
+    signature; the other one was never checked. The middleware prefers
+    ``?token=`` (``token_auth`` middleware and ``_extract_and_validate``, both
+    ``request.query.get("token") or request.cookies.get(...)``), so reading the
+    cookie first would let a request that authenticated with a bounded query
+    token have its bounds read from an unverified, attacker-settable cookie —
+    dropping ``no_refresh`` and raising the TTL ceiling to the full maximum,
+    which is precisely the ceiling-escape this function exists to prevent.
+
+    **A non-positive remaining lifetime is never rounded up.** Clamping it to a
+    floor of one second would let a caller whose own session has just run out
+    mint a link that outlives it, and the exchange the recipient performs starts
+    a fresh window — so repeating the mint would walk the expiry forward
+    indefinitely from a session that should already be dead. Report ``0`` and
+    let the caller be refused.
+    """
+    port = request.app.get("port", 7777)
+    cookie_name = f"mc_token_{_cookie_port_from_host(request, port)}"
+    token = request.query.get("token", "") or request.cookies.get(cookie_name, "")
+    carried: dict[str, str] = {}
+    ttl_ceiling = MAX_SESSION_TTL_SECS
+    if not token:
+        # Authenticated without a readable token (unexpected on this surface):
+        # fail closed by bounding the mint rather than trusting it.
+        return {"no_refresh": "1"}, ttl_ceiling
+    try:
+        data = json.loads(_b64url_decode(token.split(".", 1)[0]))
+        boot = str(data.get("boot", ""))
+        if boot:
+            carried["boot"] = boot
+        if str(data.get("no_refresh", "")) == "1":
+            carried["no_refresh"] = "1"
+        session_exp = float(data.get("session_exp", 0.0))
+        if session_exp:
+            remaining = int(session_exp - time.time())
+            if remaining <= 0:
+                return carried, 0
+            ttl_ceiling = min(ttl_ceiling, remaining)
+    except Exception:
+        return {"no_refresh": "1"}, ttl_ceiling
+    return carried, ttl_ceiling
 
 
 def _is_restricted_session(state: DashboardState, request: "Any") -> bool:

--- a/src/kiro_crew/dashboard/handlers/auth_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/auth_mobile.py
@@ -17,30 +17,22 @@ caller's own token bounds (``boot``, ``no_refresh``, remaining ``session_exp``)
 are carried into the minted link so the new session inherits — never exceeds —
 them.
 
-The sibling QR surface does NOT yet carry those bounds:
-``tailnet_mobile._guard`` gates on app-token, owner and restricted-slot only,
-so a ``no_refresh`` or short-``session_exp`` owner session still passes it and
-mints a boot-bound, refresh-chained credential. Extending ``_caller_bounds`` to
-that surface is tracked separately; do not read that guard as closing this
-ceiling.
+The bound-reading half lives in ``_shared._caller_bounds`` because the sibling
+tailnet QR mint (``tailnet_mobile``) enforces the same invariant on its own
+mint; one shared reader keeps the two surfaces from drifting apart.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import time
 
 from aiohttp import web
 
-from kiro_crew.dashboard.handlers._shared import _is_restricted_session
+from kiro_crew.dashboard.handlers._shared import _caller_bounds, _is_restricted_session
 from kiro_crew.dashboard.origin import check_origin
 from kiro_crew.dashboard.token_auth import (
     LINK_WINDOW_SECS,
-    MAX_SESSION_TTL_SECS,
-    _b64url_decode,
-    _cookie_port_from_host,
     generate_token,
 )
 from kiro_crew.dashboard.urls import build_dashboard_url, dashboard_origin
@@ -72,63 +64,6 @@ async def _audit_async(user_id: str, outcome: str, error: str = "") -> None:
     gateway is serving.
     """
     await asyncio.to_thread(_audit, user_id, outcome, error)
-
-
-def _caller_bounds(request: web.Request) -> tuple[dict[str, str], int]:
-    """Read the caller's own session bounds from the token that authenticated it.
-
-    Returns ``(carried_claims, ttl_ceiling_seconds)``. ``ttl_ceiling`` is ``0``
-    when the caller has no lifetime left to lend, which the handler refuses
-    rather than minting against. Claims are carried, never re-derived: ``boot``
-    copied verbatim (same rule as the link→session exchange in ``token_auth``),
-    ``no_refresh`` copied so the recipient session never grows a refresh chain,
-    and the remaining ``session_exp`` becomes the TTL ceiling so a short-lived
-    caller cannot mint a longer-lived credential. Fail-closed on an unreadable
-    payload: a caller whose bounds cannot be established gets a bounded
-    (no-refresh, default-TTL-capped) link rather than an unbounded one.
-
-    **Extraction order must mirror the middleware's, query param before cookie.**
-    Only the credential the middleware actually validated has a verified
-    signature; the other one was never checked. The middleware prefers
-    ``?token=`` (``token_auth`` middleware and ``_extract_and_validate``, both
-    ``request.query.get("token") or request.cookies.get(...)``), so reading the
-    cookie first would let a request that authenticated with a bounded query
-    token have its bounds read from an unverified, attacker-settable cookie —
-    dropping ``no_refresh`` and raising the TTL ceiling to the full maximum,
-    which is precisely the ceiling-escape this function exists to prevent.
-
-    **A non-positive remaining lifetime is never rounded up.** Clamping it to a
-    floor of one second would let a caller whose own session has just run out
-    mint a link that outlives it, and the exchange the recipient performs starts
-    a fresh window — so repeating the mint would walk the expiry forward
-    indefinitely from a session that should already be dead. Report ``0`` and
-    let the caller be refused.
-    """
-    port = request.app.get("port", 7777)
-    cookie_name = f"mc_token_{_cookie_port_from_host(request, port)}"
-    token = request.query.get("token", "") or request.cookies.get(cookie_name, "")
-    carried: dict[str, str] = {}
-    ttl_ceiling = MAX_SESSION_TTL_SECS
-    if not token:
-        # Authenticated without a readable token (unexpected on this surface):
-        # fail closed by bounding the mint rather than trusting it.
-        return {"no_refresh": "1"}, ttl_ceiling
-    try:
-        data = json.loads(_b64url_decode(token.split(".", 1)[0]))
-        boot = str(data.get("boot", ""))
-        if boot:
-            carried["boot"] = boot
-        if str(data.get("no_refresh", "")) == "1":
-            carried["no_refresh"] = "1"
-        session_exp = float(data.get("session_exp", 0.0))
-        if session_exp:
-            remaining = int(session_exp - time.time())
-            if remaining <= 0:
-                return carried, 0
-            ttl_ceiling = min(ttl_ceiling, remaining)
-    except Exception:
-        return {"no_refresh": "1"}, ttl_ceiling
-    return carried, ttl_ceiling
 
 
 async def api_auth_mobile_link(request: web.Request) -> web.Response:
@@ -181,7 +116,12 @@ async def api_auth_mobile_link(request: web.Request) -> web.Response:
     return web.json_response(
         {
             "url": build_dashboard_url(external_origin, token, local_only=False),
-            "expires_in": LINK_WINDOW_SECS,
+            # The live click window: generate_token clamps the link-click
+            # ``exp`` to the session TTL, so a caller lending less than the
+            # nominal window mints a link that dies with its own remaining
+            # lifetime — report that, not the constant, or the UI countdown
+            # overstates how long the link actually works.
+            "expires_in": min(LINK_WINDOW_SECS, ttl_ceiling),
         },
         headers={"Cache-Control": "no-store"},
     )

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -54,7 +54,7 @@ from aiohttp import web
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.dashboard import tailnet, tailnet_serve
 from kiro_crew.dashboard.boot_id import current_boot_id
-from kiro_crew.dashboard.handlers._shared import _is_restricted_session
+from kiro_crew.dashboard.handlers._shared import _caller_bounds, _is_restricted_session
 from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 from kiro_crew.dashboard.token_auth import (
     LINK_WINDOW_SECS,
@@ -575,10 +575,14 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     backed routes admit, so a bespoke subject would produce a phone session that
     looks fine and is silently denied those routes.
 
-    Refuses unless the derived step is ``ready``. That is the whole precondition
-    set, read from ``_derive_step`` rather than re-checked here: a QR for a URL
-    nothing answers is a support ticket, not a feature, and a QR issued under an
-    administrator's tailnet pin is a credential the ceiling forbids.
+    Refuses unless the derived step is ``ready``. That is the whole machine-state
+    precondition set, read from ``_derive_step`` rather than re-checked here: a
+    QR for a URL nothing answers is a support ticket, not a feature, and a QR
+    issued under an administrator's tailnet pin is a credential the ceiling
+    forbids. On top of the machine state, the CALLER's own session bounds are
+    enforced via ``_shared._caller_bounds`` (the same helper the mobile-link
+    mint uses): the minted token never out-scopes the session authorizing it,
+    and a caller with no lifetime left to lend is refused.
     """
     refusal = _guard(request)
     if refusal is not None:
@@ -641,9 +645,11 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
             parsed = parse_duration(raw_ttl)
             if parsed:
                 ttl = parsed
-    # Clamped twice on purpose: this endpoint's own ceiling first, then the
-    # global session ceiling, so neither a caller-supplied value nor a future
-    # raise of MAX_QR_TTL_SECS can exceed what token_auth itself allows.
+    # Clamped by this endpoint's own ceiling first, then the global session
+    # ceiling, so neither a caller-supplied value nor a future raise of
+    # MAX_QR_TTL_SECS can exceed what token_auth itself allows. The caller's
+    # own remaining lifetime is applied further down, after the last awaited
+    # step before the mint, so it cannot go stale while this handler waits.
     ttl = min(ttl, MAX_QR_TTL_SECS, MAX_SESSION_TTL_SECS)
 
     state_obj = request.app.get("state")
@@ -670,8 +676,13 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     # lapses. Kept as a supported shape for an operator who wants the credential
     # bounded by a clock regardless of process lifetime.
     #
-    # Mutually exclusive on purpose: carrying both would mean a session that
-    # neither refreshes nor lasts, which is worse than either.
+    # Mutually exclusive as the DEFAULT shapes on purpose: choosing both for an
+    # unbounded caller would mean a session that neither refreshes nor lasts,
+    # which is worse than either. A BOUNDED caller is different — its carried
+    # claims are merged over the configured shape below, and a token carrying
+    # both ``boot`` and ``no_refresh`` is then the honest intersection: the
+    # session ends at whichever bound is hit first, which is exactly what
+    # "never out-scope the caller" requires.
     #
     # The TTL clamp above is untouched under both shapes. Rotation is what
     # extends a boot-bound session, so no ceiling and no security constant moves.
@@ -692,9 +703,49 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
         _until_restart = True
 
     if _until_restart:
-        claims = {"boot": current_boot_id()}
+        shape = {"boot": current_boot_id()}
     else:
-        claims = {"no_refresh": "1"}
+        shape = {"no_refresh": "1"}
+    # The calling session's own bounds cap everything minted below — the same
+    # invariant the sibling mobile-link mint enforces, read through the same
+    # shared helper so the two surfaces cannot drift. A deliberately bounded
+    # owner session (``no_refresh``, or a short remaining ``session_exp``) must
+    # not trade itself for a boot-bound, refresh-chained credential on another
+    # device: behind ``tailscale serve`` every request reaches the gateway from
+    # 127.0.0.1, so the token cannot be device-pinned and its own bounds are the
+    # only limit that holds. A caller with no lifetime left to lend is refused
+    # outright — minting against it would hand out a credential that outlives
+    # the session authorizing it.
+    #
+    # Read AFTER every awaited step above (the request body and the config
+    # load), deliberately: the remaining lifetime is a wall-clock snapshot, and
+    # a client that trickles the request body in controls how long this handler
+    # waits — a snapshot taken before those awaits would let a caller in its
+    # last seconds stretch the mint past its own expiry.
+    carried, ttl_ceiling = _caller_bounds(request)
+    if ttl_ceiling <= 0:
+        await _audit_async(request, "tailnet.mobile.qr", "denied", "caller-session-expired")
+        return web.json_response(
+            {
+                "error": (
+                    "This session has no lifetime left to lend, so no sign-in "
+                    "link can be issued. Sign in again, then scan."
+                ),
+                "code": "caller_session_expired",
+            },
+            status=403,
+        )
+    # The caller's remaining lifetime completes the clamp: a short-lived caller
+    # asking for the default cannot exceed what the authorizing session itself
+    # has left.
+    ttl = min(ttl, ttl_ceiling)
+    # The caller's carried bounds win on conflict and are never dropped: a
+    # ``boot`` claim is carried verbatim rather than re-derived (the same rule
+    # the link→session exchange follows), and a ``no_refresh`` caller stamps the
+    # minted credential ``no_refresh`` regardless of the configured shape, so
+    # the phone session never grows a refresh chain its authorizing session did
+    # not have.
+    claims = {**shape, **carried}
     token = generate_token(owner_id or "local-app", ttl_seconds=ttl, extra=claims)
     url = f"https://{host}/?token={token}"
     try:
@@ -721,8 +772,10 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
             # The window in which the LINK must be opened, which is not the
             # session lifetime and is the thing that surprises people: the token
             # stops being redeemable long before the session it would have
-            # created would have expired.
-            "link_window_secs": LINK_WINDOW_SECS,
+            # created would have expired. generate_token clamps the link-click
+            # ``exp`` to the session TTL, so a short-lived caller's link dies
+            # with the ttl it lent — report the live window, not the constant.
+            "link_window_secs": min(LINK_WINDOW_SECS, ttl),
             "host": host,
         }
     )

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -752,7 +752,9 @@ def generate_token(
     """Return ``base64url(payload).base64url(signature)``.
 
     The token carries two expiry times:
-    - ``exp``: link click window (5 minutes) — URL must be opened before this
+    - ``exp``: link click window (5 minutes, clamped to the session TTL so the
+      link never authenticates past the session it grants) — URL must be
+      opened before this
     - ``session_exp``: cookie session TTL (capped at 20 hours)
 
     When *app* is provided, the token payload includes ``"app": app`` so
@@ -797,7 +799,14 @@ def generate_token(
 
     payload_dict: dict[str, object] = {
         "sub": user_id,
-        "exp": now + LINK_WINDOW_SECS,
+        # The link-click window never extends past the session the link
+        # grants. The query-param path validates against ``exp`` alone (the
+        # nonce set is membership-only), so an uncapped window would let the
+        # raw link keep authenticating requests after ``session_exp`` passed —
+        # a token whose session lifetime was capped by its caller's own bounds
+        # (the mobile-link and tailnet-QR mints) would outlive the session
+        # that authorized it by up to the full window.
+        "exp": now + min(LINK_WINDOW_SECS, session_ttl),
         "session_exp": now + session_ttl,
         "iat": now,
         "nonce": nonce,

--- a/test/test_mobile_login_link.py
+++ b/test/test_mobile_login_link.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from aiohttp import web
 
-from kiro_crew.dashboard.handlers import auth_mobile
+from kiro_crew.dashboard.handlers import _shared, auth_mobile
 from kiro_crew.dashboard.token_auth import (
     LINK_WINDOW_SECS,
     MAX_SESSION_TTL_SECS,
@@ -145,6 +145,25 @@ def test_mobile_link_caps_ttl_at_the_callers_remaining_session():
     assert remaining > 0
 
 
+def test_mobile_link_reports_the_live_window_for_a_short_caller():
+    """``expires_in`` reports the clamped click window, not the constant.
+
+    generate_token clamps the link-click ``exp`` to the session TTL, so a
+    caller lending less than the nominal window mints a link that dies with
+    its remaining lifetime. Reporting the constant would make the UI
+    countdown promise minutes the link does not have.
+    """
+    short = generate_token("alice", ttl_seconds=120)
+    response = _call(_request(dashboard_url="https://dashboard.example", cookie_token=short))
+
+    assert response.status == 200
+    payload = json.loads(response.text)
+    assert 0 < payload["expires_in"] <= 120 < LINK_WINDOW_SECS
+    # The reported window matches the minted token's actual exp.
+    claims = _minted_claims(payload)
+    assert claims["exp"] <= time.time() + payload["expires_in"] + 5
+
+
 def test_mobile_link_fails_closed_on_an_unreadable_caller_token():
     """Bounds that cannot be established yield a bounded (no-refresh) link."""
     response = _call(
@@ -197,7 +216,7 @@ def test_mobile_link_refuses_a_caller_with_no_lifetime_left():
     indefinitely from a session that should already be dead.
     """
     expired = generate_token("alice", ttl_seconds=MAX_SESSION_TTL_SECS)
-    with patch.object(auth_mobile.time, "time", return_value=time.time() + 10**7):
+    with patch.object(_shared.time, "time", return_value=time.time() + 10**7):
         response = _call(_request(dashboard_url="https://dashboard.example", cookie_token=expired))
 
     assert response.status == 403

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -36,6 +36,8 @@ the wrong thing would be destructive rather than merely unhelpful.
 from __future__ import annotations
 
 import asyncio
+import json
+import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import get_args
@@ -46,9 +48,20 @@ import pytest
 from kiro_crew.dashboard import tailnet
 from kiro_crew.dashboard.handlers import tailnet_mobile
 from kiro_crew.dashboard.tailnet import DaemonProbe
+from kiro_crew.dashboard.token_auth import (
+    LINK_WINDOW_SECS,
+    MAX_SESSION_TTL_SECS,
+    _b64url_encode,
+    generate_token,
+)
 
 _PORT = 5476
 _HOST = "desk.tail-abc.ts.net"
+
+
+def _owner_session_token(*, ttl_seconds: int = MAX_SESSION_TTL_SECS, **extra: str) -> str:
+    """A real caller credential, as the auth middleware would have validated it."""
+    return generate_token(_OWNER, ttl_seconds=ttl_seconds, extra=extra or None)
 
 
 def _probe(
@@ -344,6 +357,8 @@ def _request(
     app_identity: str | None = "",
     user: str | None = _OWNER,
     tailnet_host: str = "",
+    query_token: str = "",
+    cookie_token: str = "",
 ):
     """Minimal stand-in for the aiohttp request these handlers actually touch.
 
@@ -360,6 +375,9 @@ def _request(
     ``tailnet_host`` models the name the RUNNING server trusted at startup. Empty
     (the default) means the fixed allowlist does not carry the resolvable name,
     so ``_derive_step`` reports ``restart_gateway``. Ready paths must set it.
+    ``query_token`` / ``cookie_token`` model the credential the middleware
+    authenticated with, which the QR mint reads its caller bounds from. Both
+    empty (the default) exercises the fail-closed no-readable-token path.
     """
 
     class _Req:
@@ -372,6 +390,10 @@ def _request(
             }
             self.remote = "127.0.0.1"
             self.headers: dict[str, str] = {}
+            self.query: dict[str, str] = {"token": query_token} if query_token else {}
+            self.cookies: dict[str, str] = (
+                {f"mc_token_{port}": cookie_token} if cookie_token else {}
+            )
             self._items: dict[str, object] = {}
             if app_identity is not None:
                 self._items["app"] = app_identity
@@ -569,7 +591,9 @@ class TestQrRefusals:
                     tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
                 ),
             ):
-                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
         assert resp.status == 200
         assert captured["extra"] == {"boot": current_boot_id()}
         assert "no_refresh" not in (captured["extra"] or {})
@@ -594,7 +618,9 @@ class TestQrRefusals:
                     tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
                 ),
             ):
-                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
         assert resp.status == 200
         assert captured["extra"] == {"no_refresh": "1"}
         assert "boot" not in (captured["extra"] or {})
@@ -647,7 +673,9 @@ class TestQrRefusals:
                     tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
                 ),
             ):
-                resp = await tailnet_mobile.api_tailnet_mobile_qr(_request(tailnet_host=_HOST))
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
         assert resp.status == 200
         assert loads["n"] >= 2, "the handler must do its own read, not reuse _live_state's"
         assert captured["extra"] == {"boot": current_boot_id()}
@@ -696,6 +724,179 @@ class TestQrRefusals:
         assert resp.status == 200
         for call in audit.call_args_list:
             assert "SECRET-TOKEN-VALUE" not in " ".join(str(a) for a in call.args)
+
+
+class TestQrCallerBounds:
+    """The QR-minted token never out-scopes the session that authorized it.
+
+    Mirrors the coverage of the sibling mobile-link mint
+    (``test_mobile_login_link.py``): the mint reads the CALLER's own token
+    bounds through the shared ``_caller_bounds`` helper and carries them into
+    the credential. Behind ``tailscale serve`` every request reaches the
+    gateway from 127.0.0.1, so the token cannot be device-pinned — its own
+    bounds are the only limit that holds, which is what made this surface the
+    laundering path: one POST from a deliberately bounded owner session used to
+    mint a boot-bound, refresh-chained credential that outlived it.
+    """
+
+    @staticmethod
+    def _capture(captured: dict):
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["ttl"] = ttl_seconds
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        return _fake_mint
+
+    async def _mint(self, captured: dict, **request_kw):
+        with _machine():
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=self._capture(captured)),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                return await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, **request_kw)
+                )
+
+    @pytest.mark.asyncio
+    async def test_a_no_refresh_caller_mints_a_no_refresh_credential(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """A caller whose session never grows a refresh chain must not mint a
+        credential that does — that is the laundering this gate closes."""
+        captured: dict[str, object] = {}
+        resp = await self._mint(
+            captured, cookie_token=_owner_session_token(ttl_seconds=600, no_refresh="1")
+        )
+        assert resp.status == 200
+        extra = captured["extra"]
+        assert isinstance(extra, dict) and extra["no_refresh"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_a_short_lived_caller_caps_the_qr_ttl(self, _unrestricted, _quiet_audit) -> None:
+        """The default QR TTL is above this caller's remaining lifetime, so the
+        remaining lifetime wins — a short-lived session cannot lend more time
+        than it has."""
+        captured: dict[str, object] = {}
+        resp = await self._mint(captured, cookie_token=_owner_session_token(ttl_seconds=600))
+        assert resp.status == 200
+        assert isinstance(captured["ttl"], int)
+        assert 0 < captured["ttl"] <= 600 < tailnet_mobile.DEFAULT_QR_TTL_SECS
+
+    @pytest.mark.asyncio
+    async def test_the_reported_link_window_never_exceeds_the_lent_ttl(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """``link_window_secs`` reports the clamped click window, not the
+        constant — generate_token clamps the link-click ``exp`` to the session
+        TTL, so a caller lending less than the nominal window mints a QR whose
+        link dies with the ttl it lent, and the UI countdown must say so."""
+        captured: dict[str, object] = {}
+        resp = await self._mint(captured, cookie_token=_owner_session_token(ttl_seconds=120))
+        assert resp.status == 200
+        payload = json.loads(resp.body)
+        assert 0 < payload["link_window_secs"] <= 120
+        assert payload["link_window_secs"] == min(payload["ttl_secs"], LINK_WINDOW_SECS)
+
+    @pytest.mark.asyncio
+    async def test_a_caller_with_nothing_left_is_refused(self, _unrestricted, _quiet_audit) -> None:
+        """An exhausted remaining lifetime refuses BEFORE minting, never rounds
+        up — a floor of one second would let a dead session walk its expiry
+        forward indefinitely, one mint at a time."""
+        expired = _b64url_encode(json.dumps({"session_exp": time.time() - 100}).encode()) + ".sig"
+        with _machine():
+            with patch.object(tailnet_mobile, "generate_token") as mint:
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=expired)
+                )
+        assert resp.status == 403
+        assert b"caller_session_expired" in resp.body
+        mint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_caller_expiring_during_a_slow_body_read_is_refused(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """The bounds are read AFTER every awaited step, so a stale snapshot
+        cannot authorize the mint. A client controls how long ``request.json()``
+        takes (it can trickle the body byte by byte), so a remaining-lifetime
+        snapshot taken before that await would let a session in its last
+        seconds stretch the mint past its own expiry — the wall clock moves
+        while the handler waits, the snapshot does not."""
+        caller = _owner_session_token(ttl_seconds=60)
+        req = _request(tailnet_host=_HOST, cookie_token=caller)
+        clock = patch(
+            "kiro_crew.dashboard.handlers._shared.time.time",
+            return_value=time.time() + 120,
+        )
+
+        async def _slow_body():
+            # The caller's session expires while the body trickles in: from
+            # here on, the shared helper's clock reads past ``session_exp``.
+            clock.start()
+            return {}
+
+        req.json = _slow_body
+        try:
+            with _machine():
+                with patch.object(tailnet_mobile, "generate_token") as mint:
+                    resp = await tailnet_mobile.api_tailnet_mobile_qr(req)
+        finally:
+            clock.stop()
+        assert resp.status == 403
+        assert b"caller_session_expired" in resp.body
+        mint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unbounded_owner_session_is_unaffected(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """The ordinary case must not regress: a full-length owner session mints
+        the configured default shape at the default TTL."""
+        from kiro_crew.dashboard.boot_id import current_boot_id
+
+        captured: dict[str, object] = {}
+        resp = await self._mint(captured, cookie_token=_owner_session_token())
+        assert resp.status == 200
+        assert captured["extra"] == {"boot": current_boot_id()}
+        assert captured["ttl"] == tailnet_mobile.DEFAULT_QR_TTL_SECS
+
+    @pytest.mark.asyncio
+    async def test_a_callers_boot_claim_is_carried_verbatim(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Carried, never re-derived — the same rule the link→session exchange
+        follows, so a bound is copied from the credential that authorized the
+        mint rather than re-invented from process state."""
+        captured: dict[str, object] = {}
+        resp = await self._mint(
+            captured, cookie_token=_owner_session_token(boot="boot-from-caller")
+        )
+        assert resp.status == 200
+        extra = captured["extra"]
+        assert isinstance(extra, dict) and extra["boot"] == "boot-from-caller"
+
+    @pytest.mark.asyncio
+    async def test_bounds_come_from_the_query_token_not_a_stray_cookie(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Bounds must be read from the credential the middleware validated. It
+        prefers ``?token=`` over the cookie, so a bounded query token beside a
+        permissive (unverified, attacker-settable) cookie must still bound the
+        mint — reading the cookie first would drop ``no_refresh`` and raise the
+        TTL ceiling back to the maximum."""
+        captured: dict[str, object] = {}
+        resp = await self._mint(
+            captured,
+            query_token=_owner_session_token(ttl_seconds=600, no_refresh="1"),
+            cookie_token=_owner_session_token(),
+        )
+        assert resp.status == 200
+        extra = captured["extra"]
+        assert isinstance(extra, dict) and extra["no_refresh"] == "1"
+        assert isinstance(captured["ttl"], int) and captured["ttl"] <= 600
 
 
 class TestRestrictedSessionRefused:

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -204,6 +204,41 @@ def test_session_exp_still_valid_after_link_window() -> None:
     assert uid == "user6b"
 
 
+def test_link_window_never_outlives_a_short_session() -> None:
+    """The link-click window clamps to the session TTL, never exceeds it.
+
+    The query-param path validates against ``exp`` alone (the nonce set is
+    membership-only), so an uncapped 5-minute window would let the raw link
+    keep authenticating after ``session_exp`` passed. A token whose session
+    lifetime was capped by its caller's own bounds (the mobile-link and
+    tailnet-QR mints lend the caller's remaining lifetime) would then outlive
+    the session that authorized it by up to the full window — the residual
+    half of the laundering those mints exist to prevent.
+    """
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        token = generate_token("user6c", ttl_seconds=60)
+    # Past the short session but still inside the nominal 5-minute window:
+    # the LINK path must refuse too, not just the cookie path.
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0 + 61
+        link_valid, _, link_reason = validate_token(token)
+        cookie_valid, _, _ = validate_token(token, use_session_exp=True)
+    assert link_valid is False
+    assert "expired" in link_reason
+    assert cookie_valid is False
+    # A full-length session keeps the whole window: the clamp only ever
+    # tightens, so ordinary links are unaffected.
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        long_token = generate_token("user6d", ttl_seconds=3600)
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0 + 299
+        valid, uid, _ = validate_token(long_token)
+    assert valid is True
+    assert uid == "user6d"
+
+
 def test_tampered_token_rejected() -> None:
     token = generate_token("user7")
     tampered = token[:-1] + ("A" if token[-1] != "A" else "B")


### PR DESCRIPTION
## Problem / Motivation

The tailnet QR mint (`POST /api/tailnet/mobile/qr`) issues a boot-bound, refresh-chained credential without reading the calling session's own bounds. Its guard gates only on app-token, owner, and restricted-slot, so a deliberately bounded owner session (`no_refresh`, or a short remaining `session_exp`) still passes and mints a credential that outlives the session that authorized it — silently laundering a bounded session into an unbounded one on another device.

The sibling mobile-link surface (`auth_mobile.py`) already establishes the correct invariant via `_caller_bounds`; the QR surface was the remaining gap. Behind `tailscale serve` every request reaches the gateway from 127.0.0.1, so the token cannot be device-pinned — its own bounds are the only limit that holds, making this gap more load-bearing on the QR surface, not less.

## Why it matters

An operator who deliberately bounds a session (an incognito-adjacent short session, or a `no_refresh` grant that must end) trusts that bound. One POST from that session used to trade it for a boot-bound, refresh-chained phone credential — the exact escalation the bounds exist to prevent, on the surface where no device pinning can catch it.

## What changed (motivation → approach → change)

Symptom → root cause: the QR mint never read the caller's own token bounds; it derived claims purely from config/machine state (`boot`/`no_refresh` shape) and clamped TTL only by endpoint and global ceilings.

Change: the `_caller_bounds` helper moves verbatim from `auth_mobile.py` to `handlers/_shared.py` so both mint surfaces read the caller's bounds through one implementation and cannot drift. The QR mint now:
- refuses outright (403, machine-readable `code: caller_session_expired`, audited before any mint) when the caller has no lifetime left to lend;
- clamps the QR TTL by the caller's remaining `session_exp` alongside the existing endpoint and global ceilings;
- merges the caller's carried claims (`boot` verbatim, `no_refresh`) over the configured token shape, so the phone session never grows a refresh chain or boot scope its authorizing session did not have.

Closing the bound on the mint surfaces exposed a residual in `generate_token` itself: `exp` (the link-click window) was pinned at the full five minutes regardless of the session TTL, and the query-param path validates against `exp` alone with a membership-only nonce check — so a caller lending less than the window would mint a link that kept authenticating requests after the session it granted had expired. The window now clamps to the session TTL (`exp` never exceeds `session_exp`), which only ever tightens: any TTL at or above the window is byte-identical to before. The responses that surface the window (`expires_in` on the mobile link, `link_window_secs` on the QR) report the clamped live value rather than the constant, so the UI countdown never promises minutes the link does not have. In the QR handler the bounds read, refusal, and clamp sit after every awaited step (the request body read and the config load), immediately before the mint — the remaining lifetime is a wall-clock snapshot, and a client that trickles the request body controls how long the handler waits, so an early snapshot would let a session in its last seconds stretch the mint past its own expiry.

## Tests

New `TestQrCallerBounds` in `test/test_tailnet_mobile.py`, mirroring the mobile-link coverage:
- a `no_refresh` caller mints a `no_refresh` credential (the laundering this gate closes);
- a short-lived caller caps the QR TTL below the default;
- a caller with nothing left to lend is refused **before** minting (`generate_token` never called);
- an unbounded owner session is unaffected (default shape, default TTL — no regression);
- a caller's `boot` claim is carried verbatim, never re-derived;
- bounds are read from the query token the middleware validated, not an unverified cookie.

New `test_link_window_never_outlives_a_short_session` in `test/test_token_auth.py` locks the `exp` clamp: the link path refuses after a short `session_exp` passes, and a full-length session keeps the whole window. `test_mobile_link_reports_the_live_window_for_a_short_caller` and `test_the_reported_link_window_never_exceeds_the_lent_ttl` lock the reported window to the minted token's actual click window on both surfaces. All new tests are mutation-verified (each fails with its half of the fix reverted). `test_mobile_login_link.py` retargets its `time` patch to the helper's new module.

## Manual verification

N/A — unit coverage sufficient: the handler is exercised end-to-end through the same in-memory request stub the existing QR suite uses, and the invariant is asserted on the exact claims/TTL handed to `generate_token`.

## Related Issues

Closes #6033

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented in docstrings/comments at the change sites
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (dashboard handlers + token auth); no rendered pixel changes.
