### PR TITLE
refactor(mcp-grant): spell the audit outcome as if/elif/else

### DIFF
--- a/src/kiro_crew/mcp_grant.py
+++ b/src/kiro_crew/mcp_grant.py
@@ -175,7 +175,12 @@ async def grant_observed(mcp_url: str, *, audit_absence: bool = False) -> bool |
         # ``safe_read_file_internal``'s vocabulary, so one outcome word means the
         # same thing across the SEL surface: the pair is there, definitively is
         # not, or could not be looked at.
-        outcome = "success" if present is True else "missing" if present is False else "unreadable"
+        if present is True:
+            outcome = "success"
+        elif present is False:
+            outcome = "missing"
+        else:
+            outcome = "unreadable"
         recorded = await asyncio.to_thread(
             _hooks.emit_internal_read_audit, _GRANT_PRESENCE_READ_ID, outcome
         )


### PR DESCRIPTION
## Problem / Motivation

`mcp_grant.grant_observed` picks the outcome word for its grant-presence SEL audit
from a chained conditional expression:

```python
outcome = "success" if present is True else "missing" if present is False else "unreadable"
```

The value it classifies is a tri-state (`bool | None`), and the three-line comment
directly above enumerates the three cases in order — "the pair is there,
definitively is not, or could not be looked at". A chained conditional does not
line up with that enumeration: the reader has to know that Python groups
`A if c1 else B if c2 else C` to the *right* before they can say which branch
answers which value of `present`, and the line sat at the 100-character limit with
both `is` tests compressed onto it.

This is the one actionable site an out-of-repo module-simplification detector
reports for the top-level module — that tool is a maintainer-side campaign script
and is deliberately **not** checked into this repository, so the counts it produces
are not reproducible from this checkout and nothing here depends on them. The
module's other chained-conditional candidates are all in `safety_override.py` and
are excluded as keystone: a tri-state audit label in a keystone security file does
not get respelled for style.

## Why it matters

The word this expression produces is what lands in the SEL audit log, and the
`unreadable` case is the one that must not silently fold into `missing` — an
unreadable cache home means "could not look", not "nobody signed in", and
collapsing the two tells the owner of an authorized server to sign in again. A
form that has to be read right-to-left to verify that mapping is the wrong form
for a branch with that consequence. Making the three cases visible as three
branches means the next reader checks the mapping by looking, not by recalling an
associativity rule.

## What changed (motivation → approach → change)

The chained conditional expression became an `if`/`elif`/`else` chain. That is the
whole diff: one file, +6/−1, entirely inside `grant_observed`.

Equivalence, since the value of this change is being a no-op:

- **Grouping.** Python's conditional expression is right-associative, so the
  original already meant `A if c1 else (B if c2 else C)` — structurally the same
  shape as `if c1: A / elif c2: B / else: C`.
- **Predicates and order.** Both `is` identity tests are kept, in the same order.
  `present is False` is still evaluated only when `present is True` is false.
  Because they are identity tests rather than truthiness, `0` / `1` / `""` do not
  match `False` / `True` in either form — every value of `present`, including a
  non-`bool` one a future caller could pass, yields the same word.
- **Typing.** All three branches assign a `str` literal and the `else` is
  unconditional, so `outcome` still infers as `str` with no annotation and is bound
  on every reachable path before its single read.
- **Position.** No statement moved into or out of a `try`/`except`/`finally` (there
  is none in this function) or across an `await`. The two `asyncio.to_thread` hops
  either side of the hunk are unchanged, so no new suspension point exists.
- **Untouched:** the audit's read id (`_GRANT_PRESENCE_READ_ID`), the
  `if present is True or audit_absence:` guard that decides which observations get
  recorded, the fail-open `if not recorded:` branch, the redacted warning that logs
  the cache key rather than the url, and the terminal `return present`. No import
  was added, removed, or moved; the module has no in-function imports at all.

`mcp_grant.py` is a consumer of the keystone audit surface, not part of it — it is
not a matcher, guard, deny-by-default evaluator, policy evaluator, or redaction
implementation, and it never opens a file (presence is established by `stat`). It
is correctly outside the campaign's keystone set, and the hunk touches none of the
properties that make it keystone-adjacent anyway.

**Deliberately out of scope**, so the diff is not widened past the one site:

- The `grant_observed` docstring names `success` and `missing` but not
  `unreadable`. Pre-existing, outside the hunk, and pinned by test either way.
- `hooks.py`'s `_AUDIT_ONLY_READ_IDS` justification block refers to
  `kiro_crew.mcp_grant.grant_present`, a symbol that does not exist (the function
  is `grant_presence`, and the emitter is `grant_observed`). A stale reference in
  a different file.

## Tests

No test changes — a behavior-preserving rewrite adds no behavior to lock in, and
all three branches already have live coverage that would fail loudly on a
mis-wired mapping:

- `test_connections_mint.py` pins `"success"` (grant observed),
  `"missing"` (`audit_absence=True` over a definitively absent pair), and
  `"unreadable"` (an indeterminate stat) as three separate assertions — the last
  exists specifically so "could not look" is not folded into "missing".
- `test_connections_mint.py` also pins that a polling caller records nothing, that
  an unrecordable audit does not withhold the grant, and that the fail-open warning
  names the cache key and never the url.

Run green on the Python 3.12 CI-parity venv: `test_connections_mint.py`,
`test_connections_status.py`, `test_mcp_discovery.py`,
`test_connections_l1_smoke.py` — 393 passed, 4 skipped.

## Manual verification

N/A — unit coverage sufficient. The rewritten expression is pure local branching
over a `bool | None` with all three arms asserted by existing tests.

Gates run from the worktree on the 3.12 CI-parity venv, all exit 0: `flake8`,
`isort --check-only`, `mypy src/kiro_crew`, `check_black_formatting.py`,
`check_subprocess_encoding.py`, `check_brand_name.py`, `check_harness_parity.py`,
`docs_lint.py --test`, `docs-lint.sh`, `check_per_file_coverage.py --test`,
`verify_vendor_manifest.py`, `scrub-lint.sh --no-history`.

Backend-only diff: nothing under `website/`, `.github/`, or `scripts/` is touched,
so the `changes` job reports `only_backend=true` and the frontend suites cannot
newly fail — they were not run locally.

**File-overlap check:** PR #5899 also modifies `src/kiro_crew/mcp_grant.py`
(+100/−4), but its hunks cover original lines 1–9, 21–27 and an insertion after
`grant_presence` at 136–141. This hunk is at 175–181 inside `grant_observed`, so
there is no line-range overlap and no >50% rewrite of the file.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor of one Python expression; no rendered
surface is reached and no pixel changes.

## Related Issues

no linked issue: routine module-simplification sweep with no filed issue behind it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
