### PR TITLE
fix: honour the role="menu" arrow-key contract on all five sibling menu surfaces

### DIFF
--- a/website/src/apps/meetings/components/AgentPillBar.tsx
+++ b/website/src/apps/meetings/components/AgentPillBar.tsx
@@ -4,12 +4,13 @@
 // Each pill turns one agent on or off for THIS meeting. An enabled, unmuted
 // agent shows a live dot while the meeting is running.
 
+import { useEffect, useRef } from 'react'
 import { Paperclip, Plus, Settings2, Sparkles, Star, X } from 'lucide-react'
 
 import { i18nT } from '../../../i18n/t'
-import Clickable from '../../../components/Clickable'
 import SimpleSelect from '../../../components/SimpleSelect'
 import { Btn } from '../../../components/ui'
+import { menuItemsOf, useMenuKeyboard } from '../../../hooks/useMenuKeyboard'
 import type { AgentDef, Attachment, MeetingStatus, Preset } from '../api'
 
 interface Props {
@@ -48,6 +49,52 @@ export default function AgentPillBar({
   onRemoveAttachment,
 }: Props) {
   const presetNames = Object.keys(presets)
+
+  // The attachment menu is `role="menu"`, so it owes the WAI-ARIA menu keyboard
+  // contract: arrows/Home/End move real focus between the items, Tab stays inside
+  // the open menu, and focus enters on open. `useMenuKeyboard` carries all of it
+  // (#6231); the items are the menu's actual CONTROLS (each row's remove button,
+  // the footer action) — a row <div> is layout, not a stop.
+  const menuRef = useRef<HTMLDivElement>(null)
+  // The trigger, so Escape can hand focus back (see the Escape branch below).
+  const attachBtnRef = useRef<HTMLButtonElement>(null)
+  useMenuKeyboard({ enabled: attachMenuOpen, containerRef: menuRef })
+
+  // Focus entry owes a matching REPAIR, because this component is controlled:
+  // activating an item changes nothing here, the HOST changes a prop on a later
+  // render, and two of those renders pull the DOM out from under the focused
+  // element:
+  //   (a) a removal keeps the menu OPEN and refreshes `attachments`, so the
+  //       index-keyed row holding focus unmounts. Focus falls to <body>, from
+  //       where Tab escapes the still-open menu and the Escape branch below is
+  //       unreachable (it is bound to the menu element, not the document).
+  //   (b) a successful 'Add a link' CLOSES the menu from the host with focus
+  //       still inside it, orphaning focus on <body> rather than returning it
+  //       to the paperclip the way an explicit Escape does.
+  // A plain effect, NOT the mochi-ContextMenu restore-on-unmount shape: this
+  // component stays mounted across both paths, so there is no unmount to hang
+  // the restore on — the prop change IS the event.
+  const prevMenuOpenRef = useRef(attachMenuOpen)
+  useEffect(() => {
+    const wasOpen = prevMenuOpenRef.current
+    prevMenuOpenRef.current = attachMenuOpen
+    // Adopt ONLY focus that is genuinely lost. Anything else — the trigger, the
+    // composer, a still-live menu item, another pane — is somewhere the user or
+    // the browser deliberately put focus, and moving it would be the theft this
+    // repair exists to prevent.
+    if (document.activeElement !== document.body) return
+    if (attachMenuOpen) {
+      // Still open: put the keyboard back on the first surviving item (the
+      // trigger only as a fallback for a menu that has no items at all).
+      ;(menuItemsOf(menuRef.current)[0] ?? attachBtnRef.current)?.focus()
+    } else if (wasOpen) {
+      // Restore to the trigger ONLY on an actual close. Gated on the previous
+      // render having been open so an unrelated `attachments` refresh while the
+      // menu is shut — and the very first render, where nothing was focused yet
+      // — cannot yank focus onto the paperclip out of nowhere.
+      attachBtnRef.current?.focus()
+    }
+  }, [attachments, attachMenuOpen])
 
   return (
     <div className="px-4 md:px-6 py-2 border-b border-border flex flex-wrap items-center gap-2">
@@ -121,6 +168,7 @@ export default function AgentPillBar({
 
       <div className="relative">
         <Btn
+          ref={attachBtnRef}
           onClick={onToggleAttachMenu}
           aria-label={i18nT('apps.meetings.pillBar.manageAttachments')}
           aria-expanded={attachMenuOpen}
@@ -143,18 +191,34 @@ export default function AgentPillBar({
               onClick={onToggleAttachMenu}
             />
             <div
+              ref={menuRef}
               className="absolute top-full left-0 mt-1 w-64 bg-card border border-border rounded-lg shadow-lg z-20 py-1"
               role="menu"
               tabIndex={-1}
               aria-label={i18nT('apps.meetings.pillBar.attachmentsMenu')}
               onKeyDown={e => {
-                if (e.key === 'Escape') onToggleAttachMenu()
+                if (e.key === 'Escape') {
+                  onToggleAttachMenu()
+                  // `useMenuKeyboard` moved focus INTO the menu when it opened, so
+                  // the rows are about to unmount from under the keyboard user.
+                  // Hand focus back to the paperclip — the same dismissal posture
+                  // MenuBtn takes (focus in on open, back to the trigger on
+                  // explicit dismissal); without it focus would be orphaned on
+                  // <body> with no obvious way back into the bar.
+                  attachBtnRef.current?.focus()
+                }
               }}
             >
               {attachments.length > 0 ? (
                 attachments.map((attachment, index) => (
                   <div
                     key={`${attachment.label}-${index}`}
+                    // Plain layout, deliberately NOT `role="menuitem"`: the row
+                    // has no activation of its own, and `menuitem` subclasses
+                    // `command`, so labelling it would announce an item whose
+                    // Enter/Space does nothing — the same promise-not-kept
+                    // defect #6231 is fixing. The menu semantics sit on the
+                    // control below, which the hook discovers directly.
                     className="flex items-center justify-between gap-2 px-3 py-1.5 text-[13px] hover:bg-bg-hover"
                   >
                     <span className="text-text truncate" title={attachment.url ?? attachment.path}>
@@ -162,6 +226,12 @@ export default function AgentPillBar({
                     </span>
                     <Btn
                       danger
+                      // The actual menu item: a native <button> (so Enter/Space
+                      // activate it for free) wearing `menuitem` so assistive
+                      // tech announces it as an item OF this menu rather than a
+                      // loose button inside one. `menuItemsOf` finds it either
+                      // way; the role is for the announcement.
+                      role="menuitem"
                       onClick={() => onRemoveAttachment(index)}
                       aria-label={i18nT('apps.meetings.pillBar.removeAttachment', {
                         label: attachment.label,
@@ -177,13 +247,26 @@ export default function AgentPillBar({
                 </div>
               )}
               <div className="border-t border-border mt-1 pt-1 px-2 pb-1">
-                <Clickable
+                {/* A native <button role="menuitem">, not `Clickable`: role="menu"
+                    owns only menuitem / menuitemradio / menuitemcheckbox / group
+                    / separator, and `Clickable` hardcodes role="button" (and Omits
+                    `role` from its props), which made this footer an INVALID owned
+                    child — assistive tech announced a loose button sitting inside
+                    the menu instead of an item OF it, and the menu's item count
+                    was short by one. A plain <button> carries the same free
+                    Enter/Space activation `Clickable` was providing, so the swap
+                    costs nothing; the classes below reproduce Clickable's look
+                    (`bg-transparent border-none` undoes the native chrome, the
+                    same spelling MicSourceMenu's rows use). */}
+                <button
+                  type="button"
+                  role="menuitem"
                   onClick={onAddAttachment}
-                  className="w-full text-left px-2 py-1 text-[13px] text-accent hover:bg-bg-hover rounded cursor-pointer"
+                  className="w-full text-left px-2 py-1 text-[13px] text-accent hover:bg-bg-hover rounded cursor-pointer bg-transparent border-none"
                 >
                   <Plus className="lucide-inline" />
                   {i18nT('apps.meetings.pillBar.addLink')}
-                </Clickable>
+                </button>
               </div>
             </div>
           </>

--- a/website/src/apps/mochi/src/renderer/ContextMenu.tsx
+++ b/website/src/apps/mochi/src/renderer/ContextMenu.tsx
@@ -3,8 +3,9 @@
  * Used by PetWidget (overlay) and ChatPanel (chat window).
  * Handles edge clamping, click-outside dismiss, and optional hitbox reporting for overlay use.
  */
-import React, { useEffect, useRef, useCallback } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 
+import { useMenuKeyboard } from '../../../../hooks/useMenuKeyboard'
 import { api } from '../mochiApi'
 
 export interface ContextMenuItem {
@@ -51,6 +52,107 @@ const MENU_MIN_W = 160
 
 export function ContextMenu({ x, y, items, reportHitbox, onAction, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
+
+  /*
+   * The container below carries `role="menu"`, which tells assistive technology
+   * that focus is MANAGED here and the arrow keys walk the rows (WAI-ARIA menu
+   * pattern) — a promise this component made and then did not keep: the rows
+   * were `tabIndex={0}` divs with an Enter/Space handler and nothing else, so a
+   * screen-reader user who reached for the arrows got page scroll instead of
+   * item navigation (#6231, #5851).
+   *
+   * `useMenuKeyboard` is the shared spelling of that contract (extracted from
+   * `MenuBtn` in DevFleetPage) — ArrowDown/ArrowUp with wrap at both ends,
+   * Home/End to the boundary rows, Tab/Shift-Tab contained inside the menu
+   * (#2533), and an IME composition latch so a candidate-list arrow is not
+   * stolen from the input method. `enabled` is a literal `true` because this
+   * component is MOUNTED ONLY WHILE OPEN: its hosts (PetContextMenu, ChatPanel)
+   * render it conditionally, so mount is open and unmount is close — there is no
+   * separate open flag to gate on, and the hook's cleanup drops the listener.
+   *
+   * Item discovery is left at the default (`menuItemsOf`): it collects the
+   * `role="menuitem"` rows in document order and naturally steps over the
+   * `role="separator"` dividers, so no `getItems` override is needed.
+   *
+   * `focusFirstOnOpen` is left at its default (true), which matches `MenuBtn`'s
+   * posture: focus enters the menu on open so the first arrow CHOOSES a row
+   * rather than being spent entering the list. That is safe against the
+   * close-on-blur effect below because it listens for a WINDOW blur (the pet
+   * overlay losing focus), not an element one — moving focus between rows
+   * dispatches non-bubbling element blur/focusout and never reaches it.
+   *
+   * Escape and Enter/Space stay where they are: the hook deliberately owns
+   * navigation only, because what "close" means (and the per-row action) is the
+   * host's business.
+   */
+  useMenuKeyboard({ enabled: true, containerRef: menuRef })
+
+  /*
+   * The element that was focused when this menu MOUNTED — the row, bubble or
+   * pet the user right-clicked (or reached with the keyboard). Captured during
+   * the first RENDER on purpose, not in an effect: render runs before
+   * `useMenuKeyboard`'s focus-entry effect moves focus onto the first row, so
+   * this is the last moment the opener is still `document.activeElement`.
+   * Same spelling as `SlotPopover` in PackEditor.tsx, which had this problem
+   * first. `undefined` is the "not yet captured" sentinel — `activeElement`
+   * itself can in principle be null, and using null for both would re-run the
+   * capture on a later render and latch a menu ROW as the opener.
+   */
+  const opener = useRef<Element | null | undefined>(undefined)
+  if (opener.current === undefined) opener.current = document.activeElement
+
+  /*
+   * Give focus back when the menu goes away (#6267 review).
+   *
+   * Focus ENTRY without a matching restore is a regression, not half a feature:
+   * every host renders this component conditionally (ChatPanel, PetContextMenu),
+   * so closing it UNMOUNTS the element that holds focus, and the browser drops
+   * focus to `<body>`. A keyboard user who pressed Escape or picked a row would
+   * be left nowhere — the next Tab restarts from the top of the document instead
+   * of resuming beside what they right-clicked. Before the rows were focusable
+   * nothing was lost on close, so the entry is what created this debt.
+   *
+   * Doing it in an UNMOUNT cleanup rather than next to each dismissal covers all
+   * of them in one place — Escape, row activation via `handleAction`, the
+   * close-on-window-blur path, and a host that stops rendering the menu for its
+   * own reasons (a re-render, a route change) and never called `onClose` at all.
+   *
+   * The guard says: restore ONLY if focus is still inside the menu being
+   * destroyed — precisely the case where focus would otherwise be lost. If an
+   * action legitimately moved focus elsewhere (settings or the dashboard opening
+   * and focusing something there), or the menu was dismissed by an outside click
+   * that already moved focus, then focus has a rightful owner and reclaiming it
+   * would be a second bug wearing the first one's clothes. In practice react-dom
+   * ALSO defends that case for us — it snapshots `activeElement` before the
+   * mutation phase and re-focuses it after the commit when that node is still in
+   * the document, which is exactly why this restore only "wins" when the focused
+   * row is being removed. The guard is kept anyway: it states the intent at the
+   * site, and it is the only protection if this ever moves off the commit path
+   * (an explicit Escape handler, the shape `SlotPopover` uses).
+   *
+   * The container is read into `menu` AT MOUNT rather than as `menuRef.current`
+   * inside the cleanup: React detaches host refs while tearing the tree down,
+   * and the captured node answers `contains` just as well.
+   *
+   * `useLayoutEffect`, NOT `useEffect`, and that is the load-bearing detail.
+   * React runs layout cleanups synchronously as it walks the deleted subtree,
+   * while the menu is STILL in the document and still holds focus; passive
+   * (`useEffect`) cleanups are deferred until after the commit, by which point
+   * the DOM node is gone and the browser has already reset `activeElement` to
+   * `<body>`. In a passive cleanup the guard therefore reads "focus is not in
+   * the menu" every single time and restores nothing — a version of this fix
+   * written with `useEffect` looks right, type-checks, and silently does not
+   * work. The tests below the fold in CrewCompanionContextMenu.test.tsx are what
+   * distinguish the two.
+   */
+  useLayoutEffect(() => {
+    const menu = menuRef.current
+    return () => {
+      if (menu?.contains(document.activeElement)) {
+        ;(opener.current as HTMLElement | null)?.focus?.()
+      }
+    }
+  }, [])
 
   // Clamp position so menu stays within viewport
   const [clampedX, setClampedX] = React.useState(x)

--- a/website/src/apps/mochi/src/renderer/PackEditor.tsx
+++ b/website/src/apps/mochi/src/renderer/PackEditor.tsx
@@ -21,6 +21,7 @@ import { PackInfoHeader } from './PackInfoHeader'
 import { SaveDialog } from './SaveDialog'
 import { EditorFooter } from './EditorFooter'
 import { useSaveWithDialog } from './editorHooks'
+import { useMenuKeyboard } from '../../../../hooks/useMenuKeyboard'
 
 import { api } from '../mochiApi'
 import { i18nT } from '../../../../i18n/t'
@@ -211,16 +212,64 @@ function SlotPopover({ slotKey, slots, filled, anchorRect, onSelectFile, onUseSa
 }) {
   const popoverRef = useRef<HTMLDivElement>(null)
 
-  // Close on outside click
+  // The element focused when this popover MOUNTED — the slot thumbnail, when it
+  // was opened with Enter/Space. Captured during the first render on purpose:
+  // render runs before useMenuKeyboard's focus-entry effect moves focus onto the
+  // first row, so this is the last moment the opener is still `activeElement`.
+  // `undefined` is the "not yet captured" sentinel — `activeElement` itself can
+  // in principle be null, and using null for both would re-run the capture on a
+  // later render and latch a menu ROW as the opener.
+  const opener = useRef<Element | null | undefined>(undefined)
+  if (opener.current === undefined) opener.current = document.activeElement
+
+  // The menu keyboard contract this popover's role="menu" promises: arrows walk
+  // the rows and wrap, Home/End jump to the boundaries, Tab is contained (#6231).
+  // The popover only exists while open, so `enabled` is unconditionally true.
+  useMenuKeyboard({ enabled: true, containerRef: popoverRef })
+
+  // Every EXPLICIT dismissal — Escape, or activating a row — unmounts the row
+  // that currently holds focus, so the close has to hand focus back to the
+  // opener or `activeElement` falls to <body> and the keyboard user is stranded
+  // at the top of the document. Centralised here so no command path can forget
+  // it (a bare onClose() in one row is exactly how that regresses).
+  //
+  // Deliberately NOT used by the outside-mousedown dismissal: on a pointer
+  // dismissal the browser routes focus per the click target, and yanking it to
+  // the opener would steal focus from whatever the user just clicked. Same rule
+  // as MenuBtn/#2533.
+  //
+  // Row handlers keep their existing `action(); close` ordering — the restore is
+  // only added at close time. That stays correct for Select File, whose action
+  // opens a native file dialog: the dialog takes focus after the restore, and
+  // the opener is where focus should sit once the dialog is dismissed.
+  const closeToOpener = useCallback(() => {
+    onClose()
+    ;(opener.current as HTMLElement | null)?.focus?.()
+  }, [onClose])
+
+  // Close on outside click, or on Escape.
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
         onClose()
       }
     }
+    // Escape is REQUIRED here, not a nicety: the shared contract contains Tab
+    // inside the menu (#2533), so without an explicit dismissal a keyboard user
+    // who opened this popover would be TRAPPED cycling its rows. Escape plus
+    // focus-restore-to-opener mirrors MenuBtn's posture (DevFleetPage), and the
+    // restore matters because the row that holds focus is about to unmount.
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      closeToOpener()
+    }
     document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [onClose])
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', handler)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose, closeToOpener])
 
   // Find other slots that have content (for "use same as" dropdown)
   const filledOthers = ALL_SLOT_KEYS.filter(
@@ -258,7 +307,7 @@ function SlotPopover({ slotKey, slots, filled, anchorRect, onSelectFile, onUseSa
         role="menuitem"
         onMouseEnter={(e) => { (e.target as HTMLElement).style.background = 'var(--bg-input)' }}
         onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent' }}
-        onClick={() => { onSelectFile(); onClose() }}
+        onClick={() => { onSelectFile(); closeToOpener() }}
       >
         <FolderOpen size={13} /> {i18nT('apps.mochi.editor.select_file')}
       </button>
@@ -274,7 +323,7 @@ function SlotPopover({ slotKey, slots, filled, anchorRect, onSelectFile, onUseSa
               role="menuitem"
               onMouseEnter={(e) => { (e.target as HTMLElement).style.background = 'var(--bg-input)' }}
               onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent' }}
-              onClick={() => { onUseSameAs(k); onClose() }}
+              onClick={() => { onUseSameAs(k); closeToOpener() }}
             >
               <CornerDownRight size={13} style={{ flexShrink: 0 }} /> {slotLabel(k)}
             </button>
@@ -290,7 +339,7 @@ function SlotPopover({ slotKey, slots, filled, anchorRect, onSelectFile, onUseSa
             role="menuitem"
             onMouseEnter={(e) => { (e.target as HTMLElement).style.background = 'var(--bg-input)' }}
             onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent' }}
-            onClick={() => { onClear(); onClose() }}
+            onClick={() => { onClear(); closeToOpener() }}
           >
             <X size={12} style={{ marginRight: 4, verticalAlign: '-2px' }} />
             {i18nT('apps.mochi.editor.clear')}

--- a/website/src/components/MicSourceMenu.tsx
+++ b/website/src/components/MicSourceMenu.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 
 import { i18nT } from '../i18n/t'
 import { getPreferredMicId, listMicrophones } from '../hooks/mic'
+import { useMenuKeyboard } from '../hooks/useMenuKeyboard'
 
 interface Props {
   /** Label of the device actually capturing, for the trigger text. */
@@ -52,6 +53,22 @@ export default function MicSourceMenu({ deviceLabel, activeDeviceId, onSelect, r
   const [rect, setRect] = useState<{ left: number; top: number; bottom: number } | null>(null)
   const wrapRef = useRef<HTMLSpanElement | null>(null)
   const menuRef = useRef<HTMLDivElement | null>(null)
+  // The trigger, so an explicit dismissal can hand focus back to it: the menu
+  // keyboard contract moves focus INTO the portalled menu on open, and the row
+  // holding it is unmounted by the close — without a restore, focus would be
+  // orphaned on <body> and the next Tab would restart from the top of the
+  // document, nowhere near the composer the user came from. Same posture as
+  // `MenuBtn` (DevFleetPage), the precedent for this contract.
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  // role="menu" promises the WAI-ARIA menu keyboard contract (arrow-key row
+  // navigation with wrap, Home/End, Tab containment) — shared with the other
+  // role="menu" surfaces rather than re-spelled here (#6231). The rows are
+  // already native <button role="menuitemradio">, so the hook's default item
+  // discovery finds them (devices, then "System default") with no row markup
+  // change. Escape stays owned by the dismiss effect below: what "close" means
+  // here — reposition state, focus restore — is this host's business.
+  useMenuKeyboard({ enabled: open, containerRef: menuRef })
 
   useEffect(() => {
     if (!open) return
@@ -70,7 +87,15 @@ export default function MicSourceMenu({ deviceLabel, activeDeviceId, onSelect, r
       const t = e.target as Node
       if (!wrapRef.current?.contains(t) && !menuRef.current?.contains(t)) setOpen(false)
     }
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); setOpen(false) } }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        // Focus lives inside the menu at this point (see `triggerRef`), and the
+        // element holding it is about to unmount — hand it back to the trigger.
+        triggerRef.current?.focus()
+      }
+    }
     document.addEventListener('pointerdown', onDown, true)
     document.addEventListener('keydown', onKey, true)
     return () => {
@@ -89,6 +114,9 @@ export default function MicSourceMenu({ deviceLabel, activeDeviceId, onSelect, r
   const pick = (id: string) => {
     setPreferred(id)
     setOpen(false)
+    // Activation is an explicit dismissal too: the row that has focus is being
+    // unmounted, so restore to the trigger rather than dropping focus on <body>.
+    triggerRef.current?.focus()
     onSelect(id)
   }
 
@@ -140,6 +168,7 @@ export default function MicSourceMenu({ deviceLabel, activeDeviceId, onSelect, r
     <span ref={wrapRef} className="relative flex-1 min-w-0 flex items-center">
       <button
         type="button"
+        ref={triggerRef}
         onClick={toggle}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/website/src/hooks/useMenuKeyboard.test.tsx
+++ b/website/src/hooks/useMenuKeyboard.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { useRef } from 'react'
+import { menuItemsOf, useMenuKeyboard } from './useMenuKeyboard'
+
+/**
+ * The shared `role="menu"` keyboard contract (#6231) — the extraction of
+ * `MenuBtn`'s roving-focus keydown logic. These tests pin the seam itself
+ * (item discovery, wrap at both ends, Home/End, entry-from-outside, Tab
+ * containment per #2533, the IME claim, the editable-outside guard, and the
+ * degenerate item lists), so each consuming surface only needs a wiring test.
+ * `MenuBtn`'s own DevFleetPage tests double as the extraction's
+ * behaviour-preservation proof and are deliberately untouched.
+ */
+
+function Harness({
+  enabled = true,
+  focusFirstOnOpen,
+  items = ['one', 'two', 'three'],
+  disabled = [] as string[],
+}: {
+  enabled?: boolean
+  focusFirstOnOpen?: boolean
+  items?: string[]
+  disabled?: string[]
+}) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  useMenuKeyboard({ enabled, containerRef: menuRef, focusFirstOnOpen })
+  return (
+    <div>
+      <button data-testid="outside-btn">outside</button>
+      <input data-testid="outside-input" aria-label="outside editor" />
+      <div ref={menuRef} role="menu" data-testid="menu" aria-label="test menu">
+        {items.map(label => (
+          <div
+            key={label}
+            role="menuitem"
+            tabIndex={-1}
+            data-testid={`item-${label}`}
+            aria-disabled={disabled.includes(label) || undefined}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+const item = (utils: ReturnType<typeof render>, label: string) =>
+  utils.getByTestId(`item-${label}`) as HTMLElement
+
+describe('menuItemsOf', () => {
+  it('returns [] for a null container', () => {
+    expect(menuItemsOf(null)).toEqual([])
+  })
+
+  it('collects menuitem/menuitemradio/menuitemcheckbox/button rows and skips disabled ones', () => {
+    // Fixture built with DOM APIs rather than an HTML-string write — the
+    // frontend-security rule (AUTOSDE.yaml) bans those unconditionally,
+    // tests included.
+    const host = document.createElement('div')
+    const el = (tag: string, attrs: Record<string, string>, text: string) => {
+      const node = document.createElement(tag)
+      for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v)
+      node.textContent = text
+      return node
+    }
+    host.append(
+      el('div', { role: 'menuitem' }, 'a'),
+      el('button', {}, 'b'),
+      el('button', { disabled: '' }, 'c'),
+      el('div', { role: 'menuitemradio' }, 'd'),
+      el('div', { role: 'menuitemcheckbox' }, 'e'),
+      el('div', { role: 'button', 'aria-disabled': 'true' }, 'f'),
+      el('div', { role: 'separator' }, ''),
+      el('span', {}, 'not an item'),
+    )
+    expect(menuItemsOf(host).map(item => item.textContent)).toEqual(['a', 'b', 'd', 'e'])
+  })
+})
+
+describe('useMenuKeyboard', () => {
+  it('moves focus onto the first enabled item when enabled flips true', () => {
+    const utils = render(<Harness enabled={false} />)
+    expect(document.activeElement).toBe(document.body)
+    utils.rerender(<Harness enabled={true} />)
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('skips focus entry when focusFirstOnOpen is false', () => {
+    const utils = render(<Harness focusFirstOnOpen={false} />)
+    expect(item(utils, 'one')).not.toHaveFocus()
+    // The contract still works: an arrow ENTERS the list.
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('ArrowDown/ArrowUp walk the items and wrap at both ends', () => {
+    const utils = render(<Harness />)
+    const menu = utils.getByTestId('menu')
+    expect(item(utils, 'one')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(item(utils, 'two')).toHaveFocus()
+    item(utils, 'three').focus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(item(utils, 'one')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(item(utils, 'three')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(item(utils, 'two')).toHaveFocus()
+  })
+
+  it('Home/End jump to the boundary items', () => {
+    const utils = render(<Harness />)
+    const menu = utils.getByTestId('menu')
+    fireEvent.keyDown(menu, { key: 'End' })
+    expect(item(utils, 'three')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Home' })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('arrows enter the list when focus is outside it: Down to first, Up to last', () => {
+    const utils = render(<Harness focusFirstOnOpen={false} />)
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' })
+    expect(item(utils, 'three')).toHaveFocus()
+    document.body.focus()
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('lets modified arrows through untouched (OS/browser shortcuts)', () => {
+    const utils = render(<Harness />)
+    const menu = utils.getByTestId('menu')
+    fireEvent.keyDown(menu, { key: 'ArrowDown', metaKey: true })
+    fireEvent.keyDown(menu, { key: 'ArrowDown', ctrlKey: true })
+    fireEvent.keyDown(menu, { key: 'End', altKey: true })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('contains Tab/Shift-Tab within the enabled items (#2533)', () => {
+    const utils = render(<Harness />)
+    const menu = utils.getByTestId('menu')
+    item(utils, 'three').focus()
+    fireEvent.keyDown(menu, { key: 'Tab' })
+    expect(item(utils, 'one')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Tab', shiftKey: true })
+    expect(item(utils, 'three')).toHaveFocus()
+  })
+
+  it('skips disabled items in the arrow cycle and the Tab boundary', () => {
+    const utils = render(<Harness disabled={['two']} />)
+    const menu = utils.getByTestId('menu')
+    expect(item(utils, 'one')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(item(utils, 'three')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Tab' })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('a single-item menu keeps focus put on arrows and contains Tab (the Pierre degenerate case)', () => {
+    const utils = render(<Harness items={['only']} />)
+    const menu = utils.getByTestId('menu')
+    expect(item(utils, 'only')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(item(utils, 'only')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(item(utils, 'only')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Tab' })
+    expect(item(utils, 'only')).toHaveFocus()
+    fireEvent.keyDown(menu, { key: 'Tab', shiftKey: true })
+    expect(item(utils, 'only')).toHaveFocus()
+  })
+
+  it('does nothing (and does not throw) on an empty or all-disabled item list', () => {
+    const utils = render(<Harness items={[]} />)
+    expect(document.activeElement).toBe(document.body)
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    fireEvent.keyDown(document.body, { key: 'Tab' })
+    expect(document.activeElement).toBe(document.body)
+    utils.rerender(<Harness items={['a', 'b']} disabled={['a', 'b']} />)
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it('declines an arrow that belongs to an IME composition', () => {
+    // On WebKit the keydown that moves through composition candidates can
+    // arrive AFTER compositionend with `isComposing` already false — an
+    // unguarded arrow branch would move menu focus mid-composition.
+    const utils = render(<Harness />)
+    const first = item(utils, 'one')
+    expect(first).toHaveFocus()
+    fireEvent.compositionStart(first)
+    fireEvent.compositionEnd(first)
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(first).toHaveFocus()
+  })
+
+  it('leaves keys alone while focus sits in an editable element outside the menu', () => {
+    // An open popover must not hijack a caret's arrows (the composer textarea
+    // under MicSourceMenu). A non-editable outside element (the trigger
+    // button) still routes arrows into the menu.
+    const utils = render(<Harness focusFirstOnOpen={false} />)
+    const input = utils.getByTestId('outside-input')
+    input.focus()
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(input).toHaveFocus()
+    const btn = utils.getByTestId('outside-btn')
+    btn.focus()
+    fireEvent.keyDown(btn, { key: 'ArrowDown' })
+    expect(item(utils, 'one')).toHaveFocus()
+  })
+
+  it('detaches the listener when disabled', () => {
+    const utils = render(<Harness />)
+    utils.rerender(<Harness enabled={false} />)
+    document.body.focus()
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(document.body)
+  })
+})

--- a/website/src/hooks/useMenuKeyboard.ts
+++ b/website/src/hooks/useMenuKeyboard.ts
@@ -1,0 +1,175 @@
+import { useEffect } from 'react'
+import { useDocumentImeLatch, type ImeLatch } from './useImeGuard'
+
+/**
+ * Shared keyboard contract for `role="menu"` surfaces (WAI-ARIA menu pattern):
+ * ArrowDown/ArrowUp move real DOM focus between the enabled items and wrap at
+ * both ends, Home/End jump to the boundary items, and Tab/Shift-Tab are
+ * contained within the enabled items (#2533) — a Tab out of a still-open menu
+ * would drop a keyboard user behind it with no obvious way back. Escape is
+ * deliberately NOT handled here: every host already owns its own dismissal
+ * (and what "close" means — restore focus, toggle state — differs per host).
+ *
+ * This is the extraction of `MenuBtn`'s roving-focus keydown logic
+ * (DevFleetPage.tsx, landed via #6226) so the sibling `role="menu"` surfaces
+ * can honour the same contract without a per-surface re-spelling (#6231).
+ * `MenuBtn` itself consumes `handleMenuKeydown` from its existing
+ * document-level listener; popover-style hosts use the `useMenuKeyboard` hook.
+ *
+ * Not `useListboxKeyboard`: that hook closes on Tab (`closeToTrigger`), clamps
+ * instead of wrapping (`els[i+1] ?? els[els.length-1]`), and scopes its IME
+ * guard to a filter input — all three are the LISTBOX/combobox side of the
+ * pattern. The menu contract wraps, contains Tab, and needs a document-level
+ * composition latch because a menu has no editable target to anchor one to.
+ */
+
+/**
+ * The enabled, keyboard-reachable rows of a menu container. Menus in this
+ * repo mark rows as `role="menuitem"` / `role="menuitemradio"` /
+ * `role="menuitemcheckbox"`, native `<button>`s, or `Clickable`
+ * (`role="button"`) — match all of them so a host's action rows are never
+ * stranded outside the arrow/Tab cycle. Disabled rows (native `disabled` or
+ * `aria-disabled`, the `Clickable` spelling) are skipped the same way
+ * `MenuBtn` skips them.
+ */
+export function menuItemsOf(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return []
+  const sel = '[role="menuitem"],[role="menuitemradio"],[role="menuitemcheckbox"],[role="button"],button'
+  return Array.from(container.querySelectorAll<HTMLElement>(sel)).filter(
+    el => !el.hasAttribute('disabled') && el.getAttribute('aria-disabled') !== 'true',
+  )
+}
+
+/**
+ * Handle one keydown against the menu contract. Returns true when the key was
+ * consumed (or claimed by the IME latch), false when it is not the menu's key
+ * and should fall through to the host's other handling.
+ *
+ * Framework-free on purpose (same reasoning as `createImeLatch`): document-
+ * level native listeners (`MenuBtn`) and React `onKeyDown` handlers (via
+ * `e.nativeEvent`) share ONE spelling of the contract.
+ */
+export function handleMenuKeydown(
+  e: globalThis.KeyboardEvent,
+  getItems: () => HTMLElement[],
+  imeLatch: ImeLatch,
+): boolean {
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Home' || e.key === 'End') {
+    // role="menu" promises arrow-key item navigation (WAI-ARIA menu
+    // pattern) — screen-reader users reach for arrows first (#5851).
+    // Wrap at both ends; Home/End jump to the boundary items.
+    // preventDefault stops the page scrolling behind the open menu.
+    // Modified arrows (Cmd/Ctrl/Alt) are OS/browser shortcuts the menu
+    // pattern assigns no behavior to — let them through untouched.
+    if (e.altKey || e.ctrlKey || e.metaKey) return false
+    // An arrow the IME owns is moving through composition candidates, not
+    // menu items — the claim runs BEFORE the preventDefault() and focus
+    // move. (useListKeyboardNav deliberately lets composition arrows
+    // through because its list coexists with a text input; a menu holds no
+    // editable target, so it takes the stricter side.)
+    const focusable = getItems()
+    if (focusable.length === 0) return false
+    if (!imeLatch.claimKey(e)) return true
+    e.preventDefault()
+    if (e.key === 'Home') { focusable[0].focus(); return true }
+    if (e.key === 'End') { focusable[focusable.length - 1].focus(); return true }
+    const idx = focusable.indexOf(document.activeElement as HTMLElement)
+    // Focus outside the item list (edge: it never entered) — treat the
+    // arrow as entry: Down lands on the first item, Up on the last.
+    const next = idx === -1
+      ? (e.key === 'ArrowDown' ? 0 : focusable.length - 1)
+      : (idx + (e.key === 'ArrowDown' ? 1 : -1) + focusable.length) % focusable.length
+    focusable[next].focus()
+    return true
+  }
+  if (e.key !== 'Tab') return false
+  // Contain Tab/Shift-Tab within the menu's enabled items (#2533). A boundary
+  // Tab the IME owns must not cycle focus: the claim runs BEFORE the
+  // preventDefault() and focus move.
+  const focusable = getItems()
+  if (focusable.length === 0) return false
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    if (!imeLatch.claimKey(e)) return true
+    e.preventDefault()
+    last.focus()
+    return true
+  }
+  if (!e.shiftKey && document.activeElement === last) {
+    if (!imeLatch.claimKey(e)) return true
+    e.preventDefault()
+    first.focus()
+    return true
+  }
+  return false
+}
+
+/**
+ * Wire an open `role="menu"` container onto the shared menu keyboard
+ * contract. While `enabled`:
+ *
+ *  - a DOCUMENT-level keydown listener drives `handleMenuKeydown` (same shape
+ *    as `MenuBtn`): arrows work even while focus still sits on the trigger —
+ *    the first arrow ENTERS the item list — and portaled menus need no React
+ *    bubbling path;
+ *  - focus moves onto the first enabled item when the menu opens
+ *    (`focusFirstOnOpen`, default true): role="menu" tells assistive
+ *    technology that focus is managed here, so a keyboard user lands inside
+ *    the menu they were just told is open. Hosts that already own focus entry
+ *    (Pierre's tree menu) pass false;
+ *  - a shared document IME latch keeps composition keys out of the contract
+ *    (see `useDocumentImeLatch`).
+ *
+ * One guard `MenuBtn` does not need but a document-level contract here does:
+ * when focus sits in an EDITABLE element outside the menu (the composer
+ * textarea under `MicSourceMenu`), the keys belong to the editor — an open
+ * menu must not hijack a caret's arrows. `MenuBtn` closes on any outside
+ * click, so its menu and an outside caret cannot coexist; these popovers can.
+ *
+ * PRECONDITION: at most one hook-driven menu open at a time. Each instance
+ * installs its own document listener and treats focus-outside-the-list as
+ * "enter the list", so two open menus would both act on the same arrow and
+ * the unfocused one would steal focus. Every current host already guarantees
+ * this (all dismiss on outside pointerdown/mousedown, and Tab containment
+ * keeps the keyboard from reaching a second trigger while one is open) — a
+ * new consumer must keep that dismissal shape or add arbitration here first.
+ *
+ * Focus RESTORE on close is the HOST's job, and there are two sanctioned
+ * postures — pick one on purpose: restore-on-every-unmount, guarded by
+ * "focus is still inside the menu" (mochi ContextMenu — covers host-driven
+ * unmounts too), or restore-only-on-explicit-dismissal, leaving outside-
+ * pointer dismissal alone (SlotPopover/MenuBtn — the browser routes focus
+ * per the click target, #2533). Focus entry without a matching restore
+ * strands a keyboard user on <body> when the focused item unmounts.
+ *
+ * Item discovery is `menuItemsOf(containerRef.current)`.
+ */
+export function useMenuKeyboard(opts: {
+  /** The menu's open state; gates the listener, latch, and focus entry. */
+  enabled: boolean
+  containerRef: React.RefObject<HTMLElement | null>
+  /** Move focus onto the first enabled item when `enabled` flips true. */
+  focusFirstOnOpen?: boolean
+}): void {
+  const { enabled, containerRef, focusFirstOnOpen = true } = opts
+  const imeLatch = useDocumentImeLatch(enabled)
+  useEffect(() => {
+    if (!enabled) return
+    const items = () => menuItemsOf(containerRef.current)
+    if (focusFirstOnOpen) items()[0]?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      const active = document.activeElement as HTMLElement | null
+      if (active && !containerRef.current?.contains(active)) {
+        const tag = active.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || active.isContentEditable) return
+      }
+      handleMenuKeydown(e, items, imeLatch)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+    // `imeLatch` is identity-stable (useDocumentImeLatch); `containerRef` is a
+    // stable ref object. Only open/close (and the static focusFirstOnOpen)
+    // should re-run this effect.
+  }, [enabled, focusFirstOnOpen, containerRef, imeLatch])
+}

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -12,6 +12,7 @@ import Modal from '../components/Modal'
 import Clickable from '../components/Clickable'
 import { useNavigate } from 'react-router-dom'
 import { useDocumentImeLatch } from '../hooks/useImeGuard'
+import { handleMenuKeydown } from '../hooks/useMenuKeyboard'
 import { useAppDispatch } from '../store'
 import { addNotification } from '../store/notificationsSlice'
 import { setPendingInput } from '../store/chatSlice'
@@ -340,51 +341,12 @@ function MenuBtn({ items }: { items: (MenuItemDef | null)[] }) {
         close()
         return
       }
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Home' || e.key === 'End') {
-        // role="menu" promises arrow-key item navigation (WAI-ARIA menu
-        // pattern) — screen-reader users reach for arrows first (#5851).
-        // Wrap at both ends; Home/End jump to the boundary items.
-        // preventDefault stops the page scrolling behind the open menu.
-        // Modified arrows (Cmd/Ctrl/Alt) are OS/browser shortcuts the menu
-        // pattern assigns no behavior to — let them through untouched.
-        if (e.altKey || e.ctrlKey || e.metaKey) return
-        // An arrow the IME owns is moving through composition candidates,
-        // not menu items — same claim, same reason as the Tab branch below,
-        // and the claim runs BEFORE the preventDefault() and focus move.
-        // (useListKeyboardNav deliberately lets composition arrows through
-        // because its list coexists with a text input; this menu holds no
-        // editable target, so it takes the stricter side.)
-        const focusable = focusableItems()
-        if (focusable.length === 0) return
-        if (!imeLatch.claimKey(e)) return
-        e.preventDefault()
-        if (e.key === 'Home') { focusable[0].focus(); return }
-        if (e.key === 'End') { focusable[focusable.length - 1].focus(); return }
-        const idx = focusable.indexOf(document.activeElement as HTMLDivElement)
-        // Focus outside the item list (edge: it never entered) — treat the
-        // arrow as entry: Down lands on the first item, Up on the last.
-        const next = idx === -1
-          ? (e.key === 'ArrowDown' ? 0 : focusable.length - 1)
-          : (idx + (e.key === 'ArrowDown' ? 1 : -1) + focusable.length) % focusable.length
-        focusable[next].focus()
-        return
-      }
-      if (e.key !== 'Tab') return
-      // Contain Tab/Shift-Tab within the menu's enabled items — a Tab out of
-      // a still-open menu would drop a keyboard user behind it with no
-      // obvious way back (#2533). A boundary Tab the IME owns must not cycle
-      // focus: the claim runs BEFORE the preventDefault() and focus move.
-      const focusable = focusableItems()
-      if (focusable.length === 0) return
-      const first = focusable[0]
-      const last = focusable[focusable.length - 1]
-      if (e.shiftKey && document.activeElement === first) {
-        if (!imeLatch.claimKey(e)) return
-        e.preventDefault(); last.focus()
-      } else if (!e.shiftKey && document.activeElement === last) {
-        if (!imeLatch.claimKey(e)) return
-        e.preventDefault(); first.focus()
-      }
+      // Arrow/Home/End navigation and Tab containment live in the shared
+      // menu contract (useMenuKeyboard.ts) — extracted from here (#6231) so
+      // the sibling role="menu" surfaces honour the same keyboard promise
+      // without another inline spelling. Escape stays local: what "close"
+      // means (restore focus to the trigger) is this host's own semantics.
+      handleMenuKeydown(e, focusableItems, imeLatch)
     }
     // position:fixed desyncs from any scrolling ancestor — close on scroll
     // (capture phase catches nested scrollers) and on resize. A wheel scroll

--- a/website/src/pierre/PierreWorkspaceTreeImpl.tsx
+++ b/website/src/pierre/PierreWorkspaceTreeImpl.tsx
@@ -21,6 +21,7 @@ import type {
 import { FileTree, useFileTree } from '@pierre/trees/react'
 import { AtSign, FileDiff, FolderOpen } from 'lucide-react'
 import { api } from '../api/client'
+import { useMenuKeyboard } from '../hooks/useMenuKeyboard'
 import { i18nT } from '../i18n/t'
 import { normalizeWindowsPath } from '../utils/fileTokens'
 import { TreeSkeleton } from './tree'
@@ -80,8 +81,25 @@ function TreeContextMenu({ item, context, root, onAddToContext }: {
   useEffect(() => {
     firstItemRef.current?.focus()
   }, [])
+  // The DEGENERATE single-item case of the shared role="menu" keyboard contract
+  // (#6231): with exactly one item the arrows have nothing to move between, so
+  // the wiring buys no navigation today. It is here because the CONTRACT is
+  // what role="menu" advertises to assistive technology, and honouring it
+  // per-surface-by-item-count is how surfaces drift: an arrow inside an open
+  // menu must be consumed rather than scrolling the tree behind it, Tab must
+  // stay contained (#2533), and IME composition keys must not reach the menu at
+  // all — all true of a one-item menu. It also means the day this menu grows a
+  // second action (an Open, a Reveal), real navigation arrives with it instead
+  // of being a second bug to find. `enabled: true` unconditionally because
+  // Pierre only mounts this component while the menu is open.
+  // focusFirstOnOpen: false — the firstItemRef effect above already owns focus
+  // entry (it must, because Pierre focuses the tree ROW, not this slotted
+  // content); letting the hook also focus would be a redundant second move.
+  const menuRef = useRef<HTMLDivElement>(null)
+  useMenuKeyboard({ enabled: true, containerRef: menuRef, focusFirstOnOpen: false })
   return (
     <div
+      ref={menuRef}
       role="menu"
       className="min-w-[176px] rounded-lg border border-border bg-bg-elevated p-1 shadow-lg"
     >

--- a/website/src/test/CrewCompanionContextMenu.test.tsx
+++ b/website/src/test/CrewCompanionContextMenu.test.tsx
@@ -431,7 +431,7 @@ describe('mochi context menu — focus returns to the opener on close (#6267 rev
     // it after the commit whenever that node is still in the document. So an
     // unconditional restore is overwritten right back to `elsewhere` here. The
     // guard is therefore belt-and-braces in this path rather than the thing that
-    // makes this test pass — no black-box test through React's unmount can
+    // makes this test pass — no closed-box test through React's unmount can
     // separate the two. Kept because it states the intent at the site, and
     // because it is the only thing protecting the invariant if the restore is
     // ever moved off the commit path (e.g. into an explicit Escape handler, the

--- a/website/src/test/CrewCompanionContextMenu.test.tsx
+++ b/website/src/test/CrewCompanionContextMenu.test.tsx
@@ -19,11 +19,27 @@
  * here means the renderer half is correct; the Electron half is pinned separately in
  * electron/crew-companion/test/petHitbox.test.js.
  */
+import { useState } from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, fireEvent, cleanup } from '@testing-library/react'
+import { render, fireEvent, cleanup, act } from '@testing-library/react'
 
 import { ContextMenu, type ContextMenuEntry } from '../apps/crew-companion/ContextMenu'
 import { petBridge } from '../apps/crew-companion/petBridge'
+import {
+  ContextMenu as MochiContextMenu,
+  type ContextMenuEntry as MochiContextMenuEntry,
+} from '../apps/mochi/src/renderer/ContextMenu'
+
+/*
+ * The mochi copy reaches the main process through `api` (its ONE seam, see
+ * mochiApi.ts) — stub it so importing the component does not drag the real
+ * preload surface into this suite. Every method it touches is optional and
+ * guarded with `?.` there, so an empty object is a faithful "no host" stand-in;
+ * these keyboard tests never open in overlay mode (`reportHitbox`) anyway. The
+ * crew-companion blocks above go through `petBridge` instead and are untouched
+ * by this mock.
+ */
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: {} }))
 
 const items: ContextMenuEntry[] = [
   { label: 'Change avatar', action: 'gallery' },
@@ -115,5 +131,329 @@ describe('chat context menu — unchanged by the overlay fix', () => {
     )
     expect(container.querySelector('.cc-menu-backdrop')).toBeNull()
     expect(setMenuHitbox).not.toHaveBeenCalled()
+  })
+})
+
+/*
+ * ───── mochi's ContextMenu: the role="menu" keyboard contract (#6231) ─────
+ *
+ * A second, independently-vendored copy of this component lives at
+ * `src/apps/mochi/src/renderer/ContextMenu.tsx`, and it is the copy that
+ * actually puts `role="menu"` on its container. That role is a PROMISE to
+ * assistive technology — "focus is managed here, use the arrow keys" — and
+ * before #6231 the menu made it and then ignored every arrow: the rows were
+ * `tabIndex={0}` divs with an Enter/Space handler and nothing else, so a screen
+ * reader announced an arrow-navigable menu that only responded to Tab. The
+ * tests below pin the shared contract (`useMenuKeyboard`) onto that surface,
+ * and pin the behaviour it must NOT disturb.
+ *
+ * They live in this file because it is the repo's only ContextMenu test file;
+ * the crew-companion describes above are untouched.
+ */
+
+const mochiItems: MochiContextMenuEntry[] = [
+  { label: 'Change avatar', action: 'gallery' },
+  { label: 'Hide', action: 'hide' },
+  // A separator between the middle and last rows: it is a `role="separator"`
+  // div, NOT a menuitem, so it must never receive focus — arrow navigation has
+  // to step straight over it rather than parking a keyboard user on a divider.
+  { separator: true },
+  { label: 'Turn off companion', action: 'quit', danger: true },
+]
+
+function renderMochiMenu(handlers: { onAction?: (a: string) => void; onClose?: () => void } = {}) {
+  return render(
+    <MochiContextMenu
+      x={10}
+      y={10}
+      items={mochiItems}
+      onAction={handlers.onAction ?? (() => {})}
+      onClose={handlers.onClose ?? (() => {})}
+    />,
+  )
+}
+
+/**
+ * The menu's focusable rows in document order. Queried from the DOM rather than
+ * derived from `mochiItems` so the separator's absence from this list is a fact
+ * about the rendered markup, which is what the arrow keys actually walk.
+ */
+function menuRows(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+}
+
+describe('mochi context menu — role="menu" keyboard contract', () => {
+  it('moves DOM focus onto the first menuitem when the menu opens', () => {
+    const { container } = renderMochiMenu()
+    const rows = menuRows(container)
+    expect(rows).toHaveLength(3)
+    // role="menu" says focus is managed here, so a keyboard user has to LAND
+    // inside the menu they were just told is open — otherwise the first arrow
+    // is spent entering the list instead of choosing a row.
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('ArrowDown walks the menuitems in order, skips the separator, and wraps last → first', () => {
+    const { container } = renderMochiMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[1]).toHaveFocus()
+    // The separator sits between rows[1] and rows[2] in the markup; one
+    // ArrowDown crosses it.
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[2]).toHaveFocus()
+    // Wrap, not clamp: this is the menu contract, not the listbox one.
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('ArrowUp wraps first → last and then walks back up, skipping the separator', () => {
+    const { container } = renderMochiMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' })
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('Home and End jump to the boundary menuitems', () => {
+    const { container } = renderMochiMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'End' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'Home' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('contains Tab inside the menu: last → first, and Shift-Tab first → last', () => {
+    const { container } = renderMochiMenu()
+    const rows = menuRows(container)
+    // Focused directly rather than arrowed to, so this test fails only on the
+    // Tab containment it is about (#2533) and not on the arrow keys.
+    rows[2].focus()
+    // A Tab out of a still-open menu drops a keyboard user behind it with no
+    // obvious way back — the menu keeps the cycle.
+    fireEvent.keyDown(document.body, { key: 'Tab' })
+    expect(rows[0]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'Tab', shiftKey: true })
+    expect(rows[2]).toHaveFocus()
+  })
+
+  it('PIN: Enter on the focused menuitem still fires onAction and closes', () => {
+    const onAction = vi.fn()
+    const onClose = vi.fn()
+    const { container } = renderMochiMenu({ onAction, onClose })
+    const rows = menuRows(container)
+    rows[1].focus()
+    // The per-row Enter/Space handler is the menu's activation path and is NOT
+    // moved into the shared hook (the hook deliberately owns navigation only).
+    fireEvent.keyDown(rows[1], { key: 'Enter' })
+    expect(onAction).toHaveBeenCalledWith('hide')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('PIN: Escape still closes the menu', () => {
+    vi.useFakeTimers()
+    try {
+      const onClose = vi.fn()
+      renderMochiMenu({ onClose })
+      // Same 50ms guard as the crew-companion copy: the closing listeners are
+      // attached one tick late so the click that OPENED the menu cannot
+      // immediately dismiss it. Step past it before dispatching.
+      vi.advanceTimersByTime(60)
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('PIN: entering and moving focus does not self-close the menu', () => {
+    vi.useFakeTimers()
+    try {
+      const onClose = vi.fn()
+      const { container } = renderMochiMenu({ onClose })
+      // Past the 50ms guard, so the close-on-window-blur listener is live for
+      // the focus move below — the case worth pinning, because focus entry
+      // blurs whatever held focus before and an arrow blurs a row on every
+      // step. Those are ELEMENT blurs, which do not bubble, and the closer
+      // listens for WINDOW blur; if that ever changed, this menu would close
+      // itself the moment it opened.
+      vi.advanceTimersByTime(60)
+      const rows = menuRows(container)
+      expect(rows[0]).toHaveFocus()
+      expect(onClose).not.toHaveBeenCalled()
+      fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+      expect(rows[1]).toHaveFocus()
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+/*
+ * ───── mochi's ContextMenu: focus RESTORE on close (#6267 review) ─────
+ *
+ * The block above pins focus ENTRY: the menu now moves DOM focus onto its first
+ * row when it opens. That half alone is a regression, because the row holding
+ * focus is about to be DESTROYED — every real host (PetContextMenu, ChatPanel)
+ * renders this component conditionally, so "close" means unmount, and unmounting
+ * the focused element drops focus to `<body>`. A keyboard user who pressed
+ * Escape, or picked a row, would land nowhere: the next Tab restarts from the
+ * top of the document instead of resuming beside the thing they right-clicked.
+ * Before #6231 nothing focused the rows at all, so nothing was lost on close —
+ * the entry is what created the debt.
+ *
+ * The tests in the block above cannot see any of this: they pass a `vi.fn()`
+ * `onClose` that records the call and leaves the menu mounted, which is the one
+ * arrangement in which the bug is invisible. So these tests render the menu
+ * inside a MINIMAL CONTROLLED HOST that behaves like the real ones — `onClose`
+ * flips a `useState` flag and the menu genuinely unmounts — with a real
+ * focusable opener button standing in for the surface that was right-clicked.
+ */
+
+/**
+ * A stand-in for PetContextMenu/ChatPanel: holds the open flag, unmounts the
+ * menu when `onClose` fires, and owns two focusable buttons — the OPENER (focus
+ * should come back here) and an unrelated one, used by the two PIN cases below
+ * to play the part of "focus moved somewhere else on purpose".
+ */
+function MochiMenuHost({ onAction }: { onAction?: (action: string) => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button data-testid="opener" onClick={() => setOpen(true)}>Open menu</button>
+      <button data-testid="elsewhere">Somewhere else</button>
+      {open ? (
+        <MochiContextMenu
+          x={10}
+          y={10}
+          items={mochiItems}
+          onAction={(action) => onAction?.(action)}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+describe('mochi context menu — focus returns to the opener on close (#6267 review)', () => {
+  /**
+   * Focus the opener the way a keyboard user leaves it (the context menu is
+   * reached from the element that already had focus), then open the menu and
+   * assert the entry landed — so a failure below is about RESTORE and not about
+   * the harness never having opened the menu.
+   */
+  function openFromOpener(onAction?: (action: string) => void) {
+    const utils = render(<MochiMenuHost onAction={onAction} />)
+    const opener = utils.getByTestId('opener')
+    opener.focus()
+    expect(opener).toHaveFocus()
+    fireEvent.click(opener)
+    const rows = menuRows(utils.container)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveFocus()
+    return { ...utils, opener, rows }
+  }
+
+  it('Escape unmounts the menu and returns focus to the opener', () => {
+    vi.useFakeTimers()
+    try {
+      const { container, opener } = openFromOpener()
+      // Same 50ms guard as everywhere else in this file: the closing listeners
+      // are attached one tick late so the click that OPENED the menu cannot
+      // dismiss it. Inside `act` because advancing timers runs React effects.
+      act(() => { vi.advanceTimersByTime(60) })
+      fireEvent.keyDown(window, { key: 'Escape' })
+      // The host really unmounted it — this is the condition the mocked-onClose
+      // tests above never reproduce.
+      expect(menuRows(container)).toHaveLength(0)
+      expect(opener).toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clicking a menuitem unmounts the menu and returns focus to the opener', () => {
+    const onAction = vi.fn()
+    const { container, opener, rows } = openFromOpener(onAction)
+    fireEvent.click(rows[1])
+    expect(onAction).toHaveBeenCalledWith('hide')
+    expect(menuRows(container)).toHaveLength(0)
+    expect(opener).toHaveFocus()
+  })
+
+  it('Enter on the focused menuitem unmounts the menu and returns focus to the opener', () => {
+    const onAction = vi.fn()
+    const { container, opener, rows } = openFromOpener(onAction)
+    // Activation from the keyboard is the path that MATTERS for restore: this
+    // user has no pointer to re-establish a focus position with.
+    fireEvent.keyDown(rows[0], { key: 'Enter' })
+    expect(onAction).toHaveBeenCalledWith('gallery')
+    expect(menuRows(container)).toHaveLength(0)
+    expect(opener).toHaveFocus()
+  })
+
+  it('PIN: an action that moves focus elsewhere ends with focus where the ACTION put it, not on the opener', () => {
+    // Real actions open other surfaces (settings, the dashboard) and focus
+    // something there. Whatever the close/restore ordering, the user must end up
+    // where the action sent them.
+    //
+    // Labelled a PIN rather than a guard test on purpose: `handleAction` calls
+    // `onClose()` before `onAction()`, and in this host the state flush unmounts
+    // the menu inside that first call — so focus is still on a menu row when the
+    // restore cleanup runs, the restore fires, and the action's own `focus()`
+    // lands afterwards and wins on ordering. The `contains` guard is therefore
+    // NOT what makes this pass; the test below is the one that exercises it.
+    let elsewhere: HTMLElement | null = null
+    const utils = render(<MochiMenuHost onAction={() => { elsewhere?.focus() }} />)
+    elsewhere = utils.getByTestId('elsewhere')
+    const opener = utils.getByTestId('opener')
+    opener.focus()
+    fireEvent.click(opener)
+    const rows = menuRows(utils.container)
+    expect(rows[0]).toHaveFocus()
+    fireEvent.click(rows[1])
+    expect(menuRows(utils.container)).toHaveLength(0)
+    expect(elsewhere).toHaveFocus()
+    expect(opener).not.toHaveFocus()
+  })
+
+  it('PIN: dismissing by an outside click leaves focus where the click put it — it is not yanked back to the opener', () => {
+    // The everyday shape of "focus already left the menu on its own": the user
+    // clicked another control, which both focused it and dismissed the menu.
+    // Focus must stay on the control they chose.
+    //
+    // Labelled a PIN, not a guard test, and the reason is worth writing down:
+    // this passes even with the `contains(...)` guard REMOVED, because react-dom
+    // snapshots `document.activeElement` before the mutation phase and re-focuses
+    // it after the commit whenever that node is still in the document. So an
+    // unconditional restore is overwritten right back to `elsewhere` here. The
+    // guard is therefore belt-and-braces in this path rather than the thing that
+    // makes this test pass — no black-box test through React's unmount can
+    // separate the two. Kept because it states the intent at the site, and
+    // because it is the only thing protecting the invariant if the restore is
+    // ever moved off the commit path (e.g. into an explicit Escape handler, the
+    // shape `SlotPopover` uses).
+    vi.useFakeTimers()
+    try {
+      const utils = render(<MochiMenuHost />)
+      const opener = utils.getByTestId('opener')
+      const elsewhere = utils.getByTestId('elsewhere')
+      opener.focus()
+      fireEvent.click(opener)
+      expect(menuRows(utils.container)[0]).toHaveFocus()
+      // Past the 50ms guard so the close-on-outside-mousedown listener is live.
+      act(() => { vi.advanceTimersByTime(60) })
+      // A real click on another control focuses it and then dismisses the menu.
+      elsewhere.focus()
+      fireEvent.mouseDown(document.body)
+      expect(menuRows(utils.container)).toHaveLength(0)
+      expect(elsewhere).toHaveFocus()
+      expect(opener).not.toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/website/src/test/MeetingsAgentPillBar.test.tsx
+++ b/website/src/test/MeetingsAgentPillBar.test.tsx
@@ -5,10 +5,12 @@
 // and the attachment menu's icon-only controls carry accessible labels (the
 // blocking `icon-buttons-need-labels` rule).
 
+import { useState } from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
 import AgentPillBar from '../apps/meetings/components/AgentPillBar'
+import { menuItemsOf } from '../hooks/useMenuKeyboard'
 import type { AgentDef, Attachment, MeetingStatus, Preset } from '../apps/meetings/api'
 
 const AGENTS: AgentDef[] = [
@@ -150,5 +152,333 @@ describe('AgentPillBar', () => {
       const named = button.textContent?.trim() || button.getAttribute('aria-label')
       expect(named, `unlabelled control: ${button.outerHTML.slice(0, 80)}`).toBeTruthy()
     }
+  })
+})
+
+// The attachment menu is `role="menu"`, which promises the WAI-ARIA menu
+// keyboard contract (#6231): arrows move real focus between the ACTIONABLE items
+// and wrap, Home/End jump to the boundaries, Tab is contained inside the open
+// menu, and focus enters the menu on open / returns to the trigger on Escape.
+// The items are the controls (each row's remove button, the footer action), not
+// the layout rows — see `expectedOrder` for why.
+describe('AgentPillBar attachment menu keyboard contract', () => {
+  const TWO: Attachment[] = [
+    { type: 'url', url: 'https://example.test/doc', label: 'Design Doc' },
+    { type: 'url', url: 'https://example.test/spec', label: 'Spec' },
+  ]
+
+  /**
+   * Mount closed, then flip `attachMenuOpen` the way the host does when the
+   * paperclip is clicked — so the hook observes `enabled` transitioning false →
+   * true, which is what arms focus entry. Mounting straight into the open state
+   * would exercise a different (first-render) path than a real open.
+   */
+  function openMenu(overrides: Partial<React.ComponentProps<typeof AgentPillBar>> = {}) {
+    const utils = mount({ attachments: TWO, attachMenuOpen: false, ...overrides })
+    utils.rerender(<AgentPillBar {...utils.props} attachMenuOpen />)
+    return utils
+  }
+
+  /**
+   * The expected traversal order, spelled out positionally rather than queried
+   * from the DOM so the test pins the ORDER too: one stop per ACTIONABLE item —
+   * each row's remove button, then the footer action. Every stop is looked up
+   * BY `role="menuitem"`, because `role="menu"` only permits `menuitem` /
+   * `menuitemradio` / `menuitemcheckbox` / `group` / `separator` as owned
+   * children — a stop wearing any other role (the footer's old `role="button"`)
+   * is an invalid child that assistive tech announces as a loose button inside
+   * a menu rather than an item OF it. The attachment ROWS are deliberately NOT
+   * stops: a row is a layout container with no activation handler, and
+   * `role="menuitem"` subclasses `command`, so announcing a row as a menu item
+   * would promise an Enter/Space activation that does nothing (the same
+   * promise-not-kept defect class as #6231 itself). Menu semantics belong on
+   * the controls, not the row.
+   */
+  function expectedOrder(): HTMLElement[] {
+    return [
+      screen.getByLabelText('Remove Design Doc'),
+      screen.getByLabelText('Remove Spec'),
+      screen.getByRole('menuitem', { name: 'Add a link' }),
+    ]
+  }
+
+  const menu = () => screen.getByRole('menu')
+  const trigger = () => screen.getByLabelText('Manage attachments')
+
+  it('moves focus onto the first remove button when the menu opens', () => {
+    openMenu()
+    expect(expectedOrder()[0]).toHaveFocus()
+  })
+
+  // The hook's own discovery is the thing that decides the traversal, so assert
+  // it directly: any non-actionable row that crept back into the item set would
+  // show up here as an extra stop even if an ordering test happened to pass.
+  it('discovers exactly the actionable controls as menu items — no inert rows', () => {
+    openMenu()
+    expect(menuItemsOf(menu())).toEqual(expectedOrder())
+  })
+
+  // ARIA-owned-children pin: `role="menu"` permits only menuitem /
+  // menuitemradio / menuitemcheckbox / group / separator as its owned children.
+  // The remove controls already carried `menuitem`; the footer action wore
+  // `role="button"` (Clickable hardcodes it), so a screen reader announced the
+  // menu as having TWO items with a stray button loose inside it. Assert all
+  // three stops announce as menuitems, and that the menu owns nothing else.
+  it('announces all three stops as menuitems — role="menu" owns no invalid child', () => {
+    openMenu()
+    expect(screen.getAllByRole('menuitem')).toEqual(expectedOrder())
+    // Nothing inside the menu claims a role `menu` may not own.
+    expect(menu().querySelectorAll('[role="button"]')).toHaveLength(0)
+  })
+
+  it('walks ArrowDown through the remove buttons and the footer in document order, wrapping past the footer', () => {
+    openMenu()
+    const items = expectedOrder()
+    for (let i = 1; i < items.length; i++) {
+      fireEvent.keyDown(menu(), { key: 'ArrowDown' })
+      expect(items[i], `ArrowDown step ${i}`).toHaveFocus()
+    }
+    // Past the last item (the footer action) it wraps back to the first.
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' })
+    expect(items[0]).toHaveFocus()
+  })
+
+  it('walks ArrowUp the other way and wraps from the first item to the footer', () => {
+    openMenu()
+    const items = expectedOrder()
+    fireEvent.keyDown(menu(), { key: 'ArrowUp' })
+    expect(items[items.length - 1]).toHaveFocus()
+    fireEvent.keyDown(menu(), { key: 'ArrowUp' })
+    expect(items[items.length - 2]).toHaveFocus()
+  })
+
+  it('jumps to the boundary items with End and Home', () => {
+    openMenu()
+    const items = expectedOrder()
+    fireEvent.keyDown(menu(), { key: 'End' })
+    expect(items[items.length - 1]).toHaveFocus()
+    fireEvent.keyDown(menu(), { key: 'Home' })
+    expect(items[0]).toHaveFocus()
+  })
+
+  it('contains Tab inside the open menu, wrapping at both ends', () => {
+    openMenu()
+    const items = expectedOrder()
+    fireEvent.keyDown(menu(), { key: 'End' })
+    fireEvent.keyDown(menu(), { key: 'Tab' })
+    expect(items[0], 'Tab off the last item wraps to the first').toHaveFocus()
+    fireEvent.keyDown(menu(), { key: 'Tab', shiftKey: true })
+    expect(items[items.length - 1], 'Shift-Tab off the first item wraps to the last').toHaveFocus()
+  })
+
+  // The point of the traversal is reaching something you can then ACTIVATE.
+  // `role="menuitem"` subclasses `command`, so every stop the arrows land on
+  // owes an activation — a focusable stop that does nothing when pressed is the
+  // defect this surface previously shipped on the row <div>.
+  it('activates the focused remove button, reporting the right attachment index', () => {
+    const onRemoveAttachment = vi.fn()
+    openMenu({ onRemoveAttachment })
+    const items = expectedOrder()
+    // Focus entry already put us on the first remove button; activate it there.
+    expect(items[0]).toHaveFocus()
+    fireEvent.click(document.activeElement as HTMLElement)
+    expect(onRemoveAttachment).toHaveBeenCalledWith(0)
+
+    // Arrow to the second row's remove button and activate that one — the index
+    // has to follow focus, not stay pinned to the first row.
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' })
+    expect(items[1]).toHaveFocus()
+    fireEvent.click(document.activeElement as HTMLElement)
+    expect(onRemoveAttachment).toHaveBeenCalledWith(1)
+  })
+
+  it('activates every discovered menu item — no stop is inert', () => {
+    const onRemoveAttachment = vi.fn()
+    const onAddAttachment = vi.fn()
+    openMenu({ onRemoveAttachment, onAddAttachment })
+    // Walk the hook's OWN item list and activate each stop where the arrows put
+    // focus, then assert the callback each one promises actually fired. An inert
+    // stop (a layout row wearing role="menuitem") lands here as a missing call.
+    const items = menuItemsOf(menu())
+    expect(items).toHaveLength(3)
+    fireEvent.keyDown(menu(), { key: 'Home' })
+    for (const item of items) {
+      expect(document.activeElement).toBe(item)
+      fireEvent.click(document.activeElement as HTMLElement)
+      fireEvent.keyDown(menu(), { key: 'ArrowDown' })
+    }
+    expect(onRemoveAttachment.mock.calls).toEqual([[0], [1]])
+    expect(onAddAttachment).toHaveBeenCalledTimes(1)
+  })
+
+  // Regression PIN for the native activation path: the remove control is a real
+  // <button>, so the browser turns Enter into a click for free — but only if the
+  // menu contract leaves the key alone. This pins that Enter is NOT consumed
+  // (fireEvent returns false when a handler called preventDefault). Asserted via
+  // the event rather than a callback because jsdom/happy-dom do not synthesise
+  // the native Enter→click on a focused button.
+  it('leaves Enter on a focused remove button to the button\'s native activation', () => {
+    openMenu()
+    const focused = document.activeElement as HTMLElement
+    expect(focused).toBe(expectedOrder()[0])
+    expect(fireEvent.keyDown(focused, { key: 'Enter' })).toBe(true)
+  })
+
+  // Regression PIN: Escape already asked the host to close before this wiring.
+  it('asks the host to close the menu on Escape', () => {
+    const onToggleAttachMenu = vi.fn()
+    openMenu({ onToggleAttachMenu })
+    fireEvent.keyDown(menu(), { key: 'Escape' })
+    expect(onToggleAttachMenu).toHaveBeenCalled()
+  })
+
+  it('returns focus to the paperclip trigger on Escape', () => {
+    openMenu()
+    // Focus now sits INSIDE the menu (focus entry on open), so a close that did
+    // not restore would orphan focus on a control that is about to unmount.
+    fireEvent.keyDown(menu(), { key: 'Escape' })
+    expect(trigger()).toHaveFocus()
+  })
+})
+
+// Focus repair for the two HOST-driven paths that can strand focus on <body>.
+// AgentPillBar is CONTROLLED — `attachments` and `attachMenuOpen` are props —
+// so activating an item never changes the menu itself; the host does, on a
+// later render:
+//
+//   (a) a removal keeps the menu OPEN and refreshes `attachments`, so the
+//       index-keyed row holding focus unmounts from under the keyboard user.
+//       Focus falls to <body>, from where Tab escapes the still-open menu and
+//       the container's Escape handler is unreachable (Escape is bound to the
+//       menu element, not the document).
+//   (b) a successful 'Add a link' CLOSES the menu from the host while focus is
+//       still inside it, orphaning focus on <body> instead of handing it back
+//       to the paperclip the way Escape does.
+//
+// These tests drive AgentPillBar through a real controlled host, so the props
+// move the way the app moves them rather than the way a rerender() spells them.
+describe('AgentPillBar attachment menu focus repair (controlled host)', () => {
+  const TWO: Attachment[] = [
+    { type: 'url', url: 'https://example.test/doc', label: 'Design Doc' },
+    { type: 'url', url: 'https://example.test/spec', label: 'Spec' },
+  ]
+
+  interface HostProps {
+    initial?: Attachment[]
+    onAdd?: () => void
+  }
+
+  function Host({ initial = TWO, onAdd }: HostProps) {
+    const [attachments, setAttachments] = useState<Attachment[]>(initial)
+    const [attachMenuOpen, setAttachMenuOpen] = useState(false)
+    return (
+      <>
+        {/* Refreshes the `attachments` prop identity WITHOUT touching the menu's
+            open state — path (a)'s host re-render, reachable from a test without
+            performing a removal (used by the negative test below). */}
+        <button
+          type="button"
+          data-testid="host-refresh"
+          onClick={() => setAttachments(a => [...a])}
+        >
+          refresh
+        </button>
+        <AgentPillBar
+          agents={AGENTS}
+          enabledIds={['note-taker']}
+          mutedAgents={[]}
+          presets={PRESETS}
+          defaultPreset="standup"
+          selectedPreset="standup"
+          status={'idle' as MeetingStatus}
+          attachments={attachments}
+          attachMenuOpen={attachMenuOpen}
+          onPresetChange={vi.fn()}
+          onToggleAgent={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onToggleAttachMenu={() => setAttachMenuOpen(o => !o)}
+          // The real handler opens a prompt and, on success, closes the menu.
+          onAddAttachment={() => {
+            onAdd?.()
+            setAttachMenuOpen(false)
+          }}
+          // The real handler drops the entry and leaves the menu open.
+          onRemoveAttachment={i => setAttachments(a => a.filter((_, n) => n !== i))}
+        />
+      </>
+    )
+  }
+
+  const trigger = () => screen.getByLabelText('Manage attachments')
+  const menu = () => screen.getByRole('menu')
+  const footer = () => screen.getByRole('menuitem', { name: 'Add a link' })
+
+  /** Click the paperclip the way a user does, so the hook sees closed → open. */
+  function openMenu(props: HostProps = {}) {
+    const utils = render(<Host {...props} />)
+    fireEvent.click(trigger())
+    return utils
+  }
+
+  // PIN, and the guard against over-reaching: the restore-to-trigger branch must
+  // not fire on a first render that merely happens to find focus on <body>.
+  it('does not steal focus on mount while the menu is closed', () => {
+    render(<Host />)
+    expect(document.body).toHaveFocus()
+    expect(trigger()).not.toHaveFocus()
+  })
+
+  it('repairs focus onto the first surviving menu item when the focused row is removed', () => {
+    openMenu()
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' })
+    const second = screen.getByLabelText('Remove Spec')
+    expect(second).toHaveFocus()
+    fireEvent.click(second)
+    // The host dropped 'Spec', so the control holding focus unmounted while the
+    // menu stayed open — focus belongs on the menu's first surviving item.
+    expect(screen.queryByText('Spec')).toBeNull()
+    expect(document.body).not.toHaveFocus()
+    expect(menuItemsOf(menu())[0]).toHaveFocus()
+    expect(screen.getByLabelText('Remove Design Doc')).toHaveFocus()
+  })
+
+  it('repairs focus onto the footer action when the LAST attachment is removed', () => {
+    openMenu({ initial: [TWO[0]] })
+    const only = screen.getByLabelText('Remove Design Doc')
+    expect(only).toHaveFocus()
+    fireEvent.click(only)
+    // No rows are left, so the menu's only surviving item is the footer action,
+    // and that is what this implementation focuses (`menuItemsOf(...)[0]`). The
+    // trigger is only the fallback for an open menu with NO items at all.
+    expect(screen.getByText('No attachments')).toBeTruthy()
+    expect(document.body).not.toHaveFocus()
+    expect(footer()).toHaveFocus()
+  })
+
+  it('returns focus to the paperclip when the host closes the menu after "Add a link"', () => {
+    const onAdd = vi.fn()
+    openMenu({ onAdd })
+    fireEvent.keyDown(menu(), { key: 'End' })
+    expect(footer()).toHaveFocus()
+    fireEvent.click(footer())
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).toBeNull()
+    // Focus was inside the menu the host just closed; orphaning it on <body> is
+    // the defect. The paperclip is where Escape already puts it.
+    expect(document.body).not.toHaveFocus()
+    expect(trigger()).toHaveFocus()
+  })
+
+  // NEGATIVE guard: the repair only ever adopts focus that is genuinely LOST
+  // (`document.activeElement === document.body`). A host re-render while focus
+  // sits somewhere legitimate must leave it exactly there.
+  it('does NOT steal focus when a host re-render arrives while focus sits on the trigger', () => {
+    openMenu()
+    // Park focus back on the paperclip with the menu still open — a legitimate
+    // place for it (Shift-Tab reach, or a pointer click on the trigger itself).
+    trigger().focus()
+    fireEvent.click(screen.getByTestId('host-refresh'))
+    // The `attachments` identity changed, so the effect re-ran; it must no-op.
+    expect(trigger()).toHaveFocus()
   })
 })

--- a/website/src/test/MicSourceMenu.test.tsx
+++ b/website/src/test/MicSourceMenu.test.tsx
@@ -207,6 +207,134 @@ describe('MicSourceMenu', () => {
   })
 })
 
+describe('MicSourceMenu keyboard navigation', () => {
+  // The dropdown declares role="menu", which promises the WAI-ARIA menu
+  // keyboard contract (arrows move focus between rows and wrap, Home/End jump
+  // to the boundaries, Tab is contained while the menu is open). None of that
+  // existed here: the rows were reachable only by mouse or by Tabbing blindly
+  // out of the trigger, and a screen-reader user who was just told "menu" got
+  // nothing from the arrow keys they reach for first (#6231).
+  beforeEach(() => {
+    localStorage.clear()
+    mockDevices()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  /** The menu is PORTALLED to <body>, so it lives outside the RTL container. */
+  const menuEl = () => document.querySelector('[role="menu"]') as HTMLElement | null
+  /** Rows in document order: one per device, then "System default". */
+  const rowsOf = () => Array.from(menuEl()!.querySelectorAll<HTMLButtonElement>('button'))
+
+  /**
+   * Open the menu and wait for enumeration to land, so the row list under test
+   * is the full one (devices are fetched when the menu opens, not on mount).
+   * Returns the trigger, which must be grabbed BEFORE opening: once the menu is
+   * up, `getByRole('button')` is ambiguous.
+   */
+  async function openWithDevices() {
+    render(<MicSourceMenu onSelect={() => {}} />)
+    const trigger = screen.getByRole('button')
+    fireEvent.click(trigger)
+    await screen.findByText('AirPods Pro')
+    return trigger
+  }
+
+  it('moves focus into the menu when it opens', async () => {
+    await openWithDevices()
+    // role="menu" tells assistive tech that focus is managed inside the menu,
+    // so opening must land the user there rather than leaving focus on the
+    // trigger with the menu an unreachable island.
+    expect(menuEl()!.contains(document.activeElement)).toBe(true)
+    expect(rowsOf()).toContain(document.activeElement)
+  })
+
+  it('lands on the first device row when the device list is already known', async () => {
+    // Second open: `devices` state survived the first one, so the first row at
+    // focus-entry time is a real device row (the case a keyboard user hits for
+    // every open after the first).
+    const trigger = await openWithDevices()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.click(trigger)
+    await screen.findByRole('menu')
+    const rows = rowsOf()
+    expect(rows[0].textContent).toContain('MacBook Pro Microphone')
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('walks the rows with ArrowDown and wraps past the last one', async () => {
+    await openWithDevices()
+    const rows = rowsOf()
+    expect(rows).toHaveLength(3) // two audio inputs + "System default"
+    rows[0].focus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(rows[1]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    // The action row is part of the same cycle as the device rows — a user
+    // arrowing down must be able to reach "System default".
+    expect(rows[2].textContent).toContain('System default')
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(rows[0]).toHaveFocus() // wraps, rather than dead-ending
+  })
+
+  it('walks the rows with ArrowUp and wraps past the first one', async () => {
+    await openWithDevices()
+    const rows = rowsOf()
+    rows[0].focus()
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('jumps to the boundary rows with Home and End', async () => {
+    await openWithDevices()
+    const rows = rowsOf()
+    rows[1].focus()
+    fireEvent.keyDown(document, { key: 'End' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Home' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('contains Tab and Shift-Tab inside the open menu', async () => {
+    // #2533: a Tab out of a still-open menu drops a keyboard user behind it
+    // with no obvious way back — the menu is portalled to <body>, so the next
+    // tab stop is nowhere near the composer they came from.
+    await openWithDevices()
+    const rows = rowsOf()
+    rows[2].focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(rows[0]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(rows[2]).toHaveFocus()
+  })
+
+  it('closes on Escape and hands focus back to the trigger', async () => {
+    // "Escape closes" is a pin on existing behaviour; the focus restore is the
+    // new part. Focus now ENTERS the menu on open, so closing without a restore
+    // would orphan focus on <body> and lose the user's place entirely.
+    const trigger = await openWithDevices()
+    expect(trigger).not.toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(menuEl()).toBeNull()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('hands focus back to the trigger after picking a row', async () => {
+    const onSelect = vi.fn()
+    render(<MicSourceMenu onSelect={onSelect} />)
+    const trigger = screen.getByRole('button')
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByText('AirPods Pro'))
+    expect(onSelect).toHaveBeenCalledWith('airpods') // pin: the pick still reports
+    expect(menuEl()).toBeNull()
+    // The focused row is unmounted by the close, so without a restore focus
+    // falls to <body> and the next Tab restarts from the top of the document.
+    expect(trigger).toHaveFocus()
+  })
+})
+
 describe('mic device identity helpers', () => {
   beforeEach(() => localStorage.clear())
 

--- a/website/src/test/MochiPackEditorCoverage.test.tsx
+++ b/website/src/test/MochiPackEditorCoverage.test.tsx
@@ -391,7 +391,10 @@ describe('PackEditor — slot popover', () => {
     fireEvent.keyDown(slot('Peeking'), { key: 'Enter' })
     expect(screen.getByRole('menu').getAttribute('aria-label')).toBe('Peeking')
 
-    fireEvent.keyDown(slot('Peeking'), { key: 'Escape' })
+    // A key the slot does not own leaves the open popover alone. This probe used
+    // to be Escape; Escape is now the popover's dismissal (#6231, required
+    // because Tab is contained inside the menu), so an inert key stands in.
+    fireEvent.keyDown(slot('Peeking'), { key: 'x' })
     expect(screen.getByRole('menu')).toBeTruthy()
 
     fireEvent.mouseDown(document.body)
@@ -709,5 +712,137 @@ describe('PackEditor — edit mode', () => {
     pending.resolve(detailWithRequiredStates())
     await pending.promise
     expect(screen.queryByText('Edit Pack')).toBeNull()
+  })
+})
+
+// ── The slot popover's keyboard contract (#6231) ────────────────────────────
+
+/**
+ * The popover carries `role="menu"`, which promises the WAI-ARIA menu keyboard
+ * contract: focus enters the menu on open, arrows move between rows and wrap at
+ * both ends, Home/End jump to the boundaries, and Tab is contained inside the
+ * menu. Because Tab is contained, dismissal has to exist too — Escape closes
+ * the popover and hands focus back to the slot that opened it, or a keyboard
+ * user would be stuck cycling the rows forever.
+ *
+ * The rows are addressed by index rather than by name: the contract is about
+ * ORDER, and the copy-source rows in the middle vary with what is filled.
+ */
+describe('PackEditor — slot popover keyboard contract', () => {
+  /** The open menu's rows, in DOM order. */
+  function items(): HTMLElement[] {
+    return within(screen.getByRole('menu')).getAllByRole('menuitem')
+  }
+
+  /**
+   * Fill two slots and open Idle's popover FROM THE KEYBOARD, with the slot card
+   * genuinely focused so the focus-restore assertion has a real opener to return
+   * to. Idle's menu then has three rows — Select File / the Walking copy source
+   * / Clear — which is the minimum that tells a wrap apart from a clamp.
+   */
+  async function openIdleMenu(): Promise<HTMLElement> {
+    await importInto('Idle', svgFile('idle'))
+    copyInto('Walking', 'Idle')
+    const card = slot('Idle')
+    card.focus()
+    fireEvent.keyDown(card, { key: 'Enter' })
+    expect(items().map((el) => el.textContent?.trim()))
+      .toEqual(['Select File', 'Walking', 'Clear'])
+    return card
+  }
+
+  it('moves focus onto the first row when the popover opens', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    await openIdleMenu()
+
+    // role="menu" tells assistive tech that focus is managed here, so a
+    // keyboard user must land inside the menu they were just told is open.
+    expect(items()[0]).toHaveFocus()
+  })
+
+  it('walks the rows with ArrowDown/ArrowUp and wraps at both ends', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    await openIdleMenu()
+
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(items()[1]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(items()[2]).toHaveFocus()
+    // Last row → wraps forward to the first, not a clamp.
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(items()[0]).toHaveFocus()
+    // First row → wraps backward to the last.
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(items()[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(items()[1]).toHaveFocus()
+  })
+
+  it('jumps to the boundary rows on End and Home', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    await openIdleMenu()
+
+    fireEvent.keyDown(document, { key: 'End' })
+    expect(items()[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Home' })
+    expect(items()[0]).toHaveFocus()
+  })
+
+  it('contains Tab and Shift-Tab inside the menu', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    await openIdleMenu()
+
+    // A Tab off the last row would drop the user behind the still-open popover
+    // with no obvious way back (#2533), so it cycles to the first row instead.
+    fireEvent.keyDown(document, { key: 'End' })
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(items()[0]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(items()[2]).toHaveFocus()
+  })
+
+  it('closes on Escape and hands focus back to the slot that opened it', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    const card = await openIdleMenu()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+    // Focus must not be left on a row that no longer exists: it goes back to
+    // the opener, the way MenuBtn returns focus to its trigger.
+    expect(card).toHaveFocus()
+  })
+
+  // Escape is not the only dismissal that unmounts the focused row: EVERY menu
+  // command closes the popover too, and the row the user just activated is the
+  // active element at that moment. Without a focus restore the activeElement
+  // falls back to <body> and the keyboard user is stranded at the top of the
+  // document — worse than Escape, because activating a command is the COMMON
+  // path. These two pin the copy row and Clear, the commands whose actions stay
+  // in-process (Select File hands off to a native file dialog).
+  it('returns focus to the opener when the focused "use same as" row is activated', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    const card = await openIdleMenu()
+
+    // Walk to the copy row the way a keyboard user does, then activate it.
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(items()[1]).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).not.toBe(document.body)
+    expect(card).toHaveFocus()
+  })
+
+  it('returns focus to the opener when the focused Clear row is activated', async () => {
+    render(<PackEditor onSave={vi.fn()} onCancel={vi.fn()} />)
+    const card = await openIdleMenu()
+
+    fireEvent.keyDown(document, { key: 'End' })
+    expect(items()[2]).toHaveFocus()
+    fireEvent.click(items()[2])
+
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).not.toBe(document.body)
+    expect(card).toHaveFocus()
   })
 })

--- a/website/src/test/PierreWorkspaceTreeImpl.test.tsx
+++ b/website/src/test/PierreWorkspaceTreeImpl.test.tsx
@@ -556,3 +556,74 @@ describe('PierreWorkspaceTreeImpl — row context menu', () => {
     expect(onAddToContext).toHaveBeenCalledWith(`${ROOT}/src/weird\\name.txt`, 'file')
   })
 })
+
+describe('PierreWorkspaceTreeImpl — row context menu keyboard contract (#6231)', () => {
+  // The DEGENERATE case of the shared `role="menu"` contract: this menu hosts
+  // exactly ONE menuitem, so every focus-move assertion is vacuously true —
+  // "focus lands on the next item" and "focus does not move" are the same
+  // observation. What the contract still owes a keyboard user is CONSUMPTION:
+  // an arrow inside an open menu must not scroll the page behind it, and a Tab
+  // must not drop the user out of a menu they were just told is open (#2533).
+  // These tests therefore assert on `fireEvent`'s return value — false means
+  // `preventDefault()` was called, i.e. the contract claimed the key — which is
+  // the only signal that distinguishes wired from unwired on a one-item menu.
+  const openMenu = (item: MenuItem) => {
+    const context: MenuContext = {
+      anchorElement: document.createElement('div'),
+      anchorRect: document.createElement('div').getBoundingClientRect(),
+      close: vi.fn(),
+      restoreFocus: vi.fn(),
+    }
+    const node = treeMock.fileTreeProps.at(-1)!.renderContextMenu!(item, context)
+    return render(<>{node}</>)
+  }
+
+  /** Open the row menu and hand back its single item, focused (the
+   *  component's own firstItemRef effect owns that focus entry). */
+  const openSingleItemMenu = async () => {
+    renderTree({ onAddToContext: vi.fn() })
+    await waitForTree()
+    openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    const menuitem = screen.getByRole('menuitem', { name: 'Add to chat' })
+    expect(menuitem).toHaveFocus()
+    return menuitem
+  }
+
+  it.each(['ArrowDown', 'ArrowUp', 'Home', 'End'])(
+    'consumes %s rather than letting it scroll the page behind the open menu',
+    async key => {
+      const menuitem = await openSingleItemMenu()
+
+      // false = preventDefault() was called: the menu contract claimed the key.
+      expect(fireEvent.keyDown(menuitem, { key })).toBe(false)
+      // One item, so navigation is a no-op — but it is a no-op that STAYS
+      // inside the menu rather than moving focus nowhere useful.
+      expect(menuitem).toHaveFocus()
+    },
+  )
+
+  it.each([
+    ['Tab', false],
+    ['Shift+Tab', true],
+  ] as const)('contains %s within the menu instead of dropping focus behind it', async (_label, shiftKey) => {
+    const menuitem = await openSingleItemMenu()
+
+    // The single item is simultaneously the first and the last item, so both
+    // Tab directions sit on a containment boundary and must wrap onto it.
+    expect(fireEvent.keyDown(menuitem, { key: 'Tab', shiftKey })).toBe(false)
+    expect(menuitem).toHaveFocus()
+  })
+
+  it('leaves a key the menu contract does not own alone', async () => {
+    // Regression PIN, not new behaviour: Enter still belongs to the item's own
+    // activation handler, and the contract must not swallow it on the way.
+    const onAddToContext = vi.fn()
+    renderTree({ onAddToContext })
+    await waitForTree()
+    openMenu({ kind: 'file', name: 'b.ts', path: 'src/a/b.ts' })
+    const menuitem = screen.getByRole('menuitem', { name: 'Add to chat' })
+
+    fireEvent.keyDown(menuitem, { key: 'Enter' })
+    expect(onAddToContext).toHaveBeenCalledWith(`${ROOT}/src/a/b.ts`, 'file')
+  })
+})


### PR DESCRIPTION
Fixes #6231

## What

Five containers declare `role="menu"` — which tells assistive technology that arrow keys move between items (WAI-ARIA menu pattern) — and none of them implemented that movement. This PR **replicates an in-repo, already-correct implementation rather than designing one**: `MenuBtn` in `website/src/pages/DevFleetPage.tsx` (landed via #6226) already carries the full contract. Its roving-focus keydown logic is extracted into one shared hook, `website/src/hooks/useMenuKeyboard.ts` (beside `useListboxKeyboard`), and the five surfaces are wired onto it:

| Surface | Adaptation |
|---|---|
| `apps/meetings/components/AgentPillBar.tsx` | menu semantics on the actual controls: each remove button carries `role="menuitem"`, the footer "Add a link" is a native `<button role="menuitem">`; a focus-repair effect covers host-driven list refreshes and menu closes; Escape restores focus to the trigger |
| `components/MicSourceMenu.tsx` | attach-only (rows were already `role="menuitemradio"` buttons); Escape/selection restore focus to the trigger |
| `apps/mochi/src/renderer/ContextMenu.tsx` | attach + guarded `useLayoutEffect` unmount focus restore (opener captured at first render) |
| `apps/mochi/src/renderer/PackEditor.tsx` (SlotPopover) | attach + `closeToOpener()`: Escape and every menu command restore focus; outside-pointer dismissal deliberately does not |
| `pierre/PierreWorkspaceTreeImpl.tsx` | attach-only — **a semantic no-op**: this menu hosts exactly one menuitem, so there is nothing to navigate between; wired for contract consistency (arrows consumed instead of scrolling the tree; Tab contained), not claimed as a fifth behavioural fix |

The contract: ArrowDown/ArrowUp move real DOM focus and **wrap at both ends**, Home/End jump to boundary items, Tab/Shift-Tab are **contained** within enabled items (#2533), an IME composition latch keeps candidate-navigation keys out (#5851), and focus enters the menu on open. Focus-entry's dual: every explicit dismissal restores focus (two sanctioned postures, documented on the hook).

**Zero `i18n` changes** — no locale bundle touched, no visible label, ordering, or click behaviour changed.

## Why not `useListboxKeyboard`

The issue's DIRECTION section framed this as extend-the-listbox-hook vs extract-a-new-primitive. The three cited properties of `useListboxKeyboard` are real, but the conclusion drawn from them was false — `MenuBtn` is a closer, already-correct `role="menu"` implementation that resolves all three, so the contract was **already settled by #6226**, not an open design question:

1. Listbox Tab calls `closeToTrigger()` (`useListboxKeyboard.ts` ~106) → `MenuBtn` **contains** Tab within enabled items (now `useMenuKeyboard.ts`, Tab branch).
2. Listbox ArrowDown clamps, `els[i+1] ?? els[els.length-1]` (~117), no wrap → `MenuBtn` wraps at both ends via the `% focusable.length` modulo.
3. Listbox scopes its IME guard to the filter input → `MenuBtn` uses the document-level `useDocumentImeLatch`, which a menu (no editable target) needs.

`useListboxKeyboard` is untouched.

## Why `DevFleetPage.tsx` is in the diff

The issue explicitly asks for "no fifth inline spelling". `MenuBtn` itself is refactored onto the extracted helper — leaving the original inline would have made a **sixth** spelling. Its existing tests pass **unchanged** (92/92): that is the extraction's behaviour-preservation proof.

## Review-driven hardening (rounds 1–2, both local lanes)

- **mochi ContextMenu**: focus entry without restore was a regression — fixed with an opener captured at first render and a **guarded `useLayoutEffect` unmount cleanup**. The layout phase is load-bearing: a passive `useEffect` cleanup runs after the node is detached (activeElement already reset to `<body>`) and silently never fires — mutation-tested (`useLayoutEffect`→`useEffect` flips 3 tests red). The `contains` guard is not black-box detectable through React's commit path (react-dom's selection-restore masks it); kept for intent and non-commit-path futures, documented in code and tests.
- **AgentPillBar**: rows are layout divs, not menuitems (`menuitem` subclasses `command`; an inert row is the same promise-not-kept defect class as #6231 itself); menu semantics sit on the controls. A focus-repair effect adopts focus **only when it genuinely fell to `<body>`** after a host-driven attachments refresh (index-keyed rows remount) or menu close — covered by controlled-host tests that really mutate state.
- **SlotPopover**: `closeToOpener()` centralised; the action → close → focus order is preserved (correct for the Select File native-dialog path).
- Helper-test fixture rebuilt with DOM APIs to honour the repo's blocking frontend-security rule (no HTML-string writes).

## Honest disclosures

- **MicSourceMenu first-open focus target**: devices are enumerated when the menu opens (async), so the first open lands on "System default"; subsequent opens land on the first device row. Both pinned by tests. The cause is the focus-entry effect's dependency list — a dependency-shaped follow-up, not a redesign; out of this fix's scope.
- **One pre-existing test edited** (`MochiPackEditorCoverage.test.tsx`): its "unowned key" probe used Escape and asserted the popover stays open — invalidated by the (required) Escape dismissal; probe key moved to inert `x`.
- **A sixth sibling exists outside this issue's inventory**: `apps/crew-companion/ContextMenu.tsx` has `role="menuitem"` rows with **no** `role="menu"` container. Filed as #6266.
- **Tab-containment shape is boundary-keyed** (inherited verbatim from `MenuBtn` — changing it would invalidate the 92/92 extraction proof): an orphaned activeElement escapes via Tab until arrows re-enter. The AgentPillBar focus-repair effect removes the one reachable path to that state in this diff.

## Verification

- **Red before green, per surface and per review round**: every behavioural test confirmed failing pre-fix (Pierre's single-item case via event-consumption assertions — `fireEvent.keyDown(...) === false` — since focus assertions are vacuous there).
- **Mutation checks**: wiring reverted per surface → red → byte-identical restore; the **wrap modulo** replaced with a clamp → caught by helper + DevFleetPage tests; focus-repair effect removed → 3 red; `useLayoutEffect`→`useEffect` → 3 red.
- **Extraction proof**: DevFleetPage's 92 tests pass unchanged.
- **Gates**: full website suite **25,010 passed / 0 failed**; `tsc -b` clean; eslint 0 errors, warnings on touched files byte-identical to `origin/main`.
- **Zero-regression proofs vs an `origin/main` worktree**: electron failing set 43 = 43 byte-identical; backend cross-surface guards 54 = 54 byte-identical (pre-existing environmental; `comm` empty both directions).
- Re-verified after each rebase onto moved main (all touched suites 272/272 at `fe49a46`).

### Evidence — focus-trace assertion dump (keyboard behaviour does not screenshot)

```
✓ AgentPillBar attachment menu keyboard contract > moves focus onto the first remove button when the menu opens
✓ AgentPillBar attachment menu keyboard contract > walks ArrowDown ... wrapping past the footer
✓ AgentPillBar attachment menu keyboard contract > jumps to the boundary items with End and Home
✓ AgentPillBar attachment menu keyboard contract > contains Tab inside the open menu, wrapping at both ends
✓ AgentPillBar attachment menu keyboard contract > announces all three stops as menuitems — role="menu" owns no invalid child
✓ AgentPillBar attachment menu keyboard contract > returns focus to the paperclip trigger on Escape
✓ focus repair (controlled host) > repairs focus onto the first surviving menu item when the focused row is removed
✓ focus repair (controlled host) > returns focus to the paperclip when the host closes the menu after "Add a link"
```

<!-- no-visual-delta -->
**Why no screenshot:** this PR changes keyboard focus behaviour only — no pixel renders differently, so a still frame cannot show the delta. Per the task spec, evidence is the focus-trace assertion dump above (real DOM focus moves asserted per keystroke) instead of a screenshot.
