### PR TITLE
fix(dashboard): preserve malformed entries across chat_pins/tags/tag_boards saves

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2844,7 +2844,10 @@ async def start_dashboard(
     await asyncio.to_thread(state.load_cron_folders)
     # Off-loop: a large chat_pins.json must not block the event loop at startup.
     await asyncio.to_thread(state.load_chat_pins)
-    state.load_tags()
+    # Off-loop: load_tags runs a synchronous save_tags() during load (status
+    # back-fill / seed) which fsyncs on the event loop; a large tags.json —
+    # including preserved-but-malformed rows (#5792) — must not stall startup.
+    await asyncio.to_thread(state.load_tags)
     app["port"] = port
     app["dashboard_url"] = dashboard_url
 
@@ -3840,7 +3843,10 @@ async def start_api_server(
     await asyncio.to_thread(state.load_cron_folders)
     # Off-loop: a large chat_pins.json must not block the event loop at startup.
     await asyncio.to_thread(state.load_chat_pins)
-    state.load_tags()
+    # Off-loop: load_tags runs a synchronous save_tags() during load (status
+    # back-fill / seed) which fsyncs on the event loop; a large tags.json —
+    # including preserved-but-malformed rows (#5792) — must not stall startup.
+    await asyncio.to_thread(state.load_tags)
     app["port"] = port
 
     _precompute_telemetry(state)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4993,6 +4993,11 @@ class DashboardState:
         # could not parse (mirrors the hooks store's unparsed-entry preservation).
         self._unparsed_cron_folder_entries: list[Any] = []
         self._chat_pins: list[dict[str, Any]] = []  # pinned chat messages
+        # Malformed chat_pins.json entries dropped at load time, kept verbatim
+        # so save_chat_pins round-trips them back instead of erasing bytes a
+        # hand-edit left in a shape the loader could not validate (mirrors the
+        # cron-folder unparsed-entry preservation, #5768/#5792).
+        self._unparsed_chat_pin_entries: list[Any] = []
         # Serializes pin mutation + persistence so concurrent requests cannot
         # interleave snapshots and replace chat_pins.json out of order.
         # LoopBoundLock, not asyncio.Lock (#4800): DashboardState outlives any
@@ -5007,6 +5012,13 @@ class DashboardState:
         self._folders_lock = LoopBoundLock()
         # Tag vocabulary: list of {id, name, color, order}. User-managed.
         self._tags: list[dict[str, Any]] = []
+        # Malformed tags.json entries dropped at load time, kept verbatim so a
+        # save round-trips them back instead of erasing bytes a hand-edit left
+        # in a shape the loader could not validate. This store's save path runs
+        # DURING load (seed/back-fill), so without preservation a single
+        # hand-edited-but-malformed row is wiped at boot with no user action
+        # (#5792, the worst of the sibling cases).
+        self._unparsed_tag_entries: list[Any] = []
         # True once load_tags() parsed tags.json successfully (or seeded a
         # fresh install). False means the vocabulary state is UNKNOWN (parse
         # or I/O failure) — restore-time pruning must fail open then, because
@@ -5015,6 +5027,10 @@ class DashboardState:
         self._tags_authoritative: bool = False
         # Sidebar columns — flat list of {id, name, tag_ids, mode, order, include_untagged}
         self._tag_boards: list[dict[str, Any]] = []
+        # Malformed tag-board (sidebar column) entries dropped at load time,
+        # kept verbatim so a save round-trips them back rather than erasing a
+        # hand-edited-but-typo'd column (#5792).
+        self._unparsed_tag_board_entries: list[Any] = []
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         # Gateway replacement is process-wide, not an ordinary repeatable
         # background mutation.  The task latch coalesces duplicate /api/restart
@@ -7405,6 +7421,11 @@ class DashboardState:
         Legacy pins (pre-mid era) may lack the ``mid`` field — they are preserved
         for backward compatibility; new pins always carry ``mid``.
 
+        Individual malformed entries are dropped from the active list but kept
+        verbatim in ``_unparsed_chat_pin_entries`` so the next ``save_chat_pins``
+        round-trips them back to disk rather than silently erasing a user's
+        hand-edited-but-typo'd pin (mirrors the cron-folder contract, #5792).
+
         Error classification:
         - Missing file: normal (first run) → empty list.
         - Malformed JSON / invalid shape: tolerated for compatibility → empty list.
@@ -7415,12 +7436,16 @@ class DashboardState:
         try:
             if not path.exists():
                 self._chat_pins = []
+                self._unparsed_chat_pin_entries = []
                 return
             raw = json.loads(path.read_text(encoding="utf-8"))
         except (UnicodeDecodeError, ValueError) as exc:
             # Malformed content — treat as empty (data corruption).
             logger.warning("chat_pins.json has malformed content: %s", exc)
             self._chat_pins = []
+            # Whole-file parse failure: nothing was parsed, so there are no
+            # per-entry bytes to preserve. Do NOT clear a prior load's
+            # preserved entries against an unreadable read.
             return
         except OSError:
             # Transient I/O error — do NOT clobber valid in-memory state.
@@ -7432,28 +7457,49 @@ class DashboardState:
             self._chat_pins = []
             return
 
-        valid = [
-            pin
-            for pin in raw
-            if isinstance(pin, dict)
-            and all(isinstance(pin.get(key), str) and pin.get(key) for key in ("id", "slot_key"))
-            # Require at least one identity field: mid or message_ts
-            and (
-                (isinstance(pin.get("mid"), str) and pin.get("mid"))
-                or (isinstance(pin.get("message_ts"), str) and pin.get("message_ts"))
+        def _is_valid(pin: Any) -> bool:
+            return (
+                isinstance(pin, dict)
+                and all(
+                    isinstance(pin.get(key), str) and pin.get(key) for key in ("id", "slot_key")
+                )
+                # Require at least one identity field: mid or message_ts
+                and bool(
+                    (isinstance(pin.get("mid"), str) and pin.get("mid"))
+                    or (isinstance(pin.get("message_ts"), str) and pin.get("message_ts"))
+                )
+                and isinstance(pin.get("preview"), str)
+                and isinstance(pin.get("pinned_at"), str)
+                and bool(pin.get("pinned_at"))
             )
-            and isinstance(pin.get("preview"), str)
-            and isinstance(pin.get("pinned_at"), str)
-            and pin.get("pinned_at")
-        ]
-        if len(valid) != len(raw):
-            logger.warning("Dropped %d malformed chat pin record(s) on load", len(raw) - len(valid))
+
+        valid = [pin for pin in raw if _is_valid(pin)]
+        unparsed = [pin for pin in raw if not _is_valid(pin)]
+        if unparsed:
+            logger.warning(
+                "Preserving %d malformed chat pin record(s) while loading "
+                "chat_pins.json (kept verbatim, not active)",
+                len(unparsed),
+            )
         self._chat_pins = valid
+        self._unparsed_chat_pin_entries = unparsed
 
     def save_chat_pins(self) -> None:
-        """Persist pinned chat messages with an atomic, owner-only file replacement."""
+        """Persist pinned chat messages with an atomic, owner-only file replacement.
+
+        Writes the active pins plus any malformed entries preserved at load
+        time (``_unparsed_chat_pin_entries``), so a save triggered by an
+        unrelated pin operation cannot erase bytes a hand-edit left in a shape
+        this loader could not validate.
+        """
         path = config_dir() / self._CHAT_PINS_FILE
-        atomic_write(path, json.dumps(self._chat_pins), fsync=True, mode=0o600)
+        unparsed = getattr(self, "_unparsed_chat_pin_entries", [])
+        atomic_write(
+            path,
+            json.dumps([*self._chat_pins, *unparsed]),
+            fsync=True,
+            mode=0o600,
+        )
 
     async def remove_chat_pins_for_slots(self, slot_keys: set[str]) -> int:
         """Remove pins when their persisted history sessions are permanently deleted."""
@@ -7605,6 +7651,18 @@ class DashboardState:
                 raw = json.loads(tags_path.read_text(encoding="utf-8"))
                 if isinstance(raw, list):
                     self._tags = [t for t in raw if isinstance(t, dict) and t.get("id")]
+                    # Keep rows the active list dropped verbatim so the seed/
+                    # back-fill save below (and every later save) round-trips
+                    # them back instead of erasing a hand-edited-but-typo'd row
+                    # at boot with no user action (#5792).
+                    unparsed = [t for t in raw if not (isinstance(t, dict) and t.get("id"))]
+                    if unparsed:
+                        logger.warning(
+                            "Preserving %d malformed tag entr(ies) while loading "
+                            "tags.json (kept verbatim, not active)",
+                            len(unparsed),
+                        )
+                    self._unparsed_tag_entries = unparsed
                 else:
                     # Valid JSON but not a list (e.g. {}): the vocabulary
                     # state is UNKNOWN, same as a parse failure — do not let
@@ -7644,6 +7702,17 @@ class DashboardState:
                 raw = json.loads(columns_path.read_text(encoding="utf-8"))
                 if isinstance(raw, list):
                     self._tag_boards = [c for c in raw if isinstance(c, dict) and c.get("id")]
+                    # Preserve dropped columns verbatim so a later save
+                    # round-trips them rather than erasing a hand-edited-but-
+                    # typo'd column (#5792).
+                    unparsed_cols = [c for c in raw if not (isinstance(c, dict) and c.get("id"))]
+                    if unparsed_cols:
+                        logger.warning(
+                            "Preserving %d malformed sidebar column(s) while "
+                            "loading tag_boards.json (kept verbatim, not active)",
+                            len(unparsed_cols),
+                        )
+                    self._unparsed_tag_board_entries = unparsed_cols
                     # Prune column tag_ids missing from the vocabulary: tag
                     # deletion commits the vocab write first (crash-atomic),
                     # so a crash mid-delete can leave dangling ids here. The
@@ -7662,8 +7731,15 @@ class DashboardState:
             logger.warning("Failed to load sidebar columns", exc_info=True)
 
     def save_tags(self) -> None:
-        """Persist tag vocabulary to disk (atomic write)."""
-        self._atomic_write_json(config_dir() / self._TAGS_FILE, self._tags)
+        """Persist tag vocabulary to disk (atomic write).
+
+        Appends any malformed entries preserved at load time
+        (``_unparsed_tag_entries``) so a save — including the seed/back-fill
+        save that runs during ``load_tags`` itself — cannot erase bytes a
+        hand-edit left in a shape the loader could not validate (#5792).
+        """
+        unparsed = getattr(self, "_unparsed_tag_entries", [])
+        self._atomic_write_json(config_dir() / self._TAGS_FILE, [*self._tags, *unparsed])
 
     def save_tags_snapshot(self, snapshot: list[dict]) -> None:
         """Persist a pre-captured tag snapshot to disk (strict -- raises on failure).
@@ -7674,14 +7750,26 @@ class DashboardState:
         location resolves through this module's ``config_dir`` exactly like
         ``save_tags`` -- keeping tests that patch it working unchanged.
 
+        Malformed entries preserved at load time (``_unparsed_tag_entries``)
+        are appended so this write path preserves them too (#5792).
+
         Raises on I/O failure so callers can roll back in-memory state and
         surface HTTP 5xx rather than silently losing data.
         """
-        self._atomic_write_json_strict(config_dir() / self._TAGS_FILE, snapshot)
+        unparsed = getattr(self, "_unparsed_tag_entries", [])
+        self._atomic_write_json_strict(config_dir() / self._TAGS_FILE, [*snapshot, *unparsed])
 
     def save_tag_boards(self) -> None:
-        """Persist sidebar column layout to disk (atomic write)."""
-        self._atomic_write_json(config_dir() / self._TAG_BOARDS_FILE, self._tag_boards)
+        """Persist sidebar column layout to disk (atomic write).
+
+        Appends any malformed columns preserved at load time
+        (``_unparsed_tag_board_entries``) so a save cannot erase bytes a
+        hand-edit left in a shape the loader could not validate (#5792).
+        """
+        unparsed = getattr(self, "_unparsed_tag_board_entries", [])
+        self._atomic_write_json(
+            config_dir() / self._TAG_BOARDS_FILE, [*self._tag_boards, *unparsed]
+        )
 
     def save_tag_boards_snapshot(self, snapshot: list[dict]) -> None:
         """Persist a pre-captured boards snapshot to disk (strict -- raises on failure).
@@ -7692,10 +7780,15 @@ class DashboardState:
         resolves through this module's ``config_dir`` exactly like
         ``save_tag_boards`` -- keeping tests that patch it working unchanged.
 
+        Malformed columns preserved at load time
+        (``_unparsed_tag_board_entries``) are appended so this write path
+        preserves them too (#5792).
+
         Raises on I/O failure so callers can roll back in-memory state and
         surface HTTP 5xx rather than silently losing data.
         """
-        self._atomic_write_json_strict(config_dir() / self._TAG_BOARDS_FILE, snapshot)
+        unparsed = getattr(self, "_unparsed_tag_board_entries", [])
+        self._atomic_write_json_strict(config_dir() / self._TAG_BOARDS_FILE, [*snapshot, *unparsed])
 
     @staticmethod
     def _atomic_write_json_strict(path: Path, data: Any) -> None:

--- a/test/test_state_store_preservation.py
+++ b/test/test_state_store_preservation.py
@@ -1,0 +1,262 @@
+"""Malformed-entry preservation across the sibling JSON stores in state.py.
+
+Regression coverage for #5792: ``load_*`` drops rows the active list cannot
+use but must keep them verbatim in an ``_unparsed_*`` list so the next
+``save_*`` round-trips them back to disk, rather than the previous behaviour
+where a dropped row's bytes were erased on the next write. Mirrors the
+cron-folder contract landed in #5768 across ``chat_pins``, ``tags`` and
+``tag_boards`` — the ``tags`` case is the worst because its save runs DURING
+load (seed / back-fill), so a hand-edited typo was wiped at boot with no user
+action.
+
+These use ``DashboardState.__new__`` + a ``config_dir`` monkeypatch, the same
+lightweight load/save harness the cron-folder tests use — no event loop, no
+full DashboardState construction.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.dashboard.state import DashboardState
+
+
+@pytest.fixture()
+def cfg(tmp_path, monkeypatch):
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path, raising=False)
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# chat_pins
+# --------------------------------------------------------------------------- #
+class TestChatPinsPreservation:
+    def _fresh(self):
+        st = DashboardState.__new__(DashboardState)
+        st._chat_pins = []
+        st._unparsed_chat_pin_entries = []
+        return st
+
+    def _valid_pin(self, pin_id):
+        return {
+            "id": pin_id,
+            "slot_key": "slot1",
+            "mid": "m-" + pin_id,
+            "preview": "hello",
+            "pinned_at": "2026-01-01T00:00:00Z",
+        }
+
+    def test_load_keeps_malformed_entries_inactive(self, cfg):
+        (cfg / "chat_pins.json").write_text(
+            json.dumps(
+                [
+                    self._valid_pin("good1"),
+                    "not-a-dict",
+                    {"id": "no-slot", "mid": "x", "preview": "p", "pinned_at": "t"},
+                    {"slot_key": "s", "mid": "x", "preview": "p", "pinned_at": "t"},  # no id
+                    {  # no identity field (no mid, no message_ts)
+                        "id": "no-ident",
+                        "slot_key": "s",
+                        "preview": "p",
+                        "pinned_at": "t",
+                    },
+                    self._valid_pin("good2"),
+                ]
+            ),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_chat_pins()
+        assert [p["id"] for p in st._chat_pins] == ["good1", "good2"]
+        assert len(st._unparsed_chat_pin_entries) == 4
+        assert "not-a-dict" in st._unparsed_chat_pin_entries
+
+    def test_malformed_entry_survives_a_subsequent_save(self, cfg):
+        """A hand-edited pin with a typo must not be erased when an unrelated
+        save fires."""
+        path = cfg / "chat_pins.json"
+        malformed = {"id": "bbb", "slot_key": "s", "preview": "typo", "pinnd_at": "t", "mid": "m"}
+        path.write_text(
+            json.dumps([self._valid_pin("aaa"), malformed, self._valid_pin("ccc")]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_chat_pins()
+        assert [p["id"] for p in st._chat_pins] == ["aaa", "ccc"]
+
+        # An unrelated pin write persists — the malformed entry must ride along.
+        st.save_chat_pins()
+
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert malformed in on_disk
+        assert {
+            p["id"] for p in on_disk if isinstance(p, dict) and "slot_key" in p and p.get("id")
+        } >= {
+            "aaa",
+            "ccc",
+        }
+
+    def test_no_unparsed_entries_leaves_payload_clean(self, cfg):
+        path = cfg / "chat_pins.json"
+        path.write_text(json.dumps([self._valid_pin("aaa")]), encoding="utf-8")
+        st = self._fresh()
+        st.load_chat_pins()
+        assert st._unparsed_chat_pin_entries == []
+        st.save_chat_pins()
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert [p["id"] for p in on_disk] == ["aaa"]
+
+    def test_whole_file_parse_error_does_not_clear_prior_preservation(self, cfg):
+        """A later unreadable read must not wipe entries preserved by an earlier
+        good read (whole-file corruption is out of the per-entry contract)."""
+        st = self._fresh()
+        st._unparsed_chat_pin_entries = [{"stale": "kept"}]
+        (cfg / "chat_pins.json").write_text("{ not json", encoding="utf-8")
+        st.load_chat_pins()
+        assert st._chat_pins == []
+        assert st._unparsed_chat_pin_entries == [{"stale": "kept"}]
+
+
+# --------------------------------------------------------------------------- #
+# tags — the boot-erasure case
+# --------------------------------------------------------------------------- #
+class TestTagsPreservation:
+    def _fresh(self):
+        st = DashboardState.__new__(DashboardState)
+        st._tags = []
+        st._unparsed_tag_entries = []
+        st._tag_boards = []
+        st._unparsed_tag_board_entries = []
+        st._tags_authoritative = False
+        return st
+
+    def test_load_keeps_malformed_tag_entries_inactive(self, cfg):
+        (cfg / "tags.json").write_text(
+            json.dumps(
+                [
+                    {"id": "t1", "name": "Keep", "status": True},
+                    "not-a-dict",
+                    {"name": "no id"},
+                    {"id": "", "name": "empty id"},
+                    {"id": "t2", "name": "Also keep", "status": False},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()
+        assert [t["id"] for t in st._tags] == ["t1", "t2"]
+        assert len(st._unparsed_tag_entries) == 3
+        assert "not-a-dict" in st._unparsed_tag_entries
+
+    def test_malformed_tag_survives_the_boot_save(self, cfg):
+        """The regression: load_tags back-fills the ``status`` flag and calls
+        ``save_tags()`` DURING load. A hand-edited malformed row must survive
+        that boot-time save rather than being erased with no user action."""
+        path = cfg / "tags.json"
+        malformed = {"nome": "typo-key", "colour": "red"}  # no id -> dropped
+        # A valid row WITHOUT the status field forces the back-fill save to run.
+        path.write_text(
+            json.dumps([{"id": "t1", "name": "Keep"}, malformed]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()  # triggers the status back-fill save internally
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert malformed in on_disk
+        assert any(isinstance(t, dict) and t.get("id") == "t1" for t in on_disk)
+
+    def test_malformed_tag_survives_snapshot_save(self, cfg):
+        path = cfg / "tags.json"
+        malformed = {"broken": True}
+        path.write_text(
+            json.dumps([{"id": "t1", "name": "Keep", "status": False}, malformed]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()
+        # The chat_tags.py write path captures an active snapshot then persists.
+        snapshot = [dict(t) for t in st._tags]
+        st.save_tags_snapshot(snapshot)
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert malformed in on_disk
+        assert any(isinstance(t, dict) and t.get("id") == "t1" for t in on_disk)
+
+    def test_no_unparsed_tags_leaves_payload_clean(self, cfg):
+        path = cfg / "tags.json"
+        path.write_text(
+            json.dumps([{"id": "t1", "name": "Keep", "status": False}]), encoding="utf-8"
+        )
+        st = self._fresh()
+        st.load_tags()
+        assert st._unparsed_tag_entries == []
+
+
+# --------------------------------------------------------------------------- #
+# tag_boards (sidebar columns)
+# --------------------------------------------------------------------------- #
+class TestTagBoardsPreservation:
+    def _fresh(self):
+        st = DashboardState.__new__(DashboardState)
+        st._tags = []
+        st._unparsed_tag_entries = []
+        st._tag_boards = []
+        st._unparsed_tag_board_entries = []
+        st._tags_authoritative = False
+        return st
+
+    def test_load_keeps_malformed_columns_inactive(self, cfg):
+        # tags.json present-but-empty so load_tags does not seed and the board
+        # block runs cleanly.
+        (cfg / "tags.json").write_text(json.dumps([]), encoding="utf-8")
+        (cfg / "tag_boards.json").write_text(
+            json.dumps(
+                [
+                    {"id": "c1", "name": "Col", "tag_ids": [], "order": 0},
+                    "not-a-dict",
+                    {"name": "no id"},
+                    {"id": "c2", "name": "Col2", "tag_ids": [], "order": 1},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()
+        assert [c["id"] for c in st._tag_boards] == ["c1", "c2"]
+        assert len(st._unparsed_tag_board_entries) == 2
+        assert "not-a-dict" in st._unparsed_tag_board_entries
+
+    def test_malformed_column_survives_a_subsequent_save(self, cfg):
+        (cfg / "tags.json").write_text(json.dumps([]), encoding="utf-8")
+        path = cfg / "tag_boards.json"
+        malformed = {"nme": "typo"}  # no id -> dropped
+        path.write_text(
+            json.dumps([{"id": "c1", "name": "Col", "tag_ids": [], "order": 0}, malformed]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()
+        assert [c["id"] for c in st._tag_boards] == ["c1"]
+
+        # The chat_tags.py board write path persists a captured snapshot.
+        snapshot = [dict(c) for c in st._tag_boards]
+        st.save_tag_boards_snapshot(snapshot)
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert malformed in on_disk
+        assert any(isinstance(c, dict) and c.get("id") == "c1" for c in on_disk)
+
+    def test_no_unparsed_columns_leaves_payload_clean(self, cfg):
+        (cfg / "tags.json").write_text(json.dumps([]), encoding="utf-8")
+        path = cfg / "tag_boards.json"
+        path.write_text(
+            json.dumps([{"id": "c1", "name": "Col", "tag_ids": [], "order": 0}]),
+            encoding="utf-8",
+        )
+        st = self._fresh()
+        st.load_tags()
+        assert st._unparsed_tag_board_entries == []
+        st.save_tag_boards()
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert [c["id"] for c in on_disk] == ["c1"]


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to the dashboard state persistence layer (`state.py`) — no rendered UI delta.

## Problem / Motivation

PR #5768 taught the **cron folders** store to keep malformed-but-hand-edited rows verbatim (`_unparsed_cron_folder_entries`) so an unrelated save cannot erase bytes the loader could not validate. Review of #5768 (First Principles + Design) surfaced that the **same drop-then-overwrite-on-save pattern still exists in three sibling stores** in `src/kiro_crew/dashboard/state.py`:

- `load_chat_pins` / `save_chat_pins`
- `load_tags` / `save_tags`
- `_tag_boards` load (inside `load_tags`) / `save_tag_boards`

Each drops rows at load time that the next save then erases. The **tags** store is worse than the cron case: `load_tags()` back-fills the `status` flag and calls `save_tags()` **during load itself**, so a single hand-edited-but-malformed `tags.json` row is wiped at gateway **boot with no user action**.

## Why it matters

Same silent, unrecoverable user-data loss as #5764/#5768, but across more stores — and the `tags.json` case triggers at boot, so a single hand-edit typo can wipe a user's tags on the next restart before they ever touch the UI.

## What changed (motivation → approach → change)

Symptom: a hand-edited-but-malformed row in `chat_pins.json` / `tags.json` / `tag_boards.json` disappears on the next save (for tags, on the very next gateway boot). Root cause: each `load_*` filters malformed rows out of the in-memory list and each `save_*` writes only that list, so the dropped rows' bytes are overwritten. Fix: generalize the `_unparsed_*` preservation contract from #5768 across the three sibling stores.

- Each `load_*` partitions rows into the active list and an `_unparsed_*` list using **the same predicate**, so the two lists are disjoint by construction (a preserved row never has a usable id, so it can never collide with an active row).
- Each `save_*` appends the preserved `_unparsed_*` entries to what it writes.
- The **snapshot writers** (`save_tags_snapshot` / `save_tag_boards_snapshot`, the serialized `chat_tags.py` write path) append the preserved entries **at write time**, so that path preserves them too. This is what closes the boot-erasure: the seed/back-fill `save_tags()` inside `load_tags()` now round-trips the malformed rows.

Two deliberate scope decisions, both matching the issue's "decide the whole-file case deliberately":

- **`load_folders` is intentionally NOT converted.** Its #5768 docstring argues that a folder row with no usable id "can never be the row a request addresses, so dropping it is the correct answer and not merely the safe one." That reasoned drop-and-log contract landed with #5768 and is not reopened here.
- **The whole-file cases** (unparseable JSON, non-list root) stay out of the per-entry contract: no rows are parsed, so there are no per-entry bytes to preserve. The loaders leave a prior good load's preserved entries untouched rather than clearing them against an unreadable read (covered by a test).

## Tests

New `test/test_state_store_preservation.py` (11 tests, all passing):

- **chat_pins** — malformed entries kept inactive; a typo'd pin survives a subsequent `save_chat_pins`; a clean file gets no sentinel padding; a whole-file parse error does not clear a prior load's preserved entries.
- **tags** — malformed entries kept inactive; **the regression**: a malformed row survives the `status` back-fill save that runs *during* `load_tags` (the boot-erasure case); a malformed row survives the `save_tags_snapshot` write path; a clean file stays clean.
- **tag_boards** — malformed columns kept inactive; a typo'd column survives the `save_tag_boards_snapshot` write path; a clean file stays clean.

All 210 existing tests in `test_dashboard_chat_pins.py`, `test_chat_tags.py`, `test_dashboard_cron_folders.py`, and `test_dashboard_cron_folder_id.py` still pass.

## Manual verification

N/A — unit coverage is sufficient; the fix is a pure persistence-layer round-trip contract fully exercised by the load→save→re-read tests above (including the boot-time seed/back-fill save path).

## Related Issues

Fixes #5792

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A (docstrings updated inline)
- [x] No secrets, credentials, or internal references in the diff
