### PR TITLE
chore: drop RC suffix for 0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.4.0-rc.9"
+version = "0.4.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.4.0-rc.9"
+__version__ = "0.4.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0-rc.9",
+  "version": "0.4.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
Drops the RC suffix (`0.4.0-rc.9` -> bare `0.4.0`) in `__version__`, `pyproject.toml`, and `website/electron/package.json` per the stable promotion runbook (docs/build/release.md).

This is step 1 of 3 in promoting the 0.4.0 insider line to stable:
1. **This PR** — drop the RC suffix.
2. Tag one more insider RC (`v0.4.0-insider.14`) on the merge commit and let it soak.
3. Tag bare `v0.4.0` on that same commit to promote (byte-for-byte republish, no rebuild).

No behavior change; version-only bump.