### PR TITLE
fix: move theme-create mkdir and collision check off the event loop (#6198)

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1358,
+    "missing_code": 1357,
     "opaque_body": 18,
     "dynamic_status": 43
   },
@@ -166,7 +166,7 @@
     },
     "dashboard/handlers/themes.py": {
       "dynamic_status": 4,
-      "missing_code": 22
+      "missing_code": 21
     },
     "dashboard/handlers/updates.py": {
       "missing_code": 9

--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -162,11 +162,13 @@ async def api_themes_create(request: web.Request) -> web.Response:
         or _THEME_DEFAULT_EMOJI
     )
 
+    # No NEW filesystem call on the loop: ``_themes_dir()`` returns the
+    # ``config_dir()`` memo resolved at boot, and the mkdir, the collision
+    # stats, and the write all happen inside ``_create_locked`` on a worker
+    # thread. On a UNC/SMB-backed data home a single on-loop stat or mkdir
+    # can block the whole gateway.
     themes_path = _themes_dir()
-    themes_path.mkdir(parents=True, exist_ok=True)
     target = themes_path / f"{slug}.json"
-    if target.exists():
-        return web.json_response({"error": f"theme '{slug}' already exists"}, status=409)
 
     theme_data = {
         "name": name,
@@ -186,6 +188,7 @@ async def api_themes_create(request: web.Request) -> web.Response:
     # record and a dir), the duplicate-slug corruption the installer guards too.
     def _create_locked() -> bool:
         with _theme_install_lock(slug):
+            themes_path.mkdir(parents=True, exist_ok=True)
             if target.exists() or _installed_theme_dir(slug).exists():
                 return False
             _atomic_write_theme_json(

--- a/test/test_dashboard_themes_coverage.py
+++ b/test/test_dashboard_themes_coverage.py
@@ -259,8 +259,8 @@ class TestApiThemesCreate:
 
     @pytest.mark.asyncio
     async def test_installed_pack_with_the_same_slug_is_409(self, themes_dir: Path) -> None:
-        # The pre-lock check only sees <slug>.json; the in-lock check is what
-        # refuses a slug already taken by an installed <slug>/ directory.
+        # The in-lock check refuses a slug already taken by an installed
+        # <slug>/ directory, not just an existing <slug>.json record.
         (themes_dir / "sunset").mkdir()
         resp = await th.api_themes_create(
             _request("POST", "/api/themes", body=_theme_body())
@@ -278,6 +278,64 @@ class TestApiThemesCreate:
         )
         assert resp.status == 200
         assert (home / "themes" / "sunset.json").is_file()
+
+
+class TestApiThemesCreateOffLoop:
+    """#6198: the create handler's filesystem work must never run on the loop.
+
+    On a UNC data home ``mkdir``/``exists`` are SMB-backed and can block for
+    as long as the network takes; one such call on the loop stalls every other
+    request the gateway serves. Spy on ``Path.mkdir``/``exists``/``is_dir``/
+    ``is_file`` for the handler's paths (and the data home itself) and assert
+    every call happened on a worker thread — the same discipline #5963 pinned
+    for the detail route's target stats.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("preexisting", [False, True])
+    async def test_filesystem_work_runs_on_a_worker_thread(
+        self, preexisting: bool, themes_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if preexisting:
+            _write_json(themes_dir / "sunset.json", {"name": "Sunset"})
+        # Build the watched set through the handler's own resolver: the
+        # fixture path is unresolved, while ``_themes_dir()`` goes through
+        # ``config_dir()``'s ``resolve()`` — on Darwin ``/tmp`` is a symlink,
+        # so comparing against the raw fixture path would never match. The
+        # data home itself is watched too, so a cold ``config_dir()``
+        # resolve sneaking onto the loop would also be caught.
+        watched = {
+            th._themes_dir().parent,
+            th._themes_dir(),
+            th._themes_dir() / "sunset.json",
+            th._themes_dir() / "sunset",
+        }
+        loop_thread = threading.get_ident()
+        fs_threads: list[int] = []
+        real_calls = {
+            name: getattr(Path, name) for name in ("mkdir", "exists", "is_dir", "is_file")
+        }
+
+        def _spy(name: str) -> Any:
+            real = real_calls[name]
+
+            def spy(self: Path, *args: Any, **kwargs: Any) -> Any:
+                if self in watched:
+                    fs_threads.append(threading.get_ident())
+                return real(self, *args, **kwargs)
+
+            return spy
+
+        for name in real_calls:
+            monkeypatch.setattr(Path, name, _spy(name))
+
+        resp = await th.api_themes_create(
+            _request("POST", "/api/themes", body=_theme_body())
+        )
+        assert resp.status == (409 if preexisting else 200)
+        assert fs_threads, "expected the handler to touch the filesystem"
+        on_loop = [t for t in fs_threads if t == loop_thread]
+        assert not on_loop, f"{len(on_loop)} filesystem call(s) ran on the event loop"
 
 
 # ── _resolve_local_source ──────────────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

`api_themes_create` still runs two blocking filesystem calls directly on the asyncio event loop: `themes_path.mkdir(parents=True, exist_ok=True)` and a `target.exists()` pre-check. On a UNC/SMB-backed data home either call can block for as long as the network takes, stalling every other request the gateway serves — the identical defect class #5963 fixed for the theme detail route.

Closes #6198

## Why it matters

One on-loop stat freezes the user's chat turn AND the liveness heartbeat until the watchdog kills the process — the crash-loop wedge the `no-blocking-call-on-event-loop` rule exists to prevent. The create route was the last on-loop filesystem site in the theme handlers after #5943 and #5963.

## What changed (motivation → approach → change)

Fix by subtraction, per the First Principles review that raised this on PR #6190:

- **Deleted** the on-loop `target.exists()` pre-check outright. The in-lock check inside `_create_locked` already returns the same 409 authoritatively, so the pre-check was a redundant second spelling, not protection.
- **Moved** the `mkdir` into `_create_locked`, which already runs on a worker thread (`run_in_executor(discovery_executor(), ...)`) under the per-slug lock — no extra executor hop in the handler. The mkdir runs before the collision checks in the same critical section, so `_atomic_write_theme_json` still finds its parent directory present.
- The handler now does only path construction on the loop (`_themes_dir()` is the `config_dir()` memo resolved at boot).
- Re-snapshotted `error-code-baseline.json`: deleting the uncoded pre-check 409 improved the ratchet count for `themes.py` (22 → 21), and the stale-baseline test requires improved counts to be recorded.
- Verified the other `mkdir`/`exists` sites in `themes.py` (~331, ~372, ~462): all run inside `_do_install`/`_copy_installed_theme`, which are executor-dispatched — already off-loop, left untouched.

Recorded trade-off: an exact-duplicate-slug POST now always takes a `discovery_executor` worker and the per-slug lock where it previously answered 409 from the (on-loop) fast path. Accepted deliberately — a single authoritative in-lock check is worth more than a fast path, and re-adding a cheap pre-check is what created the on-loop stat in the first place. Bounded cost on an authenticated, local-only endpoint.

## Tests

- New `TestApiThemesCreateOffLoop` (parametrized: fresh create + 409 collision): spies `Path.mkdir`/`exists`/`is_dir`/`is_file` on the handler's paths and the data home, asserting every filesystem call ran on a worker thread — mirrors `TestApiThemeDetailStatsOffLoop` from #6190. Mutation-verified: reds on the pre-fix code with "2 filesystem call(s) ran on the event loop".
- Updated a stale comment in `test_installed_pack_with_the_same_slug_is_409` (there is no pre-lock check anymore).
- Existing create-route tests pass unchanged, including `test_creates_the_themes_directory_when_absent` (the mkdir-inside-lock still creates an absent themes dir) and both 409 paths.

Local gates: isort / flake8 / mypy / black gate / subprocess-encoding gate / brand gate / harness gate all green; full backend suite 69,972 passed with 87 failures proven pre-existing host-env on the unmodified base (identical failure set, zero theme-related).

## Manual verification

N/A — unit coverage sufficient: the off-loop property is asserted directly by the spy test, and the route's observable contract (200/409 bodies) is pinned by the existing tests.

no linked issue: N/A — linked, closes #6198.
