### PR TITLE
fix(dashboard): carry HTTP status through switchSlot rejection (#6199)

### DIFF
--- a/website/src/store/chatSlice.switchSlotRejection.test.ts
+++ b/website/src/store/chatSlice.switchSlotRejection.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The switchSlot thunk boundary carries the numeric HTTP status (#6199).
+ *
+ * The classifier tests in `../test/agentSessionResumeMissingSlot.test.ts` feed
+ * `isMissingSlotError` its payload directly, and the flow tests there fake
+ * `unwrap()` — so neither would notice if `switchSlot` itself stopped producing
+ * the payload. This file pins the WIRING: the real thunk, dispatched against a
+ * real store, must reject with `{ status, message }` (via `rejectWithValue`,
+ * which `unwrap()` throws verbatim) whenever the slot-detail fetch failed with
+ * a status attached, and must keep the ordinary serialized-error shape when no
+ * status exists, so the prose fallback still has something to read.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+vi.mock('../api/client', () => ({ api: { chatSlotDetail: vi.fn() } }))
+
+import chatReducer, { switchSlot } from './chatSlice'
+import { api } from '../api/client'
+import { isMissingSlotError } from '../utils/thunkError'
+
+function makeStore() {
+  return configureStore({
+    reducer: { chat: chatReducer },
+    // serializableCheck stays ON deliberately: "the payload can safely enter
+    // the store" is part of the contract this file pins, and the check is what
+    // would flag a future payload smuggling a Response or Error instance.
+    middleware: (getDefault) => getDefault({ immutableCheck: false }),
+  })
+}
+
+const detail = vi.mocked(api.chatSlotDetail)
+
+/** What the api client throws, shaped structurally (`status` + `message`) the
+ *  way `ApiError` carries them. The thunk's catch is deliberately structural
+ *  rather than `instanceof ApiError` — mocking `../api/client` wholesale, as
+ *  this file and its siblings do, is exactly why (see the comment in
+ *  `switchSlot`) — so the real class is not needed to exercise it. */
+const apiError = (status: number, message: string) => Object.assign(new Error(message), { status })
+
+/** The value `unwrap()` throws for *key*, or null if the switch succeeded. */
+async function rejection(key: string): Promise<unknown> {
+  try {
+    await makeStore().dispatch(switchSlot(key)).unwrap()
+    return null
+  } catch (e) {
+    return e
+  }
+}
+
+describe('switchSlot — the rejection carries the numeric status (#6199)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('rejects with { status, message }, and 404 classifies as slot-gone', async () => {
+    // The message deliberately carries NO prose hint ("404"/"not found"): the
+    // pre-fix classifier answered false here, so this case pins the
+    // false-NEGATIVE half of the bug, not just the wiring.
+    detail.mockRejectedValue(apiError(404, 'slot unavailable'))
+    const e = await rejection('gone')
+    expect(e).toEqual({ status: 404, message: 'slot unavailable' })
+    expect(isMissingSlotError(e)).toBe(true)
+  })
+
+  it('a 500 quoting "not found" is NOT a missing slot, end to end', async () => {
+    // The shipped regression: before the status survived the boundary, this
+    // rejection matched /not found/i and a live session was replaced.
+    detail.mockRejectedValue(apiError(500, 'agent "foo" not found'))
+    const e = await rejection('alive')
+    expect(e).toEqual({ status: 500, message: 'agent "foo" not found' })
+    expect(isMissingSlotError(e)).toBe(false)
+  })
+
+  it('a status-less failure keeps the serialized-error shape for the prose fallback', async () => {
+    detail.mockRejectedValue(new TypeError('Failed to fetch'))
+    const e = await rejection('k')
+    // miniSerializeError: a plain object, not an Error, message preserved.
+    expect(e).toMatchObject({ message: 'Failed to fetch' })
+    expect(e instanceof Error).toBe(false)
+    expect(isMissingSlotError(e)).toBe(false)
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -10,6 +10,7 @@ import type { ChatMessage, ChatSlot, SessionInfo, SubagentActivity, ToolActivity
 import { SOFT_STOP_DEBOUNCE_MS, SPAWN_LAUNCH_MARKER } from '../pages/chat/types'
 import { mergePreservedPastes } from '../utils/pasteTokens'
 import { safeSetItem } from '../utils/safeStorage'
+import { errMessage, type StatusRejection } from '../utils/thunkError'
 import { jsonEqual } from '../utils/structuralEqual'
 import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
 import { i18nT } from '../i18n/t'
@@ -1413,9 +1414,13 @@ function seedContextUsage(
   if (context.window) state.slotContextTokens[k] = { used: context.used, window: context.window }
 }
 
-export const switchSlot = createAsyncThunk(
+export const switchSlot = createAsyncThunk<
+  Awaited<ReturnType<typeof fetchSlotDetail>>,
+  string,
+  { rejectValue: StatusRejection }
+>(
   'chat/switchSlot',
-  async (key: string, { dispatch, getState }) => {
+  async (key, { dispatch, getState, rejectWithValue }) => {
     // Safe unconditionally: this fetch resets the pane's messages and cursor, so
     // any older page still in flight is superseded even when the key is unchanged.
     _abortLoadOlder?.()
@@ -1434,7 +1439,22 @@ export const switchSlot = createAsyncThunk(
     // can omit `slotRun` entirely, and throwing here would skip the fetch.
     const state = (getState() as { chat: ChatState }).chat
     const streaming = (state.slotRun?.[key]?.state ?? 'idle') !== 'idle'
-    return fetchSlotDetail(key, streaming ? undefined : OLDER_PAGE_LIMIT)
+    try {
+      return await fetchSlotDetail(key, streaming ? undefined : OLDER_PAGE_LIMIT)
+    } catch (e) {
+      // A thrown error crosses the thunk boundary as `miniSerializeError(e)`,
+      // which keeps string fields only -- `ApiError.status` (a number) never
+      // reaches the consumer, which left `isMissingSlotError` matching prose
+      // (#6199). Reject with a structured payload instead: `unwrap()` throws a
+      // `rejectWithValue` payload verbatim, status intact. The check is
+      // STRUCTURAL rather than `instanceof ApiError` because store tests
+      // replace the `../api/client` module wholesale, and an `instanceof`
+      // against a class the mock does not export throws inside this very
+      // handler (see utils/agentSwitchFeedback.ts for the precedent).
+      const status = (e as { status?: unknown } | null)?.status
+      if (typeof status === 'number') return rejectWithValue({ status, message: errMessage(e) })
+      throw e
+    }
   },
 )
 

--- a/website/src/test/agentSessionResumeMissingSlot.test.ts
+++ b/website/src/test/agentSessionResumeMissingSlot.test.ts
@@ -125,6 +125,27 @@ describe('Issue Radar resume — a serialized rejection still names a missing sl
     await open()
     expect(createdSlot()).toBe(true)
   })
+
+  // `switchSlot` now rejects via `rejectWithValue`, and `unwrap()` throws that
+  // payload VERBATIM — `{ status, message }`, numbers intact — so the flow no
+  // longer depends on prose once a status is present. Both directions:
+
+  it('falls through to a fresh session on a structured 404 payload', async () => {
+    harness({ status: 404, message: 'HTTP 404: no such slot' })
+    const record = await open()
+    expect(createdSlot()).toBe(true)
+    expect(record).toEqual({ slot_key: 'slot-new' })
+  })
+
+  it('does NOT replace the session on a non-404 whose prose says "not found"', async () => {
+    // The regression #6199 fixes: a 500 quoting "not found" used to read as a
+    // dead slot and overwrite a session that was still alive. The structured
+    // status must outrank the message.
+    harness({ status: 500, message: 'agent "foo" not found' })
+    const record = await open()
+    expect(createdSlot()).toBe(false)
+    expect(record).toBeNull()
+  })
 })
 
 /**
@@ -147,6 +168,32 @@ describe('isMissingSlotError — the shared thunk-boundary rule', () => {
   it('reads a real Error, unchanged from before', () => {
     expect(isMissingSlotError(new Error('HTTP 404'))).toBe(true)
     expect(isMissingSlotError(new Error('boom'))).toBe(false)
+  })
+
+  it('classifies on a structured status, message not consulted', () => {
+    // Status alone decides: no "404"/"not found" hint in the prose is needed…
+    expect(isMissingSlotError({ status: 404, message: 'gone' })).toBe(true)
+    expect(isMissingSlotError({ status: 404, message: '' })).toBe(true)
+    // …and the payload stays readable by every message-based caller.
+    expect(errMessage({ status: 404, message: 'gone' })).toBe('gone')
+  })
+
+  it('a structured non-404 status VETOES the prose match (the #6199 regression)', () => {
+    // Before the status survived the boundary, both of these misread as "the
+    // slot is gone" and replaced a live session. The regex may only speak for
+    // rejections that carry no status at all.
+    expect(isMissingSlotError({ status: 500, message: 'agent "foo" not found' })).toBe(false)
+    expect(isMissingSlotError({ status: 502, message: 'HTTP 404 while proxying upstream' })).toBe(false)
+    // A raw ApiError-shaped object that never crossed a thunk behaves the same.
+    expect(isMissingSlotError(Object.assign(new Error('model not found'), { status: 500 }))).toBe(false)
+    expect(isMissingSlotError(Object.assign(new Error('nope'), { status: 404 }))).toBe(true)
+  })
+
+  it('ignores a non-numeric status field and falls back to prose', () => {
+    // Only a NUMERIC status is the wire contract; a string 'status' from some
+    // unrelated shape must not suppress the fallback.
+    expect(isMissingSlotError({ status: 'rejected', message: 'not found' })).toBe(true)
+    expect(isMissingSlotError({ status: '500', message: 'not found' })).toBe(true)
   })
 
   it('refuses anything that is not a missing slot, so a live session is safe', () => {

--- a/website/src/utils/thunkError.ts
+++ b/website/src/utils/thunkError.ts
@@ -21,7 +21,24 @@
  * open a fresh session" fallback (Issue Radar and Auto Improvement), and made
  * both fallbacks unreachable. One definition lives here so the next thunk-side
  * classifier inherits the fix instead of re-deriving the bug.
+ *
+ * The serializer cannot be reasoned around, but it CAN be sidestepped: a thunk
+ * that wants its consumer to see the status rejects with a `StatusRejection`
+ * via `rejectWithValue` instead of throwing — `unwrap()` throws a
+ * `rejectWithValue` payload verbatim, numbers intact. `switchSlot` does this
+ * for any failure that carries a numeric status, and rethrows the rest into
+ * the ordinary serialized path; that is what lets `isMissingSlotError`
+ * classify on the real status below instead of pattern-matching prose (#6199).
  */
+
+/** Rejection payload that carries an HTTP status ACROSS the thunk boundary.
+ *
+ * `miniSerializeError` keeps string-valued fields only (see the module doc), so
+ * a thunk whose consumer needs `ApiError.status` must catch the error and
+ * `return rejectWithValue({ status, message })` rather than rethrow. `message`
+ * stays a string so `errMessage` reads the payload unchanged and every
+ * `errMessage(e) || <fallback>` call site keeps working. */
+export type StatusRejection = { status: number; message: string }
 
 /** The human message of a rejection, in whichever shape it arrives.
  *
@@ -52,8 +69,26 @@ export function errMessage(e: unknown): string {
  * Deliberately narrow, and the narrowness is the point: only a missing slot
  * justifies replacing a session. Reading a network blip or a 500 as "deleted"
  * would orphan a session that is still alive and overwrite the record pointing
- * at it, which is a worse failure than the one the fallback repairs. */
+ * at it, which is a worse failure than the one the fallback repairs.
+ *
+ * Two tiers, in order:
+ *
+ *   1. A structured numeric `status` (a `StatusRejection` payload from
+ *      `switchSlot`, or a raw `ApiError` that never crossed a thunk) is
+ *      AUTHORITATIVE in both directions: 404 means gone, anything else means
+ *      NOT gone — even when the message happens to contain "not found". A 500
+ *      whose body quotes that phrase must not read as a dead slot; that
+ *      misclassification is exactly the worse failure described above.
+ *   2. The prose match survives as the fallback for rejections that never
+ *      carried a status: a payload-less serialized error, a hand-thrown
+ *      `Error`, a bare string. Do not delete it — those shapes still exist. */
 export function isMissingSlotError(e: unknown): boolean {
+  if (e && typeof e === 'object') {
+    const { status } = e as { status?: unknown }
+    // `NaN === 404` is false, so a degenerate numeric status refuses (the safe
+    // direction) rather than falling through to the prose guess.
+    if (typeof status === 'number') return status === 404
+  }
   const msg = errMessage(e)
   return /\b404\b/.test(msg) || /not found/i.test(msg)
 }


### PR DESCRIPTION
## Problem / Motivation

A Redux thunk rejection loses the HTTP status code, so "the chat slot is gone" is decided by pattern-matching the error PROSE instead of the status the gateway already sent.

`createAsyncThunk` stores thrown errors via `miniSerializeError`, which keeps only string-valued fields (`name`, `message`, `stack`, `code`). `ApiError` carries a NUMERIC `status` (`website/src/api/client.ts`), so the status is dropped at the thunk boundary and never reaches the consumer. That left `isMissingSlotError` (`website/src/utils/thunkError.ts`) nothing to test but the message: it matches `/\b404\b/` or `/not found/i` on prose, so any unrelated failure whose message happens to contain "not found" — a 500 body, for example — is misread as a dead slot.

## Why it matters

The misread is destructive in the worse direction: the Issue Radar and Auto Improvement resume paths swallow a "slot gone" verdict and open a REPLACEMENT session, overwriting the record pointing at a session that is still alive. The file's own docstring states that this misclassification is exactly the failure the classifier's narrowness exists to prevent — the code already agreed this was a defect (#6199).

## What changed (motivation → approach → change)

Symptom → root cause → change:

1. **`website/src/store/chatSlice.ts` — `switchSlot` rejects with a structured payload.** The payload creator now catches a status-carrying failure and does `return rejectWithValue({ status, message })`; `unwrap()` throws a `rejectWithValue` payload **verbatim**, numbers intact, so the status survives the boundary. Status-less failures still rethrow into the ordinary serialized path. The thunk declares its `rejectValue` generic with the new exported `StatusRejection` type, so the payload is typed at every consumer — no casts.
   - The catch is **structural** (`typeof status === 'number'`), not `instanceof ApiError`, following the documented precedent in `utils/agentSwitchFeedback.ts`: store tests replace the `../api/client` module wholesale, and an `instanceof` against a class the mock does not export throws inside the failure handler itself.
   - The payload is minimal (`{ status, message }`, no `body`/`authRequired`) per the issue's ask and this slice's existing `rejectWithValue({ slot })` precedent; `message` stays a string so every `errMessage(e) || fallback` call site keeps working unchanged.
2. **`website/src/utils/thunkError.ts` — `isMissingSlotError` classifies status-first.** A numeric `status` is authoritative in BOTH directions: `404` means gone, anything else means NOT gone even when the prose says "not found". The message regex is kept solely as the fallback for rejections that never carried a status (payload-less serialized errors, hand-thrown `Error`s, bare strings) — deleting it would break those still-existing shapes. The module doc and the function doc both document the two-tier ordering.
3. **Sibling-thunk check (convergence norm):** `isMissingSlotError` has exactly two consumers — `apps/issue-radar/lib/agentSession.ts` and `apps/auto-improvement/lib/agentSession.ts` — and both feed it only `switchSlot` rejections. No other thunk in the slice feeds the classifier, so no shared try/catch helper is warranted; `switchSlot` is the single treated site.

### Consumers re-checked (verified, not assumed)

- `apps/issue-radar/lib/agentSession.ts:109` and `apps/auto-improvement/lib/agentSession.ts:215` — **no change needed**: both call `isMissingSlotError(e)` on exactly what `unwrap()` throws, which now handles the payload; the rethrown non-404 object still carries `.message`, which is all the downstream error surfaces read (e.g. `AgentSessionButton` renders `error.message`).
- `pages/KiroCrewAgentsPage.tsx:30` — **unaffected**: it imports `errMessage` for `createSlot` rejections and contains zero `switchSlot` references; `createSlot`'s rejection shape is untouched.
- `switchSlot.rejected` reducer reads only `action.meta.requestId` / `action.meta.arg` (both present on the `rejectWithValue` path); `chatSlice.ts` `.unwrap().catch(() => …)` at the navigation site ignores the error entirely; the store has no custom middleware or `isRejectedWithValue` listeners reading `action.error`.

## Tests

- `website/src/test/agentSessionResumeMissingSlot.test.ts` (extended):
  - Flow level, direction (a): a structured `{ status: 404 }` rejection falls through to a fresh session.
  - Flow level, direction (b) — **the regression this fixes**: a `{ status: 500, message: 'agent "foo" not found' }` rejection must NOT replace the session (`createdSlot() === false`).
  - Classifier level: status alone classifies (no prose hint needed); a non-404 status VETOES the prose match (500 + "not found", 502 + "HTTP 404 …" both `false`); a raw `ApiError`-shaped object behaves identically; a non-numeric `status` field does not suppress the prose fallback; `errMessage` reads the payload's message.
- `website/src/store/chatSlice.switchSlotRejection.test.ts` (new): pins the WIRING the mocked-unwrap flow tests cannot see — the real `switchSlot` thunk dispatched against a real store rejects with `{ status, message }` (404 case uses a message with NO prose hint, so it also pins the pre-fix false-negative), the 500-quoting-"not found" case classifies `false` end to end, and a status-less `TypeError` keeps the serialized-error shape for the prose fallback. `serializableCheck` stays ON so a future non-serializable payload would be flagged.

Local gates (from `website/`): `npx tsc -b` clean; `npx vitest run` **1584 files / 24968 tests passed, 0 failed**; `npx eslint src/ --max-warnings 664` → 0 errors, 653 warnings (under budget); `npx jscpd .` → 0 clones.

Note for reviewers: the new test file's `use-react-query` regex heuristic does not apply — it contains no `.then(…=>` data fetching (the rejection helper is a plain `try/catch`), and it is a store test, not a component.

## Manual verification

N/A — unit coverage sufficient: the defect and fix live entirely at the thunk/classifier seam, which the new store-level wiring test exercises with the real thunk and real store; no UI pixels change.

## Related Issues

Closes #6199

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module/function docstrings updated in the same commit
- [x] No secrets, credentials, or internal references in the diff
