### PR TITLE
fix(dashboard): let a frame re-issue its own sandbox-doc GET (#6176)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sandbox_doc.py
+++ b/src/kiro_crew/dashboard/handlers/sandbox_doc.py
@@ -16,9 +16,13 @@ case, whose bytes are not persisted anywhere and so have no other URL to give.
 Security posture, mirroring the webapp-preview channel next door:
 
 * The GET route is on the auth-middleware bypass list, and the **HMAC path token
-  IS the credential**. It is bound to the requesting client address, because the
-  token rides in the frame's own location where model-authored script can read
-  it — an exfiltrated token is useless from another connection.
+  IS the credential**. The first successful GET spends it — the entry's life
+  collapses to a seconds-long grace window that lets the same frame re-issue its
+  own GET and nothing more. That, not the binding below, is what makes an
+  exfiltrated URL useless, because ``request.remote`` is the PROXY's address
+  whenever the dashboard is reached through one. The token is also bound to that
+  address as a cheap second layer for the direct case, since the token rides in
+  the frame's own location where model-authored script can read it.
 * ``Content-Security-Policy: sandbox`` makes the response an opaque origin
   **even when opened top-level**, so the URL existing on the dashboard's own
   origin does not turn model HTML into same-origin script. The sandbox flags
@@ -73,19 +77,22 @@ _lock = threading.Lock()
 _stash: OrderedDict[str, tuple[float, bytes]] = OrderedDict()
 
 
-#: How long a freshly minted document counts as IN FLIGHT and must not be
-#: evicted to make room for a newer one. A frame issues its GET immediately
-#: after the mint resolves, so this only has to cover that round trip.
+#: How long a document may still be legitimately fetched. It covers the two
+#: windows that are the same length for the same reason — a frame issues its GET
+#: immediately after the mint resolves, and a renderer that re-issues that GET
+#: (recovery, restore-from-tray, history navigation) does so just as promptly.
+#: Within this window an entry must not be evicted to make room for a newer one,
+#: and a URL already served may be served again; past it the entry is gone.
 _IN_FLIGHT_GRACE_SECS = 10
 
 
 def _prune(now: float) -> bool:
     """Drop what is safe to drop; report whether the stash is inside its caps.
 
-    Eviction never touches an entry that is still IN FLIGHT. An entry is removed
-    when it is SERVED, so every live entry is one nobody has fetched yet, and
-    dropping the oldest to make room for a newer one would silently invalidate a
-    URL some frame is about to load — the mint succeeded, so the frontend has no
+    Eviction never touches an entry that is still IN FLIGHT — one that nobody has
+    fetched yet, or that was fetched within the last ``_IN_FLIGHT_GRACE_SECS``.
+    Dropping such an entry to make room for a newer one would silently invalidate
+    a URL some frame is about to load — the mint succeeded, so the frontend has no
     failure to show and the frame just renders blank. That is reachable without
     an attacker: a gallery of image-bearing artifacts can push several MB of
     pending documents through here at once.
@@ -97,8 +104,14 @@ def _prune(now: float) -> bool:
         _stash.pop(doc_id, None)
 
     def _evictable() -> str | None:
+        # In flight = minted within the last `_IN_FLIGHT_GRACE_SECS` (the frame's
+        # first GET is still on its way) or served within it (the frame may
+        # re-issue that GET). Both show up as remaining life, so one comparison
+        # covers them: a fresh mint has nearly the full TTL left, and a serve
+        # collapses the deadline into the grace window.
+        cutoff = now + _TOKEN_TTL_SECS - _IN_FLIGHT_GRACE_SECS
         for doc_id, (exp, _) in _stash.items():  # oldest first
-            if (exp - _TOKEN_TTL_SECS) + _IN_FLIGHT_GRACE_SECS <= now:
+            if exp <= cutoff:
                 return doc_id
         return None
 
@@ -147,7 +160,7 @@ async def api_stash_sandbox_doc(request: web.Request) -> web.Response:
 
     # Encode HERE, not at serve time. A document carrying a lone surrogate is
     # representable in JSON and in a Python str but NOT in UTF-8, and encoding it
-    # after the single-use pop turned that into a 500 plus a document that could
+    # after the entry was spent turned that into a 500 plus a document that could
     # never be fetched again. Rejecting at the mint is the honest place: the
     # caller still holds the bytes and gets a reason.
     try:
@@ -176,27 +189,34 @@ async def api_stash_sandbox_doc(request: web.Request) -> web.Response:
 
 
 async def serve_sandbox_doc(request: web.Request) -> web.Response:
-    """``GET /sandbox-doc/{doc_id}/{token}`` — the document itself, ONCE.
+    """``GET /sandbox-doc/{doc_id}/{token}`` — the document, for one load only.
 
     Auth = the HMAC path token (this route is on the middleware bypass list).
     Fails closed as 404 for every invalid condition, so the route is not an
     oracle for which ids exist.
 
-    **Single use.** The entry is popped before the body is written, so a URL that
-    leaks is already spent: the frame it was minted for consumed it. This is the
-    load-bearing control rather than the client binding below, because
-    ``request.remote`` is the PROXY's address whenever the dashboard is reached
-    through one (a tunnel, a reverse proxy), and every client then shares it — the
-    binding is worth nothing in exactly the deployments where a URL is most
-    reachable. The binding stays as a second, cheap layer for the direct case.
+    **Spent on first serve, with a grace window for the SAME load.** The first
+    successful GET collapses the entry's expiry to ``_IN_FLIGHT_GRACE_SECS``, so
+    the URL stops working seconds later instead of lasting out its 15-minute mint
+    TTL. Single use is the load-bearing control rather than the client binding
+    below, because ``request.remote`` is the PROXY's address whenever the
+    dashboard is reached through one (a tunnel, a reverse proxy), and every
+    client then shares it — the binding is worth nothing in exactly the
+    deployments where a URL is most reachable. Collapsing rather than popping
+    keeps that property to within the grace window and buys back the one thing an
+    atomic pop got wrong: a frame that re-issues its own GET (renderer recovery,
+    restore from tray, history navigation — all of which Electron does) found the
+    document already spent and got a 404 INSIDE the frame, which renders as a
+    permanently blank area because the iframe stays at ``opacity: 0`` until
+    ``onLoad`` fires and nothing in the frontend observes the GET.
 
-    The cost is that a frame the BROWSER reloads on its own (rather than a page
-    reload, which remounts the app and mints again) finds its document spent and
-    gets this 404 inside the frame. Nothing in the frontend observes the GET —
-    the document is served with an opaque origin, so the parent cannot read
-    whether it loaded — and the retry control appears only when the MINT itself
-    fails. Recovering a spent URL therefore needs a page reload. Detecting it
-    would take a beacon injected into the document plus a deadline, which is
+    The window is deliberately the same length as the in-flight eviction grace:
+    both answer "how long may this document still be legitimately fetched", and a
+    re-issued GET follows its predecessor by milliseconds, not minutes.
+
+    Recovering a URL spent longer ago still needs a re-mint, and the retry
+    control still appears only when the MINT itself fails. Detecting a spent
+    load would take a beacon injected into the document plus a deadline, which is
     not built; do not describe one here until it is.
     """
     doc_id = request.match_info.get("doc_id", "")
@@ -207,9 +227,15 @@ async def serve_sandbox_doc(request: web.Request) -> web.Response:
         raise web.HTTPNotFound()
     now = time.time()
     with _lock:
-        entry = _stash.pop(doc_id, None)
+        entry = _stash.get(doc_id, None)
         if entry is not None and entry[0] < now:
             entry = None
+        elif entry is not None:
+            # Under the lock, so two concurrent GETs cannot both start their own
+            # window. `min` makes this idempotent: a later serve inside the
+            # window never pushes the deadline out, so replay cannot be kept
+            # alive by fetching in a loop.
+            _stash[doc_id] = (min(entry[0], now + _IN_FLIGHT_GRACE_SECS), entry[1])
     if entry is None:
         _audit("denied", doc_id[:8])
         raise web.HTTPNotFound()
@@ -218,8 +244,8 @@ async def serve_sandbox_doc(request: web.Request) -> web.Response:
     # Already bytes: the encode happened at MINT time, so serving cannot raise.
     # It used to encode here, which meant a document carrying a lone surrogate
     # (JSON accepts "\ud800", Python holds it in a str, UTF-8 cannot represent it)
-    # popped the entry and THEN raised — a 500 for the frame and a document lost
-    # to the single-use pop, with no way to ask for it again.
+    # spent the entry and THEN raised — a 500 for the frame and a document that
+    # could not be asked for again.
     resp = web.Response(body=entry[1], content_type="text/html", charset="utf-8")
     # The load form changed; the trust level must not. `sandbox` gives the
     # document an opaque origin even opened top-level, and the flags are exactly

--- a/test/test_sandbox_doc_channel.py
+++ b/test/test_sandbox_doc_channel.py
@@ -209,10 +209,11 @@ def test_the_response_grants_only_what_the_embedding_frame_grants() -> None:
 def test_an_in_flight_document_is_never_evicted_to_make_room() -> None:
     """The failure mode this replaces was silent, and reachable without an attacker.
 
-    An entry is removed when it is SERVED, so every live entry is one nobody has
-    fetched yet. Dropping the oldest to fit a newer one invalidates a URL some
-    frame is about to load — and because the MINT succeeded, the frontend has no
-    failure to show and that frame just renders blank. A gallery of image-bearing
+    An entry is in flight while nobody has fetched it yet AND for a short grace
+    window after the first fetch, so the frame that owns it may re-issue its own
+    GET. Dropping such an entry to fit a newer one invalidates a URL some frame is
+    about to load -- and because the MINT succeeded, the frontend has no failure
+    to show and that frame just renders blank. A gallery of image-bearing
     artifacts can push several MB of pending documents through at once, so this
     is normal use, not an edge case.
     """
@@ -248,36 +249,43 @@ def test_the_stash_caps_still_bound_it() -> None:
         "_MAX_ENTRIES" in prune and "_MAX_BYTES" in prune
     ), "_prune stopped consulting one of its caps"
 
-    """The control that actually holds when the client binding cannot.
 
-    ``request.remote`` is the PROXY's address whenever the dashboard is reached
-    through one, so every client shares it and the binding is worth nothing in
-    exactly the deployments where a leaked URL is most reachable. Popping the
-    entry before the body is written means a URL that leaks is already spent.
+def test_the_spend_happens_under_the_lock() -> None:
+    """Two concurrent GETs must not each start their own grace window.
+
+    The read and the deadline collapse are one critical section: if the write
+    were outside the lock, the second GET could restore a deadline the first had
+    already shortened, and the URL would stay live for the full mint TTL.
     """
     src = sd.__file__ or ""
     with open(src, encoding="utf-8") as fh:
         body = fh.read()
     serve = body[body.index("async def serve_sandbox_doc") :]
-    assert "_stash.pop(doc_id, None)" in serve, (
-        "the serving handler no longer consumes the entry, so an exfiltrated URL "
-        "can be replayed by anyone sharing the requesting address"
-    )
-    assert "_stash.get(doc_id)" not in serve, (
-        "the handler reads the entry without removing it — that is the replayable "
-        "shape this test exists to prevent"
-    )
+    lock_at = serve.index("with _lock:")
+    get_at = serve.index("_stash.get(doc_id, None)")
+    spend_at = serve.index("min(entry[0], now + _IN_FLIGHT_GRACE_SECS)")
+    assert lock_at < get_at, "the stash read is outside the lock"
+    assert lock_at < spend_at, "the deadline collapse is outside the lock"
 
 
-def test_the_pop_happens_under_the_lock() -> None:
-    """Two concurrent GETs must not both win: the pop is the atomic step."""
+def test_a_served_url_is_spent_rather_than_replayable_for_its_whole_ttl() -> None:
+    """The control that holds when the client binding cannot.
+
+    ``request.remote`` is the PROXY's address whenever the dashboard is reached
+    through one, so every client shares it and the binding is worth nothing in
+    exactly the deployments where a leaked URL is most reachable. What bounds an
+    exfiltrated URL is that serving it collapses its deadline to the grace
+    window — a plain read that left the 15-minute mint TTL in place would hand a
+    co-tenant behind that proxy the whole window to replay it.
+    """
     src = sd.__file__ or ""
     with open(src, encoding="utf-8") as fh:
         body = fh.read()
     serve = body[body.index("async def serve_sandbox_doc") :]
-    lock_at = serve.index("with _lock:")
-    pop_at = serve.index("_stash.pop(doc_id, None)")
-    assert lock_at < pop_at, "the consuming pop is outside the lock"
+    assert "min(entry[0], now + _IN_FLIGHT_GRACE_SECS)" in serve, (
+        "serving no longer shortens the entry's deadline, so an exfiltrated URL "
+        "can be replayed for the full mint TTL by anyone sharing the address"
+    )
 
 
 def test_the_serving_route_is_on_the_auth_bypass_list() -> None:
@@ -330,22 +338,60 @@ async def _mint(html: str, remote: str = "127.0.0.1") -> tuple[str, str]:
 
 
 @pytest.mark.asyncio
-async def test_a_minted_document_is_served_once_and_then_gone() -> None:
-    """Single use is the load-bearing control, so it is proven by serving twice.
+async def test_the_same_frame_can_re_issue_its_own_get() -> None:
+    """The blank-frame defect this fixes, proven by fetching twice back to back.
 
-    The client binding cannot carry this weight: ``request.remote`` is the
-    PROXY's address whenever the dashboard is reached through one, so every
-    client shares it. What actually makes a leaked URL useless is that the frame
-    it was minted for already spent it.
+    A renderer that re-issues the GET it just made (recovery, restore from tray,
+    history navigation — Electron does all three) used to find the document
+    already popped. The 404 lands INSIDE the frame, which nothing in the frontend
+    observes, and the frame stays at ``opacity: 0`` — a permanently blank area.
     """
-    doc_id, token = await _mint("<p>once</p>")
+    doc_id, token = await _mint("<p>reloaded</p>")
 
     first = await sd.serve_sandbox_doc(_serve_req(doc_id, token))
-    assert first.body == b"<p>once</p>"
+    assert first.body == b"<p>reloaded</p>"
+
+    second = await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+    assert second.body == b"<p>reloaded</p>"
+
+
+@pytest.mark.asyncio
+async def test_serving_collapses_the_deadline_to_the_grace_window() -> None:
+    """The re-issue window is seconds, not the 15 minutes the mint handed out."""
+    doc_id, token = await _mint("<p>spent</p>")
+    minted_deadline = sd._stash[doc_id][0]
+
+    await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+
+    served_deadline = sd._stash[doc_id][0]
+    assert served_deadline < minted_deadline, "serving did not spend the entry"
+    assert served_deadline <= time.time() + sd._IN_FLIGHT_GRACE_SECS
+
+
+@pytest.mark.asyncio
+async def test_replaying_inside_the_window_does_not_extend_it() -> None:
+    """Otherwise a fetch loop keeps an exfiltrated URL alive indefinitely."""
+    doc_id, token = await _mint("<p>no extension</p>")
+
+    await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+    after_first = sd._stash[doc_id][0]
+    await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+
+    assert sd._stash[doc_id][0] == after_first, "a replay pushed the deadline out"
+
+
+@pytest.mark.asyncio
+async def test_a_url_is_dead_once_the_grace_window_has_passed() -> None:
+    """Past the window the entry is refused even though no mint has pruned it."""
+    doc_id, token = await _mint("<p>expired</p>")
+    await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+
+    with sd._lock:
+        exp, html = sd._stash[doc_id]
+        sd._stash[doc_id] = (exp - sd._IN_FLIGHT_GRACE_SECS - 1, html)
 
     with pytest.raises(web.HTTPNotFound):
         await sd.serve_sandbox_doc(_serve_req(doc_id, token))
-    assert doc_id not in sd._stash
 
 
 @pytest.mark.asyncio
@@ -438,12 +484,12 @@ async def test_a_mint_with_no_room_is_refused_and_leaves_no_entry(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_a_tampered_token_is_refused_without_spending_the_document() -> None:
-    """Fails closed BEFORE the pop, so a probe cannot burn someone else's URL."""
+async def test_a_tampered_token_is_refused_without_returning_the_document() -> None:
+    """Fails closed BEFORE the stash read, so a probe cannot access the document."""
     doc_id, token = await _mint("<p>hi</p>")
     with pytest.raises(web.HTTPNotFound):
         await sd.serve_sandbox_doc(_serve_req(doc_id, token[:-1] + "x"))
-    assert doc_id in sd._stash, "a rejected request consumed the entry anyway"
+    assert doc_id in sd._stash, "a rejected request removed the entry anyway"
 
 
 @pytest.mark.asyncio
@@ -461,6 +507,29 @@ async def test_an_expired_entry_is_refused_even_with_a_valid_token() -> None:
         sd._stash[doc_id] = (time.time() - 1, b"<p>hi</p>")
     with pytest.raises(web.HTTPNotFound):
         await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+
+
+@pytest.mark.asyncio
+async def test_serve_path_inline_ttl_check_refuses_stale_entry_without_prune() -> None:
+    """The inline TTL guard in serve_sandbox_doc refuses a stale entry even when
+    _prune has not run. This is what makes the grace window real rather than
+    advisory: the entry still sits in the stash (no mint has happened, so no
+    prune has cleared it), but serve_sandbox_doc treats it as absent because its
+    deadline is in the past.
+    """
+    doc_id = "directly-stashed-stale"
+    token = sd._signer.mint(doc_id, "127.0.0.1")
+    # Insert directly into stash with an expiry in the past -- no mint handler
+    # involved, so _prune never ran to clear it.
+    with sd._lock:
+        sd._stash[doc_id] = (time.time() - 60, b"<p>stale</p>")
+    # The entry IS in the stash (not yet pruned)
+    assert doc_id in sd._stash
+    # But serve_sandbox_doc refuses it because the inline TTL check fires
+    with pytest.raises(web.HTTPNotFound):
+        await sd.serve_sandbox_doc(_serve_req(doc_id, token))
+    # The entry was not removed by the serve path -- it just treated it as absent
+    assert doc_id in sd._stash
 
 
 @pytest.mark.asyncio

--- a/website/src/hooks/useSandboxDoc.ts
+++ b/website/src/hooks/useSandboxDoc.ts
@@ -26,8 +26,9 @@ export function useSandboxDoc(srcdoc: string | null | undefined): {
   url: string | null
   /** The last mint attempt failed. `url` may still hold a working document. */
   failed: boolean
-  /** Mint again. Required for recovery: the URL is single-use server-side, so
-   *  re-rendering a spent one recovers nothing. */
+  /** Mint again. Required for recovery: a URL is spent by its first load and
+   *  survives only a seconds-long grace window after it, so re-rendering one
+   *  that was loaded a while ago recovers nothing. */
   retry: () => void
 } {
   const [url, setUrl] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

Fixes #6176 — generated widgets and HTML artifacts render blank in the desktop app while working fine in a browser.

**Revision 2 rewrites this PR.** The first revision claimed two root causes and shipped a fix for each; one of them was wrong. Both blocking reviews were correct and the diff is now 3 files instead of 5.

## Root cause

The sandbox-doc handler `_stash.pop()`'d the entry on the first GET, so the URL was permanently spent. A frame that re-issues the GET it just made — renderer recovery, restore from tray, back/forward navigation, all of which Electron does — got a 404. That 404 lands **inside** the frame, where nothing in the frontend observes it (the document is served with an opaque origin, so the parent cannot read whether it loaded), and the frame stays at `opacity: 0` until `onLoad` fires. The result is a permanently blank area with no error and no retry affordance.

## Changes

| File | Change |
|------|--------|
| `src/kiro_crew/dashboard/handlers/sandbox_doc.py` | The first successful GET collapses the entry's deadline to `_IN_FLIGHT_GRACE_SECS` instead of popping it — same lock, `min()` so a replay cannot push the deadline out. `_evictable` rewritten to the equivalent form that reads honestly for both a fresh mint and a served entry (same inequality, no behaviour change). |
| `test/test_sandbox_doc_channel.py` | Re-issue works; the deadline collapses; a replay does not extend it; the URL is dead past the window; source-level guard that the collapse cannot be silently reverted to a plain read. |
| `website/src/hooks/useSandboxDoc.ts` | Corrects the `retry` doc comment, which asserted the URL was single-use with no grace. |

## Responding to the blocking reviews

**GPT 5.6 — "replayable token bypasses client binding behind shared proxies" (BLOCKING).** Correct, and the first revision made it worse by deleting the paragraph that documented exactly this: `request.remote` is the *proxy's* address whenever the dashboard is reached through a tunnel or reverse proxy, so every client shares it and the binding is worth nothing precisely where a leaked URL is most reachable. A plain `_stash.get()` therefore left a 15-minute replay window for any co-tenant behind that proxy.

A bare `pop()` cannot be restored, because it is the cause of the bug this PR closes. Session-cookie auth is foreclosed by design — the module docstring records that a sandboxed frame in some engines does not send one, which is why the route is on the auth bypass list at all. So the resolution is to keep the spend and bound the window: **serving collapses the deadline to seconds** (`_IN_FLIGHT_GRACE_SECS`, 10s), long enough for a renderer to re-issue a GET that follows its predecessor by milliseconds, 90× shorter than the mint TTL the plain read left in place. The reasoning is restored to the docstring rather than removed, and pinned by a source-level test.

**First Principles — "the `frame-ancestors` strip has no reachable cause" (BLOCK).** Correct. Verified independently: the mint returns a **relative** url (`sandbox_doc.py`), all four consumers (`WidgetFrame`, `ArtifactBody`, `ArtifactsPage`, `RemoteArtifactDetailPage`) assign it straight to `iframe src`, and the desktop window loads the dashboard **top-level** at `http://localhost:<port>` (`main.js` `BACKEND_URL`). A relative src resolves against the parent's own origin, so frame and parent origins are identical by construction and `frame-ancestors 'self'` matches whatever the host spelling — there is no `localhost` vs `127.0.0.1` producer in this tree. `website/electron/sandbox-doc-headers.js`, its test file, and the `onHeadersReceived` block are all deleted, which is also what the failing **Electron Shell Tests** check was reporting (`Missing from build.files: sandbox-doc-headers.js`).

The now-false sentence in `useSandboxDoc.ts` is fixed as well.

## Not in scope

First Principles' second Watch item — `_evictable` cap-evicting an entry ~10s after mint, 404ing a legitimate late re-fetch — is pre-existing on main and independent of this change. It is left alone here so this diff stays the size of the defect it closes.

## Security

- Single use remains the load-bearing control; the replay window is bounded to seconds and is not extendable by fetching in a loop.
- `Content-Security-Policy: sandbox` on the response is untouched, and no CSP is now rewritten anywhere in the Electron shell — model-authored HTML still gets an opaque origin.
- Stash caps (`_MAX_ENTRIES`, `_MAX_BYTES`) unchanged; a served entry becomes evictable, so the first revision's added `stash_full` pressure is gone too.
- Every authorization decision stays SEL-audited.

## Testing

- `test/test_sandbox_doc_channel.py` — 42 passed
- `website/electron` `shell-contract.test.js` — 5 passed (was failing on the deleted module)
- black ratchet, isort, flake8, mypy, `tsc --noEmit`, eslint — all clean
- Rebased onto `main` @ `24cb5e76c`
