### PR TITLE
fix(mcp-gateway): re-attach a stub to a restarted broker

### DIFF
--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -67,6 +67,21 @@ _BRIDGE_PONG_TYPE = "pong"
 # succeeding or failing IS the signal, and it is consumed here rather than
 # forwarded, exactly like the pong frame above.
 _BRIDGE_KEEPALIVE_TYPE = "keepalive"
+# --- Reconnect budget -------------------------------------------------------
+# What the stub spends trying to re-attach after a live gateway connection dies
+# mid-session. The daemon is supervised and respawns itself with its own
+# exponential backoff, so one connect attempt would lose the race against an
+# ordinary restart -- but the budget must be finite, because a gateway that is
+# gone for good has to reach the terminal exit that tells kiro-cli this server
+# is done rather than leave the session hanging on a socket nobody will bind.
+_RECONNECT_BACKOFF_START_SECS = 0.5
+_RECONNECT_BACKOFF_MAX_SECS = 4.0
+_RECONNECT_TOTAL_BUDGET_SECS = 60.0
+# Bounds the replayed ``initialize`` on a fresh connection. The daemon answers
+# it either from its init cache or by driving a real upstream handshake, so this
+# has to cover a cold backend spawn; on timeout the reconnect is abandoned and
+# the stub takes the terminal exit.
+_REPLAY_INIT_TIMEOUT_SECS = 30.0
 # Pre-flight ``ensure_backend`` reply timeout. Must comfortably
 # exceed cold backend fork latency. On timeout the stub falls back to a
 # direct per-session exec, so an over-generous value only costs a slower
@@ -591,16 +606,144 @@ async def handshake(
     raise FallbackRequestedError(f"unexpected handshake reply: type={msg_type!r}")
 
 
-class BridgeLivenessFailure:
-    """Returned by :func:`run_bridge` when the peer stops responding to
-    liveness pings while requests are outstanding. Contains the IDs of
-    the requests that were still pending so the caller can emit JSON-RPC
-    error frames before degrading."""
+class StubSession:
+    """Per-STUB state that must outlive any single gateway connection.
 
-    __slots__ = ("outstanding_ids",)
+    A connection dies with the daemon; the stub does not. Everything a reconnect
+    needs therefore lives here rather than inside :func:`run_bridge`'s frame,
+    which is scoped to one socket:
 
-    def __init__(self, outstanding_ids: list) -> None:  # noqa: D107
-        self.outstanding_ids = outstanding_ids
+    * **the stdin reader thread and its queue.** This is why a reconnect cannot
+      simply call ``run_bridge`` again on a fresh socket. The reader used to be
+      created per call, so a second call would put two threads on fd 0 --
+      splitting kiro-cli's lines between two consumers -- while any line the
+      first one had already dequeued died with the old frame.
+    * **the ``initialize`` frame.** The stdin pump consumes and forwards it
+      once and kiro-cli never re-sends it, so without a copy here a fresh daemon
+      would hold a never-initialized backend that rejects every later call --
+      the reason the liveness path deliberately does not exec a replacement.
+    * **the ``initialize`` result**, so a reconnect can refuse a daemon
+      generation that would answer this session differently from the toolset it
+      froze at ``session/new``.
+    * **why the last bridge ended**, which is what decides reconnect vs exit.
+    """
+
+    #: Bridge endings a reconnect may follow. Everything else is a real
+    #: shutdown -- kiro-cli closed stdin, a signal arrived, or kiro-cli's own
+    #: reader died -- where re-attaching would serve nobody.
+    RECONNECTABLE = frozenset({"peer_dead", "socket_eof", "socket_write_failed"})
+
+    def __init__(self) -> None:  # noqa: D107
+        #: Why the most recent bridge ended; see :attr:`RECONNECTABLE`.
+        self.reason: str = ""
+        #: Request IDs still unanswered when that bridge ended.
+        self.outstanding_ids: list = []
+        #: Verbatim ``initialize`` line as kiro-cli sent it.
+        self.captured_init: Optional[bytes] = None
+        #: The ``result`` object this session was told at handshake time.
+        self.init_result: Optional[dict] = None
+        #: Successful reconnects so far, for logging and the audit record.
+        self.reconnects: int = 0
+        self._subscribed: bool = False
+        self._line_q: Optional["asyncio.Queue[bytes]"] = None
+
+    def note_outbound(self, line: bytes, msg: dict) -> None:
+        """Record what a forwarded frame means for a future reconnect."""
+        method = msg.get("method")
+        if self.captured_init is None and method == "initialize":
+            # Bounded by construction: one frame, replaced never, and only the
+            # handshake matches -- so this cannot grow with session traffic.
+            self.captured_init = line if line.endswith(b"\n") else line + b"\n"
+        elif method == "resources/subscribe":
+            # Latched on the REQUEST and never released. Counting on the request
+            # is deliberate: a subscribe this session believes it holds is what
+            # must not be dropped silently, and over-counting only costs a
+            # reconnect that would have been safe.
+            #
+            # Never released even on ``resources/unsubscribe``, which is the
+            # subtler half: that too is only a request, so an unsubscribe the
+            # server REJECTED would clear the flag while the subscription stayed
+            # live upstream -- and the reconnect would then be allowed for a
+            # session whose resource updates are about to stop with nothing
+            # said. Confirming it would mean tracking responses per id, which is
+            # more machinery than the recovery is worth while replaying
+            # subscriptions is still a follow-up.
+            self._subscribed = True
+
+    def has_live_subscriptions(self) -> bool:
+        """Has this session asked for resource subscriptions a restart loses?
+
+        The daemon's subscription table lives in its process and dies with it, so
+        a reconnect that replayed only ``initialize`` would come back looking
+        healthy while resource updates never arrived again. That is a silent
+        degradation this fix must not introduce, so a subscribed session is
+        refused the reconnect and takes the pre-existing terminal exit instead --
+        the same outcome it had before, rather than a new quiet one.
+        """
+        return self._subscribed
+
+    def note_init_result(self, msg: dict) -> None:
+        """Remember the handshake result the FIRST daemon gave this session."""
+        if self.init_result is None and isinstance(msg.get("result"), dict):
+            self.init_result = msg["result"]
+
+    def captured_init_id(self) -> Any:
+        """The request id of the captured handshake, or ``None``."""
+        if self.captured_init is None:
+            return None
+        try:
+            msg = json.loads(self.captured_init)
+        except (ValueError, TypeError):
+            return None
+        return msg.get("id") if isinstance(msg, dict) else None
+
+    async def next_line(self) -> bytes:
+        """One line from the real ``sys.stdin``, via a single reader thread.
+
+        The read runs on a DEDICATED DAEMON thread and hands lines over through
+        a bounded queue. A daemon thread is never joined at interpreter or
+        asyncio shutdown, so a ``readline`` still blocked because kiro-cli holds
+        stdin open cannot hang graceful SIGTERM -- the older
+        ``run_in_executor(readline)`` used the default executor, which
+        ``asyncio.run()`` joins via ``shutdown_default_executor()``.
+        """
+        if self._line_q is None:
+            self._line_q = self._start_reader()
+        return await self._line_q.get()
+
+    def _start_reader(self) -> "asyncio.Queue[bytes]":
+        loop = asyncio.get_running_loop()
+        # Bounded + backpressured: the reader thread blocks on put() (via
+        # run_coroutine_threadsafe) when the queue is full, so a stalled
+        # writer.drain() (gatewayd slow to accept) cannot let the reader keep
+        # draining stdin into an unbounded queue and balloon RSS.
+        line_q: "asyncio.Queue[bytes]" = asyncio.Queue(maxsize=256)
+
+        def _blocking_reader() -> None:
+            fh = sys.stdin.buffer
+            try:
+                while True:
+                    chunk = fh.readline()
+                    # Block this thread until the queue has room. .result()
+                    # waits on the loop; if the loop has stopped (shutdown) it
+                    # raises and the daemon thread simply exits.
+                    asyncio.run_coroutine_threadsafe(
+                        line_q.put(chunk), loop
+                    ).result()
+                    if not chunk:
+                        return
+            except Exception:  # pragma: no cover — defensive
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        line_q.put(b""), loop
+                    ).result(timeout=1.0)
+                except Exception:
+                    pass
+
+        threading.Thread(
+            target=_blocking_reader, name="stub-stdin", daemon=True
+        ).start()
+        return line_q
 
 
 async def run_bridge(
@@ -613,7 +756,8 @@ async def run_bridge(
     ping_interval: float = _BRIDGE_PING_INTERVAL_SECS,
     ping_max_misses: int = _BRIDGE_PING_MAX_MISSES,
     peer_supports_ping: bool = False,
-) -> Optional[BridgeLivenessFailure]:
+    session: StubSession,
+) -> None:
     """Pump stdin ↔ socket until either side closes or ``stop_event`` fires.
 
     ``stdin``/``stdout_writer`` are dependency-injected so tests can drive
@@ -621,11 +765,16 @@ async def run_bridge(
     ``sys.stdin``/``sys.stdout``. On clean stdin EOF an ``Unregister``
     frame is sent so gatewayd detaches without waiting on refcount.
 
-    Returns ``None`` on normal termination. Returns a
-    :class:`BridgeLivenessFailure` when the gateway stopped answering
-    liveness pings while requests were outstanding — the caller should
-    emit JSON-RPC errors for the listed IDs and fall back to a direct
-    exec.
+    ``session`` is the SINGLE channel this reports through, and it carries the
+    state that must survive THIS connection so the caller can re-attach to a
+    restarted gateway: pass the same :class:`StubSession` across successive calls
+    and the stdin reader, the captured handshake and the ending all persist.
+    ``session.reason`` names the ending precisely -- which is what distinguishes
+    a transport loss worth reconnecting from a real shutdown -- and
+    ``session.outstanding_ids`` lists what was left unanswered. It is required
+    rather than defaulted because there is deliberately no return value: a
+    caller without a session would learn nothing, and a second spelling of "why
+    the bridge ended" would have to be kept in step with the first forever.
     """
 
     # Writer-thread liveness signals. The real bridge hands stdout frames to a
@@ -638,6 +787,11 @@ async def run_bridge(
     # call_soon_threadsafe from the writer thread, wakes a dedicated bridge task
     # so teardown never depends on upstream traffic.
     bridge_loop = asyncio.get_running_loop()
+    # Per-CONNECTION fields, cleared so a reconnect is not judged on the last
+    # connection's ending. The captured handshake and the stdin reader are
+    # deliberately NOT cleared: those are what a reconnect exists to reuse.
+    session.reason = ""
+    session.outstanding_ids = []
     # stdin_pump and _recaller_loop both write this shared stub->gateway socket;
     # serialize their write+drain through one lock (mirrors gatewayd/backend).
     if getattr(writer, "_mc_write_lock", None) is None:
@@ -661,68 +815,38 @@ async def run_bridge(
     _peer_dead_evt = asyncio.Event()
 
     async def stdin_pump() -> None:
-        # Inbound line source. Tests inject an in-process StreamReader; the
-        # real stub reads sys.stdin on a DEDICATED DAEMON THREAD and hands
-        # lines over via a queue. A daemon thread is never joined at
-        # interpreter/asyncio shutdown, so a readline still blocked because
-        # kiro-cli holds stdin open can no longer hang graceful SIGTERM — the
-        # old run_in_executor(readline) used the default executor, which
-        # asyncio.run() joins via shutdown_default_executor().
-        loop = asyncio.get_running_loop()
-        # Bounded + backpressured: the reader thread blocks on put() (via
-        # run_coroutine_threadsafe) when the queue is full, so a stalled
-        # writer.drain() (gatewayd slow to accept) can no longer let the reader
-        # keep draining stdin into an unbounded queue and balloon RSS.
-        line_q: "asyncio.Queue[bytes]" = asyncio.Queue(maxsize=256)
-        if stdin is None:
-            def _blocking_reader() -> None:
-                fh = sys.stdin.buffer
-                try:
-                    while True:
-                        chunk = fh.readline()
-                        # Block this thread until the queue has room. .result()
-                        # waits on the loop; if the loop has stopped (shutdown)
-                        # it raises and the daemon thread simply exits.
-                        asyncio.run_coroutine_threadsafe(
-                            line_q.put(chunk), loop
-                        ).result()
-                        if not chunk:
-                            return
-                except Exception:  # pragma: no cover — defensive
-                    try:
-                        asyncio.run_coroutine_threadsafe(
-                            line_q.put(b""), loop
-                        ).result(timeout=1.0)
-                    except Exception:
-                        pass
-
-            threading.Thread(
-                target=_blocking_reader, name="stub-stdin", daemon=True
-            ).start()
-
+        # Inbound line source. Tests inject an in-process StreamReader; the real
+        # stub reads sys.stdin through the SESSION, which owns exactly one
+        # reader thread per process. Owning it here instead would put a second
+        # thread on fd 0 the moment a reconnect ran this pump again, splitting
+        # kiro-cli's lines between two consumers (see StubSession).
         async def _next_line() -> bytes:
             if stdin is not None:
                 try:
                     return await stdin.readuntil(b"\n")
                 except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
                     return b""
-            return await line_q.get()
+            return await session.next_line()
 
         while True:
             line = await _next_line()
             if not line:
+                session.reason = session.reason or "stdin_eof"
                 try:
                     await _write_frame(writer, {"type": "unregister"})
                 except Exception:
                     pass
                 return
-            # Track outbound JSON-RPC request IDs (have "method" + "id").
+            # Track outbound JSON-RPC request IDs (have "method" + "id"), and
+            # let the session keep whatever a reconnect will need.
             # Best-effort: parse failures are silently ignored — the frame is
             # still forwarded verbatim.
             try:
                 msg = json.loads(line)
-                if isinstance(msg, dict) and "method" in msg and "id" in msg:
-                    _outstanding_ids.add(msg["id"])
+                if isinstance(msg, dict):
+                    session.note_outbound(line, msg)
+                    if "method" in msg and "id" in msg:
+                        _outstanding_ids.add(msg["id"])
             except (ValueError, TypeError):
                 pass
             try:
@@ -738,6 +862,7 @@ async def run_bridge(
                     writer.write(line if line.endswith(b"\n") else line + b"\n")
                     await writer.drain()
             except (ConnectionError, BrokenPipeError):
+                session.reason = session.reason or "socket_write_failed"
                 return
 
     async def stdout_pump() -> None:
@@ -803,8 +928,10 @@ async def run_bridge(
                 try:
                     line = await reader.readuntil(b"\n")
                 except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+                    session.reason = session.reason or "socket_eof"
                     return
                 if not line:
+                    session.reason = session.reason or "socket_eof"
                     return
                 # Intercept control frames (gateway liveness reply, gateway
                 # keepalive) and track response IDs to clear outstanding
@@ -827,6 +954,12 @@ async def run_bridge(
                             # A response (has id, no method) — clear from
                             # outstanding set.
                             _outstanding_ids.discard(msg["id"])
+                            if msg["id"] == session.captured_init_id():
+                                # What this session was told at handshake time.
+                                # A later daemon generation answering the
+                                # replayed handshake differently must not be
+                                # passed off as the same server.
+                                session.note_init_result(msg)
                 except (ValueError, TypeError):
                     pass
                 # Control frames are gateway<->stub only; never forward to
@@ -836,6 +969,7 @@ async def run_bridge(
                 try:
                     await _emit(line)
                 except (ConnectionError, BrokenPipeError):
+                    session.reason = session.reason or "writer_failed"
                     return
         finally:
             # Best-effort stop signal; the daemon thread is never joined, so
@@ -930,7 +1064,6 @@ async def run_bridge(
                 _liveness_monitor(), name="kirocrew-mcp-stub-liveness"
             )
         )
-    result: Optional[BridgeLivenessFailure] = None
     try:
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     finally:
@@ -939,11 +1072,315 @@ async def run_bridge(
                 t.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         await _safe_close(writer)
-        # If the peer-dead event fired, report a liveness failure so the
-        # caller can emit JSON-RPC errors and degrade.
-        if _peer_dead_evt.is_set() and _outstanding_ids:
-            result = BridgeLivenessFailure(list(_outstanding_ids))
-    return result
+        # Ending reason, most authoritative cause first. A dead peer also breaks
+        # the stdin pump's next write, so the pump-set reason must not mask it;
+        # and a deliberate stop outranks every transport symptom it produces.
+        if stop_event.is_set():
+            session.reason = "stop"
+        elif _peer_dead_evt.is_set():
+            session.reason = "peer_dead"
+        elif writer_failed.is_set():
+            session.reason = "writer_failed"
+        elif not session.reason:
+            # No pump claimed an ending. Unknown is deliberately NOT
+            # reconnectable: re-attaching on a cause nobody can name is how a
+            # recoverable outage turns into a session that answers wrongly.
+            session.reason = "unknown"
+        session.outstanding_ids = list(_outstanding_ids)
+
+
+async def _emit_error_frames(req_ids: list, message: str, *, pool_label: str) -> None:
+    """Answer abandoned requests so the caller is never left parked.
+
+    The write runs on a worker thread and is bounded by
+    ``_ERROR_EMIT_TIMEOUT_SECS``: a blocked kiro-cli reader (full stdout pipe)
+    must not wedge the very path whose job is to unwedge the caller, which is
+    the defect this path exists to prevent.
+    """
+    if not req_ids:
+        return
+
+    def _write() -> None:
+        for req_id in req_ids:
+            err_frame = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32603, "message": message},
+            }
+            sys.stdout.buffer.write(
+                json.dumps(err_frame, separators=(",", ":")).encode("utf-8") + b"\n"
+            )
+        sys.stdout.buffer.flush()
+
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(_write), timeout=_ERROR_EMIT_TIMEOUT_SECS
+        )
+    except (asyncio.TimeoutError, OSError, ValueError):
+        # Nothing better to do: the reader is gone or wedged. Exiting still
+        # closes stdout, which is what tells kiro-cli this server is done.
+        logger.warning("could not emit error frames pool=%s", pool_label)
+
+
+#: Replay outcomes. The distinction is the whole point: a REFUSAL will answer the
+#: same way on every later attempt, so retrying it only delays the terminal exit;
+#: a transport loss says nothing about the answer, and giving up on one would
+#: waste the reconnect budget in exactly the case it exists for -- a supervisor
+#: respawn, where the daemon this stub reaches may still be starting up or may
+#: itself die again mid-replay.
+_REPLAY_OK = "ok"
+_REPLAY_RETRY = "retry"
+_REPLAY_REFUSE = "refuse"
+
+
+async def _replay_initialize(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    session: StubSession,
+) -> tuple[str, Optional[bytes], str]:
+    """Re-establish the MCP handshake for a reconnected stub.
+
+    kiro-cli sends ``initialize`` exactly once and never repeats it, and the
+    daemon held the captured copy in per-connection memory that died with it. So
+    the stub replays its own copy: the fresh daemon either answers from a
+    backend's init cache or drives a real upstream handshake, and either way the
+    connection ends up in the state the session already believes it is in.
+    Replaying more than once is safe for the same reason -- a backend that is
+    already handshake-complete answers a later stub from that cache.
+
+    Returns ``(status, forward, detail)`` where status is one of
+    :data:`_REPLAY_OK`, :data:`_REPLAY_RETRY` or :data:`_REPLAY_REFUSE`.
+    ``forward`` is a line the caller must write to kiro-cli -- non-empty ONLY
+    when the original handshake never got its answer, in which case this reply is
+    the one kiro-cli is still waiting for. When the session DID get an answer,
+    the reply is compared against it and swallowed: kiro-cli already holds a
+    response for that id, and a second one for the same id is a protocol
+    violation.
+    """
+    if session.captured_init is None:
+        return _REPLAY_REFUSE, None, "no_captured_initialize"
+    init_id = session.captured_init_id()
+    try:
+        await _write_frame(writer, json.loads(session.captured_init))
+    except (OSError, ConnectionError) as exc:
+        return _REPLAY_RETRY, None, f"replay_write_failed: {exc}"
+    except (ValueError, TypeError) as exc:
+        # Our own captured frame does not parse; no connection will fix that.
+        return _REPLAY_REFUSE, None, f"captured_initialize_malformed: {exc}"
+
+    async def _await_reply() -> tuple[str, Optional[bytes], str]:
+        while True:
+            line = await reader.readuntil(b"\n")
+            if not line:
+                return _REPLAY_RETRY, None, "closed_during_replay"
+            try:
+                msg = json.loads(line.decode("utf-8", errors="replace"))
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("type") in (_BRIDGE_PONG_TYPE, _BRIDGE_KEEPALIVE_TYPE):
+                continue
+            if msg.get("id") != init_id or "method" in msg:
+                # Anything else on a connection whose only traffic so far is our
+                # own replay is not addressed to this session's handshake.
+                continue
+            if "error" in msg:
+                return _REPLAY_REFUSE, None, f"replay_rejected: {msg['error']}"
+            if session.init_result is None:
+                # The first handshake never completed, so kiro-cli is still
+                # waiting: this reply is genuinely its answer, not a duplicate.
+                return _REPLAY_OK, line, "forwarded_first_answer"
+            if msg.get("result") != session.init_result:
+                # Fail CLOSED, and terminally. A daemon generation whose
+                # configuration moved on can answer with a different server than
+                # the one whose tools this session froze at session/new; carrying
+                # on would turn a recoverable outage into a session that answers
+                # wrongly, which is strictly worse than the terminal exit. It is
+                # also not worth retrying: that generation owns the endpoint.
+                return _REPLAY_REFUSE, None, "handshake_result_changed"
+            return _REPLAY_OK, None, "result_matched"
+
+    try:
+        return await asyncio.wait_for(
+            _await_reply(), timeout=_REPLAY_INIT_TIMEOUT_SECS
+        )
+    except asyncio.TimeoutError:
+        return _REPLAY_RETRY, None, "replay_timeout"
+    except (
+        asyncio.IncompleteReadError,
+        asyncio.LimitOverrunError,
+        OSError,
+        ConnectionError,
+    ) as exc:
+        return _REPLAY_RETRY, None, f"replay_read_failed: {exc}"
+
+
+def _split_abandoned_ids(session: StubSession) -> tuple[list, Any]:
+    """Which in-flight ids to fail now, and which single one to defer.
+
+    An id answered twice is a protocol violation, not a belt-and-braces retry,
+    so every id gets exactly one response. Calls are failed retryably because the
+    stub cannot know whether the dead daemon forwarded them upstream before it
+    died, and replaying them could double a side effect.
+
+    An unanswered ``initialize`` is the one exception. The replay on a fresh
+    connection can still answer it for real, so erroring it here would either
+    contradict that success or duplicate the error the terminal path emits. It is
+    deferred and resolved once -- by the replay if that works, by the terminal
+    path if it does not. An ``initialize`` this session ALREADY has a result for
+    is not deferred: the replay swallows that reply as a duplicate, so nobody
+    downstream would ever answer the id.
+    """
+    deferred: Any = None
+    if session.captured_init is not None and session.init_result is None:
+        init_id = session.captured_init_id()
+        if init_id is not None and init_id in session.outstanding_ids:
+            deferred = init_id
+    return [i for i in session.outstanding_ids if i != deferred], deferred
+
+
+async def _reconnect(
+    socket_path: str,
+    payload: dict,
+    session: StubSession,
+    stop_event: asyncio.Event,
+    *,
+    poolable: bool,
+    pool_label: str,
+) -> Optional[tuple[asyncio.StreamReader, asyncio.StreamWriter, dict, str]]:
+    """Re-attach to a restarted gateway, or give up within a finite budget.
+
+    Retries the Register handshake because the daemon's supervisor respawns it
+    with its own backoff, so the endpoint is typically absent for a moment
+    rather than gone -- and retries a handshake replay that lost its connection
+    for the same reason, since the daemon reached first may still be starting or
+    may die again. What is NOT retried is a refusal: an older daemon will not
+    grow the ``poolable_ack`` capability, and a generation that answers the
+    handshake differently will keep answering that way, so retrying either only
+    delays the terminal exit.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _RECONNECT_TOTAL_BUDGET_SECS
+    delay = _RECONNECT_BACKOFF_START_SECS
+
+    async def _pause() -> bool:
+        """Burn one backoff step. False means a stop arrived; give up."""
+        nonlocal delay
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=delay)
+            return False
+        except asyncio.TimeoutError:
+            pass
+        delay = min(delay * 2, _RECONNECT_BACKOFF_MAX_SECS)
+        return True
+
+    while not stop_event.is_set() and loop.time() < deadline:
+        # A fresh handle per ATTEMPT, not merely per reconnect. The daemon keys
+        # attach, refcount and the private-backend map on this uuid, and an
+        # attempt that died mid-replay may leave its registration in place for a
+        # moment -- so retrying under the same uuid would let the predecessor's
+        # teardown remove the replacement's backend, which is the very collision
+        # a per-registration handle exists to avoid. Minted here rather than by
+        # the caller because only this loop knows how many attempts there were.
+        payload = {**payload, "stub_uuid": str(uuid.uuid4())}
+        try:
+            reader, writer, _uuid, registered = await asyncio.wait_for(
+                handshake(socket_path, payload), timeout=_HANDSHAKE_TIMEOUT_SECS
+            )
+        except (asyncio.TimeoutError, FallbackRequestedError) as exc:
+            logger.info(
+                "stub reconnect: gateway not back yet (%s) pool=%s", exc, pool_label
+            )
+            if not await _pause():
+                return None
+            continue
+
+        _caps = registered.get("capabilities") if isinstance(registered, dict) else None
+        _caps = _caps if isinstance(_caps, list) else []
+        # The same check the cold-start handshake makes, for the same reason and
+        # with more force here: the endpoint a reconnect binds to need not be
+        # the generation this stub first registered with, and the manager adopts
+        # anything answering ``pong`` with no version handshake. A daemon
+        # predating the ``poolable`` field ignores it and routes this register
+        # through the shared index, co-tenanting a server the operator never
+        # allowlisted. Cold start degrades to a per-session exec; here that is
+        # not available (``initialize`` is long consumed), so the honest move is
+        # to refuse this generation and take the terminal exit. Refusal is
+        # terminal, not retried -- an older daemon will not grow the capability
+        # on the next attempt.
+        if must_degrade_unshareable(poolable, _caps):
+            await _safe_close(writer)
+            logger.warning(
+                "stub reconnect: the new gateway generation does not honour the "
+                "poolable field and this server is not shareable; refusing "
+                "rather than risk being pooled pool=%s",
+                pool_label,
+            )
+            return None
+
+        status, forward, detail = await _replay_initialize(reader, writer, session)
+        if status == _REPLAY_RETRY:
+            # The connection died mid-replay, which says nothing about what the
+            # answer would have been -- and this is the likeliest shape of a
+            # supervisor respawn, where the daemon reached first may still be
+            # starting or may die again. Spend a backoff step and try a fresh
+            # connection rather than burning the session here.
+            await _safe_close(writer)
+            logger.info(
+                "stub reconnect: lost the connection during handshake replay "
+                "(%s); retrying pool=%s",
+                detail,
+                pool_label,
+            )
+            if not await _pause():
+                return None
+            continue
+        if status != _REPLAY_OK:
+            await _safe_close(writer)
+            logger.warning(
+                "stub reconnect: refusing the new gateway generation (%s) pool=%s",
+                detail,
+                pool_label,
+            )
+            return None
+        if forward is not None:
+            # The session's original handshake never got an answer; hand this one
+            # to kiro-cli rather than swallowing it.
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(_write_stdout_line, forward),
+                    timeout=_ERROR_EMIT_TIMEOUT_SECS,
+                )
+            except (asyncio.TimeoutError, OSError, ValueError):
+                await _safe_close(writer)
+                logger.warning(
+                    "stub reconnect: could not deliver the replayed handshake "
+                    "pool=%s",
+                    pool_label,
+                )
+                return None
+            session.note_init_result(json.loads(forward))
+        session.reconnects += 1
+        logger.info(
+            "stub reconnected to a restarted gateway (%s, reconnect #%d) pool=%s",
+            detail,
+            session.reconnects,
+            pool_label,
+        )
+        return (
+            reader,
+            writer,
+            registered if isinstance(registered, dict) else {},
+            payload["stub_uuid"],
+        )
+    return None
+
+
+def _write_stdout_line(line: bytes) -> None:
+    """Write one whole line to kiro-cli's stdin, flushed."""
+    sys.stdout.buffer.write(line if line.endswith(b"\n") else line + b"\n")
+    sys.stdout.buffer.flush()
 
 
 def _fallback_log_path() -> Path:
@@ -1326,87 +1763,191 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
             fallback_exec(args)
             return 1  # unreachable
 
-    # Warm-pool caller repair: if we registered without a session key (the
-    # kiro-cli was pool-spawned before its session was claimed), watch for the
-    # key to materialize and re-register the caller so state-mutating tools
-    # (learn_add et al.) work for the claimed session. No-op for stubs that
-    # already had a key at register.
-    recaller_task: Optional[asyncio.Task[None]] = None
-    if not payload.get("session_key"):
-        recaller_task = asyncio.create_task(
-            _recaller_loop(writer, _resolve_channel_id(args.channel_id), stop_event),
-            name="kirocrew-mcp-stub-recaller",
-        )
-    try:
-        liveness_failure = await run_bridge(
-            reader,
-            writer,
-            stop_event,
-            peer_supports_ping=bool(
-                isinstance(capabilities, list) and "bridge_ping" in capabilities
-            ),
-        )
-    finally:
-        if recaller_task is not None:
-            if not recaller_task.done():
-                recaller_task.cancel()
-            # Always await — even a task that already finished (successfully or
-            # with an exception) must have its result/exception retrieved, or
-            # asyncio logs "Task exception was never retrieved" and hides a bug.
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await recaller_task
+    # One session across every connection this stub makes. The stdin reader, the
+    # captured handshake and the ending reason all live here precisely because a
+    # connection dies with the daemon and the stub does not.
+    session = StubSession()
+    peer_supports_ping = bool(
+        isinstance(capabilities, list) and "bridge_ping" in capabilities
+    )
+    while True:
+        # Warm-pool caller repair: if we registered without a session key (the
+        # kiro-cli was pool-spawned before its session was claimed), watch for
+        # the key to materialize and re-register the caller so state-mutating
+        # tools (learn_add et al.) work for the claimed session. No-op for stubs
+        # that already had a key at register. Re-armed per connection: the task
+        # writes THIS socket, so one that outlived its connection would write a
+        # closed writer.
+        recaller_task: Optional[asyncio.Task[None]] = None
+        if not payload.get("session_key"):
+            recaller_task = asyncio.create_task(
+                _recaller_loop(
+                    writer, _resolve_channel_id(args.channel_id), stop_event
+                ),
+                name="kirocrew-mcp-stub-recaller",
+            )
+        try:
+            # The return value is the legacy single-connection signal; this
+            # caller reads the richer ending off the session instead.
+            await run_bridge(
+                reader,
+                writer,
+                stop_event,
+                peer_supports_ping=peer_supports_ping,
+                session=session,
+            )
+        finally:
+            if recaller_task is not None:
+                if not recaller_task.done():
+                    recaller_task.cancel()
+                # Always await — even a task that already finished (successfully
+                # or with an exception) must have its result/exception
+                # retrieved, or asyncio logs "Task exception was never
+                # retrieved" and hides a bug.
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await recaller_task
 
-    # Liveness failure: the gateway stopped answering pings while requests were
-    # outstanding. Fail the outstanding calls FAST and CLEANLY instead of leaving
-    # them parked forever.
+        if session.reason not in StubSession.RECONNECTABLE:
+            break
+
+        # The transport is gone but this process, its stdin and kiro-cli's frozen
+        # toolset are not. Answer whatever was in flight, exactly once, and hold
+        # back only what the replay below can still answer for real -- see
+        # _split_abandoned_ids for why each half is treated the way it is.
+        _to_fail, deferred_init_id = _split_abandoned_ids(session)
+        await _emit_error_frames(
+            _to_fail,
+            "Gateway restarted; this call was failed so it would not hang. "
+            "Retry it.",
+            pool_label=pool_label,
+        )
+        session.outstanding_ids = (
+            [] if deferred_init_id is None else [deferred_init_id]
+        )
+
+        if session.has_live_subscriptions():
+            # Recovering the transport for a subscribed session would hand it
+            # back a connection that answers calls but never delivers another
+            # resource update: the daemon's subscription table died with the old
+            # process. That is a NEW silent degradation, and trading a visible
+            # outage for a quiet one is precisely what this fix exists to stop.
+            # Refuse, and leave replaying subscriptions to the change that can
+            # do it properly.
+            logger.warning(
+                "stub bridge ended (%s) with live resource subscriptions; "
+                "refusing to reconnect because they cannot be re-established "
+                "here pool=%s",
+                session.reason,
+                pool_label,
+            )
+            break
+
+        if session.captured_init is None:
+            # Nothing to re-prime a fresh daemon with, so a reconnect could only
+            # produce a never-initialized backend that rejects every later call.
+            logger.warning(
+                "stub bridge ended (%s) before initialize was seen; no reconnect "
+                "is possible pool=%s",
+                session.reason,
+                pool_label,
+            )
+            break
+
+        # Refresh the caller before re-registering: the session key may have
+        # materialized since the first Register (warm-pool claim), and carrying
+        # it in the new handshake is better than re-running the recaller.
+        #
+        # The uuid in this payload is a placeholder: ``_reconnect`` mints a fresh
+        # one per handshake ATTEMPT, because it is a per-REGISTRATION handle the
+        # daemon keys attach, refcount and the private backend map on. A
+        # reconnectable ending does not prove the daemon died -- a wedged peer or
+        # a broken write leaves the predecessor registration in place -- so
+        # reusing a handle would either attach twice under one or let the
+        # predecessor's teardown tear down the replacement.
+        try:
+            payload = await loop.run_in_executor(
+                subprocess_executor(), build_register_payload, args
+            )
+        except Exception as exc:  # noqa: BLE001 — never lose the reconnect to this
+            logger.warning(
+                "stub reconnect: keeping the previous register payload (%s)", exc
+            )
+
+        await alog_fallback(f"bridge_lost_{session.reason}", stub_uuid, pool_label, args)
+        attached = await _reconnect(
+            args.socket,
+            payload,
+            session,
+            stop_event,
+            poolable=bool(args.poolable),
+            pool_label=pool_label,
+        )
+        if attached is None:
+            logger.warning(
+                "stub could not re-attach to the gateway after %s; this session "
+                "loses these servers pool=%s",
+                session.reason,
+                pool_label,
+            )
+            break
+        reader, writer, registered, stub_uuid = attached
+        # The audit and log records must name the registration that is actually
+        # live: the reconnect loop mints one per ATTEMPT, so the payload this
+        # frame holds is not necessarily the one that registered.
+        capabilities = registered.get("capabilities")
+        peer_supports_ping = bool(
+            isinstance(capabilities, list) and "bridge_ping" in capabilities
+        )
+
+    # Terminal: the bridge ended for a reason no reconnect can address, or the
+    # reconnect budget ran out.
     #
     # Deliberately NOT followed by fallback_exec. The four pre-flight fallback
     # sites work because kiro-cli's ``initialize`` is still unread in fd0, so the
     # exec'd server comes up initialized. Here stdin_pump has already consumed
-    # and forwarded ``initialize``, and kiro-cli never re-sends it (see
-    # gatewayd's ``captured_init`` rationale), so an exec'd server would be a
-    # fresh, never-initialized MCP server that rejects every subsequent call.
-    # Exec would convert "wedged" into "fast-failing", not into "working" — and
-    # it would also throw away the socket a future reconnect could reuse.
-    if liveness_failure is not None:
-        def _emit_errors() -> None:
-            """Write the error frames on a worker thread.
-
-            A blocked kiro-cli reader (full stdout pipe) must not wedge the very
-            path whose job is to unwedge the caller, so the write is offloaded
-            and bounded by the caller's timeout rather than run inline.
-            """
-            for req_id in liveness_failure.outstanding_ids:
-                err_frame = {
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "error": {
-                        "code": -32603,
-                        "message": (
-                            "Gateway stopped responding; this call was failed so "
-                            "it would not hang. Retry it."
-                        ),
-                    },
-                }
-                sys.stdout.buffer.write(
-                    json.dumps(err_frame, separators=(",", ":")).encode("utf-8") + b"\n"
-                )
-            sys.stdout.buffer.flush()
-
-        try:
-            await asyncio.wait_for(
-                asyncio.to_thread(_emit_errors), timeout=_ERROR_EMIT_TIMEOUT_SECS
-            )
-        except (asyncio.TimeoutError, OSError, ValueError):
-            # Nothing better to do: the reader is gone or wedged, and the caller
-            # is already being abandoned. Exiting still closes stdout, which is
-            # what tells kiro-cli this server is done.
-            logger.warning("could not emit liveness error frames pool=%s", pool_label)
-        await alog_fallback("bridge_liveness_dead", stub_uuid, pool_label, args)
+    # and forwarded ``initialize``, and kiro-cli never re-sends it, so an exec'd
+    # server would be a fresh, never-initialized MCP server that rejects every
+    # subsequent call. Exec would convert "wedged" into "fast-failing", not into
+    # "working" — reconnecting is what converts it into "working", and it has
+    # already been tried by the time we get here.
+    if session.outstanding_ids:
+        _abandoned = session.outstanding_ids
+        # Dropped as they are answered: this is the last writer, but leaving them
+        # listed would let any future path here emit a second response for an id
+        # kiro-cli has already been given one for.
+        session.outstanding_ids = []
+        await _emit_error_frames(
+            _abandoned,
+            "Gateway stopped responding and could not be reached again; this "
+            "call was failed so it would not hang. Start a new session to "
+            "restore these tools.",
+            pool_label=pool_label,
+        )
+        await alog_fallback(
+            f"bridge_dead_{session.reason}", stub_uuid, pool_label, args
+        )
         logger.warning(
-            "bridge peer stopped answering pings; failed %d outstanding call(s) "
+            "bridge ended (%s) with %d outstanding call(s) after %d reconnect(s) "
             "pool=%s",
-            len(liveness_failure.outstanding_ids),
+            session.reason,
+            len(_abandoned),
+            session.reconnects,
+            pool_label,
+        )
+        return 1
+    if session.reason in StubSession.RECONNECTABLE:
+        # The transport was lost with nothing in flight, so no call needs an
+        # answer — but the session still loses these servers, and that used to
+        # leave no trace at all. Record it so a degraded session is explicable
+        # afterwards instead of looking like a healthy one whose tools fail.
+        await alog_fallback(
+            f"bridge_dead_{session.reason}", stub_uuid, pool_label, args
+        )
+        logger.warning(
+            "bridge ended (%s) and could not re-attach after %d reconnect(s); "
+            "this session loses these servers pool=%s",
+            session.reason,
+            session.reconnects,
             pool_label,
         )
         return 1

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -8347,13 +8347,12 @@ class GatewayOrchestrator:
         cycled; the change only ever matters to sessions created later, and the
         next start builds their routing from this config.
 
-        Restarting to shorten that wait actively destroys work. The drain gives
-        in-flight tool calls ``DRAIN_SECS`` to finish and then cancels them, and
-        the stub does not re-handshake afterwards -- ``handshake()`` has a single
-        call site at startup, and the post-``initialize`` path deliberately does
-        not fall back to a per-session exec (kiro-cli never re-sends
-        ``initialize``, so an exec'd server would reject every later call). An
-        attached session therefore loses those servers for the rest of its life.
+        Restarting to shorten that wait still destroys work: the drain gives
+        in-flight tool calls ``DRAIN_SECS`` to finish and then cancels them.
+        The stub re-attaches to the replacement daemon afterwards, so those
+        servers are no longer lost for the session's life -- but a cancelled call
+        is still a cancelled call, and the restart buys the running session
+        nothing, because its toolset was fixed at ``session/new``.
 
         Rewriting the agent specs without restarting is worse still: a new
         session would route a server through the stub while the running daemon

--- a/test/test_mcp_gateway_stub_recaller.py
+++ b/test/test_mcp_gateway_stub_recaller.py
@@ -215,7 +215,10 @@ async def test_run_bridge_installs_write_lock() -> None:
     stdin = asyncio.StreamReader()
     stdin.feed_eof()
     await asyncio.wait_for(
-        stub_mod.run_bridge(reader, w, stop, stdin=stdin, stdout_writer=w),
+        stub_mod.run_bridge(
+            reader, w, stop, stdin=stdin, stdout_writer=w,
+            session=stub_mod.StubSession(),
+        ),
         timeout=2.0,
     )
     assert getattr(w, "_mc_write_lock", None) is not None

--- a/test/test_stub_bridge_liveness.py
+++ b/test/test_stub_bridge_liveness.py
@@ -2,9 +2,10 @@
 
 Covers:
 * A silent peer (accepts, never answers) causes the stub to emit a JSON-RPC
-  error and return a BridgeLivenessFailure — not park forever.
+  error and report ``peer_dead`` on the session -- not park forever.
 * A legitimately slow call (peer still answers pings) is NOT killed.
-* Normal bridge teardown (stdin EOF) returns None (no liveness failure).
+* Normal bridge teardown (stdin EOF, or a stop) is reported as itself, so a
+  reconnect is never attempted on a shutdown.
 """
 
 from __future__ import annotations
@@ -18,11 +19,35 @@ import pytest
 from kiro_crew.mcp_gateway.stub import (
     _BRIDGE_PING_TYPE,
     _BRIDGE_PONG_TYPE,
-    BridgeLivenessFailure,
+    StubSession,
     run_bridge,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _strip_comments(source: str) -> str:
+    """``source`` with every comment removed, for source-text ratchets.
+
+    A ratchet that greps raw text cannot tell a call from a comment explaining
+    why that call is absent, so a well-documented invariant trips the very
+    assertion documenting it. Tokenizing is exact where a ``#`` split would also
+    cut string literals.
+    """
+    import io
+    import tokenize
+
+    kept: list[str] = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type != tokenize.COMMENT:
+                kept.append(tok.string)
+    except (tokenize.TokenError, IndentationError):
+        # A partial tail need not be valid Python on its own; fall back to a
+        # line-wise cut, which is coarser but never blind.
+        return "\n".join(ln.split("#", 1)[0] for ln in source.splitlines())
+    return "\n".join(kept)
+
 
 # Pin to one xdist worker (requires --dist loadgroup) alongside the other
 # mcp_gateway suites.
@@ -46,7 +71,7 @@ def _jsonrpc_response(req_id: str = "req-1") -> bytes:
 @pytest.mark.asyncio
 async def test_silent_peer_triggers_liveness_failure() -> None:
     """A gateway that accepts connections but never replies to pings or
-    requests must trigger a BridgeLivenessFailure within a bounded time,
+    requests must be reported as ``peer_dead`` within a bounded time,
     not park the stub forever."""
     # Socket-side reader: gateway never sends anything.
     gw_reader = asyncio.StreamReader()
@@ -88,7 +113,8 @@ async def test_silent_peer_triggers_liveness_failure() -> None:
 
     # Use very short intervals so the test completes quickly.
     # 3 misses × 0.05s interval = 0.15s wait per ping + response wait.
-    result = await asyncio.wait_for(
+    session = StubSession()
+    await asyncio.wait_for(
         run_bridge(
             gw_reader,
             _FakeWriter(),  # type: ignore[arg-type]
@@ -98,13 +124,13 @@ async def test_silent_peer_triggers_liveness_failure() -> None:
             ping_interval=0.05,
             ping_max_misses=3,
             peer_supports_ping=True,
+            session=session,
         ),
         timeout=10,
     )
 
-    assert result is not None
-    assert isinstance(result, BridgeLivenessFailure)
-    assert "call-42" in result.outstanding_ids
+    assert session.reason == "peer_dead"
+    assert "call-42" in session.outstanding_ids
 
     # Verify pings were sent to the gateway.
     ping_frames = [
@@ -175,7 +201,8 @@ async def test_slow_call_not_killed_when_pongs_arrive() -> None:
 
     stop_task = asyncio.create_task(_stop_after_pings())
 
-    result = await asyncio.wait_for(
+    session = StubSession()
+    await asyncio.wait_for(
         run_bridge(
             gw_reader,
             fake_writer,  # type: ignore[arg-type]
@@ -185,13 +212,15 @@ async def test_slow_call_not_killed_when_pongs_arrive() -> None:
             ping_interval=0.05,
             ping_max_misses=3,
             peer_supports_ping=True,
+            session=session,
         ),
         timeout=10,
     )
     await stop_task
 
-    # No liveness failure: the peer answered pings.
-    assert result is None
+    # No liveness failure: the peer answered pings, so the bridge ended on the
+    # stop event rather than on a dead peer.
+    assert session.reason == "stop"
 
     # Verify pings were sent AND pongs were received (at least 2 cycles).
     ping_frames = [
@@ -239,7 +268,8 @@ async def test_normal_teardown_returns_none() -> None:
     )
 
     stop_event = asyncio.Event()
-    result = await asyncio.wait_for(
+    session = StubSession()
+    await asyncio.wait_for(
         run_bridge(
             gw_reader,
             _FakeWriter(),  # type: ignore[arg-type]
@@ -249,11 +279,12 @@ async def test_normal_teardown_returns_none() -> None:
             ping_interval=0.05,
             ping_max_misses=3,
             peer_supports_ping=True,
+            session=session,
         ),
         timeout=10,
     )
 
-    assert result is None
+    assert session.reason != "peer_dead"
 
 
 @pytest.mark.asyncio
@@ -297,7 +328,8 @@ async def test_no_pings_when_idle() -> None:
 
     stop_task = asyncio.create_task(_stop_after())
 
-    result = await asyncio.wait_for(
+    session = StubSession()
+    await asyncio.wait_for(
         run_bridge(
             gw_reader,
             _FakeWriter(),  # type: ignore[arg-type]
@@ -307,12 +339,13 @@ async def test_no_pings_when_idle() -> None:
             ping_interval=0.05,
             ping_max_misses=3,
             peer_supports_ping=True,
+            session=session,
         ),
         timeout=10,
     )
     await stop_task
 
-    assert result is None
+    assert session.reason != "peer_dead"
     # No pings should have been sent (only an unregister on clean close, if any).
     ping_frames = [
         b for b in gw_written
@@ -388,16 +421,28 @@ class TestLivenessIsNegotiated:
         assert "bridge_ping" in REGISTERED_CAPABILITIES
 
     def test_liveness_path_does_not_exec(self) -> None:
-        """The degrade path must fail fast, not exec a fresh server.
+        """The degrade path must reconnect or fail fast, never exec a server.
 
         Pre-flight fallbacks work because kiro-cli's `initialize` is still unread
         in fd0. Mid-bridge it has already been consumed and kiro-cli never
-        re-sends it, so an exec'd server would reject every later call — the
-        session's tools are lost either way, and exec would additionally discard
-        the socket a future reconnect could reuse.
+        re-sends it, so an exec'd server would reject every later call. What
+        recovers the session instead is re-attaching to the restarted gateway and
+        replaying the captured handshake, so this pins both halves: from the
+        point the stub owns state that outlives one connection there is no
+        ``fallback_exec``, and a reconnect is actually attempted rather than the
+        outage being merely reported.
         """
         src = (_REPO_ROOT / "src/kiro_crew/mcp_gateway/stub.py").read_text(encoding="utf-8")
-        marker = "if liveness_failure is not None:"
+        # Anchor where the stub starts owning cross-connection state: every
+        # pre-flight fallback site sits above it.
+        marker = "    session = StubSession()"
         assert marker in src
         tail = src[src.index(marker):]
-        assert "fallback_exec" not in tail
+        # Judge CODE, not prose. The tail deliberately explains at length why it
+        # does not exec, and a text search would read those very words as the
+        # violation -- so comments are tokenized away before the check.
+        assert "fallback_exec" not in _strip_comments(tail)
+        assert "_reconnect(" in tail, (
+            "the mid-bridge degrade path no longer attempts a reconnect, so a "
+            "broker restart again strips an attached session's servers for good"
+        )

--- a/test/test_stub_broker_reconnect.py
+++ b/test/test_stub_broker_reconnect.py
@@ -1,0 +1,777 @@
+"""Integration test: a session must survive the MCP broker going away.
+
+Every other bridge test drives ``run_bridge`` in-process with an injected
+socket, which can prove how the stub REACTS to a dead peer but not what happens
+to the session afterwards. That leaves the property this module exists for
+unasserted: *after the broker comes back, can the session still call its
+servers?*
+
+The answer used to be no, and the failure was silent and permanent. A session's
+MCP toolset is frozen at ``session/new``, so the tools stayed listed and simply
+failed for the rest of the session's life; the only recovery was opening a new
+one. Two shapes, neither observable from a "nothing errored" assertion:
+
+* with a call in flight, the liveness monitor failed it with ``-32603`` and a
+  message telling the caller to retry -- advice that could never succeed,
+  because nothing reconnected;
+* with the bridge idle, the socket simply EOF'd and the stub exited with no
+  error frame at all.
+
+Both are reachable by ordinary operation rather than by a crash: the daemon's
+own supervisor respawns it, so any broker restart did this to every attached
+session.
+
+So this file counts the property from the OUTSIDE. It runs a REAL daemon, a REAL
+stub process, stops the daemon the way an operator restart does (its stop event),
+starts a fresh one on the same endpoint, and then asks the same stub for another
+tool call. A closed-box round trip survives refactors of the reconnect internals
+in a way that reading the stub's private state would not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat as pc
+from kiro_crew.mcp_gateway import gatewayd as gw
+from kiro_crew.mcp_gateway import transport
+
+_FAKE_SERVER = Path(__file__).with_name("fake_pool_mcp_server.py")
+
+#: Generous on purpose: this bounds a stub reconnect plus a Windows named-pipe
+#: round trip plus a backend spawn. A tight value here would read as "reconnect
+#: broke" on a slow runner.
+_REPLY_TIMEOUT = 60.0
+
+#: How long to wait for a freshly started daemon to bind its endpoint.
+_BIND_TIMEOUT = 10.0
+
+pytestmark = pytest.mark.xdist_group("mcp_gateway")
+
+
+def _clean_env() -> dict[str, str]:
+    # Drop any inherited channel id: it feeds PoolKey.channel_id, and a value
+    # leaking in from the developer's shell would silently change partitioning.
+    return {k: v for k, v in os.environ.items() if k != "KIROCREW_CHANNEL_ID"}
+
+
+def _init_frame(req_id: int) -> str:
+    return (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "reconnect-integ", "version": "0.0.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+def _tool_frame(req_id: int) -> str:
+    return (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": "tools/call",
+                "params": {"name": "noop", "arguments": {}},
+            }
+        )
+        + "\n"
+    )
+
+
+async def _spawn_stub(
+    *,
+    socket_path: Path,
+    work_dir: Path,
+    home: Path,
+    session_key: str,
+) -> asyncio.subprocess.Process:
+    """Launch a REAL stub process, exactly as the rewriter's overlay would."""
+    env = {**_clean_env(), "KIROCREW_HOME": str(home)}
+    env["KIROCREW_SESSION_KEY"] = session_key
+    return await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "kiro_crew.mcp_gateway.stub",
+        "--server",
+        "fake",
+        "--agent",
+        "probe",
+        "--target-command",
+        sys.executable,
+        "--target-args",
+        str(_FAKE_SERVER),
+        "--work-dir",
+        str(work_dir),
+        "--socket",
+        str(socket_path),
+        "--sandbox-mode",
+        "off",
+        "--approval-mode",
+        "auto",
+        "--poolable",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        # Its own directory, not pytest's: a child inheriting the repository CWD
+        # can leave a relative artifact behind in the checkout.
+        cwd=str(work_dir),
+        # KIROCREW_HOME redirects the stub's fallback audit log into the test's
+        # own tree, so a degradation is observable instead of landing in the
+        # developer's real home.
+        env=env,
+    )
+
+
+async def _drive(proc: asyncio.subprocess.Process, frame: str, req_id: int) -> dict:
+    """Write one JSON-RPC frame through the stub and read the matching reply."""
+    assert proc.stdin is not None and proc.stdout is not None
+    stdin, stdout = proc.stdin, proc.stdout
+    stdin.write(frame.encode("utf-8"))
+    await stdin.drain()
+
+    async def _read_reply() -> dict:
+        while True:
+            line = await stdout.readline()
+            if not line:
+                raise AssertionError(f"stub closed stdout before replying to id={req_id}")
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("id") == req_id:
+                return msg
+
+    return await asyncio.wait_for(_read_reply(), timeout=_REPLY_TIMEOUT)
+
+
+def _resolver_for(
+    launch_log: Path, caller_log: Path, work_dir: Path
+):  # noqa: ANN202 - matches gatewayd's target_resolver shape
+    def _resolver(_key: object) -> tuple[str, list[str], dict[str, str], str]:
+        return (
+            sys.executable,
+            [str(_FAKE_SERVER), str(launch_log), str(caller_log)],
+            {},
+            str(work_dir),
+        )
+
+    return _resolver
+
+
+def _observed_callers(log: Path) -> list[str]:
+    """The session key each ``tools/call`` reached the backend carrying."""
+    if not log.exists():
+        return []
+    return log.read_text(encoding="utf-8").splitlines()
+
+
+async def _start_daemon(sock: Path, resolver) -> tuple[asyncio.Event, asyncio.Task]:
+    """Start one gatewayd generation and wait for its endpoint to be live."""
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        gw.run_gatewayd(
+            socket_path=sock,
+            max_backends=8,
+            idle_timeout_secs=300,
+            stop_event=stop,
+            target_resolver=resolver,
+            prewarm_count=0,
+        )
+    )
+    deadline = asyncio.get_running_loop().time() + _BIND_TIMEOUT
+    while asyncio.get_running_loop().time() < deadline:
+        if transport.endpoint_exists(sock):
+            return stop, task
+        await asyncio.sleep(0.05)
+    stop.set()
+    await asyncio.wait_for(task, timeout=30)
+    raise AssertionError("gatewayd never bound its endpoint")
+
+
+async def _stop_daemon(stop: asyncio.Event, task: asyncio.Task) -> None:
+    """Stop a generation the way an operator restart does."""
+    stop.set()
+    await asyncio.wait_for(task, timeout=60)
+
+
+async def _reap(procs: list[asyncio.subprocess.Process]) -> None:
+    for p in procs:
+        if p.returncode is None:
+            try:
+                await pc.kill_process_tree_async(p.pid, pc.SIGKILL)
+            except Exception:  # noqa: BLE001 - teardown must never mask a failure
+                pass
+    for p in procs:
+        try:
+            await asyncio.wait_for(p.wait(), timeout=15)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_session_survives_a_broker_restart(tmp_path: Path, short_sock_dir) -> None:
+    """THE reconnect assertion: restart the broker, the session keeps working.
+
+    The stub is asked for a tool call before the restart (proving the chain was
+    live), then for another one after a fresh daemon owns the same endpoint. A
+    stub with no reconnect path fails the second one -- and fails it by having
+    already exited, which is why the liveness of the process is asserted first:
+    it names the defect without waiting out a round-trip timeout.
+    """
+    sock = Path(short_sock_dir) / "gw.sock"
+    work_dir = tmp_path / "wd"
+    work_dir.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    launch_log = tmp_path / "launches.txt"
+    caller_log = tmp_path / "callers.txt"
+    resolver = _resolver_for(launch_log, caller_log, work_dir)
+
+    stop, daemon = await _start_daemon(sock, resolver)
+    procs: list[asyncio.subprocess.Process] = []
+    second_stop: asyncio.Event | None = None
+    second_daemon: asyncio.Task | None = None
+    try:
+        proc = await _spawn_stub(
+            socket_path=sock,
+            work_dir=work_dir,
+            home=home,
+            session_key="dashboard:reconnect",
+        )
+        procs.append(proc)
+
+        reply = await _drive(proc, _init_frame(1), req_id=1)
+        assert "result" in reply, f"no initialize result before restart: {reply}"
+        reply = await _drive(proc, _tool_frame(2), req_id=2)
+        assert "result" in reply, f"no tools/call result before restart: {reply}"
+
+        # The broker goes away. This is the supervisor-respawn / operator-restart
+        # path, not a crash: the daemon drains and exits through its stop event.
+        await _stop_daemon(stop, daemon)
+        daemon = None  # type: ignore[assignment]
+
+        second_stop, second_daemon = await _start_daemon(sock, resolver)
+
+        # Give the stub a bounded window to notice the peer died and re-handshake
+        # against the new generation before judging it.
+        deadline = asyncio.get_running_loop().time() + 30.0
+        while asyncio.get_running_loop().time() < deadline:
+            if proc.returncode is not None:
+                break
+            await asyncio.sleep(0.2)
+
+        assert proc.returncode is None, (
+            "the stub process exited when the broker went away, so this "
+            "session lost those MCP servers permanently -- its toolset is "
+            "frozen at session/new, so the tools stay listed and every later "
+            "call fails with no way back short of a new session"
+        )
+
+        reply = await _drive(proc, _tool_frame(3), req_id=3)
+        assert "result" in reply, f"the stub did not carry a call to the restarted broker: {reply}"
+
+        # A reconnect that reopened the socket but did not re-register would
+        # carry an empty caller block, and every session-scoped path in the
+        # backend would silently fall back to unattached behaviour.
+        assert _observed_callers(caller_log) == [
+            "dashboard:reconnect",
+            "dashboard:reconnect",
+        ], (
+            "the post-restart call did not reach the backend carrying this "
+            f"session's identity: {_observed_callers(caller_log)!r}"
+        )
+    finally:
+        await _reap(procs)
+        if second_stop is not None and second_daemon is not None:
+            await _stop_daemon(second_stop, second_daemon)
+        if daemon is not None:
+            await _stop_daemon(stop, daemon)
+
+
+# --- The branches the round trip above cannot reach -------------------------
+# A reconnect that carried on regardless would be worse than the outage it
+# fixes, and a reconnect loop with no floor would replace a terminal exit with
+# an unbounded one. Neither shows up in a happy-path round trip, so both are
+# pinned directly.
+
+
+class _CaptureWriter:
+    """Minimal ``asyncio.StreamWriter`` stand-in for the gateway socket."""
+
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+        self._mc_write_lock = asyncio.Lock()
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+def _reader_with(*frames: dict) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    for frame in frames:
+        reader.feed_data(json.dumps(frame, separators=(",", ":")).encode("utf-8") + b"\n")
+    reader.feed_eof()
+    return reader
+
+
+def _session_with_captured_init(init_result: dict | None) -> object:
+    from kiro_crew.mcp_gateway.stub import StubSession
+
+    session = StubSession()
+    session.captured_init = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05"},
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+    session.init_result = init_result
+    return session
+
+
+_SERVER_RESULT = {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {"tools": {}},
+    "serverInfo": {"name": "fake", "version": "1"},
+}
+
+
+@pytest.mark.asyncio
+async def test_replay_accepts_a_generation_that_answers_identically() -> None:
+    """The ordinary case: same server, so the session may carry on."""
+    from kiro_crew.mcp_gateway.stub import _REPLAY_OK, _replay_initialize
+
+    session = _session_with_captured_init(_SERVER_RESULT)
+    status, forward, detail = await _replay_initialize(
+        _reader_with({"jsonrpc": "2.0", "id": 7, "result": dict(_SERVER_RESULT)}),
+        _CaptureWriter(),  # type: ignore[arg-type]
+        session,  # type: ignore[arg-type]
+    )
+    assert (status, forward, detail) == (_REPLAY_OK, None, "result_matched")
+
+
+@pytest.mark.asyncio
+async def test_replay_refuses_a_generation_that_answers_differently() -> None:
+    """A moved-on daemon must NOT be passed off as the same server.
+
+    The session's toolset was frozen at ``session/new`` against the first
+    answer. If a new generation resolves this server to something else -- a
+    different binary, a changed config -- then reconnecting would leave the
+    session calling tools that are no longer the ones it was offered. Answering
+    wrongly is worse than the terminal exit, so this fails closed. It is also
+    REFUSE rather than RETRY: that generation owns the endpoint, so the next
+    attempt would get the same answer.
+    """
+    from kiro_crew.mcp_gateway.stub import _REPLAY_REFUSE, _replay_initialize
+
+    moved_on = {**_SERVER_RESULT, "serverInfo": {"name": "other", "version": "9"}}
+    session = _session_with_captured_init(_SERVER_RESULT)
+    status, forward, detail = await _replay_initialize(
+        _reader_with({"jsonrpc": "2.0", "id": 7, "result": moved_on}),
+        _CaptureWriter(),  # type: ignore[arg-type]
+        session,  # type: ignore[arg-type]
+    )
+    assert status == _REPLAY_REFUSE
+    assert forward is None
+    assert detail == "handshake_result_changed"
+
+
+@pytest.mark.asyncio
+async def test_a_connection_lost_during_replay_is_retryable_not_terminal() -> None:
+    """Losing the connection mid-replay says nothing about the answer.
+
+    This is the likeliest shape of the very event the reconnect exists for: a
+    supervisor respawn, where the daemon reached first may still be starting up
+    or may itself die again. Treating it as terminal would spend the session in
+    exactly the case the budget was bought for.
+    """
+    from kiro_crew.mcp_gateway.stub import _REPLAY_RETRY, _replay_initialize
+
+    closed = asyncio.StreamReader()
+    closed.feed_eof()
+    session = _session_with_captured_init(_SERVER_RESULT)
+    status, forward, detail = await _replay_initialize(
+        closed,
+        _CaptureWriter(),  # type: ignore[arg-type]
+        session,  # type: ignore[arg-type]
+    )
+    assert status == _REPLAY_RETRY, (
+        f"a mid-replay transport loss was classified {status!r} ({detail}), so "
+        "the reconnect gives up on a daemon that was merely still starting"
+    )
+    assert forward is None
+
+
+@pytest.mark.asyncio
+async def test_replay_forwards_the_answer_a_session_never_received() -> None:
+    """A daemon that died mid-handshake leaves kiro-cli still waiting.
+
+    There is no earlier answer to compare against and no duplicate to avoid, so
+    the replayed reply is the one the caller is owed and must reach it.
+    """
+    from kiro_crew.mcp_gateway.stub import _REPLAY_OK, _replay_initialize
+
+    session = _session_with_captured_init(None)
+    status, forward, detail = await _replay_initialize(
+        _reader_with({"jsonrpc": "2.0", "id": 7, "result": dict(_SERVER_RESULT)}),
+        _CaptureWriter(),  # type: ignore[arg-type]
+        session,  # type: ignore[arg-type]
+    )
+    assert status == _REPLAY_OK
+    assert forward is not None and b'"id":7' in forward
+    assert detail == "forwarded_first_answer"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_retries_past_a_daemon_that_dies_mid_replay(
+    monkeypatch,
+) -> None:
+    """The budget must actually be spent on the case it was bought for.
+
+    First attempt: the handshake succeeds and the connection then dies during the
+    replay -- a daemon still starting, or one that died again. Second attempt
+    answers. Giving up after the first would lose the session to the very event
+    the reconnect exists to survive.
+    """
+    from kiro_crew.mcp_gateway import stub as stub_mod
+
+    monkeypatch.setattr(stub_mod, "_RECONNECT_BACKOFF_START_SECS", 0.01)
+    attempts: list[int] = []
+    seen_uuids: list[str] = []
+
+    async def _hs(_socket_path: str, _payload: dict):
+        attempts.append(1)
+        seen_uuids.append(_payload["stub_uuid"])
+        if len(attempts) == 1:
+            dead = asyncio.StreamReader()
+            dead.feed_eof()
+            reader = dead
+        else:
+            reader = _reader_with({"jsonrpc": "2.0", "id": 7, "result": dict(_SERVER_RESULT)})
+        return (
+            reader,
+            _CaptureWriter(),
+            "stub-uuid",
+            {
+                "type": "registered",
+                "capabilities": ["poolable_ack"],
+            },
+        )
+
+    monkeypatch.setattr(stub_mod, "handshake", _hs)
+    session = _session_with_captured_init(_SERVER_RESULT)
+    attached = await stub_mod._reconnect(
+        "unused",
+        {"stub_uuid": "u", "session_key": "dashboard:x"},
+        session,  # type: ignore[arg-type]
+        asyncio.Event(),
+        poolable=True,
+        pool_label="probe:fake",
+    )
+    assert attached is not None, (
+        "the reconnect gave up after one lost replay, so a daemon that was "
+        "merely still starting costs the session its servers"
+    )
+    assert len(attempts) == 2
+    assert len(set(seen_uuids)) == 2, (
+        f"both handshake attempts registered under {seen_uuids!r}: a retry that "
+        "reuses a live registration handle lets the predecessor's teardown "
+        "remove the replacement's backend"
+    )
+    assert attached[3] == seen_uuids[-1], (
+        "the reconnect reported a different uuid than the one it registered, so "
+        "the audit record names a registration that never existed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_gives_up_within_its_budget(tmp_path: Path, monkeypatch) -> None:
+    """A gateway that never comes back must reach the terminal exit.
+
+    Retrying is what survives an ordinary supervisor respawn; retrying forever
+    would replace "this session lost its servers" with a stub that never exits
+    and never tells kiro-cli the server is done.
+    """
+    from kiro_crew.mcp_gateway import stub as stub_mod
+
+    monkeypatch.setattr(stub_mod, "_RECONNECT_TOTAL_BUDGET_SECS", 0.4)
+    monkeypatch.setattr(stub_mod, "_RECONNECT_BACKOFF_START_SECS", 0.05)
+    monkeypatch.setattr(stub_mod, "_RECONNECT_BACKOFF_MAX_SECS", 0.1)
+
+    session = _session_with_captured_init(_SERVER_RESULT)
+    started = asyncio.get_running_loop().time()
+    attached = await stub_mod._reconnect(
+        str(tmp_path / "definitely-not-bound.sock"),
+        {"stub_uuid": "u", "session_key": "dashboard:x"},
+        session,  # type: ignore[arg-type]
+        asyncio.Event(),
+        poolable=True,
+        pool_label="probe:fake",
+    )
+    elapsed = asyncio.get_running_loop().time() - started
+    assert attached is None
+    assert elapsed < 10.0, (
+        f"reconnect ran {elapsed:.1f}s against a 0.4s budget, so the budget is "
+        "not what bounds it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_closed_stdin_is_not_a_reconnectable_ending() -> None:
+    """kiro-cli closing stdin is a shutdown, not an outage.
+
+    Treating it as reconnectable would make every normal exit spend the whole
+    reconnect budget re-attaching a bridge with nobody left to serve.
+    """
+    from kiro_crew.mcp_gateway.stub import StubSession, run_bridge
+
+    session = StubSession()
+    stdin = asyncio.StreamReader()
+    stdin.feed_eof()
+    gw_reader = asyncio.StreamReader()
+    stdout_target = asyncio.StreamReader()
+    loop = asyncio.get_running_loop()
+    stdout_writer = asyncio.StreamWriter(
+        _NullTransport(),
+        asyncio.StreamReaderProtocol(stdout_target),
+        stdout_target,
+        loop,
+    )
+
+    await asyncio.wait_for(
+        run_bridge(
+            gw_reader,
+            _CaptureWriter(),  # type: ignore[arg-type]
+            asyncio.Event(),
+            stdin=stdin,
+            stdout_writer=stdout_writer,
+            session=session,
+        ),
+        timeout=10,
+    )
+    assert session.reason == "stdin_eof"
+    assert session.reason not in StubSession.RECONNECTABLE
+
+
+# --- A reconnect must not silently drop resource subscriptions --------------
+# The daemon's subscription table lives in its process. Replaying only
+# ``initialize`` would return a connection that answers calls while resource
+# updates never arrive again -- a quiet degradation where there used to be a
+# visible one, which is the opposite of what this fix is for. A subscribed
+# session is refused the reconnect until replaying subscriptions is done
+# properly.
+
+
+def _session_after(*frames: dict) -> object:
+    from kiro_crew.mcp_gateway.stub import StubSession
+
+    session = StubSession()
+    for frame in frames:
+        line = (json.dumps(frame) + "\n").encode("utf-8")
+        session.note_outbound(line, frame)
+    return session
+
+
+def test_a_subscribed_session_is_not_offered_a_reconnect() -> None:
+    session = _session_after(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "resources/subscribe",
+            "params": {"uri": "file:///a"},
+        }
+    )
+    assert session.has_live_subscriptions() is True  # type: ignore[attr-defined]
+
+
+def test_unsubscribing_does_not_make_a_session_reconnectable_again() -> None:
+    """An unsubscribe is only a REQUEST, so it cannot clear the refusal.
+
+    A server that rejected the unsubscribe leaves the subscription live upstream
+    while the stub had already forgotten it -- and the reconnect would then be
+    allowed for a session whose resource updates are about to stop with nothing
+    said. Confirming it would need per-id response tracking, which is more
+    machinery than the recovery is worth while replaying subscriptions is still
+    a follow-up. So the latch never releases.
+    """
+    session = _session_after(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "resources/subscribe",
+            "params": {"uri": "file:///a"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "resources/unsubscribe",
+            "params": {"uri": "file:///a"},
+        },
+    )
+    assert session.has_live_subscriptions() is True  # type: ignore[attr-defined]
+
+
+def test_a_subscribe_with_an_unreadable_uri_still_counts() -> None:
+    """Failing to parse the uri must not read as "no subscription"."""
+    session = _session_after(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "resources/subscribe",
+            "params": None,
+        }
+    )
+    assert session.has_live_subscriptions() is True  # type: ignore[attr-defined]
+
+
+def test_an_ordinary_session_holds_no_subscriptions() -> None:
+    session = _session_after(
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "noop"}},
+    )
+    assert session.has_live_subscriptions() is False  # type: ignore[attr-defined]
+
+
+class _NullTransport(asyncio.Transport):
+    """Swallows writes; the stdout side is not what these cases assert on."""
+
+    def write(self, data: object) -> None:  # noqa: D102
+        pass
+
+    def is_closing(self) -> bool:  # noqa: D102
+        return False
+
+    def close(self) -> None:  # noqa: D102
+        pass
+
+
+# --- Answer each abandoned request exactly once ------------------------------
+# Two responses for one id is a protocol violation, and "an error, then a
+# success" for the same id is worse than either alone. Both were reachable: a
+# failed reconnect errored ids the loop had already errored, and an unanswered
+# initialize could be errored here and then answered for real by the replay.
+
+
+def test_abandoned_calls_are_failed_once_when_no_replay_can_answer_them() -> None:
+    from kiro_crew.mcp_gateway.stub import StubSession, _split_abandoned_ids
+
+    session = StubSession()
+    session.outstanding_ids = [11, 12]
+    to_fail, deferred = _split_abandoned_ids(session)
+    assert to_fail == [11, 12]
+    assert deferred is None
+
+
+def test_an_unanswered_initialize_is_deferred_to_the_replay() -> None:
+    """Erroring it here would contradict a replay that answers it for real."""
+    from kiro_crew.mcp_gateway.stub import _split_abandoned_ids
+
+    session = _session_with_captured_init(None)
+    session.outstanding_ids = [7, 12]  # type: ignore[attr-defined]
+    to_fail, deferred = _split_abandoned_ids(session)  # type: ignore[arg-type]
+    assert to_fail == [12], (
+        "the initialize id was failed here, so a successful replay would hand "
+        "kiro-cli a second, contradicting response for the same id"
+    )
+    assert deferred == 7
+
+
+def test_an_already_answered_initialize_is_not_deferred() -> None:
+    """The replay swallows that reply, so nobody downstream would answer it."""
+    from kiro_crew.mcp_gateway.stub import _split_abandoned_ids
+
+    session = _session_with_captured_init(_SERVER_RESULT)
+    session.outstanding_ids = [7]  # type: ignore[attr-defined]
+    to_fail, deferred = _split_abandoned_ids(session)  # type: ignore[arg-type]
+    assert to_fail == [7]
+    assert deferred is None
+
+
+# --- A reconnect must re-apply the private-backend check --------------------
+# The endpoint a reconnect binds to need not be the generation this stub first
+# registered with, and the manager adopts anything answering ``pong`` with no
+# version handshake -- so a daemon predating the ``poolable`` field can serve the
+# reconnect and silently co-tenant a server the operator never allowlisted.
+
+
+def _fake_handshake(capabilities: list[str]):  # noqa: ANN202
+    async def _hs(_socket_path: str, _payload: dict):
+        return (
+            _reader_with({"jsonrpc": "2.0", "id": 7, "result": dict(_SERVER_RESULT)}),
+            _CaptureWriter(),
+            "stub-uuid",
+            {"type": "registered", "capabilities": capabilities},
+        )
+
+    return _hs
+
+
+@pytest.mark.asyncio
+async def test_reconnect_refuses_a_daemon_that_ignores_the_poolable_field(
+    monkeypatch,
+) -> None:
+    """A private server must never be silently pooled by an older generation."""
+    from kiro_crew.mcp_gateway import stub as stub_mod
+
+    monkeypatch.setattr(stub_mod, "handshake", _fake_handshake([]))
+    session = _session_with_captured_init(_SERVER_RESULT)
+    attached = await stub_mod._reconnect(
+        "unused",
+        {"stub_uuid": "u", "session_key": "dashboard:x"},
+        session,  # type: ignore[arg-type]
+        asyncio.Event(),
+        poolable=False,
+        pool_label="probe:fake",
+    )
+    assert attached is None, (
+        "the reconnect accepted a registration from a daemon that does not "
+        "advertise poolable_ack, so this unshareable server is now co-tenanted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_accepts_that_daemon_when_sharing_was_requested(
+    monkeypatch,
+) -> None:
+    """A stub that ASKED to share needs no attestation: pooling is what it wanted."""
+    from kiro_crew.mcp_gateway import stub as stub_mod
+
+    monkeypatch.setattr(stub_mod, "handshake", _fake_handshake(["poolable_ack"]))
+    session = _session_with_captured_init(_SERVER_RESULT)
+    attached = await stub_mod._reconnect(
+        "unused",
+        {"stub_uuid": "u", "session_key": "dashboard:x"},
+        session,  # type: ignore[arg-type]
+        asyncio.Event(),
+        poolable=True,
+        pool_label="probe:fake",
+    )
+    assert attached is not None

--- a/test/test_stub_writer_death.py
+++ b/test/test_stub_writer_death.py
@@ -48,7 +48,14 @@ async def test_bridge_terminates_when_writer_thread_dies(monkeypatch) -> None:
 
     # Falls back to the real writer-thread path (stdout_writer=None).
     await asyncio.wait_for(
-        stub.run_bridge(reader, writer, stop_event, stdin=stdin, stdout_writer=None),
+        stub.run_bridge(
+            reader,
+            writer,
+            stop_event,
+            stdin=stdin,
+            stdout_writer=None,
+            session=stub.StubSession(),
+        ),
         timeout=10,
     )
 
@@ -78,6 +85,13 @@ async def test_bridge_terminates_when_writer_dies_and_upstream_silent(
     writer = MagicMock()
 
     await asyncio.wait_for(
-        stub.run_bridge(reader, writer, stop_event, stdin=stdin, stdout_writer=None),
+        stub.run_bridge(
+            reader,
+            writer,
+            stop_event,
+            stdin=stdin,
+            stdout_writer=None,
+            session=stub.StubSession(),
+        ),
         timeout=10,
     )


### PR DESCRIPTION
## What is the problem?

When the MCP broker goes away, every session attached to it loses those servers for the rest of its life, and it does not recover when the broker comes back.

`handshake()` had a single call site, at stub startup. Nothing reconnected. Two shapes followed, neither of them visible:

- with a call in flight, the liveness monitor failed it with `-32603` and a message telling the caller to *retry* -- advice that could never succeed, because nothing was going to re-attach;
- with the bridge idle, the socket simply EOF'd and the stub exited with **no error frame at all**.

The mid-bridge path deliberately does not `fallback_exec`, and that decision was right: `stdin_pump` has already consumed and forwarded `initialize`, kiro-cli never re-sends it, so an exec'd server would be a fresh never-initialized MCP server that rejects every later call. Exec converts "wedged" into "fast-failing", not into "working".

## Why this issue matters to the user

The failure was silent and permanent. A session's MCP toolset is fixed at `session/new`, so the tools stayed listed and simply failed when called -- nothing on the surface said the session was now permanently degraded rather than transiently unlucky, and the only recovery was opening a new one.

It is reachable by ordinary operation rather than by a crash: the daemon is supervised and respawns itself, so any broker restart did this to every attached session. That cost is already shaping other decisions -- the stub-toggle path stopped cycling the broker specifically to avoid paying it on a one-bit configuration edit.

## How our fix solves it

The root cause is *where the handshake state lived*. The daemon kept the captured `initialize` in per-connection memory, which is exactly the memory a daemon exit destroys; the stub, which survives, pumped lines opaquely and kept no copy. So neither side held the one frame a reconnect needs.

- **`StubSession` now owns the state that must outlive one connection.** The single stdin reader thread, the captured `initialize` frame, the handshake result, and why the last bridge ended. The reader belongs here and not in `run_bridge`: it used to be created per call, so simply calling the bridge again would have put a second thread on the stub's standard input, splitting kiro-cli's lines between two consumers while the first one's already-dequeued line died with the old frame.
- **`run_bridge` names its ending.** `stdin_eof`, `stop`, `writer_failed` are real shutdowns; `peer_dead`, `socket_eof`, `socket_write_failed` are transport losses worth re-attaching. An unattributable ending is recorded as `unknown` and is deliberately **not** reconnectable.
- **`_amain` wraps the bridge in a bounded reconnect loop.** It answers whatever was in flight retryably, refreshes the register payload (so a session key that materialized since the first Register is carried, rather than relying on the recaller), re-handshakes with exponential backoff, and replays its own `initialize`. No daemon change is needed: `_handle_initialize` already answers a later stub from the init cache, and the fresh connection handler re-populates its own `captured_init` from the replayed frame, restoring the backend-respawn safety net too.
- **In-flight calls are failed, never replayed.** The stub cannot know whether the dead daemon forwarded them upstream before it died, so a replay could double a side effect. This is the same contract `gatewayd` already applies one layer down when a pooled backend dies under a live stub -- the stub-level fix lifts it one layer up. The `-32603` message now says "Gateway restarted ... Retry it", and for the first time that advice is true.
- **A moved-on generation is refused, not adopted.** If the replayed handshake comes back with a different result, the reconnect fails closed to the pre-existing terminal exit. A session whose tools silently changed underneath it is worse than one that stops.
- **A session holding resource subscriptions is refused too.** The daemon's subscription table lives in its process and dies with it, so replaying only `initialize` would return a connection that answers calls while resource updates never arrive again. Trading a visible outage for a quiet one is the opposite of the point, so such a session keeps the pre-existing terminal exit and replaying subscriptions is left to the change that can do it properly. The latch is set on the `resources/subscribe` REQUEST and never released -- an `unsubscribe` is also only a request, so a rejected one would clear the latch while the subscription stayed live upstream.
- **Each handshake ATTEMPT registers under its own `stub_uuid`.** It is a per-registration handle the daemon keys attach, refcount and the private-backend map on. A reconnectable ending does not prove the daemon died -- a wedged peer or a broken write leaves the predecessor registration in place -- and a retry inside one reconnect can overlap a predecessor that died mid-replay, so reusing a handle would either attach twice under one or let the predecessor's teardown tear down the replacement. The loop mints one per attempt and reports back which one registered, so the audit record names a registration that existed.
- **The reconnect re-applies the private-backend check.** The endpoint a reconnect binds to need not be the generation this stub first registered with, and the manager adopts anything answering `pong` with no version handshake. A daemon predating the `poolable` field would ignore it and route the register through the shared index, co-tenanting a server the operator never allowlisted. Cold start degrades to a per-session exec; that is unavailable here, so the generation is refused, and the refusal is terminal rather than retried.
- **Every abandoned request is answered exactly once.** An unanswered `initialize` is deferred to the replay, which can still answer it for real; everything else is failed immediately and dropped from the session, so no path can emit a second response for an id kiro-cli already has one for.
- **The bridge reports its ending through ONE channel.** `BridgeLivenessFailure` and `run_bridge`'s return value are deleted: `session.reason` plus `session.outstanding_ids` carry strictly more, and two spellings of "why the bridge ended" would have to be kept in step forever. `session` is a required parameter rather than a defaulted one -- with no return value a caller that omitted it would learn nothing, so the fallback branch existed only for tests. The tests that asserted on the return now assert the precise ending instead of merely denying a failure.
- **The budget is finite.** A gateway that is gone for good still reaches the exit that tells kiro-cli this server is done, instead of a stub that never exits.
- **Retryable and terminal are separated.** A handshake replay that loses its connection is retried inside the same budget -- that is the likeliest shape of a supervisor respawn, where the daemon reached first may still be starting or may die again -- while a refusal is terminal, because an older daemon will not grow `poolable_ack` and a moved-on generation will keep answering the same way. Both are named outcomes rather than a bare boolean, so the classification cannot drift into prose matching.
- **A lost session now leaves a trace.** The idle path used to exit with zero signal; both endings are recorded, so a degraded session is explicable afterwards.

## What tests we did

`test/test_stub_broker_reconnect.py` (new) counts the property from the outside: a REAL daemon, a REAL stub process, the daemon stopped the way an operator restart does, a fresh generation started on the same endpoint, then the same stub asked for another tool call.

- **Reproduced first, on unmodified base:** RED at `assert proc.returncode is None` in 12.4s -- the stub process exits when the broker goes away. GREEN with the fix in 31.9s, and the post-restart call reaches the backend carrying this session's own identity, so the reconnect re-registers rather than merely reopening a socket.
- Four unit cases cover what a happy-path round trip cannot reach: the replay is accepted when the generation answers identically, **refused** when it answers differently, forwarded when the original handshake never got its answer (a daemon that died mid-handshake), and the reconnect gives up inside its budget against an endpoint nobody will bind. A closed standard input is asserted to be a non-reconnectable ending, so a normal exit does not spend the budget.
- **Mutation-verified:** disabling the result comparison turns the refusal case RED.
- The existing source ratchet on "the liveness path must not exec" is re-anchored and **strengthened** -- it now also pins that a reconnect is attempted, and it judges code rather than raw text (tokenizing comments away), so the paragraph explaining why the path does not exec can no longer trip the assertion that checks it.
- `flake8` / `isort` / `mypy` clean on the changed files. 46 passed across the stub, bridge-liveness, writer-death, recaller and pool-integration suites. A 4662-test `-k "mcp or stub or gatewayd"` sweep passed except 5 `test_host_isolation_floor.py` cases and one `AF_UNIX path too long` error, all A/B-proven environment-owned: reverting this diff leaves 11 failures in that same file.

## Any other suggestions on the work

The reconnect restores the transport and the handshake. Two things are deliberately left to follow-ups, and neither is silent here:

- **Replaying `resources/subscribe` state.** A subscribed session is refused the reconnect rather than handed a deaf one, so nothing degrades quietly -- but it also does not recover, and it could. There is already replay machinery for the backend-respawn case that should be reused rather than reinvented; doing it right wants its own change, and lifting that refusal is the observable win it would deliver.
- **A user-visible signal.** This PR makes a lost session explicable in the logs, but the dashboard still cannot say "this session's MCP servers are gone". That belongs with the surfacing work rather than in the transport.
- **Replaying `logging/setLevel`.** The third piece of daemon-held session state and the one not handled here: a session that raised its MCP log level reconnects with verbosity back at default. It rides with the subscription-replay follow-up rather than the refusal path, because its cost is diagnostic verbosity, not data -- refusing a session its tools to preserve a log level would be the wrong trade.

Also worth noting for reviewers: the strict equality on the handshake result is the deliberately conservative choice. If a legitimate case turns up where a generation's `serverInfo` moves for a benign reason, that comparison is the one knob to narrow -- but it should be narrowed with a named case, not loosened on principle.

Closes #4506
