### PR TITLE
fix(skills): gate disabled-app skills across all user-facing surfaces

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -1061,6 +1061,16 @@ The `false` value carries no new privilege surface: it can only reduce what a
 skill delivers, and foreign-imported skills are refused for declaring `triggers`
 at all (`onboarding_import.py`), so an import cannot reach either path.
 
+**Disabled-app skill gating.** When an app is disabled (`_disabled_app_names()`),
+its bundled skills are withheld across all user-facing surfaces: trigger matching
+(`get_triggered_skills`), per-turn index listing and search (`list_skills`,
+`get_context`, `search_skills`), always-injected bodies (`get_always_skills`),
+and explicit `$skill` token resolution (`resolve_dollar_skills`). An unreadable
+app registry fails open so a transient read error never hides enabled skills.
+Internal plumbing helpers (`load_skill`, `_served_key_by_realpath`,
+`resolve_ledger_aliases`, `_resolve_path_and_root`) remain ungated so
+reconciliation and pinned paths function without modification.
+
 **Setting it from the dashboard.** `POST /api/skills/-/inject-on-trigger` (body
 `{name, inject}`) edits that one frontmatter line server-side via
 `SkillsLoader.set_inject_on_trigger()`, mirroring `set_pinned()` — atomic write,

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -1498,6 +1498,7 @@ class SkillsLoader:
         # slot would serve one session's project skills to a session working in
         # a different project for the whole TTL. (monotonic_deadline, results)
         self._iter_cache: dict[str, tuple[float, list[tuple[str, Path, str | None]]]] = {}
+        self._disabled_apps_cache: tuple[float, frozenset[str]] | None = None
         # (canonical key, allowed) pairs already audited, so the enforcement
         # record is written on first use rather than once per message.
         self._audited_projects: set[tuple[str, bool]] = set()
@@ -1640,6 +1641,27 @@ class SkillsLoader:
         self._iter_cache[key] = (time.monotonic() + _ITER_CACHE_TTL_SECS, results)
         return results
 
+    def _get_disabled_app_names(self) -> frozenset[str]:
+        now = time.monotonic()
+        if self._disabled_apps_cache is not None and now < self._disabled_apps_cache[0]:
+            return self._disabled_apps_cache[1]
+        disabled = _disabled_app_names()
+        self._disabled_apps_cache = (now + _ITER_CACHE_TTL_SECS, disabled)
+        return disabled
+
+    def _iter_visible(
+        self, project_dir: str | Path | None = None
+    ) -> list[tuple[str, Path, str | None]]:
+        """Return all ``(name, skill_file, within)`` pairs, filtering out disabled app skills."""
+        disabled_apps = self._get_disabled_app_names()
+        if not disabled_apps:
+            return self._iter(project_dir)
+        return [
+            (name, skill_file, within)
+            for name, skill_file, within in self._iter(project_dir)
+            if self._owning_app(name, skill_file) not in disabled_apps
+        ]
+
     def catalog_project_skills(self, project_dir: str | Path) -> list[dict]:
         """Return confined project rows without requiring or exercising trust.
 
@@ -1747,6 +1769,7 @@ class SkillsLoader:
         stale parse. Dropping it here keeps the mutator's edit immediately
         reflected in ``list_skills`` / ``get_triggered_skills``.
         """
+        self._disabled_apps_cache = None
         self._iter_cache = {}
         self._fm_cache.clear()
 
@@ -1900,7 +1923,7 @@ class SkillsLoader:
         size and cache token come from bytes admitted by the no-link reader.
         """
         skills: list[dict] = []
-        for name, skill_file, _within in self._iter(project_dir):
+        for name, skill_file, _within in self._iter_visible(project_dir):
             if _within is not None:
                 meta, size_bytes = self._confined_frontmatter_and_size(skill_file, _within)
             else:
@@ -3988,7 +4011,7 @@ class SkillsLoader:
         to the process working directory).
         """
         result: list[str] = []
-        for name, skill_file, _within in self._iter(project_dir):
+        for name, skill_file, _within in self._iter_visible(project_dir):
             meta = self._cached_frontmatter(skill_file, within=_within)
             if meta.get("always", "").lower() == "true":
                 scope = meta.get("repo_scope", "")
@@ -4023,21 +4046,11 @@ class SkillsLoader:
         Returns up to ``max_triggered`` skills sorted by best overlap score.
         """
         text_words = set(re.findall(r"\w+", text.lower()))
-        # Disabling an app must actually stop its skills loading. The skill tree
-        # an app bundles was never gated on the app's enabled state, so a
-        # disabled app's skills stayed in this index and kept matching into
-        # every turn's context on generic trigger words — burning tokens and
-        # polluting the prompt for an app the user explicitly opted out of,
-        # with no visible reason (#4023).
-        disabled_apps = _disabled_app_names()
-
         scored: list[tuple[str, float]] = []
         # Skills a negative trigger actively excluded — a permission DENY that
         # must still be audited (see the audit event below).
         negated_skills: list[str] = []
-        for name, skill_file, _within in self._iter(project_dir):
-            if disabled_apps and self._owning_app(name, skill_file) in disabled_apps:
-                continue
+        for name, skill_file, _within in self._iter_visible(project_dir):
             meta = self._cached_frontmatter(skill_file, within=_within)
             if meta.get("always", "").lower() == "true":
                 continue
@@ -4582,7 +4595,7 @@ class SkillsLoader:
         # _iter() already applies local > extra-path precedence and dedupes
         # by full key, so the first full key seen for a given leaf wins.
         leaf_to_name: dict[str, str] = {}
-        for name, _path, _within in self._iter(project_dir):
+        for name, skill_file, _within in self._iter_visible(project_dir):
             leaf = name.rsplit("/", 1)[-1].lower()
             leaf_to_name.setdefault(leaf, name)
 

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -2038,6 +2038,85 @@ class TestDisabledAppSkillsAreNotTriggered:
 
         assert loader.get_triggered_skills("find hotspots for me") == ["ai-discover"]
 
+    def test_disabled_app_skills_excluded_from_list_skills_and_context(self, tmp_path, monkeypatch):
+        """#5781: Disabled app skills must not appear in list_skills or get_context index."""
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._write_app_skill(skills, "ops_mc", "ops-mission-control", "deploy")
+        self._apps(monkeypatch, deploy_web=False, ops_mc=True)
+        loader = SkillsLoader(
+            skills_path=skills,
+            install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        listed_keys = [s["key"] for s in loader.list_skills()]
+        assert "deploy_web/artifact-deploy" not in listed_keys
+        assert "ops_mc/ops-mission-control" in listed_keys
+
+        context = loader.get_context(budget=10000)
+        assert "artifact-deploy" not in context
+        assert "ops-mission-control" in context
+
+    def test_disabled_app_always_skill_is_excluded(self, tmp_path, monkeypatch):
+        """#5781: Disabled app skills with always: true must not be injected."""
+        skills = tmp_path / "skills"
+        d = skills / "deploy_web" / "always-helper"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: always-helper\nalways: true\n---\n\nBody of always helper\n"
+        )
+        self._apps(monkeypatch, deploy_web=False)
+        loader = SkillsLoader(
+            skills_path=skills,
+            install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.get_always_skills() == []
+
+        loader._invalidate_iter_cache()
+        self._apps(monkeypatch, deploy_web=True)
+        assert loader.get_always_skills() == ["deploy_web/always-helper"]
+
+    def test_disabled_app_dollar_skill_is_not_resolved(self, tmp_path, monkeypatch):
+        """#5781: Explicit $skill invocation must not resolve a disabled app's skill."""
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._apps(monkeypatch, deploy_web=False)
+        loader = SkillsLoader(
+            skills_path=skills,
+            install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.resolve_dollar_skills("run $artifact-deploy please") == []
+
+        loader._invalidate_iter_cache()
+        self._apps(monkeypatch, deploy_web=True)
+        res = loader.resolve_dollar_skills("run $artifact-deploy please")
+        assert len(res) == 1
+        assert res[0][1] == "deploy_web/artifact-deploy"
+
+    def test_disabled_app_skill_is_excluded_from_search(self, tmp_path, monkeypatch):
+        """#5781: skill_search must not return results from disabled apps."""
+        skills = tmp_path / "skills"
+        self._write_app_skill(skills, "deploy_web", "artifact-deploy", "deploy")
+        self._apps(monkeypatch, deploy_web=False)
+        loader = SkillsLoader(
+            skills_path=skills,
+            install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
+
+        assert loader.search_skills("artifact-deploy") == []
+
+        loader._invalidate_iter_cache()
+        self._apps(monkeypatch, deploy_web=True)
+        results = loader.search_skills("artifact-deploy")
+        assert len(results) == 1
+        assert results[0]["key"] == "deploy_web/artifact-deploy"
+
 
 class TestStripFrontmatterCloserParity:
     """#6182: strip_frontmatter's closer must accept everything the display


### PR DESCRIPTION
## Problem / Motivation

When an app is disabled (e.g. via `kirocrew app disable <name>`), its bundled skills should stop appearing across all user-facing surfaces.

PR #4067 (issue #4023) gated **trigger matching** (`get_triggered_skills`) on the owning app's enabled state (`_disabled_app_names()`), but the other user-facing `SkillsLoader._iter` consumers remained ungated. As a result, skills from disabled apps remained reachable and visible through:
- the per-turn skill index summary lines injected by `get_context` (via `list_skills`);
- the dashboard Skills page listing and `skill_search` results (via `list_skills`);
- `always: true` full-body skill injection every turn (`get_always_skills`);
- explicit `$skill` mentions (`resolve_dollar_skills`).

## Why it matters

An operator who explicitly disables an app expects that app's skills to stop polluting the prompt and context window. Without this gating across all surfaces:
- Disabled app skills still appear in the per-turn skill index summary lines, consuming prompt tokens and advertising irrelevant procedures to the model.
- Disabled app skills marked `always: true` continue to have their full bodies injected into every message turn.
- Explicit `$skill` resolution and `skill_search` continue resolving and returning skills belonging to disabled apps.

## What changed (motivation → approach → change)

- **Motivation**: Ensure that disabling an app consistently withholds its bundled skills from all user-facing surfaces without breaking internal plumbing (reconcile, pinned loaders, realpath helpers).
- **Approach**: Extend the `_disabled_app_names()` and `self._owning_app(name, skill_file)` check added in #4067 to the three remaining user-facing `SkillsLoader` methods:
  1. `list_skills(project_dir)`: filters out disabled app skills during enumeration. Because `get_context()` and `search_skills()` call `list_skills()`, gating `list_skills` automatically gates both the per-turn skill index and `skill_search` results.
  2. `get_always_skills(project_dir)`: filters out disabled app skills so `always: true` bodies from disabled apps are never injected.
  3. `resolve_dollar_skills(text, project_dir)`: filters out disabled app skills during leaf-to-name mapping so `$skill` mentions do not resolve disabled app skills.
  4. Internal plumbing helpers (`load_skill`, `_served_key_by_realpath`, `resolve_ledger_aliases`, `_resolve_path_and_root`) remain ungated as designed so reconciliation and pinned paths stay operational.
- **Spec update**: Documented the disabled-app skill gating contract across all user-facing surfaces in `docs/system-specs/modules/memory-skills-hooks.md`.

## Tests

- Added unit tests in `test/test_skills.py::TestDisabledAppSkillsAreNotTriggered`:
  - `test_disabled_app_skills_excluded_from_list_skills_and_context`: asserts disabled app skills do not appear in `list_skills` or `get_context` index, and appear when enabled.
  - `test_disabled_app_always_skill_is_excluded`: asserts `always: true` skills belonging to a disabled app are not returned by `get_always_skills`, and are returned when enabled.
  - `test_disabled_app_dollar_skill_is_not_resolved`: asserts explicit `$skill` mentions do not resolve for disabled apps, and resolve when enabled.
  - `test_disabled_app_skill_is_excluded_from_search`: asserts `search_skills` does not return results for disabled apps, and returns results when enabled.
- All 144 unit tests in `test/test_skills.py` pass.

## Manual verification

N/A — unit coverage in `test/test_skills.py` exercises all affected `SkillsLoader` methods across enabled and disabled states.

## Related Issues

Closes #5781

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
- [x] Contribution License Agreement
