### PR TITLE
fix(mcp): let an observed hazard stop a server being pooled again

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -2219,10 +2219,50 @@ async def _handle_connection(
     # the safe default in both directions: an overlay written before the flag
     # existed never silently starts sharing, and a malformed frame cannot widen
     # a connection's blast radius beyond itself.
-    exclusive_stub_uuid = "" if register.get("poolable") is True else stub_uuid
+    poolable_requested = register.get("poolable") is True
+    exclusive_stub_uuid = "" if poolable_requested else stub_uuid
+
+    # Retreat: a server OBSERVED behaving per-client while shared is not pooled
+    # again, whatever the overlay still says. This is the consuming half of the
+    # hazard ledger. Without it, recording a hazard changed a label on the MCP
+    # page and nothing else, so "share by default, retreat when observed" had no
+    # retreat -- the ledger's own evidence never reached a routing decision.
+    #
+    # The identity-checked read is the right one precisely BECAUSE this acts on
+    # the verdict: it answers for the program this launch actually runs, so an
+    # upgrade or a config edit re-earns pooling instead of leaving the server
+    # stranded on evidence about the build it replaced.
+    #
+    # Per-connection and per-key, so nothing global is switched off: every other
+    # server keeps pooling, and this one still gets a working PRIVATE backend --
+    # the same topology it would have with no gateway at all. The cost of a
+    # wrong retreat is therefore lost process reuse, never a broken server.
+    if poolable_requested:
+        observed = hazards.observed_codes(
+            pool_key.server_name,
+            hazards.launch_identity(
+                pool_key.command_args_hash,
+                pool_key.effective_env_hash,
+                pool_key.binary_version,
+            ),
+        )
+        if observed:
+            exclusive_stub_uuid = stub_uuid
+            logger.warning(
+                "hazard retreat: serving %r a private backend because %s was "
+                "observed while it was shared",
+                pool_key.server_name,
+                ", ".join(observed),
+            )
 
     def _release_reservation() -> None:
         """Release the hand-out reservation this connection actually took.
+
+        Keyed on the OUTCOME, because that is what decides which acquire path
+        ran: ``pool.get_or_create`` reserves, ``pool.acquire_exclusive`` does
+        not. A hazard-retreated connection therefore reserved nothing even
+        though it asked to pool, so releasing on the REQUEST would decrement a
+        digest this connection never reserved.
 
         A private backend takes none: it never enters the shared index, so no
         sweeper can reclaim it between hand-out and attach. Releasing one anyway
@@ -2230,9 +2270,10 @@ async def _handle_connection(
         ``poolable`` is not a PoolKey dimension, so a pooled connection with an
         identical PoolKey shares the digest. That pairing is reachable whenever
         the allowlist changes under a daemon that outlives the gateway: the old
-        overlay's stub still registers poolable while the new one does not. The
-        stray decrement would drop the pooled connection's eviction protection
-        before its stub attaches.
+        overlay's stub still registers poolable while the new one does not, and
+        now also whenever a retreat lands beside a concurrent pooled connection
+        on the same key. The stray decrement would drop the pooled connection's
+        eviction protection before its stub attaches.
         """
         if not exclusive_stub_uuid:
             pool.unreserve(pool_key)
@@ -3007,14 +3048,43 @@ async def _respawn_backend_for_stub(
         )
         return None
 
+    # A respawn must honour the ledger too, or the retreat has a hole exactly
+    # where it matters most. The recycle that follows an unroutable server
+    # request comes straight back here, so re-pooling would hand the SAME stubs
+    # a shared backend for the server just observed misbehaving -- and no new
+    # register happens to re-decide it, so the retreat would not take effect
+    # until those sessions reconnected.
+    #
+    # ONE local drives both the acquire below and the release in the ``finally``,
+    # because those two must agree: only ``pool.get_or_create`` reserves, so a
+    # release keyed on a different predicate than the acquire would decrement a
+    # digest this respawn never reserved and drop a concurrent pooled
+    # connection's eviction protection.
+    respawn_exclusive_uuid = stub_uuid if old_backend.exclusive_token else ""
+    if not respawn_exclusive_uuid and hazards.observed_codes(
+        pool_key.server_name,
+        hazards.launch_identity(
+            pool_key.command_args_hash,
+            pool_key.effective_env_hash,
+            pool_key.binary_version,
+        ),
+    ):
+        respawn_exclusive_uuid = stub_uuid
+        logger.warning(
+            "hazard retreat on respawn: %r comes back private because a "
+            "hazard is on record for this launch",
+            pool_key.server_name,
+        )
+
     try:
         new_backend, _ = await _acquire_backend(
             pool,
             pool_key,
             resolver,
             # A respawn must not silently promote a private backend into the
-            # shared bucket: the replacement inherits the original binding.
-            exclusive_stub_uuid=stub_uuid if old_backend.exclusive_token else "",
+            # shared bucket: the replacement inherits the original binding,
+            # unless the ledger has since argued against sharing it at all.
+            exclusive_stub_uuid=respawn_exclusive_uuid,
         )
     except (_TargetUnknown, BackendUnavailable, PoolAtCapacity, OSError) as exc:
         logger.info(
@@ -3092,8 +3162,11 @@ async def _respawn_backend_for_stub(
     finally:
         # A private backend never took a reservation, and releasing one would
         # decrement a POOLED connection sharing this digest (see
-        # ``_release_reservation`` in the connection handler).
-        if not old_backend.exclusive_token:
+        # ``_release_reservation`` in the connection handler). Read the SAME
+        # local the acquire used, not ``old_backend.exclusive_token``: a hazard
+        # retreat above can make this respawn private while the old backend was
+        # pooled, and the two must not disagree.
+        if not respawn_exclusive_uuid:
             pool.unreserve(pool_key)
     new_writer_task = asyncio.create_task(
         _drain_inbox_to_stub(new_inbox, writer, stub_uuid),

--- a/src/kiro_crew/mcp_gateway/hazards.py
+++ b/src/kiro_crew/mcp_gateway/hazards.py
@@ -383,6 +383,28 @@ def record_observed(server_name: str, code: str, identity: str = "") -> bool:
     return _sink.record(server_name, code, identity)
 
 
+def observed_codes(server_name: str, identity: str = "") -> tuple[str, ...]:
+    """Codes observed for *server_name* under *identity*, off the process sink.
+
+    The read half of ``record_observed``, and the reason :meth:`codes_for` had no
+    caller on the serve path: the observation sites reach the sink through these
+    module functions, and until now only the writers existed. Recording a hazard
+    could therefore change a label on the MCP page and nothing else.
+
+    Identity-checked deliberately -- see :meth:`HazardLedger.codes_for`. A caller
+    that ACTS on this (refusing to pool) must not strand a server on evidence
+    about the build it replaced, so an upgrade or a config edit reads as
+    unobserved and re-earns pooling.
+
+    In-memory and IO-free, so it is safe on the event loop. Returns empty when no
+    sink is installed, which is the truth for a process that never observes
+    anything (the stub, and unit tests).
+    """
+    if _sink is None:
+        return ()
+    return _sink.codes_for(server_name, identity)
+
+
 def clear_observed(server_name: str) -> bool:
     """Drop every observation for *server_name* from the process sink.
 

--- a/test/test_mcp_gateway_exclusive_backend.py
+++ b/test/test_mcp_gateway_exclusive_backend.py
@@ -406,6 +406,10 @@ class _RecordingPool:
 
     def __init__(self) -> None:
         self.unreserved: list[Any] = []
+        #: Every kwargs dict the handler passed to ``_acquire_backend``. The
+        #: retreat is only observable here: it changes which backend the handler
+        #: ASKS for, and the fake acquire below is what the real pool would see.
+        self.acquire_kwargs: list[dict[str, Any]] = []
 
     def unreserve(self, key: Any) -> None:
         self.unreserved.append(key)
@@ -428,7 +432,10 @@ async def _drive_handler(monkeypatch: pytest.MonkeyPatch, *, poolable: bool) -> 
         def log_api_access(self, **kwargs: Any) -> None:
             pass
 
+    pool = _RecordingPool()
+
     async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any, **_kw: Any):
+        pool.acquire_kwargs.append(dict(_kw))
         return _HandlerBackend(), True
 
     async def _fake_drain(_inbox: Any, _writer: Any, _stub_uuid: str = "") -> None:
@@ -438,7 +445,6 @@ async def _drive_handler(monkeypatch: pytest.MonkeyPatch, *, poolable: bool) -> 
     monkeypatch.setattr(gw, "_acquire_backend", _fake_acquire)
     monkeypatch.setattr(gw, "_drain_inbox_to_stub", _fake_drain)
 
-    pool = _RecordingPool()
     await asyncio.wait_for(
         gw._handle_connection(
             _FrameReader([_register_frame(poolable=poolable), _TOOL_CALL]),
@@ -477,3 +483,119 @@ async def test_handler_still_releases_for_a_pooled_connection(
     the life of the process."""
     pool = await _drive_handler(monkeypatch, poolable=True)
     assert len(pool.unreserved) == 1
+
+
+def _install_hazard_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    command_args_hash: str = "0" * 64,
+    env_hash: str = "1" * 64,
+    binary_version: str = "deadbeef",
+) -> None:
+    """Bind a hazard sink carrying one observation for ``echo-mcp``.
+
+    The defaults are exactly the launch fields ``_register_frame`` reports, so a
+    caller that overrides one is describing a DIFFERENT program -- which is the
+    whole point of the identity-checked read.
+    """
+    from kiro_crew.mcp_gateway import hazards
+
+    ledger = hazards.HazardLedger(tmp_path / hazards.HAZARDS_FILENAME)
+    ledger.record(
+        "echo-mcp",
+        hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+        hazards.launch_identity(command_args_hash, env_hash, binary_version),
+    )
+    monkeypatch.setattr(hazards, "_sink", ledger)
+
+
+@pytest.mark.asyncio
+async def test_an_observed_hazard_retreats_a_poolable_connection_to_private(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The consuming half of the ledger: an observation reaches the routing decision.
+
+    Before this wiring, recording a hazard changed a label on the MCP page and
+    nothing else -- the stub still registered ``poolable`` and still landed on a
+    shared backend, so "share by default, retreat when observed" had no retreat.
+    """
+    _install_hazard_sink(monkeypatch, tmp_path)
+    pool = await _drive_handler(monkeypatch, poolable=True)
+    assert pool.acquire_kwargs, "handler never reached the acquire"
+    assert pool.acquire_kwargs[0]["exclusive_stub_uuid"] == "ex-stub-0001"
+
+
+@pytest.mark.asyncio
+async def test_a_retreated_connection_releases_no_reservation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A retreat must not decrement a reservation it never took.
+
+    ``pool.get_or_create`` is what reserves; ``pool.acquire_exclusive`` does not.
+    A retreated connection asked to pool but resolved down the exclusive path, so
+    it reserved nothing -- and because the refcount is per DIGEST while
+    ``poolable`` is not a PoolKey dimension, releasing here would decrement a
+    CONCURRENT pooled connection's reservation on the same key and drop its
+    eviction protection before its stub attaches.
+    """
+    _install_hazard_sink(monkeypatch, tmp_path)
+    pool = await _drive_handler(monkeypatch, poolable=True)
+    assert pool.acquire_kwargs[0]["exclusive_stub_uuid"] == "ex-stub-0001"
+    assert pool.unreserved == [], "retreat released a reservation it never took"
+
+
+@pytest.mark.asyncio
+async def test_a_hazard_from_another_launch_identity_does_not_retreat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An upgrade or a config edit re-earns pooling.
+
+    The evidence described the program that was replaced, so answering with it
+    would strand a server for ever on behaviour its current build never showed.
+    """
+    _install_hazard_sink(monkeypatch, tmp_path, binary_version="a-different-build")
+    pool = await _drive_handler(monkeypatch, poolable=True)
+    assert pool.acquire_kwargs[0]["exclusive_stub_uuid"] == ""
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_record_lets_the_server_pool_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The retreat is undoable, which is what makes it safe to switch on.
+
+    One cause of a record is a defect on OUR side -- a frame the gateway
+    misattributed -- and the identity check cannot clear that, because fixing our
+    own bug does not change the server's launch identity. Without an undo the
+    evidence would stand for ever against a server that never misbehaved. This
+    pins the whole round trip: retreat, clear, pool again.
+
+    The clear itself is ``hazards.clear_observed`` plus a flush, which is what an
+    operator reaches through offline (stop the daemon, delete the record from
+    ``observed-hazards.json``, start). An online socket verb for it was descoped
+    from this change -- see the PR discussion.
+    """
+    from kiro_crew.mcp_gateway import hazards
+
+    _install_hazard_sink(monkeypatch, tmp_path)
+
+    retreated = await _drive_handler(monkeypatch, poolable=True)
+    assert retreated.acquire_kwargs[0]["exclusive_stub_uuid"] == "ex-stub-0001"
+
+    assert hazards.clear_observed("echo-mcp") is True
+
+    restored = await _drive_handler(monkeypatch, poolable=True)
+    assert restored.acquire_kwargs[0]["exclusive_stub_uuid"] == ""
+
+
+@pytest.mark.asyncio
+async def test_clearing_a_server_with_nothing_recorded_reports_no_change(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """False is the honest answer, not an error: there was nothing to forget."""
+    from kiro_crew.mcp_gateway import hazards
+
+    _install_hazard_sink(monkeypatch, tmp_path)
+
+    assert hazards.clear_observed("some-other-mcp") is False

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -1217,6 +1217,62 @@ class TestRespawnBackendForStub:
         await _drain_task(got_task)
 
     @pytest.mark.asyncio
+    async def test_a_recorded_hazard_makes_the_respawn_come_back_private(
+        self, monkeypatch, tmp_path
+    ):
+        """The retreat's hole if the respawn inherited the shared binding blindly.
+
+        The recycle that follows an unroutable server request comes straight back
+        here, so re-pooling would hand the SAME stubs a shared backend for the
+        server just observed misbehaving, and no new register happens to
+        re-decide it. Also pins that a now-private respawn releases NO
+        reservation: only ``pool.get_or_create`` reserves, so releasing on the
+        old backend's binding instead would decrement a digest this respawn never
+        reserved and drop a concurrent pooled connection's eviction protection.
+        """
+        from kiro_crew.mcp_gateway import hazards
+
+        key = _pool_key(server="respawn-hazard-mcp")
+        ledger = hazards.HazardLedger(tmp_path / hazards.HAZARDS_FILENAME)
+        ledger.record(
+            "respawn-hazard-mcp",
+            hazards.HAZARD_UNROUTABLE_SERVER_REQUEST,
+            hazards.launch_identity(
+                key.command_args_hash, key.effective_env_hash, key.binary_version
+            ),
+        )
+        monkeypatch.setattr(hazards, "_sink", ledger)
+
+        pool = BackendPool(max_backends=2)
+        pool.unreserve = MagicMock()  # type: ignore[method-assign]
+        old = _fake_backend()
+        old.detach_stub = AsyncMock(return_value=0)  # type: ignore[method-assign]
+        assert not old.exclusive_token, "old backend must be POOLED for this case"
+        fresh = _fake_backend(key, pid=6262)
+        fresh.prime_initialize = AsyncMock()  # type: ignore[method-assign]
+        new_inbox: asyncio.Queue[bytes] = asyncio.Queue()
+        fresh.attach_stub = AsyncMock(return_value=new_inbox)  # type: ignore[method-assign]
+        acquire = AsyncMock(return_value=(fresh, True))
+        monkeypatch.setattr(gw, "_acquire_backend", acquire)
+
+        out = await gw._respawn_backend_for_stub(
+            pool,
+            key,
+            lambda k: None,
+            "stub-hz1",
+            cast(Any, _FakeWriter()),
+            {"id": 0, "method": "initialize"},
+            old,
+            None,
+            None,
+        )
+
+        assert out is not None
+        assert acquire.await_args.kwargs["exclusive_stub_uuid"] == "stub-hz1"
+        pool.unreserve.assert_not_called()
+        await _drain_task(out[2])
+
+    @pytest.mark.asyncio
     async def test_replay_skipped_when_owner_rekeyed_mid_respawn(self, monkeypatch):
         """A ``claim`` frame can retarget this connection's identity during
         the respawn's acquire/prime awaits. The captured URIs belong to the


### PR DESCRIPTION
## What is the problem?

The MCP shareability layer has two halves. One predicts, before pooling, whether a
server can be co-tenanted; the other observes, during real traffic, when a shared
backend actually behaves per-client and records it in a hazard ledger.

The observing half was not connected to anything. `HazardLedger.codes_for` had zero
callers outside its own module, and the serve path decided whether to pool purely
from the overlay's `poolable` hint. Recording a hazard therefore changed a label on
the MCP Management page and nothing else: the server kept being handed a shared
backend on every subsequent connection.

The module's own docstring already described the intended consumer -- "This is the
read a caller that acts on the verdict wants -- refusing to pool, most of all" --
and no such caller existed.

## Why this issue matters to the user

The layer's stated posture is to pool by default and retreat when something is
observed. That is only sound to the extent the observation can cause a retreat.
Without one, a server the gateway has already caught handing one session's
in-process state to another goes on being pooled, and the only signal the operator
gets is a changed word on a settings page they may never open.

## How our fix solves it

Symptom: a server observed misbehaving while shared keeps getting a shared backend.

Cause: the observation was written to the ledger but never read on the serve path,
and there was no sink-level accessor for the read half -- only `record_observed` and
`clear_observed` existed, so the recording sites could write but nothing could ask.

Fix:

1. `hazards.observed_codes` adds the missing read accessor on the process sink.
   In-memory and IO-free, so it is safe on the event loop.

2. Both sites that hand a backend to a stub consult it and retreat that one
   connection to a private backend when a record exists:
   - the register path in `_handle_connection`;
   - `_respawn_backend_for_stub`, which is where it matters most -- the recycle
     that follows an unroutable server request lands there, so re-pooling would
     hand the SAME stubs a shared backend for the server just observed
     misbehaving, and no new register happens to re-decide it.

   Both use the identity-checked read, so an upgrade or a config edit re-earns
   pooling rather than stranding a server on evidence about the build it replaced.
   Per-connection and per-key: every other server keeps pooling, and the retreated
   one still gets a working private backend, the same topology it would have with
   no gateway at all.

Two interactions the review surfaced, recorded because the diff does not show them:

- Only `pool.get_or_create` reserves a digest against the idle/LRU sweeper;
  `pool.acquire_exclusive` does not. A retreated connection asks to pool but
  resolves down the exclusive path, so it reserves nothing, and releasing for it
  would decrement a CONCURRENT pooled connection's refcount on the same digest and
  drop that connection's eviction protection before its stub attached. Both sites
  therefore key the release on the OUTCOME, and in the respawn path one local
  drives the acquire and the release so they cannot disagree.

- An online socket verb for clearing a record was part of this change and was
  DESCOPED after review; see below.

## What tests we did

Seven new tests, each mutation-verified -- the mutation is named, and the test that
died is named:

| Mutation | Test that failed |
| --- | --- |
| neutralize the register-path retreat | the two register-path retreat tests |
| key the reservation release on the request, not the outcome | `test_a_retreated_connection_releases_no_reservation` |
| make the ledger read identity-blind | `test_a_hazard_from_another_launch_identity_does_not_retreat` |
| neutralize the respawn retreat | `test_a_recorded_hazard_makes_the_respawn_come_back_private` |
| key the respawn release on the old backend's binding | same test, on its reservation assertion |

The round-trip test covers retreat, clear, pool again, so the undo is pinned by
effect and not by a response shape.

Gates: `flake8`, `isort` and the repo's own `scripts/check_black_formatting.py`
clean; `mypy` clean on every touched file (its two errors are in
`src/kiro_crew/transcribe.py`, untouched here and present on base). The error-code
ratchet passes. 456 tests pass across the gateway, gatewayd, shareability,
error-code and dashboard-MCP suites.

## Any other suggestions on the work

**The online clear verb was descoped, and why.** This change originally added a
`clear-hazards` gatewayd frame plus a dashboard endpoint so an operator could forget
a record the gateway made in error -- which matters, because one cause of a record
is a frame WE misattributed, and the identity check cannot clear that. Review found
four successive real defects in that path, the last of them structural: detach-first
leaves a window where the ledger reads clean for the duration of the write, so a
registration in that window gets a shared backend that survives the rollback.
Closing it properly means never mutating memory until the write has succeeded,
which is a different design, and it also still owes an answer to the fact that the
gatewayd socket is uid-gated 0700 and every agent on the box runs as that uid.

Neither belongs in a PR whose subject is connecting the ledger to the routing
decision, so the verb is gone and the undo is offline: stop the gateway, delete the
server's entry from `observed-hazards.json` in the gateway runtime directory, start
it again. The ledger is read from disk at startup. Worse ergonomics, honest trade.
The full round-by-round record, including the two constraints any future online
version must satisfy, is in the PR comments.

**No UI.** With the verb gone there is nothing to put a button on. The MCP
Management page already displays the observations, so a future online undo would
belong there.

**This closes the dependency #4625 is waiting on.** That issue asks what ELSE the
broker could observe as evidence of cross-session state, and its priority was
explicitly tied to the retreat existing. With this merged, a new hazard code would
actually change routing. The lowest-cost candidate found while reading: the
`tools/list` response interception in `backend.py` already holds both the requesting
stub and the complete result and replaces a per-backend map on every listing, so
"two callers saw different tool sets with no `tools/list_changed` in between" is
observable there with no new plumbing.
