### PR TITLE
fix(chat): stop counting transient rows in the paging cursor, read it live

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -6143,6 +6143,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // so decide only once this window is known to belong to the target chat.
     if (initialSidRef.current && initialSidRef.current !== activeSlot) return
     if (!cursorIsForActiveSlot) return
+    // The captured pair predates the mount effect that dispatches `switchSlot`, whose
+    // `pending` nulls the cursor key even on a same-key switch -- so read it live.
+    const liveChat = store.getState().chat
+    if (liveChat.slotCursorKey !== liveChat.activeSlot) return
     const resolved = resolveMsgIndex(messages, targetTs, targetMid)
     // A mid that is merely OFF-PAGE falls back to ts in the helper, and that is a
     // DIFFERENT row of the same tick -- treat it as unresolved so the hand-off runs.

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1307,9 +1307,11 @@ function olderHeadAbovePage(
 
 /** How many rows of a kept older head came from SERVER history, for shifting the
  *  paging cursor. The cursor is a row OFFSET, so client-only rows must not count
- *  toward it. `thinking` is already held out by the caller. */
+ *  toward it. `thinking` is already held out by the caller. `permission` is in the
+ *  backend's `_TRANSIENT_ROLES` and is never persisted, so it holds no offset --
+ *  unlike `error`/`mcp_oauth`, which ARE written to history and must keep counting. */
 function serverRowCount(rows: ChatMessage[]): number {
-  return rows.filter(m => m.role !== 'queued' && m.role !== 'streaming').length
+  return rows.filter(m => m.role !== 'queued' && m.role !== 'streaming' && m.role !== 'permission').length
 }
 
 /** The `(hasMore, cursor)` pair to install after keeping an older head above a

--- a/website/src/test/chatSlice.boundedInitialFetch.test.ts
+++ b/website/src/test/chatSlice.boundedInitialFetch.test.ts
@@ -564,6 +564,30 @@ describe('switching back keeps a paged-in window above the bounded page', () => 
     expect(chat.slotOldestIndex).toBe(8)
   })
 
+  it('excludes a client-only permission card from the kept head\u2019s server-row count', async () => {
+    // `permission` is in the backend's `_TRANSIENT_ROLES` and `_build_message_entry_uncached`
+    // returns None for it, so it occupies NO server offset and must not shift the cursor.
+    const PERM: Row = {
+      role: 'permission', content: 'Allow this tool?', cls: 'msg msg-permission',
+      ts: '2026-01-01T00:01:09Z', meta: { approval_id: 'a1', resolved: 'accepted' },
+    }
+    const chat = await switchBack([M('m8', 8), PERM, M('m9', 9), ...PAGE], PAGE)
+    // Two SERVER rows kept (m8, m9), so 10 - 2. Counting the card gives 7 and the
+    // next "load earlier" fetches before row 7, skipping genuine row 7 entirely.
+    expect(chat.slotOldestIndex).toBe(8)
+  })
+
+  it('still counts error and mcp_oauth rows, which the server DOES persist', async () => {
+    // NEGATIVE CONTROL for the exclusion above: neither role appears in
+    // `_TRANSIENT_ROLES`, so both are written to history and hold a real offset.
+    const ERR: Row = { role: 'error', content: 'boom', cls: 'msg msg-error', ts: '2026-01-01T00:01:08Z' }
+    const OAUTH: Row = { role: 'mcp_oauth', content: 'authorize', cls: 'msg msg-oauth', ts: '2026-01-01T00:01:09Z' }
+    const chat = await switchBack([M('m8', 8), ERR, OAUTH, M('m9', 9), ...PAGE], PAGE)
+    // Four kept rows all persist, so 10 - 4. Widening the permission exclusion to
+    // these two would read 8 here and strand two rows the reader already has.
+    expect(chat.slotOldestIndex).toBe(6)
+  })
+
   it('declines to keep a head whose rows carry no identity', async () => {
     // OPPOSITE direction: no mid means decline, so an unidentifiable head must
     // not be PREPENDED. Head-only: the trailing-reply reattach may still append.


### PR DESCRIPTION
Follow-up to #4359, which merged at `f75de358c6` without two fixes that AI review lanes raised as `FINDING`s against that head. Both were verified at source; neither is in `main`. This PR carries only those two fixes and their tests.

## Problem / Motivation

**1. The paging cursor counted rows the server never stored.** The cursor is a server row *offset*, so a client-only row holds no offset. `serverRowCount` held out `queued` and `streaming` but not `permission` — and `permission` is in the backend's `_TRANSIENT_ROLES` (`chat_persistence.py:1819`), where `_build_message_entry_uncached` returns `None` for it (`:1762`, docstring: *"Returns None for transient roles that are never persisted"*). The caller filters only `thinking` (`chatSlice.ts:4488`), so a permission row reached the count unfiltered.

**2. The deep-link effect decided on a cursor that had already been invalidated.** `cursorIsForActiveSlot` is captured at render (`ChatPage.tsx:1014`) and consumed in the effect at `:6145`. The mount effect at `:3815` dispatches `switchSlot(activeSlot)` for an **already-active** slot, and `switchSlot.pending` nulls `slotCursorKey` (`chatSlice.ts:4350`) — its own comment says so in place: *"This fetch replaces the cursor, so it is stale from here until it lands -- including a same-key switch, where the key alone still looks valid."*

## Why it matters

Fix 1 is a silent correctness bug in history paging, in both directions. Over-counting the kept head shifts the cursor too low, so the next "load earlier" fetches *past* a genuine older row and the reader loses it with no error; or completeness flips early and the "load older" affordance stays visible but does nothing. It needs only a resolved permission card left in the window across a slot switch — an ordinary state, not an edge case.

Fix 2 is a user-visible dead end on a shared link. An already-active `?sid=&msg=` link can resolve against a window that is about to be replaced, wrongly report the target unavailable, and clear `initialMsgRef` on the way out — so the link is spent and a retry needs a reload. Severity is moderate and the window is narrow (a render/store skew), which is also why it resists a test; see Tests.

## What changed

- `website/src/store/chatSlice.ts` — `serverRowCount` also excludes `permission`. `error` and `mcp_oauth` are **not** in `_TRANSIENT_ROLES`, are written to history, and deliberately keep counting; the comment records that boundary so the next reader does not "complete" the list.
- `website/src/pages/ChatPage.tsx` — the deep-link effect reads `slotCursorKey`/`activeSlot` from `store.getState().chat` at decision time instead of trusting the captured pair. The early return is not a permanent skip: `cursorIsForActiveSlot` is already an effect dependency, so the effect re-runs once the switch lands.
- `website/src/test/chatSlice.boundedInitialFetch.test.ts` — two tests (below).

32 insertions, 2 deletions across 3 files.

## Follow-ups

- No discriminating test exists for fix 2 (see Tests). A test harness able to hold a `switchSlot` genuinely in flight for one render, scoped to a single test, would close that gap.
- Not attempted here: an audit of the other `_TRANSIENT_ROLES` members (`chunk`, `done`) for whether they can reach `serverRowCount` at all. `queued`/`streaming` were already excluded; whether the remaining two are reachable on this path was not established either way.

## Tests

**Fix 1 — RED-first, both directions, observed in this branch:**

| Source state | `chatSlice.boundedInitialFetch` |
|---|---|
| Fix reverted, tests kept | **1 failed** — `expected 7 to be 8` (the new permission test), 43 passed |
| Fix as shipped | **44 passed** |
| Filter over-widened to `error`/`mcp_oauth` | **1 failed** — `expected 8 to be 6` (the negative control), 43 passed |

The third row is the point of the second test: it fails if someone "finishes the job" by excluding the two roles that the server does persist, which would strand rows the reader already has.

**Fix 2 — no dedicated test, stated plainly.** It has no failing-first evidence and I am not claiming any. The condition is a skew between a captured render value and live store state; React Testing Library flushes that skew away, and holding the switch in flight needed a persistent mock that leaked into 21 other tests in `ChatPage.sid.test.tsx`. Shipping that would have been coverage in name only. What is verified instead: all **36** existing `?sid=` tests pass with the fix applied, including the control at `ChatPage.sid.test.tsx:223` which asserts the unavailability notice **does** still appear once the switch has settled — so the new guard does not simply suppress the notice.

**Gates run in this branch, at the committed tree:**

| Gate | Result |
|---|---|
| `tsc -b` (project references, not `--noEmit`) | rc=0, no output |
| `eslint src --ext .ts,.tsx` | rc=0 — 0 errors, 653 warnings, **identical to the unmodified `main` baseline** measured in the same worktree |
| `i18n:check` | rc=0 |
| `lint:i18n` | rc=0 — 490 untranslated strings, baseline 1015 |
| `vitest chatSlice.boundedInitialFetch` | 44/44 |
| `vitest ChatPage.sid` | 36/36 |

`git apply --check` of the patch against `609c2e1012` returned rc=0 alongside a deliberately mutated control returning rc=1, so the check was not passing vacuously. One commit, one parent, clean tree.

## Screenshot evidence

<!-- no-visual-delta -->

**Why no screenshot:** both changes are non-visual: fix 1 alters an integer offset used for the next history fetch, and fix 2 removes a wrong "no longer available" notice on a race that cannot be posed deterministically for a capture. No component renders differently in any state I can stage, so a screenshot would show two identical images and imply verification I did not do. The `:223` control test is the standing evidence that the notice still renders when it should.

