### PR TITLE
fix(dashboard): keep a real queryFn on the shared prerequisite query

### DIFF
--- a/website/src/hooks/useGatewayPlatform.ts
+++ b/website/src/hooks/useGatewayPlatform.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
-import { QueryClient, QueryClientContext, useQuery, skipToken } from '@tanstack/react-query'
-import type { KiroPrerequisiteStatus } from '../api/client'
+import { QueryClient, QueryClientContext, useQuery } from '@tanstack/react-query'
+import { api, type KiroPrerequisiteStatus } from '../api/client'
 
 /** What the gateway host is, for copy that names an OS feature by its real name. */
 export type GatewayPlatform = 'darwin' | 'windows' | 'other'
@@ -29,6 +29,9 @@ export function classifyPlatform(raw: string | undefined | null): GatewayPlatfor
   return 'other'
 }
 
+/** The query the prerequisite gate owns; this hook subscribes without driving it. */
+const PREREQUISITE_QUERY_KEY = ['kiro-prerequisite'] as const
+
 /**
  * Read-only stand-in for a tree that has no `QueryClientProvider`.
  *
@@ -48,17 +51,30 @@ const ORPHAN_TREE_CACHE = new QueryClient()
  * against a Linux gateway must not name Finder. The install command has the same
  * property and is resolved server-side for the same reason.
  *
- * A pure reader — `skipToken` means this hook never fetches. The prerequisite
- * gate wraps the whole dashboard and owns that query, so the value is cached
- * before any page mounts, and this subscription re-renders when the gate
- * refreshes it.
+ * A pure reader: `enabled: false` means this hook never fetches. The
+ * prerequisite gate wraps the whole dashboard and owns that query, so the value
+ * is cached before any page mounts, and this subscription re-renders when the
+ * gate refreshes it.
+ *
+ * The `queryFn` is nevertheless a real fetch, and must stay one. React Query
+ * keeps a single options object per query, so whichever observer mounted last
+ * decides what a refetch driven through the CLIENT — rather than through an
+ * observer — runs. A fetch-less `queryFn` registered here therefore surfaces as
+ * `Missing queryFn` on the gate's query the next time something invalidates it
+ * (the token-refresh scheduler does), which strands the whole dashboard behind
+ * the gate's error screen. Reading the latched state is the cheap mode, so a
+ * refetch that resolves through these options costs no `kiro-cli` spawn.
  *
  * See `classifyPlatform` for why anything unrecognised is generic wording.
  */
 export function useGatewayPlatform(): GatewayPlatform {
   const provided = useContext(QueryClientContext)
   const { data } = useQuery<KiroPrerequisiteStatus>(
-    { queryKey: ['kiro-prerequisite'], queryFn: skipToken },
+    {
+      queryKey: PREREQUISITE_QUERY_KEY,
+      queryFn: () => api.kiroPrerequisite(false),
+      enabled: false,
+    },
     provided ?? ORPHAN_TREE_CACHE,
   )
   return classifyPlatform(data?.platform)

--- a/website/src/test/useGatewayPlatform.test.tsx
+++ b/website/src/test/useGatewayPlatform.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for useGatewayPlatform.
+ *
+ * The hook reads the query the prerequisite gate owns. React Query keeps ONE
+ * options object per query key, so an observer that registers a fetch-less
+ * `queryFn` can decide what a client-driven refetch runs — which is why these
+ * tests mount the reader AFTER the owner and then refetch through the client:
+ * that is the ordering in which a reader can strand the gate's query without a
+ * usable `queryFn`.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+
+vi.mock('../api/client', () => ({
+  api: { kiroPrerequisite: vi.fn().mockResolvedValue({ platform: 'linux' }) },
+}))
+
+import { useGatewayPlatform } from '../hooks/useGatewayPlatform'
+import { api } from '../api/client'
+
+const PREREQUISITE_KEY = ['kiro-prerequisite']
+
+const makeClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false },
+    },
+  })
+
+const wrapperFor = (qc: QueryClient): React.FC<{ children: React.ReactNode }> =>
+  ({ children }): JSX.Element => <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+
+/** Stands in for the prerequisite gate: the owner of the query. */
+const GateOwner = ({ queryFn }: { queryFn: () => Promise<unknown> }): JSX.Element => {
+  const { data } = useQuery({ queryKey: PREREQUISITE_KEY, queryFn })
+  const platform = (data as { platform?: string } | undefined)?.platform
+  return <div>owner:{platform ?? 'pending'}</div>
+}
+
+const PlatformReader = (): JSX.Element => <div>reader:{useGatewayPlatform()}</div>
+
+/** Keeps the owner mounted across rerenders so only the reader is newly added. */
+const Harness = ({
+  queryFn,
+  withReader,
+}: {
+  queryFn: () => Promise<unknown>
+  withReader: boolean
+}): JSX.Element => (
+  <>
+    <GateOwner queryFn={queryFn} />
+    {withReader ? <PlatformReader /> : null}
+  </>
+)
+
+afterEach(() => {
+  cleanup()
+  vi.mocked(api.kiroPrerequisite).mockClear()
+})
+
+describe('useGatewayPlatform', () => {
+  it('leaves the shared query fetchable when the reader mounts after the gate', async () => {
+    const qc = makeClient()
+    const queryFn = vi.fn().mockResolvedValue({ platform: 'darwin' })
+    const view = render(<Harness queryFn={queryFn} withReader={false} />, {
+      wrapper: wrapperFor(qc),
+    })
+    await waitFor(() => expect(screen.getByText('owner:darwin')).toBeTruthy())
+
+    view.rerender(<Harness queryFn={queryFn} withReader />)
+    await waitFor(() => expect(screen.getByText('reader:darwin')).toBeTruthy())
+
+    await act(async () => {
+      await qc.refetchQueries({ queryKey: PREREQUISITE_KEY })
+    })
+
+    expect(qc.getQueryState(PREREQUISITE_KEY)?.error).toBeNull()
+    expect(qc.getQueryState(PREREQUISITE_KEY)?.status).toBe('success')
+  })
+
+  it('holds the cached status against collection while only the reader is mounted', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    render(<PlatformReader />, { wrapper: wrapperFor(qc) })
+
+    act(() => {
+      qc.setQueryData(PREREQUISITE_KEY, { platform: 'darwin' })
+    })
+
+    await waitFor(() => expect(screen.getByText('reader:darwin')).toBeTruthy())
+  })
+
+  it('never fetches on its own', async () => {
+    const qc = makeClient()
+    render(<PlatformReader />, { wrapper: wrapperFor(qc) })
+
+    await act(async () => {
+      await qc.refetchQueries({ queryKey: PREREQUISITE_KEY })
+    })
+
+    expect(api.kiroPrerequisite).not.toHaveBeenCalled()
+  })
+
+  it('re-renders when the cached status changes', async () => {
+    const qc = makeClient()
+    render(<PlatformReader />, { wrapper: wrapperFor(qc) })
+    expect(screen.getByText('reader:other')).toBeTruthy()
+
+    act(() => {
+      qc.setQueryData(PREREQUISITE_KEY, { platform: 'win32' })
+    })
+
+    await waitFor(() => expect(screen.getByText('reader:windows')).toBeTruthy())
+  })
+
+  it('resolves to generic wording in a tree with no QueryClientProvider', () => {
+    render(<PlatformReader />)
+
+    expect(screen.getByText('reader:other')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Starting a session can fail on the dashboard's first-run gate with a full-screen
"We could not check Kiro CLI." screen reading:

```
Missing queryFn: '["kiro-prerequisite"]'. Retry the gateway check before starting a session.
```

The first sentence is React Query's internal error surfaced verbatim:
`KiroPrerequisiteGate` renders `{asSentence(message)}` followed by the retry copy,
so a rejected fetch on its own query becomes the gate's error state.

## Why it matters

The gate wraps the whole dashboard, so this is not a degraded corner — the user
cannot get past it to any page or start a session, and "Try again" re-enters the
same rejection. It reproduces only for some users on some loads because the
trigger is component mount order (see below), which makes it look flaky and hard
to self-diagnose.

## What changed (motivation → approach → change)

**Symptom → root cause.** Two observers share the query key
`['kiro-prerequisite']` with different options:

- `KiroPrerequisiteGate` — the owner, with a real `queryFn`
  (`api.kiroPrerequisite(refresh)`) plus a `refetchInterval`.
- `useGatewayPlatform` — a deliberate read-only subscriber, registering
  `queryFn: skipToken`.

React Query keeps one options object per query and every observer writes its own
onto it (`QueryObserver#setOptions` → `Query#setOptions`), so whichever observer
mounted last decides what a fetch driven through the **client** runs. When an
observer triggers a fetch it passes its own options, but
`queryClient.invalidateQueries` / `refetchQueries` call `query.fetch()` with
none — and `ensureQueryFn` then sees `skipToken`:

```ts
if (!options.queryFn || options.queryFn === skipToken) {
  return () => Promise.reject(new Error(`Missing queryFn: '${options.queryHash}'`))
}
```

`useGatewayPlatform` is mounted by six components (`FileViewer`, Mochi's
`ChatPanel`, `MarkdownPanel`, `MarkdownRenderer`, `ReportProblemModal`,
`FolderPanel`), so any of them mounting after the gate leaves the shared query
holding a fetch-less `queryFn`. `useRefreshScheduler` invalidates that exact key
after a token refresh, which is the trigger in the wild.

**Approach.** The hook must stay a reader that never fetches, but it must stop
registering options that are unsafe to inherit. Two alternatives were rejected on
evidence: sharing the gate's fetch-capable options would make the hook fetch in
Mochi's provider-less trees, and dropping `useQuery` for a plain cache read
(`useSyncExternalStore`) removes the observer that holds the cached status
against garbage collection — that variant broke the platform-copy cases in
`FileExplorerPageCoverage.test.tsx`, which run with `gcTime: 0`.

**Change.** `useGatewayPlatform` keeps `useQuery` and gains:

- `enabled: false` — it never fetches on its own, and remains an observer, so the
  cached status survives while any consumer is mounted.
- a real `queryFn` (`api.kiroPrerequisite(false)`) — a client-driven refetch that
  resolves through these options performs the cheap latched read instead of
  rejecting. `false` spawns no `kiro-cli`.

## Tests

New `website/src/test/useGatewayPlatform.test.tsx` (5 tests):

- *leaves the shared query fetchable when the reader mounts after the gate* —
  the regression. Mounts the reader after the owner, refetches through the
  client, and asserts no error. Reverting only the hook fails it with
  `expected Error: Missing queryFn: '["kiro-prerequisite"]' to be null`, so it
  reproduces the reported error rather than a proxy for it.
- *holds the cached status against collection while only the reader is mounted* —
  locks the observer role under `gcTime: 0`.
- *never fetches on its own* — asserts the api is not called, including across a
  client refetch.
- *re-renders when the cached status changes* — reactivity preserved.
- *resolves to generic wording in a tree with no QueryClientProvider* — the
  provider-less Mochi/popout path.

## Manual verification

N/A — unit coverage sufficient: the failure is a cache-options interaction fully
reproducible in the test harness, and the regression test asserts the exact
production error string.

Local gates: `npx tsc -b` clean; full frontend suite run; the previously
affected `FileExplorerPageCoverage.test.tsx` platform cases pass; brand-name,
focus-cue, and scrub lint gates pass diff-scoped against the base.

One unrelated failure appeared only under the full parallel run —
`ChatPage.responsivePanel.test.tsx > renders the panel inline when no slot
exists, then migrates into a slot that appears later`. It passes in isolation
(2/2), and that file mocks `MarkdownPanel` and `MarkdownRenderer` to
`() => null` — the only consumers of this hook in its tree — so the hook never
executes there. Load-sensitive, not from this change.

Backend gates were not run locally (no Python toolchain on that host); this diff
contains no Python.

## Related Issues

None filed — reported directly by a user hitting it on session start.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff
