### PR TITLE
fix(security): gate linked ancestors before fs probes (#5962)

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1462,7 +1462,12 @@ answer is not permission: a raised evaluation and a `Decision` without
   primitive rather than a usability question (`task run ~/.ssh/id_rsa`). Both
   grammars route through `hooks.validate_file_path`, which applies the Windows UNC
   trusted-root check before resolving (a `realpath` on a UNC path is itself the
-  outbound SMB probe), canonicalizes through every symlink, and refuses a resolved
+  outbound SMB probe) to the raw and anchored forms, refuses a path with a
+  linked ancestor on Windows (the walk or the resolve would itself be the
+  probe), screens a Windows leaf link's own target (readlink, a local
+  metadata read) so a link aimed at an untrusted UNC share is refused while
+  benign leaf symlinks still resolve, canonicalizes through every symlink on
+  POSIX, and refuses a resolved
   target under a sensitive root, so an innocent-looking path that resolves into a
   blocked root is refused through the link. The **canonical** path is what reaches
   `runner.start_background`, not the raw argument, because validating one string and

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -44,6 +44,7 @@ from kiro_crew.imaging import (  # noqa: F401 -- constants re-exported, see comm
     MAX_IMAGE_EDGE_PX,
     downscale_image_block,
 )
+from kiro_crew.platform_compat import first_linked_ancestor, is_link_or_junction
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +176,29 @@ def build_prompt_blocks(
             path = Path(raw)
             suffix = path.suffix.lower()
             mime = IMAGE_MEDIA_TYPES.get(suffix)
-            if mime is None or not path.is_file():
+            if mime is None:
+                # Unreachable for regex-produced candidates today (_PATH_RE's
+                # suffix group and IMAGE_MEDIA_TYPES share one key set), kept
+                # as the lexical backstop should the two ever drift.
+                continue
+            # A linked ANCESTOR defeats the lexical UNC screen above: the
+            # candidate is not itself UNC-shaped -- only the link's target is
+            # -- and is_file()/stat() below resolve every ancestor, so the
+            # probe itself would traverse the link and open the SMB
+            # connection. Windows-only for the same reason as the UNC gate:
+            # on POSIX stat-ing through a symlink is harmless. Reference
+            # wiring: dashboard/handlers/themes.py::_resolve_local_source.
+            if os.name == "nt" and first_linked_ancestor(path) is not None:
+                seen.add(raw)
+                continue
+            # The LEAF gets the junction-aware check the walk deliberately
+            # excludes: is_file() below FOLLOWS a final-component link, so a
+            # leaf symlink/junction targeting a UNC share is the same probe.
+            # lstat-based, so the link itself is never followed.
+            if os.name == "nt" and is_link_or_junction(path):
+                seen.add(raw)
+                continue
+            if not path.is_file():
                 continue
             try:
                 size = path.stat().st_size

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -1989,6 +1989,28 @@ def _unc_agents_root() -> Path | None:
 # start, off the loop, so the one resolution per configuration lands there.
 # Best-effort: a failure here memoizes root-absent exactly as a lazy miss would.
 _unc_agents_root()
+#: Upper bound on the Windows leaf link chain validate_file_path will walk
+#: hop-by-hop before refusing. Mirrors the kernels' own symlink-resolution
+#: ceilings (Linux SYMLOOP_MAX chains resolve to ELOOP at 40): a longer
+#: chain is refused rather than probed.
+_LEAF_LINK_CHAIN_MAX = 40
+
+#: Component-depth ceiling for the Windows link screens in
+#: validate_file_path. The ancestor walk costs one lstat per component, so an
+#: adversarially deep path (thousands of one-letter components fit inside the
+#: 32K long-path limit) would turn the screen itself into an event-loop
+#: stall. Deeper paths are refused outright, never probed -- no legitimate
+#: dashboard file I/O path approaches this depth.
+_MAX_SCREENED_PATH_DEPTH = 255
+
+#: Fully qualified local Windows target: a drive letter FOLLOWED by a
+#: separator. `D:x` (no separator) is drive-relative and deliberately not
+#: matched -- it resolves against D:'s own per-drive CWD.
+_DRIVE_ABS_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+#: Any drive-letter prefix, separator or not -- used to tell drive-relative
+#: (`D:x`) apart from plain relative (`x`).
+_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
 
 
 def unc_probe_allowed(raw: str) -> bool:
@@ -2031,15 +2053,137 @@ def validate_file_path(raw: str) -> str | None:
     """Validate and canonicalize a file path for dashboard file I/O.
 
     Enforces: the Windows UNC trusted-root gate (BEFORE any resolution --
-    ``realpath`` on a UNC path is itself the outbound SMB probe),
-    is_sensitive_path(), realpath canonicalization.
+    ``realpath`` on a UNC path is itself the outbound SMB probe), the Windows
+    linked-ancestor gate (a linked ancestor launders the same probe past the
+    lexical UNC check), is_sensitive_path(), realpath canonicalization.
     Returns the canonical path or None if rejected.
     """
     if not raw:
         return None
     if os.name == "nt" and is_unc_shape(raw) and not unc_probe_allowed(raw):
         return None
-    path = os.path.realpath(os.path.expanduser(raw))
+    expanded = os.path.expanduser(raw)
+    target = expanded
+    if os.name == "nt":
+        # Anchor a relative input lexically before the walk: the walk covers
+        # only the components the path itself names, while `realpath` resolves
+        # the CWD's own ancestors too. `abspath` performs no filesystem or
+        # network I/O (GetFullPathNameW on Windows, a string normpath on
+        # POSIX) -- but it also collapses `..` lexically, which changes what
+        # `realpath` returns for a `..` that crosses a symlinked component, so
+        # it is scoped to this branch: on POSIX the pre-change
+        # resolve-through-every-symlink semantics stay byte-identical.
+        target = os.path.abspath(expanded)
+        # The ANCHORED form -- the exact string resolved and walked below --
+        # is re-screened lexically: expansion (`~` on a roaming profile) or
+        # anchoring (a CWD on a UNC share) can surface a UNC shape the raw
+        # text did not have, and the ancestor walk is an lstat per component,
+        # so on an untrusted UNC path the walk itself would be the probe.
+        # `abspath` never strips UNC-ness, so this single screen covers the
+        # expanded form too. Mirrors the both-forms screening in
+        # dashboard/handlers/themes.py::_resolve_local_source.
+        if is_unc_shape(target) and not unc_probe_allowed(target):
+            return None
+        # Bound the walk's cost BEFORE starting it: the screen is one lstat
+        # per component, so an adversarially deep path would stall the event
+        # loop inside the guard itself. Lexical separator count; deeper
+        # paths are refused, never probed.
+        if target.count("\\") + target.count("/") > _MAX_SCREENED_PATH_DEPTH:
+            return None
+        # A linked ANCESTOR defeats the lexical UNC gates above: the path is
+        # not itself UNC-shaped -- only the link's target is -- and `realpath`
+        # below resolves the whole chain, so an ancestor symlink/junction
+        # whose target is a UNC share turns it into exactly the outbound SMB
+        # probe the gates exist to prevent. Windows-only on purpose: on POSIX
+        # resolving through a symlink is harmless and `is_sensitive_path` on
+        # the RESOLVED path below is the real guard (an unconditional walk
+        # would refuse legitimate setups like a symlinked /home). Reference:
+        # dashboard/handlers/themes.py::_resolve_local_source.
+        if platform_compat.first_linked_ancestor(target) is not None:
+            return None
+        # The LEAF is deliberately NOT blanket-refused at this site: the
+        # documented contract (pinned by tests) RESOLVES a benign leaf
+        # symlink and re-checks the resolved path. Instead the leaf's link
+        # CHAIN is walked hop by hop -- `readlink` is a local reparse-point
+        # metadata read, never a traversal -- and every hop's target is
+        # screened the same way the original path was (UNC shape, then
+        # linked-ancestor walk) BEFORE any lstat touches it, so a leaf link
+        # aimed at an untrusted UNC share, directly or through intermediate
+        # LOCAL links, is refused before the `realpath` that would probe it.
+        # Bounded like the OS's own ELOOP limit; fails closed on an
+        # unreadable link or an over-long chain.
+        hop = target
+        for _ in range(_LEAF_LINK_CHAIN_MAX):
+            if not platform_compat.is_link_or_junction(hop):
+                break
+            try:
+                # Guarded false-positive (same shape as the resolve() inside
+                # security.is_sensitive_path): this readlink IS the sanitizer
+                # -- it reads the link's own metadata to VET the user path
+                # and performs no read/write through it.
+                nxt = os.readlink(hop)  # lgtm[py/path-injection]
+            except OSError:
+                return None
+            # Fold the NT long-path spellings into the screened shapes:
+            # \\?\UNC\host\share is the long form of \\host\share, and a
+            # plain \\?\C:\... prefix is local. The OS honors the UNC
+            # component case-insensitively (\\?\unc\... resolves the same
+            # share), so the fold must too -- a case-sensitive match would
+            # let a lowercase spelling fall into the \\?\ branch below and
+            # launder the share into a relative-looking string.
+            if nxt[:8].upper() == "\\\\?\\UNC\\":
+                nxt = "\\\\" + nxt[8:]
+            elif nxt.startswith("\\\\?\\"):
+                # Only a drive-absolute remainder is a plain local spelling.
+                # Other extended namespaces (\\?\GLOBALROOT\Device\Mup\...,
+                # \\?\Volume{guid}\..., device paths) name kernel objects the
+                # walk cannot reason about, and stripping the prefix would
+                # launder them into relative-looking strings that realpath
+                # then follows -- refused fail-closed.
+                if not _DRIVE_ABS_RE.match(nxt[4:]):
+                    return None
+                nxt = nxt[4:]
+            # Shape screen FIRST: a UNC-shaped target is never relative, and
+            # anchoring must not run before the screen or it would rewrite
+            # the very shape being screened. Targets are held to a strict
+            # shape ALLOWLIST -- UNC (trusted roots only), drive-absolute,
+            # or plain relative -- because only those resolve against state
+            # this walk can also see.
+            if is_unc_shape(nxt):
+                if not unc_probe_allowed(nxt):
+                    return None
+            elif _DRIVE_ABS_RE.match(nxt):
+                pass  # fully qualified local target -- walked as-is below
+            elif nxt[:1] in "\\/" or _DRIVE_PREFIX_RE.match(nxt):
+                # Root-relative (\pivot resolves against the CURRENT drive's
+                # root) and drive-relative (D:pivot resolves against D:'s own
+                # per-drive CWD) targets depend on ambient state, so the
+                # string screened here and the string realpath resolves
+                # could diverge by drive -- the walk would inspect the wrong
+                # drive's ancestors. Legal but exotic link-target shapes no
+                # legitimate gateway path uses; refused fail-closed.
+                return None
+            else:
+                # A plain relative target resolves against the link's own
+                # directory (which carries the hop's drive); anchor it
+                # lexically the same way the OS would.
+                nxt = os.path.normpath(os.path.join(os.path.dirname(hop), nxt))
+            # Same depth bound as the entry screen: a link may point at an
+            # adversarially deep target, and the hop's own ancestor walk
+            # below costs one lstat per component.
+            if nxt.count("\\") + nxt.count("/") > _MAX_SCREENED_PATH_DEPTH:
+                return None
+            # The next hop's OWN ancestor chain is screened before the
+            # loop's lstat resolves it.
+            if platform_compat.first_linked_ancestor(nxt) is not None:
+                return None
+            hop = nxt
+        else:
+            # Chain longer than the bound: refuse rather than probe.
+            return None
+    # `realpath` consumes the SAME string the walk inspected -- resolving a
+    # different form would traverse a chain the walk never saw.
+    path = os.path.realpath(target)
     if is_sensitive_path(path):
         return None
     return path

--- a/src/kiro_crew/image_artifacts.py
+++ b/src/kiro_crew/image_artifacts.py
@@ -56,6 +56,7 @@ from kiro_crew.messaging.outbound_files import (
     strip_url_syntax,
     unescape_md,
 )
+from kiro_crew.platform_compat import first_linked_ancestor, is_link_or_junction
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.widget_slug import derive_widget_slug
 
@@ -114,6 +115,23 @@ def _local_file(raw_path: str) -> Path | None:
     """
     p = local_destination(raw_path)
     if p is None:
+        return None
+    # A linked ANCESTOR defeats local_destination's lexical UNC screen: the
+    # destination is not itself UNC-shaped -- only the link's target is --
+    # and is_file()/is_sensitive_path below both resolve every ancestor, so
+    # the probe itself would traverse the link and open the SMB connection.
+    # Same guard as the upload-side consumer (_inspect in outbound_files);
+    # local_destination stays lexical by contract, so each consumer screens
+    # its own probes. Windows-only: on POSIX stat-ing through a symlink is
+    # harmless. Reference wiring:
+    # dashboard/handlers/themes.py::_resolve_local_source.
+    if os.name == "nt" and first_linked_ancestor(p) is not None:
+        return None
+    # The LEAF gets the junction-aware check the walk deliberately excludes:
+    # is_file() below FOLLOWS a final-component link, so a leaf
+    # symlink/junction targeting a UNC share is the same probe. lstat-based,
+    # never follows.
+    if os.name == "nt" and is_link_or_junction(p):
         return None
     try:
         if not p.is_file():

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -37,7 +37,7 @@ from kiro_crew.hooks import (
     unc_probe_allowed,
 )
 from kiro_crew.metrics.db_metrics import timed, timed_query
-from kiro_crew.platform_compat import file_lock, is_link_or_junction
+from kiro_crew.platform_compat import file_lock, first_linked_ancestor, is_link_or_junction
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -186,7 +186,8 @@ class MemoryStore:
         surface enforces in :meth:`_read_root_guard`: no filesystem syscall
         may touch a path whose workspace, memory-root, or history-dir
         component is a link/junction (or an untrusted UNC workspace on
-        Windows).
+        Windows; on Windows the workspace's ancestor chain is walked too,
+        while POSIX ancestors are deliberately excluded — see the read gate).
 
         The write surface previously accumulated point defenses (hardened
         temp files, symlink-safe lock opens) while each writer still trusted
@@ -594,17 +595,28 @@ class MemoryStore:
         """Single admission gate for the structured read surface.
 
         INVARIANT: no filesystem syscall in this surface may touch a path
-        that has not passed this gate, and no component of a touched path may
-        be a link. That one property makes the whole finding class
+        that has not passed this gate, and no component of a touched path
+        may be a link -- on Windows including ancestors; on POSIX ancestors
+        are deliberately excluded (see the gate comment below). That one
+        property makes the whole REPARSE-POINT finding class
         (symlink/junction escapes, UNC credential probes, special-file reads)
-        unreachable instead of patching instances:
+        unreachable instead of patching instances. A mapped network drive or
+        ``subst`` target (a ``Z:`` drive letter bound to a network share) is
+        a residual outside this class: not UNC-shaped, no reparse point
+        anywhere, resolved only at ``realpath`` time. The gates here do not
+        screen it.
+
+        Two gates enforce the invariant:
 
         1. Windows UNC gate — purely LEXICAL, evaluated before any syscall
            (``stat``/``glob``/``exists`` on a UNC path is itself the outbound
            SMB credential probe). Mirrors ``hooks.validate_file_path``.
         2. Reparse-point gate — the memory root and history dir must not be
            symlinks or Windows junctions (``lstat``-based check that never
-           traverses the link). Leaf files get the same check in
+           traverses the link). On Windows the workspace's ANCESTOR chain is
+           walked root-first before any leaf lstat runs, because an lstat
+           resolves every ancestor even when it does not follow the final
+           component. Leaf files get the same check in
            :meth:`_guarded_entry`, so every component of every touched path
            is verified link-free.
         """
@@ -613,13 +625,31 @@ class MemoryStore:
             logger.warning("memory read refused (untrusted UNC workspace): %s", root)
             self._audit_read_refusal("unc_workspace", root, "untrusted UNC workspace")
             return False
-        # The workspace leaf is checked FIRST: a workspace swapped for a
-        # link/junction would make the two descendant checks below traverse it
-        # and validate paths inside the link's target instead of the admitted
-        # tree. lstat-based, so the link itself is never followed. (Linked
-        # ANCESTORS of the workspace are deliberately not rejected — resolving
-        # the whole chain would refuse legitimate setups like a symlinked
-        # /home, and those components are not agent-writable.)
+        # On Windows a linked ANCESTOR of the workspace defeats the lexical
+        # UNC gate above: the workspace path is not itself UNC-shaped -- only
+        # the link's target is -- and the lstat-based leaf checks below
+        # resolve every ancestor, so the probe itself would traverse the link
+        # and open the SMB connection. The walk is root-first and runs before
+        # any leaf lstat. On POSIX linked ancestors remain deliberately
+        # unrejected: resolving the whole chain would refuse legitimate
+        # setups like a symlinked /home, those components are not
+        # agent-writable, and stat-ing through a symlink is harmless there --
+        # the same Windows-only rationale as the themes wiring
+        # (dashboard/handlers/themes.py::_resolve_local_source). The walk
+        # assumes the operator-configured workspace is absolute (every
+        # in-tree constructor passes one); a relative workspace would walk
+        # only the components the path itself names.
+        if os.name == "nt" and first_linked_ancestor(self._workspace) is not None:
+            logger.warning("memory read refused (workspace ancestor is a link): %s", root)
+            self._audit_read_refusal(
+                "workspace_linked_ancestor", root, "a workspace ancestor is a link"
+            )
+            return False
+        # The workspace leaf is checked FIRST among the lstat probes: a
+        # workspace swapped for a link/junction would make the two descendant
+        # checks below traverse it and validate paths inside the link's
+        # target instead of the admitted tree. lstat-based, so the link
+        # itself is never followed.
         if (
             is_link_or_junction(self._workspace)
             or is_link_or_junction(self._memory_dir)

--- a/src/kiro_crew/messaging/outbound_files.py
+++ b/src/kiro_crew/messaging/outbound_files.py
@@ -88,6 +88,7 @@ from kiro_crew.hooks import (
 )
 from kiro_crew.messaging.raster import SNIFF_BYTES, sniff_raster_mime
 from kiro_crew.messaging.split import iter_fence_spans
+from kiro_crew.platform_compat import first_linked_ancestor, is_link_or_junction
 from kiro_crew.security import (
     is_sensitive_path,
     redact_credentials,
@@ -373,6 +374,15 @@ def local_destination(raw_dest: str) -> Path | None:
         if os.name == "nt" and is_unc_shape(clean) and not unc_probe_allowed(clean):
             return None
         path = Path(clean).expanduser()
+        # The EXPANDED form is screened too, since expansion is what actually
+        # gets stat-ed downstream: `~` resolving to a roaming-profile home can
+        # surface a UNC shape the raw text did not have. Still lexical with
+        # respect to the PATH (`expanduser` reads the environment, or the
+        # local account database for `~user` -- never the path itself), so
+        # the documented lexical-only contract holds. Mirrors the both-forms
+        # screening in dashboard/handlers/themes.py::_resolve_local_source.
+        if os.name == "nt" and is_unc_shape(str(path)) and not unc_probe_allowed(str(path)):
+            return None
         if not path.is_absolute():
             return None
     except (OSError, RuntimeError, ValueError):
@@ -429,6 +439,28 @@ def _inspect(
         except (OSError, ValueError):
             return Rejection(dest, REASON_SENSITIVE, "outside the approved workspace")
     try:
+        # A linked ANCESTOR defeats local_destination's lexical UNC screen:
+        # the destination is not itself UNC-shaped -- only the link's target
+        # is -- and EVERY resolving call below is the probe. That includes
+        # is_sensitive_path, whose candidate forms are built with
+        # realpath()/resolve(), so this guard must run before it, not merely
+        # before the is_symlink() lstat. Lives here, not in local_destination,
+        # to keep that function's documented lexical-only contract intact.
+        # Windows-only for the same reason as the UNC gate: on POSIX stat-ing
+        # through a symlink is harmless. The reply matches the leaf case on
+        # purpose -- which ancestor is a link is filesystem layout the caller
+        # supplied a path to guess at. Reference wiring:
+        # dashboard/handlers/themes.py::_resolve_local_source.
+        if os.name == "nt" and first_linked_ancestor(path) is not None:
+            return Rejection(dest, REASON_SYMLINK, "symlinks are not uploaded")
+        # The LEAF gets the junction-aware check the walk deliberately
+        # excludes. The all-platform is_symlink() refusal below is lstat-only
+        # (junction-blind) and runs after is_sensitive_path, whose candidate
+        # forms resolve the leaf too -- so on Windows the leaf must be
+        # screened here, before the first resolving call. lstat-based, never
+        # follows.
+        if os.name == "nt" and is_link_or_junction(path):
+            return Rejection(dest, REASON_SYMLINK, "symlinks are not uploaded")
         if is_sensitive_path(str(path)):
             return Rejection(dest, REASON_SENSITIVE, "reading this location is blocked")
         if path.is_symlink():

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -934,3 +934,80 @@ class TestSummarizePromptStructure:
             out = summarize_prompt_structure(bad)
             assert out["block_count"] == 0
             assert out["total_bytes"] == empty_bytes
+
+
+class TestLinkedAncestorGate:
+    """On Windows, a candidate beneath a linked ANCESTOR must be refused
+    BEFORE the first filesystem probe -- ``is_file()`` resolves every
+    ancestor, so the probe itself would traverse the link and open the SMB
+    connection the lexical UNC screen exists to prevent (#5962).
+
+    NOTE: under the module-local os patch, ``_PATH_RE`` keeps the grammar
+    chosen at import time, so candidates here stay host-native; the Windows
+    CI shard exercises real backslash shapes via ``tmp_path`` (see
+    ``test_natively_produced_path_is_inlined_on_this_host``)."""
+
+    def _windows(self, monkeypatch):
+        import types
+
+        # Patch ONLY prompt_blocks' view of os (its sole runtime use is the
+        # two gates' os.name checks; _PATH_RE was chosen at import time) --
+        # patching the global os.name would make pathlib dispatch WindowsPath
+        # everywhere on a POSIX test host.
+        monkeypatch.setattr(prompt_blocks, "os", types.SimpleNamespace(name="nt"))
+
+    def test_linked_ancestor_candidate_is_refused_before_any_probe(self, tmp_path, monkeypatch):
+        """Ordering IS the property: the leaf probe is wired to explode, so a
+        regression that probes first fails loudly instead of silently."""
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(prompt_blocks, "first_linked_ancestor", lambda _p: str(tmp_path))
+
+        def _boom(self):  # type: ignore[no-untyped-def]  # pragma: no cover
+            raise AssertionError("is_file ran before the ancestor walk")
+
+        monkeypatch.setattr(Path, "is_file", _boom)
+        blocks = build_prompt_blocks(f"see {p}")
+        # The candidate is skipped, not inlined; the text keeps the path so
+        # the turn still carries a usable reference.
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_bypassing_the_guard_restores_the_probe(self, tmp_path, monkeypatch):
+        """Mutation check: with the walk reporting no link, the same candidate
+        is probed and inlined again -- so the refusal above is attributable to
+        the guard, not to some other screen."""
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(prompt_blocks, "first_linked_ancestor", lambda _p: None)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_the_walk_is_not_consulted_on_posix(self, tmp_path, monkeypatch):
+        """macOS /tmp and /var are symlinks to /private/*; an unconditional
+        walk would refuse every image staged in a temp dir there."""
+        if os.name == "nt":
+            pytest.skip("gate is active on Windows by design")
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("ancestor walk ran on POSIX")
+
+        monkeypatch.setattr(prompt_blocks, "first_linked_ancestor", _boom)
+        p = _png(tmp_path)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_a_leaf_link_is_refused_before_the_probe(self, tmp_path, monkeypatch):
+        """The walk deliberately excludes the leaf, so the leaf gets its own
+        junction-aware check -- is_file() FOLLOWS a final-component link."""
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(prompt_blocks, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(prompt_blocks, "is_link_or_junction", lambda _p: True)
+
+        def _boom(self):  # type: ignore[no-untyped-def]  # pragma: no cover
+            raise AssertionError("is_file ran before the leaf link check")
+
+        monkeypatch.setattr(Path, "is_file", _boom)
+        blocks = build_prompt_blocks(f"see {p}")
+        assert [b["type"] for b in blocks] == ["text"]

--- a/test/test_hooks_coverage.py
+++ b/test/test_hooks_coverage.py
@@ -390,6 +390,342 @@ class TestValidateFilePath:
         f = _write(tmp_path / "ok.txt", "x")
         assert _same(validate_file_path(str(f)) or "", str(f))
 
+    def _windows(self, monkeypatch, realpath=os.path.realpath):
+        """Simulate the Windows gates without patching the global os.name
+        (which would make pathlib dispatch WindowsPath on a POSIX host).
+        NOTE: candidate strings stay host-native under this simulation; the
+        Windows CI shard exercises real backslash shapes via tmp_path. The
+        namespace carries every os attribute the validate_file_path call
+        graph can reach (unc_probe_allowed folds with normcase/normpath and
+        joins with sep) so a stub miss cannot masquerade as a product bug."""
+        import types
+
+        from kiro_crew import hooks as hooks_mod
+
+        monkeypatch.setattr(
+            hooks_mod,
+            "os",
+            types.SimpleNamespace(
+                name="nt",
+                sep=os.sep,
+                # unc_probe_allowed and main's _unc_agents_root memo key read
+                # the environment through this namespace; carry the real
+                # mapping so a stub miss cannot masquerade as a product bug.
+                environ=os.environ,
+                path=types.SimpleNamespace(
+                    expanduser=os.path.expanduser,
+                    abspath=os.path.abspath,
+                    realpath=realpath,
+                    normcase=os.path.normcase,
+                    normpath=os.path.normpath,
+                    isabs=os.path.isabs,
+                    join=os.path.join,
+                    dirname=os.path.dirname,
+                ),
+            ),
+        )
+
+    def test_linked_ancestor_is_refused_before_realpath(self, tmp_path, monkeypatch):
+        """realpath resolves the whole ancestor chain, so it IS the outbound
+        SMB probe when an ancestor junction targets a UNC share (#5962).
+        Wiring realpath to explode proves the walk returned first."""
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran before the ancestor walk")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: str(tmp_path))
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    def test_bypassing_the_ancestor_guard_restores_validation(self, tmp_path, monkeypatch):
+        """Mutation check: with the walk reporting no link, the same path
+        validates again -- the refusal above is attributable to the guard."""
+        from kiro_crew import platform_compat
+
+        f = _write(tmp_path / "ok.txt", "x")
+        self._windows(monkeypatch)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        assert _same(validate_file_path(str(f)) or "", str(f))
+
+    def test_a_leaf_link_aimed_at_unc_is_refused_before_realpath(self, tmp_path, monkeypatch):
+        """A leaf FILE symlink is part of this function's contract (it
+        resolves and re-checks), so the leaf is not blanket-refused -- but a
+        leaf link aimed straight at an untrusted UNC share must be refused
+        before the realpath that would probe it. readlink is a local
+        metadata read, wired here to prove no traversal happened."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran before the leaf target screen")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(
+            hooks_mod.os, "readlink", lambda _p: r"\\evil-host\share\doc.txt", raising=False
+        )
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    def test_a_benign_leaf_link_still_resolves_on_windows(self, tmp_path, monkeypatch):
+        """The documented contract resolves benign leaf symlinks (CI pins it
+        end-to-end with a real link in test_hooks.py test_allows_benign_symlink);
+        the Windows leaf screen must not blanket-refuse them -- only an
+        untrusted-UNC target refuses. Under this simulation no real link
+        exists, so the pin is that validation SUCCEEDS (reaches realpath)
+        rather than returning None."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        alias = tmp_path / "alias.txt"
+        self._windows(monkeypatch)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda p: str(p) == str(alias))
+        # A drive-absolute target: the shape a real Windows link carries.
+        monkeypatch.setattr(
+            hooks_mod.os, "readlink", lambda _p: r"C:\Users\me\real.txt", raising=False
+        )
+        assert validate_file_path(str(alias)) is not None
+
+    def test_a_multi_hop_chain_landing_on_unc_is_refused(self, tmp_path, monkeypatch):
+        r"""A leaf link -> LOCAL link -> UNC chain must be refused hop by hop:
+        screening only the first target would launder the probe through the
+        intermediate local link."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        alias = tmp_path / "alias.txt"
+        mid_t = r"C:\Users\me\mid.txt"
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran before the chain walk refused")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(
+            platform_compat,
+            "is_link_or_junction",
+            lambda p: str(p) in (str(alias), mid_t),
+        )
+        targets = {str(alias): mid_t, mid_t: r"\\evil-host\share\doc.txt"}
+        monkeypatch.setattr(hooks_mod.os, "readlink", lambda p: targets[str(p)], raising=False)
+        assert validate_file_path(str(alias)) is None
+
+    def test_an_overlong_leaf_chain_is_refused_not_probed(self, tmp_path, monkeypatch):
+        """A chain longer than the walk's bound refuses rather than probes --
+        the same fail-closed posture as the kernels' own ELOOP ceiling."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        alias = tmp_path / "alias.txt"
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran on an over-long chain")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(hooks_mod.os, "readlink", lambda _p: r"C:\loop\self.lnk", raising=False)
+        assert validate_file_path(str(alias)) is None
+
+    @pytest.mark.parametrize(
+        "exotic",
+        [r"\pivot\file.txt", r"D:pivot\file.txt"],
+        ids=["root-relative", "drive-relative"],
+    )
+    def test_root_and_drive_relative_targets_are_refused(self, tmp_path, monkeypatch, exotic):
+        r"""Root-relative (\pivot -> the CURRENT drive's root) and
+        drive-relative (D:pivot -> D:'s per-drive CWD) targets resolve
+        against ambient state the walk cannot see, so the screened string
+        and the resolved string could diverge by drive. Refused fail-closed
+        before realpath."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        alias = tmp_path / "alias.txt"
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran on an ambient-state target")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda p: str(p) == str(alias))
+        monkeypatch.setattr(hooks_mod.os, "readlink", lambda _p: exotic, raising=False)
+        assert validate_file_path(str(alias)) is None
+
+    def test_an_adversarially_deep_path_is_refused_before_the_walk(self, monkeypatch):
+        """The screen is one lstat per component, so the walk's cost is
+        bounded BEFORE it starts: a path with thousands of components would
+        stall the event loop inside the guard itself."""
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("ancestor walk started on an over-deep path")
+
+        self._windows(monkeypatch)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", _boom)
+        deep = "/" + "/".join("a" * 1 for _ in range(300)) + "/doc.txt"
+        assert validate_file_path(deep) is None
+
+    def test_an_unreadable_leaf_link_fails_closed(self, tmp_path, monkeypatch):
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        def _raise(_p):
+            raise OSError("unreadable reparse point")
+
+        self._windows(monkeypatch)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(hooks_mod.os, "readlink", _raise, raising=False)
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    def test_a_longform_unc_leaf_target_is_still_refused(self, tmp_path, monkeypatch):
+        r"""The \\?\UNC\host\share long-path spelling folds into the screened
+        UNC shape rather than slipping past as a non-UNC-looking string."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        self._windows(monkeypatch)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(
+            hooks_mod.os,
+            "readlink",
+            lambda _p: "\\\\?\\UNC\\evil-host\\share\\doc.txt",
+            raising=False,
+        )
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            "\\\\?\\unc\\evil-host\\share\\doc.txt",
+            "\\\\?\\Unc\\evil-host\\share\\doc.txt",
+            "\\\\?\\uNC\\evil-host\\share\\doc.txt",
+        ],
+        ids=["lowercase", "titlecase", "mixed"],
+    )
+    def test_a_mixed_case_longform_unc_target_is_still_refused(
+        self, tmp_path, monkeypatch, spelling
+    ):
+        r"""The OS resolves \\?\unc\... case-insensitively, so the fold must
+        match the UNC component case-insensitively too: a case-sensitive
+        match would drop a lowercase spelling into the plain \\?\ branch,
+        strip four characters, and launder the share into a relative-looking
+        string that realpath would then probe over SMB."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran on a mixed-case UNC target")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(hooks_mod.os, "readlink", lambda _p: spelling, raising=False)
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            "\\\\?\\GLOBALROOT\\Device\\Mup\\evil-host\\share\\doc.txt",
+            "\\\\?\\Volume{deadbeef-0000-0000-0000-000000000000}\\doc.txt",
+        ],
+        ids=["globalroot-mup", "volume-guid"],
+    )
+    def test_a_non_drive_extended_namespace_target_is_refused(
+        self, tmp_path, monkeypatch, spelling
+    ):
+        r"""A bare \\?\ prefix is only folded when the remainder is a
+        drive-absolute local path. Any other extended namespace (GLOBALROOT
+        device-namespace spelling of a UNC share, a Volume GUID) must be
+        refused outright: stripping the prefix would leave a string with no
+        leading separator and no drive, which the shape allowlist would then
+        anchor as PLAIN RELATIVE while realpath follows the real link."""
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("realpath ran on an extended-namespace target")
+
+        self._windows(monkeypatch, realpath=_boom)
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(platform_compat, "is_link_or_junction", lambda _p: True)
+        monkeypatch.setattr(hooks_mod.os, "readlink", lambda _p: spelling, raising=False)
+        assert validate_file_path(str(tmp_path / "doc.txt")) is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="pins POSIX resolve-through-symlink semantics")
+    def test_posix_dotdot_still_resolves_through_the_symlink(self, tmp_path):
+        """A `..` crossing a symlinked component must keep resolving THROUGH
+        the link (realpath order), not be collapsed lexically first -- the
+        Windows-only abspath anchoring must never leak into the POSIX path."""
+        real = tmp_path / "srv"
+        (real / "sub").mkdir(parents=True)
+        x = _write(real / "x.txt", "payload")
+        pub = tmp_path / "pub"
+        pub.mkdir()
+        link = pub / "link"
+        link.symlink_to(real / "sub", target_is_directory=True)
+
+        got = validate_file_path(str(link / ".." / "x.txt"))
+
+        # realpath: link -> srv/sub, then `..` -> srv, then x.txt. A lexical
+        # collapse would instead yield pub/x.txt, which does not exist.
+        assert got is not None
+        assert _same(got, str(x))
+
+    def test_the_ancestor_walk_is_not_consulted_on_posix(self, tmp_path, monkeypatch):
+        """On POSIX the real guard is is_sensitive_path on the RESOLVED path;
+        an unconditional walk would refuse a symlinked /home."""
+        if os.name == "nt":
+            pytest.skip("gate is active on Windows by design")
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("ancestor walk ran on POSIX")
+
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", _boom)
+        f = _write(tmp_path / "ok.txt", "x")
+        assert _same(validate_file_path(str(f)) or "", str(f))
+
+    def test_unc_shaped_anchored_form_is_refused_before_the_walk(self, monkeypatch):
+        """A `~` expanding to a roaming-profile UNC home surfaces a UNC shape
+        the raw text did not have. The ANCHORED form (the exact string walked
+        and resolved) must be screened before the ancestor walk -- the walk is
+        an lstat per component, so on an untrusted UNC path the walk itself
+        would be the outbound SMB probe. abspath never strips UNC-ness, so
+        this single screen covers the expanded form too."""
+        import types
+
+        from kiro_crew import hooks as hooks_mod
+        from kiro_crew import platform_compat
+
+        def _boom(_p):  # pragma: no cover
+            raise AssertionError("ancestor walk ran on a UNC-shaped expansion")
+
+        monkeypatch.setattr(platform_compat, "first_linked_ancestor", _boom)
+        monkeypatch.setattr(
+            hooks_mod,
+            "os",
+            types.SimpleNamespace(
+                name="nt",
+                sep=os.sep,
+                environ=os.environ,
+                path=types.SimpleNamespace(
+                    expanduser=lambda _raw: "//evil-host/share/doc.txt",
+                    abspath=os.path.abspath,
+                    realpath=os.path.realpath,
+                    # unc_probe_allowed's lexical folding runs on this
+                    # namespace too once the expanded form is UNC-shaped.
+                    normcase=os.path.normcase,
+                    normpath=os.path.normpath,
+                ),
+            ),
+        )
+        assert validate_file_path("~/doc.txt") is None
+
 
 class TestSafeReadFile:
     def test_reads_text(self, tmp_path):

--- a/test/test_image_artifacts.py
+++ b/test/test_image_artifacts.py
@@ -774,3 +774,88 @@ class TestAssetReadHardening:
         assert "private" in cache
         assert "public" not in cache
         assert offloaded["used"] is True
+
+
+class TestLinkedAncestorGate:
+    """On Windows, a registration destination beneath a linked ANCESTOR must
+    be refused BEFORE the first filesystem probe -- both is_file() and
+    is_sensitive_path's resolved candidate forms traverse every ancestor, so
+    the probe itself would open the SMB connection the lexical UNC screen in
+    local_destination exists to prevent (#5962). Mirrors the guard on the
+    upload-side consumer (_inspect in outbound_files)."""
+
+    def _windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Patch ONLY the module's view of os -- patching the global os.name
+        # would make pathlib dispatch WindowsPath on a POSIX test host.
+        import os as _os
+
+        monkeypatch.setattr(
+            image_artifacts, "os", types.SimpleNamespace(name="nt", path=_os.path)
+        )
+
+    def test_linked_ancestor_is_refused_before_any_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering IS the property: both downstream probes are wired to
+        explode, so a regression that probes first fails loudly."""
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(
+            image_artifacts, "first_linked_ancestor", lambda _p: str(tmp_path)
+        )
+
+        def _boom_is_file(self: Path) -> bool:  # pragma: no cover
+            raise AssertionError("is_file ran before the ancestor walk")
+
+        def _boom_sensitive(_p: str) -> bool:  # pragma: no cover
+            raise AssertionError("is_sensitive_path ran before the ancestor walk")
+
+        monkeypatch.setattr(Path, "is_file", _boom_is_file)
+        monkeypatch.setattr(image_artifacts, "is_sensitive_path", _boom_sensitive)
+        assert image_artifacts._local_file(str(f)) is None
+
+    def test_bypassing_the_guard_restores_the_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mutation check: with the walk reporting no link, the same file
+        resolves again -- the refusal above is attributable to the guard."""
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(image_artifacts, "first_linked_ancestor", lambda _p: None)
+        assert image_artifacts._local_file(str(f)) == f
+
+    def test_the_walk_is_not_consulted_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """POSIX behavior is pinned unchanged: the walk must not even run."""
+        import os as _os
+
+        if _os.name == "nt":
+            pytest.skip("gate is active on Windows by design")
+
+        def _boom(_p: object) -> None:  # pragma: no cover
+            raise AssertionError("ancestor walk ran on POSIX")
+
+        monkeypatch.setattr(image_artifacts, "first_linked_ancestor", _boom)
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        assert image_artifacts._local_file(str(f)) == f
+
+    def test_a_leaf_link_is_refused_before_any_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The walk deliberately excludes the leaf, so the leaf gets its own
+        junction-aware check -- is_file() FOLLOWS a final-component link."""
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(image_artifacts, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(image_artifacts, "is_link_or_junction", lambda _p: True)
+
+        def _boom_is_file(self: Path) -> bool:  # pragma: no cover
+            raise AssertionError("is_file ran before the leaf link check")
+
+        monkeypatch.setattr(Path, "is_file", _boom_is_file)
+        assert image_artifacts._local_file(str(f)) is None

--- a/test/test_memory_markdown_read.py
+++ b/test/test_memory_markdown_read.py
@@ -1224,3 +1224,87 @@ class TestEmptyIndexIsNotAbsence:
         out = capsys.readouterr().out
         assert "empty or unavailable" in out
         assert "No memory-history matches." not in out
+
+
+class TestLinkedWorkspaceAncestorGate:
+    """On Windows, a linked ANCESTOR of the workspace must be refused before
+    the leaf reparse-point checks -- those are lstats that resolve every
+    ancestor, so the probe itself would traverse the link and open the SMB
+    connection the lexical UNC gate exists to prevent (#5962)."""
+
+    def _windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import types
+
+        from kiro_crew import memory as memory_mod
+
+        # Patch ONLY memory.py's view of os (same rationale as the UNC gate
+        # tests above): patching the global os.name would make pathlib
+        # dispatch WindowsPath everywhere on a POSIX test host. lstat is
+        # carried so the read path's updated_at branch cannot surface a stub
+        # AttributeError masquerading as a product bug.
+        monkeypatch.setattr(memory_mod, "os", types.SimpleNamespace(name="nt", lstat=os.lstat))
+
+    def test_linked_ancestor_is_refused_before_any_leaf_lstat(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering IS the property: the leaf predicate is wired to explode,
+        so a regression that lstats first fails loudly instead of silently."""
+        from kiro_crew import memory as memory_mod
+
+        ms = _populated_store(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(memory_mod, "first_linked_ancestor", lambda _p: str(tmp_path))
+
+        def _boom(_p: object) -> bool:  # pragma: no cover
+            raise AssertionError("leaf reparse check ran before the ancestor walk")
+
+        monkeypatch.setattr(memory_mod, "is_link_or_junction", _boom)
+        audits: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            ms,
+            "_audit_read_refusal",
+            lambda rule, path, reason: audits.append((rule, reason)),
+        )
+
+        snapshot = ms.markdown_snapshot()
+
+        assert snapshot["preferences"]["content"] == ""
+        assert snapshot["history"] == []
+        # The guard is consulted once per read surface (preferences, projects,
+        # history) and the refusal short-circuits before any per-entry work,
+        # so the multiplicity is bounded by the surface count -- a regression
+        # to per-entry consultation would blow this bound out.
+        assert len(audits) == 3
+        assert set(audits) == {("workspace_linked_ancestor", "a workspace ancestor is a link")}
+
+    def test_bypassing_the_guard_restores_the_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mutation check: with the walk reporting no link, the same store
+        reads again -- the refusal above is attributable to the guard."""
+        from kiro_crew import memory as memory_mod
+
+        ms = _populated_store(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(memory_mod, "first_linked_ancestor", lambda _p: None)
+
+        snapshot = ms.markdown_snapshot()
+
+        assert "- prefers pytest" in snapshot["preferences"]["content"]
+
+    def test_the_walk_is_not_consulted_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """POSIX linked ancestors stay deliberately unrejected (a symlinked
+        /home is a legitimate setup and those components are not
+        agent-writable), so the walk must not even run there."""
+        if os.name == "nt":
+            pytest.skip("gate is active on Windows by design")
+        from kiro_crew import memory as memory_mod
+
+        def _boom(_p: object) -> None:  # pragma: no cover
+            raise AssertionError("ancestor walk ran on POSIX")
+
+        monkeypatch.setattr(memory_mod, "first_linked_ancestor", _boom)
+        ms = _populated_store(tmp_path)
+        assert "- prefers pytest" in ms.markdown_snapshot()["preferences"]["content"]

--- a/test/test_outbound_files.py
+++ b/test/test_outbound_files.py
@@ -697,3 +697,123 @@ class TestOutboundFile:
         f = OutboundFile(path="/tmp/a.png", data=b"x", alt="a", mime="image/png")
         with pytest.raises(Exception):
             f.path = "/etc/shadow"  # type: ignore[misc]
+
+
+class TestLinkedAncestorGate:
+    """On Windows, a destination beneath a linked ANCESTOR must be refused
+    BEFORE ``is_symlink()`` -- that leaf probe is an lstat that resolves every
+    ancestor, so the probe itself would traverse the link and open the SMB
+    connection the lexical UNC screen exists to prevent (#5962)."""
+
+    def _windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import types
+
+        from kiro_crew.messaging import outbound_files as module
+
+        # Patch ONLY the module's view of os -- patching the global os.name
+        # would make pathlib dispatch WindowsPath on a POSIX test host.
+        monkeypatch.setattr(module, "os", types.SimpleNamespace(name="nt", path=os.path))
+
+    def test_linked_ancestor_is_refused_before_the_leaf_lstat(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering IS the property: BOTH downstream probes are wired to
+        explode -- is_sensitive_path builds realpath()/resolve() candidate
+        forms, so running it first would resolve the chain just like the
+        is_symlink lstat would. A regression that probes first fails loudly."""
+        from kiro_crew.messaging import outbound_files as module
+
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(module, "first_linked_ancestor", lambda _p: str(tmp_path))
+
+        def _boom_lstat(self: Path) -> bool:  # pragma: no cover
+            raise AssertionError("is_symlink ran before the ancestor walk")
+
+        def _boom_sensitive(_p: str) -> bool:  # pragma: no cover
+            raise AssertionError("is_sensitive_path ran before the ancestor walk")
+
+        monkeypatch.setattr(Path, "is_symlink", _boom_lstat)
+        monkeypatch.setattr(module, "is_sensitive_path", _boom_sensitive)
+        got = module._inspect(str(p), p, "alt", 10_000, None, None)
+        assert isinstance(got, Rejection)
+        assert got.reason == REASON_SYMLINK
+        # The reply matches the leaf case on purpose: which ancestor is a
+        # link is filesystem layout the caller supplied a path to guess at.
+        assert got.detail == "symlinks are not uploaded"
+
+    def test_bypassing_the_guard_restores_the_upload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mutation check: with the walk reporting no link, the same file is
+        inspected and accepted -- the refusal above is attributable to the
+        guard, not to some other screen."""
+        from kiro_crew.messaging import outbound_files as module
+
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(module, "first_linked_ancestor", lambda _p: None)
+        got = module._inspect(str(p), p, "alt", 10_000, None, None)
+        assert isinstance(got, OutboundFile)
+        assert got.path == str(p)
+
+    def test_the_walk_is_not_consulted_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On POSIX stat-ing through a symlink is harmless and the real guard
+        is the sensitive-path check; an unconditional walk would refuse
+        uploads from a symlinked temp dir (macOS /tmp)."""
+        if os.name == "nt":
+            pytest.skip("gate is active on Windows by design")
+        from kiro_crew.messaging import outbound_files as module
+
+        def _boom(_p: object) -> None:  # pragma: no cover
+            raise AssertionError("ancestor walk ran on POSIX")
+
+        monkeypatch.setattr(module, "first_linked_ancestor", _boom)
+        p = _png(tmp_path)
+        got = module._inspect(str(p), p, "alt", 10_000, None, None)
+        assert isinstance(got, OutboundFile)
+
+    def test_unc_shaped_expansion_is_refused_lexically(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `~` that expands to a roaming-profile UNC home surfaces a UNC
+        shape the raw text did not have; the expanded form must be screened
+        (still lexically) before the path reaches any inspecting caller."""
+        from kiro_crew.messaging import outbound_files as module
+
+        self._windows(monkeypatch)
+
+        class _ExpandsToUnc:
+            def __init__(self, raw: str) -> None:
+                self._raw = raw
+
+            def expanduser(self) -> Path:
+                return Path("//evil-host/share/x.png")
+
+        monkeypatch.setattr(module, "Path", _ExpandsToUnc)
+        assert module.local_destination("~/x.png") is None
+
+    def test_a_leaf_link_is_refused_before_any_resolving_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The walk deliberately excludes the leaf, and the all-platform
+        is_symlink() refusal is junction-blind and runs after
+        is_sensitive_path (whose candidate forms resolve the leaf) -- so on
+        Windows the leaf needs its own junction-aware check first."""
+        from kiro_crew.messaging import outbound_files as module
+
+        p = _png(tmp_path)
+        self._windows(monkeypatch)
+        monkeypatch.setattr(module, "first_linked_ancestor", lambda _p: None)
+        monkeypatch.setattr(module, "is_link_or_junction", lambda _p: True)
+
+        def _boom_sensitive(_p: str) -> bool:  # pragma: no cover
+            raise AssertionError("is_sensitive_path ran before the leaf link check")
+
+        monkeypatch.setattr(module, "is_sensitive_path", _boom_sensitive)
+        got = module._inspect(str(p), p, "alt", 10_000, None, None)
+        assert isinstance(got, Rejection)
+        assert got.reason == REASON_SYMLINK
+        assert got.detail == "symlinks are not uploaded"


### PR DESCRIPTION
## Summary

PR #5943 added `first_linked_ancestor` and wired it in the themes handler: on Windows, an ancestor symlink/junction whose target is a UNC share launders the lexical UNC screen, because the first filesystem call (even an lstat, which resolves every ancestor) becomes the outbound SMB credential probe. This PR replicates that Windows-gated, guard-precedes-every-resolving-call pattern at the remaining `is_unc_shape` call sites, plus one sibling consumer review surfaced.

Closes #5962

## What changed

- **`src/kiro_crew/acp/prompt_blocks.py`** — image-path loop: ancestor walk + junction-aware leaf check after the lexical suffix screen, before `is_file()`; a refused candidate is skipped like the UNC case (path stays in the text).
- **`src/kiro_crew/hooks.py` `validate_file_path`** — inside a Windows-only branch: lexical `abspath` anchoring (so the walk covers what `realpath` resolves), a UNC re-screen of the anchored form (`~` on a roaming profile or a UNC CWD can surface a UNC shape the raw text lacked; `abspath` never strips UNC-ness so one screen covers both forms), the ancestor walk, and the leaf check — then `realpath` consumes the same string the walk inspected. POSIX keeps byte-identical resolve-through-every-symlink semantics, pinned by a dot-dot-through-symlink test; the `messaging.md` spec paragraph is updated in the same commit.
- **`src/kiro_crew/messaging/outbound_files.py` `_inspect`** — ancestor walk + leaf check FIRST inside the try, before `is_sensitive_path` (whose candidate forms are built with `realpath`/`resolve`, so it was the first chain-resolving call) and before the junction-blind `is_symlink()` lstat. Same reply as the leaf case, per the reference. `local_destination` additionally screens the expanded form — still lexical, its documented contract.
- **`src/kiro_crew/image_artifacts.py` `_local_file`** — the registration-side consumer of the same lexical screen gains the same ancestor + leaf guards before its `is_file()` probe.
- **`src/kiro_crew/memory.py` `_read_root_guard`** — Windows ancestor walk on the workspace before the leaf reparse checks, with an audit line (`workspace_linked_ancestor`); the old "linked ancestors deliberately not rejected" comment is rewritten to keep only the POSIX half, and the INVARIANT docstrings are qualified to match (write path inherits via `_require_link_free_roots`).

No user-facing message names the offending ancestor (which ancestor is a link is filesystem layout the caller supplied a path to guess at).

## Pre-push adversarial review

3 rounds of dual blind model-pinned review (GPT + Opus lanes, mirroring the CI charters). 14 findings total: 8 fixed (ordering vs `is_sensitive_path`, expanded/anchored-form screens, the unguarded `_local_file` sibling consumer, the leaf-link class, POSIX `abspath` semantics regression, test attributability), 4 advisory adoptions (docstring accuracy, stub completeness, audit-count bound), 2 documented trade-offs below. Round 3: GPT PASS zero findings; Opus findings were test-quality only, fixed as prescribed.

## Documented trade-offs (deliberate, matching the merged reference semantics)

1. **Refuse-all-links predicate.** The walk refuses ANY linked ancestor on Windows, including locally-targeted junctions (`C:\dev -> D:\dev`). Narrowing to UNC-targeted links only would require reading each link's target and re-validating the target's own chain recursively; the merged themes wiring (#5943) chose refuse-all, and this PR replicates those semantics as the issue mandates. At the memory site a refusal surfaces as empty memory plus a `logger.warning` + SEL audit entry — same surface the existing UNC/leaf refusals already use.
2. **TOCTOU inside `first_linked_ancestor` itself.** An ancestor could be swapped to a link between the walk and the probe. Closing this needs handle-relative (`openat`-style) traversal with no Windows equivalent — a cross-platform redesign of the merged helper, out of scope for replicating its accepted pattern.

Residuals noted in-code, follow-up planned: `is_link_or_junction` fails open on an unreadable component (pre-existing shared machinery); a mapped network drive / `subst` target is outside the reparse-point class entirely.

## Testing

- 22 new Windows-marked tests across 5 test modules, mirroring the themes tests: ordering pinned by wiring the FIRST downstream probe to explode (`realpath`, `is_file`, `is_sensitive_path`), mutation-checked (refusal disappears when the walk reports no link), POSIX behavior pinned unchanged (including the dot-dot-through-symlink canonicalization pin).
- Local gates: isort / flake8 / mypy / diff-scoped black all green; full pytest 70806 passed, 86 failures byte-identical to the pre-change host-env baseline (proven in the unmodified-base log), zero in touched modules.

no linked issue in title: issue reference carried in the trailing "(#5962)" of the conventional-commit subject and "Closes #5962" above.

No screenshots: backend-only security hardening, no UI surface.


## Pattern harvest

Rule candidate: any call site that lexically screens a user- or agent-supplied path for UNC shape must place the screen (and a Windows linked-ancestor/leaf-link check) BEFORE the first resolving filesystem call — including `is_sensitive_path`, whose candidate forms are built with `realpath()`/`resolve()`. When a lexical screen lives in a shared normalizer (`local_destination`), every consumer that later probes the path needs its own guard; grep for sibling consumers before declaring the class closed.
