### PR TITLE
refactor: one shared AWS-profile charset constant across all validators (#6063)

### DIFF
--- a/src/kiro_crew/aws_consent.py
+++ b/src/kiro_crew/aws_consent.py
@@ -67,6 +67,7 @@ from typing import Any
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import aws_consent_path
+from kiro_crew.constants import AWS_PROFILE_FIRST_CHARS
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,16 @@ _LOCK_FILENAME = ".aws_consent.lock"
 #: apply, but a leading dash would still let a value be read as an OPTION
 #: rather than as the value of the option before it. Constrain both to the
 #: charset AWS itself allows and require a leading alphanumeric.
-_PROFILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._@=+-]{0,127}$")
+#:
+#: DELIBERATE semantic differences from ``constants.AWS_PROFILE_NAME_RE``
+#: (#6063), so this derives its class from the shared fragment instead of
+#: aliasing the compiled pattern: the first char is alphanumeric only
+#: (stricter), and the continuation class additionally admits ``@`` and ``=``
+#: (IAM entity charset; existing configs may carry them). ``\Z`` (not ``$``)
+#: so a trailing newline in a config-sourced value cannot slip past, matching
+#: #6055 at the four sibling sites. ``-`` stays last so the class is a
+#: literal, never a range.
+_PROFILE_RE = re.compile(rf"^[A-Za-z0-9][{AWS_PROFILE_FIRST_CHARS}@=-]{{0,127}}\Z")
 _REGION_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 
 #: How long an identity probe result stays usable. The probe is only run by the
@@ -545,6 +555,15 @@ async def probe_identity(profile: str, region: str, *, use_cache: bool = True) -
     ``run_aws`` is synchronous, so it goes to a thread: this is called from the
     gateway's event loop.
     """
+    # Deliberately NO probe-local strip/normalization. Both values come from
+    # live config, and the paid consumers (``boto3.Session(profile_name=...)``,
+    # the ``--profile`` argv sites) use that same raw value — a probe that
+    # validated a normalized COPY could record consent for a target the real
+    # request never uses. A whitespace-padded value instead fails the shape
+    # gate below (the charset admits no whitespace and ``\Z`` rejects a
+    # trailing newline, #6063), so the probe refuses it, consent is never
+    # granted, and every consumer sees the same verdict. Fix the value in
+    # config; nothing here rewrites it.
     key = (profile, region)
     now = asyncio.get_running_loop().time()
     if use_cache:

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -224,6 +224,36 @@ WINDOWS_DEVICE_STEMS = frozenset(
     | {f"lpt{n}" for n in range(1, 10)}
 )
 
+# AWS named-profile name shape — the SINGLE SOURCE OF TRUTH (#6063). The
+# charset lived as seven hand-copied compiled patterns, and the copies
+# reintroduced the missing-'+' defect twice (#6042, #6055). Every in-package
+# validator now derives from these; the two standalone artifact-deploy scripts
+# (which cannot import the package) embed AWS_PROFILE_NAME_PATTERN verbatim
+# under a byte-equality drift guard in test/test_aws_profile_charset.py.
+#
+# Semantics (settled by #6051/#6055):
+# * '+' admitted — IAM Identity Center derives "<account>+<permission-set>"
+#   profile names.
+# * The first char excludes '-' so a stored name is never option-shaped when it
+#   later reaches a discrete ``--profile <value>`` argv element.
+# * \Z anchor — '$' matches just before a trailing newline; \Z rejects it.
+#   Call sites that match a raw (unstripped) value rely on this.
+# * Length capped at 128 inside the pattern, matching the FieldSpec
+#   ``max_len=128`` the deploy boundaries enforce.
+#
+# A site with a DELIBERATE semantic difference (e.g. aws_consent.py's wider
+# legacy continuation charset) derives its character class from these
+# fragments rather than re-spelling them. COMPOSE FROM AWS_PROFILE_FIRST_CHARS
+# ONLY (it carries no literal '-', so extra chars may follow it safely, e.g.
+# rf"[{AWS_PROFILE_FIRST_CHARS}@=-]"). AWS_PROFILE_CHARS ends with a literal
+# '-' and is safe ONLY in terminal position — appending anything after it
+# turns the trailing '-' into a RANGE (e.g. "+-@" spans 0x2B-0x40, silently
+# admitting '/', ':' and ';'). test_aws_profile_charset.py pins this contract.
+AWS_PROFILE_FIRST_CHARS = "A-Za-z0-9_.+"
+AWS_PROFILE_CHARS = "A-Za-z0-9_.+-"
+AWS_PROFILE_NAME_PATTERN = f"^[{AWS_PROFILE_FIRST_CHARS}][{AWS_PROFILE_CHARS}]{{0,127}}\\Z"
+AWS_PROFILE_NAME_RE = re.compile(AWS_PROFILE_NAME_PATTERN)
+
 # The product wordmark, figlet `small`. ONE definition on purpose: copy-pasting
 # it into cli.py and cli_chat.py risks a rename leaving a stale product name in
 # the two most-seen surfaces (bare `kirocrew`, the chat REPL). Import it; never

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -35,6 +35,7 @@ from typing import Any, Generator
 
 from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.config.paths import config_dir
+from kiro_crew.constants import AWS_PROFILE_NAME_RE
 from kiro_crew.deploy import engine
 from kiro_crew.platform_compat import file_lock
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -78,12 +79,13 @@ _NOTE_MAX = 256
 
 # Same shapes handlers.py enforces for the legacy single-profile config — these
 # values flow into subprocess argv (--profile/--region) on every aws call.
-# '+' admitted for IAM Identity Center derived profiles
-# ("<account>+<permission-set>", #6051); first char excludes '-' so a name is
-# never option-shaped, and \Z rejects trailing newlines. Also used by
+# The profile shape ('+' admitted for IAM Identity Center derived names, #6051;
+# first char excludes '-' so a name is never option-shaped; \Z rejects trailing
+# newlines) is constants.AWS_PROFILE_NAME_RE — the single source of truth
+# (#6063) — aliased rather than re-spelled here. Also used by
 # discover_aws_profiles() to filter `aws configure list-profiles` lines
-# (stripped before matching, so the anchor change is behavior-neutral there).
-_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
+# (stripped before matching, so the anchor is behavior-neutral there).
+_PROFILE_RE = AWS_PROFILE_NAME_RE
 PROFILE_SPEC = FieldSpec(name="profile", type=str, max_len=128, pattern=_PROFILE_RE)
 # Multi-segment to admit GovCloud (us-gov-west-1) alongside standard regions;
 # max_len=32 keeps the backtracking surface negligible.

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/attach_backend.py
@@ -107,14 +107,24 @@ def ensure_lambda_oac(profile, region):
 
 def _validate_args(profile: str, region: str, dist_id: str, slug: str) -> None:
     """Validate all argv before any aws call. Exit 2 on mismatch."""
-    _PROFILE_RE = re.compile(r"^[a-zA-Z0-9._:/+-]+$")
+    # VERBATIM copy of kiro_crew.constants.AWS_PROFILE_NAME_PATTERN (#6063):
+    # this script runs standalone (no package import), so the shared shape is
+    # embedded literally and byte-equality is enforced by the drift guard in
+    # test/test_aws_profile_charset.py. No leading '-' (option-shaped), '+'
+    # admitted (IAM Identity Center names), \Z rejects trailing newlines,
+    # length capped at 128.
+    _PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
     _REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
     _DIST_ID_RE = re.compile(r"^[A-Z0-9]{13,14}$")
     _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 
     errors = []
     if profile and not _PROFILE_RE.match(profile):
-        errors.append(f"--profile: invalid format: {profile!r}")
+        errors.append(
+            f"--profile: invalid format: {profile!r} (allowed: letters, digits, "
+            "'.', '_', '+', '-'; no leading '-'; max 128 chars — ':' and '/' "
+            "are no longer accepted)"
+        )
     if not _REGION_RE.match(region):
         errors.append(f"--region: not a valid AWS region: {region!r}")
     if not _DIST_ID_RE.match(dist_id):

--- a/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
+++ b/src/kiro_crew/deploy/skills/artifact-deploy/scripts/detach_backend.py
@@ -66,14 +66,25 @@ def aws(profile, region, *args):
 def _validate_args(profile: str, region: str, dist_id: str, slug: str) -> None:
     """Validate all argv before any aws call. Exit 2 on mismatch."""
     import re as _re
-    _PROFILE_RE = _re.compile(r"^[a-zA-Z0-9._:/+-]+$")
+
+    # VERBATIM copy of kiro_crew.constants.AWS_PROFILE_NAME_PATTERN (#6063):
+    # this script runs standalone (no package import), so the shared shape is
+    # embedded literally and byte-equality is enforced by the drift guard in
+    # test/test_aws_profile_charset.py. No leading '-' (option-shaped), '+'
+    # admitted (IAM Identity Center names), \Z rejects trailing newlines,
+    # length capped at 128.
+    _PROFILE_RE = _re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
     _REGION_RE = _re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
     _DIST_ID_RE = _re.compile(r"^[A-Z0-9]{13,14}$")
     _SLUG_RE = _re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 
     errors = []
     if profile and not _PROFILE_RE.match(profile):
-        errors.append(f"--profile: invalid format: {profile!r}")
+        errors.append(
+            f"--profile: invalid format: {profile!r} (allowed: letters, digits, "
+            "'.', '_', '+', '-'; no leading '-'; max 128 chars — ':' and '/' "
+            "are no longer accepted)"
+        )
     if not _REGION_RE.match(region):
         errors.append(f"--region: not a valid AWS region: {region!r}")
     if not _DIST_ID_RE.match(dist_id):

--- a/src/kiro_crew/instances/validation.py
+++ b/src/kiro_crew/instances/validation.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import re
 
+from kiro_crew.constants import AWS_PROFILE_NAME_RE
+
 # Host charset: letters, digits, dot, hyphen, underscore, and a single optional
 # ``user@`` prefix. No whitespace, no shell metacharacters. Length-bounded.
 _HOST_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]*\Z")
@@ -53,10 +55,14 @@ _DEFAULT_SSM_RUN_AS = "ec2-user"
 # '+' is included because IAM entity names permit it and it flows into
 # generated profile names (e.g. SSO-derived "<account>+<permission-set>");
 # it is not a shell metacharacter and the value is only ever passed as a
-# discrete ``--profile <value>`` argv element. This is the single source of
-# truth for the charset: registry.py aliases this compiled pattern for its
-# early record check.
-_AWS_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+-]{1,128}\Z")
+# discrete ``--profile <value>`` argv element. The shape is
+# constants.AWS_PROFILE_NAME_RE — the single source of truth (#6063) —
+# aliased rather than re-spelled here; registry.py in turn aliases this
+# module's name for its early record check. Behavior-neutral swap: the old
+# local copy admitted a leading '-' in the class and relied on the explicit
+# startswith('-') check in validate_aws_profile; the shared shape rejects it
+# in the pattern as well.
+_AWS_PROFILE_RE = AWS_PROFILE_NAME_RE
 
 # aws_region: standard AWS region shape (e.g. us-east-1, us-gov-west-1).
 _AWS_REGION_RE = re.compile(r"^[a-z]{2}(-gov)?-[a-z]+-\d{1,2}\Z")

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -31,7 +31,7 @@ from typing import Any
 # no native library is loaded on any platform. Aliased so the schema block below
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
-from kiro_crew.constants import WINDOWS_DEVICE_STEMS
+from kiro_crew.constants import AWS_PROFILE_NAME_RE, WINDOWS_DEVICE_STEMS
 
 # Reasoning-effort vocabulary: ``effort.py`` is the single source of truth for
 # the valid levels; EFFORT_VALUES additionally admits ``""`` ("unset — defer to
@@ -1454,12 +1454,13 @@ def _validate_artifact_save(cleaned: dict) -> None:
 
 # Shared slug pattern (matches _ARTIFACT_SLUG_RE + deploy slug validation).
 _WM_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
-# '+' admitted for IAM Identity Center derived profiles
+# constants.AWS_PROFILE_NAME_RE — the single source of truth (#6063): '+'
+# admitted for IAM Identity Center derived profiles
 # ("<account>+<permission-set>", #6051); first char excludes '-' so a stored
 # profile is never option-shaped when it later reaches `--profile <value>`
 # argv. \Z is load-bearing here: this path matches the raw value WITHOUT a
 # strip, so the old $ anchor let a trailing-newline value through.
-_WM_PROFILE_RE = re.compile(r"^[A-Za-z0-9_.+][A-Za-z0-9_.+-]{0,127}\Z")
+_WM_PROFILE_RE = AWS_PROFILE_NAME_RE
 _WM_URL_RE = re.compile(r"^https?://.{1,2048}$")
 _WM_LIFECYCLE_STATUSES = {"draft", "deploying", "live", "error", "expired"}
 _WM_LIST_CAP = 50

--- a/test/test_aws_profile_charset.py
+++ b/test/test_aws_profile_charset.py
@@ -1,8 +1,10 @@
-"""Regression tests for the four sibling AWS-profile character classes (#6055).
+"""Regression tests for the AWS-profile character class (#6055, #6063).
 
 IAM Identity Center derives profile names shaped ``<account>+<permission-set>``
 (e.g. ``AdminAccess+dev``), so ``+`` must be accepted. The SSM/instances pair
-was fixed by #6051; these tests pin the four remaining hand-copied patterns:
+was fixed by #6051 and four more hand copies by #6055; #6063 consolidated the
+shape into ``kiro_crew.constants.AWS_PROFILE_NAME_RE`` as the single source of
+truth. These tests pin every consumer:
 
 * ``kiro_crew.cloud.ec2._PROFILE_SPEC`` (EC2 wizard — aliases
   ``profiles.PROFILE_SPEC``)
@@ -11,26 +13,39 @@ was fixed by #6051; these tests pin the four remaining hand-copied patterns:
 * ``kiro_crew.deploy.handlers._PROFILE_SPEC`` (deploy-web HTTP boundary —
   aliases ``profiles.PROFILE_SPEC``)
 * ``kiro_crew.validation._WM_PROFILE_RE`` (workspace-manager webapp_metadata)
+* ``kiro_crew.instances.validation._AWS_PROFILE_RE`` (SSM tunnel inputs;
+  ``instances.registry`` aliases it for its early record check)
+* ``kiro_crew.aws_consent._PROFILE_RE`` (identity probe — a DELIBERATE
+  near-sibling that derives its class from the shared fragments)
+* the two standalone artifact-deploy scripts (``attach_backend.py`` /
+  ``detach_backend.py``), which cannot import the package and embed the
+  pattern verbatim under the byte-equality drift guard below
 
-All four values only ever reach a subprocess as a discrete ``--profile <value>``
-argv element (never a shell string), so the widened class must still exclude
-whitespace and shell metacharacters, must reject option-shaped (leading ``-``)
-values, and must anchor with ``\\Z`` so a trailing newline cannot slip past
-``$``'s end-of-line leniency.
+All these values only ever reach a subprocess as a discrete
+``--profile <value>`` argv element (never a shell string), so the class must
+still exclude whitespace and shell metacharacters, must reject option-shaped
+(leading ``-``) values, and must anchor with ``\\Z`` so a trailing newline
+cannot slip past ``$``'s end-of-line leniency.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
+import re
+from pathlib import Path
 
 import pytest
 
+from kiro_crew import aws_consent, constants
 from kiro_crew import validation as validation_mod
 from kiro_crew.cloud import aws as cloud_aws
 from kiro_crew.cloud import ec2
 from kiro_crew.deploy import engine as engine_mod
 from kiro_crew.deploy import handlers
 from kiro_crew.deploy import profiles as profiles_mod
+from kiro_crew.instances import registry as instances_registry
+from kiro_crew.instances import validation as instances_validation
 from kiro_crew.validation import (
     ARTIFACT_SAVE_SCHEMA,
     ValidationError,
@@ -45,11 +60,15 @@ _POSIX_ONLY = pytest.mark.skipif(
 _PATTERNS = {
     # ec2 and handlers alias profiles.PROFILE_SPEC (same idiom as handlers'
     # _REGION_SPEC); pin each boundary's ACTUAL pattern so a future divergent
-    # local copy is still caught here.
+    # local copy is still caught here. aws_consent keeps a deliberately
+    # different shape (leading alnum only, '@'/'=' admitted) but shares every
+    # property these tables assert.
     "cloud.ec2": ec2._PROFILE_SPEC.pattern,
     "deploy.profiles": profiles_mod._PROFILE_RE,
     "deploy.handlers": handlers._PROFILE_SPEC.pattern,
     "workspace-manager": validation_mod._WM_PROFILE_RE,
+    "instances.validation": instances_validation._AWS_PROFILE_RE,
+    "aws-consent": aws_consent._PROFILE_RE,
 }
 
 _ACCEPTED = [
@@ -196,3 +215,160 @@ class TestDiscreteArgvIntegration:
     def test_deploy_engine_aws_keeps_plus_profile_discrete(self) -> None:
         argv = engine_mod._aws(["s3", "ls"], "AdminAccess+dev")
         assert argv[-2:] == ["--profile", "AdminAccess+dev"]
+
+
+class TestSharedConstantAdoption:
+    """#6063: one shared shape. Every in-package alias site must bind the SAME
+    compiled object, so a re-spelled local copy fails here immediately."""
+
+    def test_all_alias_sites_share_one_compiled_pattern(self) -> None:
+        assert profiles_mod._PROFILE_RE is constants.AWS_PROFILE_NAME_RE
+        assert validation_mod._WM_PROFILE_RE is constants.AWS_PROFILE_NAME_RE
+        assert instances_validation._AWS_PROFILE_RE is constants.AWS_PROFILE_NAME_RE
+        assert instances_registry._AWS_PROFILE_RE is constants.AWS_PROFILE_NAME_RE
+        assert ec2._PROFILE_SPEC.pattern is constants.AWS_PROFILE_NAME_RE
+        assert handlers._PROFILE_SPEC.pattern is constants.AWS_PROFILE_NAME_RE
+
+    def test_pattern_composes_from_the_charset_fragments(self) -> None:
+        # The fragments are the derivation surface for near-siblings
+        # (aws_consent); the composed pattern is the verbatim-embed surface for
+        # the standalone scripts. Pin both relationships.
+        assert constants.AWS_PROFILE_NAME_PATTERN == (
+            "^[" + constants.AWS_PROFILE_FIRST_CHARS + "]"
+            "[" + constants.AWS_PROFILE_CHARS + "]{0,127}\\Z"
+        )
+        assert constants.AWS_PROFILE_NAME_RE.pattern == constants.AWS_PROFILE_NAME_PATTERN
+
+    def test_dash_stays_last_in_the_continuation_class(self) -> None:
+        # AWS_PROFILE_CHARS is TERMINAL-ONLY: its trailing literal '-' becomes
+        # a RANGE if anything is appended after it. AWS_PROFILE_FIRST_CHARS is
+        # the composable fragment (no literal '-'), which is what aws_consent
+        # composes from. Pin the whole contract, not just the dash position.
+        assert constants.AWS_PROFILE_CHARS.endswith("-")
+        assert not constants.AWS_PROFILE_FIRST_CHARS.endswith("-")
+        assert constants.AWS_PROFILE_CHARS == constants.AWS_PROFILE_FIRST_CHARS + "-"
+        # The failure mode itself: appending after AWS_PROFILE_CHARS creates
+        # the "+-@" range (0x2B-0x40) admitting '/', ':' and ';' — while the
+        # sanctioned FIRST_CHARS composition admits none of them.
+        misused = re.compile(f"^[{constants.AWS_PROFILE_CHARS}@=]+\\Z")
+        assert misused.match("a/b:c;d"), "range hazard gone? update this contract test"
+        sanctioned = re.compile(f"^[A-Za-z0-9][{constants.AWS_PROFILE_FIRST_CHARS}@=-]*\\Z")
+        for ch in "/:;":
+            assert not sanctioned.match(f"a{ch}b")
+        assert sanctioned.match("a@b=c+d-e_f.g")
+
+
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "deploy"
+    / "skills"
+    / "artifact-deploy"
+    / "scripts"
+)
+_SCRIPT_PROFILE_LITERAL_RE = re.compile(r'_PROFILE_RE = _?re\.compile\(r"([^"]+)"\)')
+
+
+def _scripts_with_profile_pattern() -> list[str]:
+    """Self-enrolling drift-guard roster: every standalone script that carries
+    its own _PROFILE_RE hand copy is discovered, so the NEXT script to copy the
+    pattern is guarded automatically rather than silently skipped."""
+    return sorted(
+        p.name for p in _SCRIPTS_DIR.glob("*.py") if "_PROFILE_RE" in p.read_text(encoding="utf-8")
+    )
+
+
+class TestStandaloneScriptDriftGuard:
+    """The artifact-deploy scripts run standalone (no package import), so they
+    embed AWS_PROFILE_NAME_PATTERN verbatim. Byte-equality against the shared
+    source is what stops a new hand copy from diverging (#6063), mirroring the
+    repo's other verbatim-copy guards."""
+
+    def test_roster_discovers_the_known_copies(self) -> None:
+        # The glob must never silently go empty (renamed dir, moved scripts):
+        # an empty roster would green-light unguarded drift.
+        assert set(_scripts_with_profile_pattern()) >= {
+            "attach_backend.py",
+            "detach_backend.py",
+        }
+
+    @pytest.mark.parametrize("script", _scripts_with_profile_pattern())
+    def test_script_literal_is_byte_identical_to_shared_pattern(self, script: str) -> None:
+        source = (_SCRIPTS_DIR / script).read_text(encoding="utf-8")
+        found = _SCRIPT_PROFILE_LITERAL_RE.search(source)
+        assert found, f"{script}: _PROFILE_RE literal not found (extractor drift?)"
+        assert found.group(1) == constants.AWS_PROFILE_NAME_PATTERN, (
+            f"{script}: embedded profile pattern diverged from "
+            "constants.AWS_PROFILE_NAME_PATTERN — update the verbatim copy"
+        )
+
+    def test_shared_semantics_close_the_scripts_old_gaps(self) -> None:
+        # The pre-#6063 script class was ^[a-zA-Z0-9._:/+-]+$ — unbounded,
+        # option-shaped values admitted, ':' and '/' admitted, $-anchored.
+        pat = re.compile(constants.AWS_PROFILE_NAME_PATTERN)
+        assert pat.match("AdminAccess+dev")
+        for bad in ("-leading-dash", "a:b", "a/b", "dev\n", "a" * 129, ""):
+            assert not pat.match(bad), f"shared pattern accepted {bad!r}"
+
+
+class TestAwsConsentProfileShape:
+    """aws_consent keeps its DELIBERATE differences (leading alnum only,
+    '@'/'=' admitted for existing configs) but derives its class from the
+    shared fragments and anchors with \\Z. There is deliberately NO
+    probe-local strip: the probe must judge the same raw value the paid
+    consumers use (#6063)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_probe_cache(self):
+        # probe_identity WRITES _probe_cache even with use_cache=False (the
+        # flag only skips the read), and a leaked ok=True entry stays valid
+        # for _PROBE_TTL_SECS — a later test on the same worker calling the
+        # real probe would inherit a fabricated success. Mirrors
+        # test_aws_consent.py's autouse clear.
+        aws_consent._probe_cache.clear()
+        yield
+        aws_consent._probe_cache.clear()
+
+    @pytest.mark.parametrize("value", ["user@site", "role=admin", "AdminAccess+dev"])
+    def test_legacy_wider_charset_still_accepted(self, value: str) -> None:
+        assert aws_consent._PROFILE_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["-leading", "_leading", ".leading", "+leading"])
+    def test_first_char_stays_alnum_only(self, value: str) -> None:
+        assert not aws_consent._PROFILE_RE.match(value)
+
+    def test_trailing_newline_rejected_raw(self) -> None:
+        # The old $ anchor matched just before a trailing newline.
+        assert not aws_consent._PROFILE_RE.match("dev\n")
+
+    def test_probe_refuses_padded_values_fail_closed(self) -> None:
+        # No probe-local normalization: the paid consumers (boto3 sessions,
+        # the --profile argv sites) use the same raw config value, so a probe
+        # that validated a stripped COPY could record consent for a target the
+        # real request never uses. A padded value must be REFUSED (the shape
+        # gate runs before any CLI resolution, so no patching is needed),
+        # never silently rewritten.
+        for padded in (" dev ", "dev ", "dev\n", "\tdev"):
+            identity = asyncio.run(aws_consent.probe_identity(padded, "us-east-1", use_cache=False))
+            assert not identity.ok, f"padded profile {padded!r} was not refused"
+
+    def test_probe_tolerates_none_profile_without_crashing(self, monkeypatch) -> None:
+        # A JSON null in config reaches the probe as None; the falsy skip in
+        # _inputs_are_safe has always tolerated it ("use the default
+        # credential chain") and #6063 must not turn it into a crash.
+        def _fake_run_aws(args: list, profile, region):
+            return 0, '{"Account": "111122223333", "Arn": "arn:aws:iam::1:x"}', ""
+
+        monkeypatch.setattr(aws_consent, "_run_aws", _fake_run_aws)
+        monkeypatch.setattr(aws_consent, "_aws_cli_resolvable", lambda: True)
+        identity = asyncio.run(
+            aws_consent.probe_identity(None, "", use_cache=False)  # type: ignore[arg-type]
+        )
+        assert identity.ok
+
+    def test_probe_identity_still_refuses_interior_whitespace(self) -> None:
+        # Whitespace anywhere in the value is unsafe; the shape gate runs
+        # before any CLI resolution, so no patching is needed.
+        identity = asyncio.run(aws_consent.probe_identity("de v", "us-east-1", use_cache=False))
+        assert not identity.ok


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

After #6051 and #6055, the AWS-profile-name character class existed as hand-copied compiled regexes across seven sites (`instances/validation.py`, `cloud/ec2.py`, `deploy/profiles.py`, `deploy/handlers.py`, `validation.py` `_WM_PROFILE_RE`, and the standalone artifact-deploy scripts `attach_backend.py` / `detach_backend.py`), plus a near-sibling in `aws_consent.py`. The duplication reintroduced the missing-`+` defect twice (#6042, #6055). Two residual sites also kept weaker anchors: `aws_consent.py` matched with `$` (which admits a trailing newline), and the two scripts admitted option-shaped (leading `-`) values, `:`/`/`, and unbounded length.

## Why it matters

Every one of these values reaches an `aws` CLI invocation as a discrete `--profile <value>` argv element, and several are persisted (deploy registry, consent grants). A charset spelled by hand at each site has already drifted twice, each time re-breaking IAM Identity Center (`<account>+<permission-set>`) profile names for one boundary while the others worked. Without a single source of truth plus a drift guard, the eighth copy is a matter of time.

## What changed (motivation → approach → change)

Symptom → cause: repeated per-site regressions traced to the charset having no single owner. Change:

- **`constants.py`** (a stdlib-only leaf module, so every consumer can import it without cycles) now owns the shape: `AWS_PROFILE_FIRST_CHARS`, `AWS_PROFILE_CHARS`, `AWS_PROFILE_NAME_PATTERN`, and the compiled `AWS_PROFILE_NAME_RE`. Comments pin the composition contract: `AWS_PROFILE_FIRST_CHARS` is the fragment to compose derived classes from; `AWS_PROFILE_CHARS` ends with a literal `-` and is terminal-only (appending after it would silently create a `+-@`-style range).
- **`deploy/profiles.py`, `validation.py` (`_WM_PROFILE_RE`), `instances/validation.py`** alias the shared compiled pattern (byte-identical semantics for the first two; for `instances/validation.py` the swap only rejects leading `-` in the pattern as well as in the pre-existing explicit `startswith("-")` check). `cloud/ec2.py`, `deploy/handlers.py`, and `instances/registry.py` already aliased these sites and inherit the constant transitively.
- **`aws_consent.py`** keeps its deliberate differences (leading char alphanumeric-only, `@`/`=` admitted for existing configs) but derives its class from the shared fragment, and tightens the anchor from `$` to `\Z` so a trailing-newline config value is refused — consistent with #6055 at the sibling sites. There is deliberately **no probe-local strip**: the paid consumers (`boto3.Session(profile_name=...)`, the `--profile` argv sites) use the same raw config value the probe judges, so normalizing a private copy could record consent for a target the real request never uses. A padded value now fails closed at the shape gate instead (both pre-push review lanes independently flagged the strip variant of this change; it was removed).
- **`attach_backend.py` / `detach_backend.py`** (standalone scripts that cannot import the package) embed `AWS_PROFILE_NAME_PATTERN` verbatim. This intentionally tightens their old `^[a-zA-Z0-9._:/+-]+$`: leading `-` (option-shaped) is closed, `:` and `/` are no longer accepted, and length is capped at 128. The error message now names the accepted shape and the tightening.
- **Drift guard**: `test/test_aws_profile_charset.py` byte-compares each script's embedded literal against `constants.AWS_PROFILE_NAME_PATTERN`, with a self-enrolling roster (any script under `skills/artifact-deploy/scripts/` that carries a `_PROFILE_RE` copy is discovered and guarded automatically), and identity-asserts that every in-package alias site binds the same compiled object.

## Tests

All in `test/test_aws_profile_charset.py` (extended from the #6055 suite):

- `_PATTERNS` table extended to `instances.validation` and `aws-consent`: charset acceptance including `+`, rejection of option-shaped values, whitespace, shell metacharacters, trailing newline (`\Z` regression), empty string, and the 128/129 length bound — now across six boundaries.
- `TestSharedConstantAdoption`: every alias site binds the identical compiled object; the pattern composes from the published fragments; the composition contract (terminal-only `AWS_PROFILE_CHARS`, range hazard demonstrated, sanctioned `FIRST_CHARS` composition proven safe) is pinned.
- `TestStandaloneScriptDriftGuard`: self-enrolling roster (guarded against silently going empty), byte-equality of each embedded literal against the shared source, and proof the shared semantics close the scripts' old gaps (`-leading`, `a:b`, `a/b`, trailing newline, 129 chars).
- `TestAwsConsentProfileShape`: legacy `@`/`=` values still accepted, first char stays alphanumeric-only, trailing newline rejected raw, padded values refused fail-closed by the probe, `None` profile tolerated without crashing, interior whitespace refused. Includes an autouse `_probe_cache` clear so the real-probe tests cannot leak a fabricated success to later tests.

## Manual verification

N/A — unit coverage sufficient: every changed site is a pure shape check exercised directly by the suite, and the full backend suite passes with only this host's known pre-existing environment failures (identical failure set on pristine main).

## Related Issues

Fixes #6063

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only validation/constants change; no watched frontend path is touched and no rendered surface changes.
