### PR TITLE
fix(reaper): report the leaked agent runtime no sweep can see

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -1458,6 +1458,113 @@ def _is_sweepable_orphan_work(pid: int, cmdline: bytes, age_seconds: float) -> b
     return _env_has_kirocrew_marker(pid)
 
 
+# PIDs already reported by the untracked-runtime detector, so a persisting
+# orphan costs ONE log line rather than one line per sweep. Replaced wholesale
+# at the end of each scan with the set still detected, which bounds the set by
+# the live orphan count and re-arms the report if the PID disappears and a
+# later process reappears under the same detection.
+_reported_untracked_agent_pids: set[int] = set()
+
+
+# Per tracking file, the index of the colon-field naming the process a reaper
+# actually TERMINATES for that entry. Only that field counts as tracked: the
+# other one names the OWNER whose death makes the entry reapable
+# (``_sweep_pid_entries`` skips a session entry while its gateway lives;
+# ``_cleanup_orphaned_mcp_servers`` kills the child once its parent is gone), and
+# an owner is never reclaimed *through* the entry that names it. Counting an
+# owner field would let a stale entry whose owner has died and had its PID
+# recycled silently suppress a genuine leak report — exactly the silence issue
+# #2930 is about. A bare line names its own process, whichever file it is in.
+_REAPABLE_PID_FIELD: tuple[tuple[str, int], ...] = (
+    ("session", 1),  # kiro_session_pids.txt: <gateway_pid>:<child_pid>[:start-id]
+    ("child", 0),  # kiro_pids.txt: <child_pid>:<parent_pid>
+)
+
+
+def _tracked_agent_pids() -> set[int]:
+    """PIDs a reaper can terminate, per both tracking files.
+
+    Both files are read because a runtime absent from BOTH is exactly what
+    :func:`_is_untracked_managed_agent_orphan` reports, and each reaper keys off
+    only one of them. Within a line only the reapable field counts — see
+    :data:`_REAPABLE_PID_FIELD` for which, and why the owner field does not. A
+    session entry's third field is a start-time identity, numeric on Linux, and
+    is never read as a PID.
+
+    Deliberately read WITHOUT either file lock. Readers cannot tear: rewrites
+    go through :func:`_rewrite_pid_file` (temp file + rename, so a reader sees
+    either the whole old or the whole new content) and tracking appends are
+    single short lines. Locking here would put a lock acquisition inside the
+    sweep's per-scan path for a purely diagnostic read. Any read failure yields
+    the entries found so far — the detector is report-only, so the worst
+    outcome is one spurious or one missing log line, never a kill.
+    """
+    tracked: set[int] = set()
+    paths = (_session_pid_file_path(), _pid_file_path())
+    for path, (_label, reapable_index) in zip(paths, _REAPABLE_PID_FIELD):
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            continue  # absent or unreadable — nothing this file can claim
+        for line in raw.split():
+            fields = line.split(":")
+            index = 0 if len(fields) == 1 else reapable_index
+            if index >= len(fields):
+                continue  # truncated entry — no reapable field to read
+            try:
+                value = int(fields[index])
+            except ValueError:
+                continue  # malformed or partially-appended line
+            if value > 0:
+                tracked.add(value)
+    return tracked
+
+
+def _is_untracked_managed_agent_orphan(pid: int, cmdline: bytes, tracked_pids: set[int]) -> bool:
+    """REPORT-ONLY: a managed agent runtime that no reaper can reach.
+
+    Every existing reaper declines this process, which is why a leaked runtime
+    has no reproduction:
+
+    * :func:`cleanup_orphaned_sessions` and :func:`_periodic_pid_sweep` iterate
+      ``kiro_session_pids.txt`` and cannot see a PID the file never recorded.
+    * :func:`_is_sweepable_orphan_mcp` declines it — a runtime argv is not an
+      MCP entrypoint.
+    * :func:`_is_sweepable_orphan_work` NEGATIVE-gates
+      :data:`_MANAGED_AGENT_MARKERS` (runtimes are owned by their tracked-PID
+      lifecycle, not by the marker sweep) and separately requires a test-runner
+      argv.
+
+    Positive identity is the conjunction of: reparenting to init/``systemd
+    --user`` — guaranteed by the caller, which only iterates
+    :func:`_our_orphan_pids`, so ownership is not re-derived here — an argv0
+    basename naming a managed runtime (:data:`_MANAGED_AGENT_MARKERS`), the
+    ``KIROCREW_SPAWNED`` environ marker (:func:`_env_has_kirocrew_marker`,
+    Linux-only and fail-closed elsewhere), and absence from BOTH PID files
+    (:func:`_tracked_agent_pids`). Peer gateways and CLIs
+    (:data:`_GATEWAY_MARKERS`) are excluded: they are not agent runtimes and
+    are never tracked as such.
+
+    This grants NO kill authority and is wired to nothing that terminates — a
+    hit only logs. Blast radius is therefore zero, which is what makes the
+    detector safe to ship ahead of a maintainer's ruling on whether an
+    untracked runtime may be reaped at all. It also means a cross-data-home
+    false positive (a second install's live runtime, tracked in ITS config dir
+    and so absent from ours) is diagnostic noise rather than a wrong kill.
+    """
+    if not cmdline:
+        return False  # kernel thread / zombie — no argv to identify
+    normalized = cmdline.replace(b"\x00", b" ")
+    if any(marker in normalized for marker in _GATEWAY_MARKERS):
+        return False
+    basename = _work_orphan_basename(cmdline)
+    if not any(marker.encode() in basename for marker in _MANAGED_AGENT_MARKERS):
+        return False
+    if pid in tracked_pids:
+        return False  # a reaper can already reach it
+    return _env_has_kirocrew_marker(pid)
+
+
 def _work_orphan_session_leader_alive(pid: int) -> bool:
     """True when *pid*'s session LEADER still exists as a session leader.
 
@@ -1492,12 +1599,25 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
 
     Returns candidate PIDs. Caller should re-verify against fresh active PIDs
     before killing (two-phase pattern to eliminate races).
+
+    Also REPORTS — never returns as a candidate — any untracked managed-agent
+    runtime orphan (:func:`_is_untracked_managed_agent_orphan`). That class is
+    unreachable by every reaper, so it would otherwise leak silently with no
+    reproduction; the report deliberately carries no kill authority, which is
+    why such a PID is excluded from ``candidates``.
     """
     candidates: list[int] = []
     my_pid = os.getpid()
     now = time.time()
 
-    for pid in _our_orphan_pids():
+    orphan_pids = _our_orphan_pids()
+    # Read once per scan, not per PID: the files are small but the scan is not.
+    # Empty on Windows and on any run with no orphans, so the diagnostic read is
+    # skipped entirely in the common case.
+    tracked_pids = _tracked_agent_pids() if orphan_pids else set()
+    untracked_seen: set[int] = set()
+
+    for pid in orphan_pids:
         if pid == my_pid or pid in active_pids:
             continue
         try:
@@ -1535,6 +1655,26 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
             continue
         if pid_age < _ORPHAN_MIN_AGE_SECONDS:
             continue
+        # Report-only arm. Placed AFTER the age gate so a runtime whose tracking
+        # append has not landed yet is never reported: the gate is orders of
+        # magnitude wider than the spawn-to-append window. Reported PIDs are
+        # deliberately NOT appended to ``candidates`` — this arm has no kill
+        # authority (see the predicate's docstring).
+        if _is_untracked_managed_agent_orphan(pid, cmdline, tracked_pids):
+            untracked_seen.add(pid)
+            if pid not in _reported_untracked_agent_pids:
+                # %r, not %s: argv0 is set by the process itself, so a newline
+                # in it would forge whole log lines in gateway.log and through
+                # /api/logs. repr escapes control characters.
+                logger.error(
+                    "Leaked agent runtime pid=%s (argv0 %r, age %.0fs): reparented "
+                    "to init/systemd with a KIROCREW_SPAWNED environ marker but "
+                    "recorded in NEITHER PID file, so no reaper can reclaim it. "
+                    "Not terminated — report only.",
+                    pid,
+                    _work_orphan_basename(cmdline).decode("utf-8", "replace"),
+                    pid_age,
+                )
         if not (
             _is_sweepable_orphan_mcp(pid, cmdline)
             or _is_sweepable_orphan_gatewayd(cmdline)
@@ -1542,6 +1682,11 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
         ):
             continue
         candidates.append(pid)
+
+    # Keep only what is still detected, so a persisting orphan stays deduped
+    # while a vanished PID re-arms the report for a future process.
+    _reported_untracked_agent_pids.clear()
+    _reported_untracked_agent_pids.update(untracked_seen)
 
     return candidates
 

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import sys
 from collections import deque
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -2365,3 +2366,386 @@ class TestPidFileRewriteIsAtomic:
             "mid-write silently drops entries and leaks their runtimes until "
             "the host reboots."
         )
+
+
+# ── Untracked managed-agent runtime orphan (REPORT-ONLY, issue #2930) ──
+
+
+@pytest.fixture()
+def reset_untracked_report_dedup() -> Iterator[None]:
+    """Clear the module-level report dedup set around each test.
+
+    The detector keeps reported PIDs in module state so a persisting orphan is
+    logged once rather than once per sweep tick; leaking that between tests
+    would make assertions order-dependent.
+    """
+    import kiro_crew.session_pid as sp
+
+    sp._reported_untracked_agent_pids.clear()
+    yield
+    sp._reported_untracked_agent_pids.clear()
+
+
+def _agent_cmdline(argv0: str = "/opt/kiro/bin/kiro-cli") -> bytes:
+    """A managed agent runtime cmdline in Linux /proc (NUL-separated) form."""
+    return b"\x00".join([argv0.encode(), b"chat", b"--no-interactive"])
+
+
+class TestTrackedAgentPids:
+    """_tracked_agent_pids unions the PIDs both tracking files claim."""
+
+    def test_no_files_yields_empty_set(self, pid_file: Path, session_pid_file: Path) -> None:
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        assert _tracked_agent_pids() == set()
+
+    def test_session_entry_collects_child_not_gateway_or_identity_field(
+        self, pid_file: Path, session_pid_file: Path
+    ) -> None:
+        """Only the child is reapable through a session entry.
+
+        The gateway field names the OWNER whose death makes the entry sweepable,
+        never a process reclaimed through it, and the third field is a
+        start-time identity (numeric on Linux). Counting either would let a
+        stale entry suppress a genuine report.
+        """
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        session_pid_file.write_text("4100:4200:987654321\n", encoding="utf-8")
+
+        assert _tracked_agent_pids() == {4200}
+
+    def test_child_parent_entry_collects_child_not_parent(
+        self, pid_file: Path, session_pid_file: Path
+    ) -> None:
+        """``_cleanup_orphaned_mcp_servers`` kills the child, not the parent."""
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        pid_file.write_text("5100:5200\n", encoding="utf-8")
+
+        assert _tracked_agent_pids() == {5100}
+
+    def test_bare_line_names_its_own_process_in_either_file(
+        self, pid_file: Path, session_pid_file: Path
+    ) -> None:
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        session_pid_file.write_text("5300\n", encoding="utf-8")
+        pid_file.write_text("5400\n", encoding="utf-8")
+
+        assert _tracked_agent_pids() == {5300, 5400}
+
+    def test_both_files_union(self, pid_file: Path, session_pid_file: Path) -> None:
+        """Each file contributes its own reapable field, at its own index."""
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        session_pid_file.write_text("10:11\n", encoding="utf-8")
+        pid_file.write_text("20:21\n", encoding="utf-8")
+
+        assert _tracked_agent_pids() == {11, 20}
+
+    def test_malformed_and_non_positive_fields_are_skipped(
+        self, pid_file: Path, session_pid_file: Path
+    ) -> None:
+        """A partially-appended or hand-edited line must not raise."""
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        session_pid_file.write_text("garbage\n0:-3\n:\n77:78\n", encoding="utf-8")
+
+        assert _tracked_agent_pids() == {78}
+
+    def test_unreadable_file_is_tolerated(self, pid_file: Path, session_pid_file: Path) -> None:
+        """Report-only: an OSError costs a log line at worst, never a raise."""
+        from kiro_crew.session_pid import _tracked_agent_pids
+
+        pid_file.write_text("31:32\n", encoding="utf-8")
+        with patch.object(Path, "read_text", side_effect=OSError("boom")):
+            assert _tracked_agent_pids() == set()
+
+
+class TestIsUntrackedManagedAgentOrphan:
+    """Positive identity for the report-only detector."""
+
+    def test_untracked_marked_runtime_is_detected(self) -> None:
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_untracked_managed_agent_orphan(900, _agent_cmdline(), set()) is True
+
+    def test_tracked_runtime_is_not_detected(self) -> None:
+        """A PID either file claims is already reachable by a reaper."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_untracked_managed_agent_orphan(900, _agent_cmdline(), {900}) is False
+
+    def test_unmarked_process_is_not_detected(self) -> None:
+        """A user's own kiro-cli (no environ marker) is never reported."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=False):
+            assert _is_untracked_managed_agent_orphan(901, _agent_cmdline(), set()) is False
+
+    def test_claude_runtime_basename_also_detected(self) -> None:
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert (
+                _is_untracked_managed_agent_orphan(
+                    902, _agent_cmdline("/usr/local/bin/claude"), set()
+                )
+                is True
+            )
+
+    def test_peer_gateway_is_not_detected(self) -> None:
+        """A gateway/CLI entrypoint is not an agent runtime."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        cmdline = b"kiro-cli\x00-m\x00kiro_crew.mcp_gateway.gatewayd"
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_untracked_managed_agent_orphan(903, cmdline, set()) is False
+
+    def test_non_runtime_basename_is_not_detected(self) -> None:
+        """A marked pytest orphan belongs to the work sweep, not this arm."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        cmdline = b"/venv/bin/pytest\x00-x"
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_untracked_managed_agent_orphan(904, cmdline, set()) is False
+
+    def test_empty_cmdline_is_not_detected(self) -> None:
+        """Kernel thread / zombie — no argv to identify."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_untracked_managed_agent_orphan(905, b"", set()) is False
+
+    def test_no_environ_read_when_shape_already_declines(self) -> None:
+        """Cheap gates run first — the /proc environ read is the last resort."""
+        from kiro_crew.session_pid import _is_untracked_managed_agent_orphan
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker") as mock_env:
+            assert (
+                _is_untracked_managed_agent_orphan(906, b"/venv/bin/pytest\x00-x", set()) is False
+            )
+        mock_env.assert_not_called()
+
+
+class TestUntrackedRuntimeReportIntegration:
+    """find_orphan_mcp_candidates reports the orphan and terminates nothing."""
+
+    def test_reports_at_error_and_never_returns_as_candidate(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The regression this fixes: the leak was previously silent.
+
+        Every existing reaper declines an untracked runtime, so before this arm
+        the sweep produced no candidate AND no diagnostic. The report must
+        appear, and the PID must stay out of ``candidates`` — this arm has no
+        kill authority.
+        """
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4242]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []  # report-only: nothing handed to the kill phase
+        records = [r for r in caplog.records if "4242" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        message = records[0].getMessage()
+        assert "kiro-cli" in message
+        assert "NEITHER PID file" in message
+        assert "report only" in message
+
+    def test_argv0_control_characters_cannot_forge_log_lines(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """argv0 is set by the process itself, so it is untrusted input.
+
+        A newline in it would otherwise forge whole lines in gateway.log and
+        through /api/logs, which read as if the gateway had emitted them.
+        """
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        hostile = b"\x00".join([b"/tmp/kiro-cli\nERROR forged line", b"chat"])
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4848]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=hostile),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        records = [r for r in caplog.records if "4848" in r.getMessage()]
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "\n" not in message  # the whole report stays one line
+        assert "\\nERROR forged line" in message  # escaped, not interpreted
+
+    def test_report_is_logged_once_across_repeated_sweeps(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A persisting orphan must not re-log on every sweep tick."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4343]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            find_orphan_mcp_candidates(active_pids=set())
+            find_orphan_mcp_candidates(active_pids=set())
+            find_orphan_mcp_candidates(active_pids=set())
+
+        assert len([r for r in caplog.records if "4343" in r.getMessage()]) == 1
+
+    def test_vanished_pid_re_arms_the_report(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dedup state is scoped to PIDs still detected, so it cannot grow."""
+        import kiro_crew.session_pid as sp
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            with patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4444]):
+                find_orphan_mcp_candidates(active_pids=set())
+            with patch("kiro_crew.session_pid._our_orphan_pids", return_value=[]):
+                find_orphan_mcp_candidates(active_pids=set())
+                assert sp._reported_untracked_agent_pids == set()
+            with patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4444]):
+                find_orphan_mcp_candidates(active_pids=set())
+
+        assert len([r for r in caplog.records if "4444" in r.getMessage()]) == 2
+
+    def test_tracked_runtime_is_not_reported(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A runtime the session file records is reachable — no diagnostic."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        session_pid_file.write_text("7:4545:99999\n", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4545]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        assert [r for r in caplog.records if "4545" in r.getMessage()] == []
+
+    def test_recycled_owner_pid_does_not_suppress_the_report(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A stale entry's OWNER field must not shadow a real leak.
+
+        The gateway field of a session entry and the parent field of a
+        child entry name processes no reaper terminates through that entry.
+        Once such an owner has died and its PID has been recycled into a leaked
+        runtime, treating the field as tracked would return the sweep to the
+        exact silence issue #2930 reports.
+        """
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        # 4747 appears only as a dead gateway (session) and a dead parent (child).
+        session_pid_file.write_text("4747:11:99999\n", encoding="utf-8")
+        pid_file.write_text("12:4747\n", encoding="utf-8")
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4747]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=3600.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []  # still report-only
+        assert len([r for r in caplog.records if "4747" in r.getMessage()]) == 1
+
+    def test_young_orphan_is_not_reported(
+        self,
+        pid_file: Path,
+        session_pid_file: Path,
+        reset_untracked_report_dedup: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Below the age floor the tracking append may simply not have landed."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[4646]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=_agent_cmdline()),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=5.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            caplog.at_level(logging.ERROR, logger="kiro_crew.session_pid"),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+        assert [r for r in caplog.records if "4646" in r.getMessage()] == []


### PR DESCRIPTION
## Problem

Issue #2930 asks whether an agent runtime can survive every reaper. It can, and that is why the leaks in that issue have no reproduction — nothing anywhere records that the process exists.

Walking the reaper inventory in `src/kiro_crew/session_pid.py`, with the ownership signal each one keys off:

| Reaper | Keys off | Verdict on an untracked runtime |
| --- | --- | --- |
| `cleanup_orphaned_sessions` | `kiro_session_pids.txt` | declines — absent from the file |
| `_periodic_pid_sweep` | same file | declines — returns early when the file does not exist |
| `_is_sweepable_orphan_mcp` | cmdline fingerprint | declines — a runtime argv is not an MCP entrypoint |
| `_is_sweepable_orphan_work` | marker + argv shape | declines — negative-gates `_MANAGED_AGENT_MARKERS` **and** separately requires a test-runner argv |

`_our_orphan_pids` genuinely *sees* the process (our uid, reparented to init/`systemd --user`), but both of its consumers decline it. So a managed-agent runtime that never made it into a PID file survives until the host reboots, silently.

## Change

One report-only arm. `_is_untracked_managed_agent_orphan`, added beside `_is_sweepable_orphan_work`, identifies that class by the conjunction of:

- reparenting to init/`systemd --user` — guaranteed by the caller, which only iterates `_our_orphan_pids`, so ownership is not re-derived;
- an argv0 basename naming a managed runtime (`_MANAGED_AGENT_MARKERS`);
- the `KIROCREW_SPAWNED` environ marker (`_env_has_kirocrew_marker`, Linux-only and fail-closed elsewhere);
- absence from **both** PID files (`_tracked_agent_pids`).

Peer gateways and CLIs (`_GATEWAY_MARKERS`) are excluded — they are not agent runtimes and are never tracked as such. On a hit, `find_orphan_mcp_candidates` logs one line at ERROR. That is all it does.

**Blast radius is zero.** This arm has no kill authority and is wired to nothing that terminates: the reported PID is deliberately *not* appended to `candidates`, so the kill phase never sees it. A cross-data-home false positive — a second install's live runtime, tracked in ITS config dir and therefore absent from ours — is diagnostic noise, not a wrong kill. That is what makes the detector safe to ship ahead of a maintainer's ruling.

Two details worth reviewing:

- The report sits **after** the existing `_ORPHAN_MIN_AGE_SECONDS` gate, so a runtime whose tracking append has not landed yet is never reported. The gate is orders of magnitude wider than the spawn-to-append window.
- Dedup uses a module-level set replaced wholesale at the end of each scan with the PIDs still detected. A persisting orphan therefore costs one line rather than one line per sweep tick, the set stays bounded by the live orphan count, and a vanished PID re-arms the report for a future process.

`_tracked_agent_pids` reads both files without their locks. Readers cannot tear — rewrites go through `_rewrite_pid_file` (temp file + rename) and tracking appends are single short lines — and locking would put a lock acquisition inside the sweep's scan path for a purely diagnostic read. Any read failure yields the entries found so far; the worst outcome is one spurious or one missing log line.

## Deliberately out of scope

- **No kill/terminate authority for this arm.** Whether an untracked runtime may be reaped at all is a blast-radius decision for a maintainer, not something to smuggle in behind a diagnostic.
- **The `cli_doctor.py` hook.** The issue thread suggests surfacing the count in `kirocrew doctor`. Left out on purpose: PR #5272 is editing that file right now, and this change has no reason to collide with it. It is a clean follow-up once #5272 lands.
- **The owning-data-home env stamp.** Would tighten the cross-data-home false positive, but is a tracking-format change and does not belong in a report-only arm.
- **The other two causes named in the issue are already fixed on main and are not touched** — `acp/runtime.py` already shields the PID and logs a failed append at ERROR (#2985), and `acp/client.py` already kills on `BaseException` in the spawn window (#6085).
- **Draft PR #6083's predicates are untouched.** It reaps detached `playwright-cli` daemons in the same file, a different scope (browser daemons, not agent runtimes).

## Tests

20 new cases in `test/test_pid_lifecycle.py`. Note this is not `test_session_pid_sig.py`, which covers the HMAC signing module — `test_pid_lifecycle.py` is the module that already owns `find_orphan_mcp_candidates`, `_env_has_kirocrew_marker` and the marked-launcher sweep coverage, so the new predicate belongs with its neighbours.

Coverage: the tracked-PID union (both file formats, bare PIDs, the start-time identity field that must **not** be read as a PID, malformed lines, unreadable file), the predicate's positive and every negative gate (tracked, unmarked, peer gateway, non-runtime basename, empty cmdline, and that the `/proc` environ read is not reached when a cheap gate already declines), and the integration behaviour through `find_orphan_mcp_candidates` (reports at ERROR, never returns a candidate, logs once across repeated sweeps, re-arms after the PID vanishes, silent for a tracked runtime, silent below the age floor).

**Red-before was verified against a pristine base worktree at `97b8378bd`**, both ways:

- as missing symbols — 14 failed, 5 errors;
- and behaviourally, which is the part that matters. Same orphan, same mocks, on base vs this branch:

```
base   candidates: []   log lines mentioning the pid: 0
branch candidates: []   log lines mentioning the pid: 1
       ERROR Leaked agent runtime pid=4242 (kiro-cli, age 3600s): reparented to
       init/systemd with a KIROCREW_SPAWNED environ marker but recorded in
       NEITHER PID file, so no reaper can reclaim it. Not terminated — report only.
```

`candidates` is empty on both sides — the arm adds a diagnostic, not a kill.

Local: `test_pid_lifecycle.py` 150 passed; `test_pid_sweep_helpers.py` + `test_session_pid_sig.py` + `test_spawn_audit.py` + `test_gatewayd_self_exit.py` + `test_mcp_cron_orphan_validation.py` + `test_sandbox_launcher_sweep.py` 152 passed; `test_session.py` 268 passed. isort, flake8 and the baselined black gate clean. The one mypy error in `test_pid_lifecycle.py` (`client._buffer = bytearray()`) is pre-existing — it reproduces identically on the base worktree.

Refs #2930
