### PR TITLE
fix(cron): validate job_id/run_id URL path params on the cron routes

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -64,6 +64,24 @@ _CRON_BUSY_STATUS = 409
 _CRON_BUSY_BODY = {"error": "cron store busy, please retry", "retryable": True}
 
 
+def _invalid_path_id_response(value: str, name: str) -> web.Response | None:
+    """Guard a URL path id (job_id/run_id/folder_id) for non-empty, bounded length.
+
+    Returns a 400 ``invalid_<name>`` response when ``value`` is empty or longer
+    than ``MAX_SHORT_STRING``, else ``None``. This is the single validator the
+    cron routes apply to every path-param id — the job/run routes and both
+    cron-folder routes — so a malformed id is rejected before any lock
+    acquisition, thread dispatch, or state lookup (the asymmetric-perimeter gap
+    #5789/#5808 closed). These ids are server-minted, so an over-long value only
+    arrives from a malformed/hostile client.
+    """
+    if not value or len(value) > MAX_SHORT_STRING:
+        return web.json_response(
+            {"error": f"invalid {name} format", "code": f"invalid_{name}"}, status=400
+        )
+    return None
+
+
 def _sel():
     """Late-binding _sel() for test monkeypatch compatibility."""
     import kiro_crew.dashboard.handlers as _pkg  # noqa: F811
@@ -302,6 +320,8 @@ async def api_cron_delete(request: web.Request) -> web.Response:
     """DELETE /api/crons/{id} — remove a cron job."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     try:
         ok = await state.crons.remove_job_async(
             job_id, actor="dashboard", source="api_cron_delete"
@@ -390,6 +410,8 @@ async def api_cron_update(request: web.Request) -> web.Response:
     """PATCH /api/crons/{id} — update a cron job (partial)."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     try:
         body = await request.json()
     except Exception:
@@ -504,6 +526,8 @@ async def api_cron_run(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/run — trigger immediate execution."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     # Freshness-guaranteed lookup: this endpoint is handed a job id minted by
     # ANOTHER process (`kirocrew cron add`, the MCP cron_add tool), which writes
     # crons.json directly. The cache-only `list_jobs()` would not see that job
@@ -541,6 +565,8 @@ async def api_cron_cancel(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/cancel — cancel a running execution."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     jobs = state.crons.list_jobs(include_disabled=True)
     job = next((j for j in jobs if j.id == job_id), None)
     if not job:
@@ -557,6 +583,8 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/to-chat — open last result in a chat session."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     slot_name = f"cron-{job_id}"
     jobs = state.crons.list_jobs(include_disabled=True)
     job = next((j for j in jobs if j.id == job_id), None)
@@ -605,6 +633,8 @@ async def api_cron_enable(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/enable — toggle enable/disable."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     try:
         body = await request.json()
     except Exception:
@@ -623,6 +653,8 @@ async def api_cron_ack(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/ack — acknowledge a cron notification."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     try:
         body = await request.json()
     except Exception:
@@ -642,6 +674,8 @@ async def api_cron_history(request: web.Request) -> web.Response:
     """GET /api/crons/{id}/history — paginated execution history (no trace)."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     try:
         limit = int(request.query.get("limit", "20"))
     except (ValueError, TypeError):
@@ -662,7 +696,11 @@ async def api_cron_history_detail(request: web.Request) -> web.Response:
     """GET /api/crons/{id}/history/{run_id} — full run detail with trace."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     run_id = request.match_info["run_id"]
+    if (_e := _invalid_path_id_response(run_id, "run_id")) is not None:
+        return _e
     detail = await state.crons.get_history().get_run_detail(job_id, run_id)
     if not detail:
         return web.json_response({"error": "run not found"}, status=404)
@@ -770,6 +808,8 @@ async def api_cron_script_source(request: web.Request) -> web.Response:
     """
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
+    if (_e := _invalid_path_id_response(job_id, "job_id")) is not None:
+        return _e
     # Freshness-guaranteed lookup, same rationale as api_cron_run: the job may
     # have been minted by another process and not yet be in the cache snapshot.
     job = await state.crons.get_job_async(job_id)
@@ -1376,10 +1416,8 @@ async def api_cron_folders_update(request: web.Request) -> web.Response:
     """PATCH /api/cron-folders/{folder_id} — rename a cron folder."""
     state: DashboardState = request.app["state"]
     folder_id = request.match_info["folder_id"]
-    if not folder_id or len(folder_id) > MAX_SHORT_STRING:
-        return web.json_response(
-            {"error": "invalid folder_id format", "code": "invalid_folder_id"}, status=400
-        )
+    if (_e := _invalid_path_id_response(folder_id, "folder_id")) is not None:
+        return _e
     try:
         body = await request.json()
     except Exception:
@@ -1414,10 +1452,8 @@ async def api_cron_folders_delete(request: web.Request) -> web.Response:
     """DELETE /api/cron-folders/{folder_id} — delete folder and clear assignments."""
     state: DashboardState = request.app["state"]
     folder_id = request.match_info["folder_id"]
-    if not folder_id or len(folder_id) > MAX_SHORT_STRING:
-        return web.json_response(
-            {"error": "invalid folder_id format", "code": "invalid_folder_id"}, status=400
-        )
+    if (_e := _invalid_path_id_response(folder_id, "folder_id")) is not None:
+        return _e
     async with _get_cron_folders_lock():
         try:
             found = await asyncio.to_thread(state.delete_cron_folder, folder_id)

--- a/test/test_dashboard_cron_path_id.py
+++ b/test/test_dashboard_cron_path_id.py
@@ -1,0 +1,153 @@
+"""Tests for the job_id / run_id URL path-parameter guard on the cron routes.
+
+PR #5789 (issue #5765) added a length/type guard to the ``folder_id`` URL path
+parameter on the cron-folder PATCH/DELETE routes, matching the body-param guard
+the job routes already apply. This locks in the parity follow-up (#5808): the
+sibling ``job_id`` / ``run_id`` URL path parameters on the cron job routes are
+now rejected with a 400 ``invalid_<name>`` BEFORE any lock acquisition, thread
+dispatch, or state lookup — closing the same asymmetric-perimeter gap.
+
+Each test drives the handler directly with a mocked request whose
+``match_info`` carries an over-long or empty id, and asserts the downstream
+state seam is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.handlers.cron import (
+    api_cron_ack,
+    api_cron_cancel,
+    api_cron_delete,
+    api_cron_enable,
+    api_cron_history,
+    api_cron_history_detail,
+    api_cron_run,
+    api_cron_script_source,
+    api_cron_to_chat,
+    api_cron_update,
+)
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.validation import MAX_SHORT_STRING
+
+# An id one character past the bound. These ids are server-minted, so an
+# over-long value only arrives from a malformed/hostile client.
+_TOO_LONG = "a" * (MAX_SHORT_STRING + 1)
+
+
+def _make_state() -> MagicMock:
+    """A state whose every cron seam is a spy, so a guard breach is visible as
+    an unexpected call."""
+    state = MagicMock(spec=DashboardState)
+    state.crons = MagicMock()
+    state.crons.remove_job_async = AsyncMock(return_value=True)
+    state.crons.update_job_async = AsyncMock()
+    state.crons.get_job_async = AsyncMock(return_value=None)
+    state.crons.list_jobs = MagicMock(return_value=[])
+    state.crons.enable_job_async = AsyncMock(return_value=True)
+    state.crons.ack_job_async = AsyncMock(return_value=True)
+    state.crons.get_history = MagicMock()
+    state.crons.get_history.return_value.get_job_history = AsyncMock(return_value=([], 0))
+    state.crons.get_history.return_value.get_run_detail = AsyncMock(return_value=None)
+    state.crons.get_history.return_value.delete_job_history = AsyncMock()
+    state.push_refresh = MagicMock()
+    return state
+
+
+def _request(state, *, match_info, body=None, query=None):
+    request = MagicMock()
+    request.app = {"state": state}
+    request.match_info = match_info
+    request.query = query or {}
+    if body is not None:
+        request.json = AsyncMock(return_value=body)
+    else:
+        request.json = AsyncMock(return_value={})
+    return request
+
+
+# (handler, match_info builder for a bad job_id, the state attr that must NOT be
+# reached once the guard fires)
+_JOB_ID_HANDLERS = [
+    (api_cron_delete, "remove_job_async"),
+    (api_cron_update, "update_job_async"),
+    (api_cron_run, "get_job_async"),
+    (api_cron_cancel, "list_jobs"),
+    (api_cron_to_chat, "list_jobs"),
+    (api_cron_enable, "enable_job_async"),
+    (api_cron_ack, "ack_job_async"),
+    (api_cron_history, "get_history"),
+    (api_cron_history_detail, "get_history"),
+    (api_cron_script_source, "get_job_async"),
+]
+
+
+class TestJobIdPathGuard:
+    @pytest.mark.parametrize("handler,seam", _JOB_ID_HANDLERS)
+    @pytest.mark.parametrize("bad_id", [_TOO_LONG, ""])
+    @pytest.mark.asyncio
+    async def test_rejects_bad_job_id_before_state(self, handler, seam, bad_id):
+        """An empty or over-long job_id path param is a 400 invalid_job_id,
+        and the downstream state seam is never reached."""
+        state = _make_state()
+        # history_detail also reads run_id; supply a valid one so the run_id
+        # guard cannot be what rejects this request.
+        match_info = {"job_id": bad_id, "run_id": "run-1"}
+        request = _request(state, match_info=match_info, body={"enabled": True})
+        resp = await handler(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_job_id"
+        getattr(state.crons, seam).assert_not_called()
+
+
+class TestRunIdPathGuard:
+    """api_cron_history_detail reads BOTH job_id and run_id from the path."""
+
+    @pytest.mark.parametrize("bad_id", [_TOO_LONG, ""])
+    @pytest.mark.asyncio
+    async def test_rejects_bad_run_id_before_state(self, bad_id):
+        state = _make_state()
+        request = _request(state, match_info={"job_id": "job-1", "run_id": bad_id})
+        resp = await api_cron_history_detail(request)
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_run_id"
+        state.crons.get_history.return_value.get_run_detail.assert_not_called()
+
+
+class TestValidIdsPass:
+    """A valid, bounded id flows through the guard to the normal handler path
+    (the guard must not narrow the accepted set)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_job_id_reaches_state(self):
+        state = _make_state()
+        request = _request(state, match_info={"job_id": "job-1"})
+        resp = await api_cron_delete(request)
+        # Guard passed: the delete seam was invoked and returned ok.
+        assert resp.status == 200
+        state.crons.remove_job_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_max_length_job_id_is_accepted(self):
+        """Exactly MAX_SHORT_STRING is the boundary — accepted, not rejected."""
+        state = _make_state()
+        request = _request(state, match_info={"job_id": "a" * MAX_SHORT_STRING})
+        resp = await api_cron_delete(request)
+        assert resp.status == 200
+        state.crons.remove_job_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_valid_run_id_reaches_history(self):
+        state = _make_state()
+        request = _request(state, match_info={"job_id": "job-1", "run_id": "run-1"})
+        resp = await api_cron_history_detail(request)
+        # get_run_detail returns None -> 404 run not found, but the guard let it
+        # through to the state seam, which is the point.
+        assert resp.status == 404
+        state.crons.get_history.return_value.get_run_detail.assert_awaited_once_with(
+            "job-1", "run-1"
+        )


### PR DESCRIPTION
## Problem / Motivation

PR #5789 (issue #5765) added length/type validation for the `folder_id` URL
path parameter on the cron-folder PATCH/DELETE routes, matching the guard the
job routes already apply to the `folder_id` **body** param. Review (First
Principles) surfaced that the sibling **`job_id` / `run_id` URL path
parameters** on the cron job routes in
`src/kiro_crew/dashboard/handlers/cron.py` have the same unguarded shape:

- `job_id` is read from `request.match_info["job_id"]` in
  `api_cron_delete`, `api_cron_update`, `api_cron_run`, `api_cron_cancel`,
  `api_cron_to_chat`, `api_cron_enable`, `api_cron_ack`, `api_cron_history`,
  `api_cron_history_detail`, and `api_cron_script_source` — with no
  length/type guard.
- `run_id` is read from `request.match_info["run_id"]` in
  `api_cron_history_detail` — likewise unguarded.

Each flowed straight into a lock acquisition / thread dispatch / state lookup
with no pre-validation — the same "asymmetric perimeter" argument #5765 was
filed on.

## Why it matters

Low severity — these ids are server-minted, so an over-long value only arrives
from a malformed or hostile client, and today it just results in a not-found
after some lock/lookup work (bounded by aiohttp's ~8 KB request-line cap). But
it is the same consistency gap #5789 closed: the folder route now validates its
path param while the sibling job/run routes do not. Closing it makes the
perimeter uniform and fails a malformed request fast, before any lock, thread,
list iteration, or log noise.

## What changed (motivation → approach → change)

**Symptom → root cause:** the `folder_id` path param is now guarded but the
`job_id`/`run_id` path params are not, so a malformed id on the job routes
still does lock/lookup work before failing.

**Approach:** the issue proposed either inlining the same guard per handler or
enforcing it once at route registration via an aiohttp route regex. A route
regex was rejected because a non-match yields a **404**, which would break the
`invalid_*` **400** error-contract the body-param guards (and #5789) use. With
11 call sites, inlining the guard verbatim (as #5789 did for its 2 sites) would
duplicate it ten times, so instead I added a small shared helper.

**Change:** a module-level `_invalid_path_id_response(value, name)` helper
returns a `400 {"error": "invalid <name> format", "code": "invalid_<name>"}`
response when the id is empty or longer than `MAX_SHORT_STRING`, else `None`.
It is called immediately after each `match_info` read (via an assignment
expression: `if (_e := _invalid_path_id_response(job_id, "job_id")) is not None: return _e`),
so a malformed id is rejected before any lock/thread/state work.
`api_cron_history_detail` guards both `job_id` and `run_id`. The helper mirrors
the exact error shape #5789 used for `folder_id` and removes the per-handler
duplication that guard inlined.

## Tests

New `test/test_dashboard_cron_path_id.py`:

- **`TestJobIdPathGuard`** — parametrized over all 10 job-id handlers × {empty,
  over-long} id: asserts each returns `400` with `code == "invalid_job_id"` and
  that the downstream state seam (`remove_job_async`, `update_job_async`,
  `get_job_async`, `list_jobs`, `enable_job_async`, `ack_job_async`,
  `get_history`) is **never reached** — proving the guard fires before any
  lock/thread/state work.
- **`TestRunIdPathGuard`** — `api_cron_history_detail` with a valid `job_id` and
  an empty/over-long `run_id`: `400` `invalid_run_id`, and `get_run_detail` is
  never called.
- **`TestValidIdsPass`** — a normal id, and an id of exactly `MAX_SHORT_STRING`
  (the boundary), flow through the guard to the normal handler path, so the
  guard does not narrow the accepted set.

All 25 new tests pass; the existing 101 cron-handler/folder tests
(`test_dashboard_cron_folders.py`, `test_dashboard_cron_delete_handler.py`,
`test_dashboard_cron_to_chat_handler.py`, `test_cron_history.py`,
`test_dashboard_cron_script_source.py`, `test_cron_patch_name_validation.py`)
still pass. `flake8`, `isort`, `mypy` clean on both changed files.

## Manual verification

N/A — unit coverage is sufficient: the tests drive each handler directly and
assert both the 400 error-contract and that the guard short-circuits before the
state seam. No behavior change on the valid path (covered by the existing suite
plus the `TestValidIdsPass` boundary cases).

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to HTTP handler validation; no
rendered UI change.

## Related Issues

Fixes #5808

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

