### PR TITLE
fix(teams): close both aiohttp sessions even when the handler drain is cancelled

### DIFF
--- a/src/kiro_crew/teams/client.py
+++ b/src/kiro_crew/teams/client.py
@@ -660,19 +660,49 @@ class TeamsClient:
             self._notify_state(False, self.last_error)
 
     async def close(self) -> None:
+        """Shut down, closing BOTH owned sessions whatever the drain does.
+
+        In-flight turns are cancelled and awaited before the sessions they send
+        through are closed -- the transport-shutdown quiescence invariant in
+        ``docs/system-specs/modules/messaging.md``. That drain awaits, so a
+        ``CancelledError`` landing in it (a shutdown while this coroutine is
+        itself being cancelled) would leave ``close()`` before either session
+        close; ``CancelledError`` is a ``BaseException``, so nothing below it
+        runs. Hence the drain gets its own ``try`` and the closes live in the
+        ``finally``.
+
+        The two closes are then nested rather than consecutive, because this
+        client owns two sessions and ``ClientSession.close()`` can raise on a
+        connector whose transport the platform already tore down: as plain
+        consecutive statements, the first failure silently skipped the second.
+        Both still propagate -- a shutdown that swallows the error reports a
+        cleanup it did not perform.
+
+        A leaked session keeps its connector and open sockets for the process
+        lifetime (aiohttp reports "Unclosed client session" at GC), and for the
+        download session also its ``_VettedResolver`` and that resolver's SSRF
+        pin map.
+        """
         self._closed = True
-        handler_tasks = list(self._handler_tasks)
-        for task in handler_tasks:
-            task.cancel()
-        if handler_tasks:
-            await asyncio.gather(*handler_tasks, return_exceptions=True)
-        if self._session is not None and not self._session.closed:
-            await self._session.close()
-            self._session = None
-        if self._download_session is not None and not self._download_session.closed:
-            # Closes the connector, which closes the resolver, which drops the pins.
-            await self._download_session.close()
-            self._download_session = None
+        try:
+            # Snapshot first: a cancelled handler's done-callback mutates the set.
+            handler_tasks = list(self._handler_tasks)
+            for task in handler_tasks:
+                task.cancel()
+            if handler_tasks:
+                # return_exceptions so one handler raising during unwind cannot
+                # abandon the others or skip the session closes below.
+                await asyncio.gather(*handler_tasks, return_exceptions=True)
+        finally:
+            try:
+                if self._session is not None and not self._session.closed:
+                    await self._session.close()
+                    self._session = None
+            finally:
+                if self._download_session is not None and not self._download_session.closed:
+                    # Closes the connector, which closes the resolver, which drops the pins.
+                    await self._download_session.close()
+                    self._download_session = None
 
     def _notify_state(self, connected: bool, error: str) -> None:
         """Publish a health transition to the dashboard badge.

--- a/test/test_transport_close_session_leak.py
+++ b/test/test_transport_close_session_leak.py
@@ -1,8 +1,11 @@
 """A transport client's ``close()`` must always close its aiohttp session.
 
-Each of the four long-lived messaging clients (Discord, Telegram, WeCom, Webex)
-owns one ``aiohttp.ClientSession`` and one background task, and each ``close()``
-cancels the task, awaits it, and then closes the session.
+Four of the long-lived messaging clients (Discord, Telegram, WeCom, Webex) own
+one ``aiohttp.ClientSession`` and one background task, and each ``close()``
+cancels the task, awaits it, and then closes the session. Teams has no polling
+task -- it is webhook-driven -- but it owns TWO sessions (a Connector session
+and a separately-resolved attachment-download session) behind the same handler
+drain, so both are exposed to the same skip.
 
 ``task.cancel()`` on a task that has ALREADY finished with an exception is a
 no-op, and the following ``await self._task`` re-raises that exception --
@@ -17,7 +20,10 @@ The cost is a leaked connector with its open sockets for the process lifetime
 left non-None, so nothing retries.
 
 These tests drive each real ``close()`` with a task that died with an error, and
-assert the session was closed anyway and the exception still propagated.
+assert the session was closed anyway and the exception still propagated. The
+invariant they pin is per-session, not per-client: EVERY session a client owns
+must receive a close attempt on shutdown, even when the handler drain above it
+is cancelled and even when closing an earlier sibling session raises.
 """
 
 from __future__ import annotations
@@ -74,6 +80,12 @@ def _webex():
     from kiro_crew.webex.client import WebexClient
 
     return WebexClient(token="t", on_message=AsyncMock())
+
+
+def _teams():
+    from kiro_crew.teams.client import TeamsClient
+
+    return TeamsClient(app_id="a", app_password="p", on_message=AsyncMock())
 
 
 _CLIENTS = [
@@ -152,6 +164,7 @@ _DRAINING_CLIENTS = [
     pytest.param(_discord, id="discord"),
     pytest.param(_wecom, id="wecom"),
     pytest.param(_webex, id="webex"),
+    pytest.param(_teams, id="teams"),
 ]
 
 
@@ -160,8 +173,9 @@ _DRAINING_CLIENTS = [
 async def test_close_closes_session_when_cancelled_while_draining_handlers(build) -> None:
     """Cancelling ``close()`` while it awaits the handler drain must still close.
 
-    These three clients drain in-flight handler tasks INSIDE the ``finally``,
-    above the session close. That drain awaits, so a ``CancelledError`` landing
+    These clients drain in-flight handler tasks above the session close --
+    Discord, WeCom and Webex inside the ``finally``, Teams with no ``finally``
+    at all. That drain awaits, so a ``CancelledError`` landing
     there would exit ``close()`` with the session -- the exact leak this module
     exists to prevent -- still open, unless the close is nested in its own
     ``finally``. (Telegram is not parametrised here: its session close is the
@@ -202,3 +216,92 @@ async def test_close_closes_session_when_cancelled_while_draining_handlers(build
         "session close; the connector and its sockets leak"
     )
     assert client._session is None
+
+
+# ── Teams: two owned sessions ──
+#
+# Teams is the only client that owns more than one session, so "the session was
+# closed" is not the whole invariant for it. Both the Connector session and the
+# attachment-download session must get a close attempt, and neither the drain
+# above them nor a failure closing the first may cancel the second.
+
+
+def _teams_with_two_sessions() -> tuple:
+    client = _teams()
+    session = _FakeSession()
+    download = _FakeSession()
+    client._session = session  # type: ignore[assignment]
+    client._download_session = download  # type: ignore[assignment]
+    return client, session, download
+
+
+@pytest.mark.asyncio
+async def test_teams_close_closes_both_sessions_when_cancelled_while_draining() -> None:
+    """A cancel landing in the drain must not strand EITHER Teams session.
+
+    The parametrised drain test above only wires ``_session``; Teams also owns
+    ``_download_session``, whose connector holds the ``_VettedResolver`` and its
+    SSRF pin map. Leaking it keeps those sockets and that map alive for the
+    process lifetime.
+    """
+    client, session, download = _teams_with_two_sessions()
+
+    swallowed_once = False
+
+    async def _stubborn_handler() -> None:
+        nonlocal swallowed_once
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            if not swallowed_once:
+                swallowed_once = True
+                await asyncio.sleep(3600)
+            raise
+
+    handler = asyncio.ensure_future(_stubborn_handler())
+    await asyncio.sleep(0)
+    client._handler_tasks.add(handler)
+
+    close_task = asyncio.ensure_future(client.close())
+    for _ in range(10):
+        await asyncio.sleep(0)
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert session.close_calls == 1, (
+        "cancelling close() during the handler drain skipped the Connector "
+        "session close; its connector and sockets leak"
+    )
+    assert download.close_calls == 1, (
+        "cancelling close() during the handler drain skipped the download "
+        "session close; its connector, resolver and SSRF pin map leak"
+    )
+
+
+@pytest.mark.asyncio
+async def test_teams_close_closes_the_download_session_when_the_first_close_raises() -> None:
+    """The sibling arm the single-session clients cannot have.
+
+    ``ClientSession.close()`` is not infallible -- its connector close can raise
+    on a transport already torn down by the platform. With the two closes as
+    consecutive statements, the second one simply never runs. The first failure
+    must still propagate: a shutdown that swallows it reports success it did not
+    achieve.
+    """
+    client, session, download = _teams_with_two_sessions()
+
+    async def _bad_close() -> None:
+        session.close_calls += 1
+        raise OSError("connector transport gone")
+
+    session.close = _bad_close  # type: ignore[assignment]
+
+    with pytest.raises(OSError):
+        await client.close()
+
+    assert session.close_calls == 1
+    assert download.close_calls == 1, (
+        "the Connector session's close() raised and took the download "
+        "session's close down with it; its sockets leak"
+    )


### PR DESCRIPTION
## Problem / Motivation

`TeamsClient.close()` (`src/kiro_crew/teams/client.py`) awaited the handler-drain `gather` above **two** bare `await ...close()` statements, with no enclosing `finally`:

```python
if handler_tasks:
    await asyncio.gather(*handler_tasks, return_exceptions=True)
if self._session is not None and not self._session.closed:
    await self._session.close()
if self._download_session is not None and not self._download_session.closed:
    await self._download_session.close()
```

That drain awaits, so a `CancelledError` landing in it — a gateway teardown racing an in-flight turn — leaves `close()` before either session close runs. `CancelledError` is a `BaseException`, so nothing below it executes. Both owned sessions leak: the Connector session and the separately-resolved attachment-download session, each with its connector and open sockets held for the process lifetime (aiohttp reports `Unclosed client session` at GC). `self._session` also stays non-None, so nothing retries.

The two closes being consecutive statements is a second, independent carrier of the same leak: `ClientSession.close()` closes its connector, which can raise on a transport the platform already tore down, and the second close then simply never runs.

This is the exact failure mode fixed for Discord/Telegram/WeCom/Webex in #4628. Teams was out of that PR's scope; the First Principles lane counted the siblings (6 `await self._session.close()` sites, 4 fixed, Weixin clean because nothing is awaited above its close, Teams outstanding) and flagged Teams as the one remaining carrier.

## Why it matters

Every gateway stop, channel-config change, and reconnect teardown that races an in-flight Teams handler task can strand sockets that are never reclaimed. A long-lived gateway that reconnects Teams repeatedly accumulates them until the process exits or hits its file-descriptor limit.

The download session is the costlier of the two to leak: its connector holds the `_VettedResolver`, so leaking it also keeps that resolver and its SSRF pin map alive.

`docs/system-specs/modules/messaging.md:1372` already names `TeamsClient.close()` as the owner of the transport-shutdown quiescence invariant. The ordering it describes was correct; what was missing is that the ordering was not unconditional.

## What changed (motivation → approach → change)

**Symptom** → both Teams sessions leak when `close()` is cancelled mid handler-drain, or when the first of the two closes raises.

**Root cause** → the session closes were plain statements in the same block as an awaiting drain, so any `BaseException` in or above them skipped the rest.

**Change** → the drain moves into its own `try` whose `finally` performs the closes, exactly as `DiscordClient.close()` does after #4628. Because Teams owns *two* sessions, the closes are **nested** rather than consecutive: the download-session close sits in a `finally` of the Connector-session close, so a failure in the first still attempts the second.

The invariant this establishes is per-session, not per-client:

> every session a client owns receives a close attempt on shutdown, even when the handler drain above it is cancelled and even when closing an earlier sibling session raises — and no failure is swallowed to achieve that.

Nothing is caught or suppressed anywhere in `close()`: a shutdown that swallowed a failure would report a cleanup it did not perform. Two points worth being precise about, rather than claiming more than the code guarantees:

- **The tested arms preserve the exception exactly.** A `CancelledError` in the drain propagates unchanged when both closes succeed (the common case), and an `OSError` from the Connector close propagates unchanged when the download close then succeeds. These are the two arms the regression tests pin.
- **Where two failures collide, ordinary Python cleanup semantics apply and the PR does not change them.** If a close raises while another exception is already unwinding — or if *both* closes raise — the later exception propagates with the earlier one attached as `__context__`, exactly as any nested `finally` behaves. Preserving the first exception across colliding cleanup failures would mean catching and aggregating in `close()`, which is a different change with a different blast radius; this PR deliberately does not attempt it, because the leak it exists to fix does not require it. The invariant being added is the close *attempt*, not exception selection.

Scope is the Teams sibling residual only — no other transport, and no change to drain ordering, to what is closed, or to `close()`'s signature.

## Tests

`test/test_transport_close_session_leak.py` (the module #4628 added):

- **`test_close_closes_session_when_cancelled_while_draining_handlers[teams]`** — Teams joins the existing `_DRAINING_CLIENTS` parametrisation rather than getting a parallel harness. Locks in: a `CancelledError` landing in the drain still closes the Connector session and clears `_session`.
- **`test_teams_close_closes_both_sessions_when_cancelled_while_draining`** — the arm the shared parametrisation cannot express, because it only wires one session. Locks in: the same cancellation also closes `_download_session`.
- **`test_teams_close_closes_the_download_session_when_the_first_close_raises`** — the sibling-ordering arm no single-session client can have. The Connector session's `close()` raises `OSError`; locks in that the download session still receives its close attempt **and** that the `OSError` still propagates.

Teams is deliberately **not** added to `_CLIENTS` (the `_task`-died parametrisations): it is webhook-driven and owns no polling task.

Red before the source change, on this branch:

```
3 failed, 12 passed
FAILED test_teams_close_closes_both_sessions_when_cancelled_while_draining
FAILED test_teams_close_closes_the_download_session_when_the_first_close_raises
FAILED test_close_closes_session_when_cancelled_while_draining_handlers[teams]
```

Green after: `15 passed`.

## Manual verification

N/A — unit coverage sufficient: the defect is a pure control-flow property of `close()`, and both failure arms (cancellation during the drain, a raising sibling close) are driven deterministically against the real `TeamsClient.close()` with no network, so a manual Teams teardown could only reproduce the same paths less reliably.

Wider gates run locally on this branch:

- `pytest test/test_transport_close_session_leak.py` → 15 passed
- `pytest test/test_teams_client.py test/test_teams_attachments.py test/test_teams_transport.py test/test_teams_gateway.py test/test_teams_liveness.py test/test_teams_dispatch.py` → 88 passed, 1 skipped
- `flake8` and `black --check` on both changed files → clean

## Related Issues

Closes #6179. Sibling of #4627, fixed for the other four transports in #4628.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `messaging.md:1372` already states the invariant `TeamsClient.close()` owns; this PR makes the code match it, so no doc text changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

