### PR TITLE
fix(conductor): reach the verbosity setting, patrol with monitor_start not wait

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4415,18 +4415,32 @@ Shell access exists solely to run the `goal-conductor` skill's bundled scripts
 for the durable ledger item-entry format); acceptance is the evaluator's
 deterministic verdict, never your reading of a child session's transcript.
 
+**Patrol with `monitor_start`, never with `wait`.** A round of child work runs
+for tens of minutes, so an in-turn `wait` + re-poll loop spends the turn's whole
+budget on latency and dies mid-round at the turn cap — losing the loop, not the
+work. `monitor_start` re-injects the round into THIS session as a fresh turn, so
+every round gets its own budget and the loop survives a tab close or a gateway
+restart. Arm it with the full cycle instructions AND the exit condition, then
+END THE TURN, and call `autonudge_stop` when you stop. A successful arm can only
+ever come back as *requested* — arming happens after this turn ends — so treat
+that as success and do NOT retry it or fall back on it. Only a synchronous
+refusal (no dashboard/Slack/Discord session to host a loop) means no loop is
+running: say so, and only then drive the round with an in-turn `wait` loop.
+
 Your session-control tools are DEFERRED: `session_create`, `session_send`,
-`session_read_message`, `session_stop`, `chat_folder_*`, `session_ledger_*` and
-`monitor_start` are not in your tool list until you load them with
-`tool_search(tool_id="<server>::<name>")`. A first direct call failing with "a
-tool with the name ... does not exist" means DEFERRED, not missing — load it and
-repeat the call. That is what `tool_search` is mounted for.
+`session_read_message`, `session_stop`, `chat_folder_*`, `session_ledger_*`,
+`monitor_start` and `autonudge_stop` are not in your tool list until you load
+them with `tool_search(tool_id="<server>::<name>")`. A first direct call
+failing with "a tool with the name ... does not exist" means DEFERRED, not
+missing — load it and repeat the call. That is what `tool_search` is mounted for.
 
 The `goal-conductor` skill carries the full operating procedure — the work-item
 tests, the dispatch steps, the patrol loop, the stop conditions. Read it
 before acting on a goal. The user can message you at any time; apply goal
 changes at the round boundary, except a message that directly invalidates an
 in-flight item, which you handle immediately.
+
+{{VERBOSITY_BLOCK}}
 """
 
 

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -63,6 +63,34 @@ class TestConductorInstaller:
         assert data["name"] == "kirocrew-conductor"
         assert "work item" in data["prompt"]
 
+    def test_prompt_carries_the_verbosity_placeholder(self, tmp_path, monkeypatch):
+        """The conductor is a custom agent, so it gets its OWN prompt.
+
+        ``build_message`` reads a custom agent's prompt from its spec instead of
+        ``config/prompt.md``, and ``_resolve_prompt_templates`` only expands the
+        token where it appears. Without the token here the user's
+        ``dashboard.verbosity`` setting silently never reaches this agent, so
+        every conductor turn answers at ``default`` length no matter what the
+        person picked. Pinned, not commented, because the omission is invisible.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        assert "{{VERBOSITY_BLOCK}}" in data["prompt"]
+
+    def test_prompt_drives_patrol_with_monitor_start_not_wait(self, tmp_path, monkeypatch):
+        """A patrol round outlives a turn, so the loop must own the turn boundary.
+
+        An in-turn ``wait`` + re-poll loop spends the turn budget on latency and
+        dies at the turn cap mid-round, which loses the loop. Both halves of the
+        contract are pinned: ``monitor_start`` drives the round, and the
+        conductor knows the tool it needs to stop the loop it armed. Whitespace
+        is normalised so re-wrapping the prompt cannot fail this for a
+        formatting reason.
+        """
+        data = self._install(tmp_path, monkeypatch)
+        prompt = " ".join(data["prompt"].split())
+        assert "Patrol with `monitor_start`, never with `wait`" in prompt
+        assert "autonudge_stop" in prompt
+
     def test_no_write_tool_and_shell_not_preapproved(self, tmp_path, monkeypatch):
         """The security properties of the spec, in one place.
 


### PR DESCRIPTION
Two gaps in the same file, both in `_CONDUCTOR_SYSTEM_PROMPT`.

## 1. `dashboard.verbosity` never reached the conductor

Set it to `answer_only` and a conductor session still answers at `default` length.

`build_message` picks the prompt by agent identity (`src/kiro_crew/context.py:2636`): a custom agent gets its own prompt via `_load_agent_prompt`, not `config/prompt.md`. `_resolve_prompt_templates` then runs on it (`:2647`), but it only expands `{{VERBOSITY_BLOCK}}` where the token appears — and the token only lived in `config/prompt.md:194`. For `kirocrew-conductor` the replace was a no-op, so the whole verbosity block was dropped silently.

Measured on a real conductor session (`Conductor Mode Long Task Reliability`, verbosity set to `answer_only`): 23 assistant messages / 15181 chars, of which 21 were between-tool narration averaging 306 chars, and the final answer was 4941 chars with 4 headers and 8 bullets — exactly the shape `answer_only` forbids.

Fix: add the token to the conductor prompt. No new mechanism; the existing resolver does the rest, and at `default` it expands to an empty string.

Scoped to the conductor deliberately. `kirocrew-research`, `kirocrew-knowledge`, `kirocrew-heartbeat` and `config/prompt-orchestrator.md` have the same gap, but those are non-interactive workers whose output length is not a user-facing setting. The conductor is the one a person reads and replies to.

## 2. Patrol had no turn-boundary contract, so it used `wait`

The prompt named `monitor_start` only in the deferred-tools list and never said to patrol with it. A round of child work runs for tens of minutes, so an in-turn `wait` + re-poll loop spends the turn's whole budget on latency and dies at the turn cap mid-round — losing the loop, not the work.

Fix: state the contract in the prompt, mirroring what the `prepare-pr` skill already does (`builtin_skills/kirocrew-dev/prepare-pr/SKILL.md:179`, `:272`) — `monitor_start` is the driver, `wait` is the no-arm fallback only. Carried over from that same wording: a successful arm can only ever come back as *requested* (arming happens after the turn ends), so that acknowledgement is the success signal and must not trigger a retry or the fallback; only a synchronous refusal means no loop is running. `autonudge_stop` is named in the same breath and added to the deferred list, since the prompt now tells the conductor to call it.

The `goal-conductor` skill already prescribed `monitor_start` for patrol (`SKILL.md:152`) — this closes the gap between the skill and the spec that reaches the model first.

## Verification

- `test/test_conductor_agent.py` 31 passed, `test/test_verbosity_config.py` clean.
- Revert-verify on the verbosity guard: removing the token makes it fail (exit 1), restoring makes it pass — the assertion is load-bearing.
- The patrol guard normalises whitespace before matching, so re-wrapping the prompt cannot fail it for a formatting reason.
- black / flake8 / isort clean on both touched files.

Takes effect for a running install once `_install_conductor_agent` rewrites `~/.kiro/agents/kirocrew-conductor.json` on next gateway start.
