### PR TITLE
fix(skills): align strip_frontmatter closer with the display parser

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -4670,13 +4670,19 @@ class SkillsLoader:
         """Remove YAML frontmatter from markdown.
 
         A fence LOCATOR, not a field parser — deliberately outside
-        ``kiro_crew.frontmatter``. Its closer grammar is stricter than
-        ``_parse_frontmatter``'s (``---`` must be followed by a newline), so
-        a ``---junk`` closer parses fields yet strips nothing; editing either
-        grammar means revisiting the other.
+        ``kiro_crew.frontmatter``. Its closer grammar matches
+        ``frontmatter._COLUMN0_BLOCK_RE`` — the ``column0_fence`` extraction
+        that ``frontmatter.SKILL_LOADER`` binds to the skills surface: the
+        closer is the first line after the opener that STARTS with ``---`` —
+        trailing text on the closer line is tolerated and consumed (#6182). Anything
+        the display parser reads as frontmatter must also be stripped here:
+        a stricter closer (the old ``---`` must-be-followed-by-newline
+        grammar) let a ``---junk`` or ``--- `` closer parse fields in the UI
+        while the whole block leaked to the model. Editing either grammar
+        means revisiting the other.
         """
         if content.startswith("---"):
-            match = re.match(r"^---\n.*?\n---\n", content, re.DOTALL)
+            match = re.match(r"^---\n.*?\n---[^\n]*\n?", content, re.DOTALL)
             if match:
                 return content[match.end() :].strip()
         return content

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -2037,3 +2037,73 @@ class TestDisabledAppSkillsAreNotTriggered:
         )
 
         assert loader.get_triggered_skills("find hotspots for me") == ["ai-discover"]
+
+
+class TestStripFrontmatterCloserParity:
+    """#6182: strip_frontmatter's closer must accept everything the display
+    parser's ``column0_fence`` grammar accepts. A closer the parser tolerates
+    but the stripper rejects shows parsed metadata in the UI while the whole
+    frontmatter block leaks to the model."""
+
+    BODY = "# Heading\n\nInstruction text."
+
+    def _doc(self, closer: str) -> str:
+        return f"---\ndescription: test skill\n{closer}\n{self.BODY}"
+
+    def test_strict_closer_still_strips(self) -> None:
+        out = SkillsLoader.strip_frontmatter(self._doc("---"))
+        assert out == self.BODY
+        assert "description:" not in out
+
+    @pytest.mark.parametrize("closer", ["--- ", "---junk", "--- comment text"])
+    def test_lenient_closer_strips_whatever_the_parser_parses(self, closer: str) -> None:
+        """The invariant itself: for the same document, the display parser
+        reads the fields AND the stripper removes the block."""
+        from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
+
+        doc = self._doc(closer)
+        fields = parse_frontmatter(doc, SKILL_LOADER)
+        assert fields.get("description") == "test skill", (
+            "premise broken: the display parser no longer tolerates this "
+            "closer — re-check _COLUMN0_BLOCK_RE before touching the stripper"
+        )
+        out = SkillsLoader.strip_frontmatter(doc)
+        assert "description:" not in out, f"frontmatter leaked past closer {closer!r}"
+        assert out == self.BODY
+
+    def test_closer_at_eof_without_newline_strips(self) -> None:
+        out = SkillsLoader.strip_frontmatter("---\ndescription: test skill\n---")
+        assert out == ""
+
+    def test_no_closer_leaves_content_unchanged(self) -> None:
+        doc = "---\ndescription: dangling opener, no closer"
+        assert SkillsLoader.strip_frontmatter(doc) == doc
+
+    def test_plain_markdown_untouched(self) -> None:
+        assert SkillsLoader.strip_frontmatter(self.BODY) == self.BODY
+
+    def test_dashes_inside_body_do_not_end_early(self) -> None:
+        """A ``---`` ruler AFTER the real closer stays in the body."""
+        doc = f"---\ndescription: test skill\n---\nintro\n---\n{self.BODY}"
+        out = SkillsLoader.strip_frontmatter(doc)
+        assert out.startswith("intro")
+        assert "---" in out
+
+    def test_leading_whitespace_opener_parity_both_sides_reject(self) -> None:
+        """Opener-side guard: today BOTH the display dialect (column0_fence)
+        and the stripper reject a leading-whitespace opener, so nothing
+        parses and nothing strips — parity holds in the reject direction.
+        If the display dialect ever goes lenient on the opener (e.g.
+        switching SKILL_LOADER to leading_ws_fence), the premise assertion
+        here goes red, forcing the stripper's opener to be revisited in the
+        same change instead of silently reopening the #6182 leak."""
+        from kiro_crew.frontmatter import SKILL_LOADER, parse_frontmatter
+
+        doc = f" ---\ndescription: test skill\n---\n{self.BODY}"
+        fields = parse_frontmatter(doc, SKILL_LOADER)
+        assert not fields.get("description"), (
+            "premise broken: the display dialect now tolerates a "
+            "leading-whitespace opener — strip_frontmatter's opener "
+            "(startswith('---')) must be widened in the same change"
+        )
+        assert SkillsLoader.strip_frontmatter(doc) == doc


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only parser/stripper alignment in `skills.py`; no rendered UI surface changes.

## Problem / Motivation

`SkillsLoader.strip_frontmatter` requires a strict `---\n` closing fence, while the paired display parser (`frontmatter._COLUMN0_BLOCK_RE`, the `column0_fence` extraction that `SKILL_LOADER` binds to the skills surface) accepts any closer line that *starts with* `---`. A skill file whose closing fence carries a trailing space or trailing text (`--- `, `---junk` — an ordinary editor artifact) therefore shows its `description:` as parsed metadata in the UI, yet `strip_frontmatter` strips nothing and the whole frontmatter block reaches the model. The old docstring named the trap itself: "a `---junk` closer parses fields yet strips nothing."

## Why it matters

Model-facing consumers call `strip_frontmatter` at five sites (skill injection, enumeration, and context assembly paths, including `context.py`), so every affected skill file leaks its full frontmatter block into the model prompt on every injection — invisible in the UI, which shows the metadata as correctly parsed. This is the same leak class as the `@prompt` mention-expansion fix (#6164 / PR #6173); the First Principles review lane on that PR counted `SkillsLoader.strip_frontmatter` as the unfixed sibling of the same root cause.

## What changed (motivation → approach → change)

Symptom → root cause: two fence locators for the same surface drifted — the display parser's closer is "first line after the opener that starts with `---`" while the stripper demanded exactly `---\n`, so parser-accepted documents were stripper-rejected.

Approach: align the stripper's closer to the parser's grammar (the minimal root-cause fix named in the issue), rather than the wider locator-unification refactor — that larger subtraction stands on its own and is not needed to close the leak.

Change: `strip_frontmatter`'s regex becomes `^---\n.*?\n---[^\n]*\n?` — the closer is the first line after the opener starting with `---`, and the entire closer line (including tolerated trailing text) is consumed. A closer at end-of-file without a trailing newline — also parser-accepted — now strips too. The docstring now documents the parity invariant and names `SKILL_LOADER` so the coupling is discoverable from both ends.

## Tests

New `TestStripFrontmatterCloserParity` class in `test/test_skills.py`:
- Parametrized parity tests (`--- `, `---junk`, `--- comment text`) assert the invariant directly: for the same document, the display parser reads the fields AND the stripper removes the block — each case first asserts the parser premise, so if the display dialect ever tightens, the test names the divergence rather than passing vacuously.
- Opener-side guard: today both sides reject a leading-whitespace opener; if the display dialect ever goes lenient on the opener, the premise assertion goes red, forcing the stripper's opener to be revisited in the same change (raised by the local Opus review lane).
- Edge cases: strict `---\n` closer parity (regression), closer at EOF without newline, dangling opener with no closer (content unchanged), plain markdown untouched, and a `---` ruler after the real closer staying in the body.
- Full `test/test_skills.py` suite green (143 tests) — covers the five model-facing call sites' enumeration/injection paths.

## Manual verification

N/A — unit coverage sufficient: the parametrized parity tests encode the exact reproduction from the issue (parser parses, stripper leaks), and reverting the regex fails them.

## Related Issues

Fixes #6182

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
