### PR TITLE
fix(security): honor unconditional trust grants for verified-identity child MCP calls

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -95,6 +95,15 @@ permission for the same call therefore retains the fact that a non-shell MCP too
 had arguments; it cannot be reclassified as an inputless canonical tool and match
 session durable trust merely because the display cache was already consumed.
 
+A remote (HTTP) MCP server's initial `tool_call` legitimately streams an empty or
+absent `rawInput`, so the params cache stays empty and every child permission
+request for such a tool is low-fidelity (`AcpEvent.child_low_fidelity`). The
+`_meta.kiro` identity caches are written unconditionally from the same frame, so
+the permission event still carries the verified `mcp_server_name`/`tool_name`
+pair; `AcpEvent.child_mcp_identity_trusted` exposes that verified-identity half
+(arguments unverified) for the unconditional grant paths documented in
+`security.md` § Child-fidelity split.
+
 The handshake also branches on the backend:
 
 - `protocolVersion` in the `initialize` request: kiro-cli expects the date string `"2025-08-22"`; claude-agent-acp expects an integer (`1`, per the upstream ACP SDK schema).

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1457,6 +1457,24 @@ becoming broad globs. Command parsing and matching live in the shared
 API instead of importing dashboard runner internals or fabricating a
 `Running: ...` title.
 
+**Child-fidelity split: identity vs arguments.** A backend-subagent permission
+event whose structured params never reached the tool_call cache is low-fidelity
+(`AcpEvent.child_low_fidelity`) and is excluded from every content-matching
+auto-approve path — trusted patterns, trust-reads, title-keyed
+`auto_approve_tools` — because the agent-authored title/params ARE the matched
+input. A remote (HTTP) MCP server legitimately streams empty `rawInput` on its
+`tool_call` frames, so every such child call is low-fidelity; but the same
+frame's `_meta.kiro` server/tool identity is cache-provenance and
+non-model-authored. `AcpEvent.child_mcp_identity_trusted` isolates that half
+(requires: child origin, RESOLVED non-shell classification, canonical
+server+tool recovered from cache), and **unconditional** grants — session
+trust-all, global YOLO, `parent_policy=auto`, per-source auto-approve, the
+`--approval yolo` override — honor the grant for identity-verified events: the
+approve decision consumes no agent-authored event data, only the arguments
+remain unverified (the same blindness the interactive card has; the identity
+split changes WHO approves, not what any gate can scan). Shell events never
+qualify: their deny gates need the command bytes the event lacks.
+
 ### SEL Audit Logging (`sel.py`)
 
 See `docs/system-specs/modules/sel.md` for full spec. Every event carries a `source` stamped by `_infer_source`; that function's return vocabulary IS the set of audited surfaces and is published via `sel.audit_sources()` (consumed by the security-posture view, so the count is derived rather than restated here).

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -93,6 +93,20 @@ is decided in strict priority order:
 Step 3 ensures parentless subagents (e.g. cron jobs) respect the user's
 global approval mode instead of falling through to interactive approval.
 
+**Child-fidelity gate.** A child-origin permission event whose SECURITY context
+is absent (`AcpEvent.child_low_fidelity`: structured params never reached the
+tool_call cache, unresolved shell classification, or a shell without a
+recoverable command) skips steps 2–3 and is handed to the interactive callback
+with an "UNVERIFIED child request" annotation (headless: rejected), because
+every field a shortcut would judge is agent-authored. One carve-out: when the
+event's canonical MCP identity IS verified (`child_mcp_identity_trusted` — the
+`_meta.kiro` server/tool pair resolved from the tool_call cache, resolved
+non-shell; the shape a remote MCP server produces by streaming empty
+`rawInput`), the **unconditional** `parent_policy == "auto"` grant still
+auto-approves: its decision consumes no agent-authored event data, only the
+arguments remain unverified. The hook auto-approve (title-pattern-matched) and
+every content-matching path stay fail-closed on the composite fidelity.
+
 The `is_yolo()` check in the cascade is live (reads current gateway state),
 providing coverage if YOLO is toggled mid-execution.
 

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -628,6 +628,44 @@ class AcpEvent:
             return True
         return False
 
+    @property
+    def child_mcp_identity_trusted(self) -> bool:
+        """True for a child MCP event whose IDENTITY is verified even when its
+        arguments are not.
+
+        ``child_low_fidelity`` conflates two independent provenances: the tool's
+        identity and its arguments. A remote (HTTP) MCP server's ``tool_call``
+        frame legitimately streams an empty ``rawInput``, so the params cache
+        stays empty and every such child permission request is low-fidelity —
+        yet the ``_meta.kiro`` server/tool identity from that same frame DID
+        reach the caches and is non-model-authored. This property isolates that
+        verified-identity half so UNCONDITIONAL grant paths — ones whose approve
+        decision consumes no agent-authored event data (session trust-all,
+        global YOLO, ``parent_policy=auto``, per-source auto-approve) — can
+        honor the grant, while every content-matching path (trusted patterns,
+        trust-reads, title-keyed ``auto_approve_tools``) stays gated on the
+        composite ``child_low_fidelity``: for those the agent-authored title or
+        inline params ARE the matched input, and a forged title must never
+        satisfy them.
+
+        Requirements, each fail-closed on its cache: a child origin
+        (``sub_session_id``), a RESOLVED non-shell classification
+        (``shell_classified`` and not ``is_shell`` — an unclassified event
+        defaults to non-shell and must not pass as one; a shell tool's deny
+        gates need the command bytes this event lacks), and the canonical
+        ``mcp_server_name`` + ``tool_name`` pair recovered from the tool_call
+        cache (empty on a miss, and populated only for genuinely MCP-served
+        tools — a host shell/builtin can never carry a server name). A
+        non-child event returns False: parents never need the split.
+        """
+        return bool(
+            self.sub_session_id
+            and self.shell_classified
+            and not self.is_shell
+            and self.mcp_server_name
+            and self.tool_name
+        )
+
 
 @dataclass
 class AcpPromptStats:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -6415,6 +6415,36 @@ async def _run_chat(
                 # to the interactive card. A child WITH full context takes the
                 # same branches as the main agent (mode parity).
                 _child_low_fidelity = event.child_low_fidelity
+                # Verified-identity half of the fidelity split (see
+                # AcpEvent.child_mcp_identity_trusted): a remote MCP server's
+                # tool_call frame streams no rawInput, so args provenance is
+                # unrecoverable — but the _meta.kiro server/tool identity DID
+                # arrive and is non-model-authored. UNCONDITIONAL grant paths
+                # below (trust-all / YOLO / native crew), whose approve decision
+                # consumes no agent-authored event data, honor the grant for
+                # such events; content-matching paths (trusted patterns,
+                # trust-reads) stay gated on the composite fidelity because the
+                # agent-authored title/params ARE their matched input.
+                _child_grant_eligible = not _child_low_fidelity or event.child_mcp_identity_trusted
+                if _child_low_fidelity:
+                    # Diagnostic for a path that is otherwise invisible in
+                    # logs: without it a trust-all session watching its
+                    # subagent stall on an approval card has no log line to
+                    # find (the annotate-and-prompt branch is silent).
+                    logger.info(
+                        "low-fidelity child permission request (child=%s, " "mcp_identity=%s): %s",
+                        event.sub_session_id,
+                        (
+                            f"verified {event.mcp_server_name}/{event.tool_name}"
+                            if event.child_mcp_identity_trusted
+                            else "unverified"
+                        ),
+                        (
+                            "unconditional grants still apply"
+                            if _child_grant_eligible
+                            else "all auto-approve paths skipped"
+                        ),
+                    )
                 # DISPLAY-ONLY warning for the interactive card: the human
                 # must know the title is ALL there is (the params the gates
                 # would verify are absent, so the displayed text is
@@ -6664,7 +6694,7 @@ async def _run_chat(
                 # through to the normal interactive/trust gate below.
                 if (
                     _native_crew_should_auto_approve(_native_tracker, state, slot)
-                    and not _child_low_fidelity
+                    and _child_grant_eligible
                 ):
                     logger.debug(
                         "Native crew auto-approve: %r (request_id=%s)",
@@ -6829,12 +6859,15 @@ async def _run_chat(
                         )
                         continue
                 # Trust mode (per-slot) or YOLO mode (global) — auto-approve.
-                # Low-fidelity child events (backend subagents whose command
-                # bytes never reached the caches) are excluded from every
-                # auto-approve path and fall through to the interactive card;
+                # Both are UNCONDITIONAL grants: the decision consumes no
+                # agent-authored event data, so a low-fidelity child event
+                # with a VERIFIED canonical MCP identity still qualifies
+                # (_child_grant_eligible — arguments unverified, but the grant
+                # never reads them). A child with neither full context nor a
+                # verified identity falls through to the interactive card;
                 # children WITH cached bytes take these branches exactly like
                 # the main agent (mode parity).
-                if (slot_trusted or yolo_active) and not _child_low_fidelity:
+                if (slot_trusted or yolo_active) and _child_grant_eligible:
                     try:
                         validated_tool = _validate_tool_name(event.title, is_shell=event.is_shell)
                     except ValueError as e:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1739,16 +1739,31 @@ class GatewayOrchestrator:
         async def _approve(event: LLMEvent, parent_session_key: str = "") -> bool:
             request_id = str(event.request_id)
             # Low-fidelity CHILD request: the structured security context is
-            # absent, so every field a shortcut below would judge (title,
-            # read-only classification, trust patterns) is agent-authored.
-            # Such a request may ONLY be approved by the human prompt at the
-            # end of this callback — every non-human auto-approve shortcut
-            # (auto_approve_sources, --approval yolo/reads, YOLO override,
-            # slot trust) is skipped for it. Strict ``is True``: real events
+            # absent, so every field a content-matching shortcut below would
+            # judge (title, read-only classification, trust patterns) is
+            # agent-authored. Unless its canonical MCP identity is verified
+            # (``_child_grant_eligible`` below), such a request may ONLY be
+            # approved by the human prompt at the end of this callback —
+            # every non-human auto-approve shortcut (auto_approve_sources,
+            # --approval yolo/reads, YOLO override, slot trust) is skipped
+            # for it. Strict ``is True``: real events
             # (AcpEvent) return a genuine bool; anything else (e.g. a mock
             # or a foreign event type) must not accidentally enter the
             # restricted path on a truthy non-bool.
             _child_lf = getattr(event, "child_low_fidelity", False) is True
+            # Verified-identity half of the fidelity split (see
+            # AcpEvent.child_mcp_identity_trusted): grant-eligible when full
+            # fidelity OR the canonical MCP server/tool identity resolved from
+            # the tool_call cache (arguments unverified). UNCONDITIONAL
+            # shortcuts below — ones whose approve decision consumes no
+            # agent-authored event data (per-source auto-approve, --approval
+            # yolo, the YOLO override, slot trust) — honor their grant for
+            # such events; the 'reads' mode stays gated on the composite
+            # ``_child_lf`` because it MATCHES the agent-authored title.
+            # Same strict ``is True`` rationale as ``_child_lf``.
+            _child_grant_eligible = (not _child_lf) or (
+                getattr(event, "child_mcp_identity_trusted", False) is True
+            )
             # Background callers pass the authoritative parent session key. Prefer it
             # over a request-ID resolver because tool permission IDs are opaque UUIDs,
             # unlike spawn approvals (``spawn:<agent_id>``). Treating a tool request ID
@@ -1786,7 +1801,7 @@ class GatewayOrchestrator:
 
             # Per-source auto-approve (e.g. cron, taskrunner, subagent)
             if source in self._cfg.hooks.get("auto_approve_sources", []):
-                if _child_lf:
+                if not _child_grant_eligible:
                     # The operator explicitly configured this source to run
                     # UNATTENDED — nobody is watching the interactive window,
                     # so parking a low-fidelity child request there would
@@ -1806,9 +1821,14 @@ class GatewayOrchestrator:
             # CLI --approval flag override (composable test mode).
             # 'yolo' auto-approves all; 'reads' auto-approves read-only tools;
             # 'interactive' falls through to the standard flow.
-            if self._approval_mode in ("yolo", "reads") and not _child_lf:
+            # 'yolo' is an UNCONDITIONAL grant (consumes no event data) so a
+            # verified-identity child qualifies; 'reads' classifies the
+            # agent-authored TITLE, so it requires the composite fidelity.
+            if self._approval_mode in ("yolo", "reads") and _child_grant_eligible:
                 approve = self._approval_mode == "yolo" or (
-                    self._approval_mode == "reads" and _is_read_only_tool(event.title or "")
+                    self._approval_mode == "reads"
+                    and not _child_lf
+                    and _is_read_only_tool(event.title or "")
                 )
                 if approve:
                     # Emit a SEL audit event so the audit trail records WHICH
@@ -1829,7 +1849,7 @@ class GatewayOrchestrator:
                     return True
 
             # Check both YOLO sources: Slack handler (!yolo on) and dashboard UI
-            if safety_override().is_active() and not _child_lf:
+            if safety_override().is_active() and _child_grant_eligible:
                 return True
 
             if self.dashboard_state:
@@ -1859,7 +1879,7 @@ class GatewayOrchestrator:
 
                 if _parent_slot_key:
                     _ps = (self.dashboard_state._slots or {}).get(_parent_slot_key)
-                    if _ps and _ps._trust and _child_lf:
+                    if _ps and _ps._trust and not _child_grant_eligible:
                         # Slot IS trusted; the fidelity gate is what blocks
                         # the auto-approve. A distinct audit reason — an
                         # auditor reading "not_trusted" for a trusted slot

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -6030,6 +6030,34 @@ class SubagentManager:
                     )
                     continue
                 if event.child_low_fidelity:
+                    # UNCONDITIONAL parent grant + verified canonical MCP
+                    # identity: parent_policy=auto approves regardless of
+                    # event content, and child_mcp_identity_trusted proves a
+                    # real MCP tool_call frame (non-model-authored _meta.kiro
+                    # identity, resolved non-shell) is behind this request —
+                    # only its ARGUMENTS are unverified, which this grant
+                    # never reads. Honor the grant instead of stalling a
+                    # trusted fan-out on an interactive card per call. The
+                    # hook auto-approve below stays fail-closed for these:
+                    # its auto_approve_tools patterns match the agent-authored
+                    # title, which a child could forge.
+                    if parent_policy == "auto" and event.child_mcp_identity_trusted:
+                        await self._approve_and_log(
+                            client,
+                            event.request_id,
+                            session_key,
+                            event,
+                            metadata={
+                                "subagent_id": info.id,
+                                "reason": "parent_policy_auto",
+                                "child_mcp_identity": (
+                                    f"{event.mcp_server_name}/{event.tool_name}"
+                                ),
+                                "child_args_unverified": True,
+                            },
+                            info=info,
+                        )
+                        continue
                     # Backend-internal child origin whose SECURITY context is
                     # absent (structured params missing, unresolved shell
                     # classification, or shell without a recoverable command —

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6679,6 +6679,100 @@ def test_child_low_fidelity_requires_structured_security_context():
     assert ev.child_low_fidelity is False
 
 
+def test_child_mcp_identity_trusted_isolates_verified_identity():
+    """The identity half of the fidelity split: verified server/tool pair on a
+    child event whose ARGUMENTS never reached the cache. Each requirement is
+    individually load-bearing (fail-closed on its own cache miss)."""
+    from kiro_crew.acp.types import AcpEvent
+
+    def _ev(**overrides):
+        base: dict = dict(
+            kind="permission_request",
+            sub_session_id="child-a",
+            shell_classified=True,
+            is_shell=False,
+            mcp_server_name="example-server",
+            tool_name="get-item",
+        )
+        base.update(overrides)
+        return AcpEvent(**base)
+
+    # The issue's shape: remote MCP tool_call streamed no rawInput — low
+    # fidelity (args unverified) but identity verified.
+    ev = _ev()
+    assert ev.child_low_fidelity is True
+    assert ev.child_mcp_identity_trusted is True
+    # A parent event never needs the split.
+    assert _ev(sub_session_id="").child_mcp_identity_trusted is False
+    # Unresolved shell classification: is_shell=False is only the miss
+    # default, so nothing proves this is not a shell tool.
+    assert _ev(shell_classified=False).child_mcp_identity_trusted is False
+    # A resolved SHELL tool: its deny gates need the command bytes this
+    # event lacks — never identity-eligible.
+    assert _ev(is_shell=True).child_mcp_identity_trusted is False
+    # Cache-missed identity halves are each fail-closed.
+    assert _ev(mcp_server_name="").child_mcp_identity_trusted is False
+    assert _ev(tool_name="").child_mcp_identity_trusted is False
+    # Full-fidelity child: the property may hold too, and grant callers use
+    # `not child_low_fidelity or child_mcp_identity_trusted` — both True is
+    # consistent, not contradictory.
+    full = _ev(raw_params_trusted=True, raw_tool_params={"itemId": "i-1"})
+    assert full.child_low_fidelity is False
+    assert full.child_mcp_identity_trusted is True
+
+
+def test_remote_mcp_empty_rawinput_keeps_identity_through_dispatch():
+    """End-to-end through the real _dispatch functions: a remote MCP server's
+    tool_call frame with EMPTY/absent rawInput leaves the params cache empty
+    (low fidelity) while the _meta.kiro identity still reaches the permission
+    event's trusted fields — the split the grant paths rely on."""
+    from kiro_crew.acp._dispatch import build_permission_event, parse_session_update
+
+    for raw_input_shape in ({}, None):
+        caches: dict = {
+            "tool_input_cache": {},
+            "shell_cache": {},
+            "raw_params_cache": {},
+            "mcp_server_name_cache": {},
+            "tool_name_cache": {},
+        }
+        child_sid, tcid = "child-a", "tc-1"
+        update = {
+            "sessionUpdate": "tool_call",
+            "toolCallId": tcid,
+            "title": "@example-server/get-item",
+            "kind": "other",
+            "_meta": {"kiro": {"mcpServerName": "example-server", "toolName": "get-item"}},
+        }
+        if raw_input_shape is not None:
+            update["rawInput"] = raw_input_shape
+        parse_session_update(update, cache_scope=child_sid, **caches)
+
+        class _Msg:
+            id = 90
+            method = "session/request_permission"
+            params = {
+                "sessionId": child_sid,
+                "toolCall": {
+                    "toolCallId": tcid,
+                    "title": "@example-server/get-item",
+                    "input": {"itemId": "item-0001"},
+                },
+                "options": [
+                    {"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+                    {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+                ],
+            }
+
+        event, _ = build_permission_event(_Msg(), cache_scope=child_sid, **caches)
+        event.sub_session_id = child_sid
+        assert event.raw_params_trusted is False
+        assert event.child_low_fidelity is True
+        assert event.mcp_server_name == "example-server"
+        assert event.tool_name == "get-item"
+        assert event.child_mcp_identity_trusted is True
+
+
 @pytest.mark.asyncio
 async def test_between_turns_child_permission_is_answered_not_queued():
     """With no in-flight prompt nothing consumes the slot queue until the next

--- a/test/test_background_approval_routing.py
+++ b/test/test_background_approval_routing.py
@@ -299,3 +299,120 @@ class TestLowFidelityChildNeverAutoApproved:
         assert await approve_fn(_event()) is True
         # Parent event: the yolo shortcut answered, no prompt raised.
         gateway.dashboard_state.request_approval.assert_not_awaited()
+
+
+def _child_identity_event(request_id: str = "req-child-mcp-1") -> LLMEvent:
+    """A low-fidelity child MCP event with VERIFIED canonical identity: the
+    remote server's tool_call frame streamed no rawInput (args unverified)
+    but its _meta.kiro identity reached the caches (see issue #6163)."""
+    ev = LLMEvent(
+        kind="permission_request",
+        request_id=request_id,
+        title="@example-server/get-item",
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    assert ev.child_low_fidelity
+    assert ev.child_mcp_identity_trusted
+    return ev
+
+
+class TestIdentityTrustedChildHonorsUnconditionalGrants:
+    """A child request with verified canonical MCP identity (arguments
+    unverified) qualifies for every UNCONDITIONAL grant — the decision
+    consumes no agent-authored event data — while content-matching shortcuts
+    ('reads' classifies the agent-authored title) stay fail-closed on the
+    composite fidelity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_sources_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway._cfg.hooks.get = MagicMock(return_value=["cron"])
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_yolo_approval_mode_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway._approval_mode = "yolo"
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reads_approval_mode_still_prompts_identity_trusted_child(self) -> None:
+        """'reads' matches the agent-authored TITLE — a verified identity does
+        not verify the title, so the read-only classification must not run."""
+        gateway = _make_gateway()
+        gateway._approval_mode = "reads"
+        approve_fn = gateway._interactive_approval("cron")
+        # A title the read-only classifier would accept, were it consulted.
+        ev = _child_identity_event()
+        ev.title = "Reading item metadata"
+        assert await approve_fn(ev) is True  # answered by the human prompt stub
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_yolo_override_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        _override = MagicMock()
+        _override.is_active = MagicMock(return_value=True)
+        with patch("kiro_crew.slack.gateway.safety_override", return_value=_override):
+            approve_fn = gateway._interactive_approval("cron")
+            assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_slot_trust_approves_identity_trusted_child(self) -> None:
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-1": _slot(running=True, trust=True)}
+        gateway.sessions.get_pid = MagicMock(return_value=None)
+        approve_fn = gateway._interactive_approval(
+            "subagent", slot_resolver=lambda _rid: "slot-1"
+        )
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_untrusted_slot_still_prompts_identity_trusted_child(self) -> None:
+        """Identity verification is not itself a grant: with no trust anywhere
+        the request still goes to the human prompt."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-1": _slot(running=True, trust=False)}
+        gateway.sessions.get_pid = MagicMock(return_value=None)
+        approve_fn = gateway._interactive_approval(
+            "subagent", slot_resolver=lambda _rid: "slot-1"
+        )
+        assert await approve_fn(_child_identity_event()) is True
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_identity_missing_child_remains_blocked_under_slot_trust(self) -> None:
+        """The counterfactual for every relaxation above: the same grants stay
+        fail-closed when the identity did NOT resolve (title-only event)."""
+        gateway = _make_gateway()
+        gateway.dashboard_state._slots = {"slot-1": _slot(running=True, trust=True)}
+        gateway.sessions.get_pid = MagicMock(return_value=None)
+        approve_fn = gateway._interactive_approval(
+            "subagent", slot_resolver=lambda _rid: "slot-1"
+        )
+        assert await approve_fn(_child_lf_event()) is True
+        gateway.dashboard_state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shell_identity_child_remains_blocked(self) -> None:
+        """A resolved SHELL child event never qualifies: its deny gates need
+        command bytes the event lacks, whatever the server identity claims."""
+        gateway = _make_gateway()
+        gateway._approval_mode = "yolo"
+        ev = _child_identity_event()
+        ev.is_shell = True
+        assert not ev.child_mcp_identity_trusted
+        approve_fn = gateway._interactive_approval("cron")
+        assert await approve_fn(ev) is True
+        gateway.dashboard_state.request_approval.assert_awaited_once()

--- a/test/test_promise_only_autoapprove_parity.py
+++ b/test/test_promise_only_autoapprove_parity.py
@@ -62,7 +62,7 @@ def test_downgrade_gate_covers_every_approval_grant_source() -> None:
 
     # The tool-event branch that auto-approves without human confirmation.
     approval = re.search(
-        r"^\s*if \((?P<cond>[^)]*yolo_active[^)]*)\) and not _child_low_fidelity:",
+        r"^\s*if \((?P<cond>[^)]*yolo_active[^)]*)\) and _child_grant_eligible:",
         source,
         re.MULTILINE,
     )

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -2043,6 +2043,104 @@ class TestSubagentUsageRow:
         assert persist.await_args.kwargs["agent"] == "researcher"
 
 
+class TestIdentityTrustedChildParentPolicyAuto:
+    """A low-fidelity child MCP permission event whose canonical identity IS
+    verified (remote server streamed no rawInput — issue #6163) honors an
+    unconditional ``parent_policy=auto`` grant instead of stalling on the
+    interactive downgrade; without the verified identity the same event stays
+    fail-closed.
+    """
+
+    def _manager_and_stream(self, event):
+        from kiro_crew.hooks import ToolHookResult
+        from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+        sessions = _mock_sessions()
+        sessions.get_approval_policy = MagicMock(return_value="auto")
+        provider = sessions.get_or_create.return_value[0]
+
+        async def _stream(*_a, **_kw):
+            yield event
+
+        provider.stream = MagicMock(side_effect=lambda *a, **kw: _stream())
+        provider.approve_tool = AsyncMock()
+        provider.reject_tool = AsyncMock()
+
+        ctx = MagicMock()
+        ctx.build_message = MagicMock(return_value=("msg", None))
+        # ALLOW (not auto-approve): the approval must come from the
+        # parent_policy grant, not the hook shortcut.
+        ctx.hooks.on_tool_call = MagicMock(return_value=ToolHookResult.allow())
+
+        manager = SubagentManager(sessions=sessions, ctx_builder=ctx, default_turn_limit=1)
+        info = SubagentInfo(id="idmcp01", task="t", parent_session_key="dashboard:default")
+        manager._agents["idmcp01"] = info
+        return manager, info, provider
+
+    @staticmethod
+    def _child_mcp_event(**overrides):
+        from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+
+        base: dict = dict(
+            kind=EVENT_PERMISSION_REQUEST,
+            title="@example-server/get-item",
+            request_id=7001,
+            sub_session_id="child-a",
+            shell_classified=True,
+            is_shell=False,
+            mcp_server_name="example-server",
+            tool_name="get-item",
+        )
+        base.update(overrides)
+        return LLMEvent(**base)
+
+    @pytest.mark.asyncio
+    async def test_identity_trusted_child_approved_under_parent_policy_auto(self) -> None:
+        event = self._child_mcp_event()
+        assert event.child_low_fidelity and event.child_mcp_identity_trusted
+        manager, info, provider = self._manager_and_stream(event)
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
+            "kiro_crew.subagent.update_state"
+        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+            await manager._run_inner(info, "subagent:idmcp01")
+
+        provider.approve_tool.assert_awaited_once_with(7001)
+        provider.reject_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_identity_missing_child_still_fails_closed(self) -> None:
+        """Counterfactual: same grant, same event shape, identity caches
+        missed — the request must NOT be auto-approved (headless: rejected)."""
+        event = self._child_mcp_event(mcp_server_name="", tool_name="")
+        assert event.child_low_fidelity and not event.child_mcp_identity_trusted
+        manager, info, provider = self._manager_and_stream(event)
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
+            "kiro_crew.subagent.update_state"
+        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+            await manager._run_inner(info, "subagent:idmcp01")
+
+        provider.approve_tool.assert_not_awaited()
+        provider.reject_tool.assert_awaited_once_with(7001)
+
+    @pytest.mark.asyncio
+    async def test_identity_trusted_child_without_auto_policy_not_approved(self) -> None:
+        """Identity verification is not itself a grant: with no auto policy
+        (and no interactive approver) the event stays fail-closed."""
+        event = self._child_mcp_event()
+        manager, info, provider = self._manager_and_stream(event)
+        manager._sessions.get_approval_policy = MagicMock(return_value="")
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"), patch(
+            "kiro_crew.subagent.update_state"
+        ), patch("kiro_crew.subagent.create_agent_folder", MagicMock(), create=True):
+            await manager._run_inner(info, "subagent:idmcp01")
+
+        provider.approve_tool.assert_not_awaited()
+        provider.reject_tool.assert_awaited_once_with(7001)
+
+
 class TestChildEscalationLimit:
     """Child-origin permission escalations get their own volume bound, and the
     bail must ANSWER the triggering request before tombstoning — a return

--- a/test/test_unattended_slot_guardrails.py
+++ b/test/test_unattended_slot_guardrails.py
@@ -866,9 +866,11 @@ class TestScopedGrantIsNeverPersisted:
         src = inspect.getsource(chat_runner._run_chat)
         assert "slot_trusted = _slot_is_trusted(slot)" in src
         # The trust/YOLO gate still branches on _slot_is_trusted's verdict; the
-        # low-fidelity qualifier only excludes backend-subagent events whose
-        # command bytes never reached the caches (see chat_runner).
-        assert "if (slot_trusted or yolo_active) and not _child_low_fidelity:" in src
+        # grant-eligibility qualifier only excludes backend-subagent events
+        # whose command bytes never reached the caches AND whose canonical MCP
+        # identity did not resolve either (see chat_runner — a verified
+        # identity keeps the unconditional grant honored).
+        assert "if (slot_trusted or yolo_active) and _child_grant_eligible:" in src
 
     def test_the_runner_writes_the_policy_through_the_helper(self) -> None:
         """Pins the call site, not just the helper.


### PR DESCRIPTION
## Summary

Closes #6163 — every tool call a backend subagent makes to a **remote (HTTP) MCP server** was presented as an interactive approval even under session trust-all, making trusted read-only fan-outs (~100 `get-item` calls = ~100 manual approvals) unusable.

**Root cause** (as traced in the issue): a remote MCP server's `tool_call` frame legitimately streams empty/absent `rawInput`, so the `raw_params_cache` write in `acp/_dispatch.py` is skipped and every such child permission event is `child_low_fidelity=True` — which gated **every** auto-approve path. But `child_low_fidelity` conflates two independent provenances: the tool's **identity** and its **arguments**. The same frame's `_meta.kiro` server/tool identity DID reach the caches and is canonical, non-model-authored.

## The fix: split identity provenance from argument provenance

New `AcpEvent.child_mcp_identity_trusted` — True when the canonical `mcp_server_name`/`tool_name` pair resolved from the tool_call cache on a **resolved non-shell** child event (each requirement fail-closed on its own cache miss).

The decision rule for consumers:

- **Unconditional grants** — paths whose approve decision consumes **no agent-authored event data** — honor the grant for identity-verified events: session trust-all + global YOLO + native-crew auto (`chat_runner.py`), `parent_policy=auto` (`subagent.py`), per-source auto-approve, `--approval yolo`, the YOLO override, and parent-slot trust (`slack/gateway.py` background router). Arguments remain unverified, but these grants never read them — and the interactive card these events previously fell to is equally argument-blind, so the split changes **who** approves, not what any gate can scan.
- **Content-matching paths stay fail-closed on the composite fidelity**: trusted patterns, trust-reads, title-keyed `auto_approve_tools`, `--approval reads` — for those the agent-authored title/params ARE the matched input, and a forged title must never satisfy them.
- **Shell events never qualify**: their deny gates (sensitive-path, deny-globs) need the command bytes the event lacks; `is_shell=False` only counts when `shell_classified` proves it, since a cache miss defaults to non-shell.

Also fixes the logging gap the issue calls out: the annotate-and-prompt downgrade path was fully silent; it now logs the child id, identity-verification state, and which disposition applied.

## What was verified

- New dispatch-level test drives the real `parse_session_update` + `build_permission_event` with empty and absent `rawInput` (the issue's repro scenarios B/C): low fidelity with verified identity survives the pipeline.
- Property unit tests: each requirement individually fail-closed (parent event, unclassified shell, resolved shell, missing server, missing tool).
- Behavioral tests per surface: gateway router (auto-approve source / yolo mode / yolo override / slot trust approve identity-verified children without a prompt; `reads` still prompts; identity-less and shell children stay blocked), subagent `parent_policy=auto` (approved with identity, rejected without, rejected without any grant).
- Source-pin tests (`test_unattended_slot_guardrails`, `test_promise_only_autoapprove_parity`) updated to the new condition shape.
- Local gates: targeted pytest (700+ tests across the affected files), isort, flake8, mypy (1115 files clean), black on non-baseline touched files, docs-lint, brand gate, harness-parity gate, subprocess-encoding gate.

## Scope notes

- `session_handle.py`'s fidelity-unaware consumer floor is untouched: an unaware consumer still auto-rejects every low-fidelity child event, identity-verified or not.
- #6009's canonical durable-trust rules are untouched: argument presence still disables canonical non-shell pattern grantability/matching.
- The issue's direction 1 (restore argument provenance from the backend) remains open upstream; treating a streamed empty `rawInput` as trusted-empty would be wrong (absence of streamed args does not prove the call has none) and would poison #6009's canonical matching.

Specs updated in the same commit: `security.md` (child-fidelity split), `subagent.md` (approval cascade carve-out), `acp-client.md` (remote-MCP rawInput behavior).
