### PR TITLE
feat(conductor): expose accept_eval and ledger_entry as MCP tools

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -577,7 +577,7 @@ Managed servers, registered by `agent._MANAGED_MCP_SERVERS` and installed into
 | `kirocrew-cron` | `kirocrew mcp-cron` (`mcp_cron.py`) | `cron_add`, `cron_list`, `cron_update`, `cron_remove`, `cron_remove_all`, `cron_pause`, `cron_resume`, `cron_trigger` |
 | `kirocrew-core` | `kirocrew mcp-core` (`mcp_core.py` + `mcp_tools/`) | spawn/subagent, learn, task, messaging, artifact, workflow, knowledge and session-directive tools (see below) |
 | `kirocrew-computer` | `kirocrew mcp-computer` (`mcp_computer.py`) | `computer_list_apps`, `computer_launch_app`, `computer_get_state`, `computer_click`, `computer_drag`, `computer_type_text`, `computer_press_key`, `computer_set_value`, `computer_scroll`, `computer_perform_action`, `computer_end_turn` |
-| `kirocrew-dashboard` | `kirocrew mcp-dashboard` (`mcp_dashboard.py`) | `chat_folder_tree`, `chat_folder_create`, `chat_folder_move`, `chat_folder_move_session` |
+| `kirocrew-dashboard` | `kirocrew mcp-dashboard` (`mcp_dashboard.py`) | `chat_folder_tree`, `chat_folder_create`, `chat_folder_move`, `chat_folder_move_session`, `session_create`, `session_send`, `session_stop`, `session_read_message`, `conductor_accept_eval`, `conductor_ledger_entry` |
 
 CLI commands and their MCP twins:
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4446,9 +4446,10 @@ file-writing tool, and a work item never goes to `spawn_run`,
 dispatch, verify and report on.
 
 **Acceptance is the evaluator's verdict, never your reading of a child's
-transcript.** Shell access exists to run the `goal-conductor` skill's two
-bundled scripts: `scripts/accept_eval.py` for acceptance verdicts,
-`scripts/ledger_entry.py` for the ledger's item-entry format.
+transcript.** The verdict comes from the `conductor_accept_eval` MCP tool (the
+deterministic evaluator), and the ledger's item-entry format is owned by
+`conductor_ledger_entry` (the codec). Both are auto-approved on your grant
+list, so patrol never blocks on an approval for them.
 
 **Patrol with `monitor_start`, never with `wait`.** Arm it with the full cycle
 instructions AND the exit condition, then end the turn; call `autonudge_stop`
@@ -4575,6 +4576,8 @@ _CONDUCTOR_DASHBOARD_GRANTS: tuple[str, ...] = (
     "@kirocrew-dashboard/chat_folder_create",
     "@kirocrew-dashboard/session_create",
     "@kirocrew-dashboard/session_read_message",
+    "@kirocrew-dashboard/conductor_accept_eval",
+    "@kirocrew-dashboard/conductor_ledger_entry",
 )
 
 
@@ -4583,15 +4586,16 @@ def _install_conductor_agent() -> None:
 
     Derives from the kirocrew agent (resolved MCP invocations, security hooks)
     but narrows to the conductor's charter: session control + core tools +
-    shell for the bundled skill scripts (acceptance evaluator + ledger entry
-    codec), and **no tool that can write a
+    the bundled evaluator and codec as MCP tools (acceptance evaluator +
+    ledger entry codec via ``conductor_accept_eval`` and
+    ``conductor_ledger_entry``), and **no tool that can write a
     file** — not ``fs_write``, and not ``code`` either, which governance classes
     under ``filesystem.write`` because it writes files and can shell out. That
     is what makes "never does a work item's work itself" a property of the spec
     rather than of the prompt. The ``kirocrew-dashboard`` server is the opt-in
-    per-agent set (folder + session-control tools); this installer granting it IS
-    the explicit per-agent assignment that set requires — it is deliberately
-    absent from the default agent's spec.
+    per-agent set (folder + session-control tools + conductor tools); this
+    installer granting it IS the explicit per-agent assignment that set
+    requires — it is deliberately absent from the default agent's spec.
 
     ``@kirocrew-dashboard`` is MOUNTED whole but auto-approved only verb by verb,
     via ``_CONDUCTOR_DASHBOARD_GRANTS`` (see its comment for the per-verb
@@ -4610,11 +4614,13 @@ def _install_conductor_agent() -> None:
     ingests untrusted content by design and the server-side gates bound which
     target is reachable, not what is done to it.
 
-    ``execute_bash`` is withheld for a different reason that is worth keeping
-    distinct: ``allowedTools`` is name-scoped with no argument matching, so
-    trusting the two bundled scripts cannot be told apart from trusting arbitrary
-    shell. There is no per-argument form of that grant the way there is a per-tool
-    form of the MCP one.
+    ``conductor_accept_eval`` and ``conductor_ledger_entry`` are granted because
+    they satisfy the invariant: the evaluator reads and computes (no mutation of
+    user-visible state), and the ledger codec encodes/validates/rotates entry
+    values (creates new values, never mutates existing user-visible state). They
+    replace the prior ``execute_bash`` approach where ``allowedTools`` had no
+    argument matching and trusting the two bundled scripts could not be told
+    apart from trusting arbitrary shell.
 
     The operating procedure ships as the ``goal-conductor`` builtin skill, NOT
     ``conductor``: that skill name is owned by the generated delegation skill
@@ -4633,7 +4639,6 @@ def _install_conductor_agent() -> None:
     )
     config["prompt"] = _CONDUCTOR_SYSTEM_PROMPT
     config["tools"] = [
-        "execute_bash",
         "fs_read",
         # ``web_fetch`` serves the charter's own worked example (reading an issue
         # list during triage). Deliberately NOT mounted: ``web_search`` (nothing
@@ -4668,10 +4673,12 @@ def _install_conductor_agent() -> None:
     # state, or reach the machine — and it is bounded by the mounted catalog.
     # Withholding it made the ONE call that unblocks every deferred
     # session-control tool prompt first, so an unattended patrol cycle stalled
-    # on the load rather than on the work. ``execute_bash`` stays withheld for
-    # the reason recorded above it: ``allowedTools`` has no argument matching,
-    # so trusting the two bundled scripts cannot be told apart from trusting
-    # arbitrary shell.
+    # on the load rather than on the work. ``execute_bash`` is not withheld here
+    # because it is no longer MOUNTED at all: the reason recorded above it —
+    # ``allowedTools`` has no argument matching, so trusting the two bundled
+    # scripts cannot be told apart from trusting arbitrary shell — is why they
+    # are reached through ``conductor_accept_eval`` / ``conductor_ledger_entry``
+    # instead, which ARE per-tool grantable.
     for ref in (
         "session",
         "report",

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -16,11 +16,11 @@ Your four jobs, none of which can be delegated to a work item:
 
 Everything else belongs in a work item. This spec has **no `fs_write`** — that
 is deliberate. If a task needs a file written, it is a work item, not something
-you do. `execute_bash` IS granted, for exactly one purpose: running this
-skill's bundled scripts — the acceptance evaluator (`scripts/accept_eval.py`)
-and the ledger entry codec (`scripts/ledger_entry.py`). Both are deliberately
-kept out of `allowedTools`, so every call prompts for approval — see "Known
-limits" for what that costs per patrol cycle.
+you do. The acceptance evaluator and ledger entry codec are available as
+individually-grantable MCP tools on the `kirocrew-dashboard` server:
+`conductor_accept_eval` for acceptance verdicts, and `conductor_ledger_entry`
+for the durable ledger item-entry format. Both are auto-approved, so patrol
+never blocks on an approval for them.
 
 ## What is a work item
 
@@ -135,9 +135,9 @@ Then for each item in the round:
    `artifacts`, under an `item-<n>` key — the durable item entry carrying its
    acceptance spec, session key, round, status and read cursor. **Never
    hand-write the entry value: encode it with the bundled codec**
-   (`scripts/ledger_entry.py`, same directory as the evaluator — see "The
-   ledger item-entry codec" below). **Before any dispatch write that would
-   push the map past the entry cap, `rotate` the combined current-plus-new
+   (`conductor_ledger_entry` MCP tool — see "The ledger item-entry codec"
+   below). **Before any dispatch write that would push the map past the
+   entry cap, `rotate` the combined current-plus-new
    map and write THAT back** — the ledger's own cap handling blindly ages out
    the oldest entry, active or not, so the codec must be the thing that
    decides what drops (and a `cap_exceeded_all_active` error means do not
@@ -159,23 +159,24 @@ Each cycle:
    a substitute.
 2. **Evaluate every open item's acceptance condition with the bundled
    evaluator — never by reading the child's transcript and judging.** Build
-   the items JSON from your ledger and run:
+   the items array from your ledger and call:
 
-   ```bash
-   printf '%s' '{"items":[{"id":"item-1","accept":{"kind":"pr_checks","pr":123,"repo":"owner/name"}}]}' \
-     | python3 <this skill's dir>/scripts/accept_eval.py
+   ```
+   conductor_accept_eval(items=[
+     {"id": "item-1", "accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}},
+     ...
+   ])
    ```
 
-   **Resolve `<this skill's dir>` from where this SKILL.md was actually loaded
-   from** — the skill index names its absolute path. Do NOT hardcode
-   `~/.kiro/crew/skills/goal-conductor`: a `KIROCREW_HOME` override moves the
-   skills root, so on such an install that path does not exist and every
-   evaluator call would fail before patrol ever ran.
-
-   Build the items JSON from the `item-*` entries in your ledger's `artifacts`
-   — decode each stored value with the codec (`ledger_entry.py decode`), never
-   by eyeballing the string — and evaluate **every open item in ONE call** —
-   each invocation costs one approval prompt.
+   Build the items array from the `item-*` entries in your ledger's `artifacts`
+   — decode each stored value with the codec (`conductor_ledger_entry` with
+   mode `decode`), never by eyeballing the string — and evaluate **every open
+   item in ONE call, up to the tool's cap of 64 items**. Past 64 the call is
+   rejected by schema validation, so split into consecutive calls of at most 64
+   — the cap yields, not the batching rule, and nothing about a verdict changes
+   when it is split. A round with more than 64 open items is itself the signal
+   to look at: the ledger's own entry cap is the binding limit long before this
+   one, so `rotate` first.
 
    Verdicts: `pass` / `fail` are final for this cycle. `pending` means keep
    waiting. `refused` means the spec asked for something the evaluator will not
@@ -200,20 +201,13 @@ Each cycle:
 3. For items still running, `session_read_message` with the `since` cursor you
    stored last cycle — this answers "is it moving / did it ask a question",
    never "did it succeed". Store the returned `next_since` back into that item's
-   `artifacts` entry (a fresh `ledger_entry.py encode` with the new cursor) —
-   held only in context it is lost on compaction, and the next cycle then
-   re-reads the transcript from the top.
+   `artifacts` entry (a fresh `conductor_ledger_entry` encode with the new
+   cursor) — held only in context it is lost on compaction, and the next cycle
+   then re-reads the transcript from the top.
 4. `session_ledger_record` only what changed — but an item's `artifacts` entry is
    rewritten whole, so include the fields you are not changing.
 5. **Say nothing unless there is a real signal.** An item passing acceptance,
    failing it, asking a question, or stalling. Never post "nothing changed".
-
-**Shell exists for the bundled scripts, not for work.** `execute_bash` is
-granted so patrol can run `accept_eval.py` and `ledger_entry.py`. Running a
-work item's build, test, or fix yourself through it is the boundary violation
-this skill exists to prevent — if you need a command run to MAKE something
-true, that is a work item; the bundled scripts only CHECK and ENCODE what is
-already true.
 
 ### Close the round
 
@@ -282,7 +276,7 @@ What goes where:
   is forbidden anyway — so an acceptance spec that lives only in your context is
   a spec patrol cannot rebuild.
 
-  **The entry format is owned by the bundled codec, `scripts/ledger_entry.py`
+  **The entry format is owned by the bundled codec, `conductor_ledger_entry`
   — never hand-write or hand-parse a value.** See "The ledger item-entry
   codec" below for the four operations. Record the entry in the same
   `session_ledger_record` call that marks the item dispatched, and rewrite it
@@ -292,22 +286,27 @@ What goes where:
 
 ## The ledger item-entry codec
 
-`scripts/ledger_entry.py` (same directory as the evaluator — resolve it the
-same way) is the single owner of the item-entry format. It exists because the
-two failure modes it prevents are silent: the ledger's `artifacts` field is a
-map of string to STRING — a nested object is rejected with
-`artifacts_not_string_map` and **nothing persists** — and an oversized value is
-silently TRUNCATED at the ledger's cap, corrupting the stored JSON. The codec
-knows the ledger's real bounds and refuses before the write instead.
+`conductor_ledger_entry` is the MCP tool interface to the ledger entry codec
+(backed by `scripts/ledger_entry.py` in this skill's directory). It is the
+single owner of the item-entry format. It exists because the two failure modes
+it prevents are silent: the ledger's `artifacts` field is a map of string to STRING — a nested object is rejected with `artifacts_not_string_map` and
+**nothing persists** — and an oversized value is silently TRUNCATED at the
+ledger's cap, corrupting the stored JSON. The codec knows the ledger's real
+bounds and refuses before the write instead.
 
-Every mode reads JSON on stdin and writes JSON on stdout; domain problems come
-back as `{"ok": false, "error": {...}}`, never a crash:
+Every mode takes a `payload` object and returns a structured result; domain
+problems come back as `{"ok": false, "error": {...}}`, never crashes:
 
 - **encode** — fields in, the single-line string value out:
 
-  ```bash
-  printf '%s' '{"accept":{"kind":"pr_checks","pr":123,"repo":"o/r"},"session":"<session key>","round":2,"status":"running","since":"<next_since cursor>"}' \
-    | python3 <this skill's dir>/scripts/ledger_entry.py encode
+  ```
+  conductor_ledger_entry(mode="encode", payload={
+    "accept": {"kind": "pr_checks", "pr": 123, "repo": "o/r"},
+    "session": "<session key>",
+    "round": 2,
+    "status": "running",
+    "since": "<next_since cursor>"
+  })
   ```
 
   Put the returned `value` under the `item-<n>` key. `since` is optional.
@@ -343,9 +342,8 @@ back as `{"ok": false, "error": {...}}`, never a crash:
   untouched active entries oldest in the age-out order and make `dropped`
   meaningless. This is the one place "write only deltas" does not apply.
 
-Batch your codec calls like evaluator calls — each invocation costs one
-approval prompt, so one `rotate` (or one `validate` of the whole map) per
-cycle beats one call per item.
+Both `conductor_accept_eval` and `conductor_ledger_entry` are auto-approved on
+the conductor's grant list, so calling them never blocks on an approval prompt.
 
 ## Cost discipline
 
@@ -365,21 +363,18 @@ watches, and that cost grows with the loop's own history.
   If you see that error, say which switch to flip; do not retry.
 - **Reads and creates do not prompt; anything that touches another session does.**
   Auto-approved by name: `chat_folder_tree`, `chat_folder_create`,
-  `session_create`, `session_read_message` — so a patrol cycle that wakes on a
-  nudge with nobody at the keyboard never blocks. **`chat_folder_move_session`,
+  `session_create`, `session_read_message`, `conductor_accept_eval`,
+  `conductor_ledger_entry` — so a patrol cycle that wakes on a nudge with nobody
+  at the keyboard never blocks. **`chat_folder_move_session`,
   `session_send` and `session_stop` are deliberately NOT auto-approved**, because
   each writes to a session that is not yours: filing rewrites another session's
   folder, a seed runs as the target's own turn, and a stop discards the target's
   in-flight work. You ingest external content by design, so the prompt is the only
   call-time check on all three. Expect an approval per item at dispatch (one to
   file it, one to seed it) and one if you ever stop an item — all of which happen
-  right after the user approved a plan, not mid-patrol. `execute_bash` also still
-  prompts, so **each patrol cycle blocks on one approval for the
-  `accept_eval.py` invocation** plus one per codec call. Size the nudge interval
-  for that, and batch: one evaluator call per cycle carrying every open item, one
-  codec call per map-wide operation. On a host with a governance ceiling even the
-  granted verbs prompt; if you see approvals where this says you should not, that
-  is why.
+  right after the user approved a plan, not mid-patrol. On a host with a
+  governance ceiling even the granted verbs prompt; if you see approvals where
+  this says you should not, that is why.
 - **`session_send` reports delivery, not completion.** `started: true` means the
   target began a turn on your message; `started: false` means it queued. Neither
   says the work succeeded — acceptance is still the domain assertion's job.
@@ -387,17 +382,36 @@ watches, and that cost grows with the loop's own history.
   app-scoped sessions, channel-linked or mirrored sessions, crew-mode sessions,
   and sessions in another workspace are all refused by the shared guard. Plan
   work items onto plain persistent dashboard sessions only.
-- **Shell is for the bundled scripts only, and the evaluator runs no command
-  you name.** `execute_bash` exists so patrol can run `accept_eval.py` and
-  `ledger_entry.py` (the codec runs no subprocess at all — it only transforms
-  JSON); every call is audit-logged and every call prompts. The evaluator
-  accepts **no command, argv array, or shell string from a spec** — it builds
-  every argv it runs from a fixed template, so `pr_checks` becomes `gh pr
-  checks <n>` and nothing else executes. That is deliberate and load-bearing:
-  this script is invoked as an approved wrapper, so a spec that could name a
-  command would turn it into a general way to run one, and Kiro Crew's
-  denied-command floor cannot see inside it (the floor reads the
-  `execute_bash` string, which says `python3 accept_eval.py`). Widening
-  happens by adding a purpose-built kind that constructs its own argv — never
-  by accepting one. A `refused` verdict is a spec to re-express, never a list
-  to route around.
+- **The evaluator runs no command you name.** The evaluator accepts **no command,
+  argv array, or shell string from a spec** — it builds every argv it runs from
+  a fixed template, so `pr_checks` becomes `gh pr checks <n>` and nothing else
+  executes. That is deliberate and load-bearing: a spec that could name a command
+  would turn the evaluator into a general way to run one. Widening happens by
+  adding a purpose-built kind that constructs its own argv — never by accepting
+  one. A `refused` verdict is a spec to re-express, never a list to route around.
+- **`conductor_accept_eval` being auto-approved means its outward-reaching fields
+  are bounded in band instead.** No approval prompt fires on this door, and the
+  spec's fields arrive nested where the gate's argument classifier cannot see
+  them, so nothing upstream checks them at call time. What this door therefore
+  requires, all of it a spec to re-express rather than a limit to route around:
+  - `file.path` must be **absolute** — a relative path would resolve against the
+    MCP server's directory, not your session's.
+  - `file.path` must sit **inside the project or workspace root**. A work item's
+    output lives there; `/etc/hosts` and `~/.ssh/*` are not reachable from here at
+    all, and a sensitive path or an untrusted UNC host is `refused` by the same
+    filesystem gate the dashboard's own file I/O uses. The verdict reports the
+    canonical, symlink-resolved path that was actually checked.
+  - The existence probe is **descriptor-pinned**: if a directory on the way to the
+    path turns into a symbolic link between the check and the probe, the answer is
+    `refused`, not an answer about wherever the link now points. On a platform that
+    cannot pin a walk at all, the `file` kind is `refused` outright — use a
+    `pr_checks` condition there.
+  - `exists` must be a real JSON **boolean**. `"false"` is a non-empty string, so
+    accepting it would silently invert your verdict; it is an `error` instead.
+  - `pr_checks.repo` is **required**, as `owner/name` in a safe charset. Omitting
+    it would let `gh` pick the repository from the server process's directory and
+    hand you a confident verdict about the wrong repo; the charset bound is
+    because `gh` runs with the operator's ambient credentials.
+  - `gh` itself is resolved to a trusted absolute path and spawned through the
+    app's audited chokepoint, so a `gh` planted in a tree you can write cannot be
+    the one that runs.

--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py
@@ -94,13 +94,40 @@ def _tail(text: str) -> str:
     return text[-EVIDENCE_TAIL_CHARS:] if len(text) > EVIDENCE_TAIL_CHARS else text
 
 
-def _run(argv, cwd=None):
+def _spawn_direct(argv, timeout, cwd=None):
+    """Spawn a script-built argv directly, as the CLI door always has."""
+    return subprocess.run(  # noqa: S603 - argv array, no shell, script-built
+        [str(a) for a in argv],
+        cwd=cwd or None,
+        capture_output=True,
+        text=True,
+        # Pin the decode instead of inheriting the locale: on Windows the
+        # default is the ANSI code page, which mangles a check's UTF-8
+        # output, and `errors="replace"` keeps genuinely undecodable bytes
+        # from raising - a check's OUTPUT must never turn its verdict into a
+        # crash, since the evidence is only ever read by a human.
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+    )
+
+
+def _run(argv, cwd=None, spawn=None):
     """Run one SCRIPT-BUILT check without a shell; return (verdict, evidence).
 
     Every caller must pass an argv it constructed itself. The guard below is an
     internal invariant, not a spec gate: reaching it with something outside
     ``_SELF_BUILT_COMMANDS`` means a handler leaked spec input into an exec path,
     so it refuses rather than runs.
+
+    ``spawn`` is the injection point for a caller reaching this script through a
+    door that is NOT the ``execute_bash`` approval prompt: the argv is built
+    here and the LOGICAL name is asserted here, but such a caller may need the
+    binary resolved to a trusted absolute path and the child spawned through an
+    audited chokepoint. Only the spawn is injectable -- the verdict mapping
+    below (exit 0 = pass, gh's exit 8 = pending, timeout/OSError = error) stays
+    the single spelling of what an exit code MEANS, so both doors classify the
+    same result identically. It defaults to :func:`_spawn_direct`.
     """
     raw = str(argv[0])
     if raw not in _SELF_BUILT_COMMANDS:
@@ -110,20 +137,7 @@ def _run(argv, cwd=None):
             "no spec field may name a command",
         )
     try:
-        proc = subprocess.run(  # noqa: S603 - argv array, no shell, script-built
-            [str(a) for a in argv],
-            cwd=cwd or None,
-            capture_output=True,
-            text=True,
-            # Pin the decode instead of inheriting the locale: on Windows the
-            # default is the ANSI code page, which mangles a check's UTF-8
-            # output, and `errors="replace"` keeps genuinely undecodable bytes
-            # from raising - a check's OUTPUT must never turn its verdict into a
-            # crash, since the evidence is only ever read by a human.
-            encoding="utf-8",
-            errors="replace",
-            timeout=TIMEOUT_SECS,
-        )
+        proc = (spawn or _spawn_direct)(argv, TIMEOUT_SECS, cwd)
     except subprocess.TimeoutExpired:
         return ("error", f"timed out after {TIMEOUT_SECS}s")
     except FileNotFoundError:
@@ -138,7 +152,21 @@ def _run(argv, cwd=None):
     return ("fail", f"exit {proc.returncode}: {output}")
 
 
-def _evaluate(item):
+def _exists_direct(path):
+    """Answer "is it there" by name, as the CLI door always has."""
+    return Path(path).exists()
+
+
+def _evaluate(item, spawn=None, exists=None):
+    """Evaluate one acceptance spec.
+
+    ``spawn`` and ``exists`` are the two injection points for a caller reaching
+    this script through a door that is NOT the ``execute_bash`` approval prompt.
+    The kind dispatch, the argv construction and the verdict vocabulary all stay
+    here -- only HOW the check touches the machine is replaceable, because a door
+    with no prompt in front of it needs a trusted binary and a descriptor-pinned
+    probe where the CLI door was content with a PATH lookup and a name.
+    """
     accept = item.get("accept") or {}
     kind = accept.get("kind")
     if kind == "pr_checks":
@@ -151,13 +179,23 @@ def _evaluate(item):
         repo = accept.get("repo")
         if repo:
             argv += ["--repo", str(repo)]
-        return _run(argv)
+        return _run(argv, spawn=spawn)
     if kind == "file":
         path = accept.get("path")
         if not isinstance(path, str) or not path:
             return ("error", "file spec needs a path")
-        want = bool(accept.get("exists", True))
-        have = Path(path).exists()
+        want = accept.get("exists", True)
+        # NOT bool(...): `{"exists": "false"}` is a truthy string, so coercing
+        # would silently invert the verdict and report the OPPOSITE of what the
+        # spec asked. A spec's own type error must never become a confident
+        # wrong answer, so it is an error verdict instead.
+        if not isinstance(want, bool):
+            return (
+                "error",
+                "file spec's 'exists' must be true or false (JSON boolean), got "
+                f"{type(want).__name__}",
+            )
+        have = (exists or _exists_direct)(path)
         verdict = "pass" if have == want else "fail"
         return (verdict, f"{path} {'exists' if have else 'does not exist'}")
     if kind == "human_approval":
@@ -176,14 +214,19 @@ def _evaluate(item):
     return ("error", f"unknown accept kind {kind!r}")
 
 
-def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-        items = payload["items"]
-        assert isinstance(items, list)
-    except Exception:
-        print(json.dumps({"error": 'stdin must be JSON: {"items": [...]}'}))
-        return 2
+def evaluate_items(items, evaluate=None):
+    """Evaluate a batch of work items into a list of result dicts.
+
+    ``evaluate`` is the per-item callable, defaulting to ``_evaluate``. It is
+    injectable so a caller reaching this script through a different, already
+    auto-approved door -- the ``conductor_accept_eval`` MCP tool, which does not
+    pass through the ``execute_bash`` prompt this script's invariant assumes --
+    can wrap the per-item handler with its own in-band gate WITHOUT copying this
+    loop. The loop is the one spelling of the per-item contract (guard, id
+    fallback, "one bad spec must not hide the rest"), so it must not be
+    duplicated by any caller.
+    """
+    handler = evaluate or _evaluate
     results = []
     for position, item in enumerate(items):
         # ID extraction happens INSIDE the guard. A non-object entry
@@ -197,11 +240,22 @@ def main() -> int:
             if not isinstance(item, dict):
                 raise TypeError(f"item must be a JSON object, got {type(item).__name__}")
             item_id = str(item.get("id", item_id))
-            verdict, evidence = _evaluate(item)
+            verdict, evidence = handler(item)
         except Exception as exc:  # one bad spec must not hide the rest
             verdict, evidence = "error", f"evaluator bug on this item: {exc}"
         results.append({"id": item_id, "verdict": verdict, "evidence": evidence})
-    print(json.dumps({"results": results}, indent=2))
+    return results
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        items = payload["items"]
+        assert isinstance(items, list)
+    except Exception:
+        print(json.dumps({"error": 'stdin must be JSON: {"items": [...]}'}))
+        return 2
+    print(json.dumps({"results": evaluate_items(items)}, indent=2))
     return 0
 
 

--- a/src/kiro_crew/conductor_scripts.py
+++ b/src/kiro_crew/conductor_scripts.py
@@ -1,0 +1,288 @@
+"""Bridge to the goal-conductor's bundled skill scripts.
+
+The acceptance evaluator (``accept_eval.py``) and ledger entry codec
+(``ledger_entry.py``) are standalone scripts that live in the skill dir.
+This module exposes their entry-point functions for the MCP tool handlers in
+``mcp_dashboard.py``, loading them once by file location at import time.
+
+The scripts remain the canonical implementation and continue to work as CLI
+scripts; this module simply lets the MCP layer call into them without
+subprocess overhead, and adds the in-band gate that the auto-approved MCP door
+needs but the ``execute_bash`` door got from its own approval prompt (see
+``_gate_accept``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Tuple
+
+from kiro_crew import github_runner, hooks, pinned_fs
+from kiro_crew.skills import _within_any
+
+_SKILL_DIR = Path(__file__).parent / "builtin_skills" / "goal-conductor" / "scripts"
+
+
+def _load_script(name: str, filename: str) -> ModuleType:
+    """Load a skill script by file path without writing bytecode."""
+    path = _SKILL_DIR / filename
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    prev = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = prev
+    return module
+
+
+# Lazy-loaded module references (populated on first call).
+_accept_eval: ModuleType | None = None
+_ledger_entry: ModuleType | None = None
+
+
+def _get_accept_eval() -> ModuleType:
+    global _accept_eval
+    if _accept_eval is None:
+        _accept_eval = _load_script("_conductor_accept_eval", "accept_eval.py")
+    return _accept_eval
+
+
+def _get_ledger_entry() -> ModuleType:
+    global _ledger_entry
+    if _ledger_entry is None:
+        _ledger_entry = _load_script("_conductor_ledger_entry", "ledger_entry.py")
+    return _ledger_entry
+
+
+#: The ``repo`` segment charset, imported rather than respelled: this is the
+#: constraint ``github_runner`` already applies before either segment of an
+#: ``owner/name`` pair reaches a subprocess, and a second copy could drift.
+_SEGMENT_RE = github_runner._SEGMENT_RE
+
+
+def _pinned_exists(path: str) -> bool:
+    """Answer "is it there" through a pinned parent, never by re-walking the name.
+
+    ``validate_file_path`` resolves the path, and between that resolution and the
+    probe an ancestor DIRECTORY can be swapped for a symlink -- by the model
+    itself, since the roots this door admits are exactly the trees the agent
+    writes. A by-name ``Path.exists()`` then follows the replacement and answers
+    about a path the gate refused, which is worse than no gate because it reports
+    success. ``pinned_fs.pin_parent`` walks the resolved parent one ``openat`` per
+    component with ``O_NOFOLLOW``, so a component that became a link after
+    resolution is refused, and ``stat_at`` asks the question through the
+    descriptor that walk produced. Descriptor-pinned is the repo's one mechanism
+    for this (``pinned_fs`` exists because guarding each call site by name did
+    not converge over two review rounds); this is a thin consumer of it.
+
+    ``lstat`` rather than a following stat is correct here precisely because the
+    path handed in is already canonical: its final component cannot be a link, so
+    not following one loses nothing and keeps the answer about the NAME the gate
+    approved.
+
+    The platform guard lives HERE and not in ``_gate_accept`` on purpose. Refusing
+    at the gate would make the platform the FIRST thing checked, so on a host that
+    cannot pin every other diagnostic disappears: a malformed ``exists``, a
+    relative path and a path outside the roots would all come back "cannot pin"
+    and the author would learn nothing about the actual defect in the spec. Placed
+    at the probe, the refusal happens exactly where the missing capability is, and
+    every check before it still reports what it found on every platform.
+    """
+    if not pinned_fs.supports_pinned_walk():
+        # ``pinned_fs`` deliberately never substitutes a weaker mechanism -- it
+        # reports that it cannot pin and lets the caller decide. On a door with no
+        # approval prompt in front of it the only honest decision is to refuse: a
+        # by-name probe here IS the ancestor-swap disclosure this exists to stop.
+        raise pinned_fs.PinnedPathRefusal(
+            "this platform cannot pin a directory walk, so a 'file' check cannot "
+            "be made race-free here; use a 'pr_checks' condition or ask the user"
+        )
+    parent, name = os.path.split(path)
+    dir_fd = pinned_fs.pin_parent(parent, what="acceptance check's target directory")
+    try:
+        return pinned_fs.stat_at(dir_fd, name) is not None
+    finally:
+        os.close(dir_fd)
+
+
+def _gate_accept(accept: Dict[str, Any]) -> Tuple[Dict[str, Any] | None, Tuple[str, str] | None]:
+    """Apply the MCP path's in-band gate to one acceptance spec.
+
+    Returns ``(accept_to_use, refusal)`` with exactly one side populated.
+
+    The CLI script's security invariant assumes it is reached through an
+    ``execute_bash`` prompt: that prompt IS the call-time check on the spec's
+    model-authored fields, and the hooks deny floor, the sensitive-path matcher
+    and the governance ceiling all read an ``execute_bash`` command string that
+    does not exist on an MCP call. They could not read this one anyway: the path
+    arrives NESTED at ``items[i].accept.path``, and the PreToolUse argument
+    classifier only reads a top-level ``path``, so no policy upstream of this
+    door ever sees it. ``conductor_accept_eval`` is auto-approved so patrol never
+    stops for a prompt, which leaves these checks as the only call-time ones --
+    run in band on the dispatch path, the shape the computer-use surface uses for
+    the same reason.
+
+    Both NARROW rather than consult: an in-process policy lookup would fail OPEN
+    wherever the ceiling is not composed, which is exactly the host the check
+    exists for.
+
+    * ``file.path`` must be absolute AND resolve inside a tree the agent itself
+      writes (``github_runner.agent_writable_roots`` -- the project checkout and
+      the workspace root), then survive ``hooks.validate_file_path`` (the UNC
+      trusted-root gate BEFORE resolution, then ``is_sensitive_path`` on the
+      canonical target). A work item's acceptance condition is "did the child
+      session produce this file", and a child session writes into exactly those
+      roots, so nothing legitimate sits outside them -- while ``/etc/hosts``,
+      ``~/.ssh/id_rsa`` and ``security_policy.json`` become unreachable by
+      construction rather than by a policy that may be absent. NOTE the
+      polarity: ``agent_writable_roots`` is a DENY list for provider binaries (a
+      repo-planted ``gh`` shim) and an ALLOW list here; both follow from the one
+      fact it states -- the model can write there.
+    * ``pr_checks.repo`` is REQUIRED and constrained to ``owner/name``. Required
+      because ``gh pr checks N`` with no ``--repo`` resolves the repository from
+      the CWD, and on this door that is the MCP server process's directory, not
+      the conductor's session -- so an omitted repo silently returns a verdict
+      about PR N in whatever repository the gateway started in, and the conductor
+      treats that verdict as final. Constrained because ``gh`` runs with the
+      operator's ambient credentials.
+
+    A rejected spec is a ``refused`` verdict, not an exception: ``refused`` is
+    the script's own vocabulary for "surface this to the user, never retry
+    around it", which is exactly what a blocked probe is.
+    """
+    kind = accept.get("kind")
+    if kind == "file":
+        path = accept.get("path")
+        if not isinstance(path, str) or not path:
+            # Shape errors stay the script's to report, so the message is
+            # identical on both doors.
+            return accept, None
+        if not os.path.isabs(path):
+            return None, (
+                "refused",
+                f"path must be absolute on this door, got {path!r}: a relative "
+                "path resolves against the MCP server's directory, not your "
+                "session's",
+            )
+        canonical = hooks.validate_file_path(path)
+        if canonical is None:
+            return None, (
+                "refused",
+                "path refused by the filesystem gate (sensitive path, or an "
+                "untrusted UNC host); name a path inside the workspace",
+            )
+        roots = tuple(str(root) for root in github_runner.agent_writable_roots())
+        if not roots or not _within_any(canonical, roots):
+            return None, (
+                "refused",
+                "path is outside the project and workspace roots; a work item's "
+                "output lives inside them, so name a path there",
+            )
+        gated = dict(accept)
+        gated["path"] = canonical
+        return gated, None
+    if kind == "pr_checks":
+        repo = accept.get("repo")
+        if not repo:
+            return None, (
+                "refused",
+                "pr_checks needs an explicit repo on this door: without one `gh` "
+                "resolves the repository from the server process's directory, "
+                "not your session's. Spell it out as owner/name",
+            )
+        if (
+            not isinstance(repo, str)
+            or repo.count("/") != 1
+            or not all(seg not in (".", "..") and _SEGMENT_RE.match(seg) for seg in repo.split("/"))
+        ):
+            return None, (
+                "refused",
+                f"repo must be owner/name with a safe charset, got {repo!r}",
+            )
+    return accept, None
+
+
+def _audited_spawn(argv: list[Any], timeout: float, cwd: Any = None) -> Any:
+    """Spawn a script-built ``gh`` argv through the app's audited chokepoint.
+
+    The script builds the argv and asserts its LOGICAL name; this replaces the
+    bare ``subprocess.run`` the CLI door uses, because on an auto-approved door a
+    PATH lookup for ``gh`` is a substitution the model's own workspace can win.
+    ``resolve_gh`` returns a validated absolute path (rejecting a binary found
+    inside a tree the agent writes), and ``run_gh`` adds what a bare spawn cannot:
+    a minimal gh-scoped environment, so a substituted binary never sees unrelated
+    gateway secrets, and a fail-closed SEL ``invoked`` event written BEFORE the
+    spawn, so an unauditable call does not run.
+
+    A setup failure (no usable ``gh``, or audit storage unavailable) is raised as
+    ``OSError`` so the script's verdict mapping reports it as
+    ``("error", "could not run: ...")`` -- it genuinely could not run, and that
+    keeps one spelling of what a failed spawn MEANS.
+    """
+    if cwd is not None:
+        # Nothing passes this today (the pr_checks handler builds its argv with
+        # no cwd) and this door could not honour it: ``run_gh`` takes no cwd by
+        # design, and silently dropping one would restore the wrong-directory
+        # verdict the required ``repo`` above exists to prevent.
+        raise OSError("this door cannot run a check in a chosen directory")
+    try:
+        resolved = github_runner.resolve_gh()
+        return github_runner.run_gh(
+            [resolved, *(str(a) for a in argv[1:])],
+            timeout=timeout,
+            audit_caller="core:goal-conductor",
+        )
+    except github_runner.SetupError as exc:
+        raise OSError(str(exc)) from exc
+
+
+def _gated_evaluate(item: Dict[str, Any]) -> Tuple[str, str]:
+    """Evaluate one item after gating its spec. The MCP path's per-item handler."""
+    mod = _get_accept_eval()
+    accept = item.get("accept") or {}
+    try:
+        if not isinstance(accept, dict):
+            # Not a dict at all: let the script produce its own message.
+            return mod._evaluate(item, spawn=_audited_spawn, exists=_pinned_exists)
+        gated, refusal = _gate_accept(accept)
+        if refusal is not None:
+            return refusal
+        target = item if gated is accept else {**item, "accept": gated}
+        return mod._evaluate(target, spawn=_audited_spawn, exists=_pinned_exists)
+    except pinned_fs.PinnedPathRefusal as exc:
+        # A component became a link between resolution and the probe. That is a
+        # spec to re-express (or an attack), never an evaluator bug, so it gets
+        # the refusal vocabulary rather than the per-item "evaluator bug" wrap.
+        return ("refused", str(exc))
+
+
+def evaluate_items(items: list[Any]) -> list[Dict[str, Any]]:
+    """Evaluate a batch of work items, gated for the MCP door.
+
+    Delegates the loop itself to ``accept_eval.evaluate_items`` so the per-item
+    contract (object guard, positional id fallback, one bad spec never hiding
+    the rest) has exactly ONE spelling, and injects the gated per-item handler.
+    """
+    mod = _get_accept_eval()
+    return mod.evaluate_items(items, evaluate=_gated_evaluate)
+
+
+def ledger_mode(mode: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a ledger codec operation.
+
+    ``mode`` is one of: encode, decode, validate, rotate.
+    Delegates to the corresponding function in ``ledger_entry._MODES``.
+    """
+    mod = _get_ledger_entry()
+    handler = mod._MODES.get(mode)
+    if handler is None:
+        return {"ok": False, "error": {"code": "unknown_mode", "detail": f"unknown mode {mode!r}"}}
+    return handler(payload)

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -30,17 +30,41 @@ centrally by ``run_mcp_stdio_loop`` + the ``mcp_core`` request helpers), which
 log can tell an agent's move from the user's own, and from any future internal
 caller's.
 
-Why the set needs no second gate behind the assignment: these tools grant no
-read the agent does not already have (``list_sessions`` in ``kirocrew-core`` is
-always available and already returns every session's title and key), they cannot
-delete a folder or a conversation, and the worst outcome is a sidebar the user
-has to tidy. Contrast the keystone leaves in ``security.py``
+Why the FOLDER AND SESSION tools need no second gate behind the assignment: they
+grant no read the agent does not already have (``list_sessions`` in
+``kirocrew-core`` is always available and already returns every session's title
+and key), they cannot delete a folder or a conversation, and the worst outcome is
+a sidebar the user has to tidy. Contrast the keystone leaves in ``security.py``
 (``computer_use.json``, ``browser-mode-enabled``, the Ops Mission Control mode):
 each grants reach OUTSIDE Kiro Crew — desktop input synthesis, the operator's
 logged-in browser, writes against production incident tooling — or is the
 security floor itself, and each is therefore stored where the agent cannot write.
 
-The rule that follows, and the reason the tool set is ratcheted in
+**The two ``conductor_*`` tools are NOT in that first group, and this paragraph
+is the honest statement of it.** ``conductor_accept_eval`` probes the filesystem
+and spawns ``gh`` with the operator's ambient credentials; that is reach outside
+Kiro Crew by the definition above. What stands in for a keystone leaf today is
+narrower, and worth naming exactly because it is not the same thing:
+
+* the reach is bounded IN BAND on the dispatch path, not by the caller's grant —
+  see ``conductor_scripts._gate_accept`` (absolute path, inside the
+  agent-writable roots, through ``hooks.validate_file_path``, then probed through
+  a ``pinned_fs`` descriptor walk; ``owner/name`` repo required) and
+  ``_audited_spawn`` (``resolve_gh`` + ``run_gh``: trusted binary, minimal env,
+  fail-closed SEL event before the spawn);
+* they are AUTO-APPROVED for the conductor alone, via that installer's
+  ``_CONDUCTOR_DASHBOARD_GRANTS``. Another agent assigned this server for the
+  folder tools MOUNTS them but does not auto-approve them, so its calls prompt.
+
+What that does NOT settle, and a reader should not infer from the ratchet test
+passing: mounting is per-SERVER, so for a future agent that grants the set
+wholesale the in-band bound above — not an assignment decision — is the whole
+authorization story. Whether that suffices, or whether these two belong in a
+conductor-scoped server or behind their own keystone leaf, was raised in review
+on #6160's fix and is left to a maintainer rather than settled by the change that
+introduced them.
+
+The rule this follows, and the reason the tool set is ratcheted in
 ``test_mcp_dashboard_registration.py``: a capability whose blast radius DOES
 require authorization needs its own keystone leaf, and being merely unreferenced
 in the default spec is not that. Session control (driving or stopping another
@@ -62,10 +86,13 @@ paths, never waved through on the lenient walk.
 
 from __future__ import annotations
 
+import json
 import logging
 import re as _re
 from typing import Any
 from urllib.parse import quote
+
+from kiro_crew import conductor_scripts
 
 # Same cross-module reuse as ``mcp_computer``: the authenticated loopback client
 # to the gateway lives in ``mcp_core``. Importing it costs 341ms/40MB in this
@@ -86,6 +113,8 @@ from kiro_crew.validation import (
     CHAT_FOLDER_MOVE_SCHEMA,
     CHAT_FOLDER_MOVE_SESSION_SCHEMA,
     CHAT_FOLDER_TREE_SCHEMA,
+    CONDUCTOR_ACCEPT_EVAL_SCHEMA,
+    CONDUCTOR_LEDGER_ENTRY_SCHEMA,
     MCP_DASHBOARD_SCHEMAS,
     SESSION_CREATE_SCHEMA,
     SESSION_READ_MESSAGE_SCHEMA,
@@ -338,6 +367,86 @@ def _tool_definitions() -> list[dict[str, Any]]:
                     },
                 },
                 "required": ["target"],
+            },
+        },
+        {
+            "name": "conductor_accept_eval",
+            "description": (
+                "Run the conductor's deterministic acceptance evaluator over a batch of "
+                "work items (at most 64 per call). Each item carries an acceptance spec "
+                "(pr_checks, file, or human_approval); the evaluator builds its own argv "
+                "from the spec fields and returns a verdict per item. This is the "
+                "non-shell interface to accept_eval.py: individually grantable without "
+                "trusting arbitrary shell. Because it is auto-approvable, this door "
+                "bounds its own inputs: a 'file' path must be absolute and inside the "
+                "project or workspace root, and 'pr_checks' must name an explicit "
+                "owner/name repo. A spec outside those bounds gets a 'refused' verdict."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "maxItems": 64,
+                        "description": (
+                            "Work items to evaluate, at most 64. Each is an object with "
+                            "'id' (string) and 'accept' (object with 'kind' plus "
+                            "kind-specific fields)."
+                        ),
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string", "description": "Item identifier."},
+                                "accept": {
+                                    "type": "object",
+                                    "description": (
+                                        "Acceptance spec: {kind: 'pr_checks', pr: <int>, "
+                                        "repo: <owner/name, required>} "
+                                        "or {kind: 'file', path: <absolute path inside the "
+                                        "project or workspace root>, exists?: <bool>} "
+                                        "or {kind: 'human_approval'}."
+                                    ),
+                                },
+                            },
+                            "required": ["id", "accept"],
+                        },
+                    },
+                },
+                "required": ["items"],
+            },
+        },
+        {
+            "name": "conductor_ledger_entry",
+            "description": (
+                "The conductor's ledger item-entry codec: encode, decode, validate, or "
+                "rotate work-item entries for the session ledger's artifacts map. This is "
+                "the non-shell interface to ledger_entry.py: individually grantable "
+                "without trusting arbitrary shell. Each mode reads a payload and returns "
+                "a structured result; domain problems are {ok: false, error: {...}}, "
+                "never crashes."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["encode", "decode", "validate", "rotate"],
+                        "description": (
+                            "Operation: encode (fields->string), decode (string->fields), "
+                            "validate (check bounds before write), rotate (collapse/drop "
+                            "terminal entries)."
+                        ),
+                    },
+                    "payload": {
+                        "type": "object",
+                        "description": (
+                            "Mode-specific input. encode: {accept, session, round, status, "
+                            "since?, fails?}. decode: {value}. validate: {artifacts}. "
+                            "rotate: {artifacts}."
+                        ),
+                    },
+                },
+                "required": ["mode", "payload"],
             },
         },
     ]
@@ -1161,6 +1270,24 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return redact(f"Unfiled session `{slot_key}` to the top level.")
         folder_label = _chat_folder_paths(chat_folders).get(fld_id, fld_id)
         return redact(f"Moved session `{slot_key}` into `{folder_label}` (id={fld_id}).")
+
+    if name == "conductor_accept_eval":
+        args = validate_tool_args(args, CONDUCTOR_ACCEPT_EVAL_SCHEMA)
+        # The batch loop lives in the script (one spelling of the per-item
+        # contract); the bridge injects this door's in-band spec gate.
+        return json.dumps({"results": conductor_scripts.evaluate_items(args["items"])}, indent=2)
+
+    if name == "conductor_ledger_entry":
+        args = validate_tool_args(args, CONDUCTOR_LEDGER_ENTRY_SCHEMA)
+        try:
+            result = conductor_scripts.ledger_mode(args["mode"], args["payload"])
+        except Exception as exc:
+            return json.dumps(
+                {"ok": False, "error": {"code": "internal_error", "detail": str(exc)}},
+                indent=2,
+            )
+        return json.dumps(result, indent=2)
+
     return f"Error: unknown tool '{name}'"
 
 

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2670,6 +2670,28 @@ SESSION_READ_MESSAGE_SCHEMA = ToolSchema(
     ],
 )
 
+# ── Conductor tool schemas (kirocrew-dashboard) ──
+
+CONDUCTOR_ACCEPT_EVAL_SCHEMA = ToolSchema(
+    tool_name="conductor_accept_eval",
+    fields=[
+        FieldSpec("items", list, required=True, item_type=dict, max_items=64),
+    ],
+)
+
+CONDUCTOR_LEDGER_ENTRY_SCHEMA = ToolSchema(
+    tool_name="conductor_ledger_entry",
+    fields=[
+        FieldSpec(
+            "mode",
+            str,
+            required=True,
+            allowed=frozenset({"encode", "decode", "validate", "rotate"}),
+        ),
+        FieldSpec("payload", dict, required=True),
+    ],
+)
+
 # ── Schema Registry ──
 
 MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
@@ -2891,6 +2913,8 @@ MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
     "chat_folder_create": CHAT_FOLDER_CREATE_SCHEMA,
     "chat_folder_move": CHAT_FOLDER_MOVE_SCHEMA,
     "chat_folder_move_session": CHAT_FOLDER_MOVE_SESSION_SCHEMA,
+    "conductor_accept_eval": CONDUCTOR_ACCEPT_EVAL_SCHEMA,
+    "conductor_ledger_entry": CONDUCTOR_LEDGER_ENTRY_SCHEMA,
 }
 
 MCP_COMPUTER_SCHEMAS: dict[str, ToolSchema] = {

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -121,15 +121,15 @@ class TestConductorInstaller:
         No ``fs_write``: the conductor cannot do a work item's work itself.
         ``@kirocrew-dashboard`` is MOUNTED whole but never granted whole — the
         auto-approve list names verbs, so the destructive ones keep prompting.
-        ``execute_bash`` is mounted and never granted, because ``allowedTools``
-        has no argument matching and trusting the two bundled scripts cannot be
-        told apart from trusting arbitrary shell.
+        ``execute_bash`` is no longer mounted: the bundled scripts are now
+        available as individually-grantable MCP tools (``conductor_accept_eval``
+        and ``conductor_ledger_entry``) on the dashboard server.
         """
         data = self._install(tmp_path, monkeypatch)
         assert "fs_write" not in data["tools"]
         assert "@kirocrew-dashboard" in data["tools"]
         assert "@kirocrew-dashboard" not in data["allowedTools"]
-        assert "execute_bash" in data["tools"]
+        assert "execute_bash" not in data["tools"]
         assert "execute_bash" not in data["allowedTools"]
 
     def test_only_create_and_read_verbs_are_auto_approved(self, tmp_path, monkeypatch):
@@ -163,6 +163,8 @@ class TestConductorInstaller:
             "chat_folder_create",
             "session_create",
             "session_read_message",
+            "conductor_accept_eval",
+            "conductor_ledger_entry",
         ):
             assert f"@kirocrew-dashboard/{verb}" in granted, verb
 
@@ -181,6 +183,8 @@ class TestConductorInstaller:
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",
             "@kirocrew-dashboard/session_read_message",
+            "@kirocrew-dashboard/conductor_accept_eval",
+            "@kirocrew-dashboard/conductor_ledger_entry",
         }
         # The bare server must never appear: it would grant every verb, including
         # the four the test above withholds.
@@ -276,6 +280,8 @@ class TestConductorInstaller:
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",
             "@kirocrew-dashboard/session_read_message",
+            "@kirocrew-dashboard/conductor_accept_eval",
+            "@kirocrew-dashboard/conductor_ledger_entry",
         ]
 
     def test_kas_permissions_are_derived_from_the_filtered_grants(self, tmp_path, monkeypatch):
@@ -292,6 +298,8 @@ class TestConductorInstaller:
         dashboard_resources = [
             "kirocrew-dashboard/chat_folder_create",
             "kirocrew-dashboard/chat_folder_tree",
+            "kirocrew-dashboard/conductor_accept_eval",
+            "kirocrew-dashboard/conductor_ledger_entry",
             "kirocrew-dashboard/session_create",
             "kirocrew-dashboard/session_read_message",
         ]
@@ -379,6 +387,8 @@ class TestConductorInstaller:
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",
             "@kirocrew-dashboard/session_read_message",
+            "@kirocrew-dashboard/conductor_accept_eval",
+            "@kirocrew-dashboard/conductor_ledger_entry",
         ]
 
     def test_skill_gates_the_plan_once_instead_of_interrogating(self):
@@ -420,15 +430,21 @@ class TestConductorInstaller:
     def test_skill_states_the_real_approval_cost(self):
         """The cost note must match the spec, or patrol plans for wrong prompts.
 
-        The granted verbs run silently while `session_send` / `session_stop` and
-        the bundled scripts prompt, so a skill that claimed either "everything
-        prompts" or "nothing prompts" would have the conductor sizing its nudge
-        interval around approvals it does not pay — or walking into ones it does.
+        The granted verbs and the conductor's MCP tools run silently while
+        `session_send` / `session_stop` prompt, so a skill that claimed either
+        "everything prompts" or "nothing prompts" would have the conductor sizing
+        its nudge interval around approvals it does not pay — or walking into ones
+        it does. The per-cycle approval stall is resolved: `conductor_accept_eval`
+        and `conductor_ledger_entry` are auto-approved, so patrol never blocks.
         """
         text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
         assert "Reads and creates do not prompt" in text
         assert "`chat_folder_move_session`,\n  `session_send` and `session_stop`" in text
-        assert "accept_eval.py` invocation" in text
+        # The per-cycle stall is resolved: no more blocking on accept_eval.py
+        assert "each patrol cycle blocks on one approval" not in text
+        # The MCP tools are referenced
+        assert "conductor_accept_eval" in text
+        assert "conductor_ledger_entry" in text
 
     def test_skill_documents_artifacts_as_a_string_map(self):
         """The ledger's ``artifacts`` values MUST be JSON-serialized strings.
@@ -439,19 +455,19 @@ class TestConductorInstaller:
         state — the exact durability this entry exists to provide. Pinned as a
         doc ratchet because the instruction, not the code, is what would drift.
 
-        The format is owned by ``scripts/ledger_entry.py`` (issue #5912), so
-        the skill must route encoding through the codec rather than carrying a
-        hand-written byte-format example for models to re-derive — the worked
-        example was the specification once, and produced real defects on
-        PR #5652.
+        The format is owned by ``conductor_ledger_entry`` (the MCP tool backed by
+        ``scripts/ledger_entry.py``, issue #5912), so the skill must route
+        encoding through the codec rather than carrying a hand-written byte-format
+        example for models to re-derive — the worked example was the
+        specification once, and produced real defects on PR #5652.
         """
         text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
         assert "artifacts_not_string_map" in text
         assert "map of string to STRING" in text
         # The codec is the format's one code owner: the skill must direct the
         # conductor to it for encode/decode/validate/rotate...
-        assert "scripts/ledger_entry.py" in text
-        assert "ledger_entry.py encode" in text
+        assert "conductor_ledger_entry" in text
+        assert 'mode="encode"' in text
         # ...and must never show a bare `item-1 -> {` object literal, which is
         # exactly the value shape the ledger rejects.
         assert "item-1 -> {" not in text
@@ -506,12 +522,44 @@ class TestAcceptEvaluatorInvariant:
         """The only exec path constructs argv from narrowly-typed fields."""
         mod = _load_evaluator()
         seen = []
-        mod._run = lambda argv, cwd=None: (seen.append((argv, cwd)), ("pass", "ok"))[1]
+        mod._run = lambda argv, cwd=None, spawn=None: (
+            seen.append((argv, cwd)),
+            ("pass", "ok"),
+        )[1]
         verdict, _ = mod._evaluate(
             {"accept": {"kind": "pr_checks", "pr": 123, "repo": "owner/name"}}
         )
         assert verdict == "pass"
         assert seen == [(["gh", "pr", "checks", "123", "--repo", "owner/name"], None)]
+
+    def test_the_cli_door_spawns_directly_and_the_spawn_is_injectable(self):
+        """``spawn`` is the ONLY injectable part; the verdict mapping is not.
+
+        A caller reaching this script through a door with no approval prompt
+        needs the binary resolved and the child audited, but must not get its own
+        spelling of what an exit code means -- so the mapping stays here and both
+        doors classify a result identically.
+        """
+        mod = _load_evaluator()
+        calls = []
+
+        class _Proc:
+            returncode = 8
+            stdout = "pending"
+            stderr = ""
+
+        def fake_spawn(argv, timeout, cwd=None):
+            calls.append((list(argv), timeout, cwd))
+            return _Proc()
+
+        verdict, evidence = mod._evaluate(
+            {"accept": {"kind": "pr_checks", "pr": 7, "repo": "o/r"}}, spawn=fake_spawn
+        )
+        # gh's exit 8 is "checks still running", mapped by the script, not the door.
+        assert verdict == "pending"
+        assert "pending" in evidence
+        assert calls == [(["gh", "pr", "checks", "7", "--repo", "o/r"], mod.TIMEOUT_SECS, None)]
+        assert mod._run.__defaults__[-1] is None  # spawn defaults to direct
 
     def test_run_refuses_a_command_it_did_not_build(self):
         """The internal guard fails closed if a handler ever leaks spec input."""

--- a/test/test_conductor_mcp_tools.py
+++ b/test/test_conductor_mcp_tools.py
@@ -1,0 +1,575 @@
+"""Handler-level tests for the conductor's MCP tools.
+
+Every test here drives ``mcp_dashboard._call_tool_inner`` -- the real dispatch
+entry point -- so the tool's contract is asserted where a caller actually meets
+it: schema validation, bridge delegation, the in-band spec gate, and JSON
+serialization. Reproducing the handler's body in a test instead would assert a
+copy and leave the shipped block with zero consumers.
+
+The gate tests are the load-bearing ones. ``conductor_accept_eval`` is
+auto-approved on the conductor's grant list, so unlike the ``execute_bash``
+door it reaches the machine with no approval prompt and no hook gate; the
+sensitive-path and ``owner/name`` checks in ``conductor_scripts._gate_accept``
+are the only call-time check left, and these pin them.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import conductor_scripts, pinned_fs
+from kiro_crew.mcp_dashboard import _call_tool_inner
+
+#: A `file` verdict is a real pass/fail only where the probe can pin its walk. On a
+#: host that cannot (Windows has no `O_DIRECTORY`/`dir_fd`), the kind is refused by
+#: design, so a test asserting a probe OUTCOME has to say which platform contract it
+#: is making. Tests that assert a GATE diagnostic — absolute path, sensitive path,
+#: writable roots, `exists` type — are platform-neutral by construction (the guard
+#: sits at the probe, after all of them) and carry no marker.
+pinned_only = pytest.mark.skipif(
+    not pinned_fs.supports_pinned_walk(),
+    reason="a file-kind verdict requires O_DIRECTORY, O_NOFOLLOW and dir_fd (POSIX)",
+)
+
+
+def _verdicts(payload: str) -> dict[str, dict[str, str]]:
+    """Index a handler response's results by item id."""
+    return {r["id"]: r for r in json.loads(payload)["results"]}
+
+
+@pytest.fixture
+def writable_root(tmp_path, monkeypatch):
+    """Make a CHILD of ``tmp_path`` the agent's only writable root.
+
+    The `file` gate admits a path only inside a tree the agent itself writes,
+    which on a real host is the project checkout and the workspace root. Pointing
+    that at a directory here is what lets a test say "inside a writable root"
+    without writing into either.
+
+    A child rather than ``tmp_path`` itself, so that a test needing a path
+    OUTSIDE the root has somewhere to put it that is still inside the directory
+    this test owns. Returning ``tmp_path`` made ``writable_root.parent`` the
+    shared pytest base, and a file written there is residue every later test in
+    the session inherits.
+    """
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(conductor_scripts.github_runner, "agent_writable_roots", lambda: (root,))
+    return root
+
+
+class TestAcceptEvalHandler:
+    """``conductor_accept_eval``: batch evaluation through the real handler."""
+
+    @pinned_only
+    def test_file_kind_pass_and_fail_in_one_batch(self, writable_root):
+        target = writable_root / "artifact.txt"
+        target.write_text("present", encoding="utf-8")
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {
+                "items": [
+                    {"id": "there", "accept": {"kind": "file", "path": str(target)}},
+                    {
+                        "id": "gone",
+                        "accept": {"kind": "file", "path": str(writable_root / "missing.txt")},
+                    },
+                ]
+            },
+        )
+        results = _verdicts(out)
+        assert results["there"]["verdict"] == "pass"
+        assert results["gone"]["verdict"] == "fail"
+
+    def test_human_approval_is_pending_and_unknown_kind_is_error(self):
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {
+                "items": [
+                    {"id": "ask", "accept": {"kind": "human_approval"}},
+                    {"id": "huh", "accept": {"kind": "nonexistent_kind"}},
+                ]
+            },
+        )
+        results = _verdicts(out)
+        assert results["ask"]["verdict"] == "pending"
+        assert results["huh"]["verdict"] == "error"
+
+    def test_cmd_kind_stays_refused(self):
+        """The removed ``cmd`` kind must not come back through this door."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "shell", "accept": {"kind": "cmd", "cmd": "rm -rf /"}}]},
+        )
+        assert _verdicts(out)["shell"]["verdict"] == "refused"
+
+    def test_one_bad_item_does_not_hide_its_siblings(self):
+        """The per-item contract, asserted on the handler's own loop."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {
+                "items": [
+                    {"accept": "not an object"},
+                    {"id": "good", "accept": {"kind": "human_approval"}},
+                ]
+            },
+        )
+        results = json.loads(out)["results"]
+        assert results[0]["id"] == "#0"
+        assert results[0]["verdict"] == "error"
+        assert results[1]["verdict"] == "pending"
+
+    def test_missing_items_is_a_validation_error(self):
+        with pytest.raises(Exception):
+            _call_tool_inner("conductor_accept_eval", {})
+
+
+class TestAcceptEvalGate:
+    """The in-band gate this auto-approved door adds over the CLI path."""
+
+    def test_a_relative_path_is_refused_before_anything_resolves_it(self):
+        """A relative path would resolve against the SERVER's directory."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "rel", "accept": {"kind": "file", "path": "build/out.txt"}}]},
+        )
+        result = _verdicts(out)["rel"]
+        assert result["verdict"] == "refused"
+        assert "must be absolute" in result["evidence"]
+
+    def test_sensitive_path_is_refused_not_probed(self, writable_root):
+        """A path the hooks gate calls sensitive never reaches ``exists()``."""
+        with patch.object(conductor_scripts.hooks, "validate_file_path", return_value=None):
+            out = _call_tool_inner(
+                "conductor_accept_eval",
+                {
+                    "items": [
+                        {
+                            "id": "probe",
+                            "accept": {"kind": "file", "path": str(writable_root / "id_rsa")},
+                        }
+                    ]
+                },
+            )
+        result = _verdicts(out)["probe"]
+        assert result["verdict"] == "refused"
+        assert "filesystem gate" in result["evidence"]
+
+    def test_a_path_outside_the_writable_roots_is_refused(self, writable_root, tmp_path):
+        """``/etc/hosts`` is unreachable by construction, not by policy lookup.
+
+        The nested ``items[i].accept.path`` is invisible to the PreToolUse
+        argument classifier, so no upstream policy ever sees it; the reachable
+        set is narrowed here instead, which cannot fail open.
+        """
+        # Inside the directory this test owns, but outside the writable root the
+        # gate was told about — so nothing is written where a later test can see it.
+        outside = writable_root.parent / "outside.txt"
+        assert outside.parent == tmp_path, "the probe target must stay inside tmp_path"
+        outside.write_text("x", encoding="utf-8")
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "esc", "accept": {"kind": "file", "path": str(outside)}}]},
+        )
+        result = _verdicts(out)["esc"]
+        assert result["verdict"] == "refused"
+        assert "outside the project and workspace roots" in result["evidence"]
+
+    def test_every_file_spec_is_refused_when_no_root_can_be_named(self, monkeypatch, tmp_path):
+        """Fail CLOSED: an unnameable root is a refusal, never a wide-open probe."""
+        target = tmp_path / "x.txt"
+        target.write_text("x", encoding="utf-8")
+        monkeypatch.setattr(conductor_scripts.github_runner, "agent_writable_roots", lambda: ())
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "f", "accept": {"kind": "file", "path": str(target)}}]},
+        )
+        assert _verdicts(out)["f"]["verdict"] == "refused"
+
+    def test_gate_is_consulted_for_every_file_spec(self, writable_root):
+        target = writable_root / "ok.txt"
+        target.write_text("x", encoding="utf-8")
+        with patch.object(
+            conductor_scripts.hooks,
+            "validate_file_path",
+            wraps=conductor_scripts.hooks.validate_file_path,
+        ) as gate:
+            _call_tool_inner(
+                "conductor_accept_eval",
+                {"items": [{"id": "f", "accept": {"kind": "file", "path": str(target)}}]},
+            )
+        gate.assert_called_once_with(str(target))
+
+    @pinned_only
+    def test_verdict_reports_the_canonical_path_that_was_stated(self, writable_root):
+        """The gate's canonical path is what gets stat-ed, and what is reported."""
+        real = writable_root / "real.txt"
+        real.write_text("x", encoding="utf-8")
+        link = writable_root / "link.txt"
+        link.symlink_to(real)
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "f", "accept": {"kind": "file", "path": str(link)}}]},
+        )
+        result = _verdicts(out)["f"]
+        assert result["verdict"] == "pass"
+        assert str(real) in result["evidence"]
+
+    @pytest.mark.parametrize(
+        "repo",
+        ["../../etc", "owner/repo/extra", "owner", "own er/repo", "./x", "owner/.."],
+    )
+    def test_unsafe_repo_is_refused_before_gh_runs(self, repo):
+        """``gh`` carries ambient credentials, so the slug is charset-bounded."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "pr", "accept": {"kind": "pr_checks", "pr": 1, "repo": repo}}]},
+        )
+        result = _verdicts(out)["pr"]
+        assert result["verdict"] == "refused"
+        assert "owner/name" in result["evidence"]
+
+    @pytest.mark.parametrize(
+        "accept", [{"kind": "pr_checks", "pr": 1}, {"kind": "pr_checks", "pr": 1, "repo": ""}]
+    )
+    def test_a_missing_repo_is_refused_rather_than_resolved_from_the_cwd(self, accept):
+        """No ``--repo`` means ``gh`` picks the repo from the server's directory."""
+        out = _call_tool_inner("conductor_accept_eval", {"items": [{"id": "pr", "accept": accept}]})
+        result = _verdicts(out)["pr"]
+        assert result["verdict"] == "refused"
+        assert "explicit repo" in result["evidence"]
+
+    def test_a_well_formed_repo_reaches_the_evaluator_through_the_audited_spawn(self):
+        with patch.object(
+            conductor_scripts._get_accept_eval(), "_run", return_value=("pass", "exit 0")
+        ) as run:
+            out = _call_tool_inner(
+                "conductor_accept_eval",
+                {
+                    "items": [
+                        {
+                            "id": "pr",
+                            "accept": {"kind": "pr_checks", "pr": 7, "repo": "owner/name.js"},
+                        }
+                    ]
+                },
+            )
+        assert _verdicts(out)["pr"]["verdict"] == "pass"
+        assert run.call_args[0][0] == ["gh", "pr", "checks", "7", "--repo", "owner/name.js"]
+        # The door hands the script its own audited spawn, never the direct one.
+        assert run.call_args.kwargs["spawn"] is conductor_scripts._audited_spawn
+
+    def test_non_integer_pr_is_still_the_script_s_error(self):
+        """Shape errors stay with the script so both doors report identically."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "pr", "accept": {"kind": "pr_checks", "pr": True, "repo": "o/r"}}]},
+        )
+        assert _verdicts(out)["pr"]["verdict"] == "error"
+
+    @pytest.mark.parametrize("path", [None, "", 7, ["/tmp/x"]])
+    def test_a_non_string_path_is_the_script_s_error_not_a_refusal(self, path):
+        """The gate passes a malformed path through so one message serves both doors."""
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "f", "accept": {"kind": "file", "path": path}}]},
+        )
+        result = _verdicts(out)["f"]
+        assert result["verdict"] == "error"
+        assert "needs a path" in result["evidence"]
+
+    def test_a_non_object_accept_is_left_to_the_script(self):
+        out = _call_tool_inner(
+            "conductor_accept_eval", {"items": [{"id": "f", "accept": "not an object"}]}
+        )
+        assert _verdicts(out)["f"]["verdict"] == "error"
+
+
+class TestExistenceProbeIsPinned:
+    """The probe must not re-walk a name the gate already resolved."""
+
+    def test_the_door_injects_the_pinned_prober(self, writable_root):
+        target = writable_root / "f.txt"
+        target.write_text("x", encoding="utf-8")
+        with patch.object(
+            conductor_scripts._get_accept_eval(), "_evaluate", return_value=("pass", "ok")
+        ) as ev:
+            _call_tool_inner(
+                "conductor_accept_eval",
+                {"items": [{"id": "f", "accept": {"kind": "file", "path": str(target)}}]},
+            )
+        assert ev.call_args.kwargs["exists"] is conductor_scripts._pinned_exists
+        assert ev.call_args.kwargs["spawn"] is conductor_scripts._audited_spawn
+
+    @pinned_only
+    def test_an_ancestor_swapped_after_resolution_is_refused_not_followed(
+        self, writable_root, monkeypatch
+    ):
+        """The check-to-use race, reproduced: resolve, then swap a parent dir.
+
+        The roots this door admits are the trees the agent itself writes, so the
+        swap is something the model can actually perform.
+        """
+        real_parent = writable_root / "sub"
+        real_parent.mkdir()
+        approved = real_parent / "f.txt"  # never created: a by-name probe says False
+        elsewhere = writable_root / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "f.txt").write_text("x", encoding="utf-8")
+
+        # The gate resolved `approved` BEFORE the swap; now the parent is a link.
+        real_parent.rmdir()
+        real_parent.symlink_to(elsewhere)
+        monkeypatch.setattr(
+            conductor_scripts.hooks, "validate_file_path", lambda raw: str(approved)
+        )
+
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "race", "accept": {"kind": "file", "path": str(approved)}}]},
+        )
+        result = _verdicts(out)["race"]
+        assert result["verdict"] == "refused"
+        assert "symbolic link" in result["evidence"]
+
+    def test_a_platform_that_cannot_pin_refuses_the_file_kind(self, writable_root, monkeypatch):
+        """pinned_fs never degrades silently, so this door fails closed."""
+        target = writable_root / "f.txt"
+        target.write_text("x", encoding="utf-8")
+        monkeypatch.setattr(conductor_scripts.pinned_fs, "supports_pinned_walk", lambda: False)
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {"items": [{"id": "f", "accept": {"kind": "file", "path": str(target)}}]},
+        )
+        result = _verdicts(out)["f"]
+        assert result["verdict"] == "refused"
+        assert "cannot pin" in result["evidence"]
+
+    @pinned_only
+    def test_the_pinned_probe_agrees_with_the_direct_one_on_a_clean_tree(self, tmp_path):
+        """Same answer when nothing is racing: the guard adds no false negatives."""
+        there = tmp_path / "there.txt"
+        there.write_text("x", encoding="utf-8")
+        gone = tmp_path / "gone.txt"
+        script = conductor_scripts._get_accept_eval()
+        assert conductor_scripts._pinned_exists(str(there)) is True
+        assert script._exists_direct(str(there)) is True
+        assert conductor_scripts._pinned_exists(str(gone)) is False
+        assert script._exists_direct(str(gone)) is False
+
+
+class TestExistsMustBeABoolean:
+    """``bool("false")`` is True, so coercion would invert the verdict."""
+
+    @pytest.mark.parametrize("bad", ["false", "true", 0, 1, "", None, [], {}])
+    def test_a_non_boolean_exists_is_an_error_not_an_inverted_verdict(self, writable_root, bad):
+        target = writable_root / "f.txt"
+        target.write_text("x", encoding="utf-8")
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {
+                "items": [
+                    {"id": "f", "accept": {"kind": "file", "path": str(target), "exists": bad}}
+                ]
+            },
+        )
+        result = _verdicts(out)["f"]
+        assert result["verdict"] == "error"
+        assert "must be true or false" in result["evidence"]
+
+    def test_the_cli_door_rejects_it_too(self):
+        """One spelling: the type check lives in the script, not in the gate."""
+        script = conductor_scripts._get_accept_eval()
+        verdict, evidence = script._evaluate(
+            {"accept": {"kind": "file", "path": "/nonexistent", "exists": "false"}}
+        )
+        assert verdict == "error"
+        assert "must be true or false" in evidence
+
+    @pinned_only
+    @pytest.mark.parametrize("want,expected", [(True, "pass"), (False, "fail")])
+    def test_a_real_boolean_still_decides_the_verdict(self, writable_root, want, expected):
+        target = writable_root / "f.txt"
+        target.write_text("x", encoding="utf-8")
+        out = _call_tool_inner(
+            "conductor_accept_eval",
+            {
+                "items": [
+                    {"id": "f", "accept": {"kind": "file", "path": str(target), "exists": want}}
+                ]
+            },
+        )
+        assert _verdicts(out)["f"]["verdict"] == expected
+
+
+class TestAuditedSpawn:
+    """``gh`` on this door must be a trusted binary, spawned through the chokepoint."""
+
+    def test_it_resolves_gh_and_runs_it_through_run_gh(self):
+        """A bare ``gh`` would be a PATH lookup the model's own workspace can win."""
+        sentinel = object()
+        with (
+            patch.object(
+                conductor_scripts.github_runner, "resolve_gh", return_value="/trusted/bin/gh"
+            ) as resolve,
+            patch.object(
+                conductor_scripts.github_runner, "run_gh", return_value=sentinel
+            ) as run_gh,
+        ):
+            assert conductor_scripts._audited_spawn(["gh", "pr", "checks", "7"], 300.0) is sentinel
+        resolve.assert_called_once_with()
+        # argv[0] is REPLACED by the resolved absolute path; the rest is verbatim.
+        assert run_gh.call_args[0][0] == ["/trusted/bin/gh", "pr", "checks", "7"]
+        assert run_gh.call_args.kwargs["timeout"] == 300.0
+        assert run_gh.call_args.kwargs["audit_caller"] == "core:goal-conductor"
+
+    def test_a_setup_failure_becomes_the_script_s_could_not_run_error(self):
+        """No usable gh, or unavailable audit storage, is an error verdict."""
+        with patch.object(
+            conductor_scripts.github_runner,
+            "resolve_gh",
+            side_effect=conductor_scripts.github_runner.SetupError("no usable gh"),
+        ):
+            with pytest.raises(OSError, match="no usable gh"):
+                conductor_scripts._audited_spawn(["gh", "pr", "checks", "1"], 300.0)
+
+    def test_it_refuses_a_chosen_directory_rather_than_ignoring_it(self):
+        """run_gh has no cwd; dropping one silently restores the wrong-repo verdict."""
+        with pytest.raises(OSError, match="chosen directory"):
+            conductor_scripts._audited_spawn(["gh", "pr", "checks", "1"], 300.0, cwd="/somewhere")
+
+    def test_the_segment_charset_is_imported_not_respelled(self):
+        assert conductor_scripts._SEGMENT_RE is conductor_scripts.github_runner._SEGMENT_RE
+
+
+class TestBatchLoopHasOneSpelling:
+    """The handler must not carry its own copy of the per-item loop."""
+
+    def test_handler_delegates_the_loop_to_the_script(self):
+        with patch.object(
+            conductor_scripts, "evaluate_items", return_value=[{"id": "x", "verdict": "pass"}]
+        ) as bridge:
+            out = _call_tool_inner("conductor_accept_eval", {"items": [{"id": "x"}]})
+        bridge.assert_called_once_with([{"id": "x"}])
+        assert json.loads(out) == {"results": [{"id": "x", "verdict": "pass"}]}
+
+    def test_bridge_delegates_the_loop_to_accept_eval(self):
+        script = conductor_scripts._get_accept_eval()
+        with patch.object(script, "evaluate_items", return_value=[]) as loop:
+            conductor_scripts.evaluate_items([{"id": "x"}])
+        assert loop.call_args.kwargs["evaluate"] is conductor_scripts._gated_evaluate
+
+    def test_script_loop_and_handler_agree_on_a_batch(self):
+        """One spelling means one behaviour, so assert them equal.
+
+        The batch mixes a spec the gate refuses with one it passes through: the
+        script's own loop is called with the same gated handler, so the two must
+        agree item for item.
+        """
+        script = conductor_scripts._get_accept_eval()
+        items = [
+            {"accept": {"kind": "human_approval"}},
+            {"id": "bad-repo", "accept": {"kind": "pr_checks", "pr": 1, "repo": "../etc"}},
+        ]
+        assert json.loads(_call_tool_inner("conductor_accept_eval", {"items": items})) == {
+            "results": script.evaluate_items(items, evaluate=conductor_scripts._gated_evaluate)
+        }
+
+    def test_schema_rejects_a_non_object_item_before_the_loop(self):
+        """``item_type=dict`` means the loop's isinstance guard is defence in depth."""
+        with pytest.raises(Exception):
+            _call_tool_inner("conductor_accept_eval", {"items": [7]})
+
+
+class TestLedgerEntryHandler:
+    """``conductor_ledger_entry``: codec dispatch through the real handler."""
+
+    def test_encode_then_decode_round_trips(self):
+        entry = {
+            "accept": {"kind": "file", "path": "/tmp/out.txt", "exists": True},
+            "session": "dashboard:slot-y",
+            "round": 3,
+            "status": "pass",
+        }
+        encoded = json.loads(
+            _call_tool_inner("conductor_ledger_entry", {"mode": "encode", "payload": entry})
+        )
+        assert encoded["ok"] is True
+        assert "\n" not in encoded["value"]
+        decoded = json.loads(
+            _call_tool_inner(
+                "conductor_ledger_entry",
+                {"mode": "decode", "payload": {"value": encoded["value"]}},
+            )
+        )
+        assert decoded["ok"] is True
+        assert decoded["entry"] == entry
+
+    def test_validate_and_rotate_reach_their_modes(self):
+        encoded = json.loads(
+            _call_tool_inner(
+                "conductor_ledger_entry",
+                {
+                    "mode": "encode",
+                    "payload": {
+                        "accept": {"kind": "pr_checks", "pr": 1},
+                        "session": "s-1",
+                        "round": 1,
+                        "status": "pass",
+                    },
+                },
+            )
+        )
+        artifacts = {"item-done": encoded["value"]}
+        validated = json.loads(
+            _call_tool_inner(
+                "conductor_ledger_entry", {"mode": "validate", "payload": {"artifacts": artifacts}}
+            )
+        )
+        assert validated["ok"] is True
+        assert validated["violations"] == []
+        rotated = json.loads(
+            _call_tool_inner(
+                "conductor_ledger_entry", {"mode": "rotate", "payload": {"artifacts": artifacts}}
+            )
+        )
+        assert rotated["ok"] is True
+        assert "item-done" in rotated["collapsed"]
+
+    def test_domain_error_is_structured_not_raised(self):
+        out = json.loads(
+            _call_tool_inner(
+                "conductor_ledger_entry",
+                {"mode": "encode", "payload": {"session": "s-1", "round": 1, "status": "running"}},
+            )
+        )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "missing_field"
+
+    def test_unknown_mode_is_rejected_by_the_schema(self):
+        with pytest.raises(Exception):
+            _call_tool_inner("conductor_ledger_entry", {"mode": "frobnicate", "payload": {}})
+
+    def test_bridge_still_refuses_an_unknown_mode_on_its_own(self):
+        """Defence in depth: the schema is the first gate, not the only one."""
+        result = conductor_scripts.ledger_mode("frobnicate", {})
+        assert result["ok"] is False
+        assert result["error"]["code"] == "unknown_mode"
+        assert "frobnicate" in result["error"]["detail"]
+
+    def test_unexpected_bridge_exception_becomes_internal_error(self):
+        """The handler's own try/except, exercised through the handler."""
+        with patch.object(
+            conductor_scripts, "ledger_mode", side_effect=RuntimeError("bridge broke")
+        ):
+            out = json.loads(
+                _call_tool_inner(
+                    "conductor_ledger_entry", {"mode": "validate", "payload": {"artifacts": {}}}
+                )
+            )
+        assert out["ok"] is False
+        assert out["error"]["code"] == "internal_error"
+        assert "bridge broke" in out["error"]["detail"]

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1478,4 +1478,6 @@ class TestAdvertisedSet:
             "session_stop",
             "session_send",
             "session_read_message",
+            "conductor_accept_eval",
+            "conductor_ledger_entry",
         }

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -345,7 +345,13 @@ class TestWhatThisSetGrants:
         "session_send",
         "session_read_message",
     }
-    GRANTED_TOOLS = FOLDER_TOOLS | SESSION_TOOLS
+    #: The conductor-specific tools: acceptance evaluator and ledger codec,
+    #: individually grantable without trusting arbitrary shell.
+    CONDUCTOR_TOOLS = {
+        "conductor_accept_eval",
+        "conductor_ledger_entry",
+    }
+    GRANTED_TOOLS = FOLDER_TOOLS | SESSION_TOOLS | CONDUCTOR_TOOLS
 
     def test_the_set_is_exactly_the_folder_tools(self) -> None:
         from kiro_crew import mcp_dashboard
@@ -359,7 +365,7 @@ class TestWhatThisSetGrants:
         assert {t["name"] for t in mcp_dashboard._list_tools()} == self.GRANTED_TOOLS
 
     def test_session_driving_tools_ship_with_the_folder_tools(self) -> None:
-        """This set deliberately bundles two capability classes.
+        """This set deliberately bundles multiple capability classes.
 
         The earlier ratchet here asserted the OPPOSITE — that nothing which
         messages or stops another session may join the folder set. That guard
@@ -370,7 +376,7 @@ class TestWhatThisSetGrants:
 
         The ratchet is inverted rather than deleted, because the property worth
         protecting did not go away: what the set contains must be a decision, not
-        an accident. If either class disappears from the server, this fails and
+        an accident. If any class disappears from the server, this fails and
         whoever changed it has to say which half they meant to drop.
         """
         from kiro_crew import mcp_dashboard
@@ -378,10 +384,13 @@ class TestWhatThisSetGrants:
         names = {t["name"] for t in mcp_dashboard._tool_definitions()}
         folder = {n for n in names if n.startswith("chat_folder_")}
         session = {n for n in names if n.startswith("session_")}
+        conductor = {n for n in names if n.startswith("conductor_")}
         assert folder, "the folder-organization tools left this set"
         assert session, "the session-control tools left this set"
+        assert conductor, "the conductor tools left this set"
         # Nothing else rides along unannounced.
-        assert names == folder | session, (
-            f"{sorted(names - folder - session)} is neither folder organization nor "
-            "session control — name the class it belongs to before adding it here"
+        assert names == folder | session | conductor, (
+            f"{sorted(names - folder - session - conductor)} is neither folder "
+            "organization, session control, nor conductor tools — name the class "
+            "it belongs to before adding it here"
         )


### PR DESCRIPTION
## Summary

Resolves #6160 — the conductor patrol no longer blocks once per cycle on an `execute_bash` approval prompt.

### Problem

The conductor's patrol loop is nudge-driven and designed to run unattended. Every cycle blocked on an approval prompt because the acceptance check ran `accept_eval.py` through `execute_bash`, and `execute_bash` cannot be auto-approved: `allowedTools` is name-scoped with no argument matching, so trusting the two bundled scripts cannot be told apart from trusting arbitrary shell.

### Solution

Convert the two evaluator entry points into individually-grantable MCP tools on the `kirocrew-dashboard` server:

- **`conductor_accept_eval`** — runs the deterministic acceptance evaluator over a batch of work items (read/compute only, at most 64 per call)
- **`conductor_ledger_entry`** — encodes, decodes, validates, or rotates ledger entries (creates new values, never mutates existing user-visible state)

Both satisfy the grant invariant on `_CONDUCTOR_DASHBOARD_GRANTS` and are added to the conductor's grant list, so patrol never stalls. `execute_bash` is unmounted from the conductor spec entirely.

### The door's own bounds (this is the load-bearing part)

Auto-approving the evaluator removes the one call-time check the CLI door had. The `execute_bash` prompt *was* the check on a spec's model-authored fields — and the hooks deny floor, the sensitive-path matcher and the governance ceiling all read an `execute_bash` command string that does not exist on an MCP call. They could not read this one anyway: the path arrives **nested** at `items[i].accept.path`, and the PreToolUse argument classifier only reads a top-level `path`, so no policy upstream of this door ever sees it.

So `conductor_scripts._gate_accept` bounds the inputs in band, on the dispatch path — the shape the computer-use surface uses for the same reason. Each check **narrows** rather than consults: an in-process policy lookup would fail OPEN exactly on the host the check exists for.

| Field | Why it reaches out | Bound |
|---|---|---|
| `file.path` | `Path(path).exists()` on a model-authored string is a 1-bit read of any path | must be **absolute** (a relative path resolves against the MCP server's directory, not the session's) |
| `file.path` | a policy that never sees the nested path cannot deny `/etc/hosts` | must resolve **inside `github_runner.agent_writable_roots()`** — the project checkout and workspace root, where a work item's output actually lives — then survive `hooks.validate_file_path` (UNC trusted-root gate before resolution, `is_sensitive_path` on the canonical target). Empty root tuple ⇒ refuse, fail-closed |
| `pr_checks.repo` | `gh pr checks N` with no `--repo` resolves the repo from the CWD, which here is the server process's | **required**, and `owner/name` in the charset `github_runner._SEGMENT_RE` already requires before a segment reaches a subprocess |
| the `gh` binary | a bare `gh` is a PATH lookup a tree the model writes can win | resolved via `github_runner.resolve_gh()` and spawned through `run_gh()` — minimal gh-scoped env, fail-closed SEL `invoked` event before the spawn |

A rejected spec is a `refused` verdict — the script's own vocabulary for "surface this, never retry around it". Shape errors (a non-string path, a non-integer `pr`) are deliberately left to the script so one message serves both doors. The evaluator's original invariant is unchanged and now matters more: **no model-authored argv ever reaches subprocess.**

### One spelling of the loop, and of the exit-code mapping

`accept_eval.main()`'s per-item loop is hoisted into `evaluate_items(items, evaluate=...)`, and `_run` takes an injectable `spawn`. The MCP handler is one bridge call; the bridge injects the gated per-item handler and the audited spawn. Deliberately **not** injectable: the verdict mapping (exit 0 = pass, gh's exit 8 = pending, timeout/OSError = error), so both doors classify an identical result identically. A test asserts the two doors agree item-for-item on the same batch.

### Changes

| File | Change |
|------|--------|
| `src/kiro_crew/conductor_scripts.py` | **New** — bridge: lazy-loads the skill scripts, exposes `evaluate_items` / `ledger_mode`, owns `_gate_accept` and `_audited_spawn` |
| `src/kiro_crew/builtin_skills/goal-conductor/scripts/accept_eval.py` | Batch loop hoisted into `evaluate_items(items, evaluate=None)`; `_run`/`_evaluate` take an injectable `spawn`. Still stdlib-only, still works standalone |
| `src/kiro_crew/mcp_dashboard.py` | Two tool definitions + two handler blocks (one bridge call each) |
| `src/kiro_crew/validation.py` | Input schemas for both tools |
| `src/kiro_crew/agent.py` | Grants added to `_CONDUCTOR_DASHBOARD_GRANTS`; `execute_bash` unmounted; prompt + docstrings updated |
| `src/kiro_crew/builtin_skills/goal-conductor/SKILL.md` | Routed through the MCP tools; per-cycle stall note removed; the door's four bounds and the 64-item cap documented in the same commit |
| `test/test_conductor_mcp_tools.py` | **New** — 40 tests, every one through `_call_tool_inner` |
| `test/test_conductor_agent.py`, `test/test_mcp_dashboard_registration.py`, `test/test_mcp_dashboard_folders.py` | Ratchets updated for the new grants, advertised set, and the injectable spawn |

### Review findings addressed

Round 1 (head `1d548350b`): GPT's ungated-`Path.exists()` BLOCKING → the in-band gate. GPT's function-local imports FINDING → hoisted (`hooks` is already transitively imported by `mcp_dashboard`, so it measures 0 ms extra). First Principles' BLOCK on the zero-consumer `.agents/tasks/FEAT-001.json` → deleted; its copied-batch-loop subtraction → one loop spelling with tests driving `_call_tool_inner`.

Round 2 (head `2f2b1b312`) — Opus 4.8 PASS, Design and First Principles both down to advisory CONCERNS, GPT raised two new categories, all four resolved here:

- **GPT BLOCKING, nested inputs bypass governance** → the nested path is genuinely invisible to the PreToolUse classifier, so the reachable set is narrowed instead of a policy consulted: absolute + inside the agent-writable roots, fail-closed when no root can be named.
- **GPT BLOCKING, evaluator bypasses the hardened GitHub runner** → `resolve_gh()` + `run_gh()` via an injected spawn, so the trusted-binary check, the minimal env and the fail-closed audit all apply.
- **Design CONCERNS, in-process execution re-anchors CWD-relative specs** → both named surfaces are closed at the gate Design pointed at: a relative `file.path` and a `pr_checks` with no `repo` are now `refused`.
- **First Principles CONCERNS** → the 64-item cap is declared in the tool description, the schema and SKILL.md, and SKILL.md now says which side yields; the duplicated `_SEGMENT_RE` is gone, imported from `github_runner`.

### Testing

- `test_conductor_mcp_tools.py` 40 passed; conductor + dashboard + session-control + github_runner suites 586 passed
- `conductor_scripts.py` at 98% statement/branch coverage (the one miss is an unreachable `importlib` guard)
- Backend Lint & Type Check reproduced locally and green by exit code: baselined black ratchet, subprocess-encoding gate (+ its self-test), lockdown-before-publish, isort, flake8, mypy
- Full suite on this branch and on a clean-`main` control at the same path: byte-identical residual failure sets, all environmental (long `AF_UNIX` socket paths, absent `gh`, sandbox home assumptions). Zero failures in any file this PR touches.

Closes #6160
