### PR TITLE
fix(dev-fleet): arrow-key navigation in row-actions menu (#5851)

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -340,6 +340,35 @@ function MenuBtn({ items }: { items: (MenuItemDef | null)[] }) {
         close()
         return
       }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Home' || e.key === 'End') {
+        // role="menu" promises arrow-key item navigation (WAI-ARIA menu
+        // pattern) — screen-reader users reach for arrows first (#5851).
+        // Wrap at both ends; Home/End jump to the boundary items.
+        // preventDefault stops the page scrolling behind the open menu.
+        // Modified arrows (Cmd/Ctrl/Alt) are OS/browser shortcuts the menu
+        // pattern assigns no behavior to — let them through untouched.
+        if (e.altKey || e.ctrlKey || e.metaKey) return
+        // An arrow the IME owns is moving through composition candidates,
+        // not menu items — same claim, same reason as the Tab branch below,
+        // and the claim runs BEFORE the preventDefault() and focus move.
+        // (useListKeyboardNav deliberately lets composition arrows through
+        // because its list coexists with a text input; this menu holds no
+        // editable target, so it takes the stricter side.)
+        const focusable = focusableItems()
+        if (focusable.length === 0) return
+        if (!imeLatch.claimKey(e)) return
+        e.preventDefault()
+        if (e.key === 'Home') { focusable[0].focus(); return }
+        if (e.key === 'End') { focusable[focusable.length - 1].focus(); return }
+        const idx = focusable.indexOf(document.activeElement as HTMLDivElement)
+        // Focus outside the item list (edge: it never entered) — treat the
+        // arrow as entry: Down lands on the first item, Up on the last.
+        const next = idx === -1
+          ? (e.key === 'ArrowDown' ? 0 : focusable.length - 1)
+          : (idx + (e.key === 'ArrowDown' ? 1 : -1) + focusable.length) % focusable.length
+        focusable[next].focus()
+        return
+      }
       if (e.key !== 'Tab') return
       // Contain Tab/Shift-Tab within the menu's enabled items — a Tab out of
       // a still-open menu would drop a keyboard user behind it with no

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -1190,6 +1190,95 @@ describe('DevFleetPage', () => {
     expect(menuItems[menuItems.length - 1]).toHaveFocus()
   })
 
+  it('row-actions menu ArrowDown/ArrowUp cycle focus through items and wrap at both ends', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    const menuItems = within(menu).getAllByRole('button')
+    expect(menuItems[0]).toHaveFocus()
+    // Down walks forward one item at a time.
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(menuItems[1]).toHaveFocus()
+    // Down on the last item wraps to the first.
+    menuItems[menuItems.length - 1].focus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(menuItems[0]).toHaveFocus()
+    // Up on the first item wraps to the last.
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+    // Up walks backward one item at a time.
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(menuItems[menuItems.length - 2]).toHaveFocus()
+  })
+
+  it('row-actions menu Home/End jump to the first/last item', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    const menuItems = within(menu).getAllByRole('button')
+    expect(menuItems[0]).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'End' })
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Home' })
+    expect(menuItems[0]).toHaveFocus()
+  })
+
+  it('row-actions menu declines an arrow that belongs to an IME composition', async () => {
+    // On WebKit the keydown that moves through composition candidates can
+    // arrive AFTER compositionend with `isComposing` already false — an
+    // unguarded arrow branch would move menu focus mid-composition. Menu
+    // items are non-editable today; this pins the claim stays load-bearing
+    // if the menu ever grows a focusable text field.
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    const menuItems = within(menu).getAllByRole('button')
+    expect(menuItems[0]).toHaveFocus()
+    fireEvent.compositionStart(menuItems[0])
+    fireEvent.compositionEnd(menuItems[0])
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    // Declined: focus stays put instead of moving to the second item.
+    expect(menuItems[0]).toHaveFocus()
+  })
+
+  it('row-actions menu arrows enter the list when focus is outside it: Down to first, Up to last', async () => {
+    // Reachable edge: the fleet page polls, so an item holding focus can
+    // unmount mid-open and drop activeElement to <body>.
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    const menuItems = within(menu).getAllByRole('button')
+    document.body.focus()
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+    document.body.focus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(menuItems[0]).toHaveFocus()
+  })
+
+  it('row-actions menu lets modified arrows through untouched (OS/browser shortcuts)', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText('More actions'))
+    const menu = await screen.findByRole('menu')
+    const menuItems = within(menu).getAllByRole('button')
+    expect(menuItems[0]).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown', metaKey: true })
+    fireEvent.keyDown(menu, { key: 'ArrowDown', ctrlKey: true })
+    fireEvent.keyDown(menu, { key: 'End', altKey: true })
+    // Not the menu's keys: focus did not move.
+    expect(menuItems[0]).toHaveFocus()
+  })
+
   it('selecting a row-actions menu item returns focus to the trigger', async () => {
     mockFleet(FLEET_MENU)
     renderPage()


### PR DESCRIPTION
## What is the problem?

The Dev Fleet row-actions dropdown (`MenuBtn` in `website/src/pages/DevFleetPage.tsx`) announces `role="menu"`, and that role promises ArrowDown/ArrowUp item navigation. PR #3525 added focus entry, Tab/Shift-Tab containment, and focus return, so the menu is usable via Tab -- but arrow keys did nothing.

## Why this issue matters to the user

Screen-reader users hear "menu" and reach for arrow keys first; when arrows do nothing the menu appears broken even though Tab works. Keyboard users get the same dead keys, and an unhandled arrow scrolls the page behind the open menu.

## How our fix solves it

The announced role and the handled keys now agree. In `MenuBtn`'s open-effect key handler, ArrowDown/ArrowUp move focus through the same `focusableItems()` list the existing Tab containment uses (disabled items are already filtered out), wrapping at both ends; Home/End jump to the boundary items; `preventDefault` stops the page scrolling behind the menu. Three guards keep the new branch honest:

- Modified arrows (Cmd/Ctrl/Alt) pass through untouched -- they are OS/browser shortcuts the menu pattern assigns no behavior to.
- The shared IME latch (`useDocumentImeLatch.claimKey`) runs before `preventDefault()` and any focus move, so an arrow that belongs to a composition (candidate navigation) never moves menu focus -- the same claim contract as the existing Tab/Escape branches. The menu takes the stricter side than `useListKeyboardNav` (which lets composition arrows through) because the menu holds no editable target; the code comment records the divergence.
- When focus is outside the item list (reachable: the fleet page polls, so a focused item can unmount mid-open), ArrowDown enters at the first item and ArrowUp at the last.

Tab containment, Escape, focus return, and outside-click behavior are unchanged. Scope note: this delivers arrow-key navigation; full menu-pattern semantics (menuitem child roles, roving tabindex) are a pre-existing gap in the shared `Clickable` component and are out of scope here.

## What tests we did

- 5 new tests in `website/src/test/DevFleetPage.test.tsx`: arrow cycling with wrap at both ends, Home/End jumps, IME-composition decline (focus stays put), outside-the-list entry (Down to first, Up to last), and modified-arrow passthrough.
- Mutation-verified: deleting the arrow branch reds the cycling tests; deleting only the `claimKey` line reds the decline test.
- Gates: `npx tsc -b` clean; full frontend suite 24646 tests passed; eslint warning count identical to base for both touched files.
- Pre-push review: two model-pinned reviewers (GPT + Opus lanes), both NO BLOCKING; all five advisories folded into this single commit or noted above.

## Any other suggestions on the work

The IME ratchet (`scanUnguardedTabFocusTraps`) only recognizes Tab-shaped traps, so an unguarded arrow branch that moves focus is invisible to it -- widening the predicate to the choose-class key set is the cause-level fix and belongs to the existing ratchet-widening issue #5475.

Closes #5851
