### PR TITLE
refactor(ops-mission-control): use exported internal_path_matches in test

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py
@@ -17,6 +17,7 @@ pins:
 import unittest
 
 from kiro_crew.dashboard.server import _MIXED_INTERNAL_API_PATHS
+from kiro_crew.dashboard.token_auth import internal_path_matches
 from kiro_crew.validation import (
     OPS_MISSION_CONTROL_ALLOWED_CALLS,
     OPS_MISSION_CONTROL_API_SCHEMA,
@@ -137,8 +138,7 @@ class TestGatewayAdmission(unittest.TestCase):
 
     @staticmethod
     def _admitted(path: str, mixed) -> bool:
-        # Mirrors token_auth.middleware's matcher: exact or prefix.
-        return any(path == p or path.startswith(p + "/") for p in mixed)
+        return internal_path_matches(path, mixed)
 
     def test_every_allowlisted_call_is_admitted(self):
         """A pair the schema allows but the gateway 403s is a broken tool."""


### PR DESCRIPTION
## Problem / Motivation

PR #4273 exported `internal_path_matches()` from `src/kiro_crew/dashboard/token_auth.py` and replaced hand-mirrored copies of the exact-or-prefix internal path matching logic in the middleware and `test/test_mcp_call_site_auth_coverage.py`. However, `TestGatewayAdmission._admitted()` in `src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py` still contained a hand-written copy of this predicate (`any(path == p or path.startswith(p + "/") for p in mixed)`).

## Why it matters

Hand-mirroring the internal path matcher creates a drift surface where changes to the middleware's matching semantics could leave this admission test silently asserting stale semantics.

## What changed (motivation → approach → change)

- Imported the exported `internal_path_matches()` helper from `kiro_crew.dashboard.token_auth`.
- Updated `TestGatewayAdmission._admitted()` in `src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py` to directly call `internal_path_matches(path, mixed)` instead of hand-mirroring the logic.

## Tests

- Ran `pytest src/kiro_crew/apps/builtins/ops_mission_control/tests/test_agent_api_tool.py` — all 12 tests passed.
- Verified formatting and linting with `black`, `isort`, and `flake8`.

## Manual verification

N/A — test-only refactor replacing a hand-written mirror with the canonical exported helper; verified via existing unit test suite.

## Related Issues

Fixes #6191

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
