### PR TITLE
perf(session-storage): stream _read_manifest line-by-line

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1277,6 +1277,34 @@ def _append_entry(handle: IO[str], entry: dict[str, Any]) -> None:
     handle.flush()
 
 
+def _iter_manifest_records(batch: Path) -> Iterator[dict[str, Any]]:
+    """Yield each parsed dict record from a batch manifest.
+
+    A file that cannot be OPENED yields nothing (caller sees an empty stream,
+    same as an empty manifest). A read error that occurs MID-ITERATION is NOT
+    swallowed — it propagates as OSError so the caller can fail all-or-nothing
+    rather than act on a silently truncated prefix (restoring only part of a
+    batch and then deleting the unrestored remainder). Blank / non-JSON /
+    non-dict lines are skipped; a trailing partial line (crash mid-append) is
+    tolerated. The FIRST yielded dict is the header; the rest are entries.
+    """
+    try:
+        fh = (batch / MANIFEST_NAME).open(encoding="utf-8")
+    except OSError:
+        return
+    with fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
 def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
     """Parse a batch manifest into its header and session entries.
 
@@ -1284,26 +1312,19 @@ def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] |
     the whole batch: every complete line before it describes real moved files that
     must stay restorable.
     """
-    try:
-        raw = (batch / MANIFEST_NAME).read_text(encoding="utf-8")
-    except OSError:
-        return None
     header: dict[str, Any] | None = None
     entries: list[dict[str, Any]] = []
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            record = json.loads(line)
-        except ValueError:
-            continue
-        if not isinstance(record, dict):
-            continue
-        if header is None:
-            header = record
-            continue
-        entries.append(record)
+    try:
+        for record in _iter_manifest_records(batch):
+            if header is None:
+                header = record
+            else:
+                entries.append(record)
+    except OSError:
+        # A mid-read I/O error must not yield a truncated-but-valid batch:
+        # _restore_locked would restore only the prefix and then delete the
+        # unrestored remainder. Fail all-or-nothing, as read_text() did.
+        return None
     if header is None or header.get("schema") != MANIFEST_SCHEMA:
         return None
     return header, entries
@@ -1330,6 +1351,38 @@ def _entry_bytes(entry: dict[str, Any]) -> int:
             if isinstance(size, int):
                 total += size
     return total
+
+
+def _read_manifest_summary(
+    batch: Path,
+) -> tuple[dict[str, Any], int, int] | None:
+    """Parse a batch manifest and return only the header plus aggregate counts.
+
+    Instead of materialising every entry dict, this function accumulates a
+    session count and a total-bytes sum as it streams each line.  Peak memory
+    stays at O(one line), making it safe to call on large batches.
+
+    Parse semantics are identical to :func:`_read_manifest`: OSError → None;
+    blank / non-JSON / non-dict lines skipped; first dict is the header; schema
+    check applied; a trailing partial line (crash mid-append) is tolerated.
+    """
+    header: dict[str, Any] | None = None
+    count = 0
+    total_bytes = 0
+    try:
+        for record in _iter_manifest_records(batch):
+            if header is None:
+                header = record
+            else:
+                count += 1
+                total_bytes += _entry_bytes(record)
+    except OSError:
+        # Mid-read I/O error: return None rather than an undercount that would
+        # misreport the batch's size in the trash listing.
+        return None
+    if header is None or header.get("schema") != MANIFEST_SCHEMA:
+        return None
+    return header, count, total_bytes
 
 
 def move_to_trash(
@@ -1588,13 +1641,13 @@ def list_trash() -> list[TrashBatch]:
         # listed as a real batch and the sweep would delete through it.
         if platform_compat.is_link_or_junction(candidate) or not candidate.is_dir():
             continue
-        parsed = _read_manifest(candidate)
-        if parsed is None:
+        summary = _read_manifest_summary(candidate)
+        if summary is None:
             # %r: the directory name is agent-controlled; repr keeps an embedded
             # newline from forging additional log records.
             logger.debug("trash batch %r has no readable manifest", candidate.name)
             continue
-        header, entries = parsed
+        header, count, total_bytes = summary
         # The DIRECTORY is the batch's identity. A header that names a different
         # batch would make a targeted empty delete the batch it named instead of
         # the one it came from, so a disagreement is treated as corruption rather
@@ -1614,8 +1667,8 @@ def list_trash() -> list[TrashBatch]:
                 batch_id=candidate.name,
                 created_at=float(created) if isinstance(created, (int, float)) else 0.0,
                 reason=str(header.get("reason") or ""),
-                sessions=len(entries),
-                bytes=sum(_entry_bytes(e) for e in entries),
+                sessions=count,
+                bytes=total_bytes,
             )
         )
     batches.sort(key=lambda b: b.created_at, reverse=True)

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -886,18 +886,20 @@ class TestTrashBatchNamesAreLogSafe:
             def is_dir() -> bool:
                 return True
 
-        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+        # list_trash now calls _read_manifest_summary (count-only, O(1) memory)
+        # rather than _read_manifest. The return shape is (header, count, bytes) | None.
+        summaries: dict[str, tuple[dict[str, object], int, float] | None] = {
             "missing": None,
-            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0.0),
         }
-        for label, parsed in manifests.items():
+        for label, summary in summaries.items():
             caplog.clear()
             monkeypatch.setattr(session_storage.Path, "iterdir", lambda self: iter([_ForgedDir()]))
             monkeypatch.setattr(
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )
             monkeypatch.setattr(
-                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+                session_storage, "_read_manifest_summary", lambda batch, summary=summary: summary
             )
 
             with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):
@@ -1811,6 +1813,99 @@ class TestTrashAccounting:
             first.batch_id,
         ]
 
+    def test_list_trash_count_and_bytes_match_entries_with_trailing_partial(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """list_trash reports exact session count and byte total via the summary path.
+
+        Exercises _read_manifest_summary: N entry lines, one trailing partial
+        line (crash mid-append), and verifies that sessions==N and bytes equals
+        the per-entry sum while the partial line is silently tolerated.
+        """
+        _, kiro_home = stores
+        # Create N sessions with known sizes so expected bytes are computable.
+        for i in range(1, 4):
+            _cli_half(kiro_home, f"sess{i:04d}", log_bytes=i * 100 + 10, age_days=40)
+        sids = [f"sess{i:04d}" for i in range(1, 4)]
+
+        batch = session_storage.move_to_trash(sids, reason="test-summary", index=_index(), now=_NOW)
+
+        # Read back what move_to_trash wrote so we can measure actual entry bytes.
+        manifest_path = (
+            session_storage.trash_root() / batch.batch_id / session_storage.MANIFEST_NAME
+        )
+        raw = manifest_path.read_text(encoding="utf-8")
+        lines = raw.splitlines()
+        # lines[0] is the header; lines[1:] are the entry lines.
+        entry_lines = lines[1:]
+        expected_count = len(entry_lines)
+        expected_bytes = sum(
+            session_storage._entry_bytes(json.loads(line)) for line in entry_lines if line.strip()
+        )
+
+        # Append a trailing partial line (simulates a crash mid-append).
+        manifest_path.write_text(raw + '{"uid": "partial', encoding="utf-8")
+
+        listed = session_storage.list_trash()
+
+        assert len(listed) == 1
+        b = listed[0]
+        assert b.sessions == expected_count, f"expected {expected_count} sessions, got {b.sessions}"
+        assert b.bytes == expected_bytes, f"expected {expected_bytes} bytes, got {b.bytes}"
+
+    def test_mid_read_oserror_yields_none_not_truncated(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A read error AFTER the header must fail all-or-nothing, not truncate.
+
+        Regression guard: the shared record iterator must not swallow a
+        mid-iteration OSError into a valid-but-short entries list, or
+        _restore_locked would restore only the prefix and then delete the
+        unrestored remainder. Both _read_manifest and _read_manifest_summary
+        must return None when the read fails after yielding some records.
+        """
+        _, kiro_home = stores
+        for i in range(1, 4):
+            _cli_half(kiro_home, f"sess{i:04d}", log_bytes=32, age_days=40)
+        sids = [f"sess{i:04d}" for i in range(1, 4)]
+        batch = session_storage.move_to_trash(sids, reason="midread", index=_index(), now=_NOW)
+        batch_dir = session_storage.trash_root() / batch.batch_id
+
+        real_open = Path.open
+
+        class _BlowUpAfterHeader:
+            """File-like wrapper: yields the first line, then raises OSError."""
+
+            def __init__(self, fh: object) -> None:
+                self._fh = fh
+                self._served_header = False
+
+            def __enter__(self) -> "_BlowUpAfterHeader":
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                self._fh.__exit__(*exc)  # type: ignore[attr-defined]
+
+            def __iter__(self) -> "_BlowUpAfterHeader":
+                return self
+
+            def __next__(self) -> str:
+                if self._served_header:
+                    raise OSError("simulated mid-read failure")
+                self._served_header = True
+                return next(iter(self._fh))  # type: ignore[arg-type]
+
+        def failing_open(self: Path, *args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+            fh = real_open(self, *args, **kwargs)
+            if self.name == session_storage.MANIFEST_NAME:
+                return _BlowUpAfterHeader(fh)
+            return fh
+
+        monkeypatch.setattr(Path, "open", failing_open)
+
+        assert session_storage._read_manifest(batch_dir) is None
+        assert session_storage._read_manifest_summary(batch_dir) is None
+
 
 class TestLegacyStems:
     """One session can own more than one transcript filename."""
@@ -2278,17 +2373,28 @@ class TestSingleTrashPass:
 
     @staticmethod
     def _counted_manifest_reads(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
-        """Count via ``_read_manifest``: it is the per-batch cost, and it is hit
-        through the module global, so it sees every ``list_trash`` pass no matter
-        which module's imported name made the call."""
+        """Count per-batch manifest reads regardless of which reader is used.
+
+        ``list_trash`` now calls ``_read_manifest_summary`` (count-only, O(1)
+        memory), while restore paths still call ``_read_manifest`` (full
+        entries). Patching both and sharing one ``reads`` list keeps the
+        'exactly once' assertion reader-agnostic: it captures every manifest
+        read no matter which code path issued it.
+        """
         reads: list[Path] = []
-        real = session_storage._read_manifest
+        real_manifest = session_storage._read_manifest
+        real_summary = session_storage._read_manifest_summary
 
-        def counted(batch: Path):
+        def counted_manifest(batch: Path):
             reads.append(batch)
-            return real(batch)
+            return real_manifest(batch)
 
-        monkeypatch.setattr(session_storage, "_read_manifest", counted)
+        def counted_summary(batch: Path):
+            reads.append(batch)
+            return real_summary(batch)
+
+        monkeypatch.setattr(session_storage, "_read_manifest", counted_manifest)
+        monkeypatch.setattr(session_storage, "_read_manifest_summary", counted_summary)
         return reads
 
     def test_report_payload_reads_each_manifest_exactly_once(


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

`_read_manifest` in `src/kiro_crew/session_storage.py` materialises the entire
manifest as a `list[dict]` (`entries`).  On large batches this allocation
dominates memory — a manifest with thousands of archived sessions produces a
200 k-entry list that lives for the duration of the call.  @dwu96 correctly
identified this in their review of the initial streaming commit: the raw-string
term was already gone, but the `entries` list remained the dominant term.

## Why it matters

`list_trash()` uses only `len(entries)` and
`sum(_entry_bytes(e) for e in entries)` — it never inspects individual entry
fields.  Building the full list to compute two aggregates is unnecessary, and on
instances with thousands of archived sessions the peak allocation is proportional
to the total number of entries across all batches.

## What changed (motivation → approach → change)

Two commits, one branch:

**Commit 1** — swap `read_text()` for line-iteration in `_read_manifest`.  Removes
the raw-string copy; `_restore_locked` and `_manifest_rels` still need every entry,
so they keep calling `_read_manifest`.

**Commit 2 (load-bearing)** — add `_read_manifest_summary(batch)` and route
`list_trash()` through it.  The new helper streams the manifest with identical
parse semantics (OSError → None; blank / non-JSON / non-dict lines skipped; first
dict = header; schema check applied; trailing-partial-line tolerated) but
accumulates only `count` and `total_bytes` per entry instead of appending to a
list.  Peak memory drops to O(one line).

`_restore_locked` and `_manifest_rels` are untouched — they genuinely need every
entry.

## Tests

`test_list_trash_count_and_bytes_match_entries_with_trailing_partial`
(added in `TestTrashAccounting`) writes a batch with N entries and a trailing
partial line, then asserts `list_trash()` reports `sessions == N` and
`bytes == expected_bytes` computed from the raw manifest lines — confirming
the summary path counts correctly and tolerates the partial line.

Full suite: `pytest test/test_session_storage.py test/test_session_storage_api.py`
→ 170 passed.

Fixes #6281