### PR TITLE
ci(ai-review): report review step failures honestly

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -64,7 +64,6 @@
 2 test/test_acp_backend_kas.py
 1 test/test_agent_home_isolation.py
 1 test/test_agent_import_hoist.py
-4 test/test_ai_review_workflows.py
 1 test/test_beacon.py
 1 test/test_bench_cli.py
 3 test/test_brand_name_gate.py

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -347,6 +347,7 @@ jobs:
           HUMAN_OVERRIDE: ${{ steps.human_override.outputs.active }}
           OVERRIDE_ACTOR: ${{ steps.human_override.outputs.actor }}
           ACTOR: ${{ github.actor }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           if [ "$HUMAN_OVERRIDE" = "true" ]; then
             OV_MARKER="<!-- design-review -->"
@@ -426,11 +427,23 @@ jobs:
             # NOT post the raw model/error text: it can carry internal detail
             # (AWS account ids, ARNs, endpoints, stack traces) into a public
             # comment. Post a generic, leak-safe notice; humans read the job logs.
+            # Name the cause from the model step's OWN outcome instead of
+            # asserting one: this branch is reached both when the model ran and
+            # returned nothing usable and when the model was never called at all,
+            # and "the model call errored" sent contributors to debug a call that
+            # had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## Design Review (Fable 5) — ⚠️ could not complete"
               echo
-              echo "_The design review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the Design Review job logs. Advisory — does not block merge._"
+              echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Design Review job logs. Advisory — does not block merge._"
             } > /tmp/design-comment.md
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -306,6 +306,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           SURFACE: ${{ steps.scope.outputs.surface }}
           CONTRACT: ${{ steps.contract.outputs.available }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           if [ "$HUMAN_OVERRIDE" = "true" ]; then
             OV_MARKER="<!-- first-principles-review -->"
@@ -335,10 +336,17 @@ jobs:
             echo "verdict=SKIPPED" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$SURFACE" = "true" ] && [ "$CONTRACT" != "true" ]; then
-            # The contract does not exist on the base commit: the lane cannot
-            # review the PR that introduces or moves it. Say so plainly rather
-            # than reporting a verdict it never produced.
+          if [ "$SURFACE" = "true" ] && [ "$CONTRACT" = "false" ]; then
+            # `false`, not just "not true": the contract step RAN and reported the
+            # contract absent from the base commit, so the lane cannot review the
+            # PR that introduces or moves it. Say so plainly rather than reporting
+            # a verdict it never produced. An EMPTY value would mean that step
+            # never ran, which is a different fact and must not be reported as a
+            # missing contract -- it falls through to the incomplete branch below.
+            # Not reachable in this lane today (the contract step runs before
+            # everything that could fail closed), but it IS reachable in
+            # fork-first-principles-review.yml, where the intent fetch sits in
+            # between; keep the two guards identical.
             echo "verdict=NO_CONTRACT" >> "$GITHUB_OUTPUT"
             {
               echo "$MARKER"
@@ -420,11 +428,23 @@ jobs:
             # NOT post the raw model/error text: it can carry internal detail
             # (AWS account ids, ARNs, endpoints, stack traces) into a public
             # comment. Post a generic, leak-safe notice; humans read the job logs.
+            # Name the cause from the model step's OWN outcome instead of
+            # asserting one: this branch is reached both when the model ran and
+            # returned nothing usable and when the model was never called at all,
+            # and "the model call errored" sent contributors to debug a call that
+            # had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## First Principles Review (Fable 5) — ⚠️ could not complete"
               echo
-              echo "_The first-principles review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the First Principles Review job logs. Advisory — does not block merge._"
+              echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the First Principles Review job logs. Advisory — does not block merge._"
             } > /tmp/fp-comment.md
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -538,6 +538,7 @@ jobs:
           PR: ${{ steps.pr.outputs.pr }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           set -uo pipefail
           [ -z "${PR:-}" ] && { echo "no PR resolved; skipping comment"; exit 0; }
@@ -560,13 +561,24 @@ jobs:
               cat "$f"
             } > "$RUNNER_TEMP/design-comment.md"
           else
-            # No parseable verdict → the review errored or emitted no header. Do
-            # NOT post raw model/error text; post a generic, leak-safe notice.
+            # No parseable verdict → post a generic, leak-safe notice (raw
+            # model/error text can carry internal detail). Name the cause from the
+            # model step's OWN outcome instead of asserting one: this branch is
+            # reached both when the model ran and returned nothing usable and when
+            # the model was never called at all, and "the model call errored" sent
+            # contributors to debug a call that had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## Design Review (Fable 5, fork) — ⚠️ could not complete"
               echo
-              echo "_The design review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the Fork Design Review job logs. Advisory — does not block merge._"
+              echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Fork Design Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/design-comment.md"
           fi
           # Author-filtered per-page jq lookup so a PR commenter can't plant the

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -473,12 +473,28 @@ jobs:
             echo "::warning::the scope step did not run (an earlier step failed closed); reporting the review as incomplete, not skipped."
             exit 0
           fi
-          # The contract is absent from the base commit -- the lane cannot review
-          # the change that introduces or moves it, and must not fall back to the
-          # head's copy.
-          if [ "${CONTRACT:-}" != "true" ]; then
+          # CONTRACT has the same three states as SURFACE above, and they must be
+          # told apart for the same reason. `false` means the contract step RAN and
+          # the contract genuinely is not on the base commit -- the lane cannot
+          # review the change that introduces or moves it, and must not fall back
+          # to the head's copy. An EMPTY value means the contract step never ran,
+          # because a step between the scope gate and it failed and the default
+          # `if: success()` skipped it. In THIS lane that is reachable: the intent
+          # fetch sits between them (the same-repo lane orders the contract step
+          # first, which is why it never showed this), so an intent-fetch failure
+          # used to surface as NO_CONTRACT -- a green check-run asserting "no
+          # contract on the base commit" when nothing ever looked for the contract,
+          # plus a comment asserting the revision ships no reviewable capability
+          # when the scope step had just found that it does. Two confident claims,
+          # neither checked. Empty resolves to UNKNOWN -> NEUTRAL, like SURFACE.
+          if [ "${CONTRACT:-}" = "false" ]; then
             echo "verdict=NO_CONTRACT" >> "$GITHUB_OUTPUT"
             echo "::warning::no trusted contract on the base commit; the review did not run. Not blocking."
+            exit 0
+          fi
+          if [ "${CONTRACT:-}" != "true" ]; then
+            echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
+            echo "::warning::the contract step did not run (an earlier step in this job failed); reporting the review as incomplete rather than as a missing contract."
             exit 0
           fi
           summary=""
@@ -542,6 +558,7 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha }}
           VERDICT: ${{ steps.verdict.outputs.verdict }}
           WITHHELD: ${{ steps.redact.outputs.withheld }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           set -uo pipefail
           [ -z "${PR:-}" ] && { echo "no PR resolved; skipping comment"; exit 0; }
@@ -570,14 +587,28 @@ jobs:
             fi
             exit 0
           fi
+          # SKIPPED and NO_CONTRACT are DIFFERENT facts and no longer share one
+          # message. SKIPPED is a statement about the contributor's diff (it adds
+          # no capability to inventory); NO_CONTRACT is a statement about this
+          # repository's base commit and says nothing about the diff at all.
+          # Reporting the second with the first's wording told contributors their
+          # change ships nothing when this lane had merely failed to find its own
+          # rubric. Same wording as first-principles-review.yml for both.
           if [ "${VERDICT:-UNKNOWN}" = "SKIPPED" ] || [ "${VERDICT:-UNKNOWN}" = "NO_CONTRACT" ]; then
+            if [ "${VERDICT:-UNKNOWN}" = "NO_CONTRACT" ]; then
+              heading="⏭️ no contract on the base commit"
+              body="_\`.github/review-prompts/first-principles.md\` does not exist on this PR's base commit, so there is no trusted contract to review \`$HEAD\` against. The contract is deliberately read from the base and never from the head, so a change cannot edit the reviewer that judges it — which also means this lane cannot review the pull request that introduces or moves the contract. Advisory — does not block merge._"
+            else
+              heading="⏭️ skipped"
+              body="_Revision \`$HEAD\` ships no reviewable capability (docs, tests or generated files only), so there is nothing to inventory. Advisory — does not block merge._"
+            fi
             existing="$(find_existing)"
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               {
                 echo "$MARKER"
-                echo "## First Principles Review (Fable 5, fork) — ⏭️ skipped"
+                echo "## First Principles Review (Fable 5, fork) — $heading"
                 echo
-                echo "_Revision \`$HEAD\` ships no reviewable capability, so there is nothing to inventory. Advisory — does not block merge._"
+                echo "$body"
               } > "$RUNNER_TEMP/fp-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
                 --field body="$(cat "$RUNNER_TEMP/fp-comment.md")" >/dev/null || true
@@ -604,11 +635,23 @@ jobs:
           else
             # No parseable verdict → the review errored or emitted no header. Do
             # NOT post raw model/error text; post a generic, leak-safe notice.
+            # Name the cause from the model step's OWN outcome instead of
+            # asserting one: this branch is reached both when the model ran and
+            # returned nothing usable and when the model was never called at all,
+            # and "the model call errored" sent contributors to debug a call that
+            # had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## First Principles Review (Fable 5, fork) — ⚠️ could not complete"
               echo
-              echo "_The first-principles review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the Fork First Principles Review job logs. Advisory — does not block merge._"
+              echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the Fork First Principles Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/fp-comment.md"
           fi
           # Author-filtered per-page jq lookup so a PR commenter can't plant the

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -674,6 +674,7 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha }}
           EXEC_FILE: ${{ steps.review.outputs.execution_file }}
           UI_SCOPE: ${{ steps.scope.outputs.ui }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           set -uo pipefail
           MARKER="<!-- ux-review -->"
@@ -760,11 +761,23 @@ jobs:
             # detail (AWS account ids, ARNs, endpoints, stack traces) into a
             # public comment. Post a generic, leak-safe notice; humans read
             # the job logs. Mirrors ux-review.yml.
+            # Name the cause from the model step's OWN outcome instead of
+            # asserting one: this branch is reached both when the model ran and
+            # returned nothing usable and when the model was never called at all,
+            # and "the model call errored" sent contributors to debug a call that
+            # had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## UX Review (Fable 5, fork) — ⚠️ could not complete"
               echo
-              echo "_The UX review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the Fork UX Review job logs. Advisory — does not block merge._"
+              echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the Fork UX Review job logs. Advisory — does not block merge._"
             } > /tmp/ux-comment.md
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -499,6 +499,7 @@ jobs:
           OVERRIDE_ACTOR: ${{ steps.human_override.outputs.actor }}
           ACTOR: ${{ github.actor }}
           UI_SCOPE: ${{ steps.scope.outputs.ui }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
         run: |
           if [ "$HUMAN_OVERRIDE" = "true" ]; then
             OV_MARKER="<!-- ux-review -->"
@@ -601,11 +602,23 @@ jobs:
             # detail (AWS account ids, ARNs, endpoints, stack traces) into a
             # public comment. Post a generic, leak-safe notice; humans read
             # the job logs.
+            # Name the cause from the model step's OWN outcome instead of
+            # asserting one: this branch is reached both when the model ran and
+            # returned nothing usable and when the model was never called at all,
+            # and "the model call errored" sent contributors to debug a call that
+            # had not happened.
+            case "${REVIEW_OUTCOME:-}" in
+              skipped) why="the review step never ran, because an earlier step in this job failed — no model call was made" ;;
+              failure) why="the review step failed" ;;
+              cancelled) why="the review step was cancelled" ;;
+              success) why="the review step completed but returned no verdict header" ;;
+              *)       why="the review step reported no outcome" ;;
+            esac
             {
               echo "$MARKER"
               echo "## UX Review (Fable 5) — ⚠️ could not complete"
               echo
-              echo "_The UX review did not produce a verdict for \`$HEAD\` (the model call errored or returned no verdict header). See the UX Review job logs. Advisory — does not block merge._"
+              echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the UX Review job logs. Advisory — does not block merge._"
             } > /tmp/ux-comment.md
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids /

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -1053,7 +1053,11 @@ class TestFirstPrinciplesShellSyntax:
             path = tmp_path / "step.sh"
             path.write_text(script, encoding="utf-8")
             result = subprocess.run(
-                [bash, "-n", str(path)], check=False, capture_output=True, text=True
+                [bash, "-n", str(path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
             )
             assert result.returncode == 0, f"{lane} / {step_name}: {result.stderr.strip()}"
 
@@ -1112,10 +1116,249 @@ class TestFirstPrinciplesScopeGateBehavior:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             env={**os.environ, "TOUCHED": touched},
         )
         assert out.returncode == 0, out.stderr
         assert (out.stdout == "true") is want, f"{lane}: {touched!r} -> {out.stdout!r}"
+
+
+class TestFirstPrinciplesIntentCapSurvivesALongBody:
+    """Execute the ACTUAL PR-intent cap from both lanes against a body far past
+    the cap.
+
+    `printf '%s' "$stripped" | head -c 8000` reads as harmless and is not: `head`
+    closes the pipe the moment it has its bytes, the upstream `printf` then takes
+    EPIPE, and `pipefail` + the runner's default `bash -e` kill the whole step.
+    A long PR description therefore aborted the reviewer before it ran, and the
+    lane went on to report that as a fact about the contributor's diff. The `|| `
+    fallback could not rescue it because it was the same construct.
+
+    Only EXECUTING the block at a size past the pipe's capacity can see this --
+    every string-matching test in this file passed while it was broken.
+    """
+
+    def _cap_block(self, lane: str) -> str:
+        workflow = _workflow(lane)
+        step = (
+            "Fetch PR intent (untrusted data file)"
+            if lane.startswith("fork-")
+            else "Prefetch the change as data files"
+        )
+        script = _step_script(workflow, step)
+        start = script.index("# Cap at 8000 bytes")
+        end = script.index('rm -f "$full"', start) + len('rm -f "$full"')
+        return script[start:end]
+
+    @pytest.mark.parametrize("lane", FP_LANES)
+    # 100_000 is past the old construct's abort threshold (the cap plus a pipe
+    # buffer). Read the body from a tmp_path file: Windows caps the complete
+    # CreateProcess environment at 32,767 characters.
+    @pytest.mark.parametrize("body_bytes", (0, 100, 8000, 8001, 100_000))
+    def test_cap_never_aborts_the_step(
+        self, lane: str, body_bytes: int, tmp_path: Path
+    ) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the cap block is Bash; skip where Bash is absent")
+        intent = tmp_path / "pr-intent.txt"
+        body = tmp_path / "body.txt"
+        body.write_bytes(b"x" * body_bytes)
+        # Reproduce the step's own prologue: `pipefail` plus the runner's `bash -e`
+        # are exactly what turned an EPIPE into a dead step.
+        script = 'set -uo pipefail\nstripped="$(cat "$BODY_FILE")"\n' + self._cap_block(lane)
+        out = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "BODY_FILE": str(body),
+                "INTENT": str(intent),
+            },
+            cwd=tmp_path,
+        )
+        assert out.returncode == 0, (
+            f"{lane}: capping a {body_bytes}-byte body killed the step "
+            f"(rc={out.returncode}) {out.stderr.strip()}"
+        )
+        written = intent.read_text(encoding="utf-8")
+        prose = written.split("\n", 1)[0]
+        assert len(prose) == min(body_bytes, 8000), f"{lane}: capped to {len(prose)}"
+        marker = "[description TRUNCATED at 8000 bytes]"
+        assert (marker in written) is (body_bytes > 8000), f"{lane}: marker wrong"
+
+    @pytest.mark.parametrize("lane", FP_LANES)
+    def test_cap_still_does_not_split_multibyte_utf8(self, lane: str, tmp_path: Path) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the cap block is Bash; skip where Bash is absent")
+        # 7999 ASCII bytes + one 3-byte character: byte 8000 lands in the MIDDLE of
+        # it, so a bare byte cap would leave an invalid UTF-8 tail. The Perl cap
+        # must drop that partial character.
+        intent = tmp_path / "pr-intent.txt"
+        body = tmp_path / "body.txt"
+        body.write_text("x" * 7999 + "€", encoding="utf-8")
+        script = 'set -uo pipefail\nstripped="$(cat "$BODY_FILE")"\n' + self._cap_block(lane)
+        out = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "BODY_FILE": str(body),
+                "INTENT": str(intent),
+            },
+            cwd=tmp_path,
+        )
+        assert out.returncode == 0, out.stderr
+        raw = intent.read_bytes()  # bytes, so a split multibyte tail would survive
+        assert raw.decode("utf-8").split("\n", 1)[0] == "x" * 7999
+
+
+class TestForkFirstPrinciplesContractStateIsThreeValued:
+    """`steps.contract.outputs.available` has three states and two of them are
+    opposite facts.
+
+    `false` means the contract step RAN and the contract is genuinely not on the
+    base commit. EMPTY means the step never ran. Collapsing them made an
+    intent-fetch failure surface as a GREEN check-run asserting "no contract on
+    the base commit" when nothing had ever looked for the contract, alongside a
+    comment asserting the revision ships no reviewable capability when the scope
+    step had just found that it does: two confident claims, neither checked.
+
+    Reachable only in the fork lane, whose intent fetch sits BETWEEN the scope
+    gate and the contract step; the same-repo lane orders the contract step first.
+    """
+
+    def _verdict_script(self) -> str:
+        workflow = _workflow("fork-first-principles-review.yml")
+        return _step_script(workflow, "Capture first-principles verdict")
+
+    @pytest.mark.parametrize(
+        ("contract", "want"),
+        [
+            # The step ran and found no contract: an honest, green skip.
+            ("false", "NO_CONTRACT"),
+            # The step never ran: nobody looked, so this must NOT claim the
+            # contract is missing -- it is an incomplete review (-> NEUTRAL).
+            ("", "UNKNOWN"),
+        ],
+    )
+    def test_absent_contract_and_never_looked_are_different(
+        self, contract: str, want: str, tmp_path: Path
+    ) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the verdict block is Bash; skip where Bash is absent")
+        out_file = tmp_path / "gh-output"
+        out_file.touch()
+        proc = subprocess.run(
+            [bash, "-e", "-c", self._verdict_script()],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "SURFACE": "true",
+                "CONTRACT": contract,
+                "EXEC_FILE": "",
+                "HEAD_SHA": "0" * 40,
+                "GITHUB_OUTPUT": str(out_file),
+                "RUNNER_TEMP": str(tmp_path),
+            },
+            cwd=tmp_path,
+        )
+        assert proc.returncode == 0, proc.stderr
+        emitted = out_file.read_text(encoding="utf-8")
+        assert f"verdict={want}" in emitted, (
+            f"contract={contract!r} -> {emitted.strip()!r}, wanted verdict={want}"
+        )
+
+    def test_no_contract_and_scope_skip_no_longer_share_one_message(self) -> None:
+        # The two are different facts: a scope skip is a statement about the
+        # contributor's diff, a missing contract is a statement about THIS repo's
+        # base commit and says nothing about the diff. The fork lane reported the
+        # second with the first's wording, and the same-repo lane never did --
+        # so this is drift back to the lane it says it mirrors.
+        workflow = _workflow("fork-first-principles-review.yml")
+        script = _step_script(workflow, "Post/update first-principles review comment")
+        assert 'heading="⏭️ no contract on the base commit"' in script
+        assert 'heading="⏭️ skipped"' in script
+        # The diff-level claim must be reachable ONLY from the scope skip.
+        ships_nothing = _line_containing(script, "ships no reviewable capability")
+        assert "docs, tests or generated files only" in ships_nothing
+
+
+CAUSE_LANES = (
+    "design-review.yml",
+    "ux-review.yml",
+    "first-principles-review.yml",
+    "fork-design-review.yml",
+    "fork-ux-review.yml",
+    "fork-first-principles-review.yml",
+)
+
+
+class TestIncompleteReviewNamesTheObservedCause:
+    """A fallback notice must report what was OBSERVED, not a plausible cause.
+
+    Every one of these lanes said "the model call errored or returned no verdict
+    header" whenever no verdict parsed -- including when the model was never
+    called at all, which is what happens when any earlier step in the job fails.
+    A wrong-but-plausible cause is worse than "could not complete, see logs": it
+    sends the contributor to debug their prompt or the model while the real
+    failure is upstream. The step's own `outcome` already distinguishes the
+    cases, so no new plumbing is needed to stop guessing.
+    """
+
+    @pytest.mark.parametrize("lane", CAUSE_LANES)
+    def test_cause_is_derived_from_the_review_step_outcome(self, lane: str) -> None:
+        workflow = _workflow(lane)
+        assert "the model call errored or returned no verdict header" not in workflow, (
+            f"{lane}: still asserts a cause it did not observe"
+        )
+        assert "REVIEW_OUTCOME: ${{ steps.review.outcome }}" in workflow, (
+            f"{lane}: the observed outcome is not wired into the comment step"
+        )
+
+    @pytest.mark.parametrize("lane", CAUSE_LANES)
+    def test_each_outcome_maps_to_a_distinct_honest_reason(self, lane: str) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the cause mapping is Bash; skip where Bash is absent")
+        workflow = _workflow(lane)
+        m = re.search(
+            r'(case "\$\{REVIEW_OUTCOME:-\}" in.*?esac)', workflow, re.S
+        )
+        assert m, f"{lane}: no REVIEW_OUTCOME case block"
+        block = "\n".join(line.strip() for line in m.group(1).splitlines())
+        seen = {}
+        for outcome in ("skipped", "failure", "cancelled", "success", ""):
+            out = subprocess.run(
+                [bash, "-e", "-c", block + '\nprintf "%s" "$why"'],
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                env={**os.environ, "REVIEW_OUTCOME": outcome},
+            )
+            assert out.returncode == 0, out.stderr
+            seen[outcome] = out.stdout
+        # The load-bearing distinction: a model that was never called must not be
+        # described as a model that errored.
+        assert "never ran" in seen["skipped"], f"{lane}: {seen['skipped']!r}"
+        assert "no model call was made" in seen["skipped"]
+        assert "review step failed" in seen["failure"]
+        assert "review step was cancelled" in seen["cancelled"]
+        assert "review step completed" in seen["success"]
+        assert seen["failure"] != seen["skipped"] != seen["success"]
+        assert len(set(seen.values())) == 5, f"{lane}: reasons collide: {seen}"
 
 
 FORK_FINALIZE_LANES = (
@@ -1928,6 +2171,7 @@ class TestGptMediaFilterBehavior:
             input=sample,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=True,
         ).stdout
         # Every media form collapses to a placeholder...
@@ -1973,6 +2217,7 @@ class TestGptMediaFilterBehavior:
                 env={**os.environ, "INTENT": "x" * n},
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 check=True,
             ).stdout
             cap_len, trunc = out.split("|")


### PR DESCRIPTION
## Problem / Motivation

AI-review lanes could publish confident but false explanations after an earlier workflow step failed:

- the fork first-principles lane treated an empty contract output (“the step never ran”) as `false` (“the base was checked and has no contract”);
- six review lanes said the model errored even when the model step was skipped and no model call occurred.

The original branch also fixed a fragile 8,000-byte intent cap. Main #6264 now contains that production fix, so this rebase keeps main's Perl implementation instead of reintroducing the older patch.

## Why it matters

An infrastructure failure must not be reported as a fact about a contributor's code. False “no contract” and “model errored” messages send contributors to debug the wrong system and can make a green advisory check assert something nobody verified.

## What changed

- Distinguish `CONTRACT=false` from an empty output. Only a completed lookup that found no contract yields `NO_CONTRACT`; a skipped lookup yields `UNKNOWN` and an incomplete/neutral review.
- Give fork scope-skip and missing-contract states separate, accurate messages.
- Feed `steps.review.outcome` into all six review-comment lanes and map `skipped`, `failure`, `cancelled`, `success`, and unknown states to distinct leak-safe explanations.
- Preserve main #6264's intent-cap implementation.
- Restore behavior-level coverage for that cap. The 100KB body comes from a temporary file, not an environment variable, so the test is valid under Windows' 32,767-character environment-block limit.
- Pin UTF-8 on all eight text-mode subprocess probes in `test_ai_review_workflows.py` and remove its now-zero entry from the encoding ratchet. This fixes the deterministic CI failure instead of rerunning it.

No permissions or merge-blocking conclusions are weakened.

## Tests

- Focused cases: 27 passed serial and 27 passed with two workers.
- Full `test_ai_review_workflows.py`: 203 collected; 199 passed, 4 capability skips.
- Related workflow matrix: 213 passed, 75 capability skips.
- Subprocess-encoding self-test: 9 flagged and 9 clean probes; actual gate passed with 242 known calls in 118 baseline files.
- Six modified YAML files parsed successfully.
- All 36 modified Bash `run:` blocks passed `bash -n`.
- isort, Flake8, Black ratchet, and diff-whitespace checks passed.

The behavior tests execute the actual workflow shell at 0/100/8000/8001/100000 bytes and across a split UTF-8 boundary. They use no retry, sleep, duration threshold, timeout relaxation, or warning filter.

## Manual verification

The fork Stage-2 workflow definition runs from the default branch, so this PR cannot exercise its edited copy before merge. Instead, tests extract and execute each modified shell block directly, including the failing state combinations and long-body inputs.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes CI workflow reporting and tests only; it has no rendered product UI effect.

## Related Issues

Fixes #6207
