### PR TITLE
fix(chat): code every fork refusal, without making the three 404s tell apart

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1285,
+    "missing_code": 1268,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1343,
+  "_compliant": 1377,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -35,9 +35,6 @@
     },
     "dashboard/chat_folders.py": {
       "missing_code": 21
-    },
-    "dashboard/chat_fork.py": {
-      "missing_code": 17
     },
     "dashboard/chat_handlers.py": {
       "missing_code": 64

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -56,7 +56,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     request_app = request.get("app", "")
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     # Rate/resource guard: reject if we're already at the cap. Counts slots still
     # under construction too (``live_slot_count``): the import path retracts a
@@ -72,7 +72,10 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             error="slot cap reached",
         )
         return web.json_response(
-            {"error": f"slot cap reached ({MAX_LIVE_SLOTS})"},
+            {
+                "error": f"slot cap reached ({MAX_LIVE_SLOTS})",
+                "code": "slot_cap_reached",
+            },
             status=429,
         )
 
@@ -87,7 +90,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                 resources=f"slot={name}",
                 error="app cannot fork unscoped slots",
             )
-            return web.json_response({"error": "not found"}, status=404)
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
         if slot._app != request_app:
             sel().log_api_access(
                 caller=request_app,
@@ -101,7 +104,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             # slot is indistinguishable from a non-existent one — prevents an
             # app-scoped caller enumerating slots across the isolation boundary
             # (CWE-204). The true reason is recorded server-side via SEL above.
-            return web.json_response({"error": "not found"}, status=404)
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     if slot.memory_mode != "persistent":
         sel().log_api_access(
@@ -112,25 +115,45 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             resources=f"slot={name},memory_mode={slot.memory_mode}",
             error="non-persistent slot",
         )
-        return web.json_response({"error": "cannot fork a non-persistent session"}, status=400)
+        return web.json_response(
+            {
+                "error": "cannot fork a non-persistent session",
+                "code": "slot_not_persistent",
+            },
+            status=400,
+        )
     if request.body_exists:
         try:
             body = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON body"}, status=400)
+            return web.json_response(
+                {"error": "invalid JSON body", "code": "invalid_json"}, status=400
+            )
         if not isinstance(body, dict):
-            return web.json_response({"error": "body must be a JSON object"}, status=400)
+            return web.json_response(
+                {"error": "body must be a JSON object", "code": "body_not_object"},
+                status=400,
+            )
     else:
         body = {}
     at_index = body.get("at_message_index")
     prompt = body.get("prompt")
     mode_override = body.get("mode")
     if mode_override is not None and mode_override not in ("", "orchestrator", "crew"):
-        return web.json_response({"error": "mode must be '', 'orchestrator' or 'crew'"}, status=400)
+        return web.json_response(
+            {
+                "error": "mode must be '', 'orchestrator' or 'crew'",
+                "code": "invalid_mode",
+            },
+            status=400,
+        )
     direction = body.get("direction", _FORK_DIRECTION_HEAD)
     if direction not in _FORK_DIRECTIONS:
         return web.json_response(
-            {"error": f"direction must be one of {list(_FORK_DIRECTIONS)}"},
+            {
+                "error": f"direction must be one of {list(_FORK_DIRECTIONS)}",
+                "code": "invalid_direction",
+            },
             status=400,
         )
     if direction == _FORK_DIRECTION_TAIL and not KiroCrewConfig.load().dashboard.tail_fork_enabled:
@@ -149,11 +172,17 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
         )
         direction = _FORK_DIRECTION_HEAD
     if prompt is not None and not isinstance(prompt, str):
-        return web.json_response({"error": "prompt must be a string"}, status=400)
+        return web.json_response(
+            {"error": "prompt must be a string", "code": "invalid_field_type"},
+            status=400,
+        )
     prompt = (prompt or "").strip()
     if len(prompt) > 32_768:
         return web.json_response(
-            {"error": "prompt too long (max 32768 chars)"},
+            {
+                "error": "prompt too long (max 32768 chars)",
+                "code": "prompt_too_long",
+            },
             status=400,
         )
 
@@ -539,7 +568,10 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                     exc_info=True,
                 )
                 return web.json_response(
-                    {"error": "could not persist source session before fork; " "please retry"},
+                    {
+                        "error": "could not persist source session before fork; " "please retry",
+                        "code": "source_save_failed",
+                    },
                     status=503,
                 )
             if not saved:
@@ -589,17 +621,24 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             )
     visible = [m for m in all_messages if m.get("role") in ("user", "assistant")]
     if not visible:
-        return web.json_response({"error": "no messages to fork"}, status=400)
+        return web.json_response(
+            {"error": "no messages to fork", "code": "no_messages_to_fork"},
+            status=400,
+        )
     if at_index is not None:
         if isinstance(at_index, bool) or not isinstance(at_index, int) or at_index < 0:
             return web.json_response(
-                {"error": "at_message_index must be a non-negative integer"},
+                {
+                    "error": "at_message_index must be a non-negative integer",
+                    "code": "invalid_field_type",
+                },
                 status=400,
             )
         if at_index >= len(visible):
             return web.json_response(
                 {
-                    "error": f"at_message_index {at_index} out of range (have {len(visible)} visible messages)"
+                    "error": f"at_message_index {at_index} out of range (have {len(visible)} visible messages)",
+                    "code": "value_out_of_range",
                 },
                 status=400,
             )
@@ -608,14 +647,20 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     if direction == _FORK_DIRECTION_TAIL:
         if at_index is None:
             return web.json_response(
-                {"error": "at_message_index is required for a tail fork"},
+                {
+                    "error": "at_message_index is required for a tail fork",
+                    "code": "at_message_index_required",
+                },
                 status=400,
             )
         head_messages = visible[: at_index + 1]
         visible = visible[at_index + 1 :]
         if not visible:
             return web.json_response(
-                {"error": "no messages after the fork point"},
+                {
+                    "error": "no messages after the fork point",
+                    "code": "no_messages_after_fork_point",
+                },
                 status=400,
             )
     elif at_index is not None:

--- a/test/test_chat_fork_error_codes.py
+++ b/test/test_chat_fork_error_codes.py
@@ -1,0 +1,270 @@
+"""Every refusal from ``POST /api/chat/slots/{slot}/fork`` carries a ``code``.
+
+``error-code-baseline.json`` — the worklist the contract gate in
+``test/test_error_code_contract.py`` ratchets down — listed
+``dashboard/chat_fork.py`` with ``missing_code: 17``. The module was already
+half-converted: its three ``503`` snapshot refusals carried
+``fork_snapshot_unstable``, so the wire contract was settled and only the
+remaining seventeen had to follow it.
+
+The prose is kept and keeps its meaning — demoted to advisory, not removed — so
+a client that only reads ``error`` is unaffected. This is backend-only because
+all three frontend callers of ``forkChatSlot`` (``useSessionActions.ts``,
+``SessionGridView.tsx``, ``chatSlice.ts``) branch on ``ok``/``key`` and none
+declares an ``onError`` or reads ``res.error`` at all.
+
+**The one refusal that must NOT become distinguishable.** ``api_chat_slot_fork``
+answers ``404 not found`` in three places: no such slot, an app-scoped caller on
+an unscoped slot, and an app-scoped caller on another app's slot. The last two
+are ``404`` rather than ``403`` on purpose — so a slot behind the App Kit
+isolation boundary is indistinguishable from one that does not exist, which is
+what stops an app enumerating slots across it (CWE-204). A conversion that gave
+those three distinct codes would rebuild that oracle in the field it just added.
+They share ``slot_not_found``, and ``test_the_three_404s_stay_indistinguishable``
+is the assertion that keeps it that way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+_TARGET = "dashboard/chat_fork.py"
+
+
+def _findings():
+    """Run the contract gate's OWN scanner, so this file cannot drift from it."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import test_error_code_contract as gate
+
+    return [f for f in gate.scan() if f.path == _TARGET]
+
+
+# ── the per-file ratchet ──
+#
+# The repo-wide gate only fails on a NET regression, so a new prose-only refusal
+# could land here behind an unrelated deletion elsewhere in the tree.
+
+
+def test_no_refusal_in_this_module_is_prose_only() -> None:
+    missing = sorted(f.lineno for f in _findings() if f.bucket == "missing_code")
+    assert missing == [], (
+        f"these src/kiro_crew/{_TARGET} lines refuse with prose and no "
+        f"machine-readable code: {missing}"
+    )
+
+
+def test_the_ratchet_can_actually_fail() -> None:
+    """Self-check: a scan matching nothing would pass the assertion above vacuously."""
+    coded = [f for f in _findings() if f.bucket == "compliant"]
+    assert len(coded) == 24, f"scanner reached {len(coded)} coded sites, expected 24"
+    assert all(f.code_value for f in coded)
+
+
+# ── behaviour ──
+
+
+def _seeded_state(tmp_path):
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("forkable")
+    slot.append("user", "hello", "msg msg-u")
+    slot.append("assistant", "hi", "msg msg-a")
+    slot._resumed_count = len(slot.messages)
+    slot._disk_window_len = len(slot.messages)
+    slot._dirty = False
+    return state
+
+
+async def _fork(state, slot: str, payload) -> tuple[int, dict]:
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post(f"/api/chat/slots/{slot}/fork", json=payload)
+        return resp.status, await resp.json()
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_slot(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "nosuchslot", {})
+    assert status == 404
+    assert body["code"] == "slot_not_found"
+    assert body["error"]
+
+
+@pytest.mark.asyncio
+async def test_a_body_that_is_not_json(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _seeded_state(tmp_path)
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post(
+            "/api/chat/slots/forkable/fork",
+            data=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        body = await resp.json()
+    assert resp.status == 400
+    assert body["code"] == "invalid_json"
+
+
+@pytest.mark.asyncio
+async def test_a_body_that_is_json_but_not_an_object(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", ["at_message_index"])
+    assert status == 400
+    assert body["code"] == "body_not_object"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_mode(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"mode": "sideways"})
+    assert status == 400
+    assert body["code"] == "invalid_mode"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_direction(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"direction": "sideways"})
+    assert status == 400
+    assert body["code"] == "invalid_direction"
+
+
+@pytest.mark.asyncio
+async def test_a_non_string_prompt(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"prompt": 7})
+    assert status == 400
+    assert body["code"] == "invalid_field_type"
+
+
+@pytest.mark.asyncio
+async def test_an_over_long_prompt(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"prompt": "x" * 32_769})
+    assert status == 400
+    assert body["code"] == "prompt_too_long"
+
+
+@pytest.mark.asyncio
+async def test_a_non_integer_index_and_an_out_of_range_one_differ(tmp_path, monkeypatch) -> None:
+    """The distinction a caller could not previously make without matching English.
+
+    "not an index" and "an index past the end" are different client bugs and want
+    different handling; before the code they were both ``400`` with prose.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    _, bad_type = await _fork(_seeded_state(tmp_path), "forkable", {"at_message_index": "2"})
+    _, out_of_range = await _fork(_seeded_state(tmp_path), "forkable", {"at_message_index": 999})
+    assert bad_type["code"] == "invalid_field_type"
+    assert out_of_range["code"] == "value_out_of_range"
+
+
+@pytest.mark.asyncio
+async def test_a_negative_index_is_a_type_refusal_not_a_range_one(tmp_path, monkeypatch) -> None:
+    """``at_index < 0`` shares the branch with the type check, so it keeps that code."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"at_message_index": -1})
+    assert status == 400
+    assert body["code"] == "invalid_field_type"
+
+
+@pytest.mark.asyncio
+async def test_a_boolean_index_is_refused_as_a_type(tmp_path, monkeypatch) -> None:
+    """``isinstance(True, int)`` is True in Python; the handler rejects bools first."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    status, body = await _fork(_seeded_state(tmp_path), "forkable", {"at_message_index": True})
+    assert status == 400
+    assert body["code"] == "invalid_field_type"
+
+
+@pytest.mark.asyncio
+async def test_a_slot_with_no_forkable_messages(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _make_state(tmp_path)
+    state.get_or_create_slot("empty")
+    status, body = await _fork(state, "empty", {})
+    assert status == 400
+    assert body["code"] == "no_messages_to_fork"
+
+
+@pytest.mark.asyncio
+async def test_a_non_persistent_slot(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _seeded_state(tmp_path)
+    state._slots["forkable"].memory_mode = "ephemeral"
+    status, body = await _fork(state, "forkable", {})
+    assert status == 400
+    assert body["code"] == "slot_not_persistent"
+
+
+# ── the property the conversion must not break ──
+
+
+@pytest.mark.asyncio
+async def test_the_three_404s_stay_indistinguishable(tmp_path, monkeypatch) -> None:
+    """An app-scoped caller must not be able to tell the three 404s apart.
+
+    ``404`` (not ``403``) is deliberate: it makes a slot owned by another app, an
+    unscoped slot, and a slot that does not exist look identical to a caller
+    behind the App Kit isolation boundary, so the boundary cannot be used to
+    enumerate slots (CWE-204). The added ``code`` is a NEW field on that same
+    response, so it is a new place for the three to diverge — this pins that
+    they do not. The true reason stays recorded server-side via SEL.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    state = _seeded_state(tmp_path)
+    # An unscoped slot (no ``_app``) and one owned by a DIFFERENT app.
+    other = state.get_or_create_slot("othersapp")
+    other.append("user", "hello", "msg msg-u")
+    other._app = "app-b"
+
+    @web.middleware
+    async def _as_app_a(request: web.Request, handler):
+        request["app"] = "app-a"
+        request["user"] = "app-a"
+        return await handler(request)
+
+    app = _make_app(state)
+    app.middlewares.insert(0, _as_app_a)
+
+    seen = []
+    async with TestClient(TestServer(app)) as client:
+        for slot in ("nosuchslot", "forkable", "othersapp"):
+            resp = await client.post(f"/api/chat/slots/{slot}/fork", json={})
+            seen.append((resp.status, await resp.json()))
+
+    statuses = {s for s, _ in seen}
+    codes = {b["code"] for _, b in seen}
+    errors = {b["error"] for _, b in seen}
+    assert statuses == {404}, seen
+    assert codes == {"slot_not_found"}, (
+        "the three 404s now carry different codes, so an app-scoped caller can "
+        f"tell a slot it may not see from one that does not exist: {seen}"
+    )
+    assert len(errors) == 1, seen
+
+
+@pytest.mark.asyncio
+async def test_every_refusal_carries_both_a_code_and_its_prose(tmp_path, monkeypatch) -> None:
+    """The behavioural ratchet: no path regresses to prose-only, and none drops
+    the advisory text an existing client still reads."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    for payload in (
+        ["at_message_index"],
+        {"mode": "sideways"},
+        {"direction": "sideways"},
+        {"prompt": 7},
+        {"prompt": "x" * 32_769},
+        {"at_message_index": "2"},
+        {"at_message_index": 999},
+        {"at_message_index": -1},
+    ):
+        status, body = await _fork(_seeded_state(tmp_path), "forkable", payload)
+        assert status == 400, payload
+        assert isinstance(body.get("code"), str) and body["code"], payload
+        assert isinstance(body.get("error"), str) and body["error"], payload


### PR DESCRIPTION
## Problem / Motivation

`AGENTS.md` states the rule plainly: *"Backend-owned strings have no catalog path yet, so a new non-2xx JSON body MUST carry a machine-readable `code` field."*

`error-code-baseline.json` — the worklist the contract gate in `test/test_error_code_contract.py` ratchets down — listed `dashboard/chat_fork.py` with `missing_code: 17`. Every refusal from `POST /api/chat/slots/{slot}/fork` answered with English prose and nothing a caller could dispatch on:

```python
return web.json_response({"error": "at_message_index must be a non-negative integer"}, status=400)
return web.json_response({"error": f"at_message_index {at_index} out of range (...)"}, status=400)
```

"that is not an index" and "that index is past the end" are different client bugs wanting different handling, and the only thing separating them was the wording.

The module was already **half**-converted: its three `503` snapshot refusals carry `fork_snapshot_unstable`. The wire contract was therefore already settled here — the remaining seventeen simply had not followed it.

## Why it matters

Fork is a mutating, resource-capped endpoint: it can refuse for a slot cap (`429`), a non-persistent session, a failed pre-fork persist (`503`), an out-of-range index, or an App Kit isolation miss. A caller that wants to retry the `503`, surface the cap, and treat the index error as a bug in its own request has to tell them apart — and today it can only do so by matching English on a surface that is explicitly not translated.

This also clears the single largest remaining zero-contention entry in its area: no open PR touches this file (checked by exact path across all 266 open PRs, and re-checked immediately before opening this one).

## What changed (motivation → approach → change)

**Symptom** → 17 refusals with no machine-readable `code`; callers must match prose.

**Root cause** → the module's `code` convention was introduced with the `503`s and never extended to the rest.

**Change** → each of the 17 sites gains a `"code"`. The prose is kept and keeps its meaning — demoted to advisory, not removed — so a client that only reads `error` is unaffected. Codes reuse the vocabulary already in the tree (`invalid_json`, `body_not_object`, `invalid_field_type`, `value_out_of_range`, `slot_not_found`) rather than inventing a parallel one, plus `slot_cap_reached`, `slot_not_persistent`, `invalid_mode`, `invalid_direction`, `prompt_too_long`, `source_save_failed`, `no_messages_to_fork`, `no_messages_after_fork_point`, `at_message_index_required`.

### The one thing this conversion had to be careful about

`api_chat_slot_fork` answers `404 not found` in **three** places:

1. no such slot;
2. an app-scoped caller on an **unscoped** slot;
3. an app-scoped caller on **another app's** slot.

(2) and (3) are `404` rather than `403` deliberately — the code says so, citing CWE-204 — so that a slot behind the App Kit isolation boundary is indistinguishable from one that does not exist, and the boundary cannot be used to enumerate slots. The true reason is recorded server-side via SEL instead.

**A `code` is a new field on that same response, and therefore a new place for those three to diverge.** Giving them distinct codes (`slot_not_found` / `app_scope_required` / `not_your_slot`) would have rebuilt the exact oracle the `404`-not-`403` choice exists to close — a regression introduced *by* a compliance change, which is the worst way to acquire one. All three share `slot_not_found`, and `test_the_three_404s_stay_indistinguishable` asserts status, code **and** prose are identical across all three from an app-scoped caller.

### Why this is backend-only

Track B normally moves with its consumers — a `code` alone changes nothing while the frontend still renders `res.error`. Here it does not. All three frontend callers of `forkChatSlot` branch on `ok`/`key` and **none declares an `onError` or reads `res.error` at all**:

- `website/src/hooks/useSessionActions.ts` — `useMutation` with `onSuccess` only;
- `website/src/components/SessionGridView.tsx` — `useMutation` with `onSuccess` only;
- `website/src/store/chatSlice.ts` — `if (d.ok) { ... }; return d`.

So there is no copy to move, no locale catalog to touch, and no consumer edit that would be honest to include. No behaviour changes either: same statuses, same prose, same control flow.

## Tests

New `test/test_chat_fork_error_codes.py`, driving the real handler through the shared `chat_test_helpers._make_app` harness rather than a parallel framework.

**Behavioural (14):**

| Test | Locks in |
|---|---|
| `test_an_unknown_slot` | `slot_not_found` |
| `test_a_body_that_is_not_json` | `invalid_json` |
| `test_a_body_that_is_json_but_not_an_object` | `body_not_object` |
| `test_an_unknown_mode` | `invalid_mode` |
| `test_an_unknown_direction` | `invalid_direction` |
| `test_a_non_string_prompt` | `invalid_field_type` |
| `test_an_over_long_prompt` | `prompt_too_long` |
| `test_a_non_integer_index_and_an_out_of_range_one_differ` | the type-vs-range split a caller could not previously make without matching English |
| `test_a_negative_index_is_a_type_refusal_not_a_range_one` | `at_index < 0` shares the type branch, so it keeps that code — pinned so a later reader does not "fix" it to a range code |
| `test_a_boolean_index_is_refused_as_a_type` | `isinstance(True, int)` is True in Python; bools are rejected first |
| `test_a_slot_with_no_forkable_messages` | `no_messages_to_fork` |
| `test_a_non_persistent_slot` | `slot_not_persistent` |
| **`test_the_three_404s_stay_indistinguishable`** | **the CWE-204 property above** — an app-scoped caller gets byte-identical status, code and prose for a missing slot, an unscoped slot, and another app's slot |
| `test_every_refusal_carries_both_a_code_and_its_prose` | the behavioural ratchet: no path regresses to prose-only, none drops the advisory text |

**Per-file static ratchet (2).** The repo-wide gate only fails on a *net* regression, so a new prose-only refusal could land here behind an unrelated deletion elsewhere in the tree. Both run the contract gate's **own** `scan()`, so the per-file rule cannot drift from the repo-wide definition:

- `test_no_refusal_in_this_module_is_prose_only` — fails with the offending line numbers;
- `test_the_ratchet_can_actually_fail` — the self-check, because a scan matching nothing would pass the assertion above vacuously. Asserts the scanner reaches all 20 coded sites (17 new + the 3 pre-existing `503`s) and each carries a non-empty code.

Red before the source change: **16 failed**. After: **16 passed**.

Wider: `pytest test/test_chat_fork_error_codes.py test/test_error_code_contract.py test/test_fork_reconciles_after_flush.py test/test_tail_fork_config.py test/test_dashboard_chat.py` → **718 passed**.

### Baseline

`missing_code` 1350 → 1333 — exactly the seventeen — and the `dashboard/chat_fork.py` entry is gone.

`_compliant` needs one word of care, because the committed-to-committed diff reads 1196 → 1224 and that is +28 rather than 17. `main`'s **committed** baseline is stale on that field: regenerating on pristine `main` at `420dbebcf`, with no change of mine applied, already yields 1207. So 11 of that swing is an inherited refresh of a number `main` has not caught up on, and this PR's own contribution is 1207 → 1224, exactly +17. The staleness is invisible to CI by design — `test_baseline_is_not_stale` fails only on a net regression, and it passes on pristine `main` with 1196 committed (verified locally).

The baseline was **regenerated** from the live tree with the repo's own `python test/test_error_code_contract.py --update`, never hand-edited: its totals are relative to this PR's base, so reconciling numbers across branches would be meaningless. Diffing the regenerated file against `main`'s shows exactly one changed entry — `dashboard/chat_fork.py`, removed — and no other file added, removed, or changed.

## Manual verification

N/A — unit coverage sufficient: every changed site is a refusal reachable by sending one malformed request, and all 17 are driven either behaviourally against the real handler or by the gate's own AST scanner. There is no UI change to look at, since the callers never rendered the string being augmented.

`flake8` is clean on both changed files. Per `AGENTS.md`'s formatting rule: `src/kiro_crew/dashboard/chat_fork.py` **is** listed in `.github/black-baseline.txt` and was already unformatted before this change, so it is deliberately **not** reformatted — the added literals follow black style, but running black on it would bury a 17-site diff under a whole-file reflow. The new test file is not in the baseline and is `black --check` clean.

## Related Issues

No issue — this is the `dashboard/chat_fork.py` line item from `error-code-baseline.json`'s own worklist ("drive `missing_code` to zero, one PR per file or per directory"), and it implements the `AGENTS.md` rule quoted at the top.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented wire contract changes; the added key is additive and follows the convention the module's `503`s already established
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


