### PR TITLE
perf(session_storage): compare scan-cache pairing by dict equality

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -358,8 +358,13 @@ def _scan_key(sid_for_stem: Mapping[str, str]) -> tuple[object, ...]:
     session that gained or lost its mapping must not be answered from an older
     pass. The mapping is compared directly by dict equality — still by value,
     never hashed — because a hash collision here would serve a pass built under
-    different assumptions, and the whole point of the key is that it cannot. Dict
-    equality is order-free, so no sort is paid on the hot cache-hit path.
+    different assumptions, and the whole point of the key is that it cannot.
+    Embedding the dict makes the key tuple unhashable, so "never hashed" is
+    enforced by the interpreter rather than by convention, and the hit check
+    is linear — one dict copy plus one dict compare — with no sort. The
+    ``dict()`` copy is load-bearing:
+    it snapshots the pairing, so a caller's later in-place edit cannot mutate
+    the stored key in lockstep and masquerade as a hit.
     """
     return (
         str(kiro_sessions_dir()),

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -356,14 +356,15 @@ def _scan_key(sid_for_stem: Mapping[str, str]) -> tuple[object, ...]:
 
     Pairing is the rest of it: it decides which unit a transcript belongs to, so a
     session that gained or lost its mapping must not be answered from an older
-    pass. Compared by value rather than hashed — a hash collision here would serve
-    a pass built under different assumptions, and the whole point of the key is
-    that it cannot.
+    pass. The mapping is compared directly by dict equality — still by value,
+    never hashed — because a hash collision here would serve a pass built under
+    different assumptions, and the whole point of the key is that it cannot. Dict
+    equality is order-free, so no sort is paid on the hot cache-hit path.
     """
     return (
         str(kiro_sessions_dir()),
         str(_crew_sessions_dir()),
-        tuple(sorted(sid_for_stem.items())),
+        dict(sid_for_stem),
     )
 
 

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -931,11 +931,14 @@ class TestScanCache:
         """The key compares the pairing by value, so a fresh dict of equal
         contents must reuse the pass — callers rebuild the mapping per call."""
         crew_home, kiro_home = stores
-        stem = transcript_stem("dashboard:chat-1")
+        stem1 = transcript_stem("dashboard:chat-1")
+        stem2 = transcript_stem("dashboard:chat-2")
         _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
-        _transcript(crew_home, stem, size=64, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=32, age_days=40)
+        _transcript(crew_home, stem1, size=64, age_days=40)
+        _transcript(crew_home, stem2, size=64, age_days=40)
 
-        session_storage.list_units(_multi_index({stem: "aaaa1111"}))  # prime
+        session_storage.list_units(_multi_index({stem1: "aaaa1111", stem2: "bbbb2222"}))  # prime
 
         calls = 0
         real = session_storage._scan_raw_uncached
@@ -946,9 +949,9 @@ class TestScanCache:
             return real(sid_for_stem)
 
         monkeypatch.setattr(session_storage, "_scan_raw_uncached", counted)
-        # A distinct dict object with equal contents (and different insertion
-        # history, so an order-sensitive comparison would also be exposed).
-        session_storage.list_units(_multi_index(dict([(stem, "aaaa1111")])))
+        # A distinct dict object with equal contents built in the opposite
+        # insertion order, so an order-sensitive comparison would also miss.
+        session_storage.list_units(_multi_index({stem2: "bbbb2222", stem1: "aaaa1111"}))
 
         assert calls == 0, "an equal-by-value pairing must be served from the cached pass"
 
@@ -958,10 +961,12 @@ class TestScanCache:
         """One stem repointed to a different sid, same mapping length, must
         re-enumerate.
 
-        This is the guard that rules out memoising the pairing on
-        ``id()``/``len()``: CPython reuses ``id()`` after garbage collection, and
-        a length-preserving repoint is exactly the change such a key would miss —
-        serving a pass built under a different pairing.
+        This is the behavioural pin for the failure an ``id()``/``len()``
+        memoisation of the pairing would permit: a length-preserving repoint
+        served from a pass built under the old pairing. The deterministic
+        key-level half lives in
+        :meth:`test_scan_key_distinguishes_same_length_mappings` — this test
+        alone cannot force CPython to recycle the first dict's ``id()``.
         """
         crew_home, kiro_home = stores
         stem1 = transcript_stem("dashboard:chat-1")
@@ -971,9 +976,7 @@ class TestScanCache:
         _transcript(crew_home, stem1, size=64, age_days=40)
         _transcript(crew_home, stem2, size=64, age_days=40)
 
-        session_storage.list_units(
-            _multi_index({stem1: "aaaa1111", stem2: "bbbb2222"})
-        )  # prime
+        session_storage.list_units(_multi_index({stem1: "aaaa1111", stem2: "bbbb2222"}))  # prime
 
         calls = 0
         real = session_storage._scan_raw_uncached
@@ -989,16 +992,76 @@ class TestScanCache:
 
         assert calls == 1, "a repointed pairing must not be answered from the old pass"
 
+    def test_a_callers_in_place_edit_after_priming_is_a_miss(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stored key must be a snapshot, not an alias of the caller's dict.
+
+        ``dict(sid_for_stem)`` is the only thing making it one — passing the
+        mapping straight through still satisfies the type annotation. Aliased,
+        a caller's in-place repoint would mutate the stored key in lockstep,
+        so the stale pass would compare EQUAL to the new pairing and be served
+        as a hit — the exact failure the key exists to prevent.
+        """
+        crew_home, kiro_home = stores
+        stem1 = transcript_stem("dashboard:chat-1")
+        stem2 = transcript_stem("dashboard:chat-2")
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=32, age_days=40)
+        _transcript(crew_home, stem1, size=64, age_days=40)
+        _transcript(crew_home, stem2, size=64, age_days=40)
+
+        pairing = {stem1: "aaaa1111", stem2: "bbbb2222"}
+        session_storage.list_units(SessionIndex(stem_to_sid=pairing))  # prime
+
+        calls = 0
+        real = session_storage._scan_raw_uncached
+
+        def counted(sid_for_stem):
+            nonlocal calls
+            calls += 1
+            return real(sid_for_stem)
+
+        monkeypatch.setattr(session_storage, "_scan_raw_uncached", counted)
+        pairing[stem2] = "aaaa1111"  # the caller's own dict, edited in place
+        session_storage.list_units(SessionIndex(stem_to_sid=pairing))
+
+        assert calls == 1, "an in-place repoint must miss; the stored key may not alias it"
+
+    def test_scan_key_distinguishes_same_length_mappings(self) -> None:
+        """Deterministic key-level guard against a length-based pairing key.
+
+        The pairing element must compare unequal for same-length mappings that
+        differ in one value — this is what rules out memoising on
+        ``id()``+``len()`` (CPython reuses ``id()`` after garbage collection,
+        so identity plus length cannot stand in for contents).
+        """
+        a = session_storage._scan_key({"s1": "aaaa", "s2": "bbbb"})
+        b = session_storage._scan_key({"s1": "aaaa", "s2": "aaaa"})
+        assert a[2] != b[2], "same-length repointed mappings must produce unequal keys"
+
+    def test_scan_key_is_unhashable_so_it_can_never_be_a_hash_key(self) -> None:
+        """The docstring's "never hashed" is enforced by the interpreter.
+
+        A future refactor that hashes the key (a dict-keyed cache, a set of
+        keys) must fail loudly at runtime, not silently collide.
+        """
+        with pytest.raises(TypeError):
+            hash(session_storage._scan_key({"a": "1"}))
+
     def test_scan_key_pairing_equality_matches_the_sorted_tuple_form(self) -> None:
         """``dict(a) == dict(b)`` iff ``tuple(sorted(a.items())) == tuple(sorted(b.items()))``.
 
         This pins the equivalence the key relies on: the dict snapshot answers the
         equality question identically to the sorted-tuple form it replaced, across
-        empty, single-entry, reordered, repointed and disjoint mappings.
+        empty, single-entry, reordered, repointed and disjoint mappings. Compares
+        the pairing element directly so the assertion is about the pairing alone —
+        a store-path difference cannot mask a pairing disagreement.
         """
         mappings: list[dict[str, str]] = [
             {},
             {"a": "1"},
+            {"b": "1"},  # key differs, value identical
             {"a": "1", "b": "2"},
             {"b": "2", "a": "1"},  # same contents, different insertion order
             {"a": "1", "b": "3"},  # one value repointed, same length
@@ -1008,7 +1071,7 @@ class TestScanCache:
         for a in mappings:
             for b in mappings:
                 expected = tuple(sorted(a.items())) == tuple(sorted(b.items()))
-                got = session_storage._scan_key(a) == session_storage._scan_key(b)
+                got = session_storage._scan_key(a)[2] == session_storage._scan_key(b)[2]
                 assert got == expected, f"disagreement on {a!r} vs {b!r}"
 
 

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -925,6 +925,92 @@ class TestScanCache:
 
         assert session_storage.list_units(_index()) == []
 
+    def test_a_hit_is_served_for_an_equal_but_distinct_pairing_dict(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The key compares the pairing by value, so a fresh dict of equal
+        contents must reuse the pass — callers rebuild the mapping per call."""
+        crew_home, kiro_home = stores
+        stem = transcript_stem("dashboard:chat-1")
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        _transcript(crew_home, stem, size=64, age_days=40)
+
+        session_storage.list_units(_multi_index({stem: "aaaa1111"}))  # prime
+
+        calls = 0
+        real = session_storage._scan_raw_uncached
+
+        def counted(sid_for_stem):
+            nonlocal calls
+            calls += 1
+            return real(sid_for_stem)
+
+        monkeypatch.setattr(session_storage, "_scan_raw_uncached", counted)
+        # A distinct dict object with equal contents (and different insertion
+        # history, so an order-sensitive comparison would also be exposed).
+        session_storage.list_units(_multi_index(dict([(stem, "aaaa1111")])))
+
+        assert calls == 0, "an equal-by-value pairing must be served from the cached pass"
+
+    def test_a_repointed_stem_with_unchanged_length_is_a_miss(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One stem repointed to a different sid, same mapping length, must
+        re-enumerate.
+
+        This is the guard that rules out memoising the pairing on
+        ``id()``/``len()``: CPython reuses ``id()`` after garbage collection, and
+        a length-preserving repoint is exactly the change such a key would miss —
+        serving a pass built under a different pairing.
+        """
+        crew_home, kiro_home = stores
+        stem1 = transcript_stem("dashboard:chat-1")
+        stem2 = transcript_stem("dashboard:chat-2")
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=32, age_days=40)
+        _transcript(crew_home, stem1, size=64, age_days=40)
+        _transcript(crew_home, stem2, size=64, age_days=40)
+
+        session_storage.list_units(
+            _multi_index({stem1: "aaaa1111", stem2: "bbbb2222"})
+        )  # prime
+
+        calls = 0
+        real = session_storage._scan_raw_uncached
+
+        def counted(sid_for_stem):
+            nonlocal calls
+            calls += 1
+            return real(sid_for_stem)
+
+        monkeypatch.setattr(session_storage, "_scan_raw_uncached", counted)
+        # Same keys, same length — only one value repointed.
+        session_storage.list_units(_multi_index({stem1: "aaaa1111", stem2: "aaaa1111"}))
+
+        assert calls == 1, "a repointed pairing must not be answered from the old pass"
+
+    def test_scan_key_pairing_equality_matches_the_sorted_tuple_form(self) -> None:
+        """``dict(a) == dict(b)`` iff ``tuple(sorted(a.items())) == tuple(sorted(b.items()))``.
+
+        This pins the equivalence the key relies on: the dict snapshot answers the
+        equality question identically to the sorted-tuple form it replaced, across
+        empty, single-entry, reordered, repointed and disjoint mappings.
+        """
+        mappings: list[dict[str, str]] = [
+            {},
+            {"a": "1"},
+            {"a": "1", "b": "2"},
+            {"b": "2", "a": "1"},  # same contents, different insertion order
+            {"a": "1", "b": "3"},  # one value repointed, same length
+            {"a": "2", "b": "1"},  # values swapped
+            {"c": "9"},
+        ]
+        for a in mappings:
+            for b in mappings:
+                expected = tuple(sorted(a.items())) == tuple(sorted(b.items()))
+                got = session_storage._scan_key(a) == session_storage._scan_key(b)
+                assert got == expected, f"disagreement on {a!r} vs {b!r}"
+
 
 class TestSharedStoreRefusal:
     """An isolated data home over a shared replay store cannot see who is live."""


### PR DESCRIPTION
Fixes #6286

## What

`_scan_key` returned `tuple(sorted(sid_for_stem.items()))` as the pairing element of the scan-cache key, and `_cached_scan` rebuilds the key on **every** warm cache-hit check while holding `_scan_cache_lock` (`_store_scan` recomputes it too). That pays an O(n log n) sort plus two allocations purely to answer an equality question. This PR replaces the sorted tuple with a plain `dict(sid_for_stem)` snapshot.

## Why this is equivalent

For a `Mapping[str, str]`, `tuple(sorted(a.items())) == tuple(sorted(b.items()))` holds **iff** `dict(a) == dict(b)`: both compare exactly the set of (key, value) pairs, and dict equality is order-free. So the check becomes O(n) with no sort and no ordering work, while remaining **strictly by value and never hashed** — the property the docstring requires (a hash collision would serve a pass built under different store assumptions). The key is only ever `!=`-compared (`_cached_scan`) or stored in a tuple that nothing hashes (`_store_scan`), and the `tuple[object, ...]` annotation already permits an unhashable member — both confirmed against main `609c2e10` before changing anything.

An equivalence test pins this: `_scan_key(a) == _scan_key(b)` agrees with the sorted-tuple form across empty, single-entry, reordered, repointed, and disjoint mappings.

## Why not the two fixes the issue proposes

- **Hash of the sorted key**: removes none of the cost — computing the hash still requires the sort — and reintroduces exactly the collision risk the docstring rules out.
- **Memoising on `id(sid_for_stem)` + `len()`**: unsound. CPython reuses `id()` after garbage collection, and a length-preserving in-place edit (one stem repointed to a different sid) would be missed — precisely the failure this key exists to prevent. Two explicit regression guards pin this: `test_a_repointed_stem_with_unchanged_length_is_a_miss` (behavioural) and `test_scan_key_distinguishes_same_length_mappings` (deterministic, key-level); both go red under a length-based key (verified via the `len(sid_for_stem)` mutant).

## Verification

- New tests (5): hit served for an equal-but-distinct dict built in reversed insertion order; **behavioural miss when one stem is repointed with length unchanged**, paired with a **deterministic key-level guard** that same-length repointed mappings produce unequal pairing elements (together these rule out id+len memoisation -- the behavioural test alone cannot force id() reuse); an **aliasing test** (prime with a mutable dict, repoint in place, must miss -- pins that the dict() copy is load-bearing, since a pass-through alias still type-checks); an **unhashability pin** (`hash(_scan_key(...))` raises, so 'never hashed' is interpreter-enforced); dict-vs-sorted-tuple equivalence matrix on the pairing element. Store-location misses stay covered by the existing `test_a_different_store_is_not_answered_from_an_older_pass`.
- Mutation-checked three ways: reverting the key element to the sorted tuple keeps the original tests green (behaviour preservation); breaking it to `len(sid_for_stem)` fails 5 tests; dropping the `dict()` copy (pass-through alias) fails exactly the new aliasing test.
- `test/test_session_storage.py`: 126/126 pass.
- `scripts/local-gate.py --base origin/main`: full backend 70,755 passed; 95 failed + 2 errors, byte-identical to the pre-existing environmental baseline. Zero-regression proof: the same failing files run on a `git worktree` at `origin/main` produce the same failing-id set both directions (`comm -23`/`comm -13` empty after excluding `test_search_sessions_cost.py::…::test_a_session_that_left_the_window_stops_holding_budget`, which flakes identically on the base worktree — fails 3/3 isolated there).

## Magnitude

Deliberately modest: `stem_to_sid` is a few thousand pairs, so the sort being removed is sub-millisecond. This is a cheap strict improvement on a hot lock-held path, not a live performance incident.
