### PR TITLE
test(bench): add deterministic KB retrieval eval harness (T0)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -475,7 +475,6 @@ test/test_bench_round18.py
 test/test_bench_round5.py
 test/test_bench_round6.py
 test/test_bench_round9.py
-test/test_bench_safepath.py
 test/test_bench_scorers.py
 test/test_bench_windows_symlink.py
 test/test_bootstrap.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,6 +35,7 @@ recursive-include src/kiro_crew/apps *.json
 # for apps ported from third-party work; Apache-2.0 attribution must ship.
 recursive-include src/kiro_crew/apps *.md
 recursive-include src/kiro_crew/eval/scenarios *.json
+recursive-include src/kiro_crew/eval/bench/data *.json
 recursive-include src/kiro_crew/docs *.md
 recursive-include src/kiro_crew/tests_fixtures *
 

--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -45,7 +45,7 @@ This is the boundary the agent's write path (§2b) captures against: verbatim, l
 
 ## Success criteria
 
-The Knowledge Library's job — surface the exact, cited chunk when memory's recall falls short — is judged on **two tiers**. No dedicated harness for either exists in-tree yet (see "What is measured today"); this section defines the target so a retrieval change (recency weighting, a reranker, content-typed TTL) can be judged against a fixed bar rather than by eye.
+The Knowledge Library's job — surface the exact, cited chunk when memory's recall falls short — is judged on **two tiers**. Tier 1 now has a deterministic in-tree harness (`kirocrew bench kb-retrieval`, see "What is measured today"); no Tier 2 harness exists in-tree yet. This section defines the target so a retrieval change (recency weighting, a reranker, content-typed TTL) can be judged against a fixed bar rather than by eye.
 
 ### Tier 1 — intrinsic retrieval quality
 
@@ -88,7 +88,9 @@ The code computes and floors a retrieval **score**, but no Tier-1/Tier-2 metric 
 - Results below `min_score = 0.012` are dropped by the tool caller (`mcp_tools/knowledge.py`), not inside the retriever.
 - `kirocrew eval` ships four scenarios (`smoke_test`, `memory_recall_basic`, `lesson_application`, `context_accumulation`) scored per-assertion (`contains` / `regex` / `judge`) with an optional 1–5 LLM judge (`eval/judge.py`, pass ≥ 3.0). All four are clean single-fact teach→recall or accumulate→summarize flows; none exercises correction / contradiction / retraction / time-bound / reinforcement / hypothetical, and none reports recall@k, MRR, or task-lift.
 
-The gap is therefore a **KB-scoped golden set over the query classes above, plus an A/B task-lift harness** — the precondition for tuning recency, adding a reranker, or content-typed TTL against evidence rather than intuition.
+- `kirocrew bench kb-retrieval` is the Tier-1 ruler: it scores a frozen golden set (`eval/bench/data/kb_golden_v1.json`, hand-authored, covering the query classes above) against a real `KnowledgeStore` + `HybridRetriever` and reports recall@k / MRR@k / nDCG@k per class, plus `abstention_rate`. It measures **bare `HybridRetriever.search`** — the tool-caller `min_score` floor above is deliberately not applied — so its numbers describe the raw retriever, not the agent-visible MCP surface; a floor change at the tool caller will not move them.
+
+The remaining gap is therefore an **A/B task-lift harness** (Tier 2), plus a floor-aware variant of the Tier-1 ruler if the agent-visible surface is ever to be scored directly — the precondition for tuning recency, adding a reranker, or content-typed TTL against evidence rather than intuition.
 
 ## Key Files
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -247,6 +247,7 @@ kiro_crew =
     builtin_skills/**/*
     deploy/skills/**/*
     eval/scenarios/*.json
+    eval/bench/data/*.json
     docs/*.md
     static/*
     tests_fixtures/**/*

--- a/src/kiro_crew/cli_bench.py
+++ b/src/kiro_crew/cli_bench.py
@@ -170,6 +170,48 @@ def register_bench_parser(sub: argparse._SubParsersAction) -> None:
         "-k", type=_positive_int, default=5, help="Cut-off to report (default: 5)"
     )
 
+    kb = bench_sub.add_parser(
+        "kb-retrieval",
+        help="Measure Knowledge Library recall/MRR/nDCG against a golden set (deterministic)",
+        description=(
+            "Ingests a labeled golden set of documents into a throwaway "
+            "KnowledgeStore, runs each query through the real HybridRetriever, and "
+            "scores whether the gold doc was surfaced -- reported as recall@k, MRR "
+            "and nDCG per query class (clean-fact, multi-hop, time-bound, "
+            "correction, contradiction, retraction, reinforcement, "
+            "hypothetical-exclusion, abstention, citation-fidelity). Distinct from "
+            "'bench retrieval', which measures the conversational memory layer. "
+            "Defaults to the deterministic toy embedder so it runs anywhere; pass "
+            "--real-embedder for a semantic run when the model is resident."
+        ),
+    )
+    kb.add_argument(
+        "golden",
+        nargs="?",
+        default=None,
+        help="Path to a golden-set JSON (default: the packaged kb_golden_v1.json)",
+    )
+    kb.add_argument(
+        "-k",
+        type=_positive_int,
+        default=3,
+        help="Cut-off to headline in the printed summary (default: 3)",
+    )
+    kb.add_argument(
+        "--real-embedder",
+        action="store_true",
+        help=(
+            "Use the in-process Qwen3 embedder instead of the deterministic toy "
+            "stand-in. Refuses if the model is not resident on this host. Required "
+            "for a reportable semantic number."
+        ),
+    )
+    kb.add_argument(
+        "--no-embeddings",
+        action="store_true",
+        help="Skip the vector leg entirely (keyword+graph only), to isolate the FTS contribution",
+    )
+
 
 def bench_cmd(args: argparse.Namespace) -> int:
     """Dispatch, with the ONE catch site for every deliberate refusal.
@@ -206,7 +248,7 @@ def _bench_dispatch(args: argparse.Namespace) -> int:
     """Route to a subcommand. Returns a process exit code."""
     action = getattr(args, "bench_action", None)
     if action is None:
-        print("usage: kirocrew bench {list,fetch,retrieval,compare}")
+        print("usage: kirocrew bench {list,fetch,retrieval,kb-retrieval,compare}")
         return 2
 
     # Deferred deliberately, and measured. `cli.py` imports this module at module
@@ -240,6 +282,9 @@ def _bench_dispatch(args: argparse.Namespace) -> int:
 
     if action == "retrieval":
         return _retrieval(args)
+
+    if action == "kb-retrieval":
+        return _kb_retrieval(args)
 
     print(f"unknown bench action: {action}")
     return 2
@@ -416,4 +461,91 @@ def _retrieval(args: argparse.Namespace) -> int:
         print(f"\nnot saved: {exc}")
         return 1
     print(f"\nwrote {md}\n      {js}")
+    return 0
+
+
+def _kb_retrieval(args: argparse.Namespace) -> int:
+    """Run the Knowledge Library recall harness against a golden set.
+
+    Lazy imports, like ``_retrieval``: this keeps ``knowledge.store`` /
+    ``knowledge.retrieval`` (and their sqlite/embedder pull-ins) out of the boot
+    path of every unrelated ``kirocrew`` subcommand -- the perf regression
+    ``test/test_perf_boot_path.py`` pins.
+    """
+    from kiro_crew.eval.bench.kb_retrieval import (
+        KBGoldenSet,
+        KBGoldenSetError,
+        default_golden_set_path,
+        format_kb_report,
+        run_kb_retrieval,
+    )
+
+    path = args.golden or default_golden_set_path()
+    try:
+        golden = KBGoldenSet.from_json(path)
+    except (KBGoldenSetError, UnicodeError) as exc:
+        # UnicodeError: a golden file with invalid UTF-8 (or a lone surrogate)
+        # raises from the decode inside from_json -- a corrupt input is a
+        # deliberate refusal, not a traceback, same as any other malformed file.
+        print(f"refusing to run: {exc}")
+        return 1
+
+    embed_fn = None
+    embedder_id = "toy-hashed-bow"
+    if args.real_embedder:
+        from kiro_crew.knowledge.embedder import InProcessEmbedder
+
+        embedder = InProcessEmbedder()
+        if not embedder.is_available():
+            print(
+                "refusing to run: --real-embedder requested but the in-process "
+                "embedding model is not resident on this host. Omit the flag to "
+                "use the deterministic toy embedder (plumbing check only)."
+            )
+            return 1
+        embed_fn = embedder.embed
+        # The embedder's own model identity, never a hardcoded literal: a run
+        # with a custom model (InProcessEmbedder(model=...) or a swapped backend)
+        # must be labeled as that model in the report, or `bench compare` diffs
+        # apples against oranges under the same name. Mirrors the fail-closed
+        # embedder-identity invariant run_kb_retrieval enforces.
+        embedder_id = embedder.model
+    elif not args.no_embeddings:
+        print(
+            "WARNING: using the toy hashed-bag-of-words embedder. These numbers "
+            "measure term overlap, not semantic recall, and must not be reported "
+            "as a benchmark result. Use --real-embedder for a real number."
+        )
+
+    # The SAME driver module the KnowledgeStore uses: on Linux x86_64 that is
+    # pysqlite3, whose exception classes are distinct from stdlib sqlite3's --
+    # catching the stdlib class there would miss every real store failure.
+    from kiro_crew._sqlite_compat import sqlite3
+
+    try:
+        report = run_kb_retrieval(
+            golden,
+            embed_fn=embed_fn,
+            embedder_id=embedder_id,
+            use_embeddings=not args.no_embeddings,
+            # Include the headlined cut-off in the computed set. Otherwise a
+            # non-default -k (e.g. -k 2) is absent from every per-query dict and
+            # headline()/by_class() default it to 0.0 -- a false-zero benchmark
+            # result, the exact failure the sibling retrieval harness forbids.
+            k_values=tuple(sorted({1, 3, 5, 10, args.k})),
+        )
+    except KBGoldenSetError as exc:
+        print(f"refusing to run: {exc}")
+        return 1
+    except (sqlite3.Error, UnicodeError) as exc:
+        # The harness builds a throwaway KnowledgeStore in a temp dir; a full
+        # temp volume (or any other database-level failure) surfaces here as a
+        # sqlite3 error, and doc content that defeats UTF-8 encoding (e.g. a
+        # lone surrogate reaching the store/embedding path) as a UnicodeError.
+        # A deliberate refusal, not a traceback -- the same boundary rule every
+        # other refusal in this dispatch follows.
+        print(f"refusing to run: store error while building the eval corpus: {exc}")
+        return 1
+
+    print(format_kb_report(report, k=args.k))
     return 0

--- a/src/kiro_crew/eval/bench/data/kb_golden_v1.json
+++ b/src/kiro_crew/eval/bench/data/kb_golden_v1.json
@@ -1,0 +1,198 @@
+{
+  "name": "kb_golden_v1",
+  "docs": [
+    {
+      "id": "d-deploy-runbook",
+      "title": "Service deploy runbook",
+      "section_title": "Rollout steps",
+      "content": "To deploy the payments service, push to the release branch, wait for the pipeline to reach the gamma stage, run the smoke suite, then approve the prod promotion. Rollbacks are one-click from the pipeline console.",
+      "tags": ["runbook", "deploy", "payments"]
+    },
+    {
+      "id": "d-oncall-rotation",
+      "title": "On-call rotation policy",
+      "section_title": "Escalation",
+      "content": "Primary on-call holds the pager for one week starting Monday. If unacknowledged for 15 minutes the page escalates to the secondary, then to the team lead. Swaps must be recorded in the rotation calendar.",
+      "tags": ["oncall", "policy"]
+    },
+    {
+      "id": "d-db-owner",
+      "title": "Database ownership",
+      "section_title": "Ownership",
+      "content": "The orders database is owned by the Fulfillment team. Schema changes require a review from a Fulfillment engineer. The team's Slack channel is fulfillment-eng.",
+      "tags": ["database", "ownership", "orders"]
+    },
+    {
+      "id": "d-db-contact",
+      "title": "Fulfillment team contacts",
+      "section_title": "Contacts",
+      "content": "The Fulfillment team lead is Dana Ruiz. Dana approves emergency schema changes to the orders database outside business hours.",
+      "tags": ["contacts", "fulfillment"]
+    },
+    {
+      "id": "d-retention-old",
+      "title": "Data retention (2023 policy)",
+      "section_title": "Log retention",
+      "content": "As of 2023, application logs are retained for 30 days before deletion. This policy applies to all non-audit logs.",
+      "tags": ["retention", "policy", "2023"]
+    },
+    {
+      "id": "d-retention-new",
+      "title": "Data retention (2025 policy, current)",
+      "section_title": "Log retention",
+      "content": "Effective January 2025, application logs are retained for 90 days before deletion, superseding the earlier 30-day rule. Audit logs are retained for seven years.",
+      "tags": ["retention", "policy", "2025", "current"]
+    },
+    {
+      "id": "d-cache-ttl-wrong",
+      "title": "Cache configuration (draft, corrected below)",
+      "section_title": "TTL",
+      "content": "The session cache TTL was documented as 3600 seconds in this early draft. This value was never deployed and is corrected in the current configuration note.",
+      "tags": ["cache", "draft"]
+    },
+    {
+      "id": "d-cache-ttl-correct",
+      "title": "Cache configuration (current)",
+      "section_title": "TTL",
+      "content": "The session cache TTL is 900 seconds. This corrects the earlier draft that stated 3600 seconds. 900 seconds is the value deployed in production.",
+      "tags": ["cache", "current", "correction"]
+    },
+    {
+      "id": "d-region-claim-a",
+      "title": "Primary region (infra wiki)",
+      "section_title": "Regions",
+      "content": "The service's primary region is us-east-1 according to the infrastructure wiki page last edited in March.",
+      "tags": ["region", "infra"]
+    },
+    {
+      "id": "d-region-claim-b",
+      "title": "Primary region (architecture decision record, authoritative)",
+      "section_title": "Regions",
+      "content": "ADR-042 establishes us-west-2 as the primary region for the service, contradicting the older infra wiki claim of us-east-1. The ADR is authoritative for region decisions.",
+      "tags": ["region", "adr", "authoritative"]
+    },
+    {
+      "id": "d-feature-flag-announcement",
+      "title": "Feature flag rollout plan (superseded by retraction)",
+      "section_title": "Rollout",
+      "content": "The new-checkout feature flag will be enabled at 100 percent of traffic starting next Tuesday. Rollout proceeds in three ramps: 10 percent, 50 percent, then 100 percent.",
+      "tags": ["feature-flag", "rollout"]
+    },
+    {
+      "id": "d-feature-flag-retracted",
+      "title": "Feature flag rollout (retracted)",
+      "section_title": "Status",
+      "content": "RETRACTED: the plan to enable the new-checkout feature flag at 100 percent was withdrawn after a regression was found. Do not rely on the earlier rollout note; the flag remains at 0 percent.",
+      "tags": ["feature-flag", "retracted"]
+    },
+    {
+      "id": "d-security-mfa-proposal",
+      "title": "Authentication proposal (draft, never adopted)",
+      "section_title": "Authentication",
+      "content": "Draft proposal: allow SMS-based MFA as an alternative for production console access where hardware tokens are impractical. This draft was not adopted; it is retained for historical context only.",
+      "tags": ["security", "mfa", "draft"]
+    },
+    {
+      "id": "d-security-mfa",
+      "title": "Security baseline",
+      "section_title": "Authentication",
+      "content": "All production console access requires hardware MFA. This requirement has been restated in every quarterly security review and remains mandatory.",
+      "tags": ["security", "mfa", "baseline"]
+    },
+    {
+      "id": "d-security-mfa-audit",
+      "title": "Q3 security audit findings",
+      "section_title": "Access controls",
+      "content": "Audit item AC-3: verified that production console access enforces hardware MFA for all sampled accounts. This independently corroborates the security baseline requirement; no exceptions were found.",
+      "tags": ["security", "mfa", "audit"]
+    },
+    {
+      "id": "d-backup-schedule",
+      "title": "Backup schedule",
+      "section_title": "Backups",
+      "content": "Full database backups run nightly at 02:00 UTC. Incremental backups run every four hours. Restores are tested monthly.",
+      "tags": ["backup", "schedule"]
+    },
+    {
+      "id": "d-deploy-cd-proposal",
+      "title": "Continuous deployment proposal (hypothetical)",
+      "section_title": "Deploys",
+      "content": "Hypothetically, if the payments service migrated to continuous deployment, the deploy steps would collapse to a single merge: no release branch, no gamma soak, and no manual approval gate. This describes a possible future state, not the current process.",
+      "tags": ["deploy", "proposal", "hypothetical"]
+    }
+  ],
+  "queries": [
+    {
+      "id": "q-clean-1",
+      "class": "clean_fact",
+      "question": "How often do full database backups run?",
+      "gold_doc_ids": ["d-backup-schedule"]
+    },
+    {
+      "id": "q-multi-1",
+      "class": "multi_hop",
+      "question": "Who can approve an emergency schema change to the orders database out of hours?",
+      "gold_doc_ids": ["d-db-owner", "d-db-contact"]
+    },
+    {
+      "id": "q-time-1",
+      "class": "time_bound",
+      "question": "What is the current log retention period as of 2025?",
+      "gold_doc_ids": ["d-retention-new"]
+    },
+    {
+      "id": "q-correction-1",
+      "class": "correction",
+      "question": "What is the deployed session cache TTL?",
+      "gold_doc_ids": ["d-cache-ttl-correct"]
+    },
+    {
+      "id": "q-contradiction-1",
+      "class": "contradiction",
+      "question": "What is the authoritative primary region for the service?",
+      "gold_doc_ids": ["d-region-claim-b"]
+    },
+    {
+      "id": "q-retraction-1",
+      "class": "retraction",
+      "question": "Is the new-checkout feature flag enabled at 100 percent?",
+      "gold_doc_ids": ["d-feature-flag-retracted"]
+    },
+    {
+      "id": "q-reinforcement-1",
+      "class": "reinforcement",
+      "question": "Is hardware MFA required for production console access?",
+      "gold_doc_ids": ["d-security-mfa", "d-security-mfa-audit"]
+    },
+    {
+      "id": "q-hypothetical-1",
+      "class": "hypothetical_exclusion",
+      "question": "What are the steps to deploy the payments service?",
+      "gold_doc_ids": ["d-deploy-runbook"]
+    },
+    {
+      "id": "q-abstain-1",
+      "class": "abstention",
+      "question": "What is the company's parental leave policy for contractors in Brazil?",
+      "gold_doc_ids": []
+    },
+    {
+      "id": "q-citation-1",
+      "class": "citation_fidelity",
+      "question": "Which section documents the on-call escalation timing?",
+      "gold_doc_ids": ["d-oncall-rotation"]
+    },
+    {
+      "id": "q-clean-2",
+      "class": "clean_fact",
+      "question": "How long does the primary on-call hold the pager before a swap window?",
+      "gold_doc_ids": ["d-oncall-rotation"]
+    },
+    {
+      "id": "q-time-2",
+      "class": "time_bound",
+      "question": "Under the older 2023 policy, how many days were application logs retained?",
+      "gold_doc_ids": ["d-retention-old"]
+    }
+  ]
+}

--- a/src/kiro_crew/eval/bench/kb_retrieval.py
+++ b/src/kiro_crew/eval/bench/kb_retrieval.py
@@ -1,0 +1,605 @@
+"""Deterministic recall harness for the Knowledge Library's ``HybridRetriever``.
+
+This is T0 of the Knowledge Library roadmap: the measurement substrate every
+retrieval-quality change (freshness weighting, a reranker, tool-description
+rewrites) is judged against. It answers one question exactly -- *given a labeled
+set of ``(query -> answering doc)`` pairs, does the KB surface the right doc,
+ranked high?* -- and it answers it the same way on every run, so a delta between
+two commits is attributable to the code change rather than to sampling.
+
+It is deliberately **separate** from ``bench retrieval`` (``run.py``): that harness
+measures the conversational *memory* layer (``VectorMemoryStore`` over LoCoMo /
+LongMemEval, turn/session gold). This one measures the *Knowledge Library* --
+``HybridRetriever.search`` over a real :class:`KnowledgeStore`, with a chunk-shaped
+golden set whose gold labels are document ids.
+
+Why a synthetic golden set. No public retrieval benchmark cleanly models "a later
+document supersedes an earlier one", which is exactly what the KB's
+correction/contradiction/retraction classes are about. The v1 set is hand-authored,
+so lexical overlap can flatter retrieval (especially with the toy embedder) and its
+1–2 queries per class are directional rather than statistically stable; a v2 can
+graft the answerable classes onto LongMemEval later without changing this scorer.
+
+The default embedder is the deterministic :func:`toy_embed_fn` -- a hashed
+bag-of-words stand-in that makes the harness runnable and testable on a host whose
+vendored llama.cpp payload cannot load, and makes a test assertion about ranking
+stable across processes. It measures term overlap, **not** semantic recall, so a
+number produced with it is a plumbing check, not a reportable benchmark result;
+the real ``InProcessEmbedder`` is used only when explicitly requested and resident.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+from kiro_crew.eval.bench.errors import BenchRefusal
+from kiro_crew.eval.bench.retrieval import (
+    ndcg_at_k,
+    recall_all_at_k,
+    recall_any_at_k,
+    recall_micro_at_k,
+)
+from kiro_crew.eval.bench.safepath import UnsafePathError, read_text_nofollow
+from kiro_crew.eval.bench.toy_embedder import TOY_EMBEDDER_ID, toy_embed_fn
+from kiro_crew.knowledge.embedder import floats_to_bytes
+from kiro_crew.knowledge.retrieval import HybridRetriever
+from kiro_crew.knowledge.store import KnowledgeStore
+
+# Module-scope imports are safe here despite the boot-path perf concern: this
+# module is itself imported ONLY lazily (cli_bench._kb_retrieval imports it inside
+# the dispatch), and eval/bench/__init__ does not import it, so nothing pulls
+# knowledge.store / sqlite into an unrelated `kirocrew` subcommand's boot path.
+# The lazy import that matters -- the one in cli_bench that gates this whole
+# module out of the boot path -- stays where it is.
+
+#: Reported as the embedder identity for a keyword-only run, so a run with the
+#: vector leg disabled can never print a semantic embedder label over numbers the
+#: embedder did not produce.
+KEYWORD_ONLY_EMBEDDER_ID = "keyword-only (no embeddings)"
+
+#: The ten query classes the Knowledge Library is judged across. Ordered as in the
+#: merged goal (docs/system-specs/modules/knowledge.md, Success criteria).
+KB_QUERY_CLASSES: tuple[str, ...] = (
+    "clean_fact",
+    "multi_hop",
+    "time_bound",
+    "correction",
+    "contradiction",
+    "retraction",
+    "reinforcement",
+    "hypothetical_exclusion",
+    "abstention",
+    "citation_fidelity",
+)
+
+#: Cut-offs reported per query class. 1 and 3 are the ranks that actually change an
+#: answer (the agent reads the top few chunks); 5/10 show the tail.
+DEFAULT_KB_K_VALUES: tuple[int, ...] = (1, 3, 5, 10)
+
+
+# Hard cap on golden-file size. The bundled v1 set is ~40 KiB; a hand-authored
+# golden set has no business approaching this, and anything larger is either a
+# mistake or a hostile input feeding the JSON parser.
+_GOLDEN_MAX_BYTES = 16 * 1024 * 1024
+
+
+class KBGoldenSetError(BenchRefusal):
+    """The golden set is missing, malformed, or internally inconsistent.
+
+    A refusal, not a crash: a golden set that references a gold doc id that no
+    document defines cannot produce an interpretable recall number, so the harness
+    declines rather than silently scoring against a corpus it cannot trust.
+    """
+
+
+def mrr_at_k(ranked: Sequence[str], gold: Sequence[str], k: int) -> float:
+    """Mean Reciprocal Rank at ``k`` for a single query (binary relevance).
+
+    The reciprocal of the 1-based rank of the FIRST gold item inside the window,
+    or 0.0 if none appear. This is the metric that captures "is the right doc at
+    the top", which is what matters when the agent only reads the first result --
+    ``recall@k`` treats rank 1 and rank k as equal, MRR does not.
+
+    Lives here rather than in ``retrieval.py`` because that module's scorers are
+    frozen against a differential harness and this is a KB-local addition.
+    """
+    if not gold:
+        return 0.0
+    goldset = set(gold)
+    for i, item in enumerate(ranked[:k]):
+        if item in goldset:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+@dataclass(frozen=True)
+class KBDoc:
+    """One document in the golden corpus. ``id`` is the retrieval gold label."""
+
+    id: str
+    title: str
+    content: str
+    section_title: str = ""
+    tags: tuple[str, ...] = ()
+
+    @classmethod
+    def from_raw(cls, raw: dict) -> "KBDoc":
+        try:
+            return cls(
+                id=str(raw["id"]),
+                title=str(raw["title"]),
+                content=str(raw["content"]),
+                section_title=str(raw.get("section_title", "")),
+                tags=tuple(str(t) for t in raw.get("tags", ())),
+            )
+        except (KeyError, TypeError) as exc:
+            raise KBGoldenSetError(f"malformed doc entry: {raw!r} ({exc})") from exc
+
+
+@dataclass(frozen=True)
+class KBQuery:
+    """One labeled query. ``gold_doc_ids`` is empty for an abstention query."""
+
+    id: str
+    query_class: str
+    question: str
+    gold_doc_ids: tuple[str, ...]
+
+    @property
+    def is_abstention(self) -> bool:
+        return not self.gold_doc_ids
+
+    @classmethod
+    def from_raw(cls, raw: dict) -> "KBQuery":
+        try:
+            qcls = str(raw["class"])
+            if qcls not in KB_QUERY_CLASSES:
+                raise KBGoldenSetError(
+                    f"query {raw.get('id')!r} has unknown class {qcls!r}; "
+                    f"known: {', '.join(KB_QUERY_CLASSES)}"
+                )
+            return cls(
+                id=str(raw["id"]),
+                query_class=qcls,
+                question=str(raw["question"]),
+                gold_doc_ids=tuple(str(g) for g in raw.get("gold_doc_ids", ())),
+            )
+        except (KeyError, TypeError) as exc:
+            raise KBGoldenSetError(f"malformed query entry: {raw!r} ({exc})") from exc
+
+
+@dataclass(frozen=True)
+class KBGoldenSet:
+    """A frozen golden set: the corpus plus the labeled queries."""
+
+    name: str
+    docs: tuple[KBDoc, ...]
+    queries: tuple[KBQuery, ...]
+
+    def validate(self) -> None:
+        """Refuse a set that cannot yield an interpretable number.
+
+        Failure modes: a duplicate doc id (ambiguous gold label); a gold
+        reference no document defines (unhittable, so recall is capped below 1.0
+        for reasons unrelated to the retriever); and a class/gold mismatch (an
+        abstention query WITH gold docs, or an answerable query WITHOUT any) --
+        either makes the query land in the wrong aggregate bucket and report a
+        metric that means nothing.
+        """
+        ids = [d.id for d in self.docs]
+        dupes = {i for i in ids if ids.count(i) > 1}
+        if dupes:
+            raise KBGoldenSetError(f"duplicate doc ids: {sorted(dupes)}")
+        idset = set(ids)
+        if not self.queries:
+            raise KBGoldenSetError("golden set has no queries")
+        for q in self.queries:
+            dangling = [g for g in q.gold_doc_ids if g not in idset]
+            if dangling:
+                raise KBGoldenSetError(f"query {q.id!r} references undefined gold docs: {dangling}")
+            if q.query_class == "abstention" and q.gold_doc_ids:
+                raise KBGoldenSetError(
+                    f"query {q.id!r} is class 'abstention' but has gold docs {list(q.gold_doc_ids)}"
+                )
+            if q.query_class != "abstention" and not q.gold_doc_ids:
+                raise KBGoldenSetError(
+                    f"query {q.id!r} is class {q.query_class!r} but has no gold docs "
+                    "(only 'abstention' queries may have an empty gold set)"
+                )
+        if all(q.query_class == "abstention" for q in self.queries):
+            # headline() averages the answerable population; with zero answerable
+            # queries _mean([]) would report 0.0 for every answerable metric --
+            # a fabricated score for a population that was never measured (the
+            # same invariant _require_k enforces for uncomputed cut-offs).
+            raise KBGoldenSetError(
+                "golden set has no answerable queries (only abstention); "
+                "answerable metrics would be fabricated 0.0s -- add at least "
+                "one answerable query"
+            )
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "KBGoldenSet":
+        p = Path(path)
+        path_display = repr(str(p))
+        # The shared reader opens once, validates that SAME descriptor is a regular
+        # non-hardlinked file, and reads at most cap + 1. Keeping file identity and
+        # the byte limit in one helper prevents a stat/open swap from turning this
+        # parser into an unbounded read of a device or a growing file.
+        try:
+            text = read_text_nofollow(p, what="golden set", max_bytes=_GOLDEN_MAX_BYTES)
+        except UnsafePathError as exc:
+            raise KBGoldenSetError(str(exc)) from exc
+        except OSError as exc:
+            raise KBGoldenSetError(
+                f"golden set could not be read: {path_display} ({exc!r})"
+            ) from exc
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise KBGoldenSetError(f"golden set is not valid JSON: {path_display} ({exc})") from exc
+        except RecursionError as exc:
+            # json.loads recurses per nesting level; ~10k nested arrays blow the
+            # interpreter's recursion limit BEFORE a JSONDecodeError can be
+            # raised. Convert at the source so every caller refuses cleanly
+            # instead of each handler chasing parse-time exception classes.
+            raise KBGoldenSetError(
+                f"golden set is too deeply nested to parse: {path_display}"
+            ) from exc
+        if not isinstance(raw, dict):
+            # A valid-JSON scalar/array (`[]`, `null`, `42`) would crash the .get()
+            # calls below with an AttributeError; refuse it as the documented error.
+            raise KBGoldenSetError(
+                f"golden set must be a JSON object, got {type(raw).__name__}: {path_display}"
+            )
+        name = raw.get("name", p.stem)
+        if not isinstance(name, str):
+            raise KBGoldenSetError(
+                f"golden set 'name' must be a string, got {type(name).__name__}: {path_display}"
+            )
+        try:
+            name.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise KBGoldenSetError(
+                f"golden set 'name' must be valid UTF-8 text: {path_display}"
+            ) from exc
+        if not name or not name.isprintable():
+            raise KBGoldenSetError(
+                f"golden set 'name' must contain only printable text: {path_display}"
+            )
+
+        docs_raw = raw.get("docs", [])
+        queries_raw = raw.get("queries", [])
+        # A present-but-null (or scalar) docs/queries value would make the tuple
+        # comprehension below raise TypeError on iteration; refuse it cleanly.
+        if not isinstance(docs_raw, list):
+            raise KBGoldenSetError(
+                f"golden set 'docs' must be a list, got {type(docs_raw).__name__}: "
+                f"{path_display}"
+            )
+        if not isinstance(queries_raw, list):
+            raise KBGoldenSetError(
+                f"golden set 'queries' must be a list, got {type(queries_raw).__name__}: "
+                f"{path_display}"
+            )
+        gs = cls(
+            name=name,
+            docs=tuple(KBDoc.from_raw(d) for d in docs_raw),
+            queries=tuple(KBQuery.from_raw(q) for q in queries_raw),
+        )
+        gs.validate()
+        return gs
+
+
+@dataclass(frozen=True)
+class KBQueryResult:
+    """Per-query scoring outcome, retained so the report can break down by class."""
+
+    query_id: str
+    query_class: str
+    is_abstention: bool
+    recall_any: dict[int, float]
+    recall_all: dict[int, float]
+    recall_micro: dict[int, float]
+    ndcg: dict[int, float]
+    mrr: dict[int, float]
+    #: For abstention queries only: 1.0 if the retriever returned nothing (or
+    #: nothing above the floor), else 0.0. ``None`` for answerable queries.
+    abstained: float | None = None
+
+
+@dataclass
+class KBRetrievalReport:
+    """The full run: per-query results plus per-class and overall aggregates."""
+
+    golden_set: str
+    embedder_id: str
+    k_values: tuple[int, ...]
+    results: list[KBQueryResult] = field(default_factory=list)
+
+    def _answerable(self) -> list[KBQueryResult]:
+        return [r for r in self.results if not r.is_abstention]
+
+    def by_class(self, k: int) -> dict[str, dict[str, float]]:
+        """Mean recall_any / recall_all / recall_micro / ndcg / mrr at ``k``, per query class.
+
+        Abstention is reported separately as an abstention rate, not folded into
+        recall (a recall number over zero gold docs is meaningless).
+        """
+        self._require_k(k)
+        out: dict[str, dict[str, float]] = {}
+        for qcls in KB_QUERY_CLASSES:
+            members = [r for r in self.results if r.query_class == qcls]
+            if not members:
+                continue
+            if qcls == "abstention":
+                vals = [r.abstained for r in members if r.abstained is not None]
+                out[qcls] = {"abstention_rate": _mean(vals)}
+                continue
+            out[qcls] = {
+                "recall_any": _mean([r.recall_any[k] for r in members]),
+                "recall_all": _mean([r.recall_all[k] for r in members]),
+                "recall_micro": _mean([r.recall_micro[k] for r in members]),
+                "ndcg": _mean([r.ndcg[k] for r in members]),
+                "mrr": _mean([r.mrr[k] for r in members]),
+            }
+        return out
+
+    def _require_k(self, k: int) -> None:
+        """A cut-off not in the computed set has no honest number.
+
+        Indexing ``[k]`` below would otherwise KeyError; a ``.get(k, 0.0)`` default
+        would be worse -- it silently reports 0.0, which reads as a real low score
+        rather than 'not measured'. Fail loud instead (the sibling harness's rule:
+        an unmeasurable metric must be absent, never 0.0).
+        """
+        if k not in self.k_values:
+            raise KBGoldenSetError(
+                f"cut-off k={k} was not computed (available: {list(self.k_values)}); "
+                "pass it in k_values so the metric is real, not a fabricated 0.0"
+            )
+
+    def headline(self, k: int = 3) -> dict[str, float]:
+        """Overall numbers across answerable queries, plus the abstention rate."""
+        self._require_k(k)
+        ans = self._answerable()
+        abst = [r.abstained for r in self.results if r.abstained is not None]
+        return {
+            "recall_any@%d" % k: _mean([r.recall_any[k] for r in ans]),
+            "recall_all@%d" % k: _mean([r.recall_all[k] for r in ans]),
+            "recall_micro@%d" % k: _mean([r.recall_micro[k] for r in ans]),
+            "ndcg@%d" % k: _mean([r.ndcg[k] for r in ans]),
+            "mrr@%d" % k: _mean([r.mrr[k] for r in ans]),
+            "abstention_rate": _mean(abst),
+            "n_answerable": float(len(ans)),
+            "n_abstention": float(len(abst)),
+        }
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def default_golden_set_path() -> Path:
+    """Path to the shipped v1 golden set (packaged next to this module)."""
+    return Path(__file__).resolve().parent / "data" / "kb_golden_v1.json"
+
+
+def _fail_closed_embed(
+    embed_fn: Callable[[str], list[float] | None],
+) -> Callable[[str], list[float]]:
+    """Wrap an embedder so an empty/None vector is a refusal, not a silent skip.
+
+    This is the ONE place the "no keyword-only numbers under an embedder label"
+    invariant is enforced, and it covers BOTH sides symmetrically: document
+    ingest (``_build_store``) and every per-query ``HybridRetriever.search`` call,
+    which re-embeds the query through this same callable. Without it, an embedder
+    that goes unready AFTER doc ingest would make the vector leg return nothing and
+    the run would report degraded keyword rankings under the semantic embedder id.
+    """
+
+    def _fn(text: str) -> list[float]:
+        vec = embed_fn(text)
+        if not vec:
+            raise KBGoldenSetError(
+                "embeddings enabled but the embedder returned an empty vector; "
+                "refusing to report keyword-only metrics under an embedder label. "
+                "Use --no-embeddings for a keyword-only run."
+            )
+        return vec
+
+    return _fn
+
+
+def _build_store(
+    store: "KnowledgeStore",
+    docs: Sequence[KBDoc],
+    embed_fn: Callable[[str], list[float]] | None,
+):
+    """Populate an already-created KnowledgeStore with the golden docs.
+
+    The caller creates and OWNS the store (and closes it in a ``finally``), so a
+    mid-ingestion raise -- e.g. the fail-closed embedder rejecting an empty vector
+    -- still leaves the connection to be closed before the temp dir is removed. On
+    Windows an un-closed SQLite handle makes ``TemporaryDirectory.cleanup()`` raise
+    ``PermissionError`` (WinError 32), which is the exact failure this ownership
+    split fixes on the refusal path. Each doc becomes one source + one item; the
+    item's embedding is the ``embed_fn`` of "title + content", packed to bytes
+    exactly as production ingestion stores it. ``embed_fn`` is None for a
+    keyword-only run; when set it is already fail-closed, so an empty vector raises
+    rather than storing NULL.
+    """
+    for doc in docs:
+        source_id = store.add_source(
+            name=doc.title,
+            source_type="doc",
+            uri=f"kbgolden://{doc.id}",
+            properties={"section_title": doc.section_title},
+        )
+        embedding = None
+        if embed_fn is not None:
+            embedding = floats_to_bytes(embed_fn(f"{doc.title}\n{doc.content}"))
+        item_id = store.add_item(
+            title=doc.title,
+            content=doc.content,
+            item_type="chunk",
+            source_id=source_id,
+            summary=None,
+            tags=list(doc.tags),
+            embedding=embedding,
+        )
+        # A source-location row so section_title / chunk_range are present in
+        # results, mirroring a real ingested chunk (and exercising the citation
+        # enrichment path the citation_fidelity class depends on). A failure here
+        # propagates: the harness's own store must accept the row, and a silent
+        # skip would let citation-fidelity "succeed" with the enrichment broken.
+        store.add_source_location(
+            item_id=item_id,
+            source_id=source_id,
+            chunk_range="1-1",
+            section_title=doc.section_title or None,
+        )
+
+
+#: Map an item's ``uri`` back to the golden doc id. The store returns its own item
+#: ids in results, so we resolve through the source uri we controlled at ingest.
+def _result_doc_id(result: dict, uri_to_docid: dict[str, str]) -> str | None:
+    uri = result.get("source_uri")
+    if uri and uri in uri_to_docid:
+        return uri_to_docid[uri]
+    return None
+
+
+def run_kb_retrieval(
+    golden: KBGoldenSet,
+    *,
+    embed_fn: Callable[[str], list[float] | None] | None = None,
+    embedder_id: str = "toy-hashed-bow",
+    k_values: Sequence[int] = DEFAULT_KB_K_VALUES,
+    use_embeddings: bool = True,
+) -> KBRetrievalReport:
+    """Score a golden set against a real ``HybridRetriever`` and return the report.
+
+    ``embed_fn`` defaults to the deterministic toy embedder. Pass the real
+    embedder's bound ``.embed`` (and its id) for a semantic run. ``use_embeddings``
+    False runs keyword-only (the vector leg is skipped), which isolates the FTS
+    leg's contribution.
+
+    Idempotent and side-effect-free: it builds the store in a private temp
+    directory (cleaned up on exit) and never touches the live KB.
+    """
+    golden.validate()
+
+    # Resolve the embedder identity from what the vector leg will ACTUALLY do, in
+    # one place, so a keyword-only run can never carry a semantic label and a
+    # default run is always the toy id. This is the invariant the reviewers kept
+    # finding leaks in; deriving it here makes it hold by construction.
+    if not use_embeddings:
+        resolved_id = KEYWORD_ONLY_EMBEDDER_ID
+        wrapped: Callable[[str], list[float]] | None = None
+    else:
+        if embed_fn is None:
+            embed_fn = toy_embed_fn()
+            embedder_id = TOY_EMBEDDER_ID
+        resolved_id = embedder_id
+        # Fail closed on BOTH sides: doc ingest below AND every query search (the
+        # retriever re-embeds the query through this same callable).
+        wrapped = _fail_closed_embed(embed_fn)
+
+    uri_to_docid = {f"kbgolden://{d.id}": d.id for d in golden.docs}
+    k_values = tuple(sorted(set(int(k) for k in k_values)))
+    # Clamp the retrieval depth to the corpus size: the store holds exactly
+    # len(docs) documents, so a deeper LIMIT cannot change any ranking, and an
+    # attacker-sized -k (e.g. 2**62) would otherwise flow into the SQL LIMIT
+    # arithmetic and crash with an uncaught OverflowError. The requested
+    # k_values are kept as-is for scoring -- recall@k for k > corpus size is
+    # well-defined over the (at most corpus-sized) ranked list.
+    limit = min(max(k_values), len(golden.docs))
+
+    tmpdir = tempfile.TemporaryDirectory(prefix="kb_eval_")
+    db_path = str(Path(tmpdir.name) / "kb.sqlite")
+
+    # Create the store here so the finally below always closes it -- even if
+    # _build_store raises mid-ingestion (e.g. the fail-closed embedder rejects an
+    # empty vector). A store created inside _build_store and abandoned on raise
+    # would leak its SQLite handle and break tmpdir.cleanup() on Windows.
+    store = KnowledgeStore(db_path)
+    try:
+        _build_store(store, golden.docs, wrapped)
+        retriever = HybridRetriever(store, embedder=wrapped)
+
+        report = KBRetrievalReport(
+            golden_set=golden.name,
+            embedder_id=resolved_id,
+            k_values=k_values,
+        )
+        for q in golden.queries:
+            hits = retriever.search(q.question, limit=limit)
+            ranked = [
+                did for did in (_result_doc_id(h, uri_to_docid) for h in hits) if did is not None
+            ]
+            gold = list(q.gold_doc_ids)
+            abstained: float | None = None
+            if q.is_abstention:
+                # No score floor exists in the retriever, so "abstained" means the
+                # retriever surfaced nothing at all for a query with no gold doc.
+                abstained = 1.0 if not hits else 0.0
+            report.results.append(
+                KBQueryResult(
+                    query_id=q.id,
+                    query_class=q.query_class,
+                    is_abstention=q.is_abstention,
+                    recall_any={k: recall_any_at_k(ranked, gold, k) for k in k_values},
+                    recall_all={k: recall_all_at_k(ranked, gold, k) for k in k_values},
+                    recall_micro={k: recall_micro_at_k(ranked, gold, k) for k in k_values},
+                    ndcg={k: ndcg_at_k(ranked, gold, k) for k in k_values},
+                    mrr={k: mrr_at_k(ranked, gold, k) for k in k_values},
+                    abstained=abstained,
+                )
+            )
+        return report
+    finally:
+        # Close the store's SQLite connection BEFORE removing the temp dir: on
+        # Windows an open handle blocks directory deletion and TemporaryDirectory
+        # .cleanup() would raise PermissionError, crashing an otherwise-good run.
+        if store is not None:
+            try:
+                store.close()
+            except Exception:
+                pass
+        tmpdir.cleanup()
+
+
+def format_kb_report(report: KBRetrievalReport, *, k: int = 3) -> str:
+    """Render a human-readable summary at cut-off ``k``."""
+    lines: list[str] = []
+    lines.append(f"KB retrieval eval: {report.golden_set}")
+    lines.append(f"embedder: {report.embedder_id}")
+    head = report.headline(k)
+    lines.append("")
+    lines.append(f"HEADLINE @{k} (answerable queries):")
+    for key in (f"recall_any@{k}", f"recall_all@{k}", f"recall_micro@{k}", f"ndcg@{k}", f"mrr@{k}"):
+        lines.append(f"  {key:<16} {head[key]:.3f}")
+    lines.append(
+        f"  abstention_rate  {head['abstention_rate']:.3f} " f"(n={int(head['n_abstention'])})"
+    )
+    lines.append("")
+    lines.append(f"BY CLASS @{k}:")
+    by_class = report.by_class(k)
+    for qcls in KB_QUERY_CLASSES:
+        if qcls not in by_class:
+            continue
+        m = by_class[qcls]
+        if qcls == "abstention":
+            lines.append(f"  {qcls:<24} abstention_rate={m['abstention_rate']:.3f}")
+        else:
+            lines.append(
+                f"  {qcls:<24} recall_any={m['recall_any']:.3f} "
+                f"recall_all={m['recall_all']:.3f} "
+                f"recall_micro={m['recall_micro']:.3f} "
+                f"ndcg={m['ndcg']:.3f} mrr={m['mrr']:.3f}"
+            )
+    return "\n".join(lines)

--- a/src/kiro_crew/eval/bench/safepath.py
+++ b/src/kiro_crew/eval/bench/safepath.py
@@ -563,40 +563,125 @@ def _sync_dir(dir_fd: int) -> None:
         pass
 
 
-def read_text_nofollow(path: str | Path, *, what: str) -> str:
-    """Read *path* as UTF-8, guarded, refusing to follow a final symlink.
+def read_text_nofollow(path: str | Path, *, what: str, max_bytes: int | None = None) -> str:
+    """Read one regular file as UTF-8 through a single validated descriptor.
 
-    Does what ``hooks.safe_read_file`` does -- canonicalize, re-check the RESOLVED
-    target against ``is_sensitive_path``, open the canonical path with ``O_NOFOLLOW``
-    -- and adds a hardlink rejection on the open descriptor.
+    The path is guarded, resolved and opened once. All properties that must match
+    the bytes returned -- hardlink count, file type and size -- are then checked on
+    that SAME descriptor with ``fstat``. This closes the check/open race that exists
+    when a caller ``stat``s a path and later asks this helper to open it.
 
-    Inlined rather than delegated for exactly that last part: a hardlink alias is only
-    recognisable from the fd (``st_nlink``), and a helper that returns text has
-    already read the bytes by the time it could be judged. ``hooks.safe_read_file``
-    is used repo-wide, so the check lives here instead of widening its contract.
+    Non-regular files are always refused. ``O_NONBLOCK`` keeps opening a FIFO from
+    hanging before the descriptor can be classified; it is inert for regular files.
+    When ``max_bytes`` is set, the helper checks the descriptor's current size AND
+    reads at most ``max_bytes + 1``. The second check is load-bearing: a regular file
+    can grow after ``fstat``, and trusting only ``st_size`` would recreate an
+    unbounded-read window.
+
+    Opening the resolved path (not the path as given) preserves the documented read
+    asymmetry: a symlink to an ordinary file remains readable. ``O_NOFOLLOW`` still
+    protects the resolved name's final component from a last-moment replacement.
     """
     import os
+    import stat
 
     from kiro_crew.security import is_sensitive_path
 
+    if max_bytes is not None and max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+
     guard_read_path(path, what=what)
-    # Mirrors `safe_read_file` -- resolve, re-check the RESOLVED target, open the
-    # canonical path with O_NOFOLLOW -- and adds the hardlink rejection, which has to
-    # happen on the descriptor and therefore cannot be delegated to a helper that
-    # returns text. Opening the resolved path (not the path as given) is deliberate:
-    # a link to an ordinary file stays readable, which is the documented read/write
-    # asymmetry.
     try:
         resolved = os.path.realpath(os.path.expanduser(str(path)))
         if is_sensitive_path(resolved):
             raise UnsafePathError(
-                f"refusing to read the {what}: {resolved} is a protected location."
+                f"refusing to read the {what}: {resolved!r} is a protected location."
             )
-        fd = os.open(resolved, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        target = Path(resolved)
+        if _supports_pinned_walk():
+            # Re-resolve/re-check the parent immediately before pinning it. A
+            # replacement after the check is then reached component-by-component
+            # with O_NOFOLLOW, and the basename is opened relative to that held fd.
+            resolved_parent = os.path.realpath(target.parent or Path("."))
+            pinned_target = Path(resolved_parent) / target.name
+            guard_read_path(pinned_target, what=what)
+            fd = _open_in_pinned_parent(
+                resolved_parent,
+                target.name,
+                flags=flags,
+                mode=0,
+                what=what,
+            )
+            resolved = str(pinned_target)
+        else:
+            # Windows has no dir_fd walk. Open once, then ask the HANDLE what it
+            # actually reached (GetFinalPathNameByHandleW there). This is an
+            # equivalent descriptor-bound attestation; inability to attest fails
+            # closed rather than trusting a raceable path name.
+            current = os.path.realpath(resolved)
+            guard_read_path(current, what=what)
+            fd = os.open(current, flags)
+            opened_path = pinned_fs.fd_real_path(fd)
+            if opened_path is None:
+                os.close(fd)
+                raise UnsafePathError(
+                    f"refusing to read the {what}: this platform cannot verify "
+                    "the path reached by the opened file descriptor."
+                )
+            opened_real = os.path.realpath(opened_path)
+            if os.path.normcase(opened_real) != os.path.normcase(current):
+                os.close(fd)
+                raise UnsafePathError(
+                    f"refusing to read the {what}: the opened file resolved to a "
+                    "different path than the one that passed validation."
+                )
+            if is_sensitive_path(opened_real):
+                os.close(fd)
+                raise UnsafePathError(
+                    f"refusing to read the {what}: the opened file is in a protected location."
+                )
+            resolved = opened_real
     except UnsafePathError:
         raise
     except OSError as exc:
-        raise UnsafePathError(f"refusing to read the {what}: {exc}") from exc
-    _refuse_hardlink_alias(fd, what=what, name=os.path.basename(resolved))
-    with os.fdopen(fd, "r", encoding="utf-8") as fh:
-        return fh.read()
+        raise UnsafePathError(f"refusing to read the {what}: {exc!r}") from exc
+
+    try:
+        _refuse_hardlink_alias(fd, what=what, name=os.path.basename(resolved))
+    except UnsafePathError:
+        raise  # the helper closed the descriptor before raising
+    except BaseException:
+        os.close(fd)
+        raise
+
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise UnsafePathError(
+                f"refusing to read the {what}: {resolved!r} is not a regular file."
+            )
+        if max_bytes is not None and opened.st_size > max_bytes:
+            raise UnsafePathError(
+                f"refusing to read the {what}: file is too large "
+                f"({opened.st_size} bytes exceeds the {max_bytes}-byte limit)."
+            )
+
+        # Transfer descriptor ownership to the file object before reading; it closes
+        # the fd on success and on decode/read failure. Keep ``fd`` negative so the
+        # outer exception path does not double-close it.
+        fh = os.fdopen(fd, "rb")
+        fd = -1
+        with fh:
+            data = fh.read() if max_bytes is None else fh.read(max_bytes + 1)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        raise
+
+    if max_bytes is not None and len(data) > max_bytes:
+        raise UnsafePathError(
+            f"refusing to read the {what}: content is too large; it exceeds "
+            f"the {max_bytes}-byte limit."
+        )
+    return data.decode("utf-8")

--- a/test/test_bench_kb_retrieval.py
+++ b/test/test_bench_kb_retrieval.py
@@ -1,0 +1,649 @@
+"""Tests for the Knowledge Library retrieval eval harness (``bench kb-retrieval``).
+
+Covers the pure metric (``mrr_at_k``), the golden-set model's refusals, the
+end-to-end deterministic run against a real ``KnowledgeStore`` + ``HybridRetriever``
+via the toy embedder, per-class and abstention scoring, cross-process determinism,
+and the CLI dispatch (toy path + the --real-embedder refusal when the model is
+absent).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.cli_bench import bench_cmd
+from kiro_crew.eval.bench.kb_retrieval import (
+    KB_QUERY_CLASSES,
+    KBGoldenSet,
+    KBGoldenSetError,
+    default_golden_set_path,
+    format_kb_report,
+    mrr_at_k,
+    run_kb_retrieval,
+)
+
+
+class _Args:
+    """Stand-in for the argparse namespace the dispatch receives."""
+
+    def __init__(self, **kw: object) -> None:
+        self.__dict__.update(kw)
+
+
+# -- mrr_at_k -----------------------------------------------------------------
+
+
+class TestMrrAtK:
+    def test_first_rank_is_one(self) -> None:
+        assert mrr_at_k(["a", "b", "c"], ["a"], 3) == 1.0
+
+    def test_second_rank_is_half(self) -> None:
+        assert mrr_at_k(["x", "a", "c"], ["a"], 3) == 0.5
+
+    def test_third_rank_is_third(self) -> None:
+        assert mrr_at_k(["x", "y", "a"], ["a"], 3) == pytest.approx(1 / 3)
+
+    def test_outside_window_is_zero(self) -> None:
+        assert mrr_at_k(["x", "y", "z", "a"], ["a"], 3) == 0.0
+
+    def test_no_gold_is_zero(self) -> None:
+        assert mrr_at_k(["a", "b"], [], 3) == 0.0
+
+    def test_first_of_multiple_gold_counts(self) -> None:
+        # Reciprocal of the FIRST gold hit, regardless of how many gold exist.
+        assert mrr_at_k(["x", "g2", "g1"], ["g1", "g2"], 5) == 0.5
+
+
+# -- golden set model ---------------------------------------------------------
+
+
+def _write_golden(tmp_path: Path, docs: list[dict], queries: list[dict]) -> Path:
+    p = tmp_path / "g.json"
+    p.write_text(json.dumps({"name": "t", "docs": docs, "queries": queries}))
+    return p
+
+
+class TestGoldenSet:
+    def test_shipped_v1_loads_and_validates(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        assert gs.docs and gs.queries
+        for q in gs.queries:
+            assert q.query_class in KB_QUERY_CLASSES
+
+    def test_shipped_v1_preserves_supersession_chronology(self) -> None:
+        # KnowledgeStore.add_item timestamps in insertion order. Older/draft evidence
+        # must therefore precede its superseding/authoritative documents, or future
+        # freshness-aware ranking would reward stale evidence.
+        ids = [d.id for d in KBGoldenSet.from_json(default_golden_set_path()).docs]
+        assert ids.index("d-feature-flag-announcement") < ids.index("d-feature-flag-retracted")
+        assert (
+            ids.index("d-security-mfa-proposal")
+            < ids.index("d-security-mfa")
+            < ids.index("d-security-mfa-audit")
+        )
+
+    def test_missing_file_refuses(self, tmp_path: Path) -> None:
+        # Match the application-owned prefix, not platform-specific errno text
+        # (POSIX says "No such file"; Windows says "cannot find the file").
+        with pytest.raises(KBGoldenSetError, match="refusing to read the golden set"):
+            KBGoldenSet.from_json(tmp_path / "nope.json")
+
+    def test_bad_json_refuses(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("{not json")
+        with pytest.raises(KBGoldenSetError, match="not valid JSON"):
+            KBGoldenSet.from_json(p)
+
+    def test_control_bearing_filename_is_escaped_in_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import kiro_crew.eval.bench.kb_retrieval as kbr
+
+        malicious = tmp_path / "bad\x1b]0;title\x07.json"
+        monkeypatch.setattr(kbr, "read_text_nofollow", lambda *_a, **_kw: "{")
+        with pytest.raises(KBGoldenSetError) as excinfo:
+            KBGoldenSet.from_json(malicious)
+        message = str(excinfo.value)
+        assert "\x1b" not in message
+        assert "\\x1b" in message
+        assert "\\x07" in message
+
+    def test_dangling_gold_ref_refuses(self, tmp_path: Path) -> None:
+        p = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[
+                {"id": "q1", "class": "clean_fact", "question": "?", "gold_doc_ids": ["MISSING"]}
+            ],
+        )
+        with pytest.raises(KBGoldenSetError, match="undefined gold docs"):
+            KBGoldenSet.from_json(p)
+
+    def test_duplicate_doc_id_refuses(self, tmp_path: Path) -> None:
+        p = _write_golden(
+            tmp_path,
+            docs=[
+                {"id": "d1", "title": "t", "content": "c"},
+                {"id": "d1", "title": "t2", "content": "c2"},
+            ],
+            queries=[{"id": "q1", "class": "clean_fact", "question": "?", "gold_doc_ids": ["d1"]}],
+        )
+        with pytest.raises(KBGoldenSetError, match="duplicate doc ids"):
+            KBGoldenSet.from_json(p)
+
+    def test_unknown_class_refuses(self, tmp_path: Path) -> None:
+        p = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[{"id": "q1", "class": "not_a_class", "question": "?", "gold_doc_ids": ["d1"]}],
+        )
+        with pytest.raises(KBGoldenSetError, match="unknown class"):
+            KBGoldenSet.from_json(p)
+
+    def test_no_queries_refuses(self, tmp_path: Path) -> None:
+        p = _write_golden(tmp_path, docs=[{"id": "d1", "title": "t", "content": "c"}], queries=[])
+        with pytest.raises(KBGoldenSetError, match="no queries"):
+            KBGoldenSet.from_json(p)
+
+    def test_abstention_query_is_flagged(self, tmp_path: Path) -> None:
+        p = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[
+                {"id": "q1", "class": "abstention", "question": "?", "gold_doc_ids": []},
+                # validate() refuses an all-abstention set (answerable metrics
+                # would be fabricated 0.0s), so keep one answerable query.
+                {"id": "q2", "class": "clean_fact", "question": "??", "gold_doc_ids": ["d1"]},
+            ],
+        )
+        gs = KBGoldenSet.from_json(p)
+        assert gs.queries[0].is_abstention is True
+        assert gs.queries[1].is_abstention is False
+
+    def test_non_dict_json_refuses(self, tmp_path: Path) -> None:
+        # Valid JSON that is not an object (list/scalar/null) must refuse cleanly,
+        # not crash with AttributeError on .get().
+        for payload in ("[]", "null", "42", '"a string"'):
+            p = tmp_path / "scalar.json"
+            p.write_text(payload)
+            with pytest.raises(KBGoldenSetError, match="must be a JSON object"):
+                KBGoldenSet.from_json(p)
+
+    def test_lone_surrogate_name_refuses_before_report_output(self, tmp_path: Path) -> None:
+        payload = {
+            "name": "\ud800",
+            "docs": [{"id": "d1", "title": "t", "content": "c"}],
+            "queries": [
+                {
+                    "id": "q1",
+                    "class": "clean_fact",
+                    "question": "?",
+                    "gold_doc_ids": ["d1"],
+                }
+            ],
+        }
+        p = tmp_path / "surrogate-name.json"
+        # ensure_ascii=True emits valid ASCII JSON whose decoded string contains
+        # the lone surrogate, reproducing the later print() UnicodeEncodeError.
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(KBGoldenSetError, match="name.*valid UTF-8"):
+            KBGoldenSet.from_json(p)
+
+    def test_terminal_escape_name_refuses_before_report_output(self, tmp_path: Path) -> None:
+        payload = {
+            "name": "\x1b]0;changed-title\x07",
+            "docs": [{"id": "d1", "title": "t", "content": "c"}],
+            "queries": [
+                {
+                    "id": "q1",
+                    "class": "clean_fact",
+                    "question": "?",
+                    "gold_doc_ids": ["d1"],
+                }
+            ],
+        }
+        p = tmp_path / "control-name.json"
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(KBGoldenSetError, match="name.*printable text"):
+            KBGoldenSet.from_json(p)
+
+    def test_null_docs_refuses(self, tmp_path: Path) -> None:
+        # A present-but-null collection would crash the tuple comprehension with
+        # TypeError; it must refuse as the documented error instead.
+        p = tmp_path / "nulldocs.json"
+        p.write_text('{"docs": null, "queries": []}')
+        with pytest.raises(KBGoldenSetError, match="'docs' must be a list"):
+            KBGoldenSet.from_json(p)
+
+    def test_class_gold_mismatch_refuses(self, tmp_path: Path) -> None:
+        # An answerable class with no gold, or abstention WITH gold, would land in
+        # the wrong aggregate bucket and report a meaningless metric.
+        no_gold = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[{"id": "q1", "class": "clean_fact", "question": "?", "gold_doc_ids": []}],
+        )
+        with pytest.raises(KBGoldenSetError, match="has no gold docs"):
+            KBGoldenSet.from_json(no_gold)
+        abst_with_gold = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[{"id": "q1", "class": "abstention", "question": "?", "gold_doc_ids": ["d1"]}],
+        )
+        with pytest.raises(KBGoldenSetError, match="abstention.*but has gold docs"):
+            KBGoldenSet.from_json(abst_with_gold)
+
+    def test_sensitive_path_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The golden path is argv-supplied and agent-reachable, so it must go
+        # through the sensitive-path gate. Inject the verdict on the classifier the
+        # guard consults, rather than relocating HOME/USERPROFILE -- moving the real
+        # protection boundary is a test side effect and does not exercise the gate
+        # against the operator's actual home.
+        import kiro_crew.security as security
+
+        secret = tmp_path / "looks_ok.json"
+        secret.write_text('{"docs": [], "queries": []}')
+        real_is_sensitive = security.is_sensitive_path
+        monkeypatch.setattr(
+            security,
+            "is_sensitive_path",
+            lambda s: str(secret) in s or real_is_sensitive(s),
+        )
+        with pytest.raises(KBGoldenSetError, match="protected location"):
+            KBGoldenSet.from_json(secret)
+
+
+# -- end-to-end run against the real store + retriever (toy embedder) ---------
+
+
+class TestRunKbRetrieval:
+    def test_shipped_set_runs_and_scores(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs)
+        assert len(report.results) == len(gs.queries)
+        head = report.headline(3)
+        for key in ("recall_any@3", "mrr@3", "ndcg@3"):
+            assert 0.0 <= head[key] <= 1.0
+
+    def test_toy_embedder_finds_clean_fact(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs)
+        clean = [r for r in report.results if r.query_class == "clean_fact"]
+        assert clean
+        assert any(r.recall_any.get(5, 0.0) == 1.0 for r in clean)
+
+    def test_abstention_scored_separately(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs)
+        abst = [r for r in report.results if r.is_abstention]
+        assert abst
+        for r in abst:
+            assert r.abstained in (0.0, 1.0)
+        by_class = report.by_class(3)
+        if "abstention" in by_class:
+            assert "abstention_rate" in by_class["abstention"]
+            assert "recall_any" not in by_class["abstention"]
+
+    def test_deterministic_across_runs(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        h1 = run_kb_retrieval(gs).headline(3)
+        h2 = run_kb_retrieval(gs).headline(3)
+        assert h1 == h2
+
+    def test_keyword_only_mode_runs(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs, use_embeddings=False)
+        assert len(report.results) == len(gs.queries)
+
+    def test_format_report_mentions_classes(self) -> None:
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        text = format_kb_report(run_kb_retrieval(gs), k=3)
+        assert "KB retrieval eval" in text
+        assert "HEADLINE" in text
+        assert "clean_fact" in text
+
+    def test_non_default_k_is_computed_not_zero(self) -> None:
+        # A cut-off outside DEFAULT_KB_K_VALUES must be explicitly computed, or the
+        # headline defaults it to 0.0 -- a false-zero benchmark result. Passing
+        # k_values including the requested k is what the CLI does; verify the dict
+        # actually carries the key so headline(k) is real.
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs, k_values=(1, 2, 3, 5, 10))
+        assert 2 in report.k_values
+        for r in report.results:
+            assert 2 in r.recall_any  # key present -> headline(2) is measured, not 0.0
+        # headline(2) is real; it must NOT silently return 0.0.
+        assert report.headline(2)  # does not raise
+
+    def test_uncomputed_k_fails_loud(self) -> None:
+        # The old .get(k, 0.0) default silently fabricated a 0.0 for an uncomputed
+        # cut-off; now it must raise rather than report a fake low score.
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs)  # default k_values = (1, 3, 5, 10)
+        with pytest.raises(KBGoldenSetError, match="was not computed"):
+            report.headline(2)
+        with pytest.raises(KBGoldenSetError, match="was not computed"):
+            report.by_class(2)
+
+    def test_empty_embedding_refuses_when_enabled(self) -> None:
+        # With embeddings enabled, an embedder that returns empty must fail closed
+        # -- otherwise a --real-embedder run silently reports keyword-only metrics
+        # under a semantic embedder label. The guard now covers both doc ingest and
+        # query search (one fail-closed wrapper). The refusal path must ALSO close
+        # the store and remove its temp dir (an open SQLite handle breaks
+        # TemporaryDirectory.cleanup() on Windows -- WinError 32).
+        import glob
+        import tempfile
+
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        before = set(glob.glob(str(Path(tempfile.gettempdir()) / "kb_eval_*")))
+        with pytest.raises(KBGoldenSetError, match="empty vector"):
+            run_kb_retrieval(gs, embed_fn=lambda _t: [], embedder_id="fake")
+        after = set(glob.glob(str(Path(tempfile.gettempdir()) / "kb_eval_*")))
+        assert after <= before  # refusal path left no temp dir behind
+        # And keyword-only mode (embeddings disabled) runs fine with no embedder.
+        report = run_kb_retrieval(gs, embed_fn=lambda _t: [], use_embeddings=False)
+        assert len(report.results) == len(gs.queries)
+
+    def test_keyword_only_run_has_keyword_only_identity(self) -> None:
+        # A --no-embeddings run must NOT carry a semantic (or toy) embedder label:
+        # the printed identity has to reflect that the vector leg was off.
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs, embedder_id="qwen3-embedding:0.6b", use_embeddings=False)
+        assert "keyword-only" in report.embedder_id.lower()
+        assert "qwen" not in report.embedder_id.lower()
+        assert "keyword-only" in format_kb_report(report).lower()
+
+    def test_temp_dir_cleaned_up_after_run(self) -> None:
+        # A completed run must close the store and remove its temp dir (the store
+        # holds an open SQLite handle; on Windows an un-closed handle would make
+        # TemporaryDirectory.cleanup() raise). Assert no kb_eval_* dir lingers.
+        import glob
+        import tempfile
+
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        before = set(glob.glob(str(Path(tempfile.gettempdir()) / "kb_eval_*")))
+        run_kb_retrieval(gs)
+        after = set(glob.glob(str(Path(tempfile.gettempdir()) / "kb_eval_*")))
+        assert after <= before  # no new kb_eval_ temp dir left behind
+
+
+# -- CLI dispatch -------------------------------------------------------------
+
+
+class TestCli:
+    def test_toy_path_returns_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=None,
+                k=3,
+                real_embedder=False,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "KB retrieval eval" in out
+        assert "toy" in out.lower()
+
+    def test_missing_golden_refuses(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=str(tmp_path / "nope.json"),
+                k=3,
+                real_embedder=False,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 1
+        assert "refusing to run" in capsys.readouterr().out
+
+    def test_real_embedder_refuses_when_absent(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import kiro_crew.knowledge.embedder as emb
+
+        monkeypatch.setattr(emb.InProcessEmbedder, "is_available", lambda self: False)
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=None,
+                k=3,
+                real_embedder=True,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 1
+        assert "not resident" in capsys.readouterr().out
+
+    def test_real_embedder_reports_actual_model_identity(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A custom embedding model must be labeled truthfully in the report.
+
+        Regression: the CLI hardcoded ``embedder_id = "qwen3-embedding:0.6b"``,
+        so a --real-embedder run whose ``InProcessEmbedder`` resolved a
+        different model still reported Qwen3. The label must come from
+        ``embedder.model``.
+        """
+        import kiro_crew.knowledge.embedder as emb
+        from kiro_crew.eval.bench.toy_embedder import toy_embed_fn
+
+        fake_model = "custom-embedding:test-9b"
+        deterministic = toy_embed_fn()
+
+        monkeypatch.setattr(emb.InProcessEmbedder, "is_available", lambda self: True)
+        monkeypatch.setattr(emb.InProcessEmbedder, "model", property(lambda self: fake_model))
+        monkeypatch.setattr(emb.InProcessEmbedder, "embed", lambda self, text: deterministic(text))
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=None,
+                k=3,
+                real_embedder=True,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert fake_model in out
+        assert "qwen" not in out.lower()
+
+
+class TestRound7Fixes:
+    """Regression tests for the head-03b9a4858 GPT review round."""
+
+    def test_huge_k_does_not_crash(self) -> None:
+        """An attacker-sized -k must not overflow the SQL LIMIT arithmetic.
+
+        Regression: ``limit = max(k_values)`` flowed an unbounded cut-off into
+        the store's SQL LIMIT, crashing with an uncaught OverflowError for
+        e.g. ``-k 4611686018427387904``. The retrieval depth is now clamped to
+        the corpus size (a deeper LIMIT cannot change any ranking).
+        """
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        huge = 2**62
+        report = run_kb_retrieval(gs, k_values=(3, huge))
+        # The requested cut-off is still computed (scoring is over the ranked
+        # list, which is at most corpus-sized) -- never silently dropped.
+        assert huge in report.k_values
+        head = report.headline(3)
+        assert 0.0 <= head["recall_any@3"] <= 1.0
+
+    def test_recall_micro_reported(self) -> None:
+        """recall_micro must appear per query, in by_class, headline, and text."""
+        gs = KBGoldenSet.from_json(default_golden_set_path())
+        report = run_kb_retrieval(gs)
+        for r in report.results:
+            assert set(r.recall_micro.keys()) == set(report.k_values)
+        head = report.headline(3)
+        assert "recall_micro@3" in head
+        by_class = report.by_class(3)
+        answerable = [c for c in by_class if c != "abstention"]
+        assert answerable and all("recall_micro" in by_class[c] for c in answerable)
+        assert "recall_micro" in format_kb_report(report, k=3)
+
+    def test_recall_micro_is_fractional_for_partial_hit(self) -> None:
+        """A two-gold query with one hit scores 0.5 micro, not the 1/0 of any/all."""
+        from kiro_crew.eval.bench.kb_retrieval import KBQueryResult, KBRetrievalReport
+        from kiro_crew.eval.bench.retrieval import recall_micro_at_k
+
+        ranked, gold = ("g1", "z1", "z2"), ("g1", "g2")
+        micro = recall_micro_at_k(ranked, gold, 3)
+        assert micro == 0.5  # the scorer itself is fractional
+        r = KBQueryResult(
+            query_id="q-x",
+            query_class="multi_hop",
+            is_abstention=False,
+            recall_any={3: 1.0},
+            recall_all={3: 0.0},
+            recall_micro={3: micro},
+            ndcg={3: 0.5},
+            mrr={3: 1.0},
+        )
+        report = KBRetrievalReport(golden_set="t", embedder_id="toy", k_values=(3,))
+        report.results.append(r)
+        head = report.headline(3)
+        assert head["recall_micro@3"] == 0.5
+        assert head["recall_any@3"] == 1.0
+        assert head["recall_all@3"] == 0.0
+
+    def test_store_error_is_a_refusal_not_a_traceback(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sqlite failure (e.g. full temp volume) exits 1 with a refusal message.
+
+        Regression: ``run_kb_retrieval``'s store build could raise
+        ``sqlite3.OperationalError`` past the CLI dispatch, printing an uncaught
+        traceback instead of the deliberate-refusal message every other failure
+        path in ``_kb_retrieval`` produces.
+        """
+        import kiro_crew.eval.bench.kb_retrieval as kbr
+        from kiro_crew._sqlite_compat import sqlite3
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise sqlite3.OperationalError("database or disk is full")
+
+        monkeypatch.setattr(kbr, "run_kb_retrieval", _boom)
+        # Route the CLI through the patched module attribute.
+        import kiro_crew.cli_bench as cb
+
+        rc = cb.bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=None,
+                k=3,
+                real_embedder=False,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "refusing to run" in out
+        assert "disk is full" in out
+
+    def test_invalid_utf8_golden_is_a_refusal_not_a_traceback(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A golden file with broken UTF-8 exits 1 with a refusal message.
+
+        Regression: ``KBGoldenSet.from_json`` decodes the file as UTF-8; invalid
+        bytes raise ``UnicodeDecodeError``, which escaped the CLI's refusal
+        handler and printed an uncaught traceback instead of the deliberate
+        ``refusing to run`` message every other malformed input produces.
+        """
+        bad = tmp_path / "bad-golden.json"
+        bad.write_bytes(b'{"name": "x", "docs": [], "queries": [\xff\xfe]}')
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=str(bad),
+                k=3,
+                real_embedder=False,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 1
+        assert "refusing to run" in capsys.readouterr().out
+
+    def test_all_abstention_golden_refuses(self, tmp_path: Path) -> None:
+        """A golden set with only abstention queries must refuse, not report 0.0s.
+
+        Regression: ``headline()`` averages the answerable population; with zero
+        answerable queries ``_mean([])`` returns 0.0 for all five answerable
+        metrics, fabricating scores for a population that was never measured
+        (the same invariant ``_require_k`` enforces for uncomputed cut-offs:
+        an unmeasurable metric must be absent or refused, never 0.0).
+        """
+        p = _write_golden(
+            tmp_path,
+            docs=[{"id": "d1", "title": "t", "content": "c"}],
+            queries=[
+                {"id": "q1", "class": "abstention", "question": "?", "gold_doc_ids": []},
+                {"id": "q2", "class": "abstention", "question": "??", "gold_doc_ids": []},
+            ],
+        )
+        with pytest.raises(KBGoldenSetError, match="no answerable queries"):
+            KBGoldenSet.from_json(p)
+
+    def test_deeply_nested_golden_is_a_refusal_not_a_traceback(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A golden file of deeply nested JSON exits 1 with a refusal message.
+
+        Regression: ``json.loads`` raises ``RecursionError`` on ~10k nested
+        arrays; it escaped ``from_json``'s JSONDecodeError conversion and the
+        CLI's ``(KBGoldenSetError, UnicodeError)`` refusal handlers, printing
+        an uncaught traceback. ``from_json`` now converts it at the source so
+        every caller refuses cleanly, whatever parse-time class the payload
+        provokes.
+        """
+        deep = tmp_path / "deep-golden.json"
+        deep.write_text("[" * 10000 + "]" * 10000)
+        with pytest.raises(KBGoldenSetError, match="not valid JSON|too deeply nested"):
+            KBGoldenSet.from_json(deep)
+        rc = bench_cmd(
+            _Args(
+                bench_action="kb-retrieval",
+                golden=str(deep),
+                k=3,
+                real_embedder=False,
+                no_embeddings=False,
+            )
+        )
+        assert rc == 1
+        assert "refusing to run" in capsys.readouterr().out
+
+    def test_nonregular_golden_refuses_without_reading(self) -> None:
+        """A non-regular golden path (device/FIFO) refuses without consuming it.
+
+        Regression: ``--golden /dev/zero`` reached an unbounded ``read()`` and
+        exhausted memory. The shared reader opens nonblocking, classifies the SAME
+        descriptor with fstat, and refuses before reading any bytes.
+        """
+        if not Path("/dev/zero").exists():
+            pytest.skip("no /dev/zero on this platform")
+        with pytest.raises(KBGoldenSetError, match="not a regular file"):
+            KBGoldenSet.from_json("/dev/zero")
+
+    def test_oversized_golden_refuses(self, tmp_path: Path) -> None:
+        """A golden file over the size cap refuses instead of being slurped.
+
+        Uses a sparse file so the test costs no real disk; the refusal must
+        come from the stat-based size check, before the read.
+        """
+        big = tmp_path / "big-golden.json"
+        with open(big, "wb") as fh:
+            fh.seek(64 * 1024 * 1024)  # 64 MiB, over the 16 MiB cap
+            fh.write(b"\0")
+        with pytest.raises(KBGoldenSetError, match="too large"):
+            KBGoldenSet.from_json(big)

--- a/test/test_bench_safepath.py
+++ b/test/test_bench_safepath.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+import kiro_crew.eval.bench.safepath as safepath
 from kiro_crew.eval.bench import datasets
 from kiro_crew.eval.bench.corpus import (
     CAT_SINGLE_HOP,
@@ -35,6 +36,7 @@ from kiro_crew.eval.bench.safepath import (
     guard_output_dir,
     guard_read_path,
     guard_write_path,
+    read_text_nofollow,
 )
 from kiro_crew.eval.bench.toy_embedder import TOY_EMBEDDER_ID, toy_embed_fn
 
@@ -94,6 +96,127 @@ def test_an_ordinary_directory_is_allowed(tmp_path: Path) -> None:
     out = tmp_path / "bench_results"
     assert guard_output_dir(out, what="report output directory") == out.resolve()
     assert guard_write_path(out / "a.json", what="report") == (out / "a.json").resolve()
+
+
+def test_read_text_refuses_a_nonregular_opened_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """File type is judged on the opened fd, not on an earlier path stat."""
+    import os
+    import stat
+    from types import SimpleNamespace
+
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            os,
+            "fstat",
+            lambda _fd: SimpleNamespace(st_nlink=1, st_mode=stat.S_IFIFO, st_size=0),
+        )
+        with pytest.raises(UnsafePathError, match="not a regular file"):
+            read_text_nofollow(payload, what="corpus file")
+
+
+def test_bounded_read_catches_growth_after_fstat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale small st_size cannot turn the byte cap into an unbounded read."""
+    import os
+    from types import SimpleNamespace
+
+    payload = tmp_path / "payload.json"
+    payload.write_text("123456789", encoding="utf-8")
+    real_fstat = os.fstat
+
+    def stale_size(fd: int) -> object:
+        opened = real_fstat(fd)
+        return SimpleNamespace(
+            st_nlink=opened.st_nlink,
+            st_mode=opened.st_mode,
+            st_size=0,  # Simulate a file that grew after descriptor inspection.
+        )
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "fstat", stale_size)
+        with pytest.raises(UnsafePathError, match="content is too large.*8-byte limit"):
+            read_text_nofollow(payload, what="corpus file", max_bytes=8)
+
+
+def test_bounded_read_allows_content_at_the_exact_limit(tmp_path: Path) -> None:
+    payload = tmp_path / "payload.json"
+    payload.write_text("12345678", encoding="utf-8")
+    assert read_text_nofollow(payload, what="corpus file", max_bytes=8) == "12345678"
+
+
+def test_read_opens_basename_through_pinned_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The final open is relative to a held parent fd, never a resolved path name."""
+    import os
+
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+    real_open = os.open
+    seen: dict[str, object] = {}
+
+    def open_from_pinned_parent(
+        resolved_parent: str,
+        name: str,
+        *,
+        flags: int,
+        mode: int,
+        what: str,
+    ) -> int:
+        seen.update(parent=resolved_parent, name=name, what=what)
+        # The helper's own dir_fd mechanics are covered in pinned_fs tests. Here we
+        # pin this reader's contract -- it delegates a basename + parent, never the
+        # full resolved path -- without requiring Windows to open a directory fd.
+        return real_open(payload, flags, mode)
+
+    monkeypatch.setattr(safepath, "_supports_pinned_walk", lambda: True)
+    monkeypatch.setattr(safepath, "_open_in_pinned_parent", open_from_pinned_parent)
+    assert read_text_nofollow(payload, what="corpus file") == "{}"
+    assert seen["parent"] == str(tmp_path.resolve())
+    assert seen["name"] == payload.name
+    assert seen["what"] == "corpus file"
+
+
+def test_unpinned_read_fails_when_opened_path_cannot_be_attested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(safepath, "_supports_pinned_walk", lambda: False)
+    monkeypatch.setattr(safepath.pinned_fs, "fd_real_path", lambda _fd: None)
+
+    with pytest.raises(UnsafePathError, match="cannot verify.*opened file descriptor"):
+        read_text_nofollow(payload, what="corpus file")
+
+
+def test_unpinned_read_refuses_a_redirected_opened_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = tmp_path / "payload.json"
+    other = tmp_path / "other.json"
+    payload.write_text("{}", encoding="utf-8")
+    other.write_text('{"secret": true}', encoding="utf-8")
+    monkeypatch.setattr(safepath, "_supports_pinned_walk", lambda: False)
+    monkeypatch.setattr(safepath.pinned_fs, "fd_real_path", lambda _fd: str(other.resolve()))
+
+    with pytest.raises(UnsafePathError, match="different path"):
+        read_text_nofollow(payload, what="corpus file")
+
+
+def test_unpinned_read_allows_an_attested_opened_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = tmp_path / "payload.json"
+    payload.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(safepath, "_supports_pinned_walk", lambda: False)
+    monkeypatch.setattr(safepath.pinned_fs, "fd_real_path", lambda _fd: str(payload.resolve()))
+
+    assert read_text_nofollow(payload, what="corpus file") == "{}"
 
 
 # ── Entry point 1: the report WRITE (reported) ───────────────────────────────
@@ -226,9 +349,7 @@ def test_a_non_resident_embedder_prints_a_refusal_not_a_traceback(
         raise IngestError("the embedding model is not resident")
 
     monkeypatch.setattr("kiro_crew.eval.bench.run.prepare_embedder", _boom)
-    monkeypatch.setattr(
-        cli_bench, "_load_corpus", lambda key: _tiny_corpus()  # noqa: ARG005
-    )
+    monkeypatch.setattr(cli_bench, "_load_corpus", lambda key: _tiny_corpus())  # noqa: ARG005
     rc = cli_bench.bench_cmd(_retrieval_args(out_dir=str(tmp_path)))
     out = capsys.readouterr().out
     assert rc == 1
@@ -246,12 +367,8 @@ def test_a_refused_report_write_does_not_discard_the_measurement(
     """
     from kiro_crew import cli_bench
 
-    monkeypatch.setattr(
-        cli_bench, "_load_corpus", lambda key: _tiny_corpus()  # noqa: ARG005
-    )
-    rc = cli_bench.bench_cmd(
-        _retrieval_args(toy_embedder=True, out_dir=str(fake_home / ".aws"))
-    )
+    monkeypatch.setattr(cli_bench, "_load_corpus", lambda key: _tiny_corpus())  # noqa: ARG005
+    rc = cli_bench.bench_cmd(_retrieval_args(toy_embedder=True, out_dir=str(fake_home / ".aws")))
     out = capsys.readouterr().out
     assert rc == 1
     assert "not saved" in out


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend/CLI-only change — a new `bench` subcommand and eval module; no dashboard/UI surface is touched.

## Problem / Motivation

The Knowledge Library's `HybridRetriever` (keyword + graph + vector RRF fusion) has no deterministic retrieval-quality ruler. The existing `bench retrieval` harness measures the conversational **memory** layer (`VectorMemoryStore` over LoCoMo / LongMemEval, turn/session gold), not the **Knowledge Library** (`HybridRetriever` over document chunks).

## Why it matters

Without a frozen measurement, later tuning (freshness weighting, reranking, or tool-description changes) can only assert improvement. A deterministic recall/MRR/nDCG result makes changes comparable across commits. This is T0 of the Knowledge Library roadmap: intrinsic retrieval measurement; it does not yet add persisted reports or Tier-2 KB-on/off task-lift.

## What changed (motivation → approach → change)

- **`src/kiro_crew/eval/bench/kb_retrieval.py`** — frozen golden-set models, KB-local `mrr_at_k`, and `run_kb_retrieval`. Each run builds a private file-backed `KnowledgeStore`, inserts the labeled documents, calls the real synchronous `HybridRetriever.search`, and reports recall-any/all/micro, nDCG, and MRR by query class. The deterministic toy embedder is the default plumbing ruler; `--real-embedder` uses the resident Qwen3 backend; `--no-embeddings` is the explicit FTS-only ablation.
- **`src/kiro_crew/eval/bench/data/kb_golden_v1.json`** — a hand-authored v1 set with 17 documents / 12 queries across 10 classes. Supersession fixtures preserve source chronology in insertion order (old policy → new policy, draft → correction, announcement → retraction, draft → baseline → corroborating audit); contrasting hypothetical/draft documents remain non-gold distractors. The set is intentionally small and lexical-overlap-biased, so per-class results are directional rather than statistically stable.
- **`src/kiro_crew/cli_bench.py`** — `bench kb-retrieval [golden] [-k N] [--real-embedder] [--no-embeddings]`, with the module imported lazily to preserve unrelated CLI boot time. Requested cutoffs are actually computed, unavailable embedders fail closed, and the report identity always reflects whether the vector leg ran.
- **Shared guarded reads (`eval/bench/safepath.py`, `pinned_fs.py`, `hooks.py`)** — `read_text_nofollow` now resolves/opens once, validates hardlink count/type/size on that descriptor, and optionally reads at most `max_bytes + 1`. On `dir_fd` platforms it opens the basename relative to a descriptor-pinned parent; on Windows/no-`dir_fd` it attests the actual opened-handle path and fails closed when identity cannot be proven. The KB loader uses a 16 MiB cap and rejects invalid UTF-8 report names before output.
- **Packaging** — the golden JSON is included in both wheel and sdist manifests.

**Known boundary:** this harness measures bare `HybridRetriever.search`. The agent-visible MCP caller applies its own score floor, so raw-retriever abstention and tool-surface abstention are different metrics. Tier-2 answer/task lift remains a separate non-deterministic evaluation stage.

## Tests

- **44 KB harness tests**: scorer semantics; golden schema/refusal cases; UTF-8 names; source chronology; sensitive/non-regular/oversized input; embedding fail-closed behavior; keyword-only identity; temp-store cleanup; deterministic runs; CLI dispatch.
- **20 canonical safepath tests**: pinned-parent basename open, no-`dir_fd` opened-handle attestation, unprovable/redirected fallback refusals, descriptor type checks, stale-size `max_bytes + 1` enforcement, exact-limit success, and existing read/write trust gates.
- **399 affected tests passed** across KB, safepath, corpus adapters/datasets, hooks, and Windows handle-path simulation (1 expected dataset skip).
- Pinned Black/isort/flake8/mypy pass; Black ratchet passes with the newly clean safepath test removed from the baseline.

## Manual verification

`kirocrew bench kb-retrieval --no-embeddings` completed against the packaged v1 fixture after the chronology correction (`recall_any@3=1.000`, `recall_all@3=1.000`, `recall_micro@3=1.000`, `nDCG@3=0.933`, `MRR@3=0.909`).

## Related Issues

no linked issue: T0 is tracked in the out-of-repo Knowledge Library roadmap.
