### PR TITLE
refactor(pins): scope unpin-race coordination to the QueryClient

### DIFF
--- a/website/src/hooks/useChatPins.ts
+++ b/website/src/hooks/useChatPins.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo, useState } from 'react'
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { PIN_PREVIEW_INPUT_MAX_CHARS, pinsApi, type ChatPin, type PinApiError, type PinMessageBody } from '../api/pins'
 import { secureRandomId } from '../utils/secureId'
 
@@ -23,6 +23,45 @@ const pinQueryKey = (slotKey: string | undefined) => ['chat-pins', slotKey] as c
 type UnpinMutation = { id: string; slotKey: string }
 
 /**
+ * Unpin-race coordination state for a single QueryClient.
+ *
+ *  - `inFlightCreates`: in-flight create promises keyed by `${slot_key}::${mid}`.
+ *    A temp-id unpin awaits this promise to learn the real server id (or that
+ *    the create failed).
+ *  - `pinGenerations`: monotonic pin-intent generation per `${slot_key}::${mid}`.
+ *    A temp-id unpin snapshots the generation it is cancelling and, after
+ *    awaiting the create, only deletes the server pin if no newer pin intent
+ *    arrived meanwhile.
+ */
+type PinCoordStore = {
+  inFlightCreates: Map<string, Promise<ChatPin>>
+  pinGenerations: Map<string, number>
+}
+
+/**
+ * Coordination state lives on the QueryClient, not in per-instance `useRef`
+ * maps, so it is shared by every `useChatPins` instance bound to the same
+ * client and survives a remount. The pin DATA it guards already lives in that
+ * client's React Query cache; keeping the coordination beside it means a
+ * remount mid-create, or a second consumer of the hook for the same slot, sees
+ * the same in-flight promise instead of the "no tracked promise" branch (which
+ * would silently drop an unpin — the pin resurfaces on the settled refetch).
+ *
+ * A WeakMap keys the store off the client identity so it is reclaimed with the
+ * client and never leaks across the QueryClients that tests create per case.
+ */
+const coordStores = new WeakMap<QueryClient, PinCoordStore>()
+
+function coordStoreFor(qc: QueryClient): PinCoordStore {
+  let store = coordStores.get(qc)
+  if (!store) {
+    store = { inFlightCreates: new Map(), pinGenerations: new Map() }
+    coordStores.set(qc, store)
+  }
+  return store
+}
+
+/**
  * Hook to manage chat message pins for a given slot.
  * Uses React Query with optimistic updates – eliminates stale-closure race
  * conditions when the user switches slots quickly (each slot has its own
@@ -44,21 +83,11 @@ export function useChatPins(slotKey: string | undefined) {
   const clearError = useCallback(() => setError(null), [])
 
   /**
-   * Tracks in-flight create promises keyed by mid.
-   * When an unpin is requested for a pin whose id is still "temp-…" we await
-   * this promise to learn the real server id (or know the create failed).
+   * Race-coordination state scoped to this QueryClient (see PinCoordStore).
+   * Shared across every hook instance on the same client and stable across
+   * remounts — the maps are NOT recreated per render or per mount.
    */
-  const inFlightCreates = useRef<Map<string, Promise<ChatPin>>>(new Map())
-
-  /**
-   * Monotonic pin-intent generation per `${slot_key}::${mid}`. Bumped by every
-   * pinMessage; a temp-id unpin snapshots the generation it is cancelling and,
-   * after awaiting the create, only deletes the server pin if no NEWER pin
-   * intent arrived meanwhile. Without this, Pin -> pending Unpin -> Pin again
-   * loses the second pin: the idempotent create returns the first record's id,
-   * and the deferred DELETE would remove the pin the user just re-created.
-   */
-  const pinGenerations = useRef<Map<string, number>>(new Map())
+  const { inFlightCreates, pinGenerations } = coordStoreFor(qc)
 
   const { data: pins = [], isLoading: loading } = useQuery<ChatPin[]>({
     queryKey,
@@ -156,7 +185,7 @@ export function useChatPins(slotKey: string | undefined) {
         )
         qc.invalidateQueries({ queryKey: mutationQueryKey })
 
-        const inFlight = inFlightCreates.current.get(`${resolvedSlotKey}::${pin.mid}`)
+        const inFlight = inFlightCreates.get(`${resolvedSlotKey}::${pin.mid}`)
         if (!inFlight) {
           // No tracked promise. This is NOT always "nothing on the server":
           // the create may have already succeeded and been cleaned from the
@@ -175,7 +204,7 @@ export function useChatPins(slotKey: string | undefined) {
 
         let realPin: ChatPin
         const inFlightKey = `${resolvedSlotKey}::${pin.mid}`
-        const generationAtUnpin = pinGenerations.current.get(inFlightKey) ?? 0
+        const generationAtUnpin = pinGenerations.get(inFlightKey) ?? 0
         try {
           realPin = await inFlight
         } catch {
@@ -186,7 +215,7 @@ export function useChatPins(slotKey: string | undefined) {
         // If the user pinned this message AGAIN while we awaited the create,
         // that newer intent wins: the idempotent create returns the same
         // record, so deleting it now would destroy the re-created pin.
-        if ((pinGenerations.current.get(inFlightKey) ?? 0) !== generationAtUnpin) {
+        if ((pinGenerations.get(inFlightKey) ?? 0) !== generationAtUnpin) {
           return
         }
 
@@ -197,7 +226,7 @@ export function useChatPins(slotKey: string | undefined) {
 
       await unpinMessageAsync({ id: pin.id, slotKey: resolvedSlotKey })
     },
-    [slotKey, qc, unpinMessageAsync],
+    [slotKey, qc, unpinMessageAsync, inFlightCreates, pinGenerations],
   )
 
   const isPinned = useCallback(
@@ -223,16 +252,16 @@ export function useChatPins(slotKey: string | undefined) {
       const inFlightKey = `${fullBody.slot_key}::${fullBody.mid}`
       // A new pin intent supersedes any unpin still awaiting the previous
       // create for this message (see pinGenerations).
-      pinGenerations.current.set(inFlightKey, (pinGenerations.current.get(inFlightKey) ?? 0) + 1)
+      pinGenerations.set(inFlightKey, (pinGenerations.get(inFlightKey) ?? 0) + 1)
       const promise = pinMessageAsync(fullBody).finally(() => {
-        if (inFlightCreates.current.get(inFlightKey) === promise) {
-          inFlightCreates.current.delete(inFlightKey)
+        if (inFlightCreates.get(inFlightKey) === promise) {
+          inFlightCreates.delete(inFlightKey)
         }
       })
-      inFlightCreates.current.set(inFlightKey, promise)
+      inFlightCreates.set(inFlightKey, promise)
       await promise
     },
-    [slotKey, pinMessageAsync],
+    [slotKey, pinMessageAsync, inFlightCreates, pinGenerations],
   )
 
   const unpinMessage = useCallback(

--- a/website/src/test/chatPins.test.tsx
+++ b/website/src/test/chatPins.test.tsx
@@ -626,6 +626,119 @@ describe('useChatPins', () => {
     })
   })
 
+  // === Coordination survives remount / second consumer (issue #5168) ===
+
+  it('a create started by one hook instance is awaited by a DIFFERENT instance on the same QueryClient', async () => {
+    // The unpin-race coordination lives on the QueryClient, not in per-instance
+    // refs. Instance A starts a create and then unmounts (a remount, or a
+    // second consumer of the same slot); instance B, sharing the QueryClient,
+    // issues the unpin. B must still find A's in-flight promise, await it, and
+    // DELETE the real server id — not fall into the "no tracked promise" branch
+    // that silently drops the unpin (the pin would resurface on refetch).
+    // With per-instance ref maps this test fails: B's map is empty.
+    let resolveCreate!: (pin: ChatPin) => void
+    ;(pinsApi.create as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<ChatPin>(resolve => { resolveCreate = resolve }),
+    )
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+    ;(pinsApi.remove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = createWrapper(qc)
+
+    // Instance A starts the create, then unmounts.
+    const hookA = renderHook(() => useChatPins('slot-remount'), { wrapper })
+    await waitFor(() => expect(hookA.result.current.loading).toBe(false))
+    let pinPromise!: Promise<void>
+    act(() => {
+      pinPromise = hookA.result.current.pinMessage({
+        mid: 'm-remount',
+        message_ts: 'ts-remount',
+        role: 'user',
+        preview: 'pin before remount',
+      })
+    })
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = hookA.result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+    hookA.unmount()
+
+    // Instance B (fresh mount, same QueryClient, same slot) issues the unpin
+    // while A's create is still in flight.
+    const hookB = renderHook(() => useChatPins('slot-remount'), { wrapper })
+    await waitFor(() => expect(hookB.result.current.loading).toBe(false))
+    let unpinPromise!: Promise<void>
+    act(() => {
+      unpinPromise = hookB.result.current.unpinById(tempPin.id)
+    })
+
+    // Resolve A's create with a real server id and let both settle.
+    const serverPin: ChatPin = { ...mockPin, id: 'pin-remount-real', slot_key: 'slot-remount', mid: 'm-remount' }
+    await act(async () => {
+      resolveCreate(serverPin)
+      await Promise.allSettled([pinPromise, unpinPromise])
+    })
+
+    // B awaited A's create and deleted the REAL server id (never a temp id).
+    await waitFor(() => {
+      expect(pinsApi.remove).toHaveBeenCalledWith('pin-remount-real')
+    })
+    const tempDeletes = (pinsApi.remove as ReturnType<typeof vi.fn>)
+      .mock.calls.filter(([id]: [string]) => id.startsWith('temp-'))
+    expect(tempDeletes).toHaveLength(0)
+  })
+
+  it('pin intent and its deferred unpin coordinate across separate hook instances (generation survives)', async () => {
+    // Pin -> pending unpin -> pin-again, but the SECOND pin comes from a
+    // different hook instance on the same QueryClient (e.g. after a remount).
+    // The generation bump must be visible to the deferred unpin so the newer
+    // intent wins and the re-created pin is NOT deleted. With per-instance
+    // generation maps the second instance's bump is invisible and the pin is
+    // wrongly removed.
+    let resolveCreate1!: (pin: ChatPin) => void
+    const serverPin: ChatPin = { ...mockPin, id: 'pin-cross-idem', slot_key: 'slot-cross', mid: 'm-cross' }
+    ;(pinsApi.create as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(new Promise<ChatPin>(r => { resolveCreate1 = r }))
+      .mockResolvedValueOnce(serverPin) // idempotent second create: same record
+    ;(pinsApi.list as ReturnType<typeof vi.fn>).mockResolvedValue({ pins: [] })
+    ;(pinsApi.remove as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = createWrapper(qc)
+    const body = { mid: 'm-cross', message_ts: 'ts-c', role: 'user' as const, preview: 'p' }
+
+    // Instance A: pin (create 1 pending), then unpin awaiting create 1.
+    const hookA = renderHook(() => useChatPins('slot-cross'), { wrapper })
+    await waitFor(() => expect(hookA.result.current.loading).toBe(false))
+    let pin1!: Promise<void>
+    act(() => { pin1 = hookA.result.current.pinMessage(body) })
+    let tempPin!: ChatPin
+    await waitFor(() => {
+      const found = hookA.result.current.pins.find(p => p.id.startsWith('temp-'))
+      expect(found).toBeDefined()
+      tempPin = found!
+    })
+    let unpin1!: Promise<void>
+    act(() => { unpin1 = hookA.result.current.unpinById(tempPin.id) })
+
+    // Instance B (same QueryClient) pins the SAME message again — a newer
+    // intent that must supersede the deferred unpin.
+    const hookB = renderHook(() => useChatPins('slot-cross'), { wrapper })
+    await waitFor(() => expect(hookB.result.current.loading).toBe(false))
+    let pin2!: Promise<void>
+    act(() => { pin2 = hookB.result.current.pinMessage(body) })
+
+    // Resolve create 1 and let everything settle.
+    act(() => { resolveCreate1(serverPin) })
+    await act(async () => { await Promise.allSettled([pin1, pin2, unpin1]) })
+
+    // The newer pin intent won across instances: no DELETE was issued.
+    expect(pinsApi.remove as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+  })
+
   it('removes ghost optimistic pin on error when ctx.prev is undefined', async () => {
     // Create a fresh QueryClient with NO pre-seeded data for the slot,
     // so when the mutation's onMutate runs cancelQueries + getQueryData,


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** internal hook refactor — moves where two coordination maps are stored (per-instance ref → QueryClient-scoped WeakMap); the rendered pins UI and its behavior are identical.

## Problem / Motivation

Follow-up from the review of the optimistic-unpin fix (#5141). The chat-pin hook's unpin-race coordination state — `inFlightCreates` and `pinGenerations` — lived in per-instance `useRef` maps, while the pin data it guards lives in the shared React Query cache. The coordination and the data it coordinates had different lifetimes and different scopes.

## Why it matters

With today's single consumer (the chat page) this is latent. But a remount mid-create, or a future second consumer of `useChatPins` for the same slot, gets a **fresh, empty** ref map: a temp-id unpin then hits the "no tracked promise" branch while the create is still pending, the deferred server DELETE never fires, and the pin **silently resurfaces** on the settled refetch — a dropped unpin the user has to repeat.

## What changed (motivation → approach → change)

- **Root cause:** coordination state was scoped to the hook *instance* (`useRef`), not to the *client* that owns the pin cache it guards. Any new instance for the same slot cannot see an in-flight create started elsewhere.
- **Approach:** hoist both maps into a QueryClient-scoped store, mirroring the scope of the data they coordinate. A module-level `WeakMap<QueryClient, PinCoordStore>` keys the store off client identity, so it is reclaimed with the client (no leak) and never bleeds across the per-case QueryClients that tests construct.
- **Change:** `useChatPins` now resolves `{ inFlightCreates, pinGenerations }` from `coordStoreFor(qc)` instead of two `useRef`s. Every instance bound to the same client shares one store; an in-flight create and a generation bump are visible across instances and across remounts. **The coordination algorithm is unchanged** — only the maps' lifetime moves from per-instance to per-client. The two callbacks that read the maps gained them as (stable) dependencies.

## Tests

Two regression tests added to `chatPins.test.tsx`, both under the issue-#5168 section:
- **cross-instance in-flight create** — instance A starts a create and unmounts; instance B (same client, same slot) issues the unpin while the create is pending. B must await A's promise and DELETE the *real* server id, never a temp id.
- **cross-instance generation** — a deferred unpin on instance A is superseded by a second pin intent issued from instance B; the newer intent must win and no DELETE is issued.

Both tests **fail on the old ref-based store** (verified by reverting the hook and re-running: B's map is empty / B's generation bump is invisible) and **pass on the client-scoped store**. All 47 `chatPins` tests pass; `tsc -b`, `eslint --max-warnings 680`, and the existing race suite stay green.

## Manual verification

N/A — unit coverage sufficient. The change is a storage-location refactor with no rendered output and no new user-facing behavior; the cross-instance regression tests exercise the exact remount/second-consumer paths the issue names.

## Related Issues

Fixes #5168

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
