### PR TITLE
fix(computer-use): give every refusal the code its audit already records

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1334,
+    "missing_code": 1314,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1223,
+  "_compliant": 1243,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -78,9 +78,6 @@
     "dashboard/handlers/autonudge.py": {
       "dynamic_status": 2,
       "missing_code": 3
-    },
-    "dashboard/handlers/computer_use.py": {
-      "missing_code": 20
     },
     "dashboard/handlers/core.py": {
       "dynamic_status": 3,

--- a/src/kiro_crew/dashboard/handlers/computer_use.py
+++ b/src/kiro_crew/dashboard/handlers/computer_use.py
@@ -581,7 +581,7 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
             error="app tokens may not write the computer-use keystone",
         )
         return web.json_response(
-            {"error": "dashboard user required"},
+            {"error": "dashboard user required", "code": "dashboard_user_required"},
             status=403,
         )
 
@@ -589,10 +589,13 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources="invalid_json")
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if not isinstance(body, dict):
         _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources="body_not_object")
-        return web.json_response({"error": "request body must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "request body must be a JSON object", "code": "body_not_object"},
+            status=400,
+        )
 
     # ── Validate EVERYTHING before writing anything ──
     state_patch: dict[str, Any] = {}
@@ -601,7 +604,10 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
             _audit(
                 request, operation=OP_CONFIG_SAVE, outcome="denied", resources="enabled=bad_type"
             )
-            return web.json_response({"error": "enabled must be a boolean"}, status=400)
+            return web.json_response(
+                {"error": "enabled must be a boolean", "code": "invalid_field_type"},
+                status=400,
+            )
         state_patch[STATE_KEY_ENABLED] = body["enabled"]
     for key in _APP_LIST_KEYS:
         if key not in body:
@@ -614,7 +620,8 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
                     "error": (
                         f"{key} must be a list of at most {MAX_APP_PATTERNS} strings, "
                         f"each at most {MAX_APP_PATTERN_LEN} characters"
-                    )
+                    ),
+                    "code": "invalid_app_patterns",
                 },
                 status=400,
             )
@@ -629,11 +636,18 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
         # explicitly — a JSON ``true`` must not become the integer 1 for a budget.
         if isinstance(value, bool) or not isinstance(value, int):
             _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources=f"{key}=bad_type")
-            return web.json_response({"error": f"{key} must be an integer"}, status=400)
+            return web.json_response(
+                {"error": f"{key} must be an integer", "code": "invalid_field_type"},
+                status=400,
+            )
         if value < low or value > high:
             _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources=f"{key}={value}")
             return web.json_response(
-                {"error": f"{key} must be between {low} and {high}"}, status=400
+                {
+                    "error": f"{key} must be between {low} and {high}",
+                    "code": "value_out_of_range",
+                },
+                status=400,
             )
         limits_patch[key] = value
     for key in _BOOL_KEYS:
@@ -641,12 +655,18 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
             continue
         if not isinstance(body[key], bool):
             _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources=f"{key}=bad_type")
-            return web.json_response({"error": f"{key} must be a boolean"}, status=400)
+            return web.json_response(
+                {"error": f"{key} must be a boolean", "code": "invalid_field_type"},
+                status=400,
+            )
         limits_patch[key] = body[key]
 
     if not state_patch and not limits_patch:
         _audit(request, operation=OP_CONFIG_SAVE, outcome="denied", resources="empty_patch")
-        return web.json_response({"error": "no known computer-use fields in body"}, status=400)
+        return web.json_response(
+            {"error": "no known computer-use fields in body", "code": "no_known_fields"},
+            status=400,
+        )
 
     # No governance step here, deliberately: the computer-use governance model
     # (and the 409 it would have returned) does not exist. The write boundary
@@ -695,7 +715,9 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
                 error=str(exc),
             )
             logger.error("refusing computer-use mutation: %s", exc)
-            return web.json_response({"error": ERR_STATE_CORRUPT}, status=500)
+            return web.json_response(
+                {"error": ERR_STATE_CORRUPT, "code": "config_corrupt"}, status=500
+            )
         except OSError as exc:
             _audit(
                 request,
@@ -705,7 +727,13 @@ async def api_computer_use_config_save(request: web.Request) -> web.Response:
                 error=str(exc),
             )
             logger.error("computer-use settings write failed: %s", exc)
-            return web.json_response({"error": "failed to write computer-use settings"}, status=500)
+            return web.json_response(
+                {
+                    "error": "failed to write computer-use settings",
+                    "code": "config_write_failed",
+                },
+                status=500,
+            )
 
     # Audit the DECISION, not the payload: the enable is the security-relevant
     # bit, and the app patterns can name applications the operator would rather
@@ -857,21 +885,31 @@ async def api_computer_use_invoke(request: web.Request) -> web.Response:
             resources=request.path,
             error="internal secret required",
         )
-        return web.json_response({"error": "forbidden"}, status=403)
+        return web.json_response(
+            {"error": "forbidden", "code": "internal_secret_required"}, status=403
+        )
 
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if not isinstance(body, dict):
-        return web.json_response({"error": "request body must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "request body must be a JSON object", "code": "body_not_object"},
+            status=400,
+        )
 
     tool = body.get("tool")
     if not isinstance(tool, str) or not tool:
-        return web.json_response({"error": "tool must be a non-empty string"}, status=400)
+        return web.json_response(
+            {"error": "tool must be a non-empty string", "code": "tool_required"},
+            status=400,
+        )
     args = body.get("args") or {}
     if not isinstance(args, dict):
-        return web.json_response({"error": "args must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "args must be a JSON object", "code": "invalid_args"}, status=400
+        )
     session_key = body.get("session_key")
     agent = body.get("agent")
     app = body.get("app")
@@ -986,7 +1024,7 @@ async def api_computer_use_frame(request: web.Request) -> web.Response:
             resources="non-loopback",
             error="loopback only",
         )
-        return web.json_response({"error": "loopback only"}, status=403)
+        return web.json_response({"error": "loopback only", "code": "loopback_only"}, status=403)
 
     # And the machine grant, for exactly the reason ``api_computer_use_invoke``
     # re-asserts it: being listed in ``_STRICT_INTERNAL_API_PATHS`` does NOT prove
@@ -1005,18 +1043,20 @@ async def api_computer_use_frame(request: web.Request) -> web.Response:
             resources=request.path,
             error="internal secret required",
         )
-        return web.json_response({"error": "forbidden"}, status=403)
+        return web.json_response(
+            {"error": "forbidden", "code": "internal_secret_required"}, status=403
+        )
 
     try:
         body = await request.json()
     except Exception:
         _audit(request, operation=OP_FRAME, outcome="invalid_input", resources="invalid-json")
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
 
     payload = build_frame_payload(body if isinstance(body, dict) else {})
     if payload is None:
         _audit(request, operation=OP_FRAME, outcome="invalid_input", resources="no-frame-data")
-        return web.json_response({"error": "no frame data"}, status=400)
+        return web.json_response({"error": "no frame data", "code": "no_frame_data"}, status=400)
 
     state = request.app["state"]
     delivered = await state.deliver_ws_owners(COMPUTER_USE_FRAME_EVENT, payload)

--- a/test/test_computer_use_api.py
+++ b/test/test_computer_use_api.py
@@ -1854,3 +1854,204 @@ class TestAMalformedKeystoneStillRendersSettings:
         state_file.write_text(json.dumps({"enabled": True, "allowed_apps": "Preview"}))
         with pytest.raises(PolicyStateError):
             enable_state.load_policy_config()
+
+
+# ── Machine-readable error codes ──
+
+
+class TestErrorCodes:
+    """Every refusal from this module carries a machine-readable ``code``.
+
+    The contract gate in ``test/test_error_code_contract.py`` inventories
+    prose-only refusals in ``error-code-baseline.json``; this module held 20 of
+    them. The prose is kept and keeps its meaning -- it is demoted to advisory,
+    not removed -- so a client that only reads ``error`` is unaffected.
+
+    Both of this module's consumers are already built for the code, which is why
+    this conversion is backend-only:
+
+    * the browser panel (``website/src/pages/settings/ComputerUsePanel.tsx``)
+      never renders the server's prose -- its ``onError`` shows a fixed localized
+      string -- so there is no copy to move and no catalog to translate;
+    * the stdio shim reaches ``/invoke`` through ``mcp_core._http_error_body``,
+      which ALREADY parses a top-level ``code``, validates it as
+      ``[a-z0-9_.-]{1,64}`` and passes it on, and the capture thread's
+      ``screencast._post_frame`` discards the response body entirely.
+    """
+
+    # -- the per-file ratchet --
+    #
+    # The repo-wide gate only fails on a NET regression, so it would let a new
+    # prose-only refusal land here behind an unrelated deletion. These two run
+    # the gate's OWN scanner, so the per-file rule cannot drift from it.
+
+    @staticmethod
+    def _findings():
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import test_error_code_contract as gate
+
+        return [f for f in gate.scan() if f.path == "dashboard/handlers/computer_use.py"]
+
+    def test_no_refusal_in_this_module_is_prose_only(self) -> None:
+        missing = sorted(f.lineno for f in self._findings() if f.bucket == "missing_code")
+        assert missing == [], (
+            "these src/kiro_crew/dashboard/handlers/computer_use.py lines refuse with "
+            f"prose and no machine-readable code: {missing}"
+        )
+
+    def test_the_ratchet_can_actually_fail(self) -> None:
+        """Self-check: a scan matching nothing would pass the assertion above vacuously."""
+        coded = [f for f in self._findings() if f.bucket == "compliant"]
+        assert len(coded) == 20, f"scanner reached {len(coded)} coded sites, expected 20"
+        assert all(f.code_value for f in coded)
+
+    # -- PUT /api/computer-use/config --
+
+    @staticmethod
+    async def _put(client: TestClient, body) -> tuple[int, dict]:
+        resp = await client.put("/api/computer-use/config", json=body)
+        return resp.status, await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_body_is_not_a_json_object(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, ["enabled"])
+        assert status == 400
+        assert body["code"] == "body_not_object"
+        assert body["error"]
+
+    @pytest.mark.asyncio
+    async def test_enabled_of_the_wrong_type(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, {"enabled": "yes"})
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    @pytest.mark.asyncio
+    async def test_an_integer_limit_of_the_wrong_type(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, {"max_tree_nodes": "1200"})
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    @pytest.mark.asyncio
+    async def test_an_integer_limit_out_of_range_is_a_different_code(self, home: Path) -> None:
+        """The distinction a caller could not previously make without matching English.
+
+        A value of the right type that is simply too large is a different refusal
+        from a value of the wrong type, and only the code separates them.
+        """
+        async with _client() as client:
+            status, body = await self._put(client, {"max_tree_nodes": 10**9})
+        assert status == 400
+        assert body["code"] == "value_out_of_range"
+
+    @pytest.mark.asyncio
+    async def test_a_boolean_limit_of_the_wrong_type(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, {"attach_screenshot": 1})
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_app_pattern_list(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, {"allowed_apps": "Preview"})
+        assert status == 400
+        assert body["code"] == "invalid_app_patterns"
+
+    @pytest.mark.asyncio
+    async def test_a_body_naming_no_known_field(self, home: Path) -> None:
+        async with _client() as client:
+            status, body = await self._put(client, {"nothing_we_know": True})
+        assert status == 400
+        assert body["code"] == "no_known_fields"
+
+    # -- POST /api/computer-use/invoke (machine leg) --
+
+    @pytest.mark.asyncio
+    async def test_invoke_without_a_tool(self, home: Path) -> None:
+        async with _client() as client:
+            resp = await client.post("/api/computer-use/invoke", json={"args": {}})
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["code"] == "tool_required"
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_non_object_args(self, home: Path) -> None:
+        async with _client() as client:
+            resp = await client.post(
+                "/api/computer-use/invoke", json={"tool": "screenshot", "args": ["a"]}
+            )
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["code"] == "invalid_args"
+
+    @pytest.mark.asyncio
+    async def test_the_code_survives_the_shims_own_error_decoder(self, home: Path) -> None:
+        """The code is only worth adding if the shim's decoder keeps it.
+
+        ``mcp_core._http_error_body`` drops any ``code`` that is not a short
+        identifier, so this drives the REAL decoder over this handler's REAL body
+        rather than asserting that the two shapes look compatible.
+        """
+        import io as _io
+        import urllib.error
+
+        from kiro_crew.mcp_core import _http_error_body
+
+        async with _client() as client:
+            resp = await client.post("/api/computer-use/invoke", json={"args": {}})
+            raw = await resp.read()
+
+        decoded = _http_error_body(
+            urllib.error.HTTPError(
+                "http://127.0.0.1/api/computer-use/invoke",
+                400,
+                "Bad Request",
+                {},
+                _io.BytesIO(raw),
+            )
+        )
+        assert decoded["code"] == "tool_required"
+
+    # -- POST /api/computer-use/frame (machine leg) --
+
+    @pytest.mark.asyncio
+    async def test_frame_without_the_internal_secret(self, home: Path) -> None:
+        async with TestClient(TestServer(_frame_app(grant_internal_auth=False))) as client:
+            resp = await client.post("/api/computer-use/frame", json=_VALID_FRAME)
+            body = await resp.json()
+        assert resp.status == 403
+        assert body["code"] == "internal_secret_required"
+
+    @pytest.mark.asyncio
+    async def test_frame_carrying_no_frame_data(self, home: Path) -> None:
+        async with TestClient(TestServer(_frame_app())) as client:
+            resp = await client.post("/api/computer-use/frame", json={"format": "jpeg"})
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["code"] == "no_frame_data"
+
+    # -- the behavioural ratchet --
+
+    @pytest.mark.asyncio
+    async def test_every_config_refusal_carries_both_a_code_and_its_prose(self, home: Path) -> None:
+        """No refusal path may regress to prose-only, and none may drop the advisory
+        text an existing client still reads."""
+        for payload in (
+            ["enabled"],
+            {"enabled": "yes"},
+            {"max_tree_nodes": "1200"},
+            {"max_tree_nodes": 10**9},
+            {"attach_screenshot": 1},
+            {"allowed_apps": "Preview"},
+            {"nothing_we_know": True},
+        ):
+            async with _client() as client:
+                status, body = await self._put(client, payload)
+            assert status == 400, payload
+            assert isinstance(body.get("code"), str) and body["code"], payload
+            assert isinstance(body.get("error"), str) and body["error"], payload


### PR DESCRIPTION
## Problem / Motivation

`error-code-baseline.json` — the repo's own Track B worklist — listed `dashboard/handlers/computer_use.py` with `missing_code: 20`. Every refusal this module can produce answered with English prose and nothing a caller could dispatch on:

```python
return web.json_response({"error": f"{key} must be an integer"}, status=400)
return web.json_response({"error": f"{key} must be between {low} and {high}"}, status=400)
```

A client that needs to tell "the value was the wrong type" from "the value was the right type but out of range" has to match English wording — the exact failure mode the contract gate in `test/test_error_code_contract.py` exists to retire.

The module already **knew** the reason. Nearly every refusal sits directly beside an `_audit()` call whose `resources=` marker names it:

| Refusal | Audit marker it already records |
|---|---|
| body was not JSON | `invalid_json` |
| body was not an object | `body_not_object` |
| `enabled` of the wrong type | `enabled=bad_type` |
| a limit of the wrong type | `{key}=bad_type` |
| a limit out of range | `{key}={value}` |
| no recognised field | `empty_patch` |
| keystone corrupt | `state_corrupt` |
| settings write failed | `write_failed` |

That marker went into the audit log and nowhere else. This PR publishes it on the wire.

## Why it matters

The 20 sites are spread across all three of this module's endpoints, and two of them are **machine** legs where a human reading prose is not even the consumer:

- `PUT /api/computer-use/config` (11) — the operator's Settings panel;
- `POST /api/computer-use/invoke` (5) — the `kirocrew-computer` stdio shim's loopback leg;
- `POST /api/computer-use/frame` (4) — the live-view frame ingress.

For `/invoke` the caller is `mcp_core._http_error_body`, whose whole job is to hand a structured failure back to a tool. Without a code it can only forward a sentence to the LLM.

This also converts the single largest zero-contention entry left on the worklist: no other open PR touches this file (checked against all 266 open PRs by exact path, and re-checked immediately before opening this one).

## What changed (motivation → approach → change)

**Symptom** → 20 refusals with no machine-readable `code`; callers must match English.

**Root cause** → the reason existed only as an `_audit()` marker, never on the response.

**Change** → each of the 20 `web.json_response({"error": ...}, status>=400)` sites gains a `"code"` naming that same reason. The prose is kept and keeps its meaning — demoted to advisory, not removed — so a client that only reads `error` is unaffected.

Codes reuse the tree's existing vocabulary wherever it already fits. Nine do: `invalid_json`, `body_not_object`, `invalid_field_type`, `value_out_of_range`, `config_corrupt`, `config_write_failed`, `dashboard_user_required`, `internal_secret_required`, `loopback_only` all already name the same reason on other handlers. Five are new, because no other handler refuses for these reasons yet — `invalid_app_patterns`, `no_known_fields`, `tool_required`, `invalid_args`, `no_frame_data` (zero occurrences repo-wide at this PR's base). They are new names, not a new scheme: each follows the established `lower_snake_case` grammar that `test_every_error_code_is_a_machine_readable_identifier` enforces.

### Why this is backend-only

Track B normally moves with its consumers — a `code` alone changes nothing while the frontend still renders `res.error` verbatim. Here both consumers are **already** built for the code, so there is no consumer edit that would be honest to include:

- **Browser.** `website/src/pages/settings/ComputerUsePanel.tsx` never renders the server's prose. Its mutation `onError` sets a fixed localized string (`pages.settings.computerUsePanel.could_not_save_computer_use_settings`) and discards the response body. Nothing to move, and no locale catalog to touch.
- **stdio shim (`/invoke`).** `mcp_core._http_error_body` already parses a top-level `code`, validates it as `[a-z0-9_.-]{1,64}`, and passes it on — the mechanism added for `unknown_session`. These codes simply start arriving.
- **Capture thread (`/frame`).** `computer_use/screencast._post_frame` does `with loopback_urlopen(request, ...): pass` — it discards the body entirely, so the added key is inert there.

No behaviour changes: same statuses, same prose, same control flow. The diff is 60 insertions / 20 deletions, all inside the 20 response literals plus the reflow `black` requires.

## Tests

Added to the module's existing `test/test_computer_use_api.py` — its `TestClient` harness and `_frame_app` helper — rather than a parallel framework.

**Behavioural (13)**, driving the real handlers:

| Test | Locks in |
|---|---|
| `test_body_is_not_a_json_object` | `body_not_object` |
| `test_enabled_of_the_wrong_type` | `invalid_field_type` |
| `test_an_integer_limit_of_the_wrong_type` | `invalid_field_type` |
| `test_an_integer_limit_out_of_range_is_a_different_code` | `value_out_of_range` — the distinction a caller could not previously make without matching English |
| `test_a_boolean_limit_of_the_wrong_type` | `invalid_field_type` |
| `test_a_malformed_app_pattern_list` | `invalid_app_patterns` |
| `test_a_body_naming_no_known_field` | `no_known_fields` |
| `test_invoke_without_a_tool` | `tool_required` |
| `test_invoke_with_non_object_args` | `invalid_args` |
| `test_the_code_survives_the_shims_own_error_decoder` | runs the **real** `mcp_core._http_error_body` over this handler's **real** response body — the code is only worth adding if the decoder keeps it, and that decoder drops anything not identifier-shaped |
| `test_frame_without_the_internal_secret` | `internal_secret_required` |
| `test_frame_carrying_no_frame_data` | `no_frame_data` |
| `test_every_config_refusal_carries_both_a_code_and_its_prose` | the behavioural ratchet: no path regresses to prose-only, none drops the advisory text |

**Per-file static ratchet (2).** Defence in depth, not a gap-filler. The repo-wide ratchet caps each *file* and *bucket* independently (`cap = allowed.get(bucket, 0)`), so once `computer_use.py` leaves the baseline its cap is zero and a later prose-only refusal here already fails the build on its own — no cross-file netting is possible. These two exist to keep the changed module's refusal contract exercised directly, beside its behavioural tests, and they run the gate's **own** `scan()`, so the per-file rule cannot drift from the repo-wide definition:

- `test_no_refusal_in_this_module_is_prose_only` — fails with the offending line numbers;
- `test_the_ratchet_can_actually_fail` — the self-check, because a scan that matched nothing would pass the assertion above vacuously. Asserts the scanner reaches all 20 sites and each carries a non-empty code.

Red before the source change: **15 failed** (12 × `KeyError: 'code'`, plus the two ratchets and the behavioural ratchet). After: **15 passed**.

Wider: `pytest test/test_computer_use_api.py test/test_error_code_contract.py test/test_mcp_computer.py test/test_computer_use_registration.py` → **345 passed, 2 skipped**.

### Baseline

`missing_code` 1334 → 1314 — exactly the twenty — and the `dashboard/handlers/computer_use.py` entry is gone. `_compliant` moves 1223 → 1243, also exactly twenty.

Both numbers are stated against a regenerated control at `main` `609c2e101`, which for this base agrees exactly with the committed baseline (1334 / 1223). An earlier revision of this description had to discount an 11-point `_compliant` under-count on `main`; that under-count is gone, so the plain committed-to-committed reading is now correct.

The baseline was **regenerated** from the live tree with the repo's own `python test/test_error_code_contract.py --update`, never hand-edited: its totals are relative to this PR's base, so reconciling numbers across branches would be meaningless. Diffing the regenerated file against `main`'s shows exactly one changed entry — `dashboard/handlers/computer_use.py`, removed — and no other file added, removed, or changed.

## Manual verification

N/A — unit coverage sufficient: every changed site is a refusal reachable by sending one malformed request, and all 20 are driven either behaviourally through the real handlers or by the gate's own AST scanner. There is no UI change to look at — the panel already ignored the string being augmented.

`flake8` and `black --check` are clean on both changed files. Neither is listed in `.github/black-baseline.txt`, and `computer_use.py` was `black`-clean before this change, so the reflow is confined to the 20 edited literals with no collateral reformat.

## Related Issues

No issue — this is the `dashboard/handlers/computer_use.py` line item from `error-code-baseline.json`'s own worklist ("drive `missing_code` to zero, one PR per file or per directory").

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented wire contract changes; the added key is additive and the module's own docstrings already describe the statuses
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->




