### PR TITLE
fix(dashboard): stale query token no longer vetoes a valid session cookie

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5653,6 +5653,7 @@
         },
         "restore_sessions": false,
         "qr_session_until_restart": true,
+        "qr_session_persist_across_restart": false,
         "restore_window_minutes": 30,
         "surface_channel_sessions": true,
         "bot_name": "",
@@ -5846,6 +5847,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true
+    },
+    {
+      "path": "dashboard.qr_session_persist_across_restart",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Phone Sign-In Survives A Gateway Restart",
+      "help": "REQUIRES BOTH: \"Phone Sign-In Lasts Until Restart\" must also be ON, and tailnet identity trust must be configured (`dashboard.tailscale.trust_identity` with a non-empty `allowed_logins`). Without either one this setting is ignored and a warning naming the missing prerequisite is logged. Note the first requirement is NOT a contradiction: \"Lasts Until Restart\" is what issues the renewable credential, and this setting then removes the restart bound from it -- turning that one OFF instead leaves a session that expires on a fixed clock, with nothing to renew. What it does: let a scanned phone stay signed in across gateway restarts, so one scan lasts until the refresh credential's own 30-day lifetime lapses. OFF by default because a restart is otherwise a hard sign-out that needs no recorded state. The identity requirement is not optional bookkeeping: behind `tailscale serve` every request reaches the gateway from 127.0.0.1, so without a daemon-verified peer identity the session is a bearer credential any tailnet peer could replay, and outliving the process is exactly what makes that matter.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
     },
     {
       "path": "dashboard.restore_window_minutes",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2970,6 +2970,30 @@ class DashboardConfig:
             "to the peer it was established from.",
         ),
     )
+    qr_session_persist_across_restart: bool = field(
+        default=False,
+        metadata=_meta(
+            "Phone Sign-In Survives A Gateway Restart",
+            'REQUIRES BOTH: "Phone Sign-In Lasts Until Restart" must also be ON, '
+            "and tailnet identity trust must be configured "
+            "(`dashboard.tailscale.trust_identity` with a non-empty "
+            "`allowed_logins`). Without either one this setting is ignored and a "
+            "warning naming the missing prerequisite is logged. Note the first "
+            'requirement is NOT a contradiction: "Lasts Until Restart" is what '
+            "issues the renewable credential, and this setting then removes the "
+            "restart bound from it -- turning that one OFF instead leaves a "
+            "session that expires on a fixed clock, with nothing to renew. "
+            "What it does: let a scanned phone stay signed in across gateway "
+            "restarts, so one scan lasts until the refresh credential's own "
+            "30-day lifetime lapses. OFF by default because a restart is "
+            "otherwise a hard sign-out that needs no recorded state. The "
+            "identity requirement is not optional bookkeeping: behind "
+            "`tailscale serve` every request reaches the gateway from 127.0.0.1, "
+            "so without a daemon-verified peer identity the session is a bearer "
+            "credential any tailnet peer could replay, and outliving the process "
+            "is exactly what makes that matter.",
+        ),
+    )
     restore_window_minutes: int = field(
         default=30,
         metadata=_meta(
@@ -7751,6 +7775,9 @@ class KiroCrewConfig:
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 qr_session_until_restart=_safe_bool(
                     dashboard_data.get("qr_session_until_restart"), True
+                ),
+                qr_session_persist_across_restart=_safe_bool(
+                    dashboard_data.get("qr_session_persist_across_restart"), False
                 ),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
                 surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -24,7 +24,6 @@ from kiro_crew.dashboard.state import VALID_MEMORY_MODES, DashboardState
 from kiro_crew.dashboard.token_auth import (
     MAX_SESSION_TTL_SECS,
     _b64url_decode,
-    _cookie_port_from_host,
 )
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.messaging.privacy_mode import hydrate as _hydrate_conv_flags
@@ -1522,15 +1521,18 @@ def _caller_bounds(request: web.Request) -> tuple[dict[str, str], int]:
     payload: a caller whose bounds cannot be established gets a bounded
     (no-refresh, default-TTL-capped) link rather than an unbounded one.
 
-    **Extraction order must mirror the middleware's, query param before cookie.**
-    Only the credential the middleware actually validated has a verified
-    signature; the other one was never checked. The middleware prefers
-    ``?token=`` (``token_auth`` middleware and ``_extract_and_validate``, both
-    ``request.query.get("token") or request.cookies.get(...)``), so reading the
-    cookie first would let a request that authenticated with a bounded query
-    token have its bounds read from an unverified, attacker-settable cookie —
-    dropping ``no_refresh`` and raising the TTL ceiling to the full maximum,
-    which is precisely the ceiling-escape this function exists to prevent.
+    **Read the credential the middleware VALIDATED, not a re-extracted one.**
+    Only that credential has a verified signature; the other one was never
+    checked. ``token_auth`` publishes it as ``request["auth_token"]`` for
+    exactly this reason: its own extraction prefers ``?token=`` but falls back
+    to the session cookie when the query token is invalid, so re-deriving with
+    a fixed query-then-cookie order could pick the credential that was NOT
+    validated — letting a request that authenticated with a bounded cookie have
+    its bounds read from an unverified, attacker-settable query token, dropping
+    ``no_refresh`` and raising the TTL ceiling to the full maximum, which is
+    precisely the ceiling-escape this function exists to prevent. When no
+    credential was published (a surface that authenticated by another means),
+    the mint is bounded fail-closed the same way an unreadable payload is.
 
     **A non-positive remaining lifetime is never rounded up.** Clamping it to a
     floor of one second would let a caller whose own session has just run out
@@ -1539,9 +1541,8 @@ def _caller_bounds(request: web.Request) -> tuple[dict[str, str], int]:
     indefinitely from a session that should already be dead. Report ``0`` and
     let the caller be refused.
     """
-    port = request.app.get("port", 7777)
-    cookie_name = f"mc_token_{_cookie_port_from_host(request, port)}"
-    token = request.query.get("token", "") or request.cookies.get(cookie_name, "")
+    published = request.get("auth_token", "")
+    token = published if isinstance(published, str) else ""
     carried: dict[str, str] = {}
     ttl_ceiling = MAX_SESSION_TTL_SECS
     if not token:

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -30,6 +30,7 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
     refresh_token_boot,
+    refresh_token_requires_peer,
     validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust, peer_pin_key, resolve_forwarded_peer
@@ -337,15 +338,33 @@ async def api_auth_me(request: web.Request) -> web.Response:
     if not user_id:
         return web.json_response({"error": "unauthenticated"}, status=401)
 
-    # The middleware has already validated the access cookie. We can read
-    # session_exp from the cookie payload directly.
+    # Read the credential the MIDDLEWARE VALIDATED, published as
+    # ``request["auth_token"]`` — the same contract ``_caller_bounds`` and the
+    # frame-ancestors reader follow. Re-extracting the cookie here was only ever
+    # correct because extraction order was guaranteed to match the middleware's;
+    # it does not hold when a valid ``?token=`` won (pre-existing) and, now that
+    # an invalid query token falls back to the cookie, the order is not fixed at
+    # all. Reading the wrong credential mis-reports ``session_exp``, which is
+    # what drives the frontend's proactive-refresh scheduler.
+    #
+    # The re-extraction stays as a FALLBACK rather than being deleted. On the
+    # first request of a link exchange the published credential is the link
+    # token, whose nonce this very request added to the cookie denylist, so the
+    # numeric read yields nothing — exactly the case where the old path already
+    # reported 0.0. Falling back keeps this strictly better than before instead
+    # of trading one blind spot for another.
     port = request.app.get("port", 7777)
     cookie_name = f"mc_token_{_cookie_port_from_host(request, port)}"
-    access_token = request.cookies.get(cookie_name, "")
+    published = request.get("auth_token", "")
+    access_token = published if isinstance(published, str) and published else ""
     # session_exp is a FLOAT claim; the string-only extract_claims_from_token
     # silently drops it (always yielding 0.0 here), which disabled the
     # frontend's proactive-refresh scheduler. Use the numeric extractor.
     session_exp = extract_numeric_claim(access_token, "session_exp") or 0.0
+    if not session_exp:
+        session_exp = (
+            extract_numeric_claim(request.cookies.get(cookie_name, ""), "session_exp") or 0.0
+        )
 
     # Refresh-cookie expiry: best effort — if a refresh cookie is present,
     # we report its session_exp. The cookie is path-scoped to /api/auth/
@@ -418,6 +437,42 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
 
     state = _get_state()
 
+    # An identity-bound chain (the persistent QR session shape) may only be USED
+    # while a daemon-verified tailnet peer can be established. Placed here, ahead
+    # of BOTH the reuse branch and the mint, because every path below this line
+    # hands the caller a live credential: the grace-replay branch re-serves the
+    # cached pair and re-sets both cookies without minting anything, so a check
+    # sited at the mint leaves a 60-second window in which a replayed token is
+    # honoured with no identity check at all. That window was the review finding.
+    #
+    # Ordering it BEFORE reuse detection is deliberate, not incidental. Reuse
+    # detection revokes the chain, so letting it run first would let any
+    # unverified caller destroy a legitimate 30-day session by replaying one
+    # consumed token — a sign-out handed to anyone who can reach the port. An
+    # unverified caller gets 401 either way, so refusing first loses no theft
+    # signal: a thief who CAN verify still trips reuse detection normally.
+    #
+    # A refusal does NOT revoke. Identity resolution fails transiently (daemon
+    # restart, a stripped header), and burning a 30-day credential over a blip
+    # would turn a recoverable hiccup into a re-scan. The session simply cannot
+    # be used until identity is established again, which is the honest reading of
+    # "bounded by identity" — and it is the only bound available here, since
+    # behind `tailscale serve` every request arrives from 127.0.0.1, so an
+    # address pin would read as a pin while excluding nobody.
+    if refresh_token_requires_peer(refresh_token) and not await _verified_peer(request):
+        _audit(user_id, "refresh_token_use", "peer_unverified", chain_id)
+        # Prose in ``error``, machine id in ``code``, per the error-code contract:
+        # the dashboard renders ``error`` verbatim into a localized UI, so an
+        # un-coded identifier would be untranslatable by construction.
+        return web.json_response(
+            {
+                "error": "This device could not be verified on the tailnet, so the session "
+                "cannot be renewed. Reconnect to the tailnet and try again.",
+                "code": "peer_identity_unverified",
+            },
+            status=401,
+        )
+
     # Reuse detection: if this jti is already consumed AND it is NOT
     # within the multi-tab grace window, treat as theft and revoke.
     if state.is_consumed(jti):
@@ -476,15 +531,25 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     # this path, carrying degrades to "unbound", while re-deriving would silently
     # mint a live binding for it.
     carried_boot = refresh_token_boot(refresh_token)
+    carried_require_peer = refresh_token_requires_peer(refresh_token)
+    _carried_claims: dict[str, str] = {}
+    if carried_boot:
+        _carried_claims["boot"] = carried_boot
+    if carried_require_peer:
+        # Carried onto BOTH halves of the rotated pair. Dropping it on either one
+        # would make the FIRST rotation silently downgrade an identity-bound
+        # session to an ordinary one — the same shape of defect as the review
+        # finding this check answers, one rotation later.
+        _carried_claims["require_peer"] = "1"
     new_access_token = generate_token(
         user_id,
         ttl_seconds=MAX_SESSION_TTL_SECS,
         register_nonce=False,
-        extra={"boot": carried_boot} if carried_boot else None,
+        extra=_carried_claims or None,
     )
     new_session_exp = now + MAX_SESSION_TTL_SECS
     new_refresh_token, _new_chain, _new_jti, new_refresh_exp = generate_refresh_token(
-        user_id, chain_id=chain_id, boot=carried_boot
+        user_id, chain_id=chain_id, boot=carried_boot, require_peer=carried_require_peer
     )
 
     public_payload = {
@@ -523,6 +588,24 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     _expire_foreign_port_cookies(resp, request)
     _audit(user_id, "refresh_token_use", "ok")
     return resp
+
+
+async def _verified_peer(request: web.Request) -> bool:
+    """Whether a daemon-verified tailnet peer resolves for this request.
+
+    Reads the same ``tailnet_trust`` gate and the same resolver that
+    :func:`_rebind_rotated_token_to_peer` uses, so "can this be pinned" and "may
+    this rotate" cannot answer differently — a rotation admitted here that the
+    rebind then could not pin is precisely the gap this pair closes.
+    """
+    trust = request.app.get("tailnet_trust")
+    if not (isinstance(trust, TailnetTrust) and trust.trust_identity and trust.allowed_logins):
+        return False
+    try:
+        return await resolve_forwarded_peer(request, trust) is not None
+    except Exception:  # noqa: BLE001 - an auth decision must not 500 on the probe
+        logger.debug("refresh: tailnet peer resolution failed", exc_info=True)
+        return False
 
 
 async def _rebind_rotated_token_to_peer(

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -692,14 +692,82 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     # that expires on a clock the operator did not ask for, which presents as a
     # phone that randomly signs itself out. The fallback is not unbounded
     # either — a boot-bound session still ends at the next restart.
+    # Read INDEPENDENTLY, each with its own conservative default, rather than as
+    # one all-or-nothing block. Coupling them means a config object missing any
+    # ONE attribute discards the other two — so adding this shape would silently
+    # take the existing opt-out away from anyone whose config predates it, which
+    # is the opposite of "an unreadable override falls back to the default".
+    # Per-field is the faithful version of that rule.
+    _until_restart = True
+    _persist = False
+    _identity_trusted = False
     try:
         _cfg = await asyncio.to_thread(KiroCrewConfig.load)
-        _until_restart = bool(_cfg.dashboard.qr_session_until_restart)
     except Exception:
         logger.debug("tailnet mobile: config unreadable for session shape", exc_info=True)
-        _until_restart = True
+    else:
+        _dash = getattr(_cfg, "dashboard", None)
+        _until_restart = bool(getattr(_dash, "qr_session_until_restart", True))
+        _persist = bool(getattr(_dash, "qr_session_persist_across_restart", False))
+        _ts = getattr(_dash, "tailscale", None)
+        _identity_trusted = bool(
+            getattr(_ts, "trust_identity", False) and getattr(_ts, "allowed_logins", None)
+        )
 
-    if _until_restart:
+    # THIRD shape - ``persistent``: the refresh chain with NO boot claim, so one
+    # scan survives a gateway restart and is bounded only by the chain's own
+    # 30-day lifetime. Opt-in, because the boot bound it removes is a hard revoke
+    # needing no recorded state, and that default was chosen deliberately.
+    #
+    # GATED on daemon-verified tailnet identity, and the gate is what makes this
+    # offerable at all rather than merely convenient. Behind ``tailscale serve``
+    # every request reaches the gateway from 127.0.0.1 (#1762), so with identity
+    # trust off the pin is ``ip:127.0.0.1`` for every tailnet client and the
+    # cookie is a bearer credential any of them could replay. A session that ends
+    # at the next restart bounds that exposure; one that outlives the process does
+    # not. With ``trust_identity`` plus an allowlist the session pins to a
+    # verified peer instead, and the exposure is bounded by identity rather than
+    # by uptime.
+    #
+    # Both refusals are LOUD. Turning the flag on and silently getting a
+    # boot-bound session is the "checked but never ran, reported as a clean
+    # result" defect: the operator would believe the phone survives restarts and
+    # find out only by being signed out.
+    if _persist and not _until_restart:
+        logger.warning(
+            "dashboard.qr_session_persist_across_restart is on but "
+            "qr_session_until_restart is off, so the timed shape is in force and "
+            "there is no refresh chain to carry across a restart. The phone "
+            "session stays bounded by its TTL; turn qr_session_until_restart on "
+            "to use the persistent shape."
+        )
+        _persist = False
+    if _persist and not _identity_trusted:
+        logger.warning(
+            "dashboard.qr_session_persist_across_restart is on but tailnet "
+            "identity trust is not configured, so the phone session stays bound "
+            "to this gateway process. Behind `tailscale serve` every request "
+            "arrives from 127.0.0.1, so without dashboard.tailscale.trust_identity "
+            "plus a non-empty allowed_logins the session cannot be pinned to a "
+            "verified peer and must not outlive the process."
+        )
+        _persist = False
+
+    if _persist:
+        # No ``boot``, so the chain rather than the process bounds this session,
+        # and no ``no_refresh``, so the chain exists at all. ``require_peer`` is
+        # what keeps that honest: this session's whole security argument is that
+        # it is pinned to a daemon-verified tailnet identity, so the chain must
+        # refuse to rotate whenever that identity cannot be established.
+        #
+        # An address pin is NOT an alternative here, and that is the whole reason
+        # this claim exists rather than reusing the boot-bound rotation path.
+        # Behind ``tailscale serve`` every request reaches the gateway from
+        # 127.0.0.1, so ``ip:127.0.0.1`` is satisfied by every peer on the
+        # tailnet - it would read as a pin in the audit trail while excluding
+        # nobody. Refusing the rotation is the only bound that actually holds.
+        shape: dict[str, str] = {"require_peer": "1"}
+    elif _until_restart:
         shape = {"boot": current_boot_id()}
     else:
         shape = {"no_refresh": "1"}
@@ -742,6 +810,14 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     # minted credential ``no_refresh`` regardless of the configured shape, so
     # the phone session never grows a refresh chain its authorizing session did
     # not have.
+    #
+    # This caps the PERSISTENT shape too, and that is correct rather than a gap:
+    # a credential must not outlive the session that authorized it, so an owner
+    # who is themselves signed in on a boot-bound session hands the phone a
+    # boot-bound session as well, whatever the config says. Reaching the
+    # persistent shape therefore also requires the authorizing session to be
+    # unbounded - which the desktop local-bootstrap mint is, since
+    # ``/api/token/local`` carries neither ``boot`` nor ``no_refresh``.
     claims = {**shape, **carried}
     token = generate_token(owner_id or "local-app", ttl_seconds=ttl, extra=claims)
     url = f"https://{host}/?token={token}"

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -411,6 +411,7 @@ def generate_refresh_token(
     chain_id: str | None = None,
     ttl_seconds: int = MAX_REFRESH_TTL_SECS,
     boot: str = "",
+    require_peer: bool = False,
 ) -> tuple[str, str, str, float]:
     """Generate a refresh token.
 
@@ -448,6 +449,13 @@ def generate_refresh_token(
         # Omitted rather than written empty so an unbound chain's payload is
         # byte-identical to what it was before this claim existed.
         payload_dict["boot"] = boot
+    if require_peer:
+        # A chain whose safety rests on a daemon-verified tailnet identity rather
+        # than on process lifetime. ``api_auth_refresh`` refuses to rotate it
+        # while no peer resolves, so the long-lived credential can never be
+        # rotated by a caller whose identity could not be established. Omitted
+        # when false for the same byte-identity reason as ``boot``.
+        payload_dict["require_peer"] = "1"
     payload = json.dumps(payload_dict, separators=(",", ":")).encode()
     encoded_payload = _b64url_encode(payload)
     signature = _sign(payload)
@@ -541,6 +549,26 @@ def refresh_token_boot(token: str) -> str:
         return ""
     value = payload.get("boot", "")
     return value if isinstance(value, str) else ""
+
+
+def refresh_token_requires_peer(token: str) -> bool:
+    """Whether this chain may only rotate for a daemon-verified tailnet peer.
+
+    Set on the QR "persistent" session shape, whose credential is bounded by
+    identity rather than by this process's lifetime. Same read-only,
+    validate-first contract as :func:`refresh_token_boot`, and the same
+    conservative failure direction is NOT available here: a decode failure must
+    answer ``True``, not ``False``. Answering ``False`` would let an
+    undecodable-but-signed token rotate without the identity check the chain was
+    minted to require, which is the one outcome this claim exists to prevent.
+    """
+    try:
+        payload = json.loads(_b64url_decode(token.split(".")[0]))
+    except Exception:
+        return True
+    if not isinstance(payload, dict):
+        return True
+    return str(payload.get("require_peer", "")) == "1"
 
 
 def refresh_cookie_name(port: str | int) -> str:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -872,7 +872,16 @@ def _extra_frame_ancestors(
         if 1 <= _p <= 65535:
             port = _p
     if port is None:
-        token = request.query.get("token") or ""
+        # Prefer the credential token_auth actually VALIDATED (it publishes it
+        # as request["auth_token"]): its extraction can adopt the session cookie
+        # over an invalid query token, so a fixed query-then-cookie re-derivation
+        # could read an unverified value. Fall back to that order only when no
+        # credential was published (e.g. a surface that never reached the
+        # middleware's authenticated paths).
+        published = request.get("auth_token", "")
+        token = published if isinstance(published, str) else ""
+        if not token:
+            token = request.query.get("token") or ""
         if not token:
             port_fallback = app.get("port", _DEFAULT_PORT) if app is not None else _DEFAULT_PORT
             cookie_port = _cookie_port_from_host(request, port_fallback)

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -970,6 +970,32 @@ def validate_token_with_app(
     return valid, user_id, reason, app_name
 
 
+def claims_an_app_unverified(token: str) -> bool:
+    """Whether *token* CLAIMS an ``app`` identity, without verifying its signature.
+
+    Used only to REFUSE — never to grant. The cookie fallback in the middleware
+    treats an invalid ``?token=`` as absent so a dead link token cannot veto a
+    live session cookie, but that must not apply to an APP token: an app token
+    and a dashboard-user cookie can legitimately arrive together (an installed
+    app's UI is served from this same origin, so the browser attaches the user's
+    cookie), and adopting the cookie there would swap an app-scoped identity for
+    the user's own and skip ``_enforce_app_scope`` entirely.
+
+    Reading an unverified claim is sound in exactly this direction. The claim can
+    only ever make the decision STRICTER, so a forged ``app`` value buys an
+    attacker a refusal, not a grant — and an unparseable payload answers ``False``
+    because such a token carries no app scope to protect in the first place (it
+    is refused on its own merits by ``validate_token`` regardless). It is NEVER
+    correct to read this to decide what a caller may reach: use the ``app_name``
+    that ``validate_token_with_app`` returns, which is signature-checked.
+    """
+    try:
+        data = json.loads(_b64url_decode(token.split(".")[0]))
+    except Exception:
+        return False
+    return bool(isinstance(data, dict) and data.get("app"))
+
+
 def extract_prompt_from_token(token: str) -> str:
     """Extract the ``prompt`` field from a validated token payload.
 
@@ -1981,11 +2007,28 @@ def token_auth_middleware(
         accepts a session pin the main flow would refuse.
         """
         cookie_name = f"mc_token_{_cookie_port_from_host(request, _port)}"
-        token = request.query.get("token") or request.cookies.get(cookie_name, "")
-        if not token:
+        query_token = request.query.get("token") or ""
+        cookie_token = request.cookies.get(cookie_name, "")
+        if not query_token and not cookie_token:
             return False, "", "no token", "", ""
-        valid, uid, reason, app = validate_token_with_app(token, use_session_exp=True)
-        return valid, uid, reason, app, token
+        if query_token:
+            valid, uid, reason, app = validate_token_with_app(query_token, use_session_exp=True)
+            # A stale ``?token=`` must not veto a still-valid session cookie
+            # (same rule as the main flow): fall through to the cookie only
+            # when the query token failed AND a cookie exists; otherwise the
+            # query token's verdict (and its failure reason) stands.
+            #
+            # An APP token is excluded from the fallback. An app's UI is served
+            # from this same origin, so the browser attaches the dashboard
+            # user's cookie alongside the app's own ``?token=``; adopting that
+            # cookie when the app token has expired would replace an app-scoped
+            # identity with the user's own and skip the ``_enforce_app_scope``
+            # gate below. An expired app token must be refused as an expired
+            # app token, so the caller re-exchanges its app secret.
+            if valid or not cookie_token or claims_an_app_unverified(query_token):
+                return valid, uid, reason, app, query_token
+        valid, uid, reason, app = validate_token_with_app(cookie_token, use_session_exp=True)
+        return valid, uid, reason, app, cookie_token
 
     @web.middleware
     async def middleware(request: web.Request, handler: object) -> web.StreamResponse:
@@ -2231,6 +2274,8 @@ def token_auth_middleware(
             # Expose identity so downstream handlers (and app-scope) see it.
             request["user"] = _uid
             request["app"] = _app
+            # The credential actually validated (see the main path's note).
+            request["auth_token"] = _tok
             # POSITIVE dashboard-user signal for the WS scope gate: the WS
             # layer must never infer trust from a falsy app claim (CWE-269).
             request["is_dashboard_user"] = not _app
@@ -2315,6 +2360,8 @@ def token_auth_middleware(
                 # (same rationale as the loopback branch above).
                 request["user"] = _uid
                 request["app"] = _app
+                # The credential actually validated (see the main path's note).
+                request["auth_token"] = _tok
                 # POSITIVE dashboard-user signal for the WS scope gate (see
                 # the loopback branch above).
                 request["is_dashboard_user"] = not _app
@@ -2419,6 +2466,45 @@ def token_auth_middleware(
         valid, user_id, reason, app_name = validate_token_with_app(
             token, use_session_exp=from_cookie
         )
+        if not valid and not from_cookie:
+            # A stale ``?token=`` must not veto a still-valid session cookie.
+            # Re-opening a bookmarked / previously-scanned link replays the
+            # long-expired link token in the URL; the browser ALSO sends the
+            # session cookie that link was exchanged for, and that cookie is
+            # the current credential. Treat the invalid query token as absent
+            # and validate the cookie instead — this grants nothing a
+            # cookie-only request would not already get (the cookie runs the
+            # full validation + the peer-pin check below), it only stops a
+            # dead historical token from being a one-vote veto. When the
+            # cookie is missing or also invalid, the original query-token
+            # failure stands so the denial reason names the credential the
+            # caller actually presented.
+            #
+            # An APP token never takes this path. An installed app's UI is
+            # served from this same origin, so the browser attaches the
+            # dashboard user's session cookie alongside the app's own
+            # ``?token=``. Falling back there would swap the app's scoped
+            # identity for the user's own — ``app_name`` would come back empty,
+            # ``_enforce_app_scope`` below would become a no-op, and an app
+            # whose token merely EXPIRED would silently gain the user's full
+            # API reach. An expired app token must be refused as such, so the
+            # app re-exchanges its secret at ``/api/apps/<name>/token``. The
+            # claim is read unverified, which is sound because it can only make
+            # this decision stricter (see ``claims_an_app_unverified``).
+            _cookie_token = request.cookies.get(cookie_name, "")
+            if _cookie_token and not claims_an_app_unverified(token):
+                _c_valid, _c_uid, _c_reason, _c_app = validate_token_with_app(
+                    _cookie_token, use_session_exp=True
+                )
+                if _c_valid:
+                    token = _cookie_token
+                    from_cookie = True
+                    valid, user_id, reason, app_name = (
+                        _c_valid,
+                        _c_uid,
+                        _c_reason,
+                        _c_app,
+                    )
         if not valid:
             # Cold-start variant: an expired/forged token is present (cookie
             # survived but its token lapsed). Same rationale — serve the shell
@@ -2516,6 +2602,14 @@ def token_auth_middleware(
                 _token_boot = str(data.get("boot", ""))
                 if _token_boot:
                     _carried["boot"] = _token_boot
+                # Carried for the same reason ``boot`` is: the session token is a
+                # fresh mint, so a claim not named here is silently dropped — and
+                # dropping this one would turn an identity-bound persistent
+                # session into an ordinary rotating one, which is exactly the
+                # binding it was minted to keep.
+                _token_require_peer = str(data.get("require_peer", ""))
+                if _token_require_peer:
+                    _carried["require_peer"] = _token_require_peer
                 # ``no_refresh`` gets the same treatment as ``boot`` and for the
                 # same reason: the claim must survive the exchange or a DOWNSTREAM
                 # consumer that reads the session cookie to learn the caller's
@@ -2604,6 +2698,16 @@ def token_auth_middleware(
         # Expose authenticated identity to handlers (deny-by-default)
         request["user"] = user_id
         request["app"] = app_name
+        # The credential this request was ACTUALLY authenticated with. Handlers
+        # that read signed claims out of the caller's own token (the mobile-link
+        # mint's bounds, the frame-ancestors parent port) must read THIS, not
+        # re-extract with their own query-then-cookie order: only the credential
+        # validated here has a verified signature, and since the cookie fallback
+        # above can adopt the cookie over an invalid query token, re-extraction
+        # is no longer guaranteed to pick the same one. Reading the other
+        # credential would let a bounded caller have its bounds read from an
+        # unverified, attacker-settable value.
+        request["auth_token"] = token
         # POSITIVE dashboard-user signal for the WS scope gate (see above).
         request["is_dashboard_user"] = not app_name
 
@@ -2705,7 +2809,9 @@ def token_auth_middleware(
                     # re-minted a fresh session on the next visit, and "ends at
                     # restart" would be false by one rotation.
                     refresh_token, chain_id, _jti, refresh_exp = generate_refresh_token(
-                        user_id, boot=str(data.get("boot", ""))
+                        user_id,
+                        boot=str(data.get("boot", "")),
+                        require_peer=str(data.get("require_peer", "")) == "1",
                     )
                     refresh_remaining = int(refresh_exp - time.time())
                     if refresh_remaining > 0:

--- a/test/test_auth_refresh_handlers_cov80.py
+++ b/test/test_auth_refresh_handlers_cov80.py
@@ -43,6 +43,7 @@ from kiro_crew.dashboard.refresh_tokens import (
     RefreshStateManager,
     generate_refresh_token,
     refresh_cookie_name,
+    refresh_token_requires_peer,
     validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust
@@ -291,6 +292,144 @@ async def test_me_reports_both_expiries(state: RefreshStateManager) -> None:
     assert payload["user_id"] == "alice"
     assert payload["session_exp"] > time.time()
     assert abs(payload["refresh_exp"] - refresh_exp) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_me_reads_session_exp_from_the_validated_credential(
+    state: RefreshStateManager,
+) -> None:
+    """``session_exp`` comes from ``request["auth_token"]``, not a re-extracted cookie.
+
+    The middleware publishes the credential it actually validated. Extraction
+    order here is no longer guaranteed to reproduce it (a valid ``?token=`` wins
+    over the cookie, and an invalid one now falls back to it), so reading the
+    cookie blind can report another credential's expiry — and this value is what
+    drives the frontend's proactive-refresh scheduler.
+    """
+    short_cookie = generate_token("alice", ttl_seconds=3600, register_nonce=False)
+    validated = generate_token("alice", ttl_seconds=MAX_SESSION_TTL_SECS, register_nonce=False)
+    request = _mk("GET", "/api/auth/me", user="alice", cookies={f"mc_token_{PORT}": short_cookie})
+    request["auth_token"] = validated
+
+    payload = _body(await h.api_auth_me(request))
+    # The published credential's ceiling, not the 1-hour cookie's.
+    assert payload["session_exp"] > time.time() + 3600 + 60
+
+
+@pytest.mark.asyncio
+async def test_me_falls_back_to_the_cookie_when_nothing_was_published(
+    state: RefreshStateManager,
+) -> None:
+    """A surface that published no credential still reports a usable expiry.
+
+    On the first request of a link exchange the published credential is the link
+    token, whose nonce that request just added to the cookie denylist, so the
+    numeric read yields nothing. Falling back keeps this no worse than the
+    re-extraction it replaces.
+    """
+    access = generate_token("bob", ttl_seconds=MAX_SESSION_TTL_SECS, register_nonce=False)
+    request = _mk("GET", "/api/auth/me", user="bob", cookies={f"mc_token_{PORT}": access})
+    payload = _body(await h.api_auth_me(request))
+    assert payload["session_exp"] > time.time()
+
+
+@pytest.mark.asyncio
+async def test_require_peer_is_enforced_before_the_grace_replay_return(
+    state: RefreshStateManager,
+) -> None:
+    """The grace-replay branch must not hand back a cached pair unverified.
+
+    Regression for a check sited too late: grace replay re-serves the previously
+    issued pair and re-sets BOTH cookies without minting anything, so a peer
+    check placed at the mint left a REFRESH_GRACE_SECS window in which a replayed
+    token was honoured with no identity check at all.
+    """
+    refresh, chain_id, jti, _exp = generate_refresh_token("phone", require_peer=True)
+    # Stage exactly the state the grace branch reads: this jti consumed as the
+    # chain head, with the replacement pair it minted available for replay.
+    state.mark_consumed(
+        jti,
+        chain_id,
+        time.time() + 3600,
+        "203.0.113.9",
+        json.dumps(
+            {
+                "session_exp": time.time() + 3600,
+                "refresh_exp": time.time() + 3600,
+                "_access_token": "cached-access",
+                "_refresh_token": "cached-refresh",
+            }
+        ),
+    )
+    request = _mk(
+        "POST",
+        "/api/auth/refresh",
+        origin="http://localhost:7777",
+        cookies={refresh_cookie_name(str(PORT)): refresh},
+    )
+    response = await h.api_auth_refresh(request)
+    assert response.status == 401
+    # The machine id is the contract; ``error`` is localizable prose.
+    assert _body(response)["code"] == "peer_identity_unverified"
+    # No credential leaked through the replay path.
+    assert "Set-Cookie" not in response.headers
+    # Refused, NOT revoked - an unverified caller must not be able to sign a
+    # legitimate session out by replaying one consumed token.
+    assert not state.is_chain_revoked(chain_id)
+
+
+@pytest.mark.asyncio
+async def test_require_peer_chain_refuses_to_rotate_without_a_verified_peer(
+    state: RefreshStateManager,
+) -> None:
+    """An identity-bound chain must not rotate when no tailnet peer resolves.
+
+    This is the whole security argument for the persistent QR shape: it drops the
+    boot bound, so identity is the only thing left bounding it. An address pin is
+    no substitute — behind ``tailscale serve`` every request arrives from
+    127.0.0.1, so ``ip:127.0.0.1`` excludes nobody on the tailnet.
+
+    The chain is REFUSED, not revoked: identity resolution fails transiently, and
+    burning a 30-day credential over a daemon blip would turn a recoverable
+    hiccup into a re-scan.
+    """
+    refresh, chain_id, _jti, _exp = generate_refresh_token("phone", require_peer=True)
+    request = _mk(
+        "POST",
+        "/api/auth/refresh",
+        origin="http://localhost:7777",
+        cookies={refresh_cookie_name(str(PORT)): refresh},
+    )
+    response = await h.api_auth_refresh(request)
+    assert response.status == 401
+    # The machine id is the contract; ``error`` is localizable prose.
+    assert _body(response)["code"] == "peer_identity_unverified"
+    # Refused, NOT revoked - the same chain must still be usable once identity
+    # can be established again.
+    assert not state.is_chain_revoked(chain_id)
+
+
+def test_require_peer_survives_rotation_and_defaults_off() -> None:
+    """The claim is carried, and absent by default.
+
+    A chain that lost the claim on its first rotation would silently become an
+    ordinary rotating session - the same defect one rotation later.
+    """
+    bound, _c, _j, _e = generate_refresh_token("phone", require_peer=True)
+    assert refresh_token_requires_peer(bound) is True
+    plain, _c2, _j2, _e2 = generate_refresh_token("desktop")
+    assert refresh_token_requires_peer(plain) is False
+
+
+def test_require_peer_fails_closed_on_an_undecodable_payload() -> None:
+    """An undecodable payload answers True, not False.
+
+    The conservative direction here is the opposite of ``refresh_token_boot``'s:
+    answering False would let a signed-but-unreadable token rotate WITHOUT the
+    identity check its chain was minted to require.
+    """
+    assert refresh_token_requires_peer("not-a-token") is True
+    assert refresh_token_requires_peer("") is True
 
 
 @pytest.mark.asyncio

--- a/test/test_mobile_login_link.py
+++ b/test/test_mobile_login_link.py
@@ -25,10 +25,18 @@ def _request(
     dashboard_url: str = "",
     cookie_token: str = "",
     query_token: str = "",
+    auth_token: str | None = None,
     state: object | None = None,
 ) -> MagicMock:
     request = MagicMock(spec=web.Request)
-    request.get.side_effect = {"user": user, "app": app}.get
+    # ``auth_token`` is what token_auth publishes: the credential it ACTUALLY
+    # validated. Defaults to the one the middleware would have picked for a
+    # request carrying these credentials (query token preferred when it is
+    # valid), so a test only sets it explicitly to model the case where the two
+    # diverge — i.e. the middleware fell back to the cookie because the query
+    # token was invalid.
+    published = auth_token if auth_token is not None else (query_token or cookie_token)
+    request.get.side_effect = {"user": user, "app": app, "auth_token": published}.get
     request.app = {"dashboard_url": dashboard_url, "port": 7777}
     if state is not None:
         request.app["state"] = state
@@ -173,6 +181,59 @@ def test_mobile_link_fails_closed_on_an_unreadable_caller_token():
     assert response.status == 200
     claims = _minted_claims(json.loads(response.text))
     assert claims["no_refresh"] == "1"
+
+
+def test_mobile_link_bounds_come_from_the_validated_credential_not_the_query_token():
+    """The cookie-fallback case: bounds must follow what the middleware VALIDATED.
+
+    When the query token is invalid, token_auth falls back to the session cookie
+    and publishes the COOKIE as request["auth_token"]. A bounded cookie session
+    must keep its bounds even though the URL still carries a permissive
+    (unverified, attacker-settable) query token — re-deriving with a fixed
+    query-then-cookie order would read that unverified value, drop
+    ``no_refresh`` and raise the TTL ceiling to the full maximum: the
+    ceiling-escape this endpoint exists to prevent.
+    """
+    permissive_query = _caller_token()  # unverified: no bounds, full-length TTL
+    bounded_cookie = generate_token(
+        "alice", ttl_seconds=600, extra={"boot": "boot-abc", "no_refresh": "1"}
+    )
+
+    response = _call(
+        _request(
+            dashboard_url="https://dashboard.example",
+            query_token=permissive_query,
+            cookie_token=bounded_cookie,
+            auth_token=bounded_cookie,  # what the middleware validated
+        )
+    )
+
+    assert response.status == 200
+    claims = _minted_claims(json.loads(response.text))
+    assert claims["no_refresh"] == "1"
+    assert claims["boot"] == "boot-abc"
+    remaining = claims["session_exp"] - time.time()
+    assert 0 < remaining <= 600 + 5
+
+
+def test_mobile_link_bounds_fail_closed_when_no_credential_was_published():
+    """No published credential means no verified claims to lend: bound the mint.
+
+    Trusting a re-extracted token here is exactly the unverified read the
+    published-credential contract removes, so the mint is bounded instead.
+    """
+    response = _call(
+        _request(
+            dashboard_url="https://dashboard.example",
+            cookie_token=_caller_token(boot="boot-abc"),
+            auth_token="",  # middleware published nothing
+        )
+    )
+
+    assert response.status == 200
+    claims = _minted_claims(json.loads(response.text))
+    assert claims["no_refresh"] == "1"
+    assert "boot" not in claims
 
 
 def test_mobile_link_bounds_come_from_the_query_token_not_a_stray_cookie():

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -359,6 +359,7 @@ def _request(
     tailnet_host: str = "",
     query_token: str = "",
     cookie_token: str = "",
+    auth_token: str | None = None,
 ):
     """Minimal stand-in for the aiohttp request these handlers actually touch.
 
@@ -375,9 +376,14 @@ def _request(
     ``tailnet_host`` models the name the RUNNING server trusted at startup. Empty
     (the default) means the fixed allowlist does not carry the resolvable name,
     so ``_derive_step`` reports ``restart_gateway``. Ready paths must set it.
-    ``query_token`` / ``cookie_token`` model the credential the middleware
-    authenticated with, which the QR mint reads its caller bounds from. Both
-    empty (the default) exercises the fail-closed no-readable-token path.
+    ``query_token`` / ``cookie_token`` model the raw credential material.
+    ``auth_token`` models what the middleware published as the VALIDATED
+    credential (``request["auth_token"]``): defaults to ``query_token or
+    cookie_token`` (the normal middleware-prefer-query behaviour), but pass
+    ``auth_token=cookie_token`` explicitly to model the fallback path where the
+    query token was invalid and the middleware fell back to the cookie. Both
+    ``query_token`` and ``cookie_token`` empty (the default) exercises the
+    fail-closed no-readable-token path.
     """
 
     class _Req:
@@ -399,6 +405,10 @@ def _request(
                 self._items["app"] = app_identity
             if user is not None:
                 self._items["user"] = user
+            # Publish the validated credential, mirroring token_auth middleware.
+            _auth = auth_token if auth_token is not None else (query_token or cookie_token)
+            if _auth:
+                self._items["auth_token"] = _auth
 
         def get(self, key: str, default: object = None) -> object:
             return self._items.get(key, default)
@@ -448,6 +458,9 @@ def _machine(
     published: bool | None = True,
     trusted: bool = True,
     qr_session_until_restart: bool = True,
+    qr_session_persist_across_restart: bool = False,
+    trust_identity: bool = False,
+    allowed_logins: tuple[str, ...] = (),
     detail: str = "",
 ):
     """Stub the four probes the REAL derivation reads, and let it run.
@@ -460,8 +473,14 @@ def _machine(
     """
     cfg = SimpleNamespace(
         dashboard=SimpleNamespace(
-            tailscale=SimpleNamespace(enabled=trusted, keep_awake=True),
+            tailscale=SimpleNamespace(
+                enabled=trusted,
+                keep_awake=True,
+                trust_identity=trust_identity,
+                allowed_logins=list(allowed_logins),
+            ),
             qr_session_until_restart=qr_session_until_restart,
+            qr_session_persist_across_restart=qr_session_persist_across_restart,
         )
     )
     probe = tailnet.DaemonProbe(
@@ -624,6 +643,104 @@ class TestQrRefusals:
         assert resp.status == 200
         assert captured["extra"] == {"no_refresh": "1"}
         assert "boot" not in (captured["extra"] or {})
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_drops_the_boot_bound(self, _unrestricted, _quiet_audit) -> None:
+        """Opted in WITH identity trust: no ``boot``, so one scan outlives a restart.
+
+        The refresh chain is still issued (no ``no_refresh``), so what bounds the
+        session is the chain's own lifetime rather than this process's.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(
+            qr_session_persist_across_restart=True,
+            trust_identity=True,
+            allowed_logins=("someone@example.com",),
+        ):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        extra = captured["extra"] or {}
+        assert "boot" not in extra
+        assert "no_refresh" not in extra
+        # The identity bound that replaces the process bound. Without it the
+        # chain would rotate for any caller, which is the whole point of not
+        # having a boot claim being safe.
+        assert extra["require_peer"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_refused_without_identity_trust(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Opted in but identity trust off: stays boot-bound, and says so.
+
+        Behind ``tailscale serve`` every request arrives from 127.0.0.1, so
+        without a daemon-verified peer the cookie is a bearer credential any
+        tailnet peer could replay - a session that outlives the process must not
+        be handed out on that basis. Silently honouring the flag would leave the
+        operator believing their phone survives restarts.
+        """
+        from kiro_crew.dashboard.boot_id import current_boot_id
+
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(qr_session_persist_across_restart=True):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        assert captured["extra"] == {"boot": current_boot_id()}
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_refused_when_timed_shape_is_in_force(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Persist + opted-out is contradictory: there is no chain to carry over."""
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(
+            qr_session_until_restart=False,
+            qr_session_persist_across_restart=True,
+            trust_identity=True,
+            allowed_logins=("someone@example.com",),
+        ):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        assert captured["extra"] == {"no_refresh": "1"}
 
     @pytest.mark.asyncio
     async def test_unreadable_config_falls_back_to_the_default(

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -23,6 +23,7 @@ from kiro_crew.dashboard.token_auth import (
     app_token_path_allowed,
     bind_token_ip,
     check_token_ip,
+    claims_an_app_unverified,
     generate_token,
     is_consumed,
     mark_consumed,
@@ -398,6 +399,147 @@ async def test_cookie_not_reset_when_present() -> None:
     assert resp.status == 200
     # Cookie should NOT be re-set on cookie-based auth
     assert "mc_token_5476" not in resp.cookies
+
+
+# -- Stale ?token= must not veto a valid session cookie (query→cookie fallback) --
+
+
+@pytest.mark.asyncio
+async def test_expired_query_token_falls_back_to_valid_cookie() -> None:
+    """Re-opening a bookmarked link replays a long-expired ``?token=`` alongside
+    the still-valid session cookie that link was exchanged for. The dead query
+    token must be ignored, not act as a one-vote veto over the live cookie."""
+    mw = token_auth_middleware()
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale = generate_token("staleuser", ttl_seconds=300)
+    cookie = generate_token("staleuser", ttl_seconds=3600)
+    bind_token_ip(cookie, "127.0.0.1")
+    mark_consumed(cookie)
+
+    req = _make_request(query={"token": stale}, cookies={"mc_token_5476": cookie})
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+    # Fallback lands on the COOKIE path: no token→session exchange, no re-set.
+    assert "mc_token_5476" not in resp.cookies
+
+
+@pytest.mark.asyncio
+async def test_expired_query_token_without_cookie_still_denied() -> None:
+    """The fallback adds no capability: a dead query token alone stays denied
+    (the SPA-shell carve-out aside — this data path is not a shell request)."""
+    mw = token_auth_middleware()
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale = generate_token("staleuser2", ttl_seconds=300)
+    req = _make_request(path="/api/status", query={"token": stale})
+    resp = await mw(req, _ok_handler)
+    assert resp.status in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_expired_query_token_with_expired_cookie_denied() -> None:
+    """When BOTH credentials are dead, the query token's failure reason stands
+    (the credential the caller actually presented) and the request is denied."""
+    mw = token_auth_middleware()
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale = generate_token("staleuser3", ttl_seconds=300)
+        dead_cookie = generate_token("staleuser3", ttl_seconds=300)
+    req = _make_request(
+        path="/api/status", query={"token": stale}, cookies={"mc_token_5476": dead_cookie}
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_valid_query_token_still_wins_over_cookie() -> None:
+    """The fallback fires only on an INVALID query token. A valid one keeps
+    today's precedence — including its token→session exchange (fresh cookie)."""
+    mw = token_auth_middleware()
+    fresh = generate_token("precedence", ttl_seconds=300)
+    cookie = generate_token("someoneelse", ttl_seconds=3600)
+    bind_token_ip(cookie, "127.0.0.1")
+    mark_consumed(cookie)
+    req = _make_request(query={"token": fresh}, cookies={"mc_token_5476": cookie})
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+    assert resp.cookies.get("mc_token_5476") is not None
+
+
+@pytest.mark.asyncio
+async def test_internal_path_expired_query_token_falls_back_to_cookie() -> None:
+    """The internal-path helper (_extract_and_validate_token) applies the same
+    rule: a stale ``?token=`` on a polled internal path must not 401 a request
+    whose session cookie is still valid."""
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale = generate_token("intuser", ttl_seconds=300)
+    cookie = generate_token("intuser", ttl_seconds=3600)
+    bind_token_ip(cookie, "127.0.0.1")
+    mark_consumed(cookie)
+    mw = token_auth_middleware(internal_paths=frozenset({"/api/spawn"}), internal_secret="s")
+    req = _make_request(
+        path="/api/spawn", query={"token": stale}, cookies={"mc_token_5476": cookie}
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_expired_app_token_does_not_fall_back_to_user_cookie() -> None:
+    """An expired APP token must NOT adopt the dashboard user's cookie.
+
+    An installed app's UI is served from this same origin, so the browser sends
+    the user's session cookie alongside the app's own ``?token=``. If the
+    fallback fired here, ``app_name`` would come back empty, the app-scope gate
+    would become a no-op, and an app whose token merely expired would silently
+    gain the user's full API reach. It must stay denied so the app re-exchanges
+    its secret instead.
+    """
+    mw = token_auth_middleware()
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale_app = generate_token("appsub", ttl_seconds=300, app="someapp")
+    cookie = generate_token("realuser", ttl_seconds=3600)
+    bind_token_ip(cookie, "127.0.0.1")
+    mark_consumed(cookie)
+
+    req = _make_request(
+        path="/api/status", query={"token": stale_app}, cookies={"mc_token_5476": cookie}
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_internal_path_expired_app_token_does_not_fall_back_to_cookie() -> None:
+    """The internal-path helper applies the same app-token exception."""
+    with patch("kiro_crew.dashboard.token_auth.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        stale_app = generate_token("appsub2", ttl_seconds=300, app="someapp")
+    cookie = generate_token("realuser2", ttl_seconds=3600)
+    bind_token_ip(cookie, "127.0.0.1")
+    mark_consumed(cookie)
+    mw = token_auth_middleware(internal_paths=frozenset({"/api/spawn"}), internal_secret="s")
+    req = _make_request(
+        path="/api/spawn", query={"token": stale_app}, cookies={"mc_token_5476": cookie}
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status in (401, 403)
+
+
+def test_claims_an_app_unverified_only_ever_refuses() -> None:
+    """The unverified reader answers True only for a payload that names an app.
+
+    Garbage and app-less payloads answer False, so the claim can never widen the
+    fallback — it can only withhold it.
+    """
+    assert claims_an_app_unverified(generate_token("u", ttl_seconds=60, app="a")) is True
+    assert claims_an_app_unverified(generate_token("u", ttl_seconds=60)) is False
+    assert claims_an_app_unverified("not-a-token") is False
+    assert claims_an_app_unverified("") is False
 
 
 # -- Cookie keyed by browser-facing (Host) port for tunneled multi-instance --

--- a/website/electron/crew-companion/index.js
+++ b/website/electron/crew-companion/index.js
@@ -54,11 +54,48 @@ let fetchLocalToken = null;
 let log = () => {};
 let timer = null;
 let reconciling = false;
+/**
+ * The token this poll reuses across ticks.
+ *
+ * Minting one per tick is what this cache exists to stop. Every mint is a full
+ * link->session exchange on the gateway: it registers a nonce in a bounded
+ * 50-slot ring (so at this cadence the ring turned over every few minutes and
+ * evicted OTHER pending one-time links — a phone-access QR among them, before
+ * its own window had even lapsed), issued a fresh 30-day refresh chain, and
+ * appended the consumed nonce to a persisted denylist. It also meant dozens of
+ * live, full-privilege sign-in links existed at any moment purely as a
+ * side-effect of asking whether an app is enabled.
+ *
+ * The token outlives the tick by hours, so reuse is the normal path and a
+ * re-mint is the exception: only an actual auth refusal invalidates it.
+ */
+let cachedToken = "";
+
+/**
+ * The token to probe with, minting only when there is nothing usable cached.
+ *
+ * @param {boolean} forceMint Re-mint even if a token is cached — for the one
+ *   retry after the gateway refused the cached one.
+ * @returns {Promise<string>}
+ */
+async function tokenForProbe(forceMint) {
+  if (!forceMint && cachedToken) return cachedToken;
+  try {
+    cachedToken = (fetchLocalToken && (await fetchLocalToken())) || "";
+  } catch {
+    cachedToken = "";
+  }
+  return cachedToken;
+}
 
 /**
  * Ask the gateway whether the app is enabled.
  *
- * @returns {Promise<"enabled"|"disabled"|"unknown">}
+ * ``unauthorized`` is split out from ``unknown`` so a cached token that the
+ * gateway has stopped accepting can be re-minted exactly once, instead of
+ * either wedging the poll forever or going back to minting every tick.
+ *
+ * @returns {Promise<"enabled"|"disabled"|"unauthorized"|"unknown">}
  */
 function probeEnabled(token) {
   return new Promise((resolve) => {
@@ -67,6 +104,11 @@ function probeEnabled(token) {
       let body = "";
       res.on("data", (c) => (body += c));
       res.on("end", () => {
+        // The credential, not the answer, is what went stale — say so, so the
+        // caller re-mints rather than treating it as "cannot tell".
+        if (res.statusCode === 401 || res.statusCode === 403) {
+          return resolve("unauthorized");
+        }
         if (res.statusCode !== 200) return resolve("unknown");
         try {
           const parsed = JSON.parse(body);
@@ -94,12 +136,7 @@ async function reconcileOnce() {
   if (reconciling) return;
   reconciling = true;
   try {
-    let token = "";
-    try {
-      token = (fetchLocalToken && (await fetchLocalToken())) || "";
-    } catch {
-      token = "";
-    }
+    let token = await tokenForProbe(false);
     if (!token) {
       // No credential means we cannot ask, which is unknown — not disabled.
       return;
@@ -108,7 +145,24 @@ async function reconcileOnce() {
     setOverlayTarget(backendUrl, token);
     setPanelTarget(backendUrl, token);
     setGalleryTarget(backendUrl, token);
-    const state = await probeEnabled(token);
+    let state = await probeEnabled(token);
+
+    if (state === "unauthorized") {
+      // The cached token was refused. Re-mint ONCE and retry; a second refusal
+      // is left as unknown rather than retried in a loop, so a genuinely broken
+      // credential path cannot turn this poll back into a mint-per-tick.
+      cachedToken = "";
+      token = await tokenForProbe(true);
+      if (!token) return;
+      setOverlayTarget(backendUrl, token);
+      setPanelTarget(backendUrl, token);
+      setGalleryTarget(backendUrl, token);
+      state = await probeEnabled(token);
+      if (state === "unauthorized") {
+        cachedToken = "";
+        return;
+      }
+    }
 
     if (state === "unknown") return; // leave every window exactly as it is
     if (state === "disabled") {
@@ -196,6 +250,10 @@ function shutdownCrewCompanion() {
     clearInterval(timer);
     timer = null;
   }
+  // Drop the reused credential with the poll that reused it, so a later
+  // initCrewCompanion starts from a fresh mint instead of a token that may have
+  // been minted against a gateway that is no longer the one we will talk to.
+  cachedToken = "";
   stopHitboxPoll();
   closePetWindow();
 }

--- a/website/electron/crew-companion/test/tokenReuse.test.js
+++ b/website/electron/crew-companion/test/tokenReuse.test.js
@@ -1,0 +1,146 @@
+"use strict";
+
+/**
+ * The reconcile poll must REUSE its dashboard token across ticks.
+ *
+ * Minting one per tick is not a cosmetic waste: every mint is a full
+ * link->session exchange on the gateway, which registers a nonce in a bounded
+ * 50-slot ring. At a 5-second cadence that ring turned over every few minutes
+ * and evicted OTHER pending one-time links — a phone-access QR among them,
+ * before its own window had lapsed — while also issuing a fresh 30-day refresh
+ * chain and appending to a persisted denylist each time. It additionally meant
+ * dozens of live, full-privilege sign-in links existed at any moment purely as a
+ * side effect of asking whether an app is enabled.
+ *
+ * These tests drive `reconcileOnce` directly (it is exported for exactly that)
+ * rather than waiting on the 5-second interval.
+ */
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const Module = require("node:module");
+const path = require("node:path");
+
+const INDEX = path.join(__dirname, "..", "index.js");
+
+/**
+ * Load a fresh copy of index.js with electron and the sibling window modules
+ * stubbed, so the module under test runs without a real Electron main process.
+ *
+ * @param {{status: number[], mints: {n: number}}} wiring
+ */
+function loadCompanion(wiring) {
+  const originalResolve = Module._resolveFilename;
+  const originalLoad = Module._load;
+  const stubs = {
+    electron: {
+      ipcMain: { on() {}, handle() {} },
+      BrowserWindow: { fromWebContents: () => null },
+    },
+  };
+  const noopWindowModule = {
+    setOverlayTarget() {},
+    setPanelTarget() {},
+    setGalleryTarget() {},
+    setOverlayLogger() {},
+    setPanelLogger() {},
+    setGalleryLogger() {},
+    registerPanelIpc() {},
+    registerGalleryIpc() {},
+    registerOverlayIpc() {},
+    setAppearanceChangedHandler() {},
+    setPanelClosedHandler() {},
+    setGalleryOpenedHandler() {},
+    setGalleryClosedHandler() {},
+    broadcastToPets() {},
+    openPetWindow() {},
+    closePetWindow() {},
+    closePanelWindow() {},
+    closeGalleryWindow() {},
+    petWindowCount: () => 0,
+    startHitboxPoll() {},
+    stopHitboxPoll() {},
+  };
+
+  Module._load = function (request, parent, isMain) {
+    if (request === "electron") return stubs.electron;
+    if (request === "node:http" || request === "http") {
+      return {
+        get(_url, _opts, cb) {
+          const statusCode = wiring.status.shift();
+          const res = {
+            statusCode,
+            on(evt, fn) {
+              if (evt === "data") fn(JSON.stringify([{ name: "crew-companion", enabled: true }]));
+              if (evt === "end") fn();
+            },
+          };
+          setImmediate(() => cb(res));
+          return { on() {}, destroy() {} };
+        },
+      };
+    }
+    if (
+      request.startsWith("./pet") ||
+      request.startsWith("./panel") ||
+      request.startsWith("./gallery") ||
+      request.startsWith("./page")
+    ) {
+      return noopWindowModule;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[require.resolve(INDEX)];
+    return require(INDEX);
+  } finally {
+    Module._load = originalLoad;
+    Module._resolveFilename = originalResolve;
+  }
+}
+
+/** Let the reconcile that `initCrewCompanion` fires itself settle. */
+async function settle() {
+  for (let i = 0; i < 10; i += 1) await new Promise((r) => setImmediate(r));
+}
+
+test("a later tick reuses the token instead of minting again", async () => {
+  const mints = { n: 0 };
+  // init fires one reconcile itself; the two hand-driven ticks follow.
+  const mod = loadCompanion({ status: [200, 200, 200] });
+  mod.initCrewCompanion({
+    backendUrl: "http://127.0.0.1:5476",
+    fetchLocalToken: async () => {
+      mints.n += 1;
+      return `tok-${mints.n}`;
+    },
+    glog: () => {},
+  });
+  await settle();
+  assert.equal(mints.n, 1, "init's own reconcile mints exactly one token");
+
+  await mod.reconcileOnce();
+  await mod.reconcileOnce();
+
+  assert.equal(mints.n, 1, "later ticks must not mint again");
+  mod.shutdownCrewCompanion();
+});
+
+test("a refused token is re-minted exactly once", async () => {
+  const mints = { n: 0 };
+  // init's probe 401s (the cached token is refused); the single retry succeeds.
+  const mod = loadCompanion({ status: [401, 200] });
+  mod.initCrewCompanion({
+    backendUrl: "http://127.0.0.1:5476",
+    fetchLocalToken: async () => {
+      mints.n += 1;
+      return `tok-${mints.n}`;
+    },
+    glog: () => {},
+  });
+  await settle();
+
+  assert.equal(mints.n, 2, "an auth refusal re-mints once, and only once");
+  mod.shutdownCrewCompanion();
+});


### PR DESCRIPTION
## Problem / Motivation

A phone signed in by scanning the tailnet QR code goes blank after roughly 30–40 minutes and has to be re-scanned. Reloading the page it was already authenticated on returns 401.

Two independent causes, both confirmed from the security event log rather than inferred from the source:

1. **A stale `?token=` vetoed a valid session cookie.** Token extraction read `request.query.get("token") or request.cookies.get(...)`, so the query parameter had absolute precedence. The QR URL keeps the link token in the phone's address bar; after `LINK_WINDOW_SECS` (300s) that token is dead, so every later reload re-presented a dead credential that beat the live cookie. The log shows `dashboard.token_auth → denied / error: token expired` from 127.0.0.1.

2. **Crew Companion minted a session every 5 seconds.** `reconcileOnce()` called `fetchLocalToken()` on every `TICK_MS` tick with no cache. Each mint is a full link→session exchange, so each one consumes a slot in the bounded 50-slot nonce ring — measured 91 mints in 5 minutes, turning the ring over every ~3–4 minutes and evicting other pending links, including the phone's QR, *before* their own 5-minute window lapsed.

Separately, a gateway restart signs the phone out by design (#5763). That is the right default, but on the insider auto-update channel it is frequent enough to be the dominant reason a working session ends, and there is currently no way to opt out.

## Why it matters

Cause 1 makes the phone unusable as a second screen: the session is alive but every reload is refused, and the only workaround is to know to delete the query string from the address bar by hand. Cause 2 evicts pending one-time links for everyone on the machine, not just the phone — a Slack challenge link minted in the same window can be gone before it is clicked.

## What changed (motivation → approach → change)

**Scope is deliberately wider than the two causes, and the author owns that.** An earlier revision of this description said the persistent-session feature had been split out to #6369. **That is no longer true and the description was wrong for a period — the feature is in this PR, #6369 is closed as superseded, and this section now declares everything the diff ships.** Nine items:

**Cause 1 → the cookie is used when the query token is invalid** (items 1–5). Both extraction sites now fall back instead of vetoing. Two consequences had to be handled rather than assumed away:

- **App-scoped tokens are excluded from the fallback** (`claims_an_app_unverified()` in `token_auth.py`). Without this, an expired app token would adopt the user's cookie and skip `_enforce_app_scope` — an app surface silently promoted to full user authority. The claim is read *unverified*, which is sound because it can only ever make the decision stricter.
- **The validated credential is now published as `request["auth_token"]`,** and the three places that re-derived it read that instead: `_caller_bounds` (`handlers/_shared.py`), `api_auth_me` (`handlers/auth_refresh.py`) and the frame-ancestors port read (`server.py`). Re-deriving with a fixed query-then-cookie order is no longer equivalent to what the middleware validated, so each site could have read an unverified value. For `_caller_bounds` that is the exact ceiling-escape it exists to prevent: bounds read from an attacker-settable query token would drop `no_refresh` and raise the TTL ceiling to the maximum. Each site falls back to the old order only when nothing was published, and fails closed the way an unreadable payload already did.

**Cause 2 → the Companion reuses its token** (item 6). A module-level cache plus `tokenForProbe(forceMint)`; `probeEnabled()` now maps 401/403 to `"unauthorized"`, distinct from `"unknown"`, so a refused token triggers exactly one re-mint rather than a mint per tick. `shutdownCrewCompanion()` clears the cache.

**Restart survival → a third, opt-in session shape** (items 7–9). New `dashboard.qr_session_persist_across_restart`, **default `false`**. The QR mint already chose between two shapes; a third is added rather than loosening either existing one:

| shape | claims | bounded by |
| --- | --- | --- |
| timed (opt-out) | `no_refresh` | a fixed TTL, no renewal |
| until-restart (default) | `boot` | this process's lifetime |
| persistent (**new**, opt-in) | `require_peer` | the refresh chain's own 30-day `MAX_REFRESH_TTL_SECS` |

Hard-gated on `dashboard.tailscale.trust_identity` plus a non-empty `allowed_logins`, and on the sibling `qr_session_until_restart` being ON; both refusals log a WARNING naming the missing prerequisite and fall back to boot-bound. Removing the boot bound removes the only thing bounding the session, so a new carried `require_peer` claim (`refresh_tokens.py`, carried through `token_auth.py` and onto both halves of every rotated pair) makes `api_auth_refresh` refuse to *use* such a chain while no daemon-verified peer resolves — checked ahead of all three exits that hand back a credential (grace replay, reuse detection, mint), and ahead of reuse detection specifically so an unverified caller cannot revoke a legitimate session by replaying one consumed token.

#6033's caller-bounds cap still wins over the configured shape and caps the persistent one too, which is correct: a credential must not outlive the session that authorized it.

Also drops a now-unused `_cookie_port_from_host` import (flake8 F401) and regenerates `config-baseline.json` for the new key.

## Two accepted security findings — read before approving

GPT 5.6 raised two BLOCKING findings against items 7–9 that are **overridden, not fixed**. They are legitimate; I verified both:

1. **Refresh accepts a different allowlisted peer.** `_verified_peer()` checks that *some* daemon-verified peer resolves and is allowlisted, not that it is the *same* peer the session was established for. Under the default `pin_scope: node` a pin is per-device, so this is weaker than `bind_token_peer`'s treatment of ordinary sessions: a stolen refresh cookie is usable by any allowlisted peer, including another device of the same login.
2. **Persistence trusts inactive identity configuration.** The gate reads the *configured values* `trust_identity` and `allowed_logins`, not whether identity resolution is actually live, so a config naming identity trust while the daemon is not resolving peers still admits the persistent shape.

The setting is off by default and inert unless an operator enables it *and* configures identity trust, so no existing deployment changes behaviour on merge. What is **not** bounded is the case the feature exists for: an operator who turns it on gets a 30-day credential whose only stated bound is identity, and both findings weaken exactly that bound. The correct fix — carry the peer pin key on the chain and compare it for equality, establish it at the link→session exchange rather than the QR mint, and require a live resolution rather than a configured value — is follow-up work.

## Tests

`test/test_token_auth.py` — the cookie is used when the query token is expired; an **app**-claiming query token does not adopt the cookie (×2); `claims_an_app_unverified` unit coverage.

`test/test_mobile_login_link.py` — link bounds come from the validated credential, not the query token; they fail closed when nothing was published.

`test/test_auth_refresh_handlers_cov80.py` — `api_auth_me` reads the published credential and falls back when none was published; an identity-bound chain is refused (and **not** revoked) when no peer resolves, including on the grace-replay path with no `Set-Cookie` on the response; the `require_peer` claim survives rotation, is absent by default, and fails closed on an undecodable payload.

`test/test_tailnet_mobile.py` — the existing caller-bounds tests updated to model the published credential; the persistent shape drops `boot` and carries `require_peer`; it is refused without identity trust and refused when the timed shape is in force.

`website/electron/crew-companion/test/tokenReuse.test.js` (new) — the token is reused across ticks; a 401 causes exactly one re-mint.

Mutation-verified: both fallback guards, the Companion cache, and the grace-replay peer check (with the check removed that test fails `assert 200 == 401`, i.e. it demonstrably exercises the path that serves a cached credential).

## Manual verification

Reproduced the original symptom on a real tailnet before the fix (phone blank after ~35 minutes, `token expired` denials in the event log) and confirmed the nonce churn at 91 mints / 5 minutes. Post-fix verification over a multi-hour window is still outstanding. Items 7–9 are **unverified on real hardware**: the identity path needs a live `tailscaled` and a second device, and neither the happy path nor the refusal of a non-allowlisted peer has been exercised outside unit tests.

## Screenshots / video

N/A — no user-visible UI change beyond the new setting's own label and help text, which is config-driven.

## Related Issues

No linked issue: reported directly in chat. Related to #1762 (behind `tailscale serve` every request arrives from 127.0.0.1, so the token is the only real credential) and #5763 (which introduced the boot-bound session items 7–9 make optional).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated — **not done**: the remote-and-mobile guide needs a line for `dashboard.qr_session_persist_across_restart` and its prerequisites. Deliberately deferred to the round that settles the peer-binding design, so the doc is not written twice.
- [x] No secrets, credentials, or internal references in the diff
