### PR TITLE
fix(ask-question): code every refusal, following the module's own spelling

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1350,
+    "missing_code": 1334,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1196,
+  "_compliant": 1223,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -71,9 +71,6 @@
     },
     "dashboard/handlers/artifacts.py": {
       "dynamic_status": 2
-    },
-    "dashboard/handlers/ask_question.py": {
-      "missing_code": 16
     },
     "dashboard/handlers/auth_refresh.py": {
       "missing_code": 8

--- a/src/kiro_crew/dashboard/handlers/ask_question.py
+++ b/src/kiro_crew/dashboard/handlers/ask_question.py
@@ -90,7 +90,11 @@ def _deny_app_token(request: web.Request, operation: str) -> web.Response | None
     except Exception:
         logger.warning("SEL audit failed for app-token denial", exc_info=True)
     return web.json_response(
-        {"error": "app token not permitted for this endpoint"}, status=403
+        {
+            "error": "app token not permitted for this endpoint",
+            "code": "app_token_forbidden",
+        },
+        status=403,
     )
 
 
@@ -129,7 +133,7 @@ def _deny_non_owner(request: web.Request, operation: str) -> web.Response | None
     stale = stale_owner_session_response(request)
     if stale is not None:
         return stale
-    return web.json_response({"error": "forbidden"}, status=403)
+    return web.json_response({"error": "forbidden", "code": "owner_only"}, status=403)
 
 
 async def api_ask_question(request: web.Request) -> web.Response:
@@ -150,34 +154,49 @@ async def api_ask_question(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response(
+            {"error": "invalid JSON", "code": "invalid_json"}, status=400
+        )
     if not isinstance(body, dict):
         # Valid JSON is not necessarily an object: `[]`, `null` and bare scalars
         # all parse, then blow up on `.get()` as a 500 instead of a 400.
-        return web.json_response({"error": "body must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "body must be a JSON object", "code": "invalid_body"}, status=400
+        )
 
     session_key = str(body.get("session_key") or "")
     if not session_key:
-        return web.json_response({"error": "session_key is required"}, status=400)
+        return web.json_response(
+            {"error": "session_key is required", "code": "missing_session_key"},
+            status=400,
+        )
     slot_key = _slot_key_from_session(session_key)
     # Refuse to address a slot that does not exist: otherwise the caller blocks
     # for the full window on a card no client will ever render. An empty slot key
     # is the same dead end — the conversation has no open tab to render into.
     if not slot_key or slot_key not in state._slots:
         return web.json_response(
-            {"error": f"unknown slot for {session_key!r} — no dashboard session to ask"},
+            {
+                "error": f"unknown slot for {session_key!r} — no dashboard session to ask",
+                "code": "slot_not_found",
+            },
             status=404,
         )
 
     try:
         questions = validate_ask_user_question(body)
     except ValidationError as exc:
-        return web.json_response({"error": str(exc)}, status=400)
+        return web.json_response(
+            {"error": str(exc), "code": "invalid_questions"}, status=400
+        )
 
     try:
         timeout_secs = int(body.get("timeout_secs") or state._QUESTION_TIMEOUT_DEFAULT)
     except (TypeError, ValueError):
-        return web.json_response({"error": "timeout_secs must be an integer"}, status=400)
+        return web.json_response(
+            {"error": "timeout_secs must be an integer", "code": "invalid_field_type"},
+            status=400,
+        )
 
     ask_id = uuid.uuid4().hex
     try:
@@ -202,7 +221,9 @@ async def api_ask_question(request: web.Request) -> web.Response:
         # Raised when redaction collapses two questions into the same key, which
         # is only detectable after the redaction pass — so it surfaces here as a
         # 400 rather than from validate_ask_user_question.
-        return web.json_response({"error": str(exc)}, status=400)
+        return web.json_response(
+            {"error": str(exc), "code": "duplicate_question_key"}, status=400
+        )
     if answers is None:
         return web.json_response({"status": "timeout", "ask_id": ask_id})
     return web.json_response({"status": "answered", "ask_id": ask_id, "answers": answers})
@@ -343,9 +364,13 @@ async def api_ask_question_answer(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response(
+            {"error": "invalid JSON", "code": "invalid_json"}, status=400
+        )
     if not isinstance(body, dict):
-        return web.json_response({"error": "body must be a JSON object"}, status=400)
+        return web.json_response(
+            {"error": "body must be a JSON object", "code": "invalid_body"}, status=400
+        )
 
     if body.get("dismissed"):
         answers: dict[str, str] | None = None
@@ -353,11 +378,16 @@ async def api_ask_question_answer(request: web.Request) -> web.Response:
         raw = body.get("answers")
         if not isinstance(raw, dict) or not raw:
             return web.json_response(
-                {"error": "answers must be a non-empty object"}, status=400
+                {"error": "answers must be a non-empty object", "code": "invalid_answers"},
+                status=400,
             )
         if len(raw) > _ASK_MAX_QUESTIONS:
             return web.json_response(
-                {"error": f"at most {_ASK_MAX_QUESTIONS} answers"}, status=400
+                {
+                    "error": f"at most {_ASK_MAX_QUESTIONS} answers",
+                    "code": "too_many_answers",
+                },
+                status=400,
             )
         # Keys and values are echoed back to the agent as tool output, so they
         # are coerced to str (a nested object cannot smuggle structure into the
@@ -372,7 +402,10 @@ async def api_ask_question_answer(request: web.Request) -> web.Response:
         for k, v in answers.items():
             if len(k) > _ASK_MAX_QUESTION_LEN:
                 return web.json_response(
-                    {"error": f"question key exceeds {_ASK_MAX_QUESTION_LEN} characters"},
+                    {
+                        "error": f"question key exceeds {_ASK_MAX_QUESTION_LEN} characters",
+                        "code": "question_key_too_long",
+                    },
                     status=400,
                 )
             if len(v) > _ASK_MAX_ANSWER_LEN:
@@ -381,14 +414,18 @@ async def api_ask_question_answer(request: web.Request) -> web.Response:
                         "error": (
                             f"answer exceeds {_ASK_MAX_ANSWER_LEN} characters "
                             "— shorten it and submit again"
-                        )
+                        ),
+                        "code": "answer_too_long",
                     },
                     status=400,
                 )
 
     if not state.resolve_question(ask_id, answers):
         return web.json_response(
-            {"error": "no pending question with that id (already answered or expired)"},
+            {
+                "error": "no pending question with that id (already answered or expired)",
+                "code": "question_not_found",
+            },
             status=404,
         )
     return web.json_response({"ok": True})

--- a/test/test_ask_question_roundtrip.py
+++ b/test/test_ask_question_roundtrip.py
@@ -1327,3 +1327,254 @@ async def test_non_owner_dashboard_token_cannot_dismiss() -> None:
     resp = await api_ask_question_dismiss(request)
     assert resp.status == 403
     assert st._slots["chat-1"].to_dict()["needs_input"] is True
+
+
+# ── Machine-readable error codes ──
+
+
+class TestErrorCodes:
+    """Every refusal from this module carries a machine-readable ``code``.
+
+    ``error-code-baseline.json`` listed
+    ``dashboard/handlers/ask_question.py`` with ``missing_code: 16``. The module
+    was already part-converted -- the dismiss handler shipped ``invalid_json``,
+    ``invalid_body``, ``missing_slot``, ``missing_card_id`` and
+    ``question_card_not_found`` -- so the wire contract and the spelling were
+    already settled here; the remaining sixteen just had to follow them. That is
+    why this uses ``invalid_body`` rather than the tree-wide ``body_not_object``:
+    inside one module, one spelling.
+
+    The prose is kept and keeps its meaning -- demoted to advisory, not removed
+    -- so a client that only reads ``error`` is unaffected. Backend-only,
+    because neither consumer renders that prose: ``useWebSocket.ts`` awaits
+    ``api.pendingQuestions()`` without reading a failure body, and
+    ``resolveAskAfterSend.ts`` catches ``ApiError`` and branches on
+    ``err.status === 404`` alone. ``POST /api/ask-question`` has no browser
+    caller at all -- it is the MCP tool's leg, and that path decodes through
+    ``mcp_core._http_error_body``, which already parses a top-level ``code``.
+
+    **What the codes deliberately do NOT add.** The two ``403``s answer for
+    different callers -- an app token on an agent-question endpoint, and a
+    non-owner dashboard subject -- and already said so in prose, so distinct
+    codes publish nothing that was hidden. Neither reveals whether any resource
+    exists. The three ``404``s name three different things the CALLER asked for
+    (its own slot, its own card, its own ask id); none is a fail-same standing in
+    for a permission denial, and one of them already carried its own distinct
+    code before this change.
+    """
+
+    # -- the per-file ratchet --
+
+    @staticmethod
+    def _findings():
+        import sys
+        from pathlib import Path
+
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import test_error_code_contract as gate
+
+        return [
+            f for f in gate.scan() if f.path == "dashboard/handlers/ask_question.py"
+        ]
+
+    def test_no_refusal_in_this_module_is_prose_only(self) -> None:
+        missing = sorted(f.lineno for f in self._findings() if f.bucket == "missing_code")
+        assert missing == [], (
+            "these src/kiro_crew/dashboard/handlers/ask_question.py lines refuse "
+            f"with prose and no machine-readable code: {missing}"
+        )
+
+    def test_the_ratchet_can_actually_fail(self) -> None:
+        """Self-check: a scan matching nothing would pass the assertion above vacuously."""
+        coded = [f for f in self._findings() if f.bucket == "compliant"]
+        assert len(coded) == 21, f"scanner reached {len(coded)} coded sites, expected 21"
+        assert all(f.code_value for f in coded)
+
+    # -- POST /api/ask-question (the MCP tool's leg) --
+
+    @staticmethod
+    async def _ask(body, *, slots=None, owner=True, app_token=False, raises=False):
+        from kiro_crew.dashboard.handlers.ask_question import api_ask_question
+
+        st = _state()
+        st._slots = {"chat-1": MagicMock()} if slots is None else slots
+        request = MagicMock()
+        request.app = {"state": st}
+        if app_token:
+            claims = {"app": "some-app", "user": "some-app"}
+            request.__contains__.side_effect = lambda k: k in claims
+            request.__getitem__.side_effect = lambda k: claims[k]
+            request.get = lambda k, d="": claims.get(k, d)
+        elif owner:
+            _as_owner(request)
+        else:
+            _as_owner(request, user="somebody-else")
+
+        async def _json() -> dict:
+            if raises:
+                raise ValueError("not json")
+            return body
+
+        request.json = _json
+        resp = await api_ask_question(request)
+        return resp.status, json.loads(resp.body)
+
+    @pytest.mark.asyncio
+    async def test_an_app_token_is_refused_with_its_own_code(self) -> None:
+        status, body = await self._ask({}, app_token=True)
+        assert status == 403
+        assert body["code"] == "app_token_forbidden"
+        assert body["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_body_that_is_not_json(self) -> None:
+        status, body = await self._ask(None, raises=True)
+        assert status == 400
+        assert body["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_a_body_that_is_not_an_object(self) -> None:
+        status, body = await self._ask(["session_key"])
+        assert status == 400
+        assert body["code"] == "invalid_body"
+
+    @pytest.mark.asyncio
+    async def test_a_body_with_no_session_key(self) -> None:
+        status, body = await self._ask({"questions": _questions()})
+        assert status == 400
+        assert body["code"] == "missing_session_key"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_slot(self) -> None:
+        status, body = await self._ask(
+            {"session_key": "dashboard:chat-9", "questions": _questions()}, slots={}
+        )
+        assert status == 404
+        assert body["code"] == "slot_not_found"
+
+    @pytest.mark.asyncio
+    async def test_an_invalid_question_payload(self) -> None:
+        status, body = await self._ask(
+            {"session_key": "dashboard:chat-1", "questions": []}
+        )
+        assert status == 400
+        assert body["code"] == "invalid_questions"
+
+    @pytest.mark.asyncio
+    async def test_a_non_integer_timeout_is_a_different_code(self) -> None:
+        """The distinction a caller could not make without matching English: a
+        malformed ``questions`` payload and a malformed ``timeout_secs`` are
+        different client bugs, and both were bare ``400``s."""
+        status, body = await self._ask(
+            {
+                "session_key": "dashboard:chat-1",
+                "questions": _questions(),
+                "timeout_secs": "soon",
+            }
+        )
+        assert status == 400
+        assert body["code"] == "invalid_field_type"
+
+    # -- POST /api/ask-question/{ask_id}/answer --
+
+    @staticmethod
+    async def _answer(body, *, ask_id="ask-1", resolves=False, raises=False):
+        from kiro_crew.dashboard.handlers.ask_question import api_ask_question_answer
+
+        st = _state()
+        st.resolve_question = MagicMock(return_value=resolves)
+        request = MagicMock()
+        request.app = {"state": st}
+        request.match_info = {"ask_id": ask_id}
+        _as_owner(request)
+
+        async def _json() -> dict:
+            if raises:
+                raise ValueError("not json")
+            return body
+
+        request.json = _json
+        resp = await api_ask_question_answer(request)
+        return resp.status, json.loads(resp.body)
+
+    @pytest.mark.asyncio
+    async def test_answer_with_an_empty_answers_object(self) -> None:
+        status, body = await self._answer({"answers": {}})
+        assert status == 400
+        assert body["code"] == "invalid_answers"
+
+    @pytest.mark.asyncio
+    async def test_answer_with_too_many_answers(self) -> None:
+        from kiro_crew.validation import _ASK_MAX_QUESTIONS
+
+        status, body = await self._answer(
+            {"answers": {f"q{i}": "a" for i in range(_ASK_MAX_QUESTIONS + 1)}}
+        )
+        assert status == 400
+        assert body["code"] == "too_many_answers"
+
+    @pytest.mark.asyncio
+    async def test_answer_with_an_over_long_question_key(self) -> None:
+        from kiro_crew.validation import _ASK_MAX_QUESTION_LEN
+
+        status, body = await self._answer(
+            {"answers": {"q" * (_ASK_MAX_QUESTION_LEN + 1): "a"}}
+        )
+        assert status == 400
+        assert body["code"] == "question_key_too_long"
+
+    @pytest.mark.asyncio
+    async def test_answer_with_an_over_long_answer(self) -> None:
+        """Refused, never truncated: a silently sliced answer resolves the wait
+        and clears the card, so the agent proceeds on input the user cannot see
+        was cut. The code makes that refusal dispatchable."""
+        from kiro_crew.validation import _ASK_MAX_ANSWER_LEN
+
+        status, body = await self._answer(
+            {"answers": {"q": "a" * (_ASK_MAX_ANSWER_LEN + 1)}}
+        )
+        assert status == 400
+        assert body["code"] == "answer_too_long"
+
+    @pytest.mark.asyncio
+    async def test_answering_a_question_that_is_gone(self) -> None:
+        status, body = await self._answer({"dismissed": True}, resolves=False)
+        assert status == 404
+        assert body["code"] == "question_not_found"
+
+    # -- the behavioural ratchet --
+
+    @pytest.mark.asyncio
+    async def test_every_refusal_carries_both_a_code_and_its_prose(self) -> None:
+        """No refusal path may regress to prose-only, and none may drop the
+        advisory text an existing client still reads."""
+        from kiro_crew.validation import _ASK_MAX_ANSWER_LEN, _ASK_MAX_QUESTIONS
+
+        seen = []
+        seen.append(await self._ask({}, app_token=True))
+        seen.append(await self._ask(None, raises=True))
+        seen.append(await self._ask(["session_key"]))
+        seen.append(await self._ask({"questions": _questions()}))
+        seen.append(
+            await self._ask(
+                {"session_key": "dashboard:chat-9", "questions": _questions()}, slots={}
+            )
+        )
+        seen.append(await self._ask({"session_key": "dashboard:chat-1", "questions": []}))
+        seen.append(await self._answer(None, raises=True))
+        seen.append(await self._answer(["answers"]))
+        seen.append(await self._answer({"answers": {}}))
+        seen.append(
+            await self._answer(
+                {"answers": {f"q{i}": "a" for i in range(_ASK_MAX_QUESTIONS + 1)}}
+            )
+        )
+        seen.append(
+            await self._answer({"answers": {"q": "a" * (_ASK_MAX_ANSWER_LEN + 1)}})
+        )
+        seen.append(await self._answer({"dismissed": True}))
+
+        for status, body in seen:
+            assert status >= 400, (status, body)
+            assert isinstance(body.get("code"), str) and body["code"], body
+            assert isinstance(body.get("error"), str) and body["error"], body


### PR DESCRIPTION
## Problem / Motivation

`AGENTS.md`: *"Backend-owned strings have no catalog path yet, so a new non-2xx JSON body MUST carry a machine-readable `code` field."*

`error-code-baseline.json` listed `dashboard/handlers/ask_question.py` with `missing_code: 16` — sixteen refusals answering with English prose and nothing a caller could dispatch on:

```python
return web.json_response({"error": "timeout_secs must be an integer"}, status=400)
return web.json_response({"error": str(exc)}, status=400)
```

The module was already **part**-converted: its dismiss handler ships `invalid_json`, `invalid_body`, `missing_slot`, `missing_card_id` and `question_card_not_found`. The wire contract and the spelling were settled here already — the remaining sixteen simply had not followed them.

## Why it matters

`POST /api/ask-question` is the **MCP tool's** leg: its caller is an agent, decoding through `mcp_core._http_error_body`. Without a code that decoder can only forward a sentence to the LLM. The distinctions actually matter to it — a malformed `questions` payload, a non-integer `timeout_secs`, and an unknown slot are three different client bugs that all answered `400`/`404` with prose.

The answer endpoint's refusals are load-bearing too. An over-long answer is deliberately **rejected rather than truncated**, because silently slicing resolves the wait and clears the card, so the agent proceeds on input the user cannot see was cut. That refusal is worth making dispatchable.

## What changed (motivation → approach → change)

**Symptom** → 16 refusals with no machine-readable `code`; callers must match English.

**Root cause** → the convention was introduced with the dismiss handler and never extended to the other two.

**Change** → each of the 16 sites gains a `"code"`. Prose is kept and keeps its meaning — demoted to advisory, not removed — so a client that only reads `error` is unaffected. Same statuses, same prose, same control flow.

Codes follow **the module's own spelling first**, then the tree: `invalid_json`, `invalid_body` (deliberately *not* the tree-wide `body_not_object` — inside one module, one spelling), `missing_session_key`, `slot_not_found`, `invalid_questions`, `invalid_field_type`, `duplicate_question_key`, `invalid_answers`, `too_many_answers`, `question_key_too_long`, `answer_too_long`, `question_not_found`, `app_token_forbidden`, `owner_only`.

### What the codes deliberately do NOT add

A `code` is a new field on an existing response, so it is a new place for refusals to become distinguishable. Checked before choosing values:

- **The two `403`s** answer for *different callers* — an app token on an agent-question endpoint (`source="app_isolation"`), and a non-owner dashboard subject (owner-only). They already said so in prose, so distinct codes publish nothing that was hidden, and neither reveals whether any resource exists. The signed pre-owner bootstrap branch (`stale_owner_session_response`) is untouched and still returns its own response ahead of the `403`.
- **The three `404`s** name three different things the **caller** asked for: its own slot, its own card, its own ask id. None is a fail-same standing in for a permission denial — and one of them already carried its own distinct code before this change, which is the module's own precedent that these are meant to be tellable apart.

No refusal here is a deliberate indistinguishability boundary, so nothing had to be collapsed onto a shared code.

### Why this is backend-only

Track B normally moves with its consumers — a `code` alone changes nothing while the frontend still renders `res.error`. Neither consumer renders it:

- `website/src/hooks/useWebSocket.ts:421` — `await api.pendingQuestions()`; the failure body is never read.
- `website/src/lib/resolveAskAfterSend.ts` — catches `ApiError` and branches on `err.status === 404` alone, never `err.body`.
- `POST /api/ask-question` has **no** browser caller at all. Its consumer is `mcp_core._http_error_body`, which already parses a top-level `code`, validates it as `[a-z0-9_.-]{1,64}`, and passes it on.

So there is no copy to move, no locale catalog to touch, and no consumer edit that would be honest to include.

## Tests

Added to the module's existing `test/test_ask_question_roundtrip.py`, reusing its `_state()` / `_as_owner()` / `_questions()` harness rather than a parallel one.

**Behavioural (13)**, driving the real handlers:

| Test | Locks in |
|---|---|
| `test_an_app_token_is_refused_with_its_own_code` | `app_token_forbidden` |
| `test_a_body_that_is_not_json` | `invalid_json` |
| `test_a_body_that_is_not_an_object` | `invalid_body` |
| `test_a_body_with_no_session_key` | `missing_session_key` |
| `test_an_unknown_slot` | `slot_not_found` |
| `test_an_invalid_question_payload` | `invalid_questions` |
| `test_a_non_integer_timeout_is_a_different_code` | `invalid_field_type` — the split a caller could not make without matching English |
| `test_answer_with_an_empty_answers_object` | `invalid_answers` |
| `test_answer_with_too_many_answers` | `too_many_answers` |
| `test_answer_with_an_over_long_question_key` | `question_key_too_long` |
| `test_answer_with_an_over_long_answer` | `answer_too_long` (the reject-never-truncate path) |
| `test_answering_a_question_that_is_gone` | `question_not_found` |
| `test_every_refusal_carries_both_a_code_and_its_prose` | the behavioural ratchet |

**Per-file static ratchet (2).** The repo-wide gate only fails on a *net* regression, so a new prose-only refusal could land here behind an unrelated deletion elsewhere. Both run the contract gate's **own** `scan()`, so the per-file rule cannot drift from the repo-wide definition:

- `test_no_refusal_in_this_module_is_prose_only` — fails with the offending line numbers;
- `test_the_ratchet_can_actually_fail` — the self-check, since a scan matching nothing would pass the assertion above vacuously. Asserts all 21 coded sites (16 new + the 5 pre-existing) are reached and each carries a non-empty code.

Red before the source change: **15 failed**. After: **15 passed**.

Wider: `pytest test/test_ask_question_roundtrip.py test/test_ask_question_mcp_tool.py test/test_error_code_contract.py` → **77 passed**.

Two sites are not driven behaviourally and are covered by the static ratchet: `duplicate_question_key` needs the redaction pass to collapse two questions onto one key, which is only reachable through `state.request_question`, and the dismiss handler's pre-existing codes are unchanged by this PR.

### Baseline

`missing_code` 1350 → 1334 — exactly the sixteen — and the `dashboard/handlers/ask_question.py` entry is gone.

`_compliant` needs one word of care, because the committed-to-committed diff reads 1196 → 1223 and +27 is not sixteen. `main`'s **committed** baseline is stale on that field: regenerating on pristine `main` at `fecb1b59e`, with no change of mine applied, already yields 1207. So 11 of that +27 is an inherited refresh of a number `main` has not caught up on, and this PR's own contribution is 1207 → 1223, exactly +16 — the same sixteen sites, counted from the other side. The staleness is invisible to CI by design: `test_baseline_is_not_stale` fails only on a net regression, and it passes on pristine `main` with 1196 committed (verified locally).

Rebased onto current `main` (`fecb1b59e`); the delta is unchanged at exactly sixteen, because these totals are branch-local. Regenerated with the repo's own `python test/test_error_code_contract.py --update`, never hand-edited: its totals are relative to this PR's base, so reconciling numbers across branches would be meaningless. Diffing the regenerated file against `main`'s shows exactly one changed entry — this file, removed — and no other file added, removed, or changed.

## Manual verification

N/A — unit coverage sufficient: every changed site is a refusal reachable by sending one malformed request, and all 16 are driven either behaviourally against the real handlers or by the gate's own AST scanner. There is no UI surface: `POST /api/ask-question` has no browser caller, and the two routes that do have one are consumed by code that never reads the failure body.

`flake8` is clean on both changed files. Per `AGENTS.md`'s formatting rule, **both** files are listed in `.github/black-baseline.txt` and were already unformatted, so neither is reformatted — the added literals follow black style, but running black would bury a 16-site diff under a whole-file reflow.

## Related Issues

No issue — this is the `dashboard/handlers/ask_question.py` line item from `error-code-baseline.json`'s own worklist ("drive `missing_code` to zero, one PR per file or per directory"), implementing the `AGENTS.md` rule quoted at the top.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the added key is additive and follows the convention this module's dismiss handler already established
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


