### PR TITLE
fix: strip YAML frontmatter from prompt mention expansion (#6164)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -1036,7 +1036,6 @@ test/test_project_alias.py
 test/test_project_git.py
 test/test_project_git_status_log.py
 test/test_prompt_timeout_follows_ceiling.py
-test/test_prompts.py
 test/test_provider_dispatch.py
 test/test_publish_feed_contract.py
 test/test_publish_providers.py

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -2770,6 +2770,47 @@ def _schedule_widget_registration(
         image_task.add_done_callback(state._background_tasks.discard)
 
 
+def _strip_yaml_frontmatter(content: str) -> str:
+    """Strip a leading YAML frontmatter block from prompt/SOP *content*.
+
+    Frontmatter carries display metadata (title, description) for the prompt
+    library UI; only the body is meant to reach the model, so injecting the
+    block would leak that metadata into the agent turn. Recognized only when
+    the first line is exactly ``---`` (an optional UTF-8 BOM is tolerated) and
+    removed through the next line that starts with ``---`` or is exactly
+    ``...``, plus any blank lines that follow the terminator. Deliberately
+    line-based — no YAML parser — so untrusted prompt files are never parsed,
+    and fail-open: with no terminator the whole file is treated as body and
+    returned unchanged rather than silently dropping content on malformed
+    frontmatter.
+
+    A fence LOCATOR, not a field parser — deliberately outside
+    ``kiro_crew.frontmatter`` (same stance as ``SkillsLoader.strip_frontmatter``).
+    The grammar that DECIDES what the prompt library shows as frontmatter is
+    ``frontmatter._COLUMN0_BLOCK_RE`` (the ``column0_fence`` extraction, reached
+    via ``_extract_sop_description`` → ``SkillsLoader._parse_frontmatter``),
+    whose closer only has to start with ``---`` — so this closer test mirrors
+    that, or a ``--- `` / ``---junk`` closer would display as metadata yet be
+    injected verbatim, reintroducing the leak. Editing either grammar means
+    revisiting the other. This locator strips a superset on purpose (BOM/CRLF
+    openers, a ``...`` closer): where the two disagree, erring toward stripping
+    withholds display metadata from the model, never body the UI treats as
+    content.
+    """
+    text = content.removeprefix("\ufeff")
+    lines = text.split("\n")
+    if not lines or lines[0].rstrip("\r") != "---":
+        return content
+    for idx in range(1, len(lines)):
+        probe = lines[idx].rstrip("\r").rstrip()
+        if probe.startswith("---") or probe == "...":
+            body_start = idx + 1
+            while body_start < len(lines) and not lines[body_start].strip():
+                body_start += 1
+            return "\n".join(lines[body_start:])
+    return content
+
+
 def _expand_prompt_mention(
     message: str,
     state: DashboardState,
@@ -2814,6 +2855,10 @@ def _expand_prompt_mention(
         )
         return message, "too_large"
     content = raw.decode("utf-8", errors="replace")
+    # Strip display-metadata frontmatter BEFORE redaction and the char count,
+    # so both the redaction pass and the user-visible "Loaded prompt … chars"
+    # line operate on exactly what the agent receives.
+    content = _strip_yaml_frontmatter(content)
 
     content, _ = redact_credentials(content)
     content, _ = redact_exfiltration_urls(content)

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -28,6 +28,7 @@ def _isolate_home(tmp_path, monkeypatch):
     monkeypatch.setattr("kiro_crew.agent._project_dir", lambda: None)
     # Clear prompt cache between tests
     import kiro_crew.dashboard.handlers as h
+
     h._prompt_cache = None
     h._prompt_cache_ts = 0
 
@@ -87,11 +88,16 @@ def _aim_pkg(base, pkg_name, event_id, sops):
 
 
 def _user_prompt(tmp_path, name, content="# Placeholder"):
-    """Create a user prompt in ~/.kiro/prompts/."""
+    """Create a user prompt in ~/.kiro/prompts/.
+
+    Written byte-faithfully (UTF-8, no newline translation): the frontmatter
+    tests assert exact line endings and a BOM, and Windows' default text mode
+    would rewrite ``\\n`` to ``\\r\\n`` and choke on the BOM under cp1252.
+    """
     d = tmp_path / ".kiro" / "prompts"
     d.mkdir(parents=True, exist_ok=True)
     p = d / f"{name}.md"
-    p.write_text(content)
+    p.write_text(content, encoding="utf-8", newline="")
     return p
 
 
@@ -126,13 +132,18 @@ class _State:
 
     def __init__(self):
         self.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
-        self.sessions = type('_MockSessions', (), {
-            'get_slack_link': lambda self, k: ('', ''),
-            'set_slack_link': lambda self, k, t, c: None,
-            'get_or_create': None, 'get_pid': lambda self, k: None,
-            'set_approval_policy': lambda self, k, v: None,
-            'check_context_usage': lambda self, k, c: None,
-        })()
+        self.sessions = type(
+            "_MockSessions",
+            (),
+            {
+                "get_slack_link": lambda self, k: ("", ""),
+                "set_slack_link": lambda self, k, t, c: None,
+                "get_or_create": None,
+                "get_pid": lambda self, k: None,
+                "set_approval_policy": lambda self, k, v: None,
+                "check_context_usage": lambda self, k, c: None,
+            },
+        )()
 
     def push_slots_update(self):
         pass
@@ -183,13 +194,21 @@ class TestExtractSopDescription:
 
 class TestListAimPrompts:
     def test_discovers_sops(self, aim_dir):
-        _aim_pkg(aim_dir, "Pkg-1.0", "1", {
-            "my-sop": "---\nname: my-sop\ndescription: Test SOP\n---\n",
-        })
+        _aim_pkg(
+            aim_dir,
+            "Pkg-1.0",
+            "1",
+            {
+                "my-sop": "---\nname: my-sop\ndescription: Test SOP\n---\n",
+            },
+        )
         r = _list_aim_prompts()
         assert len(r) == 1
         assert (r[0]["name"], r[0]["fullName"], r[0]["source"]) == (
-            "my-sop", "agent-sop:my-sop", "package")
+            "my-sop",
+            "agent-sop:my-sop",
+            "package",
+        )
         assert r[0]["description"] == "Test SOP"
         assert r[0]["package"] == "Pkg-1.0"
 
@@ -224,9 +243,7 @@ class TestListAimPrompts:
         # Default seam ([], the OSS behavior) → no package SOPs discovered.
         from kiro_crew.platform.defaults import DefaultPromptSourceProvider
 
-        monkeypatch.setattr(
-            DefaultPromptSourceProvider, "prompt_source_roots", lambda self: []
-        )
+        monkeypatch.setattr(DefaultPromptSourceProvider, "prompt_source_roots", lambda self: [])
         assert _list_aim_prompts() == []
 
     def test_name_collision(self, aim_dir):
@@ -312,6 +329,98 @@ class TestExpandPromptMention:
         _user_prompt(tmp_path, "huge", "x" * 200_000)
         msg, status = _expand_prompt_mention("@huge", _State(), _Slot())
         assert status == "too_large"
+
+
+# ── YAML frontmatter stripping ──
+
+
+_FM_BODY = "# Review\nDo the review steps."
+_FM_CONTENT = f"---\ntitle: Review SOP\ndescription: secret display metadata\n---\n\n{_FM_BODY}"
+
+
+class TestFrontmatterStrip:
+    def test_frontmatter_stripped_body_only_injected(self, tmp_path):
+        _user_prompt(tmp_path, "fm", _FM_CONTENT)
+        msg, status = _expand_prompt_mention("@fm", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg
+        assert "secret display metadata" not in msg
+        assert "title: Review SOP" not in msg
+
+    def test_no_frontmatter_unchanged(self, tmp_path):
+        content = "# Plain\nNo frontmatter here.\n"
+        _user_prompt(tmp_path, "plain", content)
+        msg, status = _expand_prompt_mention("@plain", _State(), _Slot())
+        assert status == "ok"
+        assert content in msg
+
+    def test_unterminated_frontmatter_preserved(self, tmp_path):
+        content = "---\ntitle: broken\nno terminator follows\n"
+        _user_prompt(tmp_path, "unterm", content)
+        msg, status = _expand_prompt_mention("@unterm", _State(), _Slot())
+        assert status == "ok"
+        # Fail-open: malformed frontmatter must never drop content.
+        assert content in msg
+
+    def test_char_count_matches_injected_length(self, tmp_path):
+        _user_prompt(tmp_path, "fmcount", _FM_CONTENT)
+        slot = _Slot()
+        msg, status = _expand_prompt_mention("@fmcount", _State(), slot)
+        assert status == "ok"
+        info = next(m[1] for m in slot.messages if "Loaded prompt" in m[1])
+        assert f"({len(_FM_BODY):,} chars)" in info
+
+    def test_dot_terminator(self, tmp_path):
+        _user_prompt(tmp_path, "dots", f"---\ndescription: meta\n...\n{_FM_BODY}")
+        msg, status = _expand_prompt_mention("@dots", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg and "description: meta" not in msg
+
+    def test_utf8_bom_tolerated(self, tmp_path):
+        _user_prompt(tmp_path, "bom", f"\ufeff---\ndescription: meta\n---\n{_FM_BODY}")
+        msg, status = _expand_prompt_mention("@bom", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg and "description: meta" not in msg
+
+    def test_crlf_frontmatter_stripped(self, tmp_path):
+        _user_prompt(tmp_path, "crlf", f"---\r\ndescription: meta\r\n---\r\n{_FM_BODY}")
+        msg, status = _expand_prompt_mention("@crlf", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg and "description: meta" not in msg
+
+    def test_closer_with_trailing_space_stripped(self, tmp_path):
+        # The display-side parser (frontmatter._COLUMN0_BLOCK_RE) accepts a
+        # closer that merely STARTS with "---", so this file shows its
+        # description in the prompt library — the strip must agree, or the
+        # metadata leaks to the model anyway.
+        _user_prompt(tmp_path, "trsp", f"---\ndescription: meta\n--- \n{_FM_BODY}")
+        msg, status = _expand_prompt_mention("@trsp", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg and "description: meta" not in msg
+
+    def test_closer_with_trailing_text_stripped(self, tmp_path):
+        _user_prompt(tmp_path, "trjunk", f"---\ndescription: meta\n---junk\n{_FM_BODY}")
+        msg, status = _expand_prompt_mention("@trjunk", _State(), _Slot())
+        assert status == "ok"
+        assert _FM_BODY in msg and "description: meta" not in msg
+
+    def test_opener_with_trailing_text_not_frontmatter(self, tmp_path):
+        # The opener grammar stays strict (exactly "---"), matching the
+        # display parser's ^---\n opener: "---junk" first lines are body.
+        content = f"---junk\ndescription: meta\n---\n{_FM_BODY}"
+        _user_prompt(tmp_path, "openjunk", content)
+        msg, status = _expand_prompt_mention("@openjunk", _State(), _Slot())
+        assert status == "ok"
+        assert content in msg
+
+    def test_thematic_break_mid_file_untouched(self, tmp_path):
+        # A "---" that is NOT the first line is a markdown thematic break,
+        # never frontmatter.
+        content = "# Doc\n\n---\n\nSection two."
+        _user_prompt(tmp_path, "hr", content)
+        msg, status = _expand_prompt_mention("@hr", _State(), _Slot())
+        assert status == "ok"
+        assert content in msg
 
 
 # ── API handlers ──
@@ -422,7 +531,9 @@ class TestRunChatPrompts:
         asyncio.run(_run_chat(s, sl, "/prompts get agent-sop:secret"))
         assert any("blocked" in m[1].lower() for m in sl.messages)
 
-    @pytest.mark.skip(reason="Broken by chat.py split (6d4e4493) — mock setup needs updating for new _run_chat flow.")
+    @pytest.mark.skip(
+        reason="Broken by chat.py split (6d4e4493) — mock setup needs updating for new _run_chat flow."
+    )
     def test_at_prompt_blocked(self, aim_dir, mock_sel, monkeypatch):
         """@mention prompt blocked at read time by chat-level check."""
         _aim_pkg(aim_dir, "Pkg-1.0", "1", {"secret": "# S"})


### PR DESCRIPTION
## Summary

`@prompt-name` mention expansion read the whole prompt file and injected it verbatim into the agent turn, so prompts and SOPs with a leading YAML frontmatter block leaked display metadata (`title`, `description`, …) to the model alongside the body. Affects hand-authored SOPs today and every prompt the dashboard editor will create once #4634 lands.

Closes #6164

## Change

- New `_strip_yaml_frontmatter` helper beside `_expand_prompt_mention` in `src/kiro_crew/dashboard/chat_runner.py`: recognized only when the first line is exactly `---` (UTF-8 BOM tolerated), removed through the next line that **starts with** `---` or is exactly `...`, plus trailing blank lines. No terminator ⇒ whole file treated as body, injected unchanged (fail-open — malformed frontmatter never silently drops content). Deliberately line-based, **no YAML parser**: untrusted prompt files are never parsed.
- The closer grammar deliberately mirrors the parser that DECIDES what the prompt library displays as frontmatter (`frontmatter._COLUMN0_BLOCK_RE`, reached via `_extract_sop_description` → `SkillsLoader._parse_frontmatter`), whose closer only has to start with `---`. A stricter closer here would let a `--- `/`---junk` closer display as metadata in the UI yet be injected verbatim — reintroducing the leak. Cross-referenced in both docstrings, same fence-locator stance as `SkillsLoader.strip_frontmatter`.
- Strip runs after decode and **before** redaction and the char count, so the user-visible `Loaded prompt … chars` line reports exactly the injected length.
- `chat.py` imports `_expand_prompt_mention` from `chat_runner` — verified single implementation; helper lives beside it.
- `.github/black-baseline.txt`: pruned `test/test_prompts.py` (graduated to black-clean by this change, per the gate's own instruction).

## Bundled-file audit (spec step 4)

- No `*.sop.md` files ship in the repo — the `@mention` path discovers user prompts (`~/.kiro/prompts/`), local project prompts, and edition package SOPs only.
- Bundled `builtin_skills/*/SKILL.md` files DO carry frontmatter, but they load through the `$skill` path (`SkillsLoader`, which already has its own `strip_frontmatter`), not `@prompt` mention — unaffected.
- Conclusion: no bundled prompt/SOP relies on frontmatter reaching the model.

## Pre-push review

- GPT lane (gpt-5.6-sol): PASS, 0 findings.
- Opus lane (claude-opus-5): 1 blocking — original closer test (`exactly ---`) diverged from the display parser's lenient closer, leaving a residual leak for `--- `/`---junk` closers. **Fixed** (closer now `startswith("---")` or `...`) with pinning tests for both closer variants and a strict-opener counter-case.
- Opus advisories dispositioned: (a) "add a named locator to `kiro_crew.frontmatter`" — followed the repo's existing convention instead: fence LOCATORS live beside their caller, deliberately outside the field-parser module (same stance as `SkillsLoader.strip_frontmatter`), with mutual cross-reference docstrings; (b) frontmatter-only file injects an empty body — intentional: re-injecting metadata on an empty body would re-leak; the `(0 chars)` count surfaces it; (c) debug log on large strips — declined, the char-count line already makes the strip visible and a size threshold would add an unowned constant.

## Testing

- `test/test_prompts.py::TestFrontmatterStrip` (11 tests): frontmatter ⇒ body-only injection; no frontmatter ⇒ unchanged; unterminated `---` ⇒ full content preserved; reported char count equals injected length; `...` closer; lenient closers (`--- `, `---junk`); strict opener (`---junk` first line is body); UTF-8 BOM; CRLF; mid-file thematic break untouched.
- Full local gates: isort / flake8 / mypy (1114 files clean) / pytest (`test_prompts.py` + `test_chat_runner_coverage.py` + `test_active_turn_session_key.py` all green; full-suite reds are pre-existing host-environment failures, verified identical with the change stashed) / black gate / brand gate / harness-parity gate / subprocess-encoding gate.
