### PR TITLE
fix(mcp-gateway): check a surviving daemon's fitness before adopting it

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -58,7 +58,7 @@ from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
 from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
 from kiro_crew.mcp_gateway.backend_tmp import sweep_all_backend_tmp
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
-from kiro_crew.mcp_gateway.hashing import hash_effective_env, non_secret_env
+from kiro_crew.mcp_gateway.hashing import hash_effective_env, hash_target_env, non_secret_env
 from kiro_crew.mcp_gateway.manager import _scrub_sensitive_env, is_credential_env_key
 from kiro_crew.mcp_gateway.pool import (
     DRAIN_DEADLINE_SECS,
@@ -160,9 +160,11 @@ _REGISTER_TIMEOUT_SECS = 5.0
 #                    a daemon predating the field ignores it and routes the
 #                    register through the shared index, silently co-tenanting a
 #                    server the operator never allowlisted. Such a daemon is
-#                    reachable, because the manager adopts anything answering
-#                    ``pong`` with no version handshake — so one that outlived a
-#                    package upgrade serves new stubs.
+#                    still reachable: the manager now compares the target set a
+#                    ``pong`` reports before adopting (#4569), but a daemon old
+#                    enough to omit that field is adopted unchecked precisely
+#                    because it cannot be assessed — so one that outlived a
+#                    package upgrade still serves new stubs.
 REGISTERED_CAPABILITIES: tuple[str, ...] = ("ensure_backend", "bridge_ping", "poolable_ack")
 # Upper bound on a single control/handshake reply's ``drain()`` (pong, stats,
 # registered, rejected, ready, forward-error — everything sent via
@@ -401,7 +403,9 @@ async def run_gatewayd(
     async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         task = asyncio.current_task()
         try:
-            await _handle_connection(reader, writer, pool, resolver, socket_path, hot_keys)
+            await _handle_connection(
+                reader, writer, pool, resolver, socket_path, hot_keys, stop_event=stop_event
+            )
         except asyncio.CancelledError:
             # Normal on shutdown — propagate for the gather() below.
             raise
@@ -2032,6 +2036,97 @@ def _audit_prewarm_spawn(pool_label: str) -> None:
         logger.debug("SEL audit emit for prewarm spawn failed", exc_info=True)
 
 
+def _served_target_fingerprint() -> str:
+    """Fingerprint of the target set THIS daemon can serve.
+
+    :func:`env_target_resolver` resolves every launch command out of
+    ``os.environ``, and a live process's environment cannot be changed, so this
+    value is constant for the daemon's lifetime and names exactly which servers
+    it can route. Reported in every ``pong`` so a starting
+    :class:`~kiro_crew.mcp_gateway.manager.GatewayManager` can tell an incumbent
+    that matches the specs it is about to write from one that does not — the
+    latter would reject those servers terminally (see :class:`_TargetUnknown`)
+    for the whole life of every session that connects to it.
+
+    Recomputed per call rather than cached at import: the cost is one SHA-256
+    over a handful of keys, and a cache would make the value a snapshot of
+    whenever the module happened to load.
+    """
+    return hash_target_env(os.environ)
+
+
+def _audit_stand_down(reason: str, outcome: str) -> None:
+    """Emit a SEL audit event for a stand-down request.
+
+    A stand-down ends the daemon, so it is the most consequential frame the
+    control surface accepts and belongs in the HMAC-chained SEL alongside the
+    claim/abort/peer decisions. Wrapped defensively — an audit-log failure must
+    never break connection handling.
+    """
+    try:
+        SecurityEventLog().log_api_access(
+            caller="gateway-manager",
+            operation="mcp-gateway.stand_down",
+            outcome=outcome,
+            source="gateway",
+            resources=str(_served_target_fingerprint()),
+            error=reason,
+        )
+    except Exception:  # pragma: no cover — audit must never break the handler
+        logger.debug("SEL audit emit for stand-down failed", exc_info=True)
+
+
+def _apply_stand_down(frame: dict[str, Any], stop_event: Optional[asyncio.Event]) -> dict[str, Any]:
+    """Yield the socket voluntarily so a fitter daemon can take it.
+
+    Setting ``stop_event`` takes exactly the graceful path SIGTERM takes: accepts
+    stop, attached stubs drain, ``pool.shutdown_all()`` runs, the endpoint is
+    removed, the process exits. That is the whole point of doing it this way
+    round. The alternative — the starting gateway unlinking the socket to take it
+    — is a connect-probe-then-unlink, which in its documented false-stale window
+    steals a LIVE incumbent's endpoint and re-introduces the socket-theft class
+    the flock guard exists to prevent. Here the incumbent decides, and the
+    request only ever arrives over a connection that proves the incumbent is
+    alive, so there is no stale-vs-live judgement to get wrong.
+
+    ``want`` is the fingerprint the caller needs served. A request whose ``want``
+    equals what this daemon already serves is REFUSED: the caller and the daemon
+    agree, so there is nothing to reconcile, and honouring it would turn this
+    into a bare kill switch that a confused caller could aim at a daemon that
+    was serving it correctly. Trust basis for the rest is the same uid-gated
+    owner-only socket that authenticates Register/Claim/Abort.
+    """
+    want = frame.get("want")
+    if not isinstance(want, str) or not want:
+        _audit_stand_down("missing or invalid want fingerprint", "denied")
+        return {"type": "stand-down-rejected", "reason": "missing or invalid 'want' fingerprint"}
+    served = _served_target_fingerprint()
+    if want == served:
+        _audit_stand_down(f"want matches served set {served[:12]}", "denied")
+        return {
+            "type": "stand-down-rejected",
+            "reason": "this daemon already serves the requested target set",
+        }
+    if stop_event is None:
+        # Reached only by a handler wired without a stop event (unit tests
+        # constructing _handle_connection directly). Refuse rather than claim a
+        # shutdown that cannot happen — an accepted-but-inert control frame is
+        # worse than a rejected one, because the caller waits for an endpoint
+        # that never goes away.
+        _audit_stand_down("handler has no stop event", "denied")
+        return {"type": "stand-down-rejected", "reason": "shutdown not wired on this handler"}
+    logger.warning(
+        "gatewayd: standing down on request — this daemon serves target set %s "
+        "but the caller needs %s; draining so a daemon with the requested set "
+        "can bind",
+        served[:12],
+        want[:12],
+    )
+    _audit_stand_down(f"served {served[:12]} != want {want[:12]}", "allowed")
+    stop_event.set()
+    return {"type": "standing-down", "served": served}
+
+
 async def _handle_connection(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
@@ -2039,6 +2134,8 @@ async def _handle_connection(
     resolver: TargetResolver,
     socket_path: Path,
     hot_keys: Optional[HotKeyStore] = None,
+    *,
+    stop_event: Optional[asyncio.Event] = None,
 ) -> None:
     """Process one stub connection end-to-end.
 
@@ -2123,8 +2220,15 @@ async def _handle_connection(
     # with one round-trip without advertising a PoolKey. GatewayManager
     # uses this to confirm the daemon is serving before returning from
     # ``start()``.
+    #
+    # ``targets`` rides along because liveness alone is not enough to decide
+    # whether to ADOPT this daemon: a survivor of a gateway that died without
+    # running its shutdown path answers pong perfectly while serving a target
+    # set from before the specs were last rewritten. Its presence is also how
+    # the manager negotiates the ``stand-down`` frame below — a daemon old
+    # enough to omit this field is old enough not to understand that frame.
     if register.get("type") == "ping":
-        await _write_json_line(writer, {"type": "pong"})
+        await _write_json_line(writer, {"type": "pong", "targets": _served_target_fingerprint()})
         return
 
     # Metrics short-circuit: return a point-in-time pool snapshot (backends,
@@ -2163,6 +2267,16 @@ async def _handle_connection(
     # same uid-gated 0700 socket as Register/Claim.
     if register.get("type") == "abort":
         await _write_json_line(writer, await _apply_abort(register, pool))
+        return
+
+    # Stand-down short-circuit (one-shot control connection from a STARTING
+    # gateway): "you serve a target set I cannot use — yield the socket". The
+    # only frame that ends the daemon, and the reason adoption can now refuse an
+    # unfit incumbent without anyone unlinking a live socket. Trust basis: same
+    # uid-gated owner-only socket as Register/Claim/Abort. Validation, the
+    # same-set refusal and auditing live in ``_apply_stand_down``.
+    if register.get("type") == "stand-down":
+        await _write_json_line(writer, _apply_stand_down(register, stop_event))
         return
 
     # App-call short-circuit (one-shot control connection from the dashboard):
@@ -2504,6 +2618,13 @@ async def _handle_connection(
             # while it has outstanding requests to verify the gateway is still
             # responsive. Reply with ``{"type": "pong"}`` — never forwarded
             # to the backend.
+            #
+            # Deliberately does NOT carry the ``targets`` fingerprint the
+            # health-probe pong carries. The two have different readers: the
+            # manager's adoption gate opens its own one-shot control connection
+            # and reads that one, while this reply answers a stub that is already
+            # bridged and has no use for a routing fingerprint. Adding it here
+            # for shape symmetry would ship a field with no consumer.
             if msg.get("type") == "ping":
                 try:
                     await _write_json_line(writer, {"type": "pong"})

--- a/src/kiro_crew/mcp_gateway/hashing.py
+++ b/src/kiro_crew/mcp_gateway/hashing.py
@@ -108,6 +108,76 @@ def non_secret_env(
     return {k: v for k, v in env_pairs.items() if k in keep or not is_secret_env_key(k)}
 
 
+#: Env-key prefixes the rewriter writes one entry per stubbed server under,
+#: valued ``"cmd arg arg"``. ``MC_MCP_TARGET_`` is the legacy spelling still
+#: accepted for overlays written by older versions (#928).
+#:
+#: Canonical here rather than in ``resolve_once`` (its previous home) because
+#: ``manager`` and ``gatewayd`` now both need it to agree on a target-set
+#: fingerprint, and a prefix list that two processes compare across a socket is
+#: exactly the kind of constant that must have one definition.
+TARGET_ENV_PREFIXES: tuple[str, ...] = ("KIROCREW_MCP_TARGET_", "MC_MCP_TARGET_")
+
+
+def target_env_pairs(env: Mapping[str, str]) -> dict[str, str]:
+    """Return only the :data:`TARGET_ENV_PREFIXES` entries of ``env``.
+
+    The set of servers a gatewayd process can resolve a launch command for, in
+    the only form that set exists: ``gatewayd.env_target_resolver`` reads these
+    keys straight out of ``os.environ``, so they ARE the daemon's routing table.
+    """
+    return {k: v for k, v in env.items() if any(k.startswith(p) for p in TARGET_ENV_PREFIXES)}
+
+
+def hash_target_env(env: Mapping[str, str]) -> str:
+    """Sorted ``K=V\\0``-delimited SHA-256 over ``env``'s target mappings.
+
+    A daemon's routing table is fixed at spawn (a live process's environment
+    cannot be changed), so this fingerprint identifies for its whole lifetime
+    which servers it can serve and with which command. ``gatewayd`` reports it
+    in its ``pong``; ``manager`` computes it over the environment it is about to
+    write agent specs for, and refuses to adopt an incumbent whose value differs
+    — the daemon would reject exactly the servers whose entry changed.
+
+    Values are folded in, not just keys: a server whose launch command changed
+    is as unservable by the incumbent as one it never had.
+
+    DELIBERATELY OVER-SENSITIVE, and the direction matters. The hash covers every
+    target entry, including one the resolver would never read -- a legacy
+    ``MC_MCP_TARGET_<SERVER>`` shadowed by a modern key for the same server, or an
+    args-disambiguated entry no live pool key asks for. Changing only a shadowed
+    entry therefore moves the fingerprint even though every effective route is
+    identical, and costs one needless broker replacement at startup.
+
+    That is the safe error. Canonicalising to "effective routes" is not cleanly
+    computable here: ``gatewayd.env_target_resolver`` picks between the
+    disambiguated, bare and legacy spellings PER LOOKUP, using the requesting
+    pool key's ``command_args_hash``, which no one knows at start time. An
+    approximation would have to guess, and a guess that collapses two entries the
+    resolver would have distinguished fails the other way -- reporting a daemon
+    fit when it cannot serve a route -- which is the bug this whole fingerprint
+    exists to catch. So the over-sensitivity is kept and paid for in one restart.
+    """
+    return _hash_pairs(target_env_pairs(env))
+
+
+def _hash_pairs(pairs: Mapping[str, str]) -> str:
+    """Sorted ``K=V\\0``-delimited SHA-256 over ``pairs``.
+
+    The one hashing loop behind :func:`hash_effective_env` and
+    :func:`hash_target_env`, shared so the two cannot drift in delimiter or sort
+    order. Extracting it is output-preserving by construction — the byte
+    sequence fed to SHA-256 is unchanged, so no existing ``PoolKey`` moves.
+    """
+    h = hashlib.sha256()
+    for k in sorted(pairs):
+        h.update(k.encode("utf-8"))
+        h.update(b"=")
+        h.update(pairs[k].encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
+
+
 def hash_effective_env(env_pairs: Mapping[str, str], *, identity_keys: Collection[str] = ()) -> str:
     """Sorted ``K=V\\0``-delimited SHA-256 over the NON-SECRET env pairs.
 
@@ -125,10 +195,4 @@ def hash_effective_env(env_pairs: Mapping[str, str], *, identity_keys: Collectio
     hash the daemon does not reproduce, so forwarding fails closed.
     """
     filtered = non_secret_env(env_pairs, identity_keys=identity_keys)
-    h = hashlib.sha256()
-    for k in sorted(filtered):
-        h.update(k.encode("utf-8"))
-        h.update(b"=")
-        h.update(filtered[k].encode("utf-8"))
-        h.update(b"\0")
-    return h.hexdigest()
+    return _hash_pairs(filtered)

--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -2,9 +2,12 @@
 
 Lifecycle:
 
-1. :meth:`GatewayManager.start` — spawn ``python -m
-   kiro_crew.mcp_gateway.gatewayd``, wait until the unix socket appears,
-   then round-trip one ping/pong to confirm the daemon is serving.
+1. :meth:`GatewayManager.start` — if a daemon already answers on the socket,
+   compare the target set it reports against the one the agent specs were just
+   written for and adopt it only when they agree; an unfit incumbent is asked to
+   stand down first (issue #4569). Otherwise spawn ``python -m
+   kiro_crew.mcp_gateway.gatewayd``, wait until the unix socket appears, then
+   round-trip one ping/pong to confirm the daemon is serving.
 2. Background watchdog — detect exit and respawn with exponential backoff.
 3. :meth:`GatewayManager.shutdown` — SIGTERM → SIGKILL the daemon on
    KiroCrew shutdown.
@@ -32,6 +35,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
 from kiro_crew.env import resolve_krb5_ccname
 from kiro_crew.mcp_gateway import transport
+from kiro_crew.mcp_gateway.hashing import hash_target_env
 from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES
 from kiro_crew.mcp_gateway.shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.sandbox import _SENSITIVE_ENV_PREFIXES as _SANDBOX_SENSITIVE_ENV_PREFIXES
@@ -69,6 +73,41 @@ _SHUTDOWN_GRACE_SECS = TOTAL_SHUTDOWN_BUDGET_SECS
 # Respawn backoff: start here, double up to max.
 _RESPAWN_BACKOFF_START_SECS = 1.0
 _RESPAWN_BACKOFF_MAX_SECS = 60.0
+# How many times start() will re-run assess-then-spawn before giving up. Two,
+# because the socket can change hands exactly once under a single start: an
+# unfit incumbent yields and another gateway instance on the same machine wins
+# the freed lock first. Round two assesses that daemon; a cap is what stops two
+# instances trading the socket in a loop, and the give-up path is an ERROR
+# rather than a silent success against a daemon that cannot serve the specs.
+_ELECTION_ROUNDS = 2
+# Lifetime cap on stand-down requests one manager will issue. _ELECTION_ROUNDS
+# bounds hand-offs WITHIN a single start(); this bounds them across the whole
+# process, which is the case the other cap cannot reach: the watchdog also
+# assesses incumbents, on an unbounded respawn loop, so two long-lived gateway
+# instances sharing a socket path with divergent target sets would otherwise
+# stand each other's daemon down on every respawn, forever. Past the cap this
+# manager stops asking and adopts whatever holds the socket, logging the reason
+# -- a bounded number of cycles followed by a loud, stable state. Removing the
+# oscillation entirely needs an ownership/generation lease so one instance is
+# the authorised successor; that is a protocol design and is deliberately not
+# invented here.
+_MAX_STAND_DOWN_REQUESTS = 3
+
+# Outcomes of assessing the daemon that holds the socket. Plain strings rather
+# than an Enum so they read the same in a log line as in a branch.
+#: Keep the incumbent (it is fit, or unfit-but-still-serving and unreconcilable).
+_ADOPT = "adopt"
+#: It released the socket; put our own daemon there.
+_SPAWN = "spawn"
+#: Neither is safe right now — fail the start rather than report a false ready.
+_ABORT = "abort"
+
+# Outcomes of a stand-down request. _DRAINING must stay distinct from _REFUSED:
+# a daemon that ACCEPTED has already closed its accept loop and so is not
+# adoptable, while one that REFUSED is still serving and is.
+_RELEASED = "released"
+_DRAINING = "draining"
+_REFUSED = "refused"
 
 # Python module invoked as the gateway daemon. Kept as a constant so
 # tests can monkey-patch it and the spawn path stays one line.
@@ -141,12 +180,19 @@ class GatewaySpec:
 class GatewayManager:
     """Supervise a single gateway daemon subprocess."""
 
+    #: Class-level default so the attribute is TOTAL regardless of construction
+    #: path. Tests and other call sites build this object via ``__new__``,
+    #: bypassing ``__init__``, and an instance-only attribute would raise
+    #: AttributeError on every such path the moment adoption reads it.
+    _stand_downs_issued: int = 0
+
     def __init__(self, spec: GatewaySpec) -> None:
         self._spec = spec
         self._process: asyncio.subprocess.Process | None = None
         self._watchdog: asyncio.Task[None] | None = None
         self._stopping = False
         self._adopted = False
+        self._stand_downs_issued = 0
         self._lifecycle_lock = asyncio.Lock()
 
     @property
@@ -179,26 +225,108 @@ class GatewayManager:
         if self._adopted:
             return True
 
-        # Singleton adoption: if a healthy daemon already owns the socket
-        # (a sibling manager in this process won the spawn race, or a
-        # survivor from a prior gateway), adopt it instead of spawning a
-        # competitor. gatewayd's flock guard already makes a duplicate spawn
-        # a clean no-op, but adopting skips the wasted spawn/exit churn.
-        if await self._ping_once():
-            self._adopted = True
-            logger.info(
-                "mcp-gateway: a healthy daemon already owns %s — adopting "
-                "(no spawn)", self._spec.socket_path,
-            )
-            # Supervise even when adopting: the adopted daemon may be a
-            # prior-gateway survivor with no other watchdog in this process.
-            # The watchdog's adopted branch re-checks liveness by ping and
-            # re-elects (spawns a replacement) if the adopted daemon dies.
-            self._watchdog = asyncio.create_task(
-                self._run_watchdog(), name="mcp-gateway-watchdog"
-            )
-            return True
+        # Bounded election. One round is not enough because the socket this
+        # start is contending for can change hands under it: an unfit incumbent
+        # yields, and a DIFFERENT daemon — a second gateway instance on the same
+        # machine — can win the freed lock before our own spawn does, leaving us
+        # ping-confirming a daemon whose target set we never checked. Round two
+        # assesses that daemon the same way round one assessed the first, and
+        # the cap is what stops two instances handing the socket back and forth.
+        for _attempt in range(_ELECTION_ROUNDS):
+            # Singleton adoption: if a healthy daemon already owns the socket
+            # (a sibling manager in this process won the spawn race, or a
+            # survivor from a prior gateway), adopt it instead of spawning a
+            # competitor. gatewayd's flock guard already makes a duplicate spawn
+            # a clean no-op, but adopting skips the wasted spawn/exit churn.
+            #
+            # Liveness is not sufficient on its own. Startup rewrites every agent
+            # spec from current config and then arrives here; a survivor of a
+            # gateway that died without running its shutdown path answers pong
+            # perfectly while serving the target set it was spawned with, which
+            # can predate those specs. _adopt_or_stand_down compares the two and
+            # gives an unfit incumbent the chance to yield the socket first.
+            pong = await self._ping_probe()
+            if pong is not None:
+                verdict = await self._adopt_or_stand_down(pong)
+                if verdict == _ADOPT:
+                    return self._adopt_incumbent()
+                if verdict == _ABORT:
+                    # A draining incumbent: not adoptable (it no longer accepts)
+                    # and not replaceable (it still holds the lock). Reporting
+                    # ready here would be the laundering this check exists to
+                    # avoid, so the start fails and the caller falls back to
+                    # per-session MCP.
+                    return False
 
+            spawned = await self._spawn_and_confirm()
+            if spawned is None:
+                return False
+            if self._is_fit(spawned):
+                if self.is_running:
+                    self._watchdog = asyncio.create_task(
+                        self._run_watchdog(), name="mcp-gateway-watchdog"
+                    )
+                    logger.info(
+                        "mcp-gateway: started pid=%s socket=%s",
+                        self._process.pid if self._process else "?",
+                        self._spec.socket_path,
+                    )
+                    return True
+                # Our spawn lost the lock but whoever holds it serves the set we
+                # need. Adopt rather than respawn: a fit daemon is a fit daemon
+                # regardless of who started it, and leaving _adopted False here
+                # would send the watchdog spawning doomed competitors.
+                return self._adopt_incumbent()
+            # A foreign daemon owns the socket and cannot serve our specs. Drop
+            # our exited handle and let the next round assess it as an incumbent.
+            logger.warning(
+                "mcp-gateway: our spawn on %s lost the election to a daemon that "
+                "cannot serve the current target set — re-electing",
+                self._spec.socket_path,
+            )
+            self._process = None
+        logger.error(
+            "mcp-gateway: could not put a daemon serving the current target set "
+            "on %s within %d election rounds; gateway unavailable",
+            self._spec.socket_path, _ELECTION_ROUNDS,
+        )
+        return False
+
+    def _adopt_incumbent(self) -> bool:
+        """Mark the daemon on the socket as adopted and supervise it. Always ``True``."""
+        self._adopted = True
+        self._process = None
+        logger.info(
+            "mcp-gateway: a healthy daemon already owns %s — adopting "
+            "(no spawn)", self._spec.socket_path,
+        )
+        # Supervise even when adopting: the adopted daemon may be a
+        # prior-gateway survivor with no other watchdog in this process.
+        # The watchdog's adopted branch re-checks liveness by ping and
+        # re-elects (spawns a replacement) if the adopted daemon dies.
+        self._watchdog = asyncio.create_task(
+            self._run_watchdog(), name="mcp-gateway-watchdog"
+        )
+        return True
+
+    def _is_fit(self, pong: dict[str, Any]) -> bool:
+        """Whether the daemon that sent ``pong`` serves the set we are writing specs for."""
+        served = pong.get("targets")
+        return isinstance(served, str) and served == self._wanted_target_fingerprint()
+
+    async def _spawn_and_confirm(self) -> dict[str, Any] | None:
+        """Spawn a daemon and return the ``pong`` of whoever ends up serving.
+
+        ``None`` means the start has failed outright (spawn raised, shutdown
+        intervened, the endpoint never appeared, or nothing answered) and the
+        caller must give up — the process handle is already cleaned up.
+
+        A returned pong is NOT proof that the daemon is ours: gatewayd's flock
+        guard makes a duplicate spawn exit rc=0 without binding, so on a
+        contended socket the answer can come from a foreign daemon. The caller
+        decides by fingerprint, which is why this returns the frame rather than a
+        bool.
+        """
         # Clear any stale socket from a prior crash.
         await self._clear_stale_socket()
         # Owner-only containing directory: the socketsec model calls this the
@@ -209,14 +337,14 @@ class GatewayManager:
         # icacls with a multi-second timeout, and this runs inside the live
         # gateway's loop (dashboard toggle -> _init_mcp_gateway -> start()),
         # so calling it inline stalls chat turns and the liveness heartbeat.
-        # Mirrors the log-file hunk below, which offloads the same helper.
+        # Mirrors the log-file hunk in _spawn_once, which offloads the same helper.
         await asyncio.to_thread(transport.prepare_dir, self._spec.socket_path)
 
         try:
             await self._spawn_once()
         except Exception:
             logger.exception("mcp-gateway: initial spawn failed")
-            return False
+            return None
 
         # Re-check after spawn: shutdown() may have been called while we
         # were awaiting _spawn_once(). If so, terminate the freshly-spawned
@@ -224,7 +352,7 @@ class GatewayManager:
         if self._stopping:
             logger.info("mcp-gateway: stopping flag set after spawn — aborting start")
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
+            return None
 
         ok = await self._wait_for_socket(self._spec.socket_path, _SOCKET_READY_TIMEOUT_SECS)
         if not ok:
@@ -233,27 +361,29 @@ class GatewayManager:
                 _SOCKET_READY_TIMEOUT_SECS,
             )
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
+            return None
 
         # One ping/pong round-trip confirms the daemon's accept loop is
         # live before we hand control back to the caller. Without this the
         # socket appearing only proves bind() succeeded; the handler task
         # might still be wiring up when the first stub connects.
-        if not await self._ping_once():
+        pong = await self._ping_probe()
+        if pong is None:
             logger.warning("mcp-gateway ping failed — treating start as failure")
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
-
-        self._watchdog = asyncio.create_task(self._run_watchdog(), name="mcp-gateway-watchdog")
-        logger.info(
-            "mcp-gateway: started pid=%s socket=%s",
-            self._process.pid if self._process else "?",
-            self._spec.socket_path,
-        )
-        return True
+            return None
+        return pong
 
     async def shutdown(self) -> None:
         """Stop the watchdog and terminate the daemon."""
+        # Set BEFORE contending for the lock, not inside the locked section. A
+        # start() that met an unfit incumbent can hold this lock for the whole
+        # stand-down wait (another process's drain budget), and _stopping is the
+        # only way to tell it to give up; setting it after acquiring the lock
+        # would mean shutdown waits out that drain before it can even say so.
+        # Safe to hoist: the flag is monotonic (only ever set on the way down)
+        # and every path that reads it already treats it as "abort".
+        self._stopping = True
         async with self._lifecycle_lock:
             await self._shutdown_locked()
 
@@ -393,9 +523,19 @@ class GatewayManager:
         """Public liveness probe: ``True`` iff the daemon replies pong."""
         return await self._ping_once()
 
-    async def _ping_once(self) -> bool:
-        """Return ``True`` iff the daemon replies ``{"type":"pong"}`` within
-        ``_PING_TIMEOUT_SECS``. Any transport or parse error → ``False``.
+    async def _control_roundtrip(self, frame: dict[str, Any]) -> dict[str, Any] | None:
+        """Send one control frame on a fresh connection and return the reply.
+
+        ``None`` on any transport, timeout, decode or non-object reply — every
+        caller here treats an unreadable answer as "no answer", never as a
+        negative one, so the distinction is not worth propagating. Bounded by
+        ``_PING_TIMEOUT_SECS`` at each of connect / drain / read, which is what
+        keeps a wedged daemon from stalling gateway startup.
+
+        One implementation for ping, stats and stand-down: all three are the
+        same one-shot request/response against the daemon's control surface, and
+        three hand-rolled copies of this connect-write-read-close dance is how
+        one of them ends up missing a timeout or leaking a writer.
         """
         try:
             reader, writer = await asyncio.wait_for(
@@ -406,26 +546,20 @@ class GatewayManager:
                 timeout=_PING_TIMEOUT_SECS,
             )
         except (asyncio.TimeoutError, OSError) as exc:
-            logger.warning("mcp-gateway ping connect failed: %s", exc)
-            return False
+            logger.warning(
+                "mcp-gateway %s connect failed: %s", frame.get("type", "control"), exc
+            )
+            return None
         try:
-            writer.write(b'{"type":"ping"}\n')
-            try:
-                await asyncio.wait_for(writer.drain(), timeout=_PING_TIMEOUT_SECS)
-            except (asyncio.TimeoutError, ConnectionError):
-                return False
-            try:
-                line = await asyncio.wait_for(
-                    reader.readuntil(b"\n"), timeout=_PING_TIMEOUT_SECS,
-                )
-            except (asyncio.TimeoutError, asyncio.IncompleteReadError,
-                    asyncio.LimitOverrunError):
-                return False
-            try:
-                msg = json.loads(line.decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                return False
-            return isinstance(msg, dict) and msg.get("type") == "pong"
+            writer.write(json.dumps(frame).encode("utf-8") + b"\n")
+            await asyncio.wait_for(writer.drain(), timeout=_PING_TIMEOUT_SECS)
+            line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=_PING_TIMEOUT_SECS)
+            msg = json.loads(line.decode("utf-8"))
+            return msg if isinstance(msg, dict) else None
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError, ConnectionError,
+                asyncio.LimitOverrunError, UnicodeDecodeError, json.JSONDecodeError,
+                OSError):
+            return None
         finally:
             try:
                 writer.close()
@@ -433,34 +567,216 @@ class GatewayManager:
             except Exception:
                 pass
 
+    async def _ping_probe(self) -> dict[str, Any] | None:
+        """Return the daemon's ``pong`` frame, or ``None`` if it did not answer.
+
+        The payload matters and not just the fact of a reply: ``pong`` carries
+        the fingerprint of the target set the answering daemon can serve, which
+        is what :meth:`_adopt_or_stand_down` needs to decide whether adopting it
+        is safe. :meth:`_ping_once` remains the boolean liveness view for the
+        callers that only ask "is it alive".
+        """
+        msg = await self._control_roundtrip({"type": "ping"})
+        if msg is None or msg.get("type") != "pong":
+            return None
+        return msg
+
+    async def _ping_once(self) -> bool:
+        """Return ``True`` iff the daemon replies ``{"type":"pong"}`` within
+        ``_PING_TIMEOUT_SECS``. Any transport or parse error → ``False``.
+        """
+        return await self._ping_probe() is not None
+
+    def _wanted_target_fingerprint(self) -> str:
+        """Fingerprint of the target set the daemon we want would serve.
+
+        Computed over the SAME environment :meth:`_spawn_once` would hand a
+        fresh daemon — the scrubbed parent environment with
+        ``spec.mcp_target_env`` overlaid, in that precedence — so a fresh spawn
+        is fingerprint-equal to this value by construction. That equality is
+        the whole guarantee: comparing it against a running daemon's reported
+        value answers "could this daemon serve the specs we are about to write"
+        without asking it about servers one at a time.
+
+        The credential scrub cannot touch the answer (it removes no
+        target-prefixed key) but is applied anyway, so this stays a copy of the
+        spawn env rather than a lookalike that drifts if either list changes.
+        """
+        env = {**_scrub_sensitive_env(dict(os.environ)), **self._spec.mcp_target_env}
+        return hash_target_env(env)
+
+    async def _adopt_or_stand_down(self, pong: dict[str, Any]) -> str:
+        """Decide what to do about the daemon that answered ``pong``.
+
+        Returns :data:`_ADOPT` (keep the incumbent), :data:`_SPAWN` (it released
+        the socket, put our own daemon there) or :data:`_ABORT` (neither is safe
+        — fail the start).
+
+        Four outcomes, and only one of them is a fail-open:
+
+        * **Fit** → ``_ADOPT``. Its target set matches what we are about to
+          write. The ordinary case, including the sibling-manager race that
+          adoption was built for, since a sibling in this process computes the
+          same fingerprint from the same spec.
+        * **Unfit, yields** → ``_SPAWN``. It serves a different set (or cannot
+          say what it serves), so every server whose entry moved would be
+          rejected terminally for the life of each session that connects. It
+          stood down and released the singleton lock.
+        * **Unfit, accepted but still draining** → ``_ABORT``. It has already
+          closed its accept loop, so adopting it would be WORSE than the
+          mismatch this change exists to fix: a daemon that answers ping but
+          accepts no new connection turns a partial outage (the changed servers)
+          into a total one (every server), while reporting success. Spawning is
+          not available either, because it still holds the lock. Fail the start;
+          the socket frees itself moments later.
+        * **Unfit, will not yield** → ``_ADOPT``, the deliberate fail-open. A
+          refusal, or a pre-fingerprint daemon that does not understand the
+          frame. It is still accepting connections, so adopting preserves the
+          servers that DO work; refusing would leave the socket held by a daemon
+          nobody supervises and no working gateway at all. Logged at ERROR: this
+          failure used to be silent, and "one MCP server is broken for no
+          reason" was all an operator had to go on.
+
+        A daemon that reports no fingerprint is treated as UNFIT, not as fit.
+        Unknown is not the same as wrong, but adopting on unknown is what
+        reproduces the reported bug on this fix's very first deployment: the
+        survivor of a gateway that died without its shutdown path after a package
+        upgrade is exactly a daemon too old to report a target set. Asking it to
+        stand down costs one bounded round-trip that such a daemon answers by
+        closing the connection (it refuses an unrecognised first frame), after
+        which the fail-open branch adopts it with the breakage named — strictly
+        more informative than adopting it silently, and free in steady state
+        because a current daemon always reports.
+        """
+        served = pong.get("targets")
+        wanted = self._wanted_target_fingerprint()
+        if isinstance(served, str) and served and served == wanted:
+            return _ADOPT
+        described = served[:12] if isinstance(served, str) and served else "<unreported>"
+        if self._stand_downs_issued >= _MAX_STAND_DOWN_REQUESTS:
+            # Oscillation guard. Reached only when this process has already asked
+            # _MAX_STAND_DOWN_REQUESTS times, which in practice means another
+            # live gateway instance keeps re-winning the socket with a different
+            # target set. Stop asking and settle: adopting a serving daemon
+            # leaves the servers it CAN serve working, which beats trading the
+            # socket back and forth forever.
+            logger.error(
+                "mcp-gateway: incumbent on %s serves target set %s, not the %s "
+                "the specs need, but this gateway has already issued %d "
+                "stand-downs — adopting it instead of contending further. "
+                "Another gateway instance is likely sharing this socket path "
+                "with a different target set; the servers whose launch command "
+                "differs will be REJECTED for new sessions.",
+                self._spec.socket_path,
+                described,
+                wanted[:12],
+                self._stand_downs_issued,
+            )
+            return _ADOPT
+        logger.warning(
+            "mcp-gateway: incumbent on %s serves target set %s but the agent "
+            "specs being written need %s — asking it to stand down",
+            self._spec.socket_path,
+            described,
+            wanted[:12],
+        )
+        outcome = await self._request_stand_down(wanted)
+        if outcome == _RELEASED:
+            logger.info(
+                "mcp-gateway: incumbent stood down and released %s — spawning a "
+                "daemon for the current target set",
+                self._spec.socket_path,
+            )
+            return _SPAWN
+        if outcome == _DRAINING:
+            logger.error(
+                "mcp-gateway: incumbent on %s accepted the stand-down but had not "
+                "released the socket within %.0fs. It is draining and no longer "
+                "accepting connections, so it is NOT adopted — adopting a daemon "
+                "that cannot accept would make every server unreachable instead "
+                "of the changed ones. Starting without a shared broker; sessions "
+                "fall back to per-session MCP and the next start finds it free.",
+                self._spec.socket_path,
+                _SHUTDOWN_GRACE_SECS,
+            )
+            return _ABORT
+        logger.error(
+            "mcp-gateway: incumbent on %s serves target set %s, not the %s the "
+            "agent specs were just written for, and refused to release the socket "
+            "— adopting it anyway. Every stubbed server whose launch command "
+            "changed since that daemon started will be REJECTED for new "
+            "sessions until it is stopped and the gateway restarted.",
+            self._spec.socket_path,
+            described,
+            wanted[:12],
+        )
+        return _ADOPT
+
+    async def _request_stand_down(self, wanted: str) -> str:
+        """Ask the incumbent to yield the socket.
+
+        Returns :data:`_RELEASED` (it accepted and the lock is free),
+        :data:`_DRAINING` (it accepted but has not finished within the budget) or
+        :data:`_REFUSED` (it did not accept, or never answered). The caller must
+        keep ``_DRAINING`` distinct from ``_REFUSED``: a daemon that accepted has
+        already stopped accepting connections, so it is not adoptable, whereas a
+        daemon that refused is still serving and is.
+
+        Voluntary by design. The starting gateway must not take the endpoint
+        itself: :meth:`_clear_stale_socket` is a connect-probe-then-unlink, and
+        in its documented false-stale window that unlinks a LIVE incumbent's
+        socket — the socket-theft class the flock guard exists to prevent. Here
+        the incumbent performs its own SIGTERM-equivalent drain and removes its
+        own endpoint, so there is no stale-vs-live judgement to get wrong: the
+        request only reaches a daemon that just answered on that socket.
+
+        ``wanted`` travels with the request so the daemon can refuse a stand-down
+        it has no reason to perform (see ``gatewayd._apply_stand_down``).
+
+        What is waited ON is the singleton lock becoming free, NOT the endpoint
+        disappearing, and the difference is load-bearing. A draining daemon stops
+        accepting first and releases the lock last, so the endpoint goes away
+        while the lock is still held — on Windows for the daemon's whole drain,
+        since the kernel drops a pipe name as soon as the last handle closes. A
+        replacement spawned in that gap loses the lock, exits rc=0 without
+        binding, and ``_wait_for_socket`` then fails the start with no watchdog
+        left to retry. The lock is precisely what the replacement must win, so it
+        is the only correct readiness signal.
+
+        The wait is bounded by the daemon's own published shutdown budget,
+        because that is how long a graceful drain is allowed to take. It also
+        gives up as soon as ``_stopping`` is set, so a shutdown racing a start is
+        not made to wait out another process's drain.
+        """
+        reply = await self._control_roundtrip({"type": "stand-down", "want": wanted})
+        self._stand_downs_issued += 1
+        if reply is None or reply.get("type") != "standing-down":
+            logger.warning(
+                "mcp-gateway: stand-down request on %s was not accepted (%s)",
+                self._spec.socket_path,
+                (reply or {}).get("reason") or "no answer",
+            )
+            return _REFUSED
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _SHUTDOWN_GRACE_SECS
+        while loop.time() < deadline:
+            if self._stopping:
+                logger.info(
+                    "mcp-gateway: abandoning the stand-down wait on %s — shutting down",
+                    self._spec.socket_path,
+                )
+                return _DRAINING
+            if await asyncio.to_thread(transport.singleton_lock_free, self._spec.socket_path):
+                return _RELEASED
+            await asyncio.sleep(_SOCKET_POLL_INTERVAL_SECS)
+        if await asyncio.to_thread(transport.singleton_lock_free, self._spec.socket_path):
+            return _RELEASED
+        return _DRAINING
+
     async def stats(self) -> dict:
         """Return the daemon's pool snapshot, or ``{}`` on any error."""
-        try:
-            reader, writer = await asyncio.wait_for(
-                transport.connect(
-                    self._spec.socket_path,
-                    limit=READ_BUFFER_LIMIT_BYTES,
-                ),
-                timeout=_PING_TIMEOUT_SECS,
-            )
-        except (asyncio.TimeoutError, OSError) as exc:
-            logger.warning("mcp-gateway stats connect failed: %s", exc)
-            return {}
-        try:
-            writer.write(b'{"type":"stats"}\n')
-            await asyncio.wait_for(writer.drain(), timeout=_PING_TIMEOUT_SECS)
-            line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=_PING_TIMEOUT_SECS)
-            msg = json.loads(line.decode("utf-8"))
-            return msg if isinstance(msg, dict) and msg.get("type") == "stats" else {}
-        except (asyncio.TimeoutError, asyncio.IncompleteReadError, ConnectionError,
-                asyncio.LimitOverrunError, UnicodeDecodeError, json.JSONDecodeError):
-            return {}
-        finally:
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
+        msg = await self._control_roundtrip({"type": "stats"})
+        return msg if msg is not None and msg.get("type") == "stats" else {}
 
     async def _run_watchdog(self) -> None:
         """Supervise the daemon: respawn on exit or on liveness failure.
@@ -597,19 +913,40 @@ class GatewayManager:
             # or gatewayd's flock guard rejected our last spawn (it exited
             # rc=0 without binding). If so, adopt the incumbent and stand the
             # watchdog down instead of respawn-looping doomed competitors.
-            if await self._ping_once():
-                self._adopted = True
-                logger.info(
-                    "mcp-gateway: socket %s already served by another daemon "
-                    "— adopting; watchdog will supervise it via ping",
-                    self._spec.socket_path,
-                )
-                # continue (NOT return): re-enter the loop so the adopted
-                # branch (proc is None and self._adopted) supervises the
-                # incumbent by ping and re-elects if it later dies. Returning
-                # here would terminate the watchdog and leave the adopted
-                # daemon unsupervised.
-                continue
+            # Same fitness gate as the startup path: the incumbent this loop
+            # meets is reached by exactly the same reasoning, so a respawn must
+            # not silently accept a target set that startup would have refused.
+            #
+            # No SEPARATE post-respawn fitness check is needed here, unlike in
+            # _start_locked. A respawn that loses the flock exits rc=0, the
+            # wait-race below observes that exit, and control returns to THIS
+            # gate — so an unfit daemon that won the socket is assessed within
+            # one backoff cycle rather than accepted permanently. _start_locked
+            # needed its own check because it returns to the caller instead of
+            # looping back to a gate.
+            pong = await self._ping_probe()
+            if pong is not None:
+                verdict = await self._adopt_or_stand_down(pong)
+                if verdict == _ABORT:
+                    # Draining incumbent: neither adoptable nor replaceable yet.
+                    # Back off and let the next iteration re-assess rather than
+                    # spawning into a lock that is still held.
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, _RESPAWN_BACKOFF_MAX_SECS)
+                    continue
+                if verdict == _ADOPT:
+                    self._adopted = True
+                    logger.info(
+                        "mcp-gateway: socket %s already served by another daemon "
+                        "— adopting; watchdog will supervise it via ping",
+                        self._spec.socket_path,
+                    )
+                    # continue (NOT return): re-enter the loop so the adopted
+                    # branch (proc is None and self._adopted) supervises the
+                    # incumbent by ping and re-elects if it later dies. Returning
+                    # here would terminate the watchdog and leave the adopted
+                    # daemon unsupervised.
+                    continue
             try:
                 await self._clear_stale_socket()
                 await self._spawn_once()

--- a/src/kiro_crew/mcp_gateway/resolve_once.py
+++ b/src/kiro_crew/mcp_gateway/resolve_once.py
@@ -76,6 +76,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
+from kiro_crew.mcp_gateway.hashing import TARGET_ENV_PREFIXES
 from kiro_crew.platform_compat import kill_and_reap
 from kiro_crew.sandbox import create_subprocess_limited, sandboxed_spawn_argv
 
@@ -831,7 +832,11 @@ async def ensure_resolved(
 
 
 #: Env keys the rewriter writes one per stubbed server, valued ``"cmd arg arg"``.
-_TARGET_PREFIXES = ("KIROCREW_MCP_TARGET_", "MC_MCP_TARGET_")
+#: Re-exported from the ``hashing`` leaf, which owns the canonical tuple because
+#: ``manager`` and ``gatewayd`` compare a fingerprint derived from it across a
+#: socket. Kept under the private name so this module's own call sites are
+#: unchanged.
+_TARGET_PREFIXES = TARGET_ENV_PREFIXES
 
 
 def launch_specs(target_env: Mapping[str, str]) -> list[tuple[str, list[str]]]:

--- a/src/kiro_crew/mcp_gateway/transport.py
+++ b/src/kiro_crew/mcp_gateway/transport.py
@@ -587,6 +587,39 @@ def endpoint_exists(socket_path: str | os.PathLike[str]) -> bool:
     return Path(socket_path).exists()
 
 
+def singleton_lock_free(socket_path: str | os.PathLike[str]) -> bool:
+    """Whether a replacement daemon could win the singleton lock right now.
+
+    Blocking (it opens a file and takes an advisory lock), so callers run it in
+    a thread. Acquires and immediately releases, which is the only way to ask
+    the question: the lock is held by an fd in another process and there is no
+    read-only "is it held" call.
+
+    This -- not :func:`endpoint_exists` -- is what "the incumbent has finished
+    releasing" means. A draining daemon stops accepting first and only releases
+    the lock after its drain, pool shutdown and teardown complete, so the
+    endpoint stops being reachable BEFORE the lock is free: on Windows at the
+    very start of shutdown (the kernel drops a pipe name when the last handle
+    closes, so the whole drain sits inside the gap), and on POSIX between
+    ``teardown`` unlinking the socket and process exit closing the fd. A
+    replacement spawned inside that gap loses the lock and exits rc=0 without
+    binding, and nothing rebinds afterwards.
+
+    ``True`` on an inconclusive failure: the caller uses this to decide whether
+    to spawn, and the flock itself is the real arbiter -- a spawn that turns out
+    to be premature loses the lock and exits cleanly, which is the outcome this
+    probe exists to make rare rather than the one it must prevent.
+    """
+    try:
+        fd = acquire_singleton_lock(socket_path)
+    except OSError:
+        return True
+    if fd is None:
+        return False
+    os.close(fd)
+    return True
+
+
 async def remove_stale(socket_path: str | os.PathLike[str]) -> None:
     """Remove an endpoint left behind by a prior crash.
 

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -255,7 +255,16 @@ class TestControlFrames:
     async def test_ping_is_answered_with_pong_and_closes(self, peer_ok):
         writer = _FakeWriter()
         await _handle(_ScriptedReader({"type": "ping"}, {"type": "ping"}), writer, _fake_pool())
-        assert writer.frames() == [{"type": "pong"}]
+        # Exactly one frame: the second ping is never read, the handler closes
+        # after the first. The pong carries the fingerprint of the target set
+        # this daemon can serve, which is what the manager's adoption fitness
+        # check reads (#4569) -- asserted by shape here, by value in
+        # test_mcp_gateway_adoption_fitness.py.
+        frames = writer.frames()
+        assert len(frames) == 1
+        assert frames[0]["type"] == "pong"
+        assert isinstance(frames[0]["targets"], str) and frames[0]["targets"]
+        assert set(frames[0]) == {"type", "targets"}
 
     @pytest.mark.asyncio
     async def test_stats_merges_the_warm_pool_hit_tally(self, peer_ok, monkeypatch):

--- a/test/test_mcp_gateway_adoption_fitness.py
+++ b/test/test_mcp_gateway_adoption_fitness.py
@@ -1,0 +1,1045 @@
+"""Adoption asserts FITNESS, not just liveness (issue #4569).
+
+A gateway that dies without running its shutdown path (SIGKILL, OOM, host
+reset) leaves its MCP gateway daemon alive on the socket. The next start
+rewrites every agent spec from current config and then adopts that survivor —
+whose routing table came from its own process environment at spawn and cannot
+change while it lives. Any server whose entry moved in between is routed to a
+target the survivor never learned, and ``stub.py`` treats an unknown target as a
+TERMINAL rejection, so each new session loses that server for its whole life.
+
+Three layers under test:
+
+* ``hashing.hash_target_env`` — the fingerprint both sides compare, and the
+  ``manager``/``gatewayd`` agreement that makes comparing it meaningful.
+* ``gatewayd._apply_stand_down`` — the daemon yields its own socket rather than
+  having it unlinked underneath it, and refuses a request with nothing to
+  reconcile.
+* ``GatewayManager`` adoption — fit incumbent adopted, unfit incumbent asked to
+  yield, and an unfit incumbent that will not yield adopted anyway with the
+  breakage named at ERROR level instead of staying silent.
+
+The end-to-end test binds real sockets under ``tmp_path`` and spawns a real
+daemon subprocess through the manager's own spawn path; the rest are in-process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.mcp_gateway import gatewayd as gw
+from kiro_crew.mcp_gateway import manager as mgr
+from kiro_crew.mcp_gateway import transport
+from kiro_crew.mcp_gateway.hashing import (
+    TARGET_ENV_PREFIXES,
+    hash_target_env,
+    target_env_pairs,
+)
+
+# POSIX: the end-to-end test observes the socket file disappearing, which a
+# Windows named pipe has no directory entry for.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="observes a socket file being released"
+)
+
+
+# ── the fingerprint itself ─────────────────────────────────────────
+
+
+class TestTargetFingerprint:
+    def test_only_target_keys_participate(self) -> None:
+        """Unrelated environment churn must not look like a routing change."""
+        base = {"KIROCREW_MCP_TARGET_SLACK_MCP": "slack-mcp --stdio"}
+        assert hash_target_env(base) == hash_target_env({**base, "PATH": "/usr/bin"})
+        assert hash_target_env(base) == hash_target_env({**base, "TERM": "xterm"})
+
+    def test_legacy_prefix_participates(self) -> None:
+        assert "MC_MCP_TARGET_" in TARGET_ENV_PREFIXES
+        assert target_env_pairs({"MC_MCP_TARGET_A": "a"}) == {"MC_MCP_TARGET_A": "a"}
+
+    def test_added_server_moves_the_fingerprint(self) -> None:
+        """The reported failure: a server stubbed after the daemon started."""
+        before = {"KIROCREW_MCP_TARGET_A": "a --stdio"}
+        after = {**before, "KIROCREW_MCP_TARGET_B": "b --stdio"}
+        assert hash_target_env(before) != hash_target_env(after)
+
+    def test_changed_command_moves_the_fingerprint(self) -> None:
+        """Same server, different launch — as unservable as one never had."""
+        assert hash_target_env({"KIROCREW_MCP_TARGET_A": "a --stdio"}) != hash_target_env(
+            {"KIROCREW_MCP_TARGET_A": "a --http"}
+        )
+
+    def test_order_independent(self) -> None:
+        one = {"KIROCREW_MCP_TARGET_A": "a", "KIROCREW_MCP_TARGET_B": "b"}
+        two = {"KIROCREW_MCP_TARGET_B": "b", "KIROCREW_MCP_TARGET_A": "a"}
+        assert hash_target_env(one) == hash_target_env(two)
+
+
+class TestManagerAndDaemonAgree:
+    """The load-bearing equality: a fresh spawn matches what the manager wants.
+
+    Without it the comparison is theatre — the manager would ask for a
+    fingerprint no daemon it spawns could ever report, and every start would
+    take the stand-down path.
+    """
+
+    def test_wanted_equals_what_a_fresh_daemon_would_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_MCP_TARGET_INHERITED", "inherited --stdio")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "scrubbed-by-spawn")
+        spec = mgr.GatewaySpec(
+            socket_path=tmp_path / "gw.sock",
+            mcp_target_env={"KIROCREW_MCP_TARGET_STUBBED": "stubbed --stdio"},
+        )
+        wanted = mgr.GatewayManager(spec)._wanted_target_fingerprint()
+
+        # Rebuild the daemon's view: _spawn_once hands it the scrubbed parent
+        # env with mcp_target_env overlaid, and _served_target_fingerprint
+        # hashes os.environ from inside that process. Applied through the real
+        # environ so the suite's own isolation variables survive.
+        daemon_env = {
+            **mgr._scrub_sensitive_env(dict(os.environ)),
+            **spec.mcp_target_env,
+        }
+        _only_targets(monkeypatch, target_env_pairs(daemon_env))
+        assert wanted == gw._served_target_fingerprint()
+
+    def test_spec_env_wins_over_the_inherited_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same precedence as the spawn merge, or the two sides disagree."""
+        monkeypatch.setenv("KIROCREW_MCP_TARGET_A", "stale --stdio")
+        spec = mgr.GatewaySpec(
+            socket_path=tmp_path / "gw.sock",
+            mcp_target_env={"KIROCREW_MCP_TARGET_A": "fresh --stdio"},
+        )
+        assert mgr.GatewayManager(spec)._wanted_target_fingerprint() == hash_target_env(
+            {"KIROCREW_MCP_TARGET_A": "fresh --stdio"}
+        )
+
+
+# ── gatewayd: the daemon yields its own socket ─────────────────────
+
+
+class TestApplyStandDown:
+    def test_sets_stop_event_on_a_real_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_A": "a"})
+        stop = asyncio.Event()
+        reply = gw._apply_stand_down({"type": "stand-down", "want": "deadbeef"}, stop)
+        assert reply["type"] == "standing-down"
+        assert reply["served"] == hash_target_env({"KIROCREW_MCP_TARGET_A": "a"})
+        assert stop.is_set(), "the daemon must take the graceful SIGTERM path"
+
+    def test_refuses_when_it_already_serves_the_requested_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not a bare kill switch: agreement means nothing to reconcile."""
+        env = {"KIROCREW_MCP_TARGET_A": "a"}
+        _only_targets(monkeypatch, env)
+        stop = asyncio.Event()
+        reply = gw._apply_stand_down({"type": "stand-down", "want": hash_target_env(env)}, stop)
+        assert reply["type"] == "stand-down-rejected"
+        assert not stop.is_set()
+
+    @pytest.mark.parametrize("want", [None, "", 17, {"a": 1}])
+    def test_refuses_a_malformed_want(self, want: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_A": "a"})
+        stop = asyncio.Event()
+        frame: dict[str, Any] = {"type": "stand-down"}
+        if want is not None:
+            frame["want"] = want
+        assert gw._apply_stand_down(frame, stop)["type"] == "stand-down-rejected"
+        assert not stop.is_set()
+
+    def test_refuses_when_shutdown_is_not_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An accepted-but-inert control frame would hang the caller."""
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_A": "a"})
+        reply = gw._apply_stand_down({"type": "stand-down", "want": "deadbeef"}, None)
+        assert reply["type"] == "stand-down-rejected"
+
+
+# ── GatewayManager: the adoption decision ──────────────────────────
+
+
+def _only_targets(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
+    """Make ``mapping`` the process's ENTIRE target set, leaving the rest of env alone.
+
+    Never ``setattr(os, "environ", {...})``. ``gatewayd.os`` is the shared stdlib
+    module, so replacing its ``environ`` replaces the process-wide mapping: it
+    drops every variable the suite set for isolation, and ``KIROCREW_HOME`` going
+    missing sends ``manager._gatewayd_log_path()`` to ``config_dir()`` — the real
+    operator home. A daemon started under that test then writes its log there.
+    Targeted ``delenv``/``setenv`` gets the same control with none of that.
+    """
+    for key in [k for k in os.environ if any(k.startswith(p) for p in TARGET_ENV_PREFIXES)]:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in mapping.items():
+        monkeypatch.setenv(key, value)
+
+
+def _manager(tmp_path: Path, targets: dict[str, str]) -> mgr.GatewayManager:
+    return mgr.GatewayManager(
+        mgr.GatewaySpec(socket_path=tmp_path / "gw.sock", mcp_target_env=dict(targets))
+    )
+
+
+class TestAdoptOrStandDown:
+    @pytest.mark.asyncio
+    async def test_fit_incumbent_is_adopted_without_a_stand_down(self, tmp_path: Path) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        pong = {"type": "pong", "targets": manager._wanted_target_fingerprint()}
+        asked = AsyncMock(return_value=mgr._RELEASED)
+        manager._request_stand_down = asked  # type: ignore[method-assign]
+
+        assert await manager._adopt_or_stand_down(pong) == mgr._ADOPT
+        asked.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unfit_incumbent_that_yields_makes_room_for_a_spawn(self, tmp_path: Path) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        asked = AsyncMock(return_value=mgr._RELEASED)
+        manager._request_stand_down = asked  # type: ignore[method-assign]
+
+        assert (
+            await manager._adopt_or_stand_down({"type": "pong", "targets": "stale"}) == mgr._SPAWN
+        )
+        # It is asked for the set the specs need, not merely poked.
+        asked.assert_awaited_once_with(manager._wanted_target_fingerprint())
+
+    @pytest.mark.asyncio
+    async def test_unfit_incumbent_that_refuses_is_adopted_and_named(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Fail open, but stop being silent — the whole operator-facing point."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        manager._request_stand_down = AsyncMock(return_value=mgr._REFUSED)  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert (
+                await manager._adopt_or_stand_down({"type": "pong", "targets": "stale"})
+                == mgr._ADOPT
+            )
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "an unreconciled mismatch must not be silent"
+        assert "REJECTED" in errors[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_pre_fingerprint_daemon_is_asked_to_yield_then_adopted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A daemon that cannot say what it serves is UNFIT, not fit.
+
+        Adopting on 'unknown' is what would reproduce #4569 on this fix's first
+        deployment: the survivor of a gateway killed after a package upgrade is
+        precisely a daemon too old to report a target set. It is asked to yield;
+        a genuinely old daemon refuses by closing the connection, and the
+        fail-open branch then adopts it with the breakage named.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        asked = AsyncMock(return_value=mgr._REFUSED)  # an old daemon never answers
+        manager._request_stand_down = asked  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._adopt_or_stand_down({"type": "pong"}) == mgr._ADOPT
+        asked.assert_awaited_once_with(manager._wanted_target_fingerprint())
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "an unassessable incumbent must not be adopted silently"
+        assert "<unreported>" in errors[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_pre_fingerprint_daemon_that_yields_makes_room(self, tmp_path: Path) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        manager._request_stand_down = AsyncMock(return_value=mgr._RELEASED)  # type: ignore[method-assign]
+        assert await manager._adopt_or_stand_down({"type": "pong"}) == mgr._SPAWN
+
+    @pytest.mark.asyncio
+    async def test_a_draining_incumbent_is_never_adopted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Accepted-but-slow is NOT the same as refused, and must not be adopted.
+
+        Once a daemon accepts the stand-down it closes its accept loop, so it
+        answers ping while accepting no new connection. Adopting it would turn a
+        partial outage (the changed servers) into a total one (every server) and
+        report success while doing it -- strictly worse than the bug this change
+        fixes. Spawning is not available either, since it still holds the lock.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        manager._request_stand_down = AsyncMock(  # type: ignore[method-assign]
+            return_value=mgr._DRAINING
+        )
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            verdict = await manager._adopt_or_stand_down({"type": "pong", "targets": "stale"})
+        assert verdict == mgr._ABORT
+        assert any(
+            "NOT adopted" in r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        ), "the operator must be told the broker was left unclaimed and why"
+
+    @pytest.mark.asyncio
+    async def test_start_fails_rather_than_claiming_ready_on_a_draining_incumbent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No laundering: a start that cannot place a fit daemon must not succeed."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_probe",
+            AsyncMock(return_value={"type": "pong", "targets": "stale"}),
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._DRAINING))
+        spawned = AsyncMock(side_effect=RuntimeError("must not spawn into a held lock"))
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawned)
+
+        assert await manager._start_locked() is False
+        spawned.assert_not_awaited()
+        assert manager._adopted is False, "a draining daemon must not be adopted"
+        assert manager._watchdog is None, "and no watchdog should supervise it"
+
+    @pytest.mark.asyncio
+    async def test_start_spawns_after_an_unfit_incumbent_yields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The startup path, wired end to end with the transport stubbed out."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        monkeypatch.setattr(
+            manager, "_ping_probe", AsyncMock(return_value={"type": "pong", "targets": "stale"})
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._RELEASED))
+        monkeypatch.setattr(manager, "_clear_stale_socket", AsyncMock(return_value=None))
+        monkeypatch.setattr(mgr.transport, "prepare_dir", lambda _p: None)
+        spawned = AsyncMock(side_effect=RuntimeError("spawn reached"))
+        monkeypatch.setattr(manager, "_spawn_once", spawned)
+
+        assert await manager._start_locked() is False
+        spawned.assert_awaited_once()
+        assert manager._adopted is False, "a yielded socket must not leave us adopting"
+
+    @pytest.mark.asyncio
+    async def test_start_adopts_a_fit_incumbent_without_spawning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_probe",
+            AsyncMock(
+                return_value={
+                    "type": "pong",
+                    "targets": manager._wanted_target_fingerprint(),
+                }
+            ),
+        )
+        spawned = AsyncMock(side_effect=RuntimeError("must not spawn"))
+        monkeypatch.setattr(manager, "_spawn_once", spawned)
+        try:
+            assert await manager._start_locked() is True
+            assert manager._adopted is True
+            spawned.assert_not_awaited()
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+
+class TestRequestStandDown:
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_the_daemon_refuses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refusal is reported as such — never waited out as if accepted."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager,
+            "_control_roundtrip",
+            AsyncMock(return_value={"type": "stand-down-rejected", "reason": "nope"}),
+        )
+        looked = {"n": 0}
+
+        def _free(_p: Path) -> bool:
+            looked["n"] += 1
+            return True
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        assert await manager._request_stand_down("want") == mgr._REFUSED
+        assert looked["n"] == 0, "a refusal must short-circuit before the wait"
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_no_answer_comes_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_control_roundtrip", AsyncMock(return_value=None))
+        assert await manager._request_stand_down("want") == mgr._REFUSED
+
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_the_lock_is_never_released(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Accepted is not released: a drain that outruns the budget fails open."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", lambda _p: False)
+        monkeypatch.setattr(mgr, "_SHUTDOWN_GRACE_SECS", 0.2)
+        assert await manager._request_stand_down("want") == mgr._DRAINING
+
+    @pytest.mark.asyncio
+    async def test_succeeds_once_the_lock_is_released(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+        seen = {"n": 0}
+
+        def _free(_p: Path) -> bool:
+            seen["n"] += 1
+            return seen["n"] >= 3  # released on the third look
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        assert await manager._request_stand_down("want") == mgr._RELEASED
+
+    @pytest.mark.asyncio
+    async def test_does_not_spawn_while_a_draining_daemon_still_holds_the_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Windows shape: the endpoint is gone long before the lock is free.
+
+        gatewayd closes its server FIRST and releases the singleton lock LAST, so
+        on Windows the named pipe stops resolving at the very start of shutdown
+        and the whole drain sits inside the gap. Waiting on the endpoint would
+        return here immediately, the replacement would lose the still-held lock,
+        exit rc=0 without binding, and nothing would rebind. This asserts the
+        wait ignores the endpoint entirely and tracks the lock.
+        """
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+        # Endpoint already unreachable -- the misleading signal.
+        monkeypatch.setattr(mgr.transport, "endpoint_exists", lambda _p: False)
+        drain = {"ticks": 0}
+
+        def _free(_p: Path) -> bool:
+            drain["ticks"] += 1
+            return drain["ticks"] > 4  # lock held across four polls of drain
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        assert await manager._request_stand_down("want") == mgr._RELEASED
+        assert drain["ticks"] == 5, "the wait must track the lock, not the endpoint"
+
+    @pytest.mark.asyncio
+    async def test_gives_up_the_wait_when_shutdown_is_requested(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shutdown must not be made to wait out another process's drain."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+
+        def _free(_p: Path) -> bool:
+            manager._stopping = True  # shutdown() lands mid-wait
+            return False
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        monkeypatch.setattr(mgr, "_SHUTDOWN_GRACE_SECS", 30.0)
+        assert await manager._request_stand_down("want") == mgr._DRAINING
+
+
+class TestElection:
+    """What happens when our own spawn loses the socket to somebody else.
+
+    gatewayd's flock guard makes a duplicate spawn exit rc=0 WITHOUT binding, so
+    a pong arriving after our spawn is not proof the daemon is ours. Before the
+    election loop, start() ping-confirmed whatever answered and returned success
+    — reproducing #4569 one level up, on the freed socket.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_fit_daemon_is_adopted_not_fought(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        fit = {"type": "pong", "targets": manager._wanted_target_fingerprint()}
+        monkeypatch.setattr(manager, "_ping_probe", AsyncMock(return_value=None))
+        # Our spawn lost the lock: no live process, but a fit daemon answers.
+        monkeypatch.setattr(manager, "_spawn_and_confirm", AsyncMock(return_value=fit))
+        try:
+            assert await manager._start_locked() is True
+            assert manager._adopted is True, "a fit foreign daemon must be adopted"
+            assert not manager.is_running
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_unfit_daemon_triggers_one_more_round(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Round two assesses it as an incumbent; here it yields and we win."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        wanted = manager._wanted_target_fingerprint()
+        # Round 1 finds an empty socket; round 2 finds the foreign daemon that
+        # beat our first spawn to it, and asks it to stand down.
+        monkeypatch.setattr(
+            manager,
+            "_ping_probe",
+            AsyncMock(side_effect=[None, {"type": "pong", "targets": "foreign"}]),
+        )
+        stood_down = AsyncMock(return_value=mgr._RELEASED)
+        monkeypatch.setattr(manager, "_request_stand_down", stood_down)
+        proc = MagicMock()
+        proc.returncode = None
+        proc.pid = 4242
+        rounds: list[dict[str, Any]] = []
+
+        async def _spawn() -> dict[str, Any]:
+            rounds.append({})
+            if len(rounds) == 1:
+                # Our spawn lost the flock: no process handle, foreign answer.
+                return {"type": "pong", "targets": "foreign"}
+            manager._process = proc  # this time we bound it
+            return {"type": "pong", "targets": wanted}
+
+        monkeypatch.setattr(manager, "_spawn_and_confirm", _spawn)
+        try:
+            assert await manager._start_locked() is True
+            assert len(rounds) == 2, "the unfit foreign daemon must force a second round"
+            stood_down.assert_awaited_once_with(wanted)
+            assert manager.is_running, "round two must end as the owner"
+            assert manager._adopted is False
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rounds_are_bounded_and_exhaustion_is_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two instances trading the socket must not loop forever or lie."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        monkeypatch.setattr(
+            manager, "_ping_probe", AsyncMock(return_value={"type": "pong", "targets": "foreign"})
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._RELEASED))
+        spawn = AsyncMock(return_value={"type": "pong", "targets": "still-foreign"})
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawn)
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._start_locked() is False
+        assert spawn.await_count == mgr._ELECTION_ROUNDS
+        assert manager._adopted is False
+        assert any(
+            "election rounds" in r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+        ), "exhausting the election must be reported, not returned as a bare False"
+
+    """The probe itself, against a real lock file."""
+
+    def test_free_when_nobody_holds_it(self, short_sock_dir: Path) -> None:
+        assert transport.singleton_lock_free(short_sock_dir / "gw.sock") is True
+
+    def test_held_while_another_holder_has_it(self, short_sock_dir: Path) -> None:
+        sock = short_sock_dir / "gw.sock"
+        fd = transport.acquire_singleton_lock(sock)
+        assert fd is not None
+        try:
+            assert transport.singleton_lock_free(sock) is False
+        finally:
+            os.close(fd)
+        assert transport.singleton_lock_free(sock) is True
+
+    def test_the_probe_leaves_the_lock_available(self, short_sock_dir: Path) -> None:
+        """Acquire-and-release, not acquire-and-hold — a leak would wedge every spawn."""
+        sock = short_sock_dir / "gw.sock"
+        assert transport.singleton_lock_free(sock) is True
+        fd = transport.acquire_singleton_lock(sock)
+        assert fd is not None, "the probe must not still be holding the lock"
+        os.close(fd)
+
+
+class TestShutdownAnnouncesItselfEarly:
+    @pytest.mark.asyncio
+    async def test_stopping_is_set_before_the_lifecycle_lock_is_taken(self, tmp_path: Path) -> None:
+        """Otherwise a start mid-stand-down-wait can never observe the shutdown."""
+        manager = _manager(tmp_path, {})
+        await manager._lifecycle_lock.acquire()
+        try:
+            task = asyncio.create_task(manager.shutdown())
+            await asyncio.sleep(0.05)
+            assert manager._stopping is True, "shutdown must announce before blocking"
+            assert not task.done(), "and it is genuinely still waiting for the lock"
+        finally:
+            manager._lifecycle_lock.release()
+            await asyncio.wait_for(task, timeout=10)
+
+
+class TestOscillationCap:
+    """Bounding the case _ELECTION_ROUNDS cannot reach: two long-lived instances.
+
+    The watchdog also assesses incumbents, on an unbounded respawn loop, so
+    without a process-lifetime cap two gateways sharing a socket path with
+    divergent target sets would stand each other's daemon down forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stops_asking_after_the_cap_and_settles_loudly(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        asked = AsyncMock(return_value=mgr._REFUSED)
+        manager._request_stand_down = asked  # type: ignore[method-assign]
+        unfit = {"type": "pong", "targets": "foreign"}
+
+        for _ in range(mgr._MAX_STAND_DOWN_REQUESTS):
+            assert await manager._adopt_or_stand_down(unfit) == mgr._ADOPT
+            manager._stand_downs_issued += 1  # the real counter lives in the mocked method
+        assert asked.await_count == mgr._MAX_STAND_DOWN_REQUESTS
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._adopt_or_stand_down(unfit) == mgr._ADOPT
+        assert asked.await_count == mgr._MAX_STAND_DOWN_REQUESTS, "past the cap it must stop asking"
+        assert any(
+            "already issued" in r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        ), "settling instead of contending must be explained"
+
+    @pytest.mark.asyncio
+    async def test_the_counter_advances_on_every_real_request(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_control_roundtrip", AsyncMock(return_value=None))
+        assert manager._stand_downs_issued == 0
+        await manager._request_stand_down("want")
+        await manager._request_stand_down("want")
+        assert manager._stand_downs_issued == 2
+
+    def test_the_counter_is_total_without_init(self) -> None:
+        """Built via __new__, as several call sites and tests do."""
+        bare = mgr.GatewayManager.__new__(mgr.GatewayManager)
+        assert bare._stand_downs_issued == 0
+
+
+# ── the watchdog's own election ─────────────────────────────────────
+
+
+class TestWatchdogElection:
+    """The watchdog runs the same gate, and it is reachable independently.
+
+    All startup coverage enters through ``start()``, so without this the gate in
+    ``_run_watchdog`` could be deleted with every other test still green.
+    """
+
+    @pytest.mark.asyncio
+    async def test_watchdog_adopts_a_fit_incumbent_after_our_daemon_dies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        fit = {"type": "pong", "targets": manager._wanted_target_fingerprint()}
+        monkeypatch.setattr(manager, "_ping_probe", AsyncMock(return_value=fit))
+        spawn = AsyncMock(side_effect=RuntimeError("must not spawn against a fit incumbent"))
+        monkeypatch.setattr(manager, "_spawn_once", spawn)
+        monkeypatch.setattr(manager, "_clear_stale_socket", AsyncMock(return_value=None))
+        monkeypatch.setattr(mgr, "_RESPAWN_BACKOFF_START_SECS", 0.01)
+        monkeypatch.setattr(mgr, "_LIVENESS_PING_INTERVAL_SECS", 0.01)
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.pid = 99
+        proc.wait = AsyncMock(return_value=1)
+        manager._process = proc
+
+        task = asyncio.create_task(manager._run_watchdog())
+        try:
+            for _ in range(200):
+                if manager._adopted:
+                    break
+                await asyncio.sleep(0.01)
+            assert manager._adopted is True, "the watchdog must adopt a fit incumbent"
+            spawn.assert_not_awaited()
+        finally:
+            manager._stopping = True
+            task.cancel()
+            # CancelledError is a BaseException, so suppress(Exception) alone
+            # lets the cancellation escape and fail the test in teardown.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_watchdog_stands_an_unfit_incumbent_down_before_respawning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_A": "a"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_probe",
+            AsyncMock(return_value={"type": "pong", "targets": "foreign"}),
+        )
+        stood_down = AsyncMock(return_value=mgr._RELEASED)
+        monkeypatch.setattr(manager, "_request_stand_down", stood_down)
+        monkeypatch.setattr(manager, "_clear_stale_socket", AsyncMock(return_value=None))
+        spawned = asyncio.Event()
+
+        async def _spawn() -> None:
+            spawned.set()
+
+        monkeypatch.setattr(manager, "_spawn_once", _spawn)
+        monkeypatch.setattr(mgr, "_RESPAWN_BACKOFF_START_SECS", 0.01)
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.pid = 99
+        proc.wait = AsyncMock(return_value=1)
+        manager._process = proc
+
+        task = asyncio.create_task(manager._run_watchdog())
+        try:
+            await asyncio.wait_for(spawned.wait(), timeout=20)
+            stood_down.assert_awaited()
+            assert manager._adopted is False
+        finally:
+            manager._stopping = True
+            task.cancel()
+            # CancelledError is a BaseException, so suppress(Exception) alone
+            # lets the cancellation escape and fail the test in teardown.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+
+# ── end to end over a real socket ──────────────────────────────────
+#
+# Every test below starts a REAL daemon, so each one pins KIROCREW_HOME to its
+# own tmp dir first. The suite does not isolate it, and manager._gatewayd_log_path
+# falls back to config_dir() when it is unset -- i.e. the operator's real data
+# home, which a test must never write to.
+
+
+async def _round_trip(socket_path: Path, frame: dict[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.wait_for(transport.connect(socket_path), timeout=10)
+    try:
+        writer.write(json.dumps(frame).encode("utf-8") + b"\n")
+        await writer.drain()
+        line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=10)
+        result = json.loads(line.decode("utf-8"))
+        assert isinstance(result, dict)
+        return result
+    finally:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+
+async def _await_endpoint(socket_path: Path, *, timeout: float = 30.0) -> None:
+    """Wait for a daemon to finish binding, or fail the test."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if await asyncio.to_thread(transport.endpoint_exists, socket_path):
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"daemon never bound {socket_path}")
+
+
+def _isolate_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> Path:
+    """Scope a real daemon's side effects: its data home AND its CWD.
+
+    KIROCREW_HOME because the suite does not set it and
+    ``manager._gatewayd_log_path`` falls back to ``config_dir()`` -- the
+    operator's real data home -- so a spawned daemon writes its log there.
+
+    The working directory because a spawned daemon INHERITS the test process's
+    CWD, which under pytest is the repository checkout: anything it or its own
+    children resolve relatively would land in the repo. ``_spawn_once``
+    deliberately passes no ``cwd`` (in production the daemon should inherit the
+    gateway's), so the test must move itself rather than change that.
+
+    Returns the directory, for passing as an explicit ``cwd=`` to any subprocess
+    the test launches itself.
+    """
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    monkeypatch.chdir(home)
+    return home
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_a_real_daemon_leaves_nothing_in_the_repository(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No test side effects, asserted rather than assumed.
+
+    Two escape routes exist and both are closed by ``_isolate_home``: the data
+    home (``KIROCREW_HOME`` unset falls back to the operator's real
+    ``~/.kiro/crew``) and the working directory (a spawned daemon inherits
+    pytest's CWD, which is the checkout). This walks the repo before and after
+    and asserts the tree is byte-identical.
+    """
+    repo = Path(__file__).resolve().parent.parent
+
+    def _snapshot() -> set[str]:
+        out: set[str] = set()
+        for entry in repo.iterdir():
+            if entry.name in {".git", ".venv", "node_modules", "__pycache__"}:
+                continue
+            out.add(entry.name)
+        return out
+
+    before = _snapshot()
+    run_dir = _isolate_home(monkeypatch, tmp_path / "home")
+    assert Path.cwd() == run_dir.resolve(), "the test must not run in the checkout"
+    _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_A": "a --stdio"})
+
+    sock = short_sock_dir / "gw.sock"
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=1, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        assert (await _round_trip(sock, {"type": "ping"}))["type"] == "pong"
+    finally:
+        stop.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(daemon, timeout=30)
+
+    assert _snapshot() == before, "a daemon under test must not write into the repo"
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_pong_reports_the_served_target_set_over_a_real_socket(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wiring, not just the helper: a served daemon answers with its set."""
+    _isolate_home(monkeypatch, tmp_path / "home")
+    env = {"KIROCREW_MCP_TARGET_A": "a --stdio"}
+    _only_targets(monkeypatch, env)
+    sock = short_sock_dir / "gw.sock"
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=1, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        pong = await _round_trip(sock, {"type": "ping"})
+        assert pong["type"] == "pong"
+        assert pong["targets"] == hash_target_env(env)
+    finally:
+        stop.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(daemon, timeout=30)
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_stand_down_frame_is_wired_into_the_serving_daemon(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stand-down over the real socket ends the real daemon and frees it.
+
+    This is the test that would fail if ``run_gatewayd`` stopped forwarding its
+    ``stop_event`` into the handler: the frame would be answered
+    ``stand-down-rejected`` and the socket would stay bound. It also asserts the
+    SINGLETON LOCK is released, which is what a replacement actually needs.
+    """
+    _isolate_home(monkeypatch, tmp_path / "home")
+    _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_A": "a --stdio"})
+    sock = short_sock_dir / "gw.sock"
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=1, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        reply = await _round_trip(
+            sock, {"type": "stand-down", "want": hash_target_env({"KIROCREW_MCP_TARGET_B": "b"})}
+        )
+        assert reply["type"] == "standing-down"
+        await asyncio.wait_for(daemon, timeout=60)
+        assert not await asyncio.to_thread(
+            transport.endpoint_exists, sock
+        ), "a stood-down daemon must release its endpoint"
+        assert await asyncio.to_thread(
+            transport.singleton_lock_free, sock
+        ), "and its singleton lock, which is what a replacement must win"
+    finally:
+        stop.set()
+        if not daemon.done():
+            daemon.cancel()
+            with contextlib.suppress(Exception):
+                await daemon
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_crash_survivor_is_reconciled_end_to_end(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported scenario, start to finish, with TWO real daemon processes.
+
+    The survivor is a real subprocess launched with target set A, standing in for
+    the daemon a gateway killed without its shutdown path leaves behind. That
+    matters: its environment is genuinely frozen at spawn, so the manager cannot
+    influence what it reports -- which is the invariant the whole fix rests on
+    and which an in-process survivor sharing ``os.environ`` cannot model.
+
+    The gateway then starts wanting set B, the set its specs were just rewritten
+    for. Before this change it adopted the survivor and every session lost server
+    B; now the survivor yields and the manager's own spawn path puts a daemon
+    serving B on the socket.
+    """
+    home = tmp_path / "home"
+    run_dir = _isolate_home(monkeypatch, home)
+    sock = short_sock_dir / "gw.sock"
+    survivor_targets = {"KIROCREW_MCP_TARGET_A": "a --stdio"}
+
+    # The survivor: its own process, its own frozen environment A.
+    survivor_env = {
+        **{
+            k: v
+            for k, v in os.environ.items()
+            if not any(k.startswith(pfx) for pfx in TARGET_ENV_PREFIXES)
+        },
+        **survivor_targets,
+        "KIROCREW_HOME": str(home),
+    }
+    survivor = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "kiro_crew.mcp_gateway.gatewayd",
+        "--socket",
+        str(sock),
+        "--idle-timeout-secs",
+        "60",
+        "--max-backends",
+        "2",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        env=survivor_env,
+        cwd=str(run_dir),
+        start_new_session=True,
+    )
+    manager: mgr.GatewayManager | None = None
+    try:
+        await _await_endpoint(sock, timeout=60)
+        survivor_fp = (await _round_trip(sock, {"type": "ping"}))["targets"]
+        assert survivor_fp == hash_target_env(survivor_targets)
+
+        # The starting gateway wants set B.
+        wanted_targets = {"KIROCREW_MCP_TARGET_B": "b --stdio"}
+        _only_targets(monkeypatch, {})
+        manager = mgr.GatewayManager(
+            mgr.GatewaySpec(
+                socket_path=sock,
+                max_backends=2,
+                idle_timeout_secs=60,
+                mcp_target_env=dict(wanted_targets),
+            )
+        )
+        wanted = manager._wanted_target_fingerprint()
+        assert wanted != survivor_fp
+
+        assert await manager.start() is True, "the gateway must come up"
+        # The survivor really left, on its own graceful path.
+        await asyncio.wait_for(survivor.wait(), timeout=60)
+        assert manager._adopted is False, "the survivor must not have been adopted"
+        assert manager.is_running, "the manager must own the replacement it spawned"
+        # Two distinct real OS processes, not one in-process task wearing two
+        # hats -- this is what makes the frozen-at-spawn environment real.
+        assert manager._process is not None
+        assert manager._process.pid != survivor.pid
+
+        # And the daemon now on the socket serves what the specs need.
+        pong = await _round_trip(sock, {"type": "ping"})
+        assert pong["type"] == "pong"
+        assert pong["targets"] == wanted
+    finally:
+        if manager is not None:
+            await manager.shutdown()
+        if survivor.returncode is None:
+            survivor.kill()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(survivor.wait(), timeout=10)
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_a_fit_survivor_is_still_adopted_end_to_end(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The behaviour adoption exists for must survive the new check.
+
+    A survivor already serving the wanted set is adopted with no spawn and no
+    teardown -- otherwise this change would trade a partial outage for a full
+    broker cycle on every ordinary restart.
+    """
+    _isolate_home(monkeypatch, tmp_path / "home")
+    sock = short_sock_dir / "gw.sock"
+    targets = {"KIROCREW_MCP_TARGET_A": "a --stdio"}
+    _only_targets(monkeypatch, targets)
+    manager = mgr.GatewayManager(
+        mgr.GatewaySpec(
+            socket_path=sock, max_backends=2, idle_timeout_secs=60, mcp_target_env=dict(targets)
+        )
+    )
+    stop = asyncio.Event()
+    survivor = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=2, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        assert await manager.start() is True
+        assert manager._adopted is True, "a fit survivor must still be adopted"
+        assert not manager.is_running, "adoption must not spawn a competitor"
+        assert not survivor.done(), "a fit survivor must not be torn down"
+    finally:
+        await manager.shutdown()
+        stop.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(survivor, timeout=30)
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_stand_down_is_recorded_in_the_security_event_log(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The audit claim is asserted, not just documented.
+
+    A stand-down ends the daemon, so it is the most consequential frame the
+    control surface accepts; the allow and the refusal both belong in the SEL
+    beside the claim/abort/peer decisions.
+    """
+    _isolate_home(monkeypatch, tmp_path / "home")
+    env = {"KIROCREW_MCP_TARGET_A": "a --stdio"}
+    _only_targets(monkeypatch, env)
+    recorded: list[dict[str, Any]] = []
+
+    class _Spy:
+        def log_api_access(self, **kwargs: Any) -> None:
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(gw, "SecurityEventLog", _Spy)
+
+    # Refused: it already serves the requested set.
+    gw._apply_stand_down({"type": "stand-down", "want": hash_target_env(env)}, asyncio.Event())
+    # Allowed: a genuine mismatch.
+    gw._apply_stand_down({"type": "stand-down", "want": "deadbeef"}, asyncio.Event())
+
+    ops = [r for r in recorded if r.get("operation") == "mcp-gateway.stand_down"]
+    assert len(ops) == 2, f"both outcomes must be audited, got {recorded}"
+    assert ops[0]["outcome"] == "denied"
+    assert ops[1]["outcome"] == "allowed"

--- a/test/test_mcp_gateway_transport.py
+++ b/test/test_mcp_gateway_transport.py
@@ -936,8 +936,10 @@ async def test_manager_offloads_prepare_dir_from_the_event_loop(
 
     # Drive _start_locked as far as prepare_dir, then stop: no incumbent to
     # adopt, nothing stale to clear, and a spawn that fails is swallowed into a
-    # False return.
-    monkeypatch.setattr(manager, "_ping_once", AsyncMock(return_value=False))
+    # False return. _ping_probe (not _ping_once) is the adoption gate — it
+    # returns the pong payload so the fitness check can read the incumbent's
+    # target set; None means nobody is on the socket.
+    monkeypatch.setattr(manager, "_ping_probe", AsyncMock(return_value=None))
     monkeypatch.setattr(manager, "_clear_stale_socket", AsyncMock(return_value=None))
     monkeypatch.setattr(
         manager, "_spawn_once", AsyncMock(side_effect=RuntimeError("stop here"))


### PR DESCRIPTION
## What is the problem?

If the gateway dies without running its shutdown path (SIGKILL, OOM, host reset), the MCP gateway daemon survives as an orphan. On the next start the manager adopts that survivor, while the agent specs are rewritten from current config. Any server whose stub state changed since the survivor started is then routed to a target the survivor never learned, and every new session gets a terminal rejection for it.

Adoption asserted **liveness** but not **fitness**. `manager.start()` adopted any daemon answering `pong`, explicitly including "a survivor from a prior gateway", with no version or target-set handshake -- `gatewayd.py` said so itself. And it could not simply replace the incumbent: `manager.stop()` returns early for an adopted daemon because `_clear_stale_socket()` is a connect-probe-then-unlink, so tearing one down would steal a live incumbent's socket in the documented false-stale window, re-introducing the socket-theft class the flock guard exists to prevent. The adopting side could not replace the incumbent, and the incumbent could not learn the new targets: a daemon resolves each stubbed server's launch command from `KIROCREW_MCP_TARGET_<SERVER>` in its own process environment, and a live process's environment cannot change, so its target set is fixed for its lifetime.

## Why this issue matters to the user

Servers already in the survivor's target set keep working, so the failure is partial and presents as "one MCP server is broken for no reason". Restarting the gateway does not clear it -- the restart re-adopts the same orphan. Only stopping the orphan does.

The reachable window used to be milliseconds wide: a stub toggle applied to the broker immediately, so config and daemon agreed almost instantly, and only a crash inside that window could strand a mismatch. #4470 (merged) records a stub change for the next start rather than applying it in-band, so config-vs-daemon divergence is now a normal, long-lived state by design -- and an ordinary crash lands in it. The divergence is intended; adopting a daemon that cannot serve the specs being written alongside it is not. The mismatch is also reachable without any of that, by editing `stub_servers` in `config.json` directly and then crash-restarting.

## How our fix solves it

**Symptom:** one stubbed MCP server is terminally rejected for every new session, and restarting the gateway does not help.

**Direct cause:** `start()` adopted an incumbent on liveness alone, then handed control back as if the broker were correct.

**Root cause:** adoption had no way to ask "can this daemon serve the specs we just wrote". The daemon's routing table is fixed at spawn and was never advertised, so there was nothing to compare against.

**Fix.** `gatewayd` now reports a fingerprint of the target set it can serve -- a sorted `K=V` SHA-256 over its `KIROCREW_MCP_TARGET_*` entries -- in every `pong`, and accepts a `stand-down` control frame that sets its own `stop_event`, which is exactly the graceful path SIGTERM takes. The manager computes the same fingerprint over the environment it is about to spawn with and adopts only on a match.

Both sides call one function in the dependency-free `hashing` leaf, so writer and reader cannot drift -- the module's existing job. The prefix tuple moved there from `resolve_once` for the same reason, which removes a duplicate rather than adding one.

Standing the incumbent down is **voluntary**, and that is the answer to the arbitration question the issue says is the real design problem. The starting gateway must not take the endpoint itself, because that is the connect-probe-then-unlink whose false-stale window is the socket-theft hazard. Here the incumbent performs its own drain and removes its own endpoint, and the request only ever arrives over a connection that proves the incumbent is alive -- so there is no stale-vs-live judgement to get wrong. The frame carries the fingerprint the caller needs, and a daemon that already serves it refuses, so this is not a bare kill switch. Its trust basis is the uid-gated owner-only socket that already authenticates Register/Claim/Abort, and it is SEL-audited like them.

Three further properties are load-bearing, each found by review and each pinned by a test:

- **The wait is on the singleton lock becoming free, not on the endpoint disappearing.** `gatewayd` closes its server first and releases the lock last, so the endpoint stops being reachable while the lock is still held -- on Windows for the daemon's entire drain, since the kernel drops a pipe name as soon as the last handle closes. A replacement spawned in that gap loses the lock, exits rc=0 without binding, and `_wait_for_socket` then fails the start with no watchdog left to retry. The lock is precisely what the replacement must win, so it is the only correct readiness signal.
- **`start()` runs a bounded election.** A `pong` arriving after our own spawn is not proof the daemon is ours: the flock guard makes a duplicate spawn exit rc=0 without binding, so on a contended socket a second gateway instance can win the freed lock first. The answering daemon's fingerprint is rechecked; a fit one is adopted whoever started it, an unfit one is reassessed as an incumbent in round two, and exhausting the rounds is an ERROR rather than a silent success. The cap is what stops two instances trading the socket. The watchdog needs no separate check -- a respawn that loses the flock exits, and control returns to the gate it already has.
- **A daemon that reports no fingerprint is unfit, not fit.** Adopting on unknown is what would reproduce this bug on the fix's first deployment: a survivor of a gateway that died after a package upgrade is exactly a daemon too old to report a target set. It is asked to yield, which such a daemon answers by closing the connection, after which the fail-open branch adopts it with the breakage named.

An incumbent that refuses, cannot be assessed, or outlasts the drain budget is still adopted -- refusing would leave the socket held by an unsupervised daemon and no working gateway, which is worse than partial breakage -- but now at ERROR level naming both fingerprints. That log line is the operator-facing point of the change: this failure used to be entirely silent. `shutdown()` also now sets its stopping flag before contending for the lifecycle lock, so a start waiting out another process's drain can observe it and give up instead of delaying shutdown by that budget.

## What tests we did

New `test/test_mcp_gateway_adoption_fitness.py` (38 tests) across three layers: the fingerprint and the manager-to-daemon agreement that makes comparing it meaningful; `gatewayd._apply_stand_down` including the same-set refusal, malformed frames and an unwired handler; and the manager's decision -- fit adopted with no stand-down, unfit yielding, unfit refusing adopted-and-named, the election rounds, and the lock-vs-endpoint wait. Four end-to-end tests bind real sockets and one drives the manager's own spawn path against a live survivor. The lock probe is tested against a real lock file, including that it releases rather than holds.

Nine mutants applied, all killed:

| Mutant | Killed by |
|---|---|
| adoption reverted to liveness-only | the crash-survivor e2e + the start-path unit test |
| `stop_event` unwired from the accept loop | the stand-down e2e (the frame would be accepted and inert) |
| `targets` dropped from `pong` | the real-socket pong test |
| same-set refusal removed | the "not a kill switch" test |
| the unreconciled-mismatch ERROR downgraded | the fail-open naming test |
| wait reverted to the endpoint signal | the Windows-shaped drain test plus two others |
| stopping flag un-hoisted | the early-announce test |
| post-spawn fitness always true | both election tests |
| unknown fingerprint treated as fit | both pre-fingerprint tests |

`hash_effective_env` was refactored onto a shared hashing loop, so its output was proven byte-identical over six cases including non-ASCII keys and values containing `=` and NUL -- a change there would move every `PoolKey`.

Scoped gates green: `isort`, `flake8`, `mypy` (src clean), `black` on every file the gate enforces (`manager.py`, `transport.py` and the two edited test files are in `.github/black-baseline.txt`, and the reformat `black` wants in them is entirely pre-existing lines, so they are deliberately left alone). 2,200 tests pass across the mcp-gateway, gatewayd, shareability, transport and resolve-once selection. The full backend suite is 66,213 passed / 84 failed, and the same 84 failures with the same 2 errors reproduce on an untouched checkout of the base on this host (AF_UNIX path length, xdist host budget), so they are host-owned.

Two existing tests were updated rather than worked around: the `pong` contract test now asserts the added field instead of frame equality, and a transport test that patched `_ping_once` now patches `_ping_probe`, which is the gate `_start_locked` actually calls -- left alone it would have kept passing while gating nothing.

## Any other suggestions on the work

- **No new spec file.** `mcp_gateway`'s daemon-lifecycle behaviour is documented in code comments throughout, and there is no existing spec for `gatewayd` or `manager`, so the reasoning went into docstrings beside the code rather than into a document that would be the only one of its kind. Happy to add one if maintainers would rather it lived under `docs/system-specs/`.
- **The stand-down frame is a new control verb**, so it widens the daemon's control surface by one. It is gated exactly like `claim`/`abort` and a same-uid process could already cancel every in-flight call, so the boundary is unchanged -- but it is the first frame that ends the daemon, and worth a maintainer's eye on that basis alone.
- **Not addressed here:** a session permanently losing a stubbed server when the broker goes away at all (#4506) is a different defect with a different fix (a stub-side re-handshake). This change reduces how often a broker needs replacing but does not touch that path.
- The operator-facing surface is a log line. If the MCP Management page should show "the running broker cannot serve the current configuration", that is a UI change worth its own PR.

Closes #4569
