### PR TITLE
fix(themes): move the theme-detail target stats off the event loop (#5963)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -637,13 +637,31 @@ async def api_theme_detail(request: web.Request) -> web.Response:
     target = _themes_dir() / f"{safe_slug}.json"
     dir_target = _installed_theme_dir(safe_slug)
 
+    # One stat pass for the whole handler: ``exists()``/``is_dir()`` are
+    # SMB-backed on a UNC data home and can block for as long as the network
+    # takes, so they never run on the event loop — the same off-loop
+    # discipline as the asset routes' ``_resolve_theme_asset``. Both stats
+    # ride a single executor hop because every method branch consumes the
+    # pair as one logical check; the DELETE-dir branch re-checks under the
+    # per-slug install lock off-loop.
+    def _stat_targets() -> tuple[bool, bool]:
+        return target.exists(), dir_target.is_dir()
+
+    loop = asyncio.get_running_loop()
+    target_exists, dir_is_dir = await loop.run_in_executor(
+        discovery_executor(), _stat_targets
+    )
+
     if request.method == "DELETE":
-        if target.exists():
-            await asyncio.get_running_loop().run_in_executor(
-                discovery_executor(), target.unlink
+        if target_exists:
+            # ``missing_ok``: the stat rode an earlier hop, so a concurrent
+            # delete can win the race; deleting an already-gone file is the
+            # outcome the caller asked for, not a 500.
+            await loop.run_in_executor(
+                discovery_executor(), lambda: target.unlink(missing_ok=True)
             )
             return web.json_response({"ok": True})
-        if dir_target.is_dir():
+        if dir_is_dir:
             # Recursive delete of a many-file theme dir is blocking; run off-loop.
             # Acquire the per-slug install lock (same key _do_install stages/swaps
             # under) so we never rmtree mid-reinstall and race its stage→rename;
@@ -653,19 +671,17 @@ async def api_theme_detail(request: web.Request) -> web.Response:
                     if dir_target.is_dir():
                         shutil.rmtree(dir_target, ignore_errors=True)
 
-            await asyncio.get_running_loop().run_in_executor(
-                discovery_executor(), _locked_remove
-            )
+            await loop.run_in_executor(discovery_executor(), _locked_remove)
             return web.json_response({"ok": True})
         return web.json_response({"error": "not found"}, status=404)
 
     if request.method == "PUT":
-        if dir_target.is_dir() and not target.exists():
+        if dir_is_dir and not target_exists:
             return web.json_response(
                 {"error": "installed themes are read-only; reinstall to update"},
                 status=400,
             )
-        if not target.exists():
+        if not target_exists:
             return web.json_response({"error": "not found"}, status=404)
         try:
             body = await request.json()
@@ -702,14 +718,13 @@ async def api_theme_detail(request: web.Request) -> web.Response:
                 _atomic_write_theme_json(target, json.dumps(td, indent=2) + "\n")
                 return td
 
-        theme_data = await asyncio.get_running_loop().run_in_executor(
+        theme_data = await loop.run_in_executor(
             discovery_executor(), _update_locked
         )
         return web.json_response({"ok": True, "theme": theme_data})
 
     # GET — file reads and the validation walk are blocking; run off-loop.
-    loop = asyncio.get_running_loop()
-    if target.exists():
+    if target_exists:
         try:
             raw = await loop.run_in_executor(
                 discovery_executor(), target.read_text, "utf-8"
@@ -718,7 +733,7 @@ async def api_theme_detail(request: web.Request) -> web.Response:
         except (json.JSONDecodeError, OSError):
             return web.json_response({"error": "failed to read theme"}, status=500)
         return web.json_response(data)
-    if dir_target.is_dir():
+    if dir_is_dir:
         summary, err = await loop.run_in_executor(
             discovery_executor(), _validate_theme_dir, dir_target
         )

--- a/test/test_dashboard_themes_coverage.py
+++ b/test/test_dashboard_themes_coverage.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -958,6 +959,53 @@ class TestApiThemeDetailSlugGuard:
         resp = await th.api_theme_detail(_detail("GET", slug))
         assert resp.status == 400
         assert _body(resp)["error"] == "invalid theme slug"
+
+
+class TestApiThemeDetailStatsOffLoop:
+    """#5963: the detail handler's target stats must never run on the event loop.
+
+    On a UNC data home each ``exists()``/``is_dir()`` is SMB-backed and can
+    block for as long as the network takes; a stat on the loop stalls every
+    other request the gateway serves. Spy on ``Path.exists``/``Path.is_dir``
+    for the handler's two target paths and assert every such stat happened on
+    a worker thread — the same discipline #5943 pinned for the asset routes'
+    offloaded ``_resolve_theme_asset``.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["GET", "PUT", "DELETE"])
+    async def test_target_stats_run_on_a_worker_thread(
+        self, method: str, themes_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_json(themes_dir / "sunset.json", {"name": "Sunset"})
+        # Build the watched set through the handler's own resolver: the
+        # fixture path is unresolved, while ``_themes_dir()`` goes through
+        # ``config_dir()``'s ``resolve()`` — on Darwin ``/tmp`` is a symlink,
+        # so comparing against the raw fixture path would never match.
+        watched = {th._themes_dir() / "sunset.json", th._themes_dir() / "sunset"}
+        loop_thread = threading.get_ident()
+        stat_threads: list[int] = []
+        real_exists, real_is_dir = Path.exists, Path.is_dir
+
+        def spy_exists(self: Path, *args: Any, **kwargs: Any) -> bool:
+            if self in watched:
+                stat_threads.append(threading.get_ident())
+            return real_exists(self, *args, **kwargs)
+
+        def spy_is_dir(self: Path, *args: Any, **kwargs: Any) -> bool:
+            if self in watched:
+                stat_threads.append(threading.get_ident())
+            return real_is_dir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "exists", spy_exists)
+        monkeypatch.setattr(Path, "is_dir", spy_is_dir)
+
+        body = _theme_body() if method == "PUT" else ...
+        resp = await th.api_theme_detail(_detail(method, "sunset", body=body))
+        assert resp.status == 200
+        assert stat_threads, "expected the handler to stat its target paths"
+        on_loop = [t for t in stat_threads if t == loop_thread]
+        assert not on_loop, f"{len(on_loop)} target stat(s) ran on the event loop"
 
 
 class TestApiThemeDetailDelete:


### PR DESCRIPTION
# What is the problem?

`api_theme_detail` (GET/PUT/DELETE `/api/themes/{slug}`) still makes seven inline `exists()`/`is_dir()` call expressions across six condition sites on the asyncio event loop. On a local disk these are microseconds; on a UNC data home (`KIROCREW_HOME` on an SMB share) every stat is a network round trip that can block for as long as the network takes. These sites became reachable on Windows when #5943 removed the theme-pack 501 gate; #5943 offloaded the asset routes' resolver and tracked the detail route's remaining stats as debt in #5963.

# Why this issue matters to the user

The event loop is shared by every request the gateway serves. One theme-detail request against a slow SMB data home stalls chat streaming, approvals, and every other dashboard route until the stat returns -- a whole-gateway hang triggered by a single settings page visit.

# How our fix solves it

All target stats now ride **one** `discovery_executor()` hop: a small synchronous helper (`_stat_targets`) returns `(target.exists(), dir_target.is_dir())`, and every method branch consumes the captured pair. One hop replaces six, matching how the route already offloads its reads/writes and how #5943 offloaded `_resolve_theme_asset` at the asset/overlay/topbar routes. Branch-for-branch behavior parity with main was verified (same status codes, same ordering, same error paths); the DELETE-dir branch keeps its off-loop `is_dir()` re-check under the per-slug install lock. The DELETE-file `unlink` gains `missing_ok=True`: the stat now rides an earlier hop, so a concurrent delete winning the race is answered as the idempotent ok it is, rather than escaping as a 500.

# What tests we did

- New `TestApiThemeDetailStatsOffLoop` (3 parametrized cases, GET/PUT/DELETE): spies on `Path.exists`/`Path.is_dir` for the handler's two target paths and fails if any such stat runs on the loop thread. **Mutation-verified**: inlining the helper turns all three red (`2 target stat(s) ran on the event loop`). Watched paths are built through the handler's own resolver so the assertion survives Darwin's `/tmp` symlink.
- Full themes suites green: 343 passed (`test_dashboard_themes_coverage.py` + `test_theme_install.py`).
- `isort`/`flake8` clean; black + brand gates pass; `mypy` shows only 4 pre-existing errors in untouched files (identical on clean base via stash A/B).
- Full backend `pytest`: 69,974 passed; 86 failures + 2 errors are host-environment classes (AF_UNIX path length, CPU-cap assertions, sandbox floors) with zero overlap with this diff, reproduced identically on clean base.

# Any other suggestions on the work

Pre-push review (GPT 5.6 + Opus): both **no blocking findings**. Three advisories folded in before opening (Darwin-safe watched paths, lock-comment narrowing, `missing_ok` on the unlink). One suggestion declined: short-circuiting the second stat for GET/DELETE when the first suffices -- the issue explicitly asks for the stats grouped as one logical check in a single hop, and one extra stat inside an already-offloaded worker costs no loop time. The pre-existing PUT-vs-DELETE recreate race noted by Opus is unchanged by this diff and is left for its own issue if it earns one.

Closes #5963
