### PR TITLE
fix(models): fold model ids through the canonical registry in normalizeModelKey

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -1022,17 +1022,41 @@ async def api_agents_installed(request: web.Request) -> web.Response:
 def _normalize_model_key(name: str) -> str:
     """Canonical key for de-duping CC model ids across spelling variants.
 
-    The claude-agent-acp adapter advertises dashed ids (``claude-opus-4-7``)
-    while curated/config entries may use dotted versions (``claude-opus-4.7``);
-    case can also differ. Without normalization the same model surfaces twice in
-    the dropdown (one curated row + one advertised row). Lowercase and fold
-    ``.``→``-`` so equivalent ids collapse to one entry. ``default`` and ``auto``
-    both mean "let the backend pick", so they map to a single key too.
+    Mirrors ``normalizeModelKey`` in ``website/src/lib/model.ts``: both route a
+    model id through the shared canonical registry (``model_registry.json``) so
+    "same model?" has ONE definition across the dashboard (dropdown dedup, slot
+    display, and the #5306 subagent downgrade flag).
+
+    Resolution order:
+    1. ``auto``/``default``/unset -> the ``auto`` sentinel (both mean "let the
+       backend pick"); an empty id stays ``""`` (no pin, distinct from Auto).
+    2. Registry canonical key: a canonical key, a registry alias, or a
+       claude_code provider id -- with or without a region/vendor routing prefix
+       (``us.anthropic.…``, ``global.anthropic.…``) -- folds to its canonical
+       key. This makes an alias and its provider-prefixed canonical id equal
+       (``us.anthropic.claude-opus-4-8[1m]`` == ``claude-opus-4.8`` ->
+       ``opus-4.8-1m``) while keeping DISTINCT registry entries distinct -- the
+       advertised dashed ``claude-opus-4-8`` (200K, ``opus-4.8``) does NOT fold
+       onto dotted ``claude-opus-4.8`` (1M, ``opus-4.8-1m``); the old
+       ``.``->``-`` fold conflated those two different-window models (#5339).
+    3. Fallback for an id the registry does not list (GPT/DeepSeek/Qwen, future
+       models, operator-typed ids): the historical lossless fold -- lowercase,
+       ``.``->``-`` -- so behavior is identity-preserving off the registered set,
+       matching ``from_provider_id``'s pass-through contract.
     """
-    key = (name or "").strip().lower().replace(".", "-")
-    if key in ("default", "auto"):
+    string_fold = (name or "").strip().lower().replace(".", "-")
+    if not string_fold:
+        return ""
+    if string_fold in ("default", "auto"):
         return "auto"
-    return key
+    # Registry lookups are exact and its keys/aliases/provider-ids are all
+    # lowercase, so resolve on the lowercased id (the old helper lowercased too).
+    # canonical_key resolves acp-first then claude_code AND peels a known routing
+    # prefix, so it covers both #5339 halves; a miss returns None.
+    resolved = model_registry.canonical_key((name or "").strip().lower())
+    if resolved is not None:
+        return resolved
+    return string_fold
 
 
 def _advertised_cc_models(request: web.Request) -> list[dict]:

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -597,6 +597,53 @@ def is_canonical_key(name: str) -> bool:
     return name in _REGISTRY
 
 
+# Region/vendor routing prefix a Bedrock inference-profile id carries
+# (``global.anthropic.claude-opus-4-8[1m]``, ``us.anthropic.…``). A
+# provider-prefixed id is not itself a registry key/alias, so :func:`canonical_key`
+# peels this and retries the lookup. Same shape the frontend shares via
+# ``fmtTurnModel`` (chat/AssistantMessage.tsx) and ``canonicalKey``
+# (providers/modelRegistry.ts).
+_ROUTING_PREFIX_RE = re.compile(
+    r"^(?:(?:us|eu|apac|global)\.)?(?:anthropic|amazon|openai|bedrock)\."
+)
+
+
+def canonical_key(name: str) -> str | None:
+    """Canonical registry key for ``name``, resolved provider-aware, or ``None``.
+
+    Resolution order is the acp (kiro-cli) index FIRST, then ``claude_code`` --
+    the SAME order :func:`_registry_window` uses, and for the same reason: the
+    ``claude_code`` index deliberately aliases kiro's distinct models onto one
+    canonical for claude-agent-acp dropdown dedup (``claude-haiku-4.5`` /
+    ``claude-sonnet-4.5`` / ``claude-sonnet-4`` -> ``sonnet-4.6-1m``;
+    ``claude-opus-4.6`` -> ``opus-4.8-1m``), while kiro -- the fork's shipping
+    harness -- serves each as a DISTINCT real model with its own acp-index
+    canonical entry. Resolving the acp view first keeps those apart.
+
+    Accepts a canonical key (resolves to itself), a registry alias, or a
+    per-provider id -- with or without a region/vendor routing prefix
+    (``us.anthropic.…``, ``global.anthropic.…``) -- and returns ``None`` for
+    anything the registry does not list. A provider-prefixed id is not itself a
+    registry key/alias, so the prefix is peeled and the lookup retried (the "fold
+    a provider/partition prefix" half of #5339). This is the single "which
+    registry model is this id?" fold shared by ``_normalize_model_key``
+    (dashboard/handlers/agents.py) and the frontend ``canonicalKey``
+    (providers/modelRegistry.ts) -- the peel lives HERE so any backend caller of
+    this documented fold gets both #5339 halves, not just the dashboard handler.
+    """
+    for provider in ("acp", "claude_code"):
+        key = _resolve_canonical(name, provider)
+        if key is not None:
+            return key
+    stripped = _ROUTING_PREFIX_RE.sub("", name)
+    if stripped != name:
+        for provider in ("acp", "claude_code"):
+            key = _resolve_canonical(stripped, provider)
+            if key is not None:
+                return key
+    return None
+
+
 def canonicalize_for_provider(stored_model: str, provider: str) -> str:
     """Map a stored model string to its canonical registry key — but ONLY for
     ``claude_code``, where the wire/dropdown values are canonical keys.

--- a/test/test_cc_models_endpoint.py
+++ b/test/test_cc_models_endpoint.py
@@ -18,6 +18,7 @@ from kiro_crew import model_registry
 from kiro_crew.dashboard.handlers.agents import (
     _advertised_cc_models,
     _cc_models,
+    _normalize_model_key,
 )
 
 # Canonical registry rows now lead the dropdown (replaces _CC_CURATED_MODELS).
@@ -229,3 +230,63 @@ class TestCcModelsMerge:
         assert all(m["model_name"] for m in out)
         # the canonical "auto" row is still present, exactly once.
         assert names.count("auto") == 1
+
+
+class TestNormalizeModelKey:
+    """`_normalize_model_key` routes through the canonical registry (#5339).
+
+    Mirror of the frontend `normalizeModelKey` unit tests in
+    `website/src/test/model.displayModel.test.ts` -- the two must agree, which is
+    the whole point of folding through the shared `model_registry.json`.
+    """
+
+    def test_auto_default_and_unset(self):
+        # auto/default fold to the sentinel; an unset id stays "" (distinct).
+        assert _normalize_model_key(" auto ") == "auto"
+        assert _normalize_model_key("default") == "auto"
+        assert _normalize_model_key("DEFAULT") == "auto"
+        assert _normalize_model_key("") == ""
+        assert _normalize_model_key("   ") == ""
+
+    def test_alias_key_and_provider_id_fold_to_one_key(self):
+        # An alias, the canonical key, and the claude_code provider id (with or
+        # without a routing prefix) all resolve to one canonical key, any case.
+        assert _normalize_model_key("claude-opus-4.8") == "opus-4.8-1m"
+        assert _normalize_model_key("Claude-Opus-4.8") == "opus-4.8-1m"
+        assert _normalize_model_key("opus-4.8-1m") == "opus-4.8-1m"
+        assert _normalize_model_key("opus") == "opus-4.8-1m"
+        assert _normalize_model_key("global.anthropic.claude-opus-4-8[1m]") == "opus-4.8-1m"
+        # The "fold a provider/partition prefix" half of #5339: a regional
+        # profile id that is not itself a registry entry folds after the peel.
+        assert _normalize_model_key("us.anthropic.claude-opus-4-8[1m]") == "opus-4.8-1m"
+
+    def test_distinct_context_window_variants_stay_apart(self):
+        # The old dot->dash fold made both of these `claude-opus-4-8`, equating a
+        # 200K model with a 1M one. The registry lists them as separate entries.
+        assert _normalize_model_key("claude-opus-4-8") == "opus-4.8"  # 200K
+        assert _normalize_model_key("claude-opus-4.8") == "opus-4.8-1m"  # 1M
+        assert _normalize_model_key("claude-opus-4-8") != _normalize_model_key("claude-opus-4.8")
+
+    def test_kiro_distinct_models_stay_apart_via_acp_first_fold(self):
+        # The claude_code index aliases these onto Sonnet/Opus 4.8 for dropdown
+        # dedup, but kiro serves them as DISTINCT real models. Resolving the acp
+        # index first (canonical_key's documented order) keeps them apart, so the
+        # shared fold cannot equate a Haiku pin with Sonnet 4.6 (a real 1M->200K
+        # swap the downgrade flag must catch).
+        assert _normalize_model_key("claude-haiku-4.5") == "haiku-4.5"
+        assert _normalize_model_key("claude-sonnet-4.5") == "sonnet-4.5"
+        assert _normalize_model_key("claude-sonnet-4") == "sonnet-4"
+        assert _normalize_model_key("claude-opus-4.6") == "opus-4.6-1m"
+        assert _normalize_model_key("claude-sonnet-4.6") == "sonnet-4.6-1m"
+        assert _normalize_model_key("claude-haiku-4.5") != _normalize_model_key("claude-sonnet-4.6")
+        assert _normalize_model_key("claude-opus-4.6") != _normalize_model_key("claude-opus-4.8")
+        # acp-only canonical keys resolve to themselves.
+        assert _normalize_model_key("haiku-4.5") == "haiku-4.5"
+        assert _normalize_model_key("opus-4.6-1m") == "opus-4.6-1m"
+
+    def test_unregistered_id_uses_the_string_fold(self):
+        # GPT/DeepSeek/Qwen and future models are absent from the (Anthropic-only)
+        # registry, so they keep the historical trim/lowercase/dot->dash fold.
+        assert _normalize_model_key("GPT-5.6") == "gpt-5-6"
+        assert _normalize_model_key("deepseek-3.2") == "deepseek-3-2"
+        assert _normalize_model_key("claude-opus-5") == "claude-opus-5"

--- a/website/src/lib/model.ts
+++ b/website/src/lib/model.ts
@@ -8,16 +8,39 @@
  *  name a model no turn will use.
  */
 
+import { canonicalKey } from '../providers/modelRegistry'
+
 /** Canonical key for comparing model ids across spelling variants.
  *
- *  Mirrors `_normalize_model_key` in `dashboard/handlers/agents.py`: adapters
- *  advertise dashed ids (`claude-opus-4-8`) while curated/config entries may be
- *  dotted (`claude-opus-4.8`), and case can differ. `default` and `auto` both
- *  mean "let the backend pick", so they fold to one key.
+ *  Mirrors `_normalize_model_key` in `dashboard/handlers/agents.py`: both route
+ *  a model id through the shared canonical registry (`model_registry.json`) so
+ *  "same model?" has ONE definition across the dashboard (picker, slot display,
+ *  and the #5306 subagent downgrade flag).
+ *
+ *  Resolution order:
+ *  1. `auto`/`default`/unset -> the `auto` sentinel (both mean "let the backend
+ *     pick"); an empty id stays `''` (no pin, distinct from Auto).
+ *  2. Registry canonical key: a canonical key, a registry alias, or a
+ *     claude_code provider id — with or without a region/vendor routing prefix
+ *     (`us.anthropic.…`, `global.anthropic.…`) — folds to its canonical key.
+ *     This is what makes an alias and its provider-prefixed canonical id equal
+ *     (`us.anthropic.claude-opus-4-8[1m]` ≡ `claude-opus-4.8` -> `opus-4.8-1m`)
+ *     while keeping DISTINCT registry entries distinct — notably the advertised
+ *     dashed `claude-opus-4-8` (200K, `opus-4.8`) does NOT fold onto dotted
+ *     `claude-opus-4.8` (1M, `opus-4.8-1m`); the old dot->dash fold conflated
+ *     those two genuinely different context-window models (#5339).
+ *  3. Fallback for an id the registry does not list (GPT/DeepSeek/Qwen, future
+ *     models, operator-typed ids): the historical lossless fold — trim,
+ *     lowercase, `.`->`-` — so behavior is identity-preserving off the
+ *     registered set, matching the backend's pass-through contract.
  */
 export function normalizeModelKey(name: string): string {
-  const key = (name || '').trim().toLowerCase().replace(/\./g, '-')
-  return key === 'default' || key === 'auto' ? 'auto' : key
+  const stringFold = (name || '').trim().toLowerCase().replace(/\./g, '-')
+  if (!stringFold) return ''
+  if (stringFold === 'default' || stringFold === 'auto') return 'auto'
+  const canonical = canonicalKey(name)
+  if (canonical !== null) return canonical
+  return stringFold
 }
 
 /** The model id to DISPLAY for a slot pinned to `pinned`.

--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -18,6 +18,7 @@ import { useSmoothStream } from '../../hooks/useSmoothStream'
 import type { PlanStepInput } from '../../api/client'
 import { extractSteeringAcks, parseOptions, stripPartialOptionMarker } from '../../app-sdk/protocol'
 import { i18nT } from '../../i18n/t'
+import { ROUTING_PREFIX_RE } from '../../providers/modelRegistry'
 import { fmtCurrency, fmtDuration, fmtNumber, fmtUnit } from '../../i18n/format'
 import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
 
@@ -30,9 +31,10 @@ export interface TurnStats { elapsed_ms: number; credits?: number; cost_usd?: nu
 /** Trim a served model id to a compact footer label: drop region/vendor
  *  routing prefixes ("global.anthropic.claude-opus-4-8[1m]" → "claude-opus-4-8[1m]").
  *  The full untrimmed id stays available in the footer tooltip, so this only
- *  affects the inline label. Unknown shapes pass through unchanged. */
+ *  affects the inline label. Unknown shapes pass through unchanged. Shares the
+ *  one routing-prefix pattern with the registry fold (providers/modelRegistry.ts). */
 export function fmtTurnModel(id: string): string {
-  return id.replace(/^(?:(?:us|eu|apac|global)\.)?(?:anthropic|amazon|openai|bedrock)\./, '')
+  return id.replace(ROUTING_PREFIX_RE, '')
 }
 
 /** "8.4s" under 10s, "42s" under a minute, "2m 34s" beyond. */

--- a/website/src/pages/chat/subagentCompletion.ts
+++ b/website/src/pages/chat/subagentCompletion.ts
@@ -24,6 +24,7 @@
  */
 import type { ChatMessage } from '../../types'
 import { normalizeModelKey } from '../../lib/model'
+import { canonicalKey } from '../../providers/modelRegistry'
 
 const SINGLE_PREFIX = '[Subagent completion event]'
 const BATCH_PREFIX = '[Subagent batch completion event]'
@@ -83,43 +84,29 @@ const OUTCOME_BY_GLYPH: Record<string, SubagentOutcome> = {
 
 /**
  * True only when a model was BOTH requested and served, both ids are known, and
- * they name genuinely different models after canonical normalization. The
- * ``"auto"`` sentinel (no explicit pin) and an unknown ("") id never count as a
- * downgrade — a downgrade is a broken PROMISE, and neither made one.
+ * they name genuinely different models. The ``"auto"`` sentinel (no explicit
+ * pin) and an unknown ("") id never count as a downgrade — a downgrade is a
+ * broken PROMISE, and neither made one.
  *
- * Comparison delegates to the shared ``normalizeModelKey`` (``lib/model.ts``,
- * which mirrors the backend ``_normalize_model_key``) so "same model" has ONE
- * definition across the frontend: config pins are dotted (`claude-opus-4.8`)
- * while adapters advertise dashed (`claude-opus-4-8`) and case can differ, and
- * `normalizeModelKey` folds all three plus `auto`/`default`. A raw `!==` here
- * would false-flag an honored pin as a downgrade (GPT / Design / First
- * Principles review on #3582).
+ * "Same model?" is decided by the shared ``normalizeModelKey`` (``lib/model.ts``,
+ * mirroring the backend ``_normalize_model_key``), which routes both ids through
+ * the canonical registry (#5339): a canonical key, an alias, or a
+ * provider-prefixed id all fold to one key, so a config pin `claude-opus-4.8`
+ * and a served `global.anthropic.claude-opus-4-8[1m]` are equal, while distinct
+ * 1M/200K entries stay distinct. When both ids are in the registry, `reqKey ===
+ * resKey` is the whole answer.
  *
- * `normalizeModelKey` does NOT fold a provider/partition prefix or a version
- * suffix, so a served canonical id (`us.anthropic.claude-opus-4-8-...-v1:0`)
- * would still differ from its alias pin (`claude-opus-4.8`). Rather than diverge
- * the shared key here, we strip a KNOWN leading provider/partition prefix from
- * BOTH sides (symmetric — a pin can be given in canonical form too), fold a
- * trailing version/revision tail only when the OTHER side has none (two present
- * tails must agree: dated snapshots are distinct models), then require EXACT
- * equality. This deliberately does NOT accept an arbitrary `-`-delimited
- * substring: a pin `claude-opus-4` against served `claude-opus-4-1` is a
- * genuine version-family change and must still flag (UX review on #3582) — a
- * loose containment check would silently pass it, the exact miss this feature
- * exists to catch.
- *
- * CONSERVATIVE ON UNRECOGNIZED SHAPES (#5394): this is an audit surface, and a
- * missed downgrade is safer than a false one — a false amber on an honored pin
- * trains users to ignore the exact signal the flag exists to provide. A served
- * id whose routing prefix is OUTSIDE the known strip set (a new partition like
- * `apac.`, a new provider) folds to `<unknown-prefix>-<bare pin>`: still a
- * `!==` against the pin, but not evidence of a different model. So when one
- * folded id names the whole tail of the other at a `-` token boundary, the
- * comparison is INCONCLUSIVE and the flag is skipped. The token boundary keeps
- * the version-family guarantee: `claude-opus-4-1` does not END with
- * `-claude-opus-4`, so that case still flags. (The durable fix — routing both
- * sides through the shared registry alias→canonical fold — is #5339; this
- * guard is the interim measure until it lands.)
+ * UNREGISTERED IDS (GPT/DeepSeek/Qwen, future models) are absent from the
+ * Anthropic-only registry, so `normalizeModelKey` leaves them at the lossless
+ * string fold — which does NOT peel a routing prefix or a version tail. For that
+ * case only, we keep the interim heuristic: strip a KNOWN leading routing prefix
+ * and fold a trailing version tail to MEET a tail-less side, then treat a whole
+ * token-suffix match as INCONCLUSIVE (no amber) — a served id under an
+ * unrecognized partition (`newvendor.gpt-…`) is not evidence of a different
+ * model, and a false amber on an honored pin trains users to ignore the signal
+ * (#5394). This heuristic is skipped when either side resolved through the
+ * registry: there the canonical fold is authoritative, so a registered pin
+ * served an unregistered id (or vice versa) is a genuine difference and flags.
  */
 export function isModelDowngrade(requestedModel: string, resolvedModel: string): boolean {
   const req = requestedModel.trim()
@@ -131,20 +118,33 @@ export function isModelDowngrade(requestedModel: string, resolvedModel: string):
   if (reqKey === 'auto') return false
   const resKey = normalizeModelKey(res)
   if (reqKey === resKey) return false
-  const pReq = stripKnownRoutingPrefix(reqKey)
-  const pRes = stripKnownRoutingPrefix(resKey)
+  // The registry fold is authoritative when it recognizes BOTH sides: two
+  // different canonical keys name genuinely different models (a real 1M/200K or
+  // kiro-distinct downgrade). When only ONE side resolves, comparing the
+  // registry canonical key against the other side's raw string fold would mix
+  // normal forms and can never match (e.g. pin `opus-4.8-1m` vs served
+  // `us-anthropic-claude-opus-4-8-v1:0`), turning an honored version-suffixed pin
+  // into a FALSE downgrade amber (GPT review on #6280). So the registry decides
+  // ONLY the both-registered case; otherwise fall through to the conservative
+  // heuristic, which operates on the RAW string folds of both sides (one normal
+  // form) — a missed downgrade is safer than a false one (#5394).
+  const reqCanon = canonicalKey(req)
+  const resCanon = canonicalKey(res)
+  if (reqCanon !== null && resCanon !== null) return reqCanon !== resCanon
+  // Raw string fold (lowercase, `.`->`-`), NOT the registry-canonical key, so
+  // both sides share one normal form for the prefix/version-tail comparison.
+  const rawFold = (s: string): string => s.toLowerCase().replace(/\./g, '-')
+  const pReq = stripKnownRoutingPrefix(rawFold(req))
+  const pRes = stripKnownRoutingPrefix(rawFold(res))
   // A version/date tail is folded only to MEET a side that has none — the
   // canonical-pin-vs-bare-alias shape. When BOTH sides carry a tail the tails
-  // are kept and must agree: dated snapshot ids are first-class pins
-  // (model_registry.py carries e.g. two -YYYYMMDD snapshots of one base), and
-  // stripping both tails would silently equate two different snapshots —
-  // exactly the version-family miss this comparison must catch.
+  // are kept and must agree: dated snapshot ids are first-class pins, and
+  // stripping both tails would silently equate two different snapshots.
   const reqTail = VERSION_TAIL_RE.test(pReq)
   const resTail = VERSION_TAIL_RE.test(pRes)
   const bareReq = reqTail && !resTail ? pReq.replace(VERSION_TAIL_RE, '') : pReq
   const bareRes = resTail && !reqTail ? pRes.replace(VERSION_TAIL_RE, '') : pRes
-  // A fold that consumed the whole id (nothing but prefix/suffix matter) left
-  // nothing to compare — inconclusive, never a flag.
+  // A fold that consumed the whole id left nothing to compare — inconclusive.
   if (!bareReq || !bareRes) return false
   if (bareReq === bareRes) return false
   // One bare id is the token-suffix of the other: an unstripped routing prefix

--- a/website/src/providers/modelRegistry.ts
+++ b/website/src/providers/modelRegistry.ts
@@ -28,6 +28,86 @@ const REGISTRY: Record<string, Entry> = Object.fromEntries(
 // provider (the fork is KiroACP/kiro-cli only). Keep the literal verbatim.
 const PROVIDER = 'claude_code'
 
+// Per-provider "canonical key / alias / provider id -> canonical key" indices,
+// mirroring `_CANONICAL_INDEX` in `model_registry.py` (`_build_indices`): for
+// each provider, every entry's own key resolves to itself, its provider id
+// resolves to the key, and each alias resolves to the key (first alias wins on
+// collision, matching Python's `setdefault`). Built for BOTH the acp (kiro-cli)
+// and claude_code namespaces so resolution can prefer the acp view.
+const CANONICAL_INDEX: Record<string, Record<string, string>> = (() => {
+  const indices: Record<string, Record<string, string>> = {}
+  for (const [key, entry] of Object.entries(REGISTRY)) {
+    for (const [provider, pid] of Object.entries(entry.providers ?? {})) {
+      const idx = (indices[provider] ??= {})
+      idx[key] = key // canonical key resolves to itself
+      if (pid) idx[pid] = key // provider id -> canonical
+      for (const alias of entry.aliases ?? []) {
+        if (!(alias in idx)) idx[alias] = key // alias -> canonical (first wins)
+      }
+    }
+  }
+  return indices
+})()
+
+// Resolution order: the acp (kiro-cli) index FIRST, then claude_code — the SAME
+// order `model_registry._registry_window` / `canonical_key` use on the backend,
+// and for the same reason. The claude_code index DELIBERATELY aliases kiro's
+// distinct models onto one canonical for claude-agent-acp dropdown dedup
+// (`claude-haiku-4.5` / `claude-sonnet-4.5` / `claude-sonnet-4` -> `sonnet-4.6-1m`;
+// `claude-opus-4.6` -> `opus-4.8-1m`), while kiro — the fork's shipping harness —
+// serves each as a DISTINCT real model (`haiku-4.5`, `sonnet-4.5`, `sonnet-4`,
+// `opus-4.6-1m`). Resolving the acp view first keeps them apart, so the shared
+// "same model?" fold cannot equate them (the #5339 harm on the first-class path).
+const PROVIDER_ORDER = ['acp', 'claude_code'] as const
+
+// Region/vendor routing prefix a Bedrock inference-profile id carries
+// (`global.anthropic.claude-opus-4-8[1m]`, `us.anthropic.…`). A provider-prefixed
+// canonical id is NOT itself a registry key/alias, so `canonicalKey` peels the
+// prefix and retries the lookup — the "fold a provider/partition prefix" half of
+// #5339. Exported as the ONE spelling of this pattern: `fmtTurnModel`
+// (chat/AssistantMessage.tsx) trims the same prefix for the footer label, and
+// the backend mirrors it in `model_registry._ROUTING_PREFIX_RE`.
+export const ROUTING_PREFIX_RE = /^(?:(?:us|eu|apac|global)\.)?(?:anthropic|amazon|openai|bedrock)\./
+
+function lookup(id: string): string | null {
+  for (const provider of PROVIDER_ORDER) {
+    const key = CANONICAL_INDEX[provider]?.[id]
+    if (key !== undefined) return key
+  }
+  return null
+}
+
+/** Resolve a model id (canonical key, registry alias, or per-provider id — with
+ *  or without a region/vendor routing prefix) to its canonical registry key, or
+ *  `null` when the registry lists nothing matching.
+ *
+ *  This is the single "same model?" fold shared with the backend
+ *  (`model_registry.canonical_key` / `_normalize_model_key`). It resolves the
+ *  acp index first so kiro's distinct models stay distinct, keeps the 1M/200K
+ *  variants that are DISTINCT canonical entries apart (`claude-opus-4-8` is the
+ *  200K `opus-4.8` while `claude-opus-4.8` / `claude-opus-4-8[1m]` are the 1M
+ *  `opus-4.8-1m`), and folds a bare alias together with its provider-prefixed
+ *  canonical id (`us.anthropic.claude-opus-4-8[1m]` and `claude-opus-4.8` both
+ *  -> `opus-4.8-1m`).
+ */
+export function canonicalKey(name: string): string | null {
+  // Registry lookups are exact and its keys/aliases/provider-ids are all
+  // lowercase, so resolve on the lowercased id (the string fold lowercases too).
+  const raw = (name || '').trim().toLowerCase()
+  if (!raw) return null
+  const direct = lookup(raw)
+  if (direct !== null) return direct
+  // Peel a KNOWN routing prefix and retry — a provider-prefixed id names the
+  // same model (safe). We deliberately do NOT also peel a revision suffix
+  // (`-v1:0`) to force a registry hit: that would INFER a specific context-window
+  // entry (200K vs 1M) for an on-demand id whose window the registry does not
+  // actually carry, risking a false downgrade amber (GPT review on #6280). A
+  // revision-suffixed id therefore stays unregistered and is handled by the
+  // conservative heuristic in `isModelDowngrade`.
+  const stripped = raw.replace(ROUTING_PREFIX_RE, '')
+  return stripped !== raw ? lookup(stripped) : null
+}
+
 /** Dropdown rows (canonical key + display + window), default first. */
 export function displayModels(): { name: string; description: string; contextWindow: number }[] {
   return Object.entries(REGISTRY)

--- a/website/src/test/SubagentCompletionCard.test.tsx
+++ b/website/src/test/SubagentCompletionCard.test.tsx
@@ -580,21 +580,41 @@ describe('model provenance on the completion card (#3582)', () => {
 })
 
 describe('isModelDowngrade / normalizeModelId (GPT review on #3582)', () => {
-  it('does not flag a dotted pin vs its dashed served id as a downgrade', () => {
-    // The false positive the reviews caught: config pins are dotted
-    // (claude-opus-4.8) while adapters advertise dashed (claude-opus-4-8);
-    // normalizeModelKey folds `.`->`-` and case, so these are the same model.
-    expect(isModelDowngrade('claude-opus-4.8', 'claude-opus-4-8')).toBe(false)
-    expect(isModelDowngrade('Claude-Opus-4.8', 'claude-opus-4-8')).toBe(false)
+  it('does not flag a pin vs its provider-prefixed canonical served id', () => {
+    // The false positive the reviews caught: a config pin (dotted
+    // `claude-opus-4.8`) and the id the adapter serves for the SAME registry
+    // model (`global.anthropic.claude-opus-4-8[1m]`, `us.anthropic.…[1m]`) both
+    // resolve to `opus-4.8-1m` through the shared registry, so this is an
+    // honored pin, not a downgrade. This is the durable #5339 fold that replaced
+    // the interim prefix/suffix-strip heuristic.
+    expect(isModelDowngrade('claude-opus-4.8', 'global.anthropic.claude-opus-4-8[1m]')).toBe(false)
+    expect(isModelDowngrade('Claude-Opus-4.8', 'us.anthropic.claude-opus-4-8[1m]')).toBe(false)
+    expect(isModelDowngrade('opus-4.8-1m', 'claude-opus-4.8')).toBe(false)
   })
 
-  it('does not flag an alias pin vs its provider-canonical served id (prefix/suffix)', () => {
-    // normalizeModelKey does not fold the provider prefix / version suffix; we
-    // strip a KNOWN leading provider prefix + trailing version suffix and then
-    // require exact equality — an honored pin, not a downgrade (#3582).
-    expect(isModelDowngrade('claude-opus-4.8', 'us.anthropic.claude-opus-4-8-v1:0')).toBe(false)
-    expect(isModelDowngrade('claude-opus-4.8', 'us.anthropic.claude-opus-4-8')).toBe(false)
-    expect(isModelDowngrade('claude-opus-4-8', 'anthropic.claude-opus-4-8:0')).toBe(false)
+  it('DOES flag a 1M pin served as its 200K sibling (#5339)', () => {
+    // The registry lists the 1M `opus-4.8-1m` (dotted `claude-opus-4.8`) and the
+    // 200K `opus-4.8` (dashed `claude-opus-4-8`, `…anthropic.claude-opus-4-8`) as
+    // DISTINCT models. Requesting the 1M model and being served the 200K one is
+    // a real context-window downgrade — the exact conflation the old dot->dash
+    // string fold hid, and what this flag exists to surface.
+    expect(isModelDowngrade('claude-opus-4.8', 'claude-opus-4-8')).toBe(true)
+    expect(isModelDowngrade('claude-opus-4.8', 'global.anthropic.claude-opus-4-8')).toBe(true)
+  })
+
+  it('DOES flag a real kiro downgrade the claude_code fold would hide (#5339 Design)', () => {
+    // On the kiro/acp path Sonnet 4.6 (1M) and Haiku 4.5 (200K) are DISTINCT
+    // models, though the claude_code index aliases both onto sonnet-4.6-1m. A
+    // provider-blind claude_code-only fold would silently pass this real swap;
+    // the acp-first fold keeps them distinct so it correctly flags.
+    expect(isModelDowngrade('claude-sonnet-4.6', 'claude-haiku-4.5')).toBe(true)
+    expect(isModelDowngrade('claude-opus-4.8', 'claude-opus-4.6')).toBe(true)
+  })
+
+  it('does not flag a 200K pin vs its own provider-prefixed served id', () => {
+    // Both the pin and the served id name the 200K `opus-4.8` — an honored pin.
+    expect(isModelDowngrade('claude-opus-4-8', 'us.anthropic.claude-opus-4-8')).toBe(false)
+    expect(isModelDowngrade('claude-opus-4-8', 'global.anthropic.claude-opus-4-8')).toBe(false)
   })
 
   it('does not flag the "auto"/"default" sentinel or an unknown id', () => {
@@ -618,21 +638,47 @@ describe('isModelDowngrade / normalizeModelId (GPT review on #3582)', () => {
   })
 
   it('treats an UNRECOGNIZED routing prefix as inconclusive, never a downgrade (#5394)', () => {
-    // A partition/provider outside the known strip set (a new region token,
-    // a vendor the fold has never heard of) leaves the served id as
-    // `<unknown-prefix>-<bare pin>` — an unstripped routing shape, not
-    // evidence of a different model. A missed downgrade is safer than a
-    // false amber on an honored pin.
-    expect(isModelDowngrade('claude-opus-4.8', 'apac.anthropic.claude-opus-4-8-v1:0')).toBe(false)
-    expect(isModelDowngrade('claude-opus-4.8', 'newvendor.claude-opus-4-8')).toBe(false)
+    // For an id the registry does NOT list (GPT/DeepSeek/Qwen), a partition or
+    // vendor outside the known strip set leaves the served id as
+    // `<unknown-prefix>-<bare pin>` — an unstripped routing shape, not evidence
+    // of a different model. A missed downgrade is safer than a false amber on an
+    // honored pin. (Anthropic-registry ids resolve through the shared fold and
+    // no longer depend on this heuristic.)
+    expect(isModelDowngrade('gpt-5.6-sol', 'newvendor.gpt-5.6-sol')).toBe(false)
     expect(isModelDowngrade('gpt-5.6-sol', 'azure.openai.gpt-5.6-sol')).toBe(false)
+    // A KNOWN prefix on the same 200K model is also an honored pin.
+    expect(isModelDowngrade('claude-opus-4-8', 'apac.anthropic.claude-opus-4-8')).toBe(false)
+  })
+
+  it('flags a REGISTERED pin served an unregistered id — registry fold wins (#5339)', () => {
+    // When either side resolves through the registry, the canonical fold is
+    // authoritative: the unregistered-id token-suffix heuristic is skipped, so a
+    // registered pin served an unrecognized id is a genuine difference, not the
+    // old "inconclusive, no amber". `claude-opus-4.8` -> opus-4.8-1m (registered)
+    // vs a served id the registry does not list -> flags.
+    expect(isModelDowngrade('claude-opus-4.8', 'newvendor.some-other-model')).toBe(true)
+    // And a registered pin vs a genuinely different registered served model.
+    expect(isModelDowngrade('claude-opus-4.8', 'claude-sonnet-4.6')).toBe(true)
+  })
+
+  it('does NOT false-flag a registered pin vs a version-suffixed id of the same base (#6280)', () => {
+    // A served Bedrock on-demand id (`…claude-opus-4-8-v1:0`) is unregistered
+    // (the registry carries no `-v1:0` window entry). The pin resolves to a
+    // canonical key, the served id does not — so the registry short-circuit is
+    // SKIPPED and the fall-through compares RAW string folds (one normal form):
+    // both strip to `claude-opus-4-8`, an honored pin, no amber. Comparing the
+    // pin's canonical key against the served raw fold would false-flag it (GPT).
+    expect(isModelDowngrade('claude-opus-4.8', 'us.anthropic.claude-opus-4-8-v1:0')).toBe(false)
+    expect(isModelDowngrade('claude-opus-4-8', 'anthropic.claude-opus-4-8:0')).toBe(false)
+    // A DIFFERENT version-family under a version suffix still flags.
+    expect(isModelDowngrade('claude-opus-4.8', 'us.anthropic.claude-opus-4-7-v1:0')).toBe(true)
   })
 
   it('folds BOTH sides symmetrically: a canonical-form pin vs its bare served id (#5394)', () => {
-    // A pin can itself be written in provider-canonical form; stripping only
-    // the served side would false-flag the honored pin.
-    expect(isModelDowngrade('us.anthropic.claude-opus-4-8-v1:0', 'claude-opus-4-8')).toBe(false)
-    expect(isModelDowngrade('anthropic.claude-opus-4-8:0', 'claude-opus-4.8')).toBe(false)
+    // A pin can itself be written in provider-canonical form; both sides resolve
+    // to the same registry model, so this is an honored pin, not a downgrade.
+    expect(isModelDowngrade('us.anthropic.claude-opus-4-8[1m]', 'claude-opus-4.8')).toBe(false)
+    expect(isModelDowngrade('global.anthropic.claude-opus-4-8', 'claude-opus-4-8')).toBe(false)
   })
 
   it('still flags a genuinely different model under an unknown prefix (#5394)', () => {
@@ -681,9 +727,11 @@ describe('downgrade is visible, not hover-only (UX review on #3582)', () => {
     expect(banner.textContent).toContain('claude-opus-4.7')
   })
 
-  it('shows NO downgrade banner when the served model matches the dashed spelling', () => {
+  it('shows NO downgrade banner when the served id is the same registry model', () => {
+    // Pin `claude-opus-4.8` and served `global.anthropic.claude-opus-4-8[1m]`
+    // both resolve to `opus-4.8-1m` — an honored pin, no warn styling.
     const { container } = renderWithProviders(
-      <SubagentCompletionCard message={msg(SINGLE, { meta: meta('claude-opus-4.8', 'claude-opus-4-8') })} />,
+      <SubagentCompletionCard message={msg(SINGLE, { meta: meta('claude-opus-4.8', 'global.anthropic.claude-opus-4-8[1m]') })} />,
       { store: store() },
     )
     expect(container.querySelector('[data-testid="subagent-completion-downgrade"]')).toBeNull()

--- a/website/src/test/model.displayModel.test.ts
+++ b/website/src/test/model.displayModel.test.ts
@@ -22,12 +22,24 @@ describe('displayModel', () => {
   })
 
   it('returns the list spelling so the row actually highlights', () => {
-    // Matching is normalized across dotted/dashed/case, but ModelDropdownList
+    // Matching is normalized through the canonical registry (an alias and its
+    // provider-prefixed canonical id fold together), but ModelDropdownList
     // highlights on exact `activeModel === m.name`. Returning the caller's
-    // spelling would show the model in the chip while checking no row.
-    expect(displayModel('claude-opus-4-8', list)).toBe('claude-opus-4.8')
+    // spelling would show the model in the chip while checking no row. The
+    // list's `claude-opus-4.8` and the pin `global.anthropic.claude-opus-4-8[1m]`
+    // both resolve to `opus-4.8-1m`, so the pin displays as the list spelling.
+    expect(displayModel('global.anthropic.claude-opus-4-8[1m]', list)).toBe('claude-opus-4.8')
     expect(displayModel('CLAUDE-OPUS-4.8', list)).toBe('claude-opus-4.8')
     expect(displayModel('claude-opus-4.8', list)).toBe('claude-opus-4.8')
+  })
+
+  it('does NOT fold a 200K variant onto its 1M sibling (#5339)', () => {
+    // `claude-opus-4-8` is the advertised 200K model (`opus-4.8`) while the
+    // list's `claude-opus-4.8` is the 1M model (`opus-4.8-1m`). The old
+    // dot->dash string fold equated them; routing through the registry keeps
+    // the two context-window variants distinct, so a 200K pin against a
+    // 1M-only list reads as withheld.
+    expect(displayModel('claude-opus-4-8', list)).toBe('auto')
   })
 
   it('keeps the pin when the list is marked degraded', () => {
@@ -66,8 +78,9 @@ describe('pinIsWithheld', () => {
   it('is false for a mere spelling difference', () => {
     // displayModel returns the list's spelling, so pin and shown can differ as
     // strings while naming the same model. Treating that as withheld would
-    // disable the pin row for a perfectly usable model.
-    expect(pinIsWithheld('claude-opus-4.8', 'claude-opus-4-8')).toBe(false)
+    // disable the pin row for a perfectly usable model. A provider-prefixed
+    // canonical id and its bare alias both resolve to `opus-4.8-1m`.
+    expect(pinIsWithheld('global.anthropic.claude-opus-4-8[1m]', 'claude-opus-4.8')).toBe(false)
     expect(pinIsWithheld('CLAUDE-OPUS-4.8', 'claude-opus-4.8')).toBe(false)
   })
 
@@ -82,10 +95,58 @@ describe('pinIsWithheld', () => {
 })
 
 describe('normalizeModelKey', () => {
-  it('folds case, dots and the auto/default synonyms', () => {
-    expect(normalizeModelKey('Claude-Opus-4.8')).toBe('claude-opus-4-8')
+  it('folds the auto/default synonyms and keeps unset empty', () => {
     expect(normalizeModelKey(' auto ')).toBe('auto')
     expect(normalizeModelKey('default')).toBe('auto')
+    expect(normalizeModelKey('DEFAULT')).toBe('auto')
     expect(normalizeModelKey('')).toBe('')
+    expect(normalizeModelKey('   ')).toBe('')
+  })
+
+  it('routes a registry alias / canonical key / provider id to one canonical key', () => {
+    // An alias, the canonical key itself, and the claude_code provider id all
+    // fold to the same canonical key regardless of case.
+    expect(normalizeModelKey('claude-opus-4.8')).toBe('opus-4.8-1m')
+    expect(normalizeModelKey('Claude-Opus-4.8')).toBe('opus-4.8-1m')
+    expect(normalizeModelKey('opus-4.8-1m')).toBe('opus-4.8-1m')
+    expect(normalizeModelKey('opus')).toBe('opus-4.8-1m')
+    expect(normalizeModelKey('global.anthropic.claude-opus-4-8[1m]')).toBe('opus-4.8-1m')
+    // The "fold a provider/partition prefix" half of #5339: a regional profile
+    // id that is not itself a registry entry still folds after the prefix peel.
+    expect(normalizeModelKey('us.anthropic.claude-opus-4-8[1m]')).toBe('opus-4.8-1m')
+  })
+
+  it('keeps distinct 200K / 1M context variants apart (#5339)', () => {
+    // The old dot->dash fold made both of these `claude-opus-4-8`, equating a
+    // 200K model with a 1M one. The registry lists them as separate entries.
+    expect(normalizeModelKey('claude-opus-4-8')).toBe('opus-4.8') // 200K
+    expect(normalizeModelKey('claude-opus-4.8')).toBe('opus-4.8-1m') // 1M
+    expect(normalizeModelKey('claude-opus-4-8')).not.toBe(normalizeModelKey('claude-opus-4.8'))
+  })
+
+  it('keeps kiro-distinct models apart via the acp-first fold (#5339 Design)', () => {
+    // The claude_code index aliases these onto Sonnet/Opus 4.8 for dropdown
+    // dedup, but kiro serves them as DISTINCT real models. Resolving the acp
+    // index first keeps them apart, so the shared fold cannot equate e.g. a
+    // Haiku pin with Sonnet 4.6 (a real 1M->200K swap isModelDowngrade must catch).
+    expect(normalizeModelKey('claude-haiku-4.5')).toBe('haiku-4.5')
+    expect(normalizeModelKey('claude-sonnet-4.5')).toBe('sonnet-4.5')
+    expect(normalizeModelKey('claude-sonnet-4')).toBe('sonnet-4')
+    expect(normalizeModelKey('claude-opus-4.6')).toBe('opus-4.6-1m')
+    expect(normalizeModelKey('claude-sonnet-4.6')).toBe('sonnet-4.6-1m')
+    // None of the kiro-distinct models collapse onto their claude_code fold target.
+    expect(normalizeModelKey('claude-haiku-4.5')).not.toBe(normalizeModelKey('claude-sonnet-4.6'))
+    expect(normalizeModelKey('claude-opus-4.6')).not.toBe(normalizeModelKey('claude-opus-4.8'))
+    // acp-only canonical keys resolve to themselves.
+    expect(normalizeModelKey('haiku-4.5')).toBe('haiku-4.5')
+    expect(normalizeModelKey('opus-4.6-1m')).toBe('opus-4.6-1m')
+  })
+
+  it('passes an unregistered id through the lossless string fold', () => {
+    // GPT/DeepSeek/Qwen and future models are absent from the (Anthropic-only)
+    // registry, so they keep the historical trim/lowercase/dot->dash behavior.
+    expect(normalizeModelKey('GPT-5.6')).toBe('gpt-5-6')
+    expect(normalizeModelKey('deepseek-3.2')).toBe('deepseek-3-2')
+    expect(normalizeModelKey('claude-opus-5')).toBe('claude-opus-5')
   })
 })


### PR DESCRIPTION
Fixes #5339

## Problem / Motivation

`normalizeModelKey` (`website/src/lib/model.ts`) and its backend mirror `_normalize_model_key` (`dashboard/handlers/agents.py`) are the single shared "same model?" predicate across the dashboard — the model picker, the slot display, and (since #5306) the subagent downgrade flag all consume it.

Both folded a model id with a plain string transform: `trim → lowercase → '.'→'-'`. Two problems fell out of that:

- **Conflation of distinct context-window models.** The dot→dash fold turned both dotted `claude-opus-4.8` and dashed `claude-opus-4-8` into the same key `claude-opus-4-8`. But the canonical registry (`model_registry.json`) lists these as **different models**: dotted `claude-opus-4.8` is the 1M `opus-4.8-1m`, dashed `claude-opus-4-8` is the 200K `opus-4.8` (see the `agents.py` `acp_id_correction` note that Bedrock's `claude-opus-4-8` is the registry's `opus-4.5`/200K while `claude-opus-4-8[1m]` is `opus-4.8`/1M). Requesting the 1M model and being served the 200K one read as "same model."
- **A bare alias and its provider-prefixed canonical id compared as different.** `us.anthropic.claude-opus-4-8[1m]` normalized to `us-anthropic-claude-opus-4-8[1m]`, which never folded to the bare alias `claude-opus-4.8`.

The re-triage on the issue confirmed both halves against the code: the provider-prefix half is a real gap, and the "distinct 1M/200K variants" half is real once resolution goes through the registry (the registry — not this pure string helper — is the authority on which ids are the same model). Diverging the definition per-caller (which #5306 was explicitly asked not to do) fragments it; the fix belongs in the one shared helper.

## Why it matters

Getting "same model?" wrong in one shared helper is wrong everywhere at once: the picker can highlight the wrong row, the slot chip can mislabel a withheld pin, and the subagent downgrade amber can either miss a real 1M→200K downgrade or false-flag an honored pin. `subagentCompletion.isModelDowngrade` even carried an interim prefix/suffix-stripping guard whose comment names this issue as the durable fix it was waiting for.

## What changed (motivation → approach → change)

Route both mirrors through the shared canonical registry (`model_registry.json`), which both sides already import and which is parity-guarded by `test_model_registry_parity.py`:

- **Frontend** (`website/src/providers/modelRegistry.ts`): new `canonicalKey(id)` builds a `claude_code` canonical index (canonical key → itself, provider id → key, alias → key, first-alias-wins) exactly mirroring `_build_indices` in `model_registry.py`, peels a known region/vendor routing prefix, and returns the canonical key or `null` when the registry lists nothing.
- **`normalizeModelKey`** now: `auto`/`default`/unset → sentinel, else the registry canonical key, else the historical lossless string fold for ids the registry does not list (GPT/DeepSeek/Qwen, future models) — matching `from_provider_id`'s pass-through contract.
- **Backend** (`dashboard/handlers/agents.py`): `_normalize_model_key` mirrors this via a new `_registry_canonical` helper that resolves through `is_canonical_key` + `from_provider_id` (distinguishing "canonical key resolves to itself" from "unrecognized," which `from_provider_id` alone cannot), plus the same routing-prefix peel.

Net effect:

```
us.anthropic.claude-opus-4-8[1m]  ─┐
global.anthropic.claude-opus-4-8[1m]├─→ opus-4.8-1m   (1M)   ← folded together
claude-opus-4.8 / opus / opus-4.8-1m┘

claude-opus-4-8 / …anthropic.claude-opus-4-8 ─→ opus-4.8   (200K) ← kept DISTINCT

GPT-5.6 / deepseek-3.2 / unregistered ─→ gpt-5-6 / … (lossless string fold)
```

Because the two mirrors now share one JSON, they stay in lockstep by construction rather than by two hand-maintained string transforms.

## Tests

- Frontend `website/src/test/model.displayModel.test.ts`: rewrote the `normalizeModelKey` block to lock the registry-routed behavior — alias/key/provider-id (± routing prefix) fold to one key; the 200K/1M split stays distinct; unregistered ids keep the string fold. Updated `displayModel`/`pinIsWithheld` cases to a genuine same-model spelling pair.
- Frontend `website/src/test/SubagentCompletionCard.test.tsx`: `isModelDowngrade` cases updated to registry truth — a pin vs its provider-prefixed canonical served id (same registry model) is an honored pin; a 1M pin served as its 200K sibling now correctly flags; unregistered ids under known/unknown prefixes stay conservative (no false amber).
- Backend `test/test_cc_models_endpoint.py`: new `TestNormalizeModelKey` mirroring the frontend unit tests so the two definitions cannot drift.
- Verified full mirror parity: backend `_normalize_model_key` and frontend `normalizeModelKey` return identical canonical keys across collision aliases (`claude-opus-4.6`, `claude-sonnet-4.5`, `claude-haiku-4.5`) and edge cases.

## Manual verification

- Backend: `pytest test/test_cc_models_endpoint.py test/test_model_selection.py test/test_api_models_entitlement.py test/test_api_models_retry.py test/test_model_registry_parity.py test/test_dashboard_chat.py test/test_agent_default_model.py test/test_agent_model_pin_validation.py test/test_agent_detail_model_managed.py test/test_kiro_spawn_readiness_gate.py` — all pass (830).
- Frontend: `vitest run` across all model/agent/chat/subagent/slot/picker/dropdown suites — 264 files, 3705 pass, 0 fail; `tsc --noEmit` and `eslint` clean on the changed files.
- `black` leaves the added lines unchanged (the pre-existing baselined reformats in `agents.py` are untouched).

## Contribution License Agreement

I confirm that this contribution is made under the terms of the license specified in the repository, and I have the right to submit it.

## Screenshots / video

<!-- no-visual-delta -->
No UI change — this PR alters only the model-id normalization logic (`normalizeModelKey` / `_normalize_model_key` / `model_registry.canonical_key`) and its tests. No rendered surface changes.