### PR TITLE
refactor: migrate inline owner-denial sequences to shared helper

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1312,
+    "missing_code": 1310,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1285,
+  "_compliant": 1294,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -40,7 +40,7 @@
       "missing_code": 17
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 65
+      "missing_code": 64
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 7
@@ -105,7 +105,7 @@
     },
     "dashboard/handlers/mcp_apps.py": {
       "dynamic_status": 1,
-      "missing_code": 12
+      "missing_code": 11
     },
     "dashboard/handlers/mcp_custom.py": {
       "missing_code": 18

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -71,9 +71,9 @@ from kiro_crew.apps.builtins.aws_control.backend import library as library_mod
 from kiro_crew.apps.builtins.aws_control.backend import shares as shares_mod
 from kiro_crew.apps.builtins.aws_control.backend import storage as storage_mod
 from kiro_crew.apps.manager import is_app_enabled
+from kiro_crew.dashboard.handlers._shared import _owner_denial_response
 from kiro_crew.dashboard.handlers.source_providers import (
     is_owner_dashboard_request,
-    stale_owner_session_response,
 )
 from kiro_crew.deploy import profiles as deploy_profiles
 from kiro_crew.deploy.engine import AWSError
@@ -206,10 +206,10 @@ def _guarded(handler: Handler) -> Handler:
                 "denied",
                 error=f"non-owner caller (app={request.get('app') or ''})",
             )
-            stale = stale_owner_session_response(request)
-            if stale is not None:
-                return stale
-            return _forbidden("dashboard owner required", "dashboard_owner_required")
+            # Stale-session relabel + 403 via the shared helper's tail pattern.
+            return _owner_denial_response(
+                request, "dashboard owner required", "dashboard_owner_required"
+            )
         return await handler(request)
 
     return _wrapped

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -4821,12 +4821,15 @@ def deny_non_dashboard_caller(request: web.Request, operation: str) -> web.Respo
     # Imported here, not at module scope: source_providers imports chat state
     # helpers, so a top-level import would close a cycle (same pattern as
     # api_chat_slots' owner-only check-status gate above).
-    from kiro_crew.dashboard.handlers.source_providers import (
-        is_owner_dashboard_request,
-        stale_owner_session_response,
-    )
+    from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+    from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 
     if not is_owner_dashboard_request(request):
+        # Domain-specific audit kept here rather than delegated to
+        # ``require_owner_dashboard_request``: this record carries its own
+        # ``error`` reason and no ``resources``, and the ``sel`` it reaches is
+        # this module's, which is what the coverage tests patch. Only the denial
+        # TAIL (stale-session relabel + 403) is shared.
         try:
             sel().log_api_access(
                 caller=str(request.get("user") or "anonymous"),
@@ -4839,10 +4842,7 @@ def deny_non_dashboard_caller(request: web.Request, operation: str) -> web.Respo
             logger.debug("SEL audit failed for %s denial", operation, exc_info=True)
         # Deny decision made above; only the response label changes for a
         # signed pre-owner bootstrap subject (see stale_owner_session_response).
-        stale = stale_owner_session_response(request)
-        if stale is not None:
-            return stale
-        return web.json_response({"error": "forbidden"}, status=403)
+        return _owner_denial_response(request, "forbidden")
     return None
 
 

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -1821,6 +1821,84 @@ def _read_memory_mode(path: "Path") -> str | None:
     return normalized
 
 
+async def require_owner_dashboard_request(
+    request: web.Request, operation: str
+) -> web.Response | None:
+    """Owner gate shared across dashboard handler modules.
+
+    Returns ``None`` when the caller IS the dashboard owner, allowing the
+    request to proceed.  Otherwise audits the denial via SEL (off-thread so a
+    first-process SEL construction cannot stall the event loop), checks for
+    a stale pre-owner bootstrap subject (relabelling the denial to a 401), and
+    falls back to a 403 with the standard ``owner_only`` code.
+
+    Imports ``is_owner_dashboard_request`` and ``stale_owner_session_response``
+    inside the function body to avoid a circular import: ``source_providers``
+    imports chat-state helpers that reach back into sibling handler modules.
+    """
+    import asyncio
+
+    from kiro_crew.dashboard.handlers.source_providers import (
+        is_owner_dashboard_request,
+    )
+
+    if is_owner_dashboard_request(request):
+        return None
+
+    # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
+    # creation, key validation, on Windows an icacls subprocess), so on a fresh
+    # gateway whose first mutating request is non-owner this would stall every
+    # other request.
+    caller = str(request.get("user") or "unknown")
+    try:
+        from kiro_crew.sel import sel as _sel
+
+        await asyncio.to_thread(
+            lambda: _sel().log_api_access(
+                caller=caller,
+                operation=operation,
+                outcome="denied",
+                source="dashboard",
+                resources="non_owner_block",
+            )
+        )
+    except Exception:  # pragma: no cover - audit must never change the outcome
+        logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)
+
+    # Deny decision made above; only the response label changes for a signed
+    # pre-owner bootstrap subject (see stale_owner_session_response).
+    return _owner_denial_response(request)
+
+
+def _owner_denial_response(
+    request: web.Request,
+    error_message: str = "owner authorization required",
+    error_code: str = "owner_only",
+) -> web.Response:
+    """Stale-session relabel + 403 denial -- the tail of every owner gate.
+
+    Synchronous: ``stale_owner_session_response`` is a pure predicate over
+    request attributes, so no I/O is involved.  Domain-specific wrappers that
+    perform their own SEL/audit logging before reaching the denial response can
+    call this directly instead of going through the full async
+    ``require_owner_dashboard_request`` helper.
+
+    Imports ``stale_owner_session_response`` inside the function body to avoid
+    a circular import (same reason as the async helper above).
+    """
+    from kiro_crew.dashboard.handlers.source_providers import (
+        stale_owner_session_response,
+    )
+
+    stale = stale_owner_session_response(request)
+    if stale is not None:
+        return stale
+    return web.json_response(
+        {"error": error_message, "code": error_code},
+        status=403,
+    )
+
+
 def _probe_persisted_session(slot_name: str) -> tuple[bool, str | None]:
     """``(file_exists, memory_mode_or_None)`` for *slot_name*.
 

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -61,10 +61,6 @@ from kiro_crew.dashboard.handlers._shared import (
     apply_skill_mapping,
 )
 from kiro_crew.dashboard.handlers.discover import _redact_external
-from kiro_crew.dashboard.handlers.source_providers import (
-    is_owner_dashboard_request,
-    stale_owner_session_response,
-)
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import discovery_executor, maintenance_executor, subprocess_executor
@@ -139,34 +135,9 @@ async def _require_owner(request: web.Request, operation: str) -> web.Response |
     never from a client-set header. Returns the 403 to send, or ``None`` when
     the caller is the owner.
     """
-    if is_owner_dashboard_request(request):
-        return None
-    # Off the loop: the FIRST sel() of a process CONSTRUCTS the log — trust-dir
-    # creation, key validation, and on Windows the owner-only DACL — so on a
-    # fresh gateway whose first mutating request is non-owner this would stall
-    # every other request. Same reasoning as connections._audit_started.
-    caller = str(request.get("user") or "unknown")
-    try:
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller=caller,
-                operation=operation,
-                outcome="denied",
-                source="dashboard",
-                resources="non_owner_block",
-            )
-        )
-    except Exception:  # pragma: no cover — audit must never change the outcome
-        logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)
-    # Deny decision made above; only the response label changes for a signed
-    # pre-owner bootstrap subject (see stale_owner_session_response).
-    stale = stale_owner_session_response(request)
-    if stale is not None:
-        return stale
-    return web.json_response(
-        {"error": "owner authorization required", "code": "owner_only"},
-        status=403,
-    )
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    return await require_owner_dashboard_request(request, operation)
 
 
 # ── Agent Config ──

--- a/src/kiro_crew/dashboard/handlers/ask_question.py
+++ b/src/kiro_crew/dashboard/handlers/ask_question.py
@@ -25,10 +25,7 @@ import uuid
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
-from kiro_crew.dashboard.handlers.source_providers import (
-    is_owner_dashboard_request,
-    stale_owner_session_response,
-)
+from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.sel import sel
 from kiro_crew.validation import (
@@ -115,8 +112,15 @@ def _deny_non_owner(request: web.Request, operation: str) -> web.Response | None
     is configured. That matches the identity the ``ask_question`` MCP tool
     itself carries, since its token is minted as ``owner_id or "local-app"``.
     """
+    from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+
     if is_owner_dashboard_request(request):
         return None
+    # Domain-specific audit kept here rather than delegated to
+    # ``require_owner_dashboard_request``: this record carries the endpoint as
+    # ``resources`` plus an ``error`` reason, which the shared helper's generic
+    # ``non_owner_block`` record does not. Only the denial TAIL (stale-session
+    # relabel + 403) is shared -- see ``_owner_denial_response``.
     try:
         sel().log_api_access(
             caller=str(request.get("user") or "anonymous"),
@@ -130,10 +134,7 @@ def _deny_non_owner(request: web.Request, operation: str) -> web.Response | None
         logger.warning("SEL audit failed for non-owner denial", exc_info=True)
     # Deny decision made above; only the response label changes for a signed
     # pre-owner bootstrap subject (see stale_owner_session_response).
-    stale = stale_owner_session_response(request)
-    if stale is not None:
-        return stale
-    return web.json_response({"error": "forbidden", "code": "owner_only"}, status=403)
+    return _owner_denial_response(request, "forbidden", "owner_only")
 
 
 async def api_ask_question(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers/aws_consent.py
+++ b/src/kiro_crew/dashboard/handlers/aws_consent.py
@@ -30,9 +30,9 @@ import logging
 from aiohttp import web
 
 from kiro_crew import aws_consent
+from kiro_crew.dashboard.handlers._shared import _owner_denial_response
 from kiro_crew.dashboard.handlers.source_providers import (
     is_owner_dashboard_request,
-    stale_owner_session_response,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,12 +83,7 @@ def _deny_non_owner(request: web.Request, operation: str) -> web.Response | None
     )
     # Deny decision made above; only the response label changes for a signed
     # pre-owner bootstrap subject (see stale_owner_session_response).
-    stale = stale_owner_session_response(request)
-    if stale is not None:
-        return stale
-    return web.json_response(
-        {"error": "dashboard owner required", "code": _CODE_OWNER_REQUIRED}, status=403
-    )
+    return _owner_denial_response(request, "dashboard owner required", _CODE_OWNER_REQUIRED)
 
 
 def _requested_service(request: web.Request) -> str | None:

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -157,6 +157,11 @@ def _approval_superseded(error: str, code: str) -> web.Response:
 
 async def api_mcp_oauth_relay(request: web.Request) -> web.Response:
     """POST /api/mcp/oauth/relay — deliver a failed browser redirect locally."""
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    owner_denied = await require_owner_dashboard_request(request, "mcp_oauth_relay")
+    if owner_denied is not None:
+        return owner_denied
     try:
         body = await request.json()
     except Exception:
@@ -291,6 +296,11 @@ async def api_connections_mint(request: web.Request) -> web.Response:
     Returns as soon as the mint is scheduled. The URL is not ready yet: the
     caller polls :func:`api_connections_mint_state` for it.
     """
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    owner_denied = await require_owner_dashboard_request(request, "connections_mint")
+    if owner_denied is not None:
+        return owner_denied
     parsed = await _mint_request(request)
     if isinstance(parsed, web.Response):
         return parsed
@@ -409,6 +419,11 @@ async def api_connections_cancel(request: web.Request) -> web.Response:
     keeps the working connection. Idempotent -- cancelling a provider with no
     live mint answers ``dropped=false``.
     """
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    owner_denied = await require_owner_dashboard_request(request, "connections_cancel")
+    if owner_denied is not None:
+        return owner_denied
     parsed = await _mint_request(request)
     if isinstance(parsed, web.Response):
         return parsed

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -3460,6 +3460,17 @@ async def api_dashboard_config(request: web.Request) -> web.Response:
     """GET/PUT /api/dashboard/config — read or write dashboard settings."""
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
 
+    # Owner gate for PUT: reject non-owner writes before paying the config-load
+    # I/O cost. The check is cheap (in-memory predicate + optional off-thread
+    # SEL audit on denial) compared to the KiroCrewConfig.load() thread hop
+    # below, so non-owner PUT requests are rejected immediately.
+    if request.method == "PUT":
+        from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+        owner_denied = await require_owner_dashboard_request(request, "dashboard_config.write")
+        if owner_denied is not None:
+            return owner_denied
+
     # Offloaded: KiroCrewConfig.load() stats, reads, parses, and validates config
     # files. The client polls this endpoint on an interval to pick up externally
     # edited dashboard.gitlab_hosts, so a slow or network-backed config directory

--- a/src/kiro_crew/dashboard/handlers/mcp_apps.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_apps.py
@@ -26,10 +26,6 @@ from aiohttp import web
 from kiro_crew import security
 from kiro_crew.dashboard.chat_utils import _history_key_for, effective_session_key
 from kiro_crew.dashboard.handlers._shared import _is_restricted_session, _read_session_key
-from kiro_crew.dashboard.handlers.source_providers import (
-    is_owner_dashboard_request,
-    stale_owner_session_response,
-)
 from kiro_crew.mcp_apps_render import load_spool
 from kiro_crew.mcp_gateway import transport
 from kiro_crew.mcp_gateway.rewriter import default_socket_path
@@ -134,21 +130,11 @@ async def api_mcp_apps_call(request: web.Request) -> web.Response:
     # `request["app"]`), not from any client-set header. App tokens and
     # non-owner subjects are refused — an embedded app's capability must only
     # ever be exercised by the owner's own dashboard.
-    if not is_owner_dashboard_request(request):
-        try:
-            SecurityEventLog().log_api_access(
-                caller=str(request.get("user") or "unknown"),
-                operation="mcp-apps.call", outcome="denied",
-                source="dashboard", resources="non_owner_block",
-            )
-        except Exception:  # pragma: no cover
-            logger.debug("SEL audit for non-owner mcp-apps call failed", exc_info=True)
-        # Deny decision made above; only the response label changes for a
-        # signed pre-owner bootstrap subject (see stale_owner_session_response).
-        stale = stale_owner_session_response(request)
-        if stale is not None:
-            return stale
-        return web.json_response({"error": "owner authorization required"}, status=403)
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    owner_denied = await require_owner_dashboard_request(request, "mcp-apps.call")
+    if owner_denied is not None:
+        return owner_denied
 
     # Ephemeral gate: incognito/guest sessions must not be able to drive
     # tool execution through a (leaked or shoulder-surfed) spool id — the

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -2785,9 +2785,9 @@ def _deny_non_owner_browser_request(request: web.Request, operation: str) -> web
     """
     # Deferred import: source_providers imports chat state helpers from this
     # module's sibling, so a top-level import would close a cycle.
+    from kiro_crew.dashboard.handlers._shared import _owner_denial_response
     from kiro_crew.dashboard.handlers.source_providers import (
         is_owner_dashboard_request,
-        stale_owner_session_response,
     )
 
     if is_owner_dashboard_request(request):
@@ -2824,13 +2824,7 @@ def _deny_non_owner_browser_request(request: web.Request, operation: str) -> web
     )
     # Deny decision made above; only the response label changes for a signed
     # pre-owner bootstrap subject (see stale_owner_session_response).
-    stale = stale_owner_session_response(request)
-    if stale is not None:
-        return stale
-    return web.json_response(
-        {"error": "dashboard user required", "code": "dashboard_user_required"},
-        status=403,
-    )
+    return _owner_denial_response(request, "dashboard user required", "dashboard_user_required")
 
 
 async def api_browser_token_put(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers_cloud.py
+++ b/src/kiro_crew/dashboard/handlers_cloud.py
@@ -33,9 +33,9 @@ from kiro_crew.cloud import source as source_mod
 from kiro_crew.cloud import ssm
 from kiro_crew.cloud.aws import AWSError, CloudActionDenied
 from kiro_crew.cloud.launch_engine import RealLaunchEngine
+from kiro_crew.dashboard.handlers._shared import _owner_denial_response
 from kiro_crew.dashboard.handlers.source_providers import (
     is_owner_dashboard_request,
-    stale_owner_session_response,
 )
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.sel import sel
@@ -81,32 +81,14 @@ def _guard(request: web.Request, operation: str) -> Optional[web.Response]:
             },
             status=401,
         )
-    # Denying app tokens alone was not enough. token_auth also mints a dashboard
-    # session token for every *allowed Slack user* (`!dashboard`), and that token
-    # carries request["user"] with an EMPTY request["app"] — so the old
-    # `if request.get("app")` check cleared it, admitting a non-owner human to a
-    # control plane that creates, stops and terminates billable AWS resources on the
-    # OWNER's account. "Owner-only" means the human whose dashboard this is: match the
-    # configured owner via the one shared predicate (`is_owner_dashboard_request` —
-    # exact owner_id match, or a signed local bootstrap subject when no owner is
-    # configured), the same definition ask_question and the source-provider routes
-    # use. This also subsumes the app-token case (an app identity is non-empty, so the
-    # predicate returns False), and it does NOT lock out a genuine single-owner setup:
-    # with no owner configured, the owner's own local token still matches.
+    # Owner gate: delegated to the shared helper's predicate + stale relabel.
     if not is_owner_dashboard_request(request):
         _audit(operation, "denied", error="non-owner rejected")
-        # Deny decision made above; only the response label changes for a
-        # signed pre-owner bootstrap subject (see stale_owner_session_response).
-        stale = stale_owner_session_response(request)
-        if stale is not None:
-            return stale
-        return web.json_response(
-            {
-                "error": "cloud provisioning is owner-only (the dashboard owner, "
-                "not an app or an allowed Slack user)",
-                "code": "cloud_owner_only",
-            },
-            status=403,
+        return _owner_denial_response(
+            request,
+            "cloud provisioning is owner-only (the dashboard owner, "
+            "not an app or an allowed Slack user)",
+            "cloud_owner_only",
         )
     if sys.platform.startswith("win"):
         _audit(operation, "denied", error="windows unsupported")

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -705,22 +705,21 @@ async def api_instances_search_sessions(request: web.Request) -> web.Response:
     # so it requires the positively-identified OWNER: not an app token, and not
     # a Slack user who minted a dashboard token via `!dashboard` (app == "" but
     # a non-owner subject).
-    from kiro_crew.dashboard.handlers.source_providers import (
-        is_owner_dashboard_request,
-        stale_owner_session_response,
-    )
+    from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+    from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 
     if not is_owner_dashboard_request(request):
+        # Domain audit stays here rather than delegating to
+        # ``require_owner_dashboard_request``: ``_audit`` emits
+        # ``log_tool_invocation`` under ``instances_search_sessions`` /
+        # ``dashboard:instances``, which is the record this module's SEL consumers
+        # watch, and the shared helper's generic ``log_api_access`` /
+        # ``non_owner_block`` would silently drop this route out of that stream.
+        # Only the denial TAIL is shared -- see ``_owner_denial_response``.
         _audit("search_sessions", "denied", error="non-owner identity rejected")
         # Deny decision made above; only the response label changes for a signed
         # pre-owner bootstrap subject (see stale_owner_session_response).
-        stale = stale_owner_session_response(request)
-        if stale is not None:
-            return stale
-        return web.json_response(
-            {"error": "federated session search is owner-only", "code": "owner_only"},
-            status=403,
-        )
+        return _owner_denial_response(request, "federated session search is owner-only")
     state: DashboardState = request.app["state"]
     q = sanitize_string(request.query.get("q", "")).strip()[:256]
     if len(q) < SEARCH_MIN_CHARS:
@@ -1140,19 +1139,17 @@ async def api_instances_proxy(request: web.Request) -> web.StreamResponse:
     # with the OWNER's manager-held credential, so it requires the positively
     # identified owner — the same bar api_instances_search_sessions sets, for
     # the same reason.
-    from kiro_crew.dashboard.handlers.source_providers import (
-        is_owner_dashboard_request,
-        stale_owner_session_response,
-    )
+    from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+    from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
 
     if not is_owner_dashboard_request(request):
+        # Domain audit stays here for the same reason as
+        # api_instances_search_sessions above: ``_audit`` is this module's
+        # ``instances_*`` SEL stream. Only the denial tail is shared.
         _audit("proxy", "denied", error="non-owner identity rejected")
-        stale = stale_owner_session_response(request)
-        if stale is not None:
-            return stale
-        return web.json_response(
-            {"error": "remote-crew proxy is owner-only", "code": "owner_only"}, status=403
-        )
+        # Deny decision made above; only the response label changes for a signed
+        # pre-owner bootstrap subject (see stale_owner_session_response).
+        return _owner_denial_response(request, "remote-crew proxy is owner-only")
     state: DashboardState = request.app["state"]
     instance_id = request.match_info["id"]
     path = request.match_info.get("path", "")

--- a/test/dashboard_owner_helpers.py
+++ b/test/dashboard_owner_helpers.py
@@ -1,0 +1,52 @@
+"""Owner identity for the fixtures that exercise owner-gated dashboard routes.
+
+Routes such as ``PUT /api/dashboard/config``, ``POST /api/connections/mint``,
+``POST /api/connections/cancel`` and ``POST /api/mcp/oauth/relay`` are owner-gated
+(``handlers._shared.require_owner_dashboard_request``), and the gate reads
+``request.app["state"]`` plus the authenticated claims the token-auth middleware
+normally populates. A fixture that registers the handler on
+a bare ``web.Application()`` therefore answers 500 (no ``state`` key) or 403 (no
+owner claim) before the body-validation branch under test is ever reached -- the
+test would still "pass or fail", but on the gate rather than on what it names.
+
+``as_owner`` installs the minimum the gate needs and nothing else:
+
+* an ``owner_id`` of ``""`` -- the standalone-local shape, where the predicate
+  accepts the signed local bootstrap subject. Installed ONLY when the app has no
+  ``state`` of its own, so a fixture carrying a real ``DashboardState`` keeps it.
+* a stand-in for the token middleware, so the caller defaults to ``local-app``.
+
+``NoConfiguredOwner`` is exported for the tests that hand-roll a request stub
+instead of going through a ``TestClient``.
+
+A test that wants a NON-owner sends ``X-Test-User``; one that wants an app token
+sends ``X-Test-App``. The gate's own denial behaviour is covered directly in
+``test_dashboard_files_coverage.TestDashboardConfigPutOwnerGate`` and in
+``test_agent_config_owner_gate_invariant`` -- this helper exists so the OTHER
+tests keep testing their own subject.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+
+class NoConfiguredOwner:
+    """The standalone-local shape: no owner configured yet."""
+
+    owner_id = ""
+
+
+@web.middleware
+async def _identity(request: web.Request, handler):
+    request["user"] = request.headers.get("X-Test-User", "local-app")
+    request["app"] = request.headers.get("X-Test-App", "")
+    return await handler(request)
+
+
+def as_owner(app: web.Application) -> web.Application:
+    """Make requests to *app* read as the dashboard owner. Returns *app*."""
+    if "state" not in app:
+        app["state"] = NoConfiguredOwner()
+    app.middlewares.append(_identity)
+    return app

--- a/test/test_agent_config_owner_gate_invariant.py
+++ b/test/test_agent_config_owner_gate_invariant.py
@@ -1,0 +1,293 @@
+"""Every mutating route registered by the agent_config registrar refuses non-owner callers.
+
+Unlike ``test_agents_endpoints_owner_auth.py`` which filters by handler module
+(``handlers.agents``), this test walks ALL mutating routes registered by both
+the ``agent_config`` and ``agents`` route registrars without filtering by
+handler module. This ensures that new routes added to ANY handler module in the
+registrar cannot silently escape the owner gate invariant.
+
+A mutating route (POST/PUT/PATCH/DELETE) that is registered through the
+registrar must either:
+1. Return 401 or 403 for a non-owner caller, OR
+2. Be explicitly documented in one of the exclusion sets below with a
+   justification for why the route intentionally skips the owner gate.
+
+The coherence floor ``_MINIMUM_GATED_ROUTES`` prevents the walk from going
+vacuous if a refactor empties the route table.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.routes import agent_config as agent_config_routes
+from kiro_crew.dashboard.routes import agents as agents_routes
+
+pytestmark = pytest.mark.asyncio
+
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# --------------------------------------------------------------------------- #
+# Pre-owner exclusions: routes that intentionally only require authentication
+# (not ownership) because they execute during the initial onboarding flow
+# BEFORE an owner is configured.
+# --------------------------------------------------------------------------- #
+_PRE_OWNER_EXCLUSIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Onboarding import routes use ``_caller()`` which checks authentication
+        # but not ownership. These routes run during initial setup when the user
+        # is importing configuration from another installation -- there is no
+        # configured owner yet, so the owner gate cannot apply.
+        ("POST", "/api/onboarding/import/apply"),
+        ("PUT", "/api/onboarding/import/state"),
+    }
+)
+
+# --------------------------------------------------------------------------- #
+# Known ungated routes: mutating routes that predate the owner-gating effort.
+# These routes are currently authenticated-only (not owner-gated). They are
+# candidates for future owner-gating work but are NOT in scope for the current
+# migration PR. Each entry documents WHY it is excluded.
+#
+# IMPORTANT: This set must NOT grow. Any NEW mutating route added to the
+# registrar that is not owner-gated must either be added to _PRE_OWNER_EXCLUSIONS
+# (with justification) or must implement require_owner_dashboard_request.
+# The test_known_ungated_routes_not_growing test enforces this via the
+# _MAX_KNOWN_UNGATED_ROUTES ceiling below.
+# --------------------------------------------------------------------------- #
+_KNOWN_UNGATED_ROUTES: frozenset[tuple[str, str]] = frozenset(
+    {
+        # --- MCP management routes (mcp.py) ---
+        # These routes configure MCP servers and assume any authenticated
+        # dashboard session may manage MCP configuration. Owner-gating them
+        # is tracked as future work.
+        ("POST", "/api/mcp/probe"),
+        ("POST", "/api/mcp/quarantine/clear"),
+        ("POST", "/api/mcp/measure"),
+        ("POST", "/api/mcp/sync"),
+        ("POST", "/api/mcp/apply"),
+        ("POST", "/api/mcp/toggle"),
+        ("POST", "/api/mcp/toggle-tool"),
+        ("POST", "/api/mcp/toggle-all"),
+        ("POST", "/api/mcp/remove"),
+        ("PUT", "/api/mcp/servers/{name}"),
+        ("DELETE", "/api/mcp/servers/{name}"),
+        ("POST", "/api/mcp-gateway/enable"),
+        ("POST", "/api/mcp-gateway/servers/stub"),
+        ("POST", "/api/mcp-gateway/resolve-refresh"),
+        # --- MCP custom/discover routes (mcp_custom.py, mcp_discover.py) ---
+        # Custom MCP server registration and discovery-based installation.
+        # Authenticated-only, predating the owner-gate migration.
+        ("POST", "/api/mcp/custom"),
+        ("PUT", "/api/mcp/custom/{name}"),
+        ("POST", "/api/mcp/discover/install"),
+        # --- Kiro Crew config routes (core.py) ---
+        # Application-level configuration routes that predated owner-gating.
+        # They configure the Kiro Crew application itself but were registered
+        # before ownership semantics existed.
+        ("PUT", "/api/config/kirocrew"),
+        ("PATCH", "/api/config/kirocrew"),
+        ("PUT", "/api/config/theme"),
+        # --- Workspace CRUD (files.py) ---
+        # Found BY this walk, not by the migration: none of the three carries an
+        # owner gate, and ``api_workspaces_delete`` removes a workspace from
+        # config.json for any authenticated dashboard session -- including the
+        # session token minted for an allow-listed Slack user, which has an empty
+        # app identity and so is authenticated but not the owner.
+        #
+        # Listed rather than gated HERE because gating them changes WHO may manage
+        # workspaces, which is a product decision, not the mechanical migration
+        # this change is: tracked as #6470. The DELETE is the highest-priority
+        # entry in this set.
+        ("POST", "/api/workspaces"),
+        ("PUT", "/api/workspaces/{name}"),
+        ("DELETE", "/api/workspaces/{name}"),
+        # --- Member thread creation (members.py) ---
+        # Also found by this walk. Creates a thread against a crew member for any
+        # authenticated caller. Same disposition as the workspace routes above
+        # (#6470).
+        ("POST", "/api/members/{slug}/thread"),
+    }
+)
+
+# Ceiling for the debt list above, asserted by
+# ``test_known_ungated_routes_not_growing``. Raising it is the reviewable act
+# that adding a new ungated route costs; lower it whenever an entry is gated and
+# removed, so the ratchet stays tight.
+_MAX_KNOWN_UNGATED_ROUTES = 24
+
+# --------------------------------------------------------------------------- #
+# Coherence floor: the walk must find at least this many GATED mutating routes.
+# This is the count of routes that we expect to be owner-gated (from agents.py,
+# files.py, connections.py). If a refactor removes or relocates routes such
+# that fewer than this threshold are gated, the test fails loudly rather than
+# passing vacuously.
+# --------------------------------------------------------------------------- #
+_MINIMUM_GATED_ROUTES = 19
+
+
+class _FakeState:
+    """Simulates a state object with no configured owner.
+
+    When ``owner_id`` is empty the ``is_owner_dashboard_request`` predicate
+    rejects all callers that are not the signed local bootstrap subject
+    (``local-app``, ``local-startup``).
+    """
+
+    owner_id = ""
+
+
+def _build_app() -> web.Application:
+    """Build a minimal app with both route registrars and identity middleware."""
+
+    @web.middleware
+    async def _identity(request, handler):
+        # Stand-in for the token-auth middleware: populates the AUTHENTICATED
+        # claims that the owner predicate reads. Tests select the caller via
+        # headers so we can simulate a non-owner caller.
+        request["user"] = request.headers.get("X-Test-User", "local-app")
+        request["app"] = request.headers.get("X-Test-App", "")
+        return await handler(request)
+
+    app = web.Application(middlewares=[_identity])
+    app["state"] = _FakeState()
+    # Register BOTH registrars so the walk covers the full route surface.
+    agents_routes.register(app)
+    agent_config_routes.register(app)
+    return app
+
+
+def _all_mutating_routes(app: web.Application) -> set[tuple[str, str]]:
+    """Enumerate every mutating route from the app router.
+
+    Does NOT filter by handler module -- walks all routes regardless of which
+    handler module they resolve to. This is the key difference from the
+    per-module test in ``test_agents_endpoints_owner_auth.py``.
+    """
+    found: set[tuple[str, str]] = set()
+    for route in app.router.routes():
+        if route.method not in _MUTATING_METHODS:
+            continue
+        resource = route.resource
+        if resource is None:
+            continue
+        found.add((route.method, resource.canonical))
+    return found
+
+
+def _gated_routes(app: web.Application) -> set[tuple[str, str]]:
+    """Return only the mutating routes that are expected to be owner-gated.
+
+    This is the full set of mutating routes minus both exclusion sets.
+    """
+    all_routes = _all_mutating_routes(app)
+    return all_routes - _PRE_OWNER_EXCLUSIONS - _KNOWN_UNGATED_ROUTES
+
+
+def _substitute_path_params(canonical: str) -> str:
+    """Replace ``{param}`` placeholders with a dummy value for requests."""
+    return re.sub(r"\{[^}]+\}", "test-item", canonical)
+
+
+async def test_walk_finds_minimum_gated_routes() -> None:
+    """The enumeration finds at least the coherence floor of gated routes.
+
+    Guards against the walk going vacuous if a refactor moves or removes route
+    registrations.
+    """
+    app = _build_app()
+    found = _gated_routes(app)
+    assert len(found) >= _MINIMUM_GATED_ROUTES, (
+        f"Route walk found only {len(found)} gated mutating routes "
+        f"(expected >= {_MINIMUM_GATED_ROUTES}). "
+        f"If routes were intentionally removed, lower the floor. "
+        f"Found: {sorted(found)}"
+    )
+
+
+async def test_every_gated_route_refuses_non_owner() -> None:
+    """A non-owner dashboard subject gets 401 or 403 on every gated route.
+
+    The request carries no JSON body and uses a non-owner identity header.
+    The owner gate must fire BEFORE body parsing or state access, so the
+    denial response should always come first.
+
+    We accept both 401 (stale session relabel) and 403 (direct owner denial)
+    as valid denial responses.
+    """
+    app = _build_app()
+    routes = _gated_routes(app)
+    assert routes, "no gated mutating routes found -- test setup is broken"
+
+    async with TestClient(TestServer(app)) as client:
+        for method, canonical in sorted(routes):
+            path = _substitute_path_params(canonical)
+            resp = await client.request(method, path, headers={"X-Test-User": "someone-else"})
+            assert resp.status in (401, 403), (
+                f"{method} {canonical} answered {resp.status} for a non-owner "
+                f"subject -- every gated mutating route must return 401 or 403 "
+                f"(or be explicitly listed in _PRE_OWNER_EXCLUSIONS or "
+                f"_KNOWN_UNGATED_ROUTES)"
+            )
+
+
+async def test_known_ungated_routes_not_growing() -> None:
+    """The ungated set is a shrink-only ratchet -- it must never grow.
+
+    This is the tightening direction of the invariant. ``_KNOWN_UNGATED_ROUTES``
+    is the debt list: mutating routes that predate owner-gating and are still
+    authenticated-only. Every entry is registered (asserted by
+    ``test_exclusion_sets_are_actually_registered``) and every route OUTSIDE the
+    two exclusion sets is proven to refuse non-owners (asserted by
+    ``test_every_gated_route_refuses_non_owner``).
+
+    What neither of those catches is a NEW ungated route being added to the
+    registrar and quietly appended to this set to keep CI green. Pinning the
+    ceiling makes that edit visible: the ceiling has to be raised in the same
+    diff, which is a reviewable act rather than a silent one. Gating a route and
+    deleting its entry is the only change that needs no ceiling edit -- lower
+    ``_MAX_KNOWN_UNGATED_ROUTES`` to the new size to keep the ratchet tight.
+    """
+    assert len(_KNOWN_UNGATED_ROUTES) <= _MAX_KNOWN_UNGATED_ROUTES, (
+        f"_KNOWN_UNGATED_ROUTES grew to {len(_KNOWN_UNGATED_ROUTES)} entries "
+        f"(ceiling {_MAX_KNOWN_UNGATED_ROUTES}). A new mutating route must be "
+        f"owner-gated, not added to the debt list. If the addition is genuinely "
+        f"unavoidable, raise the ceiling in the same diff and say why."
+    )
+    # The two sets must stay disjoint. An entry in both is excluded twice, so
+    # removing it from one -- the natural move when a pre-owner route grows up --
+    # silently leaves it excluded by the other and the walk never tests it.
+    overlap = _PRE_OWNER_EXCLUSIONS & _KNOWN_UNGATED_ROUTES
+    assert not overlap, f"a route is excluded by BOTH sets: {sorted(overlap)}"
+
+
+async def test_exclusion_sets_are_actually_registered() -> None:
+    """Every route in both exclusion sets must actually exist in the router.
+
+    Prevents stale exclusions from hiding the removal of a once-excluded route.
+    If a route is removed from the registrar, it must also be removed from the
+    exclusion sets.
+    """
+    app = _build_app()
+    all_routes: set[tuple[str, str]] = set()
+    for route in app.router.routes():
+        resource = route.resource
+        if resource is None:
+            continue
+        all_routes.add((route.method, resource.canonical))
+
+    for method, path in _PRE_OWNER_EXCLUSIONS:
+        assert (method, path) in all_routes, (
+            f"Pre-owner excluded route {method} {path} is not registered. "
+            f"Remove it from _PRE_OWNER_EXCLUSIONS or fix the route registration."
+        )
+
+    for method, path in _KNOWN_UNGATED_ROUTES:
+        assert (method, path) in all_routes, (
+            f"Known-ungated route {method} {path} is not registered. "
+            f"Remove it from _KNOWN_UNGATED_ROUTES or fix the route registration."
+        )

--- a/test/test_agent_delete_reference_guard.py
+++ b/test/test_agent_delete_reference_guard.py
@@ -26,7 +26,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_agent_detail_model_managed.py
+++ b/test/test_agent_detail_model_managed.py
@@ -23,7 +23,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_agent_model_pin_validation.py
+++ b/test/test_agent_model_pin_validation.py
@@ -22,7 +22,7 @@ from kiro_crew.model_registry import acp_id_correction
 def _owner_caller(monkeypatch):
     """Exercise the agent handlers past their independent owner-auth boundary."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_agent_template_skills.py
+++ b/test/test_agent_template_skills.py
@@ -50,7 +50,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -24,7 +24,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_api_agents_create_template.py
+++ b/test/test_api_agents_create_template.py
@@ -40,7 +40,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_ask_question_roundtrip.py
+++ b/test/test_ask_question_roundtrip.py
@@ -1385,9 +1385,20 @@ class TestErrorCodes:
         )
 
     def test_the_ratchet_can_actually_fail(self) -> None:
-        """Self-check: a scan matching nothing would pass the assertion above vacuously."""
+        """Self-check: a scan matching nothing would pass the assertion above vacuously.
+
+        20, not the 21 this pinned before the owner-denial migration. The
+        non-owner ``403`` is no longer written out here: its ``{"error":
+        "forbidden", "code": "owner_only"}`` body is now produced by
+        ``handlers._shared._owner_denial_response``, which the module calls with
+        exactly that message and code. The WIRE contract is unchanged -- only the
+        literal moved, and it is still coded at its new home, which is why
+        ``test_no_refusal_in_this_module_is_prose_only`` stays empty. The count
+        drops because the scanner is per-file and that site is now in another
+        file.
+        """
         coded = [f for f in self._findings() if f.bucket == "compliant"]
-        assert len(coded) == 21, f"scanner reached {len(coded)} coded sites, expected 21"
+        assert len(coded) == 20, f"scanner reached {len(coded)} coded sites, expected 20"
         assert all(f.code_value for f in coded)
 
     # -- POST /api/ask-question (the MCP tool's leg) --

--- a/test/test_auto_open_git_panel_config.py
+++ b/test/test_auto_open_git_panel_config.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -91,7 +92,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_capability_agents_plugins.py
+++ b/test/test_capability_agents_plugins.py
@@ -39,7 +39,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -30,7 +30,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_connections_mint.py
+++ b/test/test_connections_mint.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from conftest import requires_symlinks
 from kiro_crew import hooks, mcp_grant
@@ -1642,6 +1643,7 @@ async def _client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app = web.Application()
     app.router.add_post("/api/connections/mint", connections.api_connections_mint)
     app.router.add_get("/api/connections/mint", connections.api_connections_mint_state)
+    as_owner(app)
     client = TestClient(TestServer(app))
     await client.start_server()
     return client

--- a/test/test_connections_oauth_relay.py
+++ b/test/test_connections_oauth_relay.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.dashboard.handlers import connections
 
@@ -57,6 +58,7 @@ async def test_relay_delivers_to_loopback_without_following_redirects(monkeypatc
 
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -87,6 +89,7 @@ async def test_relay_delivers_to_loopback_without_following_redirects(monkeypatc
 async def test_relay_rejects_valid_non_object_json(body):
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     try:
@@ -122,6 +125,7 @@ async def test_relay_rejects_malformed_slug_before_network(monkeypatch, slug):
     """
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -156,6 +160,7 @@ async def test_relay_accepts_user_added_name_shapes(monkeypatch, name):
     """
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -196,6 +201,7 @@ async def test_relay_delivers_for_a_user_added_non_registry_server(monkeypatch):
 
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -228,6 +234,7 @@ async def test_relay_delivers_for_a_user_added_non_registry_server(monkeypatch):
 async def test_relay_rejects_non_loopback_before_network(monkeypatch):
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -263,6 +270,7 @@ async def test_relay_sends_bracketed_ipv6_host_header(monkeypatch):
 
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     audit = MagicMock()
@@ -287,6 +295,7 @@ async def _post_relay(port: int) -> tuple[int, dict]:
     """Drive the relay endpoint against a loopback port and return (status, body)."""
     relay_app = web.Application()
     relay_app.router.add_post("/api/mcp/oauth/relay", connections.api_mcp_oauth_relay)
+    as_owner(relay_app)
     relay_client = TestClient(TestServer(relay_app))
     await relay_client.start_server()
     try:

--- a/test/test_connections_status.py
+++ b/test/test_connections_status.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew import mcp_grant
 from kiro_crew.connections import mint, status
@@ -535,6 +536,7 @@ async def _client() -> TestClient:
     app = web.Application()
     app.router.add_get("/api/connections/status", connections.api_connections_status)
     app.router.add_post("/api/connections/cancel", connections.api_connections_cancel)
+    as_owner(app)
     client = TestClient(TestServer(app))
     await client.start_server()
     return client

--- a/test/test_dashboard_config_gitlab_hosts.py
+++ b/test/test_dashboard_config_gitlab_hosts.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import NoConfiguredOwner, as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -48,7 +49,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio
@@ -142,8 +143,28 @@ async def test_cancellation_during_config_load_is_audited(
     monkeypatch.setattr(files_mod.asyncio, "to_thread", cancel_load)
 
     class _FakeRequest:
+        """Owner-shaped: ``PUT`` is owner-gated ahead of the load cancelled here.
+
+        The gate reads ``request.app["state"]`` and the authenticated claims, so a
+        stub carrying neither would be refused before ``to_thread`` is ever
+        awaited and this test would assert against the denial instead of the
+        cancellation. The gate's own behaviour is covered in
+        ``test_dashboard_files_coverage.TestDashboardConfigPutOwnerGate``.
+        """
+
         def __init__(self, http_method: str) -> None:
             self.method = http_method
+            self.app = {"state": NoConfiguredOwner()}
+            self._claims = {"user": "local-app", "app": ""}
+
+        def __contains__(self, key: str) -> bool:
+            return key in self._claims
+
+        def __getitem__(self, key: str) -> str:
+            return self._claims[key]
+
+        def get(self, key: str, default: str = "") -> str:
+            return self._claims.get(key, default)
 
         async def json(self):
             return {}

--- a/test/test_dashboard_files_coverage.py
+++ b/test/test_dashboard_files_coverage.py
@@ -992,10 +992,74 @@ def cfg_file(tmp_path):
 
 @pytest.fixture()
 def config_client_app(cfg_file, mock_sel) -> web.Application:
-    app = web.Application()
+    """The endpoint under an OWNER caller, so the body-validation paths are reachable.
+
+    ``PUT`` is owner-gated, and the gate reads ``request.app["state"]`` plus the
+    authenticated claims the token middleware normally populates. Without both,
+    every PUT below would answer 403 (or 500 on the missing state) and stop
+    testing what it names. ``owner_id = ""`` with the caller defaulting to the
+    signed local bootstrap subject is the standalone-local shape, matching
+    ``test_agent_config_owner_gate_invariant``; a test that wants a non-owner
+    sends ``X-Test-User``.
+    """
+
+    class _State:
+        owner_id = ""
+
+    @web.middleware
+    async def _identity(request, handler):
+        request["user"] = request.headers.get("X-Test-User", "local-app")
+        request["app"] = request.headers.get("X-Test-App", "")
+        return await handler(request)
+
+    app = web.Application(middlewares=[_identity])
+    app["state"] = _State()
     app.router.add_get("/api/dashboard/config", files_mod.api_dashboard_config)
     app.router.add_put("/api/dashboard/config", files_mod.api_dashboard_config)
     return app
+
+
+class TestDashboardConfigPutOwnerGate:
+    """The PUT gate fires ahead of body parsing and ahead of the config load."""
+
+    @pytest.mark.asyncio
+    async def test_non_owner_put_is_refused(self, config_client_app):
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config",
+                json={"gitlab_hosts": ["gitlab.example.com"]},
+                headers={"X-Test-User": "someone-else"},
+            )
+            assert resp.status == 403
+            assert (await resp.json())["code"] == "owner_only"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused_before_the_body_is_parsed(self, config_client_app):
+        """A body that would 400 still answers 403: the gate runs first.
+
+        This is the observable form of "the gate fires BEFORE config-load I/O" —
+        an unparseable body cannot reach the 400 branch, so nothing downstream of
+        the gate ran.
+        """
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.put(
+                "/api/dashboard/config",
+                data="{",
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Test-User": "someone-else",
+                },
+            )
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_get_stays_open_to_non_owner(self, config_client_app):
+        """Only PUT is gated — the settings UI polls GET on an interval."""
+        async with TestClient(TestServer(config_client_app)) as client:
+            resp = await client.get(
+                "/api/dashboard/config", headers={"X-Test-User": "someone-else"}
+            )
+            assert resp.status == 200
 
 
 class TestDashboardConfigPut:
@@ -1147,9 +1211,19 @@ class TestDashboardConfigPut:
             mock_sel.reset_mock()
             req = MagicMock()
             req.method = method
-            with patch("asyncio.to_thread", side_effect=asyncio.CancelledError):
-                with pytest.raises(asyncio.CancelledError):
-                    await files_mod.api_dashboard_config(req)
+            # PUT is owner-gated ahead of the load. This test is about what the
+            # LOAD does when it is cancelled, so the caller is the owner here;
+            # the gate's own behaviour is covered by
+            # TestDashboardConfigPutOwnerGate. Without this the MagicMock request
+            # reads as a non-owner and the gate answers before the load runs.
+            with patch(
+                "kiro_crew.dashboard.handlers.source_providers."
+                "is_owner_dashboard_request",
+                return_value=True,
+            ):
+                with patch("asyncio.to_thread", side_effect=asyncio.CancelledError):
+                    with pytest.raises(asyncio.CancelledError):
+                        await files_mod.api_dashboard_config(req)
             mock_sel.log_tool_invocation.assert_called_once_with(
                 session_key="dashboard",
                 tool_name=tool,

--- a/test/test_link_previews_config.py
+++ b/test/test_link_previews_config.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -88,7 +89,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_mcp_app_panel_config.py
+++ b/test/test_mcp_app_panel_config.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -86,7 +87,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_mcp_sync_agent.py
+++ b/test/test_mcp_sync_agent.py
@@ -25,7 +25,7 @@ def _owner_caller(monkeypatch):
     its own enumerate-the-invariant coverage in
     test_agents_endpoints_owner_auth.py."""
     monkeypatch.setattr(
-        "kiro_crew.dashboard.handlers.agents.is_owner_dashboard_request",
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
         lambda request: True,
     )
 

--- a/test/test_merge_queued_messages.py
+++ b/test/test_merge_queued_messages.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.dashboard.chat import _dequeue_next_message
 from kiro_crew.dashboard.chat_utils import (
@@ -255,7 +256,7 @@ def _make_config_app(tmp_path):
     app["state"] = state
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 class TestDashboardConfigMergeQueued:

--- a/test/test_quick_send.py
+++ b/test/test_quick_send.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -61,7 +62,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_session_grid.py
+++ b/test/test_session_grid.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -61,7 +62,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.dashboard.chat import restore_recent_sessions
 from kiro_crew.dashboard.state import DashboardState
@@ -59,7 +60,7 @@ def _make_config_app(tmp_path):
     app["state"] = state
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 # ── restore_recent_sessions tests ──

--- a/test/test_tail_fork_config.py
+++ b/test/test_tail_fork_config.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -64,7 +65,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_use_builtin_browser_config.py
+++ b/test/test_use_builtin_browser_config.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.config.loader import KiroCrewConfig
 
@@ -78,7 +79,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio

--- a/test/test_verbosity_config.py
+++ b/test/test_verbosity_config.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 import kiro_crew
 from kiro_crew.config.loader import KiroCrewConfig
@@ -546,7 +547,7 @@ def handler_app(cfg_file, mock_sel):
     app = web.Application()
     app.router.add_put("/api/dashboard/config", api_dashboard_config)
     app.router.add_get("/api/dashboard/config", api_dashboard_config)
-    return app
+    return as_owner(app)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #6224.

Migrates the remaining inline owner-denial sequences (predicate → off-thread SEL
audit → stale-session 401 relabel → 403 `owner_only`) to a **two-tier** shared
helper in `_shared.py`, adds owner gates to 4 previously-unguarded mutating
routes, and introduces a registrar-walk invariant test that catches future
ungated routes without filtering by handler module.

## Changes

### Shared helpers (`src/kiro_crew/dashboard/handlers/_shared.py`)
- `require_owner_dashboard_request(request, operation)` — full async lifecycle:
  predicate → off-thread SEL audit → stale-session 401 relabel → 403
- `_owner_denial_response(request, error_message, error_code)` — the sync **tail**
  for domain wrappers that keep their own audit and/or error code

### Inline sequences migrated

Two tiers, and which one a site gets is decided by whether its audit record or its
wire body is domain-specific — not by preference:

**Full delegation** (generic `non_owner_block` audit, standard `owner_only` body):
- `handlers/agents.py` — `_require_owner`
- `handlers/mcp_apps.py`

**Tail only** (`_owner_denial_response`, so the module keeps its own audit record
and its own error code — delegating these would have changed either the SEL
payload or the wire body):
- `handlers/ask_question.py` — keeps `resources="/api/ask-question"` + its `error`
  reason, and its `{"error": "forbidden", "code": "owner_only"}` body
- `chat_handlers.py` — keeps `error="not the dashboard owner"` and its `forbidden`
  body (now additionally coded `owner_only`)
- `handlers_instances.py` — **both** sites (`api_instances_search_sessions` and its
  same-file sibling `api_instances_proxy`) keep `_audit(...)`, which emits
  `log_tool_invocation` under `instances_*` / `dashboard:instances` — the stream this
  module's SEL consumers watch — and keep their own messages ("federated session
  search is owner-only" / "remote-crew proxy is owner-only")
- `handlers/aws_consent.py`, `handlers/messaging.py`, `handlers_cloud.py`,
  `apps/builtins/aws_control/backend/routes.py` — each keeps its own audit

### One site deliberately NOT migrated
`source_providers._authorize_owner_request` keeps its inline tail. It is not the
same four-step shape: it has **four** separate denial branches and only the
`caller != owner_id` one reaches the stale relabel, its body is a bare
`{"error": "forbidden"}` with no `code`, and that exact body is pinned by equality
assertions in two test files. Routing it through `_shared` would also have the
module that DEFINES `stale_owner_session_response` call back into the module that
imports it. Adding a `code` there is a wire change that belongs in the error-code
track, not in this consolidation.

### New owner gates (4 routes)
- `PUT /api/dashboard/config` (files.py) — the gate fires BEFORE the config-load I/O
- `POST /api/mcp/oauth/relay`, `POST /api/connections/mint`,
  `POST /api/connections/cancel` (connections.py)

### Registrar-walk invariant test (`test/test_agent_config_owner_gate_invariant.py`)
Walks ALL mutating routes from both registrars (no handler-module filter) and
asserts a non-owner gets 401/403 on every route outside the two documented
exclusion sets. A coherence floor prevents a vacuous pass, and
`_MAX_KNOWN_UNGATED_ROUTES` makes the debt list a **shrink-only ratchet**: adding
a route to it requires raising the ceiling in the same diff.

**It paid for itself on its first run** — it surfaced 4 mutating routes with no
owner gate that were documented nowhere: `POST/PUT/DELETE /api/workspaces{,/{name}}`
and `POST /api/members/{slug}/thread`. `api_workspaces_delete` removes a workspace
from `config.json` for any authenticated non-owner (e.g. the dashboard token minted
for an allow-listed Slack user, which has an empty app identity). Gating them
changes WHO may manage workspaces — a product decision, not this migration — so
they are recorded with a justification and tracked in #6470.

### Test-fixture updates (why 14 test files are touched)
`PUT /api/dashboard/config` and the three connections routes are now gated, and the
gate reads `request.app["state"]` plus the authenticated claims. Fixtures that
registered those handlers on a bare `web.Application()` answered 500 (no `state`)
or 403 (no owner claim) **before** the branch each test names. `test/dashboard_owner_helpers.py`
installs exactly what the gate needs (`as_owner(app)`), and only when the app has no
`state` of its own, so a fixture carrying a real `DashboardState` keeps it. The gate's
own behaviour is tested directly, not incidentally, in
`test_dashboard_files_coverage.TestDashboardConfigPutOwnerGate`.

### `error-code-baseline.json`
Regenerated via the sanctioned `python test/test_error_code_contract.py --update`.
Both directions improve: `missing_code` 1312 → 1310 (two prose-only refusals became
coded by routing through the shared tail) and `_compliant` 1285 → 1294. The
per-module ratchet in `test_ask_question_roundtrip.py` drops 21 → 20 because the
scanner is per-file and that one coded site now lives in `_shared.py` — the wire
contract is unchanged.

## Verification
- Rebased onto main `24cb5e76c`; squashed to one commit
- `flake8`, `isort`, `mypy`, `scripts/check_black_formatting.py`, `scripts/check_brand_name.py` (diff-scoped) all clean
- 1778 targeted tests green across every touched surface plus every test that
  references the changed symbols or the four newly-gated endpoints
- Full backend suite compared against a clean-`main` control from the same worktree

