### PR TITLE
fix(agent): resolve the console script from the interpreter's own scripts dir

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -463,8 +463,12 @@ def _resolve_kirocrew_bin() -> str:
        whose bundled interpreter is a python-build-standalone tree exposing a
        launcher at its root, reached by this walk from the bundle's
        ``site-packages``.
-    3. ``shutil.which('kirocrew')`` — respects PATH order.
-    4. Bare ``"kirocrew"`` — last resort, may fail but surfaces the problem
+    3. The running interpreter's own install prefix (``sys.exec_prefix``). Same
+       intent as step 2 — the install this process belongs to — for layouts
+       where the console script is not an ancestor-sibling of the package and
+       the parent walk therefore cannot reach it.
+    4. ``shutil.which('kirocrew')`` — respects PATH order.
+    5. Bare ``"kirocrew"`` — last resort, may fail but surfaces the problem
        instead of caching a known-bad absolute path.
 
     Every candidate is validated with ``is_file()`` and ``os.access(X_OK)``
@@ -519,13 +523,43 @@ def _resolve_kirocrew_bin() -> str:
     except Exception:
         logger.debug("kirocrew bin walk failed", exc_info=True)
 
-    # 3. PATH lookup (also validated)
+    # 3. The running interpreter's own install prefix.
+    #
+    #    Step 2 asks "which install does this process belong to?" but answers it
+    #    by walking the package's PARENTS, so it only sees a console script that
+    #    sits above ``site-packages``. Layouts that put the two in sibling trees
+    #    are invisible to it — a prefix-style runtime can have the package at
+    #    ``<root>/lib/python3.12/site-packages/kiro_crew`` and the script at
+    #    ``<root>/python3.12/bin/kirocrew``, which is not an ancestor of the
+    #    package dir at all. The walk then finds nothing and resolution falls
+    #    through to PATH, where an unrelated ``kirocrew`` from some earlier
+    #    install wins and gets written into ``kirocrew.json`` as the command for
+    #    the built-in MCP servers.
+    #
+    #    ``sys.exec_prefix`` IS the install root for the interpreter actually
+    #    running — the venv root inside a venv, the runtime root otherwise — so
+    #    handing it to :func:`_kirocrew_bin_subpath` yields the same directory
+    #    ``sysconfig.get_path("scripts")`` would, and keeps the per-OS naming
+    #    and the Windows ``.cmd``-over-``.exe`` ranking in one place. Derived
+    #    from ``sys`` (already imported, and immune to import shadowing) rather
+    #    than by importing ``sysconfig`` here: this module is imported during
+    #    ``kiro_crew`` package init, which can run with a user project on
+    #    ``sys.path``, and a project-local ``sysconfig.py`` would then execute.
+    try:
+        candidate = _kirocrew_bin_subpath(Path(sys.exec_prefix))
+        if _usable(candidate):
+            _KIROCREW_BIN = str(candidate)
+            return _KIROCREW_BIN
+    except Exception:
+        logger.debug("kirocrew exec-prefix bin check failed", exc_info=True)
+
+    # 4. PATH lookup (also validated)
     found = shutil.which("kirocrew")
     if found and _usable(found):
         _KIROCREW_BIN = found
         return _KIROCREW_BIN
 
-    # 4. Last resort — don't cache, so a future call can retry
+    # 5. Last resort — don't cache, so a future call can retry
     logger.warning(
         "Could not resolve kirocrew binary to an existing file; "
         "falling back to bare 'kirocrew' (MCP probes may fail)"

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -664,6 +664,89 @@ class TestAllSkillPathsLocalSymlinks:
 class TestResolveKirocrewBin:
     """Tests for lazy kirocrew binary resolution."""
 
+    @pytest.fixture
+    def no_interpreter_scripts(self, tmp_path: Path):
+        """Neutralise the interpreter's-own-prefix resolution step.
+
+        That step answers from the REAL interpreter running this suite, whose
+        prefix legitimately holds a ``bin/kirocrew`` whenever the suite runs
+        inside an install — so it short-circuits resolution before any LATER
+        step can be observed. Tests asserting a later step must point it at an
+        empty prefix; tests asserting the step itself supply their own.
+        """
+        empty = tmp_path / "empty-prefix"
+        empty.mkdir(exist_ok=True)
+        with patch("sys.exec_prefix", str(empty)):
+            yield
+
+    def test_prefers_interpreter_scripts_dir_over_path(self, tmp_path: Path):
+        """A sibling-tree console script beats an unrelated one on PATH.
+
+        A prefix-style runtime can put the package under
+        ``<root>/lib/python3.12/site-packages/`` and the console script under
+        the interpreter prefix ``<root>/python3.12/`` — sibling trees, so the
+        parent walk cannot reach the script. Resolution used to fall through to
+        PATH and pick up whatever ``kirocrew`` an unrelated earlier install had
+        left there, then cache it as the command for the built-in MCP servers.
+
+        The launcher is created through ``_kirocrew_bin_subpath`` rather than at
+        a hardcoded ``bin/kirocrew``, so the layout is the one this OS actually
+        looks for (``Scripts\\kirocrew.exe`` on Windows).
+        """
+        import kiro_crew.agent as agent_mod
+        from kiro_crew.agent import _kirocrew_bin_subpath, _resolve_kirocrew_bin
+
+        root = tmp_path / "runtime"
+        pkg_dir = root / "lib" / "python3.12" / "site-packages" / "kiro_crew"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("")
+
+        # The console script lives under the interpreter PREFIX, a sibling tree
+        # of the package, not above site-packages.
+        prefix = root / "python3.12"
+        own_bin = _kirocrew_bin_subpath(prefix)
+        own_bin.parent.mkdir(parents=True, exist_ok=True)
+        own_bin.write_text("#!/bin/sh\nexec true\n")
+        own_bin.chmod(0o755)
+
+        # An unrelated install's launcher, earlier on PATH.
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        path_bin = other / "kirocrew"
+        path_bin.write_text("#!/bin/sh\nexec true\n")
+        path_bin.chmod(0o755)
+
+        mock_mc = unittest.mock.MagicMock()
+        mock_mc.__file__ = str(pkg_dir / "__init__.py")
+
+        # Keep the real validator but confine it to this tmp tree, so a
+        # ``kirocrew`` that happens to exist on the host cannot be selected.
+        _real_works = agent_mod._launcher_works
+
+        def _scoped_works(p: Path) -> bool:
+            return str(p).startswith(str(tmp_path)) and _real_works(p)
+
+        old_val = agent_mod._KIROCREW_BIN
+        try:
+            agent_mod._KIROCREW_BIN = None
+            with ExitStack() as stack:
+                stack.enter_context(patch.dict("sys.modules", {"kiro_crew": mock_mc}))
+                stack.enter_context(
+                    patch("kiro_crew.agent._launcher_works", side_effect=_scoped_works)
+                )
+                stack.enter_context(patch("sys.exec_prefix", str(prefix)))
+                stack.enter_context(
+                    patch(
+                        "shutil.which",
+                        side_effect=lambda c: str(path_bin) if c == "kirocrew" else None,
+                    )
+                )
+                result = _resolve_kirocrew_bin()
+            assert result == str(own_bin)
+            assert result != str(path_bin)
+        finally:
+            agent_mod._KIROCREW_BIN = old_val
+
     def test_finds_bin_in_parent_hierarchy(self, tmp_path: Path):
         """Walks up from package dir to find bin/kirocrew."""
         import kiro_crew.agent as agent_mod
@@ -696,7 +779,7 @@ class TestResolveKirocrewBin:
         finally:
             agent_mod._KIROCREW_BIN = old_val
 
-    def test_falls_back_to_shutil_which(self, tmp_path: Path):
+    def test_falls_back_to_shutil_which(self, tmp_path: Path, no_interpreter_scripts):
         """Falls back to PATH lookup when bin/ not found in hierarchy."""
         import kiro_crew.agent as agent_mod
         from kiro_crew.agent import _resolve_kirocrew_bin
@@ -738,7 +821,7 @@ class TestResolveKirocrewBin:
         finally:
             agent_mod._KIROCREW_BIN = old_val
 
-    def test_returns_kirocrew_when_not_found(self, tmp_path: Path):
+    def test_returns_kirocrew_when_not_found(self, tmp_path: Path, no_interpreter_scripts):
         """Returns 'kirocrew' string when not found anywhere."""
         import kiro_crew.agent as agent_mod
         from kiro_crew.agent import _resolve_kirocrew_bin
@@ -760,7 +843,7 @@ class TestResolveKirocrewBin:
         finally:
             agent_mod._KIROCREW_BIN = old_val
 
-    def test_skips_stale_shutil_which_result(self, tmp_path: Path):
+    def test_skips_stale_shutil_which_result(self, tmp_path: Path, no_interpreter_scripts):
         """Falls through to bare 'kirocrew' when shutil.which returns a
         path that no longer exists (e.g. deleted after Toolbox migration).
         Regression test for scenario where
@@ -796,7 +879,7 @@ class TestResolveKirocrewBin:
         finally:
             agent_mod._KIROCREW_BIN = old_val
 
-    def test_walk_and_path_miss_falls_back_to_bare(self, tmp_path: Path):
+    def test_walk_and_path_miss_falls_back_to_bare(self, tmp_path: Path, no_interpreter_scripts):
         """When the bin walk and PATH both miss, fall back to bare 'kirocrew'.
 
         The public install has no Brazil ``brazil-path run.runtimefarm`` step,
@@ -837,7 +920,7 @@ class TestResolveKirocrewBin:
         finally:
             agent_mod._KIROCREW_BIN = old_val
 
-    def test_brazil_path_failure_falls_through(self, tmp_path: Path):
+    def test_brazil_path_failure_falls_through(self, tmp_path: Path, no_interpreter_scripts):
         """brazil-path raising an exception falls through without crashing."""
         import kiro_crew.agent as agent_mod
         from kiro_crew.agent import _resolve_kirocrew_bin


### PR DESCRIPTION
no linked issue: found while diagnosing a live host whose built-in MCP servers had silently disappeared. Filing an issue first would only restate the description below, so the omission is deliberate.

## Problem

`_resolve_kirocrew_bin` asks *"which install does this process belong to?"* but answers it by walking the **parents** of `kiro_crew.__file__`, so it only finds a console script sitting above `site-packages`. Layouts that put the package and the script in **sibling trees** are invisible to that walk. A prefix-style runtime can have:

```
<root>/lib/python3.12/site-packages/kiro_crew/   <- the package
<root>/python3.12/bin/kirocrew                   <- the console script
```

`<root>/python3.12/bin` is not an ancestor of the package dir, so the walk finds nothing and resolution falls through to `shutil.which("kirocrew")`, returning whatever launcher an unrelated *earlier* install happened to leave on `PATH`.

## Why it is worse than a wrong return value

The result is **persisted**. `rebuild_agent_config` writes it into `kirocrew.json` as the `command` for the built-in `kirocrew-core` and `kirocrew-cron` MCP servers.

If that `PATH` launcher belongs to an install whose `site-packages` no longer contains `kiro_crew` (a superseded venv, a reinstalled interpreter), the recorded command cannot run at all:

```
$ <that>/bin/kirocrew mcp-core
ModuleNotFoundError: No module named 'kiro_crew'
```

Two consequences observed on a real host:

- The gateway's own MCP discovery probe of that server fails, and the entire report of it is one line: `MCP probe failed [kirocrew-core]: Connection lost`. Nothing names the command or says why it died, so the failure is very hard to attribute.
- `mcp_gateway`'s rewriter deliberately leaves a server **unwrapped** in several documented cases (for example when it declares env that a shared backend would withhold), and an unwrapped server is launched by the session from exactly this recorded command. There the dead launcher is what gets exec'd.

I want to be precise about scope rather than overclaim: on the host where this was found, the built-in tools were still reachable in a live session despite the dead command, so this is a broken recorded command plus a failing probe, not a proven total loss of the tool surface. The recorded value is still wrong, still points at an install that cannot serve, and still comes from a resolution order that never had a chance to find the right launcher.

## Change

Add the running interpreter's own install prefix as a resolution step, **between** the parent walk and the `PATH` lookup.

`sys.exec_prefix` *is* that install root -- the venv root inside a venv, the runtime root otherwise -- so handing it to `_kirocrew_bin_subpath` yields the same directory `sysconfig.get_path("scripts")` would, while keeping the per-OS naming and the Windows `.cmd`-over-`.exe` ranking in one place. Verified equal on both a venv install and a prefix-style runtime.

Deriving it from `sys` (already imported) rather than importing `sysconfig` is deliberate: this module is imported during `kiro_crew` package init, which can run with a user project on `sys.path`, so a project-local `sysconfig.py` would execute at import time.

Two properties make this the right place in the order:

1. **Strictly a narrowing.** It can only fire where the previous code would have gone to `PATH`. No layout that resolves correctly today changes its answer.
2. **It is the only candidate with a structural liveness guarantee.** Any code reaching this function has already imported `kiro_crew` in the current interpreter. The console script under *that interpreter's* prefix runs under the same interpreter and the same import path, so by construction it can import what this process just imported. `shutil.which` offers no such guarantee: it answers from `PATH`, which is exactly why a dead launcher could win.

## Tests

- New `test_prefers_interpreter_scripts_dir_over_path` builds the sibling-tree layout with a competing `PATH` launcher and asserts the interpreter's own script wins. It keeps the real `_launcher_works` validator, confined to the tmp tree so a `kirocrew` that happens to exist on the host cannot be selected.
- Five existing tests that assert **later** steps now request a new `no_interpreter_scripts` fixture. When the suite runs inside an install, the real scripts dir legitimately holds a real `kirocrew`, so without it the new step short-circuits them before the step under test is reached.

### Verification

- `test/test_agent.py`: **210 passed**.
- Reverting only the production hunk makes the new test fail, so it genuinely catches the bug.
- Full backend suite: **70774 passed, 51 failed, 2 errors**. Every one of those 53 reproduces identically with this change reverted (the `comm` of the two failure sets is empty), so none is introduced here. They are pre-existing or environmental: host CPU count for the xdist budget assertions, and a long checkout path for `AF_UNIX path too long`.
- Gates run locally: black, isort, flake8, brand-name, changelog-history, focus-cue, harness-parity all pass. `mypy src/kiro_crew/agent.py` reports 2 errors, both in `src/kiro_crew/transcribe.py`, which this PR does not touch.

## Known follow-up (deliberately not in this PR)

`_bin_is_usable` validates that a launcher's shebang **interpreter** exists and is executable, but never that `kiro_crew` is *importable* by it, which is why the dead launcher passed validation in the first place. This PR makes the dead candidate unreachable in the layout above, but a host where every earlier step misses could still select a broken script. Tightening that check needs a subprocess probe (or a cached equivalent) inside a function called during config refresh, so it is a separate change with its own performance question rather than scope added here.
