### PR TITLE
fix(mcp): one owner for the refused-request replay rule

### DIFF
--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -107,11 +107,10 @@ from kiro_crew.computer_use.types import (
 )
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_core import (
-    _api_base,
     _http_error_body,
     _internal_secret,
-    _invalidate_api_base,
-    _resolve_api_port,
+    _replay_target,
+    _resolve_api_target,
     _resolve_session_key_strict,
     _session_key_header_error,
 )
@@ -728,42 +727,45 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
         "X-Session-Key": session_key,
     }
 
-    def _send_once(base: str):
+    def _send_once(target: tuple[str, str]):
+        base, socket_path = target
         request = urllib.request.Request(
             f"{base}{INVOKE_PATH}", data=body, headers=headers, method="POST"
         )
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_api_base(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never agent-controlled  # noqa: E501
-        with loopback_urlopen(request, timeout=INVOKE_TIMEOUT_SECS) as response:
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_resolve_api_target(): 127.0.0.1 plus a port from config/env or a run-marker whose ownership is re-verified per request) + a fixed internal path; never agent-controlled  # noqa: E501
+        with loopback_urlopen(
+            request, timeout=INVOKE_TIMEOUT_SECS, unix_socket_path=socket_path or None
+        ) as response:
             return json.loads(response.read())
 
-    api_base = _api_base()
+    # ONE resolution for this attempt, both transports derived from it — the
+    # unix socket lets the gateway kernel-verify this process against the
+    # session key it declares, and pairing it with the base from the SAME
+    # resolution keeps the two from naming different gateways.
+    target = _resolve_api_target()
     try:
-        decoded = _send_once(api_base)
+        decoded = _send_once(target)
     except urllib.error.HTTPError as exc:
         return _http_error_body(exc)
     except urllib.error.URLError as exc:
         detail = str(exc.reason) if isinstance(exc.reason, OSError) else str(exc)
         # The resolved base can predate the gateway: its port is recorded only in
-        # the run marker, so a refusal is worth one re-resolution before giving up.
+        # the run marker, so a refusal is worth one re-resolution before giving
+        # up. Whether that replay is ALLOWED is not restated here — it is
+        # mcp_core._replay_target's rule, shared with mcp_core._send, and None
+        # means do not replay. The wording of the refusal stays this shim's own.
         if isinstance(exc.reason, (ConnectionRefusedError, socket.gaierror)):
-            _invalidate_api_base()
-            retry_port, retry_source = _resolve_api_port()
-            # A default-source fall-through carries NO evidence: a listener on
-            # the default port could be any local process, and replaying would
-            # hand it the internal secret. Replay only chases positive
-            # evidence of a moved gateway. Same rule as mcp_core._send.
-            retry_base = f"http://127.0.0.1:{retry_port}"
-            if retry_source != "default" and retry_base != api_base:
-                try:
-                    decoded = _send_once(retry_base)
-                except urllib.error.HTTPError as retry_exc:
-                    # The replay REACHED the (moved) gateway and it answered with
-                    # a normal HTTP error — surface the structured body exactly
-                    # like a first-attempt HTTPError, not a stale "unreachable".
-                    return _http_error_body(retry_exc)
-                except Exception:
-                    return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
-            else:
+            retry_target = _replay_target(target[0])
+            if retry_target is None:
+                return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
+            try:
+                decoded = _send_once(retry_target)
+            except urllib.error.HTTPError as retry_exc:
+                # The replay REACHED the (moved) gateway and it answered with
+                # a normal HTTP error — surface the structured body exactly
+                # like a first-attempt HTTPError, not a stale "unreachable".
+                return _http_error_body(retry_exc)
+            except Exception:
                 return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}
         else:
             return {"error": ERR_GATEWAY_UNREACHABLE.format(detail=detail)}

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -301,6 +301,46 @@ def _invalidate_api_base() -> None:
     _API_UNIX_SOCKET = None
 
 
+def _replay_target(refused_base: str) -> tuple[str, str] | None:
+    """The fresh ``(base, socket_path)`` to replay a refused request to, or ``None``.
+
+    THE replay rule, owned here. A refused connection usually means the resolved
+    base is stale — the gateway came up, or moved, after this tool server booted,
+    and the new port is recorded only in the run marker — so one re-resolution
+    and one replay are worth it. Two conditions end the attempt instead, and both
+    answer ``None``:
+
+    * the re-resolution fell through to the DEFAULT port, which is no evidence at
+      all. A listener there could be any local process, and the request carries
+      the internal secret; the replay exists to chase POSITIVE evidence of a
+      moved gateway, so a no-evidence fall-through never gets to dial.
+    * the re-resolution named the base that was just refused. Replaying an
+      unchanged dead port only doubles the caller's latency to reach the
+      identical failure, and nothing was handed to a live gateway — so the
+      caller's first-attempt error stands as a definite rejection.
+
+    Both halves of the returned pair come from the very resolution whose source
+    was checked (same shape as :func:`_resolve_api_target`): re-resolving again
+    could race a marker disappearing between the check and the dial, and
+    deriving the socket separately let the replay's two transports name
+    different gateways. It is always a FRESH pair, never the refused one — the
+    ownership proof is per attempt.
+
+    Callers keep their own error wording; this owns only the rule, so the two
+    request paths (:func:`_send` and ``mcp_computer._invoke``) cannot drift on
+    when a replay is allowed. ``None`` means "do not replay", not "report this
+    particular text".
+    """
+    _invalidate_api_base()
+    port, source = _resolve_api_port()
+    if source == "default":
+        return None
+    base = f"http://127.0.0.1:{port}"
+    if base == refused_base:
+        return None
+    return base, _socket_path_for(port)
+
+
 # How often a sleeping `wait` polls /api/session-keepalive.
 #
 # Two jobs in one round-trip: keeping the session's activity clock warm (the
@@ -1113,26 +1153,13 @@ def _send(
     except urllib.error.URLError as e:
         if not isinstance(e.reason, (ConnectionRefusedError, socket.gaierror)):
             return _transport_failure(str(e), mark_transport_error)
-        _invalidate_api_base()
-        retry_port, retry_source = _resolve_api_port()
-        if retry_source == "default":
-            # Re-resolution produced NO evidence — the default port is an
-            # unverified guess, and a listener there could be any local
-            # process. Replaying would hand it the internal secret and the
-            # request payload; the replay exists to chase POSITIVE evidence
-            # of a moved gateway, so a no-evidence fall-through ends here.
-            return {"error": str(e)}
-        # Build BOTH halves from the very resolution whose source was just
-        # checked (same shape as _resolve_api_target) — re-resolving again
-        # could race a marker disappearing between the check and the dial, and
-        # deriving the socket separately let the replay's two transports name
-        # different gateways. This is a FRESH pair, never the refused one: the
-        # ownership proof is per attempt.
-        retry_target = (f"http://127.0.0.1:{retry_port}", _socket_path_for(retry_port))
-        retry_base = retry_target[0]
-        if retry_base == base:
-            # Nothing was ever handed to a live gateway, so this is a definite
-            # rejection: no transport ambiguity to report.
+        # THE replay rule lives in _replay_target, shared with
+        # mcp_computer._invoke: None means "do not replay" (no evidence, or the
+        # re-resolution named the same dead base). Nothing was handed to a live
+        # gateway in either case, so the first-attempt refusal stands as a
+        # definite rejection — no transport ambiguity to report.
+        retry_target = _replay_target(base)
+        if retry_target is None:
             return {"error": str(e)}
         try:
             return _once(retry_target)

--- a/test/test_mcp_api_base_resolution.py
+++ b/test/test_mcp_api_base_resolution.py
@@ -256,7 +256,16 @@ def test_http_error_on_replay_surfaces_the_backend_body(mcp: Any, monkeypatch) -
 
 
 class TestMcpComputerReplay:
-    """``mcp_computer._invoke`` — the same refused-once-replay rule."""
+    """``mcp_computer._invoke`` — the same refused-once-replay rule, now SHARED.
+
+    #4106 item 2: this shim used to restate the rule (invalidate, re-resolve,
+    check the source, compare the base) in its own words, and restating it is
+    how it silently missed item 1 — it hand-built a ``retry_base`` with no
+    socket half at all. It now consumes ``mcp_core._replay_target``, so the
+    cases below script the rule at ITS seam (``_resolve_api_port`` on
+    ``mcp_core``) and assert this shim's error wording is unchanged: a
+    de-duplication of the rule must not normalise the two callers' messages.
+    """
 
     @pytest.fixture
     def computer(self, mcp: Any, monkeypatch) -> Any:
@@ -264,10 +273,26 @@ class TestMcpComputerReplay:
         monkeypatch.setattr(module, "_internal_secret", lambda: "s")
         return module
 
+    @staticmethod
+    def _first_target(monkeypatch: pytest.MonkeyPatch, computer: Any, base: str) -> None:
+        """Script the pair this shim resolves for its FIRST attempt."""
+        monkeypatch.setattr(computer, "_resolve_api_target", lambda: (base, ""))
+
+    @staticmethod
+    def _unreachable(computer: Any, out: dict) -> bool:
+        """This shim's own refusal wording, which the shared rule must not touch.
+
+        Compared against the module's own constant rather than a copy of its
+        text: the assertion is "still ITS message", so a reworded constant
+        should keep passing while a message borrowed from ``mcp_core`` fails.
+        """
+        prefix = computer.ERR_GATEWAY_UNREACHABLE.split("{detail}")[0]
+        return str(out.get("error", "")).startswith(prefix)
+
     def test_refusal_rediscovers_and_replays(self, computer: Any, mcp: Any, monkeypatch) -> None:
         urls: list[str] = []
-        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
-        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+        self._first_target(monkeypatch, computer, "http://127.0.0.1:5476")
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
         def fake_open(req, timeout=None, unix_socket_path=None):
             urls.append(req.full_url)
@@ -280,10 +305,12 @@ class TestMcpComputerReplay:
         assert out == {"text": "done"}
         assert len(urls) == 2
 
-    def test_refusal_with_unchanged_base_is_reported(self, computer: Any, monkeypatch) -> None:
+    def test_refusal_with_unchanged_base_is_reported(
+        self, computer: Any, mcp: Any, monkeypatch
+    ) -> None:
         attempts: list[str] = []
-        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:7788")
-        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+        self._first_target(monkeypatch, computer, "http://127.0.0.1:7788")
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
         def fake_open(req, timeout=None, unix_socket_path=None):
             attempts.append(req.full_url)
@@ -291,17 +318,18 @@ class TestMcpComputerReplay:
 
         monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
         out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
-        assert "error" in out
+        assert self._unreachable(computer, out), out
         assert len(attempts) == 1
 
     def test_no_replay_when_rediscovery_falls_through_to_default(
-        self, computer: Any, monkeypatch
+        self, computer: Any, mcp: Any, monkeypatch
     ) -> None:
-        """Same no-evidence rule as mcp_core._send: an unverified default-port
-        listener must never receive the replayed secret-bearing request."""
+        """Same no-evidence rule as mcp_core._send — because it is now literally
+        the same code: an unverified default-port listener must never receive the
+        replayed secret-bearing request."""
         attempts: list[str] = []
-        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:9999")
-        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (5476, "default"))
+        self._first_target(monkeypatch, computer, "http://127.0.0.1:9999")
+        _retry_resolution(monkeypatch, mcp, 5476, "default")
 
         def fake_open(req, timeout=None, unix_socket_path=None):
             attempts.append(req.full_url)
@@ -309,18 +337,69 @@ class TestMcpComputerReplay:
 
         monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
         out = computer._invoke("dashboard:chat-1", "computer_get_state", {})
-        assert "error" in out
+        assert self._unreachable(computer, out), out
         assert len(attempts) == 1  # nothing was sent to the unverified default port
 
+    def test_the_attempt_pairs_its_unix_socket_with_its_base(
+        self, computer: Any, mcp: Any, monkeypatch
+    ) -> None:
+        """The gap restating the rule hid: this shim dialled TCP only.
+
+        ``loopback_urlopen`` PREFERS the unix socket, and that socket is what
+        lets the gateway kernel-verify (``SO_PEERCRED`` + /proc ancestry) that
+        this process really owns the session key it declares. Passing no socket
+        path meant every computer-use call fell back to TCP and the
+        header-on-faith path — for the one tool family whose whole point is that
+        the gateway evaluates and audits it. Consuming the shared resolution
+        fixes it for free, so it is pinned here.
+        """
+        seen: list[str] = []
+        monkeypatch.setattr(mcp, "_API", "http://127.0.0.1:7788")
+        monkeypatch.setattr(mcp, "_API_UNIX_SOCKET", "/tmp/seeded-7788.sock")
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            seen.append(str(unix_socket_path or ""))
+            return _Resp(b'{"text": "done"}')
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        assert computer._invoke("dashboard:chat-1", "computer_get_state", {}) == {"text": "done"}
+        assert seen == ["/tmp/seeded-7788.sock"], f"the attempt dialled TCP only: {seen}"
+
+    def test_the_replay_pairs_a_fresh_socket_with_the_re_resolved_base(
+        self, computer: Any, mcp: Any, monkeypatch
+    ) -> None:
+        """And the replay must be paired too, from ONE fresh resolution.
+
+        The hand-built ``retry_base`` carried no socket half, so even a shim that
+        paired its first attempt would have dropped to TCP exactly when the
+        gateway had just moved. The shared owner derives both halves from the
+        resolution whose source it checked.
+        """
+        seen: list[tuple[str, str]] = []
+        self._first_target(monkeypatch, computer, "http://127.0.0.1:5476")
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
+
+        def fake_open(req, timeout=None, unix_socket_path=None):
+            seen.append((req.full_url, str(unix_socket_path or "")))
+            if ":5476" in req.full_url:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            return _Resp(b'{"text": "done"}')
+
+        monkeypatch.setattr(computer, "loopback_urlopen", fake_open)
+        assert computer._invoke("dashboard:chat-1", "computer_get_state", {}) == {"text": "done"}
+        (_, _), (url, sock) = seen
+        assert ":7788" in url
+        assert "7788" in sock and "5476" not in sock, f"replay dialled {url} with socket {sock!r}"
+
     def test_http_error_on_replay_surfaces_the_backend_body(
-        self, computer: Any, monkeypatch
+        self, computer: Any, mcp: Any, monkeypatch
     ) -> None:
         """A 4xx from the reached moved gateway must decode like a first-attempt
         4xx, not collapse into a stale 'gateway unreachable: refused'."""
         import io
 
-        monkeypatch.setattr(computer, "_api_base", lambda: "http://127.0.0.1:5476")
-        monkeypatch.setattr(computer, "_resolve_api_port", lambda: (7788, "marker"))
+        self._first_target(monkeypatch, computer, "http://127.0.0.1:5476")
+        _retry_resolution(monkeypatch, mcp, 7788, "marker")
 
         def fake_open(req, timeout=None, unix_socket_path=None):
             if ":5476" in req.full_url:

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -2255,8 +2255,13 @@ class TestTheInvokeCallIsNeverProxied:
             for key in self.PROXY_ENV_KEYS:
                 monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
+            # Paired resolution (#4106): an attempt threads (base, socket_path).
+            # The empty socket keeps this case on TCP, which is what the proxy
+            # question is about.
             monkeypatch.setattr(
-                mcp_computer, "_api_base", lambda: f"http://127.0.0.1:{gateway_port}"
+                mcp_computer,
+                "_resolve_api_target",
+                lambda: (f"http://127.0.0.1:{gateway_port}", ""),
             )
             monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
 
@@ -2289,8 +2294,13 @@ class TestTheInvokeCallIsNeverProxied:
                 monkeypatch.delenv(key, raising=False)
             monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
             monkeypatch.setenv("no_proxy", "localhost")
+            # Paired resolution (#4106): an attempt threads (base, socket_path).
+            # The empty socket keeps this case on TCP, which is what the proxy
+            # question is about.
             monkeypatch.setattr(
-                mcp_computer, "_api_base", lambda: f"http://127.0.0.1:{gateway_port}"
+                mcp_computer,
+                "_resolve_api_target",
+                lambda: (f"http://127.0.0.1:{gateway_port}", ""),
             )
             monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
 


### PR DESCRIPTION
## What

Closes #4106 — **part 2 only**: one owner for the refused-request replay rule.

`mcp_computer._invoke` restated the rule instead of sharing it. It imported
`_invalidate_api_base` + `_resolve_api_port` from `mcp_core` and re-spelled the
whole *invalidate → re-resolve → check the source → compare the base → replay*
block, including a hand-built `retry_base` of its own.

This PR extracts `mcp_core._replay_target(refused_base) -> tuple[str, str] | None`
as the single owner of that rule and has **both** `_send` and
`mcp_computer._invoke` consume it. `None` means "do not replay" and covers both
no-replay cases:

- the re-resolution fell through to the **default** port — no evidence of a moved
  gateway, and the request carries the internal secret, so it never gets dialled;
- the re-resolution named the **base just refused** — replaying an unchanged dead
  port only doubles latency to the identical failure.

Otherwise it returns a **fresh** `(base, socket_path)` pair, both halves derived
from the one resolution whose source was checked (so the check and the dial
cannot race, and the two transports cannot name different gateways).

## De-duplication, not normalisation

Each caller keeps its **own** error wording — the shared helper owns the *rule*,
not the *message*:

- `mcp_computer._invoke` still emits `ERR_GATEWAY_UNREACHABLE` exactly as before
  (asserted in the tests, not just claimed);
- `_send` still returns the first-attempt error text, with its
  `transport_error` ambiguity flag and its `HTTPError`-on-replay decoding
  unchanged.

## Intended behaviour improvement (called out deliberately)

Consuming the shared owner also gives `_invoke` the **socket-paired resolution it
was missing** — on the first attempt *and* on the replay. Because it re-spelled
the rule, it also missed part 1's fix: it called `loopback_urlopen` with no
`unix_socket_path` at all, so every computer-use call fell back to TCP and the
header-on-faith identity path, for the one tool family whose entire premise is
that the gateway evaluates and audits it. The unix socket is what lets the
gateway kernel-verify (`SO_PEERCRED` + `/proc` ancestry) that the process really
owns the session key it declares.

This is in scope because it *falls out of* sharing the rule rather than being a
separate behaviour change — and it is covered by a test proven red before the
fix (`the attempt dialled TCP only: ['']`).

## Scope

- **Part 1** (single-resolution request pair) — already landed in #4504 / #4537.
  Untouched.
- **Part 3** (migrate direct senders) — **deliberately deferred**. Two of three
  are done (`mcp_tools/artifacts.py`). The third, `mcp_tools/browser.py:253`,
  still sends directly and is intentionally NOT touched here: its contract
  returns `(status, body)` where a `None` status means "no native panel", which
  `_send`'s `{"error": ...}` dict cannot express. Migrating it needs an
  error-contract decision (keep the tuple behind a wrapper, or fold it into
  `_send`) that has not been made, and making that call silently inside a
  de-duplication PR would be the wrong place for it.

Diff kept narrow (no opportunistic tidying of surrounding code) so a rebase
against #5184, which also reaches `mcp_core.py` for an unrelated purpose, stays
cheap.

## Tests

Extended the existing computer-replay cases in
`test/test_mcp_api_base_resolution.py` (`TestMcpComputerReplay`) rather than
adding a parallel set; they now script the rule at *its* seam and assert the
shim's wording is unchanged. Two new cases pin the pairing:

- `test_the_attempt_pairs_its_unix_socket_with_its_base` — **red before**:
  `AssertionError: the attempt dialled TCP only: ['']`
- `test_the_replay_pairs_a_fresh_socket_with_the_re_resolved_base`

`test/test_mcp_computer.py`'s two proxy-leak tests were moved onto the paired
resolver (they patched `_api_base`, which this shim no longer imports).
`test/test_mcp_browser_tool.py` left alone — part 3 is out of scope.

Local: `test_mcp_api_base_resolution.py` + `test_mcp_computer.py` +
`test_mcp_browser_tool.py` → 212 passed. `mcp_core` / `mcp_api_port_resolution` /
`dashboard_peer_auth` / `loopback_proxy` / `mcp_call_site_auth_coverage` /
`mcp_caller` → 362 passed. isort, flake8, mypy clean on the four files; black's
only complaint on `mcp_core.py` is a pre-existing hunk at line ~1262 that fails
identically on the base commit (py314 target parsed by py312).
