### PR TITLE
fix(acp): fail the turn cleanly when auto-compaction fails

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -43,6 +43,7 @@ from kiro_crew.acp._dispatch import (
     make_unified_diff,
     parse_session_modes,
     parse_usage_update,
+    redact_text,
 )
 from kiro_crew.acp.liveness import (
     VERDICT_WORKING,
@@ -96,6 +97,7 @@ from kiro_crew.acp.types import (
     OPTION_ALLOW_ONCE,
     OUTCOME_CANCELLED,
     OUTCOME_SELECTED,
+    STOP_REASON_COMPACTION_FAILED,
     STOP_REASON_END_TURN,
     UPDATE_AGENT_MESSAGE_CHUNK,
     UPDATE_AGENT_THOUGHT_CHUNK,
@@ -870,6 +872,18 @@ _STALE_TURN_TIMEOUT = 90.0
 # keep resetting the timer via tool_call_update progress frames and tool
 # results, so this only trips on a genuine stall.
 _TOOL_STALL_TIMEOUT = 600.0
+# After a compaction `failed` status, kiro-cli can leave the turn it was
+# compacting for unanswered: no session/prompt response and no end_turn ever
+# arrive, so the read loop drains in silence to the caller's full prompt
+# ceiling (hours) and the slot is never released — the user waits it out or
+# presses Stop (issue #3583). Once a failure has been seen, treat this much
+# BACKEND SILENCE as a dead turn and end it with
+# STOP_REASON_COMPACTION_FAILED. Any stdout frame resets the clock, so a
+# backend that recovers and keeps streaming is unaffected and stays governed
+# by _STALE_TURN_TIMEOUT / _TOOL_STALL_TIMEOUT. Deliberately does NOT fold in
+# _last_activity (stderr/keepalive): a wedged post-compaction turn that keeps
+# writing stderr must still be reaped.
+_COMPACTION_FAILED_TURN_BUDGET = 60.0
 _CANCEL_GRACE_SECS = 10.0  # grace window for cooperative cancel ack
 # Absolute safety cap for _wait_for_response's activity-based deadline. The
 # per-call deadline resets on every received frame (so a long session/load
@@ -890,6 +904,42 @@ _ACP_SHELL_KIND = "execute"
 def _is_shell_kind(kind: str | None) -> bool:
     """True when an ACP tool_kind denotes a shell/exec command."""
     return kind == _ACP_SHELL_KIND
+
+
+# Cap for the failure detail carried into the compaction notice: it is
+# backend-echoed text on a chat row, not a log line.
+_COMPACTION_DETAIL_MAX_CHARS = 200
+
+
+def compaction_failure_detail(params: dict) -> str:
+    """Best-effort reason text from a ``failed`` compaction notification.
+
+    kiro-cli carries no dedicated error field today: ``summary`` is
+    populated on success but typically empty on failure, which collapsed the
+    user-facing notice to "unknown error" with nothing to report or grep
+    (issue #3583). Prefer any named reason the payload does carry, else fall
+    back to the raw shape so the notice says something concrete. Redacted
+    here (not at each call site) because this reaches the dashboard.
+    """
+    status = params.get("status")
+    status = status if isinstance(status, dict) else {}
+    detail = ""
+    for source in (status, params):
+        for key in ("error", "reason", "message", "detail"):
+            value = source.get(key)
+            if isinstance(value, dict):
+                value = value.get("message") or value.get("error")
+            if isinstance(value, str) and value.strip():
+                detail = value.strip()
+                break
+        if detail:
+            break
+    if not detail:
+        # No named reason anywhere — the raw params ARE the only evidence.
+        detail = f"no reason reported by the agent (raw: {params})"
+    # redact_text is the single-source scrub (exfil URLs + credentials) every
+    # other LLM-influenced surface uses, including the sibling KAS summary.
+    return redact_text(detail)[:_COMPACTION_DETAIL_MAX_CHARS]
 
 
 class AcpError(Exception):
@@ -2224,6 +2274,13 @@ class AcpClient:
         # single progress frame.  Gates the _TOOL_STALL_TIMEOUT watchdog so a
         # dispatched-but-never-resolved tool can't hang the whole turn.
         self._tool_dispatched: bool = False
+        # Armed by _handle_compaction_status on a `failed` status and cleared at
+        # turn start: gates the _COMPACTION_FAILED_TURN_BUDGET check in
+        # _prompt_loop. _compaction_failed_turn records that the check fired, so
+        # _dispatch_events ends the turn with the compaction stop reason instead
+        # of the generic timeout error.
+        self._compaction_failed_at: float | None = None
+        self._compaction_failed_turn: bool = False
         # Liveness oracle for the stale-turn gate: before ending a silent turn
         # at _STALE_TURN_TIMEOUT, consult /proc evidence so a backend that is
         # provably working (CPU/IO movement in the subprocess subtree) is not
@@ -4095,14 +4152,62 @@ class AcpClient:
             # clear the active turn's tracked consult and so allow a second walk
             # while the first is still pending.
             self._retire_liveness_state()
+            self._compaction_failed_at = None
+            self._compaction_failed_turn = False
             deadline = time.monotonic() + timeout
             consecutive_empty = 0
             last_data_ts = time.monotonic()
+            # Consumer park accounting (mirrors AcpSessionHandle._dispatch_events):
+            # the interval between this generator's yield and its resume is
+            # CONSUMER time — a human approval prompt parks the whole generator
+            # chain at that yield — so the post-compaction-failure idle clock
+            # below must subtract it or a long approval wait reads as backend
+            # silence and the budget reaps a live turn. `parked_at_data`
+            # snapshots the accumulator when `last_data_ts` is taken, so only
+            # park time accrued SINCE the last frame is excluded.
+            parked_total = 0.0
+            parked_at_data = 0.0
 
             while time.monotonic() < deadline:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
+
+                # Post-compaction-failure budget: a `failed` status arrived and the
+                # backend has since gone silent past the budget, so no prompt
+                # response or end_turn is coming. Stop reading so _dispatch_events
+                # ends the turn explicitly and the runner releases the slot,
+                # instead of draining to `deadline` (hours).
+                #
+                # SUSPENDED while a tool is in flight: kiro-cli can recover from a
+                # failed compaction and dispatch a tool, and a legitimately silent
+                # long tool (a build, a spawned subagent) would then be reaped at
+                # 60s — killing valid work that the tool-stall watchdog already
+                # governs on its own, much longer, liveness-gated budget. A tool
+                # dispatch is positive evidence the turn is alive, so this budget
+                # hands off to _TOOL_STALL_TIMEOUT and re-arms when the tool
+                # resolves (_tool_dispatched cleared in _dispatch_events).
+                #
+                # Clock asymmetry with AcpSessionHandle's twin is INTENTIONAL: this
+                # path owns a dedicated process, so every frame is its own and the
+                # park accounting below is what it needs; the shared-runtime twin
+                # instead needs session-attributable frames (a co-tenant's fanout
+                # must not defer the reap). Keep both when touching either.
+                if self._compaction_failed_at is not None and not self._tool_dispatched:
+                    _compact_idle = max(
+                        0.0,
+                        (time.monotonic() - max(self._compaction_failed_at, last_data_ts))
+                        - max(0.0, parked_total - parked_at_data),
+                    )
+                    if _compact_idle > _COMPACTION_FAILED_TURN_BUDGET:
+                        logger.warning(
+                            "Compaction failed for req %d and no prompt response "
+                            "arrived for %.0fs — ending the turn.",
+                            req_id,
+                            _compact_idle,
+                        )
+                        self._compaction_failed_turn = True
+                        return
 
                 msg = await self._read_message(timeout=min(remaining, _READ_TIMEOUT))
                 if msg is None:
@@ -4204,6 +4309,7 @@ class AcpClient:
 
                 consecutive_empty = 0
                 last_data_ts = time.monotonic()
+                parked_at_data = parked_total
                 # NB: do NOT clear _tool_dispatched here.  The last_data_ts reset
                 # above already prevents false positives for tools that stream
                 # progress frames (each frame restarts the _TOOL_STALL_TIMEOUT
@@ -4216,7 +4322,16 @@ class AcpClient:
                 self.last_prompt_stats.event_count += 1
 
                 action = self._process_message(msg, req_id)
-                yield action, msg
+                # Single yield chokepoint: everything downstream (dispatch,
+                # chat runner, a human answering an approval card) runs while
+                # this generator is suspended here, so the whole gap is
+                # consumer time. `finally` so an abandoned generator's
+                # GeneratorExit still closes the park.
+                _parked_since = time.monotonic()
+                try:
+                    yield action, msg
+                finally:
+                    parked_total += max(0.0, time.monotonic() - _parked_since)
         finally:
             self._turn_lock.release()
             # Release any cooperative-stop waiter regardless of how the loop
@@ -4530,6 +4645,11 @@ class AcpClient:
                 status = params.get("status", {})
                 status_type = status.get("type", "") if isinstance(status, dict) else str(status)
                 summary = params.get("summary", "")
+                if status_type == "failed":
+                    # The notice reads AcpEvent.title, and `summary` is empty on
+                    # failure — carry the notification's own reason so the row
+                    # stops collapsing to "unknown error".
+                    summary = compaction_failure_detail(params)
                 yield AcpEvent(kind=EVENT_COMPACTION_STATUS, text=status_type, title=summary)
             elif action == "clear":
                 yield AcpEvent(kind=EVENT_CLEAR_STATUS)
@@ -4657,6 +4777,21 @@ class AcpClient:
         if not got_complete:
             self._last_stop_reason = ""
             self._turn_done.set()
+            if self._compaction_failed_turn:
+                # Compaction failed and the turn was abandoned by the backend.
+                # Terminate explicitly — checked BEFORE the stale-turn branch so
+                # a turn that had streamed text does not report a normal
+                # end_turn, and before AcpTimeoutError so callers get the real
+                # cause. The user-facing notice is already appended by the
+                # compaction-status path; this only ends the turn.
+                self._compaction_failed_turn = False
+                self._last_stop_reason = STOP_REASON_COMPACTION_FAILED
+                yield AcpEvent(
+                    kind=EVENT_COMPLETE,
+                    stop_reason=STOP_REASON_COMPACTION_FAILED,
+                    usage=TurnUsage(credits=self.last_prompt_stats.credits),
+                )
+                return
             # If text was streamed, this is a stale turn (kiro-cli finished
             # but never sent `result`).  Yield a synthetic complete so callers
             # finalize normally instead of showing a timeout error.
@@ -5783,7 +5918,12 @@ class AcpClient:
         s_type = status.get("type", "") if isinstance(status, dict) else str(status)
         if s_type == "failed":
             logger.warning("Compaction failed — raw notification params: %s", params)
+            # Arm the bounded post-failure wait (see
+            # _COMPACTION_FAILED_TURN_BUDGET): kiro-cli may never answer the
+            # prompt this compaction was for.
+            self._compaction_failed_at = time.monotonic()
         elif s_type == "completed":
+            self._compaction_failed_at = None
             self.last_prompt_stats.reset_after_compaction()
 
     async def wait_for_compaction(self, timeout: float = COMPACT_WAIT_TIMEOUT_SECS) -> dict:

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -41,12 +41,14 @@ from kiro_crew.acp._dispatch import (
     set_model_params,
 )
 from kiro_crew.acp.client import (
+    _COMPACTION_FAILED_TURN_BUDGET,
     AcpProcessDied,
     AcpTimeoutError,
     _effective_prompt_timeout_async,
     _is_safe_oauth_url,
     _is_tool_interrupted_marker,
     _raise_acp_error,
+    compaction_failure_detail,
     format_command_result,
     parse_slash_command,
     prompt_timeout_for_ceiling,
@@ -98,6 +100,7 @@ from kiro_crew.acp.types import (
     OUTCOME_CANCELLED,
     OUTCOME_SELECTED,
     STOP_REASON_CANCELLED,
+    STOP_REASON_COMPACTION_FAILED,
     STOP_REASON_STALE_RECOVER,
     STOP_REASON_TOOL_STALL,
     UPDATE_CURRENT_MODE,
@@ -521,6 +524,10 @@ class AcpSessionHandle:
         # a yield in prompt().
         self._parked_total: float = 0.0
         self._parked_since: float | None = None
+        # Monotonic timestamp of a `failed` compaction status seen this turn
+        # (None otherwise). Arms the post-failure budget in _dispatch_events,
+        # which ends an abandoned turn instead of draining to the ceiling.
+        self._compaction_failed_at: float | None = None
         # Consumers that implement the low-fidelity child downgrade (dashboard
         # card / interactive approver) opt IN; for everyone else the handle
         # itself fail-closes low-fidelity child permission requests below, so
@@ -1848,6 +1855,10 @@ class AcpSessionHandle:
         """
         deadline = time.monotonic() + timeout
         last_data_ts = time.monotonic()
+        # Cleared per turn: armed by the compaction branch below on a
+        # `failed` status, then read by the post-failure budget check at the
+        # loop top (mirrors AcpClient._prompt_loop).
+        self._compaction_failed_at = None
         # Whether a native agent-switch notification already reported the
         # switch this turn; guards the result-extracted fallback below from
         # double-emitting EVENT_AGENT_SWITCHED (mirrors AcpClient).
@@ -1856,6 +1867,15 @@ class AcpSessionHandle:
         # taken. The idle clocks below measure BACKEND silence, so any park that
         # happens after this point must be subtracted from them.
         parked_at_data = self._parked_total
+        # SESSION-ATTRIBUTABLE twin of (last_data_ts, parked_at_data), for the
+        # post-compaction-failure budget only. On a shared runtime, ownerless
+        # global notifications are fanned out to every co-tenant queue
+        # (msg.fanout_no_owner), so another session's steady traffic would
+        # keep resetting last_data_ts and defer the budget to the multi-hour
+        # outer deadline — the exact hang this budget exists to bound. The
+        # pre-existing tool/stale clocks keep last_data_ts unchanged.
+        last_own_data_ts = last_data_ts
+        parked_at_own_data = parked_at_data
 
         _buffered: list[JsonRpcMessage] = []
         try:
@@ -1863,6 +1883,46 @@ class AcpSessionHandle:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
+
+                # Post-compaction-failure budget: automatic compaction reported
+                # `failed` and the backend has since gone silent past the budget,
+                # so no prompt response or end_turn is coming. End the turn with
+                # an explicit stop reason so the caller releases the slot instead
+                # of draining to the chat-turn ceiling (issue #3583). Consumer
+                # park time is subtracted, like every other idle clock here, so a
+                # long human approval cannot be charged to the backend.
+                #
+                # SUSPENDED while a tool is in flight, for the same reason as
+                # AcpClient's twin: a silent long tool dispatched after the failed
+                # compaction is live work, and reaping it at 60s would cancel the
+                # session out from under it. The tool-stall watchdog below owns
+                # that case; this budget re-arms when the tool resolves.
+                #
+                # Clock asymmetry with AcpClient's twin is INTENTIONAL: the shared
+                # runtime fans ownerless frames out to every co-tenant, so this
+                # side keys off SESSION-ATTRIBUTABLE frames (last_own_data_ts)
+                # where the dedicated-process side can trust last_data_ts.
+                if self._compaction_failed_at is not None and not self._tool_dispatched:
+                    _compact_idle = max(
+                        0.0,
+                        (time.monotonic() - max(last_own_data_ts, self._compaction_failed_at))
+                        - max(0.0, self._parked_total - parked_at_own_data),
+                    )
+                    if _compact_idle > _COMPACTION_FAILED_TURN_BUDGET:
+                        logger.warning(
+                            "Compaction failed on session %s and no prompt response "
+                            "arrived for %.0fs — ending the turn.",
+                            self._session_id,
+                            _compact_idle,
+                        )
+                        self._compaction_failed_at = None
+                        self._turn_done.set()
+                        yield AcpEvent(
+                            kind=EVENT_COMPLETE,
+                            stop_reason=STOP_REASON_COMPACTION_FAILED,
+                            usage=TurnUsage(credits=self.last_prompt_stats.credits),
+                        )
+                        return
 
                 # Unresponsive-cancel recovery: cancel() was sent but kiro-cli has
                 # not acked (no cancelled stopReason) within the grace budget. On a
@@ -2128,6 +2188,11 @@ class AcpSessionHandle:
 
                 last_data_ts = time.monotonic()
                 parked_at_data = self._parked_total
+                if not msg.fanout_no_owner:
+                    # Only a frame attributable to THIS session defers the
+                    # post-compaction-failure budget (see the twin's init note).
+                    last_own_data_ts = last_data_ts
+                    parked_at_own_data = parked_at_data
                 self.last_prompt_stats.event_count += 1
 
                 # Turn-complete response
@@ -2302,17 +2367,43 @@ class AcpSessionHandle:
                     params = msg.params or {}
                     status = params.get("status", {})
                     status_type = status.get("type", "") if isinstance(status, dict) else str(status)
-                    if status_type == "completed":
+                    # A compaction notification carrying no sessionId is fanned
+                    # out to EVERY co-tenant queue (AcpRuntime marks the copies
+                    # fanout_no_owner once more than one session is registered),
+                    # so at most one recipient actually compacted and nothing in
+                    # the frame says which.  Only a frame this session OWNS may
+                    # touch this session's per-turn state, in both directions:
+                    # an ownerless `failed` would arm the budget in every quiet
+                    # peer and reap its live turn (every consumer resets the
+                    # session on that terminal), and an ownerless `completed`
+                    # would disarm a peer's legitimate budget and restore the
+                    # #3583 hang this fix exists to close.  Same trust boundary
+                    # the budget's own clock already draws (last_own_data_ts) and
+                    # the subagent roster already draws (runtime_global=).  A lone
+                    # session's frame is left unmarked and genuinely is its own,
+                    # so single-session behaviour is unchanged.  The event still
+                    # surfaces either way — only the mutations are gated.
+                    owns_frame = not msg.fanout_no_owner
+                    if status_type == "completed" and owns_frame:
                         # The pre-compaction counts (and their authoritative
                         # context_tokens_from_usage flag) no longer describe
                         # the session — drop them so the context meter resets
                         # and the next telemetry can re-derive real numbers.
                         # Mirrors AcpClient._handle_compaction_status.
+                        self._compaction_failed_at = None
                         self.last_prompt_stats.reset_after_compaction()
                     # Compaction summary is backend-echoed text (LLM-influenced)
                     # that reaches the dashboard — redact exfil URLs/credentials
                     # before surfacing it (parity with other text surfaces).
                     summary = redact_text(str(params.get("summary", "") or ""))
+                    if status_type == "failed":
+                        if owns_frame:
+                            # Arm the bounded post-failure wait (the budget check
+                            # at the loop top) and carry the notification's own
+                            # reason so the notice stops collapsing to
+                            # "unknown error".
+                            self._compaction_failed_at = time.monotonic()
+                        summary = compaction_failure_detail(params)
                     yield AcpEvent(kind=EVENT_COMPACTION_STATUS, text=status_type, title=summary)
                 elif action == "clear":
                     yield AcpEvent(kind=EVENT_CLEAR_STATUS)
@@ -2917,14 +3008,25 @@ class AcpSessionHandle:
                 # them so the meter resets and fresh telemetry re-derives real
                 # numbers (parity with the kiro-cli compaction handler).
                 self.last_prompt_stats.reset_after_compaction()
+                self._compaction_failed_at = None
                 status_type = "completed"
             elif kind == kas_wire.KIND_SUMMARIZATION_FAILED:
                 status_type = "failed"
+                # KAS is the third producer of a failed compaction status and
+                # rides the SAME dispatch loop, so it gets the same bounded
+                # post-failure wait — a KAS turn abandoned after failed
+                # summarization must not drain to the ceiling either.
+                self._compaction_failed_at = time.monotonic()
             else:
                 status_type = "started"
             # conversationSummary is backend-echoed, LLM-influenced text that
             # reaches the dashboard — redact exfil URLs/credentials first.
             summary = redact_text(str(kiro.get(kas_wire.FIELD_CONVERSATION_SUMMARY, "") or ""))
+            if status_type == "failed":
+                # conversationSummary is empty on failure, so the notice would
+                # collapse to "unknown error" here too — carry KAS's own reason
+                # (redacted + bounded by the helper).
+                summary = compaction_failure_detail(kiro)
             return [AcpEvent(kind=EVENT_COMPACTION_STATUS, text=status_type, title=summary)]
         if kind in kas_wire.STEERING_KINDS:
             # KAS mid-turn steer echo. kiro-cli sends these as `session/update`

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -295,6 +295,13 @@ STOP_REASON_STALE_RECOVER = "stale_recover"
 # generic error handling; chat_runner routes it to a dedicated recovery
 # (continue-nudge, NOT a verbatim re-run of the original message).
 STOP_REASON_TOOL_STALL = "error: tool stall"
+# Signalled by the ACP layer when automatic compaction reported `failed`
+# and the backend then abandoned the turn (no prompt response, no
+# end_turn) past the post-failure budget. Kept in the "error:" family so
+# callers without a dedicated branch fall back to generic error handling;
+# it deliberately triggers NO retry — the user-visible compaction notice
+# already explains what happened, and this only releases the slot.
+STOP_REASON_COMPACTION_FAILED = "error: compaction failed"
 
 # ── Approval Modes ──
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -32,6 +32,7 @@ from kiro_crew.acp.types import (
     EVENT_MCP_SERVER_INITIALIZED,
     EVENT_STEER_CONSUMED,
     STOP_REASON_CANCELLED,
+    STOP_REASON_COMPACTION_FAILED,
     STOP_REASON_END_TURN,
     STOP_REASON_REFUSAL,
     STOP_REASON_STALE_RECOVER,
@@ -7760,6 +7761,10 @@ async def _run_chat(
                     and _stop_reason != STOP_REASON_CANCELLED
                     and _stop_reason != STOP_REASON_STALE_RECOVER
                     and _stop_reason != STOP_REASON_TOOL_STALL
+                    # An abandoned post-compaction-failure turn is an EXPECTED
+                    # terminal state (the compaction notice already told the
+                    # user); no retry, so it must not log as unexpected.
+                    and _stop_reason != STOP_REASON_COMPACTION_FAILED
                 ):
                     logger.warning(
                         "Unexpected stop_reason %r for slot %s",
@@ -7871,6 +7876,22 @@ async def _run_chat(
                 _emit_stall("Session stuck — please start a new chat.")
             else:
                 _emit_stall("⟳ Tool appeared stalled — please retry.")
+            return
+
+        # Automatic compaction failed and the backend then abandoned the turn.
+        # Returning HERE is load-bearing: this reason is in the "error:" family,
+        # and the branch below is pipe-death recovery — it would re-queue the
+        # message and label it "Connection lost", neither of which is true. A
+        # retry would also just hit the same over-threshold context and fail
+        # again. No message to add either: the compaction-status path already
+        # appended the visible notice naming the failure. The session reset IS
+        # needed, though — this completion is synthetic (the client stopped
+        # reading; the backend never sent end_turn), so the backend still
+        # counts the turn as in progress and the next prompt would collide
+        # with "prompt already in progress". The finally's reset tears that
+        # runtime down and session/load-resumes, WITHOUT re-queuing anything.
+        if _stop_reason == STOP_REASON_COMPACTION_FAILED:
+            needs_session_reset = True  # checked in finally block (reset, no re-queue)
             return
 
         # CC process died mid-turn: re-queue message for automatic retry

--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -31,6 +31,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
+from kiro_crew.acp.types import STOP_REASON_COMPACTION_FAILED
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import HOOK_REPLY, TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.driver import DirectiveConsumer, TurnDriver
@@ -629,6 +630,28 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
             directive_consumer=turn.directive_consumer,
         )
         accumulated = await driver.run(full_message)
+
+        # Defensive lookup, like every other attribute read on this seam: the
+        # driver is resolved through the module attribute, so a caller (or a
+        # test) may supply a stand-in that predates this field. A missing
+        # reason means "no synthetic completion", never an AttributeError
+        # thrown at a real inbound message after the turn already ran.
+        if getattr(driver, "last_stop_reason", "") == STOP_REASON_COMPACTION_FAILED:
+            # Synthetic completion: the backend abandoned the turn after a
+            # failed auto-compaction and never sent end_turn, so it still
+            # counts the prompt as in progress. Reset (mirrors the dashboard
+            # runner's needs_session_reset) or this channel's NEXT message
+            # collides with "prompt already in progress". No re-queue: the
+            # compaction notice already reached the user via the renderer.
+            try:
+                await sessions.reset(session_key)
+            except Exception:
+                logger.warning(
+                    "%s: session reset after compaction failure failed session=%s",
+                    turn.channel_type,
+                    session_key,
+                    exc_info=True,
+                )
 
         # ── Post-turn bookkeeping. Each step is guarded independently so a
         # failure here cannot fall through to the except and re-record a turn

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -336,6 +336,9 @@ class TurnDriver:
         # EVENT_TOOL_RESULT for a tool call whose trusted ``_meta.kiro``
         # identity was recorded at EVENT_TOOL_CALL — the forgery gate.
         self.directive_consumer = directive_consumer
+        # Terminal stop reason of the last run() — read by the dispatcher's
+        # post-turn bookkeeping (e.g. COMPACTION_FAILED -> session reset).
+        self.last_stop_reason: str = ""
 
     async def run(self, message: str) -> str:
         """Drive one turn; return the accumulated channel-safe assistant text."""
@@ -599,6 +602,11 @@ class TurnDriver:
                     OutputEvent(kind=COMPACTION, context_usage_pct=event.context_usage_pct)
                 )
             elif kind == EVENT_COMPLETE:
+                # Exposed for the dispatcher's post-turn bookkeeping: a
+                # COMPACTION_FAILED terminal is synthetic (the backend never
+                # sent end_turn) and needs a session reset the driver cannot
+                # perform itself (it holds no session key).
+                self.last_stop_reason = event.stop_reason or ""
                 pending = compaction_filter.flush()
                 if pending:
                     await dispatch_frames(steering_filter.feed(pending))

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -35,7 +35,11 @@ if TYPE_CHECKING:
     from kiro_crew.dashboard.state import DashboardState
 
 from kiro_crew.acp.client import AcpError, AcpProcessDied, AcpPromptBusy, AcpTimeoutError
-from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN
+from kiro_crew.acp.types import (
+    STOP_REASON_CANCELLED,
+    STOP_REASON_COMPACTION_FAILED,
+    STOP_REASON_END_TURN,
+)
 from kiro_crew.agent_discovery import project_agent_files, project_agent_name
 from kiro_crew.config.loader import (
     ACTIVATION_REVIEW,
@@ -3611,6 +3615,9 @@ async def handle_message(
                     _stop_reason
                     and _stop_reason != STOP_REASON_END_TURN
                     and _stop_reason != STOP_REASON_CANCELLED
+                    # Expected terminal state after a failed auto-compaction;
+                    # handled below with a session reset, so not "unexpected".
+                    and _stop_reason != STOP_REASON_COMPACTION_FAILED
                 ):
                     logger.warning(
                         "Unexpected stop_reason %r for %s — treating as normal completion",
@@ -3630,8 +3637,26 @@ async def handle_message(
             # the payload shape and model reflection cannot drift across surfaces.
             record_interaction_event(client, session_key, "slack")
 
-        # Check context usage — fires background compaction at configured threshold, never blocks
-        sessions.check_context_usage(session_key, client)
+        if _stop_reason == STOP_REASON_COMPACTION_FAILED:
+            # The completion was synthetic — the backend abandoned the turn
+            # after a failed auto-compaction and never sent end_turn, so it
+            # still counts the prompt as in progress. Reset now (mirrors the
+            # dashboard runner's needs_session_reset) or the NEXT message
+            # collides with "prompt already in progress" and burns the busy
+            # recovery path. No re-queue: the compaction notice already told
+            # the user. The context-usage probe is skipped — compaction just
+            # failed and the session was torn down.
+            try:
+                await sessions.reset(session_key)
+            except Exception:
+                logger.debug(
+                    "Failed to reset session %s after compaction failure",
+                    session_key,
+                    exc_info=True,
+                )
+        else:
+            # Check context usage — fires background compaction at configured threshold, never blocks
+            sessions.check_context_usage(session_key, client)
 
     except AcpTimeoutError as e:
         _had_error = True

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -10399,3 +10399,416 @@ class TestMiseNodeInstallsDir:
         script.write_text("#!/usr/bin/env node\n")
 
         assert client_mod._resolve_node_for_script(str(script)) is None
+
+
+class TestCompactionFailureTurnBudget:
+    """A `failed` compaction must FAIL THE TURN, not hang it.
+
+    kiro-cli can report compaction `failed` and then abandon the prompt it was
+    compacting for: no session/prompt response and no end_turn ever arrive, so
+    the read loop drained in silence to the caller's full prompt ceiling
+    (hours) while the slot stayed occupied — the user waited it out or pressed
+    Stop (issue #3583). The budget bounds that wait and the turn ends with
+    STOP_REASON_COMPACTION_FAILED. No retry is attempted: compaction stays
+    kiro-cli's, this only makes its failure fail cleanly.
+    """
+
+    def _failed_msg(self, params: dict | None = None):
+        from kiro_crew.acp.types import METHOD_COMPACTION_STATUS, JsonRpcMessage
+
+        return JsonRpcMessage(
+            method=METHOD_COMPACTION_STATUS,
+            params=params if params is not None else {"status": {"type": "failed"}},
+        )
+
+    def _silent_after(self, frames: list):
+        """_read_message double: drain `frames`, then stay silent forever."""
+
+        async def _read(timeout: float = 0.0):
+            return frames.pop(0) if frames else None
+
+        return _read
+
+    @pytest.mark.asyncio
+    async def test_silent_turn_after_failure_ends_at_budget(self, tmp_path, monkeypatch):
+        """Armed by the failed status, the loop stops reading at the budget and
+        marks the turn so the caller can terminate it explicitly."""
+        from kiro_crew.acp import client as acp_client
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        # Neither existing watchdog can save this turn: no text streamed and no
+        # tool dispatched, so only the 2h prompt ceiling applied before the fix.
+        client._stale_eligible = False
+        client._tool_dispatched = False
+        client._is_process_alive = lambda: True
+        client._read_message = self._silent_after([self._failed_msg()])
+
+        actions = []
+        t0 = time.monotonic()
+        async for action, msg in client._prompt_loop(req_id=1, timeout=30.0):
+            actions.append(action)
+            if action == "compaction":
+                # What _dispatch_events does with the frame — the arming site.
+                client._handle_compaction_status(msg)
+        elapsed = time.monotonic() - t0
+
+        assert actions == ["compaction"]
+        assert client._compaction_failed_turn is True
+        assert client._turn_done.is_set()
+        # Prove the budget ended it, not the 30s outer deadline.
+        assert elapsed < 5.0, f"loop ran too long ({elapsed:.2f}s) — budget did not fire"
+
+    @pytest.mark.asyncio
+    async def test_failed_status_then_silence_completes_the_stream(self, tmp_path, monkeypatch):
+        """Full path, the reported hang: a `failed` status arrives, the backend
+        never answers the prompt, and the stream still terminates — with the
+        compaction stop reason, well inside the 30s turn ceiling."""
+        from kiro_crew.acp import client as acp_client
+        from kiro_crew.acp.types import (
+            EVENT_COMPACTION_STATUS,
+            EVENT_COMPLETE,
+            STOP_REASON_COMPACTION_FAILED,
+            AcpEvent,
+        )
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client.ensure_ready = AsyncMock()
+        client._send_prompt = AsyncMock(return_value=1)
+        client._is_process_alive = lambda: True
+        client._read_message = self._silent_after(
+            [self._failed_msg({"status": {"type": "failed", "error": "context too large"}})]
+        )
+
+        events: list[AcpEvent] = []
+        t0 = time.monotonic()
+        async for ev in client.stream_events("hello", timeout=30.0):
+            events.append(ev)
+        elapsed = time.monotonic() - t0
+
+        assert [e.kind for e in events] == [EVENT_COMPACTION_STATUS, EVENT_COMPLETE]
+        assert events[0].title == "context too large"
+        assert events[-1].stop_reason == STOP_REASON_COMPACTION_FAILED
+        assert elapsed < 5.0, f"turn ran too long ({elapsed:.2f}s) — the hang is back"
+
+    @pytest.mark.asyncio
+    async def test_budget_is_disarmed_without_a_failure(self, tmp_path, monkeypatch):
+        """No failed status → no budget: the loop runs to its own deadline, so
+        an ordinary silent turn keeps its existing watchdog behavior."""
+        from kiro_crew.acp import client as acp_client
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.05)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        client._stale_eligible = False
+        client._tool_dispatched = False
+        client._read_message = AsyncMock(return_value=None)
+        client._is_process_alive = lambda: True
+
+        t0 = time.monotonic()
+        async for _action, _msg in client._prompt_loop(req_id=1, timeout=0.4):
+            pass
+        elapsed = time.monotonic() - t0
+
+        assert client._compaction_failed_turn is False
+        assert elapsed >= 0.35, "loop exited early — the budget fired unarmed"
+
+    @pytest.mark.asyncio
+    async def test_completed_status_disarms_the_budget(self, tmp_path):
+        """A retried compaction that succeeds must clear the armed failure, or
+        the next silent stretch of a healthy turn would end it."""
+        client = AcpClient(work_dir=tmp_path)
+        client._handle_compaction_status(self._failed_msg())
+        assert client._compaction_failed_at is not None
+
+        client._handle_compaction_status(
+            self._failed_msg({"status": {"type": "completed"}, "summary": "ok"})
+        )
+        assert client._compaction_failed_at is None
+
+    @pytest.mark.asyncio
+    async def test_frames_after_the_failure_defer_the_budget(self, tmp_path, monkeypatch):
+        """The budget measures BACKEND SILENCE: a backend that keeps sending
+        frames after a failed compaction is not reaped by it."""
+        from kiro_crew.acp import client as acp_client
+        from kiro_crew.acp.types import METHOD_METADATA, JsonRpcMessage
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.3)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        client._is_process_alive = lambda: True
+        client._handle_compaction_status(self._failed_msg())
+
+        async def _steady_stream(timeout: float = 0.0):
+            await asyncio.sleep(0.05)
+            return JsonRpcMessage(method=METHOD_METADATA, params={})
+
+        client._read_message = _steady_stream
+
+        actions = []
+        async for action, _msg in client._prompt_loop(req_id=1, timeout=0.6):
+            actions.append(action)
+
+        # Ran to its own deadline while frames kept arriving.
+        assert actions and all(a == "metadata" for a in actions)
+        assert client._compaction_failed_turn is False
+
+    @pytest.mark.asyncio
+    async def test_dispatch_ends_turn_with_compaction_stop_reason(self):
+        """The abandoned turn terminates with the explicit stop reason instead
+        of raising the generic timeout, so the runner releases the slot."""
+        from kiro_crew.acp.types import (
+            EVENT_COMPLETE,
+            STOP_REASON_COMPACTION_FAILED,
+            AcpEvent,
+        )
+
+        client = AcpClient()
+
+        async def fake_prompt_loop(req_id, timeout):
+            # The budget fired: the loop stops reading with no `complete`.
+            client._compaction_failed_turn = True
+            if False:  # pragma: no cover - keeps this an async generator
+                yield "complete", None
+
+        client.ensure_ready = AsyncMock()
+        client._send_prompt = AsyncMock(return_value=1)
+        client._prompt_loop = fake_prompt_loop
+
+        events: list[AcpEvent] = []
+        async for ev in client.stream_events("test"):
+            events.append(ev)
+
+        assert [e.kind for e in events] == [EVENT_COMPLETE]
+        assert events[0].stop_reason == STOP_REASON_COMPACTION_FAILED
+        # Single-shot: the marker must not leak into the next turn.
+        assert client._compaction_failed_turn is False
+
+    @pytest.mark.asyncio
+    async def test_streamed_text_still_reports_compaction_failure(self):
+        """A turn that streamed text before the failure must NOT be finalized as
+        a normal end_turn by the stale-turn branch — the cause is the failure."""
+        from kiro_crew.acp.types import (
+            EVENT_COMPLETE,
+            STOP_REASON_COMPACTION_FAILED,
+            AcpEvent,
+        )
+
+        client = AcpClient()
+
+        async def fake_prompt_loop(req_id, timeout):
+            client._stale_eligible = True
+            client._compaction_failed_turn = True
+            if False:  # pragma: no cover - keeps this an async generator
+                yield "complete", None
+
+        client.ensure_ready = AsyncMock()
+        client._send_prompt = AsyncMock(return_value=1)
+        client._prompt_loop = fake_prompt_loop
+
+        events: list[AcpEvent] = []
+        async for ev in client.stream_events("test"):
+            events.append(ev)
+
+        assert [e.kind for e in events] == [EVENT_COMPLETE]
+        assert events[0].stop_reason == STOP_REASON_COMPACTION_FAILED
+
+    @pytest.mark.asyncio
+    async def test_failed_event_title_carries_the_reason(self):
+        """The notice reads AcpEvent.title. kiro-cli leaves `summary` empty on
+        failure, which collapsed the row to "unknown error" — the raw
+        notification's own reason now rides the title instead."""
+        from kiro_crew.acp.types import (
+            EVENT_COMPACTION_STATUS,
+            METHOD_COMPACTION_STATUS,
+            AcpEvent,
+            JsonRpcMessage,
+        )
+
+        client = AcpClient()
+        compact_msg = JsonRpcMessage(
+            method=METHOD_COMPACTION_STATUS,
+            params={
+                "status": {"type": "failed", "error": "context window exceeded"},
+                "summary": "",
+            },
+        )
+        complete_msg = JsonRpcMessage(id=1, result={"stopReason": "end_turn"})
+
+        async def fake_prompt_loop(req_id, timeout):
+            yield "compaction", compact_msg
+            yield "complete", complete_msg
+
+        client.ensure_ready = AsyncMock()
+        client._send_prompt = AsyncMock(return_value=1)
+        client._prompt_loop = fake_prompt_loop
+
+        events: list[AcpEvent] = []
+        async for ev in client.stream_events("test"):
+            events.append(ev)
+
+        assert events[0].kind == EVENT_COMPACTION_STATUS
+        assert events[0].text == "failed"
+        assert events[0].title == "context window exceeded"
+
+    @pytest.mark.asyncio
+    async def test_consumer_park_is_not_charged_to_the_budget(self, tmp_path, monkeypatch):
+        """A human approval parks the whole generator chain at _prompt_loop's
+        single yield. That interval is CONSUMER time (mirrors the
+        AcpSessionHandle park accounting): without the exclusion, the resume
+        computes idle = the park length and reaps a live turn whose backend
+        was only ever waiting for the approval answer."""
+        from kiro_crew.acp import client as acp_client
+        from kiro_crew.acp.types import METHOD_METADATA, JsonRpcMessage
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        client._stale_eligible = False
+        client._tool_dispatched = False
+        client._is_process_alive = lambda: True
+        client._read_message = self._silent_after(
+            [self._failed_msg(), JsonRpcMessage(method=METHOD_METADATA, params={})]
+        )
+
+        parked = False
+        resumed_at = None
+        async for action, msg in client._prompt_loop(req_id=1, timeout=30.0):
+            if action == "compaction":
+                client._handle_compaction_status(msg)
+            elif action == "metadata" and not parked:
+                # The consumer holds this frame past the WHOLE budget — the
+                # shape of a human answering an approval card slowly.
+                parked = True
+                await asyncio.sleep(0.3)
+                resumed_at = time.monotonic()
+        ended_at = time.monotonic()
+
+        # The budget still ends the (genuinely) silent turn — but measured
+        # from the resume, not from the frame before the park.
+        assert client._compaction_failed_turn is True
+        assert parked and resumed_at is not None
+        assert ended_at - resumed_at >= 0.15, (
+            f"turn ended {ended_at - resumed_at:.2f}s after the consumer resumed - "
+            "the park was charged to the backend-silence budget"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_tool_in_flight_suspends_the_budget(self, tmp_path, monkeypatch):
+        """kiro-cli can recover from a failed compaction and dispatch a tool. A
+        legitimately silent long tool (a build, a spawned subagent) must NOT be
+        reaped at the compaction budget — that would cancel valid work the
+        tool-stall watchdog already governs on its own longer budget."""
+        from kiro_crew.acp import client as acp_client
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.05)
+        monkeypatch.setattr(acp_client, "_TOOL_STALL_TIMEOUT", 30.0)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        client._is_process_alive = lambda: True
+        client._read_message = self._silent_after([self._failed_msg()])
+
+        async def _drive(timeout: float) -> None:
+            async for action, msg in client._prompt_loop(req_id=1, timeout=timeout):
+                if action == "compaction":
+                    client._handle_compaction_status(msg)
+                    # The turn recovers and dispatches a tool, exactly as
+                    # _dispatch_events would mark it.
+                    client._tool_dispatched = True
+
+        t0 = time.monotonic()
+        await _drive(0.4)
+        elapsed = time.monotonic() - t0
+
+        # Ran to its own deadline: the budget stayed suspended for the whole of
+        # the tool's silence, and the turn was not marked compaction-failed.
+        assert client._compaction_failed_turn is False
+        assert elapsed >= 0.35, f"loop exited at {elapsed:.2f}s — the budget reaped a live tool"
+        # Still armed, so the budget re-fires once the tool resolves.
+        assert client._compaction_failed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_the_budget_re_arms_when_the_tool_resolves(self, tmp_path, monkeypatch):
+        """Suspension is not a permanent disarm: once the tool resolves and the
+        backend goes silent again, the abandoned turn is still ended."""
+        from kiro_crew.acp import client as acp_client
+        from kiro_crew.acp.types import METHOD_METADATA, JsonRpcMessage
+
+        monkeypatch.setattr(acp_client, "_COMPACTION_FAILED_TURN_BUDGET", 0.1)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+
+        client = AcpClient(work_dir=tmp_path)
+        client._turn_done.clear()
+        client._is_process_alive = lambda: True
+        # A failed status, then one more frame standing in for the tool's own
+        # traffic — after which the backend goes silent for good.
+        client._read_message = self._silent_after(
+            [self._failed_msg(), JsonRpcMessage(method=METHOD_METADATA, params={})]
+        )
+
+        t0 = time.monotonic()
+        async for action, msg in client._prompt_loop(req_id=1, timeout=30.0):
+            if action == "compaction":
+                client._handle_compaction_status(msg)
+                client._tool_dispatched = True
+            elif action == "metadata":
+                # The tool resolved (what _dispatch_events does on its result).
+                client._tool_dispatched = False
+        elapsed = time.monotonic() - t0
+
+        assert client._compaction_failed_turn is True
+        assert elapsed < 5.0, f"loop ran {elapsed:.2f}s — the budget did not re-arm"
+
+
+class TestCompactionFailureDetail:
+    """`compaction_failure_detail` is what stops the notice collapsing to
+    "unknown error": it prefers a named reason and otherwise surfaces the raw
+    shape, redacted, because it lands on a chat row."""
+
+    def test_prefers_a_named_reason(self):
+        from kiro_crew.acp.client import compaction_failure_detail
+
+        assert (
+            compaction_failure_detail({"status": {"type": "failed", "reason": "too large"}})
+            == "too large"
+        )
+
+    def test_reads_a_nested_error_object(self):
+        from kiro_crew.acp.client import compaction_failure_detail
+
+        detail = compaction_failure_detail(
+            {"status": {"type": "failed"}, "error": {"message": "throttled"}}
+        )
+        assert detail == "throttled"
+
+    def test_falls_back_to_the_raw_shape(self):
+        from kiro_crew.acp.client import compaction_failure_detail
+
+        detail = compaction_failure_detail({"status": {"type": "failed"}})
+        assert "no reason reported" in detail
+        assert "failed" in detail
+
+    def test_is_bounded_and_redacted(self):
+        from kiro_crew.acp.client import _COMPACTION_DETAIL_MAX_CHARS, compaction_failure_detail
+
+        detail = compaction_failure_detail({"status": {"type": "failed", "error": "x" * 5000}})
+        assert len(detail) == _COMPACTION_DETAIL_MAX_CHARS
+
+        secret = compaction_failure_detail(
+            {"status": {"type": "failed", "error": "aws_secret_access_key=AKIAIOSFODNN7EXAMPLE"}}
+        )
+        assert "AKIAIOSFODNN7EXAMPLE" not in secret

--- a/test/test_acp_session_handle_stream_command.py
+++ b/test/test_acp_session_handle_stream_command.py
@@ -20,11 +20,14 @@ import pytest
 from kiro_crew.acp.session_handle import AcpRuntimeError, AcpSessionHandle
 from kiro_crew.acp.types import (
     EVENT_AGENT_SWITCHED,
+    EVENT_COMPACTION_STATUS,
     EVENT_COMPLETE,
     EVENT_TEXT_CHUNK,
     METHOD_AGENT_SWITCHED,
     METHOD_COMMANDS_EXECUTE,
+    METHOD_COMPACTION_STATUS,
     METHOD_SESSION_UPDATE,
+    STOP_REASON_COMPACTION_FAILED,
     JsonRpcMessage,
 )
 
@@ -320,3 +323,203 @@ async def test_no_response_terminates_at_timeout():
 
 async def _collect_with_timeout(handle: AcpSessionHandle, command: str, timeout: float) -> list:
     return [ev async for ev in handle.stream_command(command, timeout=timeout)]
+
+
+# ── Post-compaction-failure budget (issue #3583) ─────────────────────────────
+
+
+def _failed_compaction(params: dict | None = None) -> JsonRpcMessage:
+    return JsonRpcMessage(
+        method=METHOD_COMPACTION_STATUS,
+        params=params if params is not None else {"status": {"type": "failed"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_compaction_then_no_response_ends_the_turn(monkeypatch):
+    """kiro-cli reports compaction `failed` and then abandons the prompt: no
+    response, no end_turn. The turn must end at the post-failure budget with
+    STOP_REASON_COMPACTION_FAILED instead of draining to the turn ceiling and
+    holding the slot (issue #3583)."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    handle, _rt = _make(respond=False, updates=[_failed_compaction()])
+    start = time.monotonic()
+    events = [ev async for ev in handle.prompt("hello", timeout=30.0)]
+    elapsed = time.monotonic() - start
+
+    assert events[0].kind == EVENT_COMPACTION_STATUS
+    assert events[0].text == "failed"
+    assert events[-1].kind == EVENT_COMPLETE
+    assert events[-1].stop_reason == STOP_REASON_COMPACTION_FAILED
+    # Proves the budget ended it, not the 30s turn deadline. The bound is loose
+    # because the check runs on the loop's own tick: the dispatch loop parks on
+    # the session queue for up to 5s, so a fired budget is acted on at the next
+    # wake, not the instant it expires.
+    assert elapsed < 10.0, f"turn ran too long ({elapsed:.2f}s) — the hang is back"
+    assert handle._turn_done.is_set()
+    assert handle.is_turn_active is False
+
+
+@pytest.mark.asyncio
+async def test_a_tool_in_flight_suspends_the_post_failure_budget(monkeypatch):
+    """Shared-runtime twin of the client rule: a tool dispatched after the failed
+    compaction is live work, so the budget must not cancel the session under it.
+    The tool-stall watchdog owns that case on its own longer, liveness-gated
+    budget."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.05)
+
+    handle, _rt = _make(respond=False, updates=[_failed_compaction()])
+
+    # The turn ceiling must outlast one queue tick (the loop parks on the
+    # session queue for up to 5s, and the budget is checked at the loop top), or
+    # the unsuspended budget could not fire either and the test would be vacuous.
+    start = time.monotonic()
+    events = []
+    async for ev in handle.prompt("hello", timeout=8.0):
+        events.append(ev)
+        if ev.kind == EVENT_COMPACTION_STATUS and ev.text == "failed":
+            # The turn recovers and dispatches a tool. Set from the consumer
+            # side because prompt()'s prologue clears the flag at turn start.
+            handle._tool_dispatched = True
+    elapsed = time.monotonic() - start
+
+    # The turn ran to its own deadline instead of being reaped at the budget,
+    # so the terminal event is the ordinary timeout, not the compaction reason.
+    assert events[-1].stop_reason != STOP_REASON_COMPACTION_FAILED
+    assert elapsed >= 7.0, f"turn ended at {elapsed:.2f}s — the budget reaped a live tool"
+    # Still armed: the budget re-fires once the tool resolves.
+    assert handle._compaction_failed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_compaction_notice_carries_the_reason(monkeypatch):
+    """The dashboard notice reads AcpEvent.title, and kiro-cli leaves `summary`
+    empty on failure — the notification's own reason rides the title so the row
+    stops collapsing to "unknown error"."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    handle, _rt = _make(
+        respond=False,
+        updates=[_failed_compaction({"status": {"type": "failed", "reason": "history too long"}})],
+    )
+    events = [ev async for ev in handle.prompt("hello", timeout=30.0)]
+
+    assert events[0].title == "history too long"
+
+
+@pytest.mark.asyncio
+async def test_co_tenant_fanout_frames_do_not_defer_the_budget(monkeypatch):
+    """On a shared runtime, ownerless global notifications are fanned out to
+    every co-tenant queue (msg.fanout_no_owner). They are ANOTHER session's
+    traffic: if they reset this session's post-failure silence clock, a busy
+    co-tenant defers the budget to the multi-hour outer deadline and the
+    original #3583 hang survives on shared runtimes."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    handle, _rt = _make(respond=False, updates=[_failed_compaction()])
+
+    stop_feeding = asyncio.Event()
+
+    async def _co_tenant_chatter():
+        # Recurring ownerless roster updates, well inside the budget interval.
+        while not stop_feeding.is_set():
+            frame = JsonRpcMessage(method="kiro/subagents/update", params={"subagents": []})
+            frame.fanout_no_owner = True
+            handle._queue.put_nowait(frame)
+            await asyncio.sleep(0.05)
+
+    feeder = asyncio.create_task(_co_tenant_chatter())
+    try:
+        start = time.monotonic()
+        events = [ev async for ev in handle.prompt("hello", timeout=30.0)]
+        elapsed = time.monotonic() - start
+    finally:
+        stop_feeding.set()
+        await feeder
+
+    assert events[-1].kind == EVENT_COMPLETE
+    assert events[-1].stop_reason == STOP_REASON_COMPACTION_FAILED
+    assert elapsed < 10.0, f"turn ran {elapsed:.2f}s — co-tenant fanout frames deferred the budget"
+
+
+@pytest.mark.asyncio
+async def test_ownerless_failure_does_not_arm_a_co_tenant_budget(monkeypatch):
+    """A compaction notification with no sessionId is fanned out to every
+    co-tenant, so at most one recipient actually compacted. Arming this
+    session's budget from a peer's failure would reap this session's live turn
+    at the budget — and every consumer resets the session on that terminal, so
+    the peer's failure destroys unrelated work."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    frame = _failed_compaction()
+    frame.fanout_no_owner = True
+    handle, _rt = _make(respond=False, updates=[frame])
+
+    # The deadline must sit past the dispatch loop's queue park (up to 5s) or
+    # the budget never gets a tick to fire on and the test cannot fail.
+    start = time.monotonic()
+    events = [ev async for ev in handle.prompt("hello", timeout=7.0)]
+    elapsed = time.monotonic() - start
+
+    assert handle._compaction_failed_at is None, "a peer's failure armed this session"
+    assert events[-1].kind == EVENT_COMPLETE
+    assert events[-1].stop_reason != STOP_REASON_COMPACTION_FAILED
+    assert (
+        elapsed >= 5.5
+    ), f"turn ended after {elapsed:.2f}s — a co-tenant's failure reaped this turn"
+
+
+@pytest.mark.asyncio
+async def test_ownerless_completion_does_not_disarm_the_budget(monkeypatch):
+    """The mirror direction, and the one that silently restores the #3583 hang:
+    a peer's SUCCESSFUL compaction is fanned out too, and clearing this
+    session's armed budget from it would leave a genuinely abandoned turn
+    draining to the multi-hour turn ceiling again."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    peer_ok = _failed_compaction({"status": {"type": "completed"}, "summary": "peer"})
+    peer_ok.fanout_no_owner = True
+    # This session's own failure arms the budget; the peer's completion must not
+    # clear it.
+    handle, _rt = _make(respond=False, updates=[_failed_compaction(), peer_ok])
+
+    events = [ev async for ev in handle.prompt("hello", timeout=30.0)]
+
+    assert events[-1].kind == EVENT_COMPLETE
+    assert (
+        events[-1].stop_reason == STOP_REASON_COMPACTION_FAILED
+    ), "a co-tenant's successful compaction disarmed this session's budget"
+
+
+@pytest.mark.asyncio
+async def test_completed_compaction_does_not_arm_the_budget(monkeypatch):
+    """A successful compaction must not arm the budget: the turn keeps running
+    and completes on the backend's own response."""
+    from kiro_crew.acp import session_handle as sh
+
+    monkeypatch.setattr(sh, "_COMPACTION_FAILED_TURN_BUDGET", 0.2)
+
+    handle, _rt = _make(
+        response_result={"stopReason": "end_turn"},
+        updates=[_failed_compaction({"status": {"type": "completed"}, "summary": "3k saved"})],
+    )
+    events = [ev async for ev in handle.prompt("hello", timeout=5.0)]
+
+    assert events[0].kind == EVENT_COMPACTION_STATUS
+    assert events[0].text == "completed"
+    assert events[-1].kind == EVENT_COMPLETE
+    assert events[-1].stop_reason == "end_turn"
+    assert handle._compaction_failed_at is None

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -37,6 +37,7 @@ from kiro_crew.acp.types import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
+    STOP_REASON_COMPACTION_FAILED,
     STOP_REASON_STALE_RECOVER,
     STOP_REASON_TOOL_STALL,
 )
@@ -2286,6 +2287,59 @@ class TestRunChatRecoveryLadders:
 
         assert any("please retry" in err for err in _errors(slot))
         assert slot._queue == []
+
+    @pytest.mark.asyncio
+    async def test_compaction_failure_neither_retries_nor_claims_a_lost_link(self, tmp_path):
+        """A compaction-failed turn is terminal: the reason is in the "error:"
+        family, so without its own branch it lands in pipe-death recovery — a
+        re-queue plus a "Connection lost" card, both false. Compaction retry
+        policy is not this layer's to invent (issue #3583)."""
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        _set_stream(
+            client,
+            [
+                LLMEvent(
+                    kind="compaction_status",
+                    text="failed",
+                    title="context window exceeded",
+                ),
+                _complete(STOP_REASON_COMPACTION_FAILED),
+            ],
+        )
+
+        await _drive(state, slot)
+
+        errors = _errors(slot)
+        assert not any("Connection lost" in err for err in errors), errors
+        assert not any("Session stuck" in err for err in errors), errors
+        assert slot._acp_pipe_death_retries == 0
+        assert slot._queue == []
+        # The failure is still explained — by the compaction notice the status
+        # path appended, which is the only message this turn needs.
+        assert any(
+            "Compaction failed" in m.get("content", "")
+            and "context window exceeded" in m.get("content", "")
+            for m in slot.messages
+        ), slot.messages
+
+    @pytest.mark.asyncio
+    async def test_compaction_failure_resets_the_abandoned_backend_session(self, tmp_path):
+        """The completion is synthetic — the client stopped reading; the
+        backend never sent end_turn — so without a reset the runtime still
+        counts the turn as in progress and the NEXT prompt collides with
+        "prompt already in progress". The finally must reset (tear down +
+        session/load resume) WITHOUT re-queuing anything."""
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+        state.sessions.reset = AsyncMock()
+        _set_stream(client, [_complete(STOP_REASON_COMPACTION_FAILED)])
+
+        await _drive(state, slot)
+
+        state.sessions.reset.assert_awaited_once()
+        assert slot._queue == []
+        assert slot._acp_pipe_death_retries == 0
 
     @pytest.mark.asyncio
     async def test_tool_stall_recovery_names_the_stalled_tool(self, tmp_path):

--- a/test/test_compaction_wait_budget.py
+++ b/test/test_compaction_wait_budget.py
@@ -150,3 +150,32 @@ def test_no_call_site_pins_a_shorter_wait():
         "Compaction wait shorter than the shared budget reintroduced (delete "
         f"the timeout argument so the shared default applies): {offenders}"
     )
+
+
+# ── Post-failure turn budget (issue #3583) ──────────────────────────────────
+#
+# A DIFFERENT budget with a different job: the constant above bounds how long a
+# caller waits for compaction to finish, this one bounds how long a turn waits
+# for the backend after compaction reported `failed`. It exists because that
+# wait was previously unbounded in practice — the read loop drained to the
+# caller's full prompt ceiling and never released the slot.
+
+
+def test_post_failure_budget_is_one_constant_for_both_dispatch_paths():
+    """The dedicated-process client and the shared-runtime handle must reap an
+    abandoned post-compaction turn on the same schedule; a second literal would
+    let one path keep hanging after the other was tuned."""
+    from kiro_crew.acp import client, session_handle
+
+    assert session_handle._COMPACTION_FAILED_TURN_BUDGET is client._COMPACTION_FAILED_TURN_BUDGET
+
+
+def test_post_failure_budget_is_bounded_by_the_ordinary_silence_window():
+    """A turn the backend has already reported a failure for must not outlive an
+    ordinary silent turn — otherwise the hang it fixes just gets shorter."""
+    from kiro_crew.acp.client import (
+        _COMPACTION_FAILED_TURN_BUDGET,
+        _STALE_TURN_TIMEOUT,
+    )
+
+    assert 0 < _COMPACTION_FAILED_TURN_BUDGET <= _STALE_TURN_TIMEOUT

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -670,6 +670,22 @@ class TestBroadcastCompactionResultBackoff:
         assert "x in a row" in msg
         assert "too large to" in msg or "unknown error" in msg
 
+    def test_enriched_title_replaces_unknown_error(self, tmp_path, monkeypatch):
+        """The notice reads the event title. kiro-cli sends no summary on
+        failure, so the ACP layer now carries the notification's own reason
+        there (issue #3583) — the row must name it instead of collapsing to
+        "unknown error"."""
+        from kiro_crew.dashboard.chat_utils import _broadcast_compaction_result
+
+        state, slot = self._make_slot_and_state(tmp_path, monkeypatch)
+
+        msg = _broadcast_compaction_result(
+            state, slot, self._failed_event("context window exceeded")
+        )
+        assert msg is not None
+        assert "context window exceeded" in msg
+        assert "unknown error" not in msg
+
     def test_success_resets_streak_and_cooldown(self, tmp_path, monkeypatch):
         from kiro_crew.dashboard.chat_utils import (
             _COMPACTION_NOTICE_SHOW_FIRST_N,

--- a/test/test_kas_display_mapping.py
+++ b/test/test_kas_display_mapping.py
@@ -288,6 +288,60 @@ def test_summarization_failed_emits_failed_and_does_not_reset() -> None:
     assert handle.last_prompt_stats.context_tokens_from_usage is True
 
 
+def test_summarization_failed_arms_the_post_failure_budget() -> None:
+    # KAS is a third producer of a failed compaction status on the SAME dispatch
+    # loop, so it must arm the bounded post-failure wait — otherwise a KAS turn
+    # abandoned after failed summarization still drains to the turn ceiling
+    # (issue #3583).
+    handle = _handle(ACP_BACKEND_KAS)
+    assert handle._compaction_failed_at is None
+    _update(
+        handle,
+        {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "summarization_failed"}}},
+    )
+    assert handle._compaction_failed_at is not None
+
+
+def test_summarization_completed_disarms_the_post_failure_budget() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    _update(
+        handle,
+        {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "summarization_failed"}}},
+    )
+    _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "summarization_completed", "conversationSummary": "ok"}},
+        },
+    )
+    assert handle._compaction_failed_at is None
+
+
+def test_summarization_failed_notice_carries_the_reason() -> None:
+    # conversationSummary is empty on failure, so the dashboard notice would read
+    # "unknown error" — KAS's own reason rides the title instead.
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(
+        handle,
+        {
+            "sessionUpdate": "session_info_update",
+            "_meta": {"kiro": {"kind": "summarization_failed", "reason": "transcript too long"}},
+        },
+    )
+    assert events[0].title == "transcript too long"
+
+
+def test_summarization_failed_notice_falls_back_to_the_raw_shape() -> None:
+    handle = _handle(ACP_BACKEND_KAS)
+    events = _update(
+        handle,
+        {"sessionUpdate": "session_info_update", "_meta": {"kiro": {"kind": "summarization_failed"}}},
+    )
+    assert "no reason reported" in events[0].title
+    assert "summarization_failed" in events[0].title
+
+
 def test_session_info_missing_or_malformed_meta_is_safe() -> None:
     handle = _handle(ACP_BACKEND_KAS)
     assert _update(handle, {"sessionUpdate": "session_info_update"}) == []

--- a/test/test_messaging_dispatch.py
+++ b/test/test_messaging_dispatch.py
@@ -23,6 +23,7 @@ class _Sessions:
         self.released = 0
         self.successes = 0
         self.failures = 0
+        self.resets = 0
         self._raise_on_acquire = raise_on_acquire
 
     async def get_or_create(self, key, agent=None, channel_id=None):
@@ -35,6 +36,9 @@ class _Sessions:
 
     def record_success(self, key):
         self.successes += 1
+
+    async def reset(self, key):
+        self.resets += 1
 
     async def record_failure(self, key):
         self.failures += 1
@@ -68,6 +72,8 @@ class _CtxBuilder:
 
 
 class _Driver:
+    last_stop_reason = ""
+
     def __init__(self, *a, **kw):
         pass
 
@@ -175,6 +181,66 @@ def test_the_happy_path_releases_exactly_once(monkeypatch) -> None:
     assert renderer.closed == 1
     assert sessions.released == 1
     assert sessions.successes == 1
+
+
+def test_a_compaction_failed_terminal_resets_the_session(monkeypatch) -> None:
+    """A COMPACTION_FAILED terminal is synthetic — the backend abandoned the
+    turn after a failed auto-compaction and never sent end_turn, so it still
+    counts the prompt as in progress. The dispatcher must reset the session
+    or this channel's NEXT message collides with "prompt already in
+    progress" (no re-queue; the notice already reached the user)."""
+    from kiro_crew.acp.types import STOP_REASON_COMPACTION_FAILED
+
+    class _AbandonedDriver(_Driver):
+        last_stop_reason = STOP_REASON_COMPACTION_FAILED
+
+    _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(D, "TurnDriver", _AbandonedDriver)
+    sessions = _Sessions()
+    renderer = _Renderer()
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert sessions.resets == 1
+    assert sessions.released == 1
+
+
+def test_a_driver_without_a_stop_reason_still_finishes_the_turn(monkeypatch) -> None:
+    """The stop-reason read is defensive, like every other attribute read on
+    this seam. ``TurnDriver`` is resolved through the module attribute, so a
+    stand-in that predates the field must mean "no synthetic completion" — not
+    an AttributeError raised at a real inbound message AFTER the turn already
+    ran and the user already got the answer."""
+
+    class _FieldlessDriver:
+        def __init__(self, *a, **kw) -> None:
+            pass
+
+        async def run(self, message: str) -> str:
+            return "the answer"
+
+    _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(D, "TurnDriver", _FieldlessDriver)
+    sessions = _Sessions()
+    renderer = _Renderer()
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert sessions.resets == 0
+    assert sessions.released == 1
+
+
+def test_an_ordinary_terminal_does_not_reset_the_session(monkeypatch) -> None:
+    """The reset is scoped to the compaction-failed terminal — an ordinary
+    end_turn keeps the session alive (resetting it would pay a cold start on
+    every message)."""
+    _patch_pipeline(monkeypatch)
+    sessions = _Sessions()
+    renderer = _Renderer()
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert sessions.resets == 0
 
 
 def test_a_denied_turn_neither_renders_nor_releases(monkeypatch) -> None:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -2915,6 +2915,32 @@ class TestCompactCommand:
         assert "destroy:thread1" not in sessions.removed
 
 
+class TestStopReasonCompactionFailed:
+    """A COMPACTION_FAILED terminal is synthetic — the backend abandoned the
+    turn after a failed auto-compaction and never sent end_turn, so it still
+    counts the prompt as in progress. The handler must reset the session or
+    the NEXT Slack message collides with "prompt already in progress"."""
+
+    @pytest.mark.asyncio
+    async def test_compaction_failed_resets_the_abandoned_session(self):
+        from kiro_crew.acp.types import STOP_REASON_COMPACTION_FAILED
+
+        slack = MockSlackClient()
+        provider = FakeProvider(
+            [
+                LLMEvent(kind="text_chunk", text="partial"),
+                LLMEvent(kind="complete", stop_reason=STOP_REASON_COMPACTION_FAILED),
+            ]
+        )
+        sessions = FakeSessionManager(provider)
+
+        await handle_message(slack, sessions, "C1", "hello", None, "msg1", "U1")
+
+        assert any(
+            r.startswith("reset:") for r in sessions.removed
+        ), f"no session reset after COMPACTION_FAILED: {sessions.removed}"
+
+
 class TestBuildTimingFooter:
     """Unit tests for the build_timing_footer helper."""
 


### PR DESCRIPTION
## Problem

Issue #3583 — automatic compaction failures at high context leave sessions hung.

On a `failed` compaction status, both dispatch loops yield `EVENT_COMPACTION_STATUS`
and keep reading on the same prompt request id. The backend may never send the
`session/prompt` response or an `end_turn` for the turn it was compacting for, so
the loop drains in silence to the caller's whole prompt ceiling (hours) and the
slot is never released. The user waits it out or presses Stop.

The issue's "no error is surfaced" claim is partly stale: a user-visible notice
already exists (`chat_utils._broadcast_compaction_result`). The real gap is turn
termination, not messaging — but the notice text collapses to "unknown error",
which is fixed here too.

## Change

1. **Bounded post-failure wait.** Once a `failed` status has been seen, backend
   silence past `_COMPACTION_FAILED_TURN_BUDGET` (60s) ends the turn with the new
   `STOP_REASON_COMPACTION_FAILED`, so the runner releases the slot. The constant
   sits beside the existing turn watchdogs (`_STALE_TURN_TIMEOUT`,
   `_TOOL_STALL_TIMEOUT`) and one number governs **all three** producers of a
   failed status: `AcpClient._prompt_loop`, the kiro-cli branch of
   `AcpSessionHandle._dispatch_events`, and the KAS `summarization_failed` path
   that rides the same loop. Any inbound frame resets the clock, so a backend
   that keeps streaming after a failed compaction is unaffected and stays
   governed by the stale-turn / tool-stall watchdogs. A `completed` /
   `summarization_completed` status disarms it. Three properties keep the clock
   honest:
   - **A tool in flight suspends it.** kiro-cli can recover from the failed
     compaction and dispatch a tool; a legitimately silent long tool (a build, a
     spawned subagent) must not be reaped at 60s, because that kills valid work
     the tool-stall watchdog already governs on its own longer, liveness-gated
     budget. Both checks are gated on `not self._tool_dispatched`, and the
     marker stays armed so the budget re-fires once the tool resolves.
   - **Consumer park time is excluded** on both dispatch paths: the generator
     chain is suspended at its yield during a human approval wait, so that wait
     must not read as backend silence (`AcpClient._prompt_loop` gains the same
     park accounting `AcpSessionHandle` already had).
   - **On a shared runtime, only session-attributable frames defer it.**
     Ownerless `fanout_no_owner` notifications are another co-tenant's traffic; a
     twin clock `last_own_data_ts` ignores them so a busy co-tenant cannot
     postpone the budget to the multi-hour outer deadline. The pre-existing
     tool-stall / stale clocks keep their original `last_data_ts` behavior.

   The two clocks are therefore **deliberately asymmetric**, and each now carries
   a comment naming why it differs from its twin, so the difference cannot drift
   into an accident.
2. **No retry, and no false "Connection lost".** The stop reason is in the
   `"error:"` family (so callers without a dedicated branch fall back to generic
   error handling), and `_run_chat` returns through its own no-retry branch
   placed **before** the pipe-death branch — which would otherwise re-queue the
   message and label it "Connection lost". The other chat_runner touch adds the
   reason to the known-stop-reason list so an expected terminal state is not
   logged as "unexpected".
   **Every persistent consumer also resets the abandoned session**: the
   completion is synthetic (the client stopped reading; the backend never sent
   `end_turn`), so the backend still counts the prompt as in progress and the
   next message would collide with "prompt already in progress". The dashboard
   runner sets `needs_session_reset` on the compaction-failed branch, the Slack
   handler awaits `sessions.reset()` (and skips the post-turn context-usage probe
   on that terminal, since the session it would measure is about to be recycled),
   and the messaging dispatcher does the same via a new
   `TurnDriver.last_stop_reason` — read with `getattr` like every other attribute
   on that seam, because `drive_turn` resolves `TurnDriver` through the module
   attribute and a stand-in that predates the field must mean "no synthetic
   completion", not an exception after the turn already answered. All three
   mirror the established prompt-busy / stale-recover reset shape, with no
   re-queue.
3. **Enriched notice.** The notification's own reason now rides `AcpEvent.title`
   via the shared `compaction_failure_detail()`, so the existing row stops saying
   "unknown error". It prefers a named reason (`status.error` / `reason` /
   `message` / nested `error.message`, and KAS's own `reason`), falls back to the
   raw shape, and redacts through the single-source `redact_text` plus a length
   cap because it lands on a chat row. The streak/cooldown notice remains the
   user-facing message; no second notice is added.

## Out of scope (deliberate)

- **No auto-retry, no new compaction fallback.** Compaction stays the backend's;
  this change only makes its failure fail the turn cleanly. Retry policy is an
  open maintainer decision and is not in this PR.
- **Manual `/compact`** (#792) — separate issue, untouched.
- **`STOP_REASON_STALE_RECOVER` on the messaging / Slack surfaces** — the same
  "prompt already in progress" collision class, unhandled there today (0 grep
  hits in either directory) and pre-existing. This PR wires the reset for the new
  reason only. Whether the fix belongs per-producer or at the session seam (mark
  the handle "needs reset", repair on the next prompt — covering compaction-failed,
  stale-recover and tool-stall in one mechanism) is a maintainer decision, raised
  in the Design Review disposition rather than pre-judged by an issue.

## Testing

Red-before proven on every arm:

- Against pristine main (`97b8378bd`): a probe that sends a `failed` status then
  goes silent drains the *entire* turn deadline on both dispatch paths (8s in the
  probe, hours in production); with the budget armed both terminate in ~0.3s with
  `error: compaction failed`.
- Removing only the `_run_chat` no-retry branch makes the runner test fail with
  `['⟳ Connection lost — retrying...']`.
- Removing only the tool-in-flight suspension makes the client test fail
  (`assert True is False`) and the shared-runtime test fail
  (`'error: compaction failed' != 'error: compaction failed'`).

Committed coverage:

- `test/test_acp_client.py` — `TestCompactionFailureTurnBudget` (armed mid-turn
  through the status chokepoint; full `stream_events` path ending with the
  compaction stop reason inside a 30s ceiling; unarmed turn unaffected; frames
  defer the budget; `completed` disarms; a turn that streamed text still reports
  the failure rather than a normal `end_turn`; **a tool in flight suspends the
  budget**, and **the budget re-arms when the tool resolves**) and
  `TestCompactionFailureDetail` (named reason, nested error, raw fallback,
  bounded + redacted).
- `test/test_acp_session_handle_stream_command.py` — shared-runtime path: failed
  status + no response ends the turn with `STOP_REASON_COMPACTION_FAILED`, title
  carries the reason, `completed` does not arm the budget, and **a tool in flight
  suspends the budget** (that test uses an 8s ceiling on purpose: the loop parks
  on its session queue for up to 5s, so a shorter ceiling would leave the
  unsuspended budget unable to fire and the test vacuous).
- `test/test_kas_display_mapping.py` — KAS parity: `summarization_failed` arms
  the budget, `summarization_completed` disarms it, and the notice carries KAS's
  reason (or the raw shape).
- `test/test_chat_runner_coverage.py` — a compaction-failed turn neither
  re-queues nor claims a lost connection, the compaction notice still explains
  it, and the abandoned backend session is reset (no re-queue).
- `test/test_messaging_dispatch.py` — the dispatcher resets on the
  compaction-failed terminal, does **not** reset on an ordinary terminal, and
  **finishes the turn when the driver has no `last_stop_reason` at all** (the
  CI red this round: an `AttributeError` reached a real inbound message).
- `test/test_slack_handler.py` — `TestStopReasonCompactionFailed`: Slack resets
  the session and skips the context-usage probe on that terminal.
- Round-2 clock coverage, each proven red-before by reverting only the production
  hunk: `test_consumer_park_is_not_charged_to_the_budget` (client park
  accounting) and `test_co_tenant_fanout_frames_do_not_defer_the_budget`
  (shared-runtime twin clock).
- `test/test_compaction_wait_budget.py` — the post-failure budget is one constant
  for both dispatch modules and is bounded by the ordinary silence window.
- `test/test_dashboard_chat.py` — the enriched title reaches the notice row
  instead of "unknown error".

Gates on `87804ede6` (rebased onto current `main`): `isort`, `flake8`,
`mypy src/kiro_crew/` (1128 files clean), and the baselined black gate
(`session_handle.py` deliberately not reformatted — it is in the baseline and
black would add 271 lines of unrelated churn). 1890 tests across the ACP / turn /
compaction / runner / messaging / Slack suites pass. An earlier round ran the full
backend suite against a pristine base worktree: identical FAILED sets (103
pre-existing environmental failures on both sides, zero introduced).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; the one user-visible surface is the
existing compaction notice row, whose text now names the backend's reason instead
of "unknown error" — pinned by a test rather than a pixel.

Closes #3583
