### PR TITLE
fix(subagent): bound cancellation drain for diagnostics writes

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -399,6 +399,11 @@ _RECOVERY_SLOT_WAIT_SECS = 60.0
 _REPORT_DRAIN_TIMEOUT = (
     30.0  # max seconds cancel_all() waits for shielded terminal reports to drain
 )
+# Max seconds a cancelled run holds cancellation open for an in-flight per-turn
+# diagnostics write worker (#6306 review): long enough for any healthy fsync,
+# short enough that a wedged FS cannot hold cancel_all()'s untimed gather —
+# bounded shutdown plus recoverable state beats unbounded shutdown.
+_DIAG_DRAIN_TIMEOUT = 5.0
 _STARTUP_TIMEOUT_SECS = 120  # max seconds a subagent may sit pre-first-turn with no runtime before the startup watchdog reaps it
 _ON_DONE_TIMEOUT = 1200.0  # outer cap: max total seconds for semaphore wait + injection
 
@@ -1428,6 +1433,13 @@ class SubagentInfo:
     # One-shot budget for auto-continue after an UNEXPECTED (non-user, non-
     # shutdown) asyncio cancellation — mirrors the main path's cancel recovery.
     _cancel_retry_used: bool = False
+    # True while a cancelled run is draining an in-flight diagnostics write
+    # worker (#6306). _run's unexpected-cancel recovery gate reads it: on
+    # Python 3.10 a second outer cancel can deliver that gate BEFORE the drain
+    # finishes (wait_for's _cancel_and_wait awaits an interruptible bare
+    # future), and scheduling a recovery writer while the worker is live
+    # re-opens the stale-overwrite race the drain exists to close.
+    _diag_drain_active: bool = False
     # True between an unexpected cancellation and the recovery respawn; the
     # _run finally block skips terminal finalization (subagent_done, on_done)
     # while set so the agent is not reported done mid-recovery.
@@ -5061,6 +5073,12 @@ class SubagentManager:
                     not info.user_stopped
                     and not self._shutting_down
                     and not info._cancel_retry_used
+                    # A live diagnostics-write drain means a worker is still
+                    # (or may still be) writing state.json: respawning a
+                    # recovery writer now re-opens the stale-overwrite race
+                    # (#6306; reachable on 3.10 via a second outer cancel
+                    # interrupting wait_for's _cancel_and_wait).
+                    and not info._diag_drain_active
                     and info.tool_count == 0
                 ):
                     # UNEXPECTED cancellation (not user Stop, not shutdown):
@@ -6107,14 +6125,100 @@ class SubagentManager:
                 # increment is parent-scoped.
                 info.last_tool = event.title or ""
                 self._note_tool_dispatch(info, event)
-                # Persist turn state for orphan recovery diagnostics.
-                # Off-loop (to_thread): update_state does a synchronous
-                # fsync, so a slow/NFS FS must not freeze the gateway
-                # heartbeat on every tool-call event (#6288).
-                try:
-                    await asyncio.to_thread(
+                # Persist turn state for orphan recovery diagnostics. Off-loop
+                # (to_thread): update_state does a synchronous fsync, so a slow
+                # FS must not freeze the gateway/heartbeat (#6288; same shape
+                # as the provenance and CC-refinement writes above). Drained on
+                # cancellation: cancelling a to_thread await detaches the
+                # worker, and update_state is an unlocked read-merge-replace,
+                # so a stale detached worker could overwrite newer state
+                # written by a cancel-respawn recovery run. Hold cancellation
+                # open until the worker finishes — but BOUNDED: cancel_all()
+                # gathers run tasks with no timeout, so an unbounded drain on
+                # a wedged FS would hold gateway shutdown forever, and this
+                # module's convention is that bounded shutdown plus
+                # recoverable state beats unbounded shutdown (same posture as
+                # _REPORT_DRAIN_TIMEOUT). On expiry the worker is abandoned
+                # with a warning; the residual stale-write window then only
+                # exists on an FS already wedged past the deadline.
+                # asyncio.wait never cancels its members, so repeated cancels
+                # of this task keep the worker future intact while the drain
+                # loop keeps waiting out the same deadline.
+                _diag_write = asyncio.ensure_future(
+                    asyncio.to_thread(
                         update_state, info.id, turns=turns, last_tool=event.title or ""
                     )
+                )
+                try:
+                    await asyncio.shield(_diag_write)
+                except asyncio.CancelledError:
+                    # Latch for _run's recovery gate: on Python 3.10,
+                    # wait_for's _cancel_and_wait awaits a bare future that a
+                    # SECOND outer cancel can interrupt, delivering _run's
+                    # CancelledError handler while this drain is still in
+                    # flight — before expiry suppression lands. The latch lets
+                    # the gate see the live drain and skip scheduling a
+                    # recovery writer the worker could race (GPT review round
+                    # 4 on #6306). 3.11+ delivers the outer cancel only after
+                    # this child task completes, so there the latch is always
+                    # observed False.
+                    info._diag_drain_active = True
+                    try:
+                        _drain_deadline = time.monotonic() + _DIAG_DRAIN_TIMEOUT
+                        while not _diag_write.done():
+                            _remaining = _drain_deadline - time.monotonic()
+                            if _remaining <= 0:
+                                logger.warning(
+                                    "diagnostics write for %s did not drain in %.0fs on "
+                                    "cancellation — abandoning worker (its write may race "
+                                    "a recovery run's)",
+                                    info.id,
+                                    _DIAG_DRAIN_TIMEOUT,
+                                )
+                                # The abandoned worker is a live stale writer: a
+                                # cancel-respawn recovery run would write fresh
+                                # PID/session state that the zombie's read-merge-
+                                # replace could then roll back. Consume the
+                                # one-shot recovery so this cancellation finalizes
+                                # instead of respawning — losing one best-effort
+                                # auto-continue on an FS already wedged past the
+                                # deadline is strictly cheaper than resurrecting
+                                # stale state (GPT server review round 3 on #6306).
+                                info._cancel_retry_used = True
+
+                                # The zombie may still raise later; retrieve it so
+                                # it never surfaces as an asynchronous "exception
+                                # was never retrieved" warning.
+                                def _log_abandoned_diag(
+                                    fut: "asyncio.Future[Any]", _aid: str = info.id
+                                ) -> None:
+                                    if not fut.cancelled() and fut.exception() is not None:
+                                        logger.debug(
+                                            "Abandoned diagnostics write for %s failed",
+                                            _aid,
+                                            exc_info=fut.exception(),
+                                        )
+
+                                _diag_write.add_done_callback(_log_abandoned_diag)
+                                break
+                            try:
+                                await asyncio.wait({_diag_write}, timeout=_remaining)
+                            except asyncio.CancelledError:
+                                pass  # repeated cancel: keep draining to the deadline
+                        if _diag_write.done() and not _diag_write.cancelled():
+                            # Retrieve (never surfaces as an unretrieved-exception
+                            # warning) and log, matching the CC-refinement sibling.
+                            _diag_exc = _diag_write.exception()
+                            if _diag_exc is not None:
+                                logger.debug(
+                                    "Best-effort diagnostics write failed for %s during "
+                                    "cancel drain",
+                                    info.id,
+                                    exc_info=_diag_exc,
+                                )
+                    finally:
+                        info._diag_drain_active = False
+                    raise
                 except Exception:
                     pass
                 await self._fire_event(

--- a/test/test_subagent_provenance_write.py
+++ b/test/test_subagent_provenance_write.py
@@ -33,6 +33,13 @@ def _mock_sessions(served_model: str) -> MagicMock:
     provider.start = AsyncMock()
     provider.shutdown = AsyncMock()
     provider.context_usage_pct = lambda: 0.0
+    # These provider accessors are synchronous in production.  Leaving them
+    # as auto-created AsyncMock children returns un-awaited coroutines from the
+    # context-budget and usage probes, making this otherwise deterministic
+    # test file emit RuntimeWarnings under xdist.
+    provider.context_used_tokens = lambda: 0
+    provider.context_window_tokens = lambda: 0
+    provider.client = None
     # Public accessor read by _resolved_model_of at spawn time. Plain string
     # attribute: an auto-created AsyncMock child would stringify to a mock repr
     # and masquerade as a served model id.
@@ -222,6 +229,408 @@ async def test_provenance_write_retries_on_silently_skipped_merge() -> None:
     assert provenance_attempts["n"] == 2, "a reported skip must trigger the retry"
     assert len(landed) == 1 and landed[0]["requested_model"] == "model-req"
     assert info.error == ""
+
+
+def _mock_sessions_with_tool_event(served_model: str, event: Any) -> MagicMock:
+    """Like ``_mock_sessions`` but the stream yields one event before ending —
+    enough to drive the per-turn EVENT_PERMISSION_REQUEST branch in
+    ``_run_inner`` (the diagnostics ``update_state`` write at issue in #6288)."""
+    sessions = _mock_sessions(served_model=served_model)
+    provider, _, _ = sessions.get_or_create.return_value
+
+    async def _one_event_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        yield event
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _one_event_stream())
+    return sessions
+
+
+async def _event_loop_checkpoint() -> None:
+    """Yield until callbacks already queued on this loop have run.
+
+    This is a deterministic scheduling barrier, not a clock-based sleep.  The
+    cancellation tests use it after ``Task.cancel()`` so the cancellation arm
+    can reach its next await before assertions inspect the task and latch.
+    """
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    reached = loop.create_future()
+    loop.call_soon(reached.set_result, None)
+    await reached
+
+
+@pytest.mark.asyncio
+async def test_per_turn_diagnostics_write_is_drained_on_cancellation() -> None:
+    """Cancelling ``await asyncio.to_thread(...)`` detaches the worker thread,
+    and ``update_state`` is an unlocked read-merge-replace — so a stale
+    detached worker could overwrite newer state written by a cancel-respawn
+    recovery run (recovery waits for the old asyncio TASK, not the worker).
+    The fix drains the worker before letting cancellation complete: the
+    cancelled task must NOT finish while the diagnostics write is in flight,
+    which orders any recovery write strictly after the worker's write and
+    closes the race (GPT + Opus review round 1 on #6306; same worker-drain
+    posture as autonudge's persistence path, #425)."""
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="turnw04", task="per-turn cancel task", model="model-req")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    landed: list[dict[str, Any]] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        landed.append(dict(kwargs))
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await entered.wait()
+
+            task.cancel()
+            # The drain must hold the cancelled task open while the worker is
+            # still writing — a task that completes here is the detached-worker
+            # race (pre-fix behaviour).
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "cancelled _run_inner completed while the diagnostics write was "
+                "in flight — the detached worker can now overwrite newer "
+                "recovery state (#6306 review)"
+            )
+            # While draining, the latch _run's recovery gate reads must be up
+            # (3.10 wait_for double-cancel can deliver that gate mid-drain).
+            assert info._diag_drain_active is True, (
+                "drain did not raise the _diag_drain_active latch — on 3.10 a "
+                "second outer cancel can schedule recovery mid-drain (#6306 "
+                "review round 4)"
+            )
+            # A SECOND cancel while draining (reachable: wait_for deadline
+            # cancels the run, then shutdown's cancel_all delivers another)
+            # must not detach the worker either — this is what distinguishes
+            # the drain loop from a single re-await (#6306 review round 2).
+            task.cancel()
+            await _event_loop_checkpoint()
+            assert not task.done(), (
+                "a second cancel during the drain detached the worker — the "
+                "drain must keep waiting to its deadline through repeated "
+                "cancels (#6306 review round 2)"
+            )
+        finally:
+            release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    # The write itself still landed (drained, not abandoned)...
+    assert landed and landed[0]["turns"] == 1
+    # ...and the latch is down again: after a completed drain there is no live
+    # worker, so recovery is safe and must not stay suppressed.
+    assert info._diag_drain_active is False, "latch leaked past the drain"
+
+
+@pytest.mark.asyncio
+async def test_no_recovery_scheduled_while_diagnostics_worker_is_live() -> None:
+    """Integration seam from GPT review round 4: drive ``_run`` (the wait_for
+    wrapper that classifies cancellation and schedules recovery), cancel it
+    twice while the diagnostics worker is gated, and prove recovery is never
+    scheduled while the worker is still live. On 3.11+ the second cancel
+    routes to the child task so the gate runs only post-drain; on 3.10 the
+    second cancel can deliver the gate mid-drain, where the
+    ``_diag_drain_active`` latch suppresses it — both paths must satisfy the
+    same invariant asserted here."""
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="turnw07", task="per-turn run-cancel task", model="model-req")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    worker_live = True
+    recovery_calls: list[Any] = []
+
+    async def _gated_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        nonlocal worker_live
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        worker_live = False
+        return True
+
+    def _spy_recovery(info_: Any) -> None:
+        # The invariant: recovery must never be scheduled while the worker
+        # is still inside update_state.
+        assert not worker_live, (
+            "cancel-respawn recovery scheduled while the diagnostics worker "
+            "was still writing — stale-overwrite race re-opened (#6306 "
+            "review round 4)"
+        )
+        recovery_calls.append(info_)
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_gated_to_thread),
+        patch.object(manager, "_schedule_cancel_recovery", side_effect=_spy_recovery),
+        patch.object(manager, "_write_tombstone"),
+    ):
+        task = asyncio.ensure_future(manager._run(info))
+        try:
+            await entered.wait()
+
+            task.cancel()
+            await _event_loop_checkpoint()
+            task.cancel()  # the 3.10 _cancel_and_wait interruption shape
+            await _event_loop_checkpoint()
+            assert not recovery_calls, "recovery was scheduled before the diagnostics drain"
+        finally:
+            release.set()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert worker_live is False
+    # _spy_recovery's own assertion is the load-bearing check; whether
+    # recovery ran at all afterwards is version-dependent and not pinned.
+
+
+@pytest.mark.asyncio
+async def test_recovery_gate_respects_live_drain_latch() -> None:
+    """Direct gate check (kills the condition mutant): an UNEXPECTED
+    cancellation with ``_diag_drain_active`` raised must NOT schedule
+    cancel-respawn recovery — a fresh recovery writer would race the live
+    worker. With the latch down, the same cancellation must recover
+    (control, so the test cannot pass by recovery being broken outright)."""
+    import asyncio
+
+    async def _cancelled_inner(info_: Any, session_key: str) -> None:
+        raise asyncio.CancelledError()
+
+    for latch, expect_recovery in ((True, False), (False, True)):
+        sessions = _mock_sessions(served_model="model-served")
+        manager = SubagentManager(
+            sessions=sessions,
+            ctx_builder=_mock_ctx_builder(),
+            is_yolo=lambda: True,
+        )
+        info = SubagentInfo(id=f"turnw08-{latch}", task="gate task", model="model-req")
+        manager._agents[info.id] = info
+        info._diag_drain_active = latch
+        recovery_calls: list[Any] = []
+
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state", return_value=True),
+            patch.object(manager, "_run_inner", side_effect=_cancelled_inner),
+            patch.object(
+                manager,
+                "_schedule_cancel_recovery",
+                side_effect=lambda i: recovery_calls.append(i),
+            ),
+            patch.object(manager, "_write_tombstone"),
+        ):
+            await manager._run(info)
+
+        assert bool(recovery_calls) is expect_recovery, (
+            f"latch={latch}: expected recovery_scheduled={expect_recovery}, "
+            f"got {bool(recovery_calls)} — the recovery gate does not respect "
+            "_diag_drain_active (#6306 review round 4)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_per_turn_diagnostics_drain_is_bounded() -> None:
+    """The drain must NOT hold cancellation open forever: cancel_all() gathers
+    run tasks with no timeout, so a worker wedged in fsync (the very slow-FS
+    premise of #6288) would otherwise hold gateway shutdown indefinitely. On
+    deadline expiry the worker is abandoned with a warning and cancellation
+    completes (#6306 review round 2; same posture as _REPORT_DRAIN_TIMEOUT)."""
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="turnw05", task="per-turn wedge task", model="model-req")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def _wedged_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        try:
+            await release.wait()
+        finally:
+            finished.set()
+        return True
+
+    with (
+        patch("kiro_crew.subagent.Stats"),
+        patch("kiro_crew.subagent.sel"),
+        patch("kiro_crew.subagent.update_state", return_value=True),
+        patch("kiro_crew.subagent.asyncio.to_thread", side_effect=_wedged_to_thread),
+        patch("kiro_crew.subagent._DIAG_DRAIN_TIMEOUT", 0.0),
+    ):
+        task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+        try:
+            await entered.wait()
+
+            task.cancel()
+            # A zero test deadline deterministically exercises expiry without
+            # relying on wall-clock scheduling or a deliberately slow test.
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # Expiry leaves a live stale writer behind, so the one-shot
+            # cancel-respawn recovery must be consumed: a fresh recovery run's
+            # PID/session writes could otherwise be rolled back by the zombie
+            # worker's read-merge-replace (GPT server review round 3).
+            assert info._cancel_retry_used is True, (
+                "drain expiry did not suppress cancel-respawn recovery — a "
+                "recovery run can now race the abandoned worker"
+            )
+        finally:
+            release.set()
+        # Do not leave an executor-shaped task pending at loop teardown.
+        await finished.wait()
+        await _event_loop_checkpoint()
+
+
+@pytest.mark.asyncio
+async def test_abandoned_diagnostics_worker_exception_is_retrieved() -> None:
+    """A worker abandoned at drain expiry may still raise later; the expiry
+    branch's done-callback must retrieve that exception so it never surfaces
+    through the loop's 'Task exception was never retrieved' handler (Opus
+    review round 3 on #6306: CPython's shield removes its retrieving callback
+    exactly when the outer await is cancelled while the inner is pending —
+    the expiry shape). Deleting the add_done_callback line fails this test."""
+    import asyncio
+
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+    event = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        title="grep",
+        tool_kind="read",
+        request_id="req-1",
+    )
+    sessions = _mock_sessions_with_tool_event("model-served", event)
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=_mock_ctx_builder(),
+        is_yolo=lambda: True,
+    )
+    info = SubagentInfo(id="turnw06", task="per-turn zombie-raise task", model="model-req")
+    manager._agents[info.id] = info
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def _wedged_raising_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        if "turns" not in kwargs:
+            return func(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        finished.set()
+        raise OSError("disk came back angry")
+
+    unretrieved: list[Any] = []
+    loop = asyncio.get_running_loop()
+    prev_handler = loop.get_exception_handler()
+
+    def _capture(loop_: Any, context: dict) -> None:
+        unretrieved.append(context)
+
+    loop.set_exception_handler(_capture)
+    try:
+        with (
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch("kiro_crew.subagent.update_state", return_value=True),
+            patch(
+                "kiro_crew.subagent.asyncio.to_thread",
+                side_effect=_wedged_raising_to_thread,
+            ),
+            patch("kiro_crew.subagent._DIAG_DRAIN_TIMEOUT", 0.0),
+        ):
+            task = asyncio.ensure_future(manager._run_inner(info, f"subagent:{info.id}"))
+            try:
+                await entered.wait()
+
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            finally:
+                release.set()
+            await finished.wait()
+            await _event_loop_checkpoint()
+            # Let the abandoned task get garbage-collected: the
+            # never-retrieved handler fires from the task's __del__, so drop
+            # the outer task reference and force collection.
+            import gc
+
+            task = None  # type: ignore[assignment]
+            gc.collect()
+            await _event_loop_checkpoint()
+        assert not unretrieved, (
+            "the abandoned diagnostics worker's exception was never retrieved "
+            f"— missing expiry done-callback (#6306 review round 3): {unretrieved}"
+        )
+    finally:
+        loop.set_exception_handler(prev_handler)
 
 
 def test_update_state_reports_write_vs_skip(tmp_path: object) -> None:


### PR DESCRIPTION
## Problem / Motivation

Main #6304 now offloads the per-turn diagnostics `update_state` write from the event loop. Cancelling an `asyncio.to_thread` await, however, detaches the worker: a stale read-merge-replace writer can continue after the run task is cancelled and overwrite newer state written by cancel-respawn recovery.

The original PR's first commit is therefore already on main. This rebase drops it and keeps only the cancellation-safety work that main does not yet contain.

## Why it matters

A stale diagnostics worker can roll back newer PID/session recovery state. Waiting forever is not acceptable either: a filesystem wedged during `fsync` would make the gateway's untimed `cancel_all()` shutdown gather hang indefinitely.

## What changed

- Shield the per-turn diagnostics worker when cancellation arrives.
- Drain the same worker through repeated cancellation attempts.
- Bound the drain at five seconds, matching the module's bounded-shutdown posture.
- On expiry, log and abandon the worker, retrieve any later exception, and consume the one-shot cancel recovery so a fresh writer cannot race the zombie.
- Add a live-drain latch to prevent Python 3.10's double-cancel path from scheduling recovery before the worker finishes.
- Keep normal write failures best-effort.
- Fix this test module's synchronous provider accessors so auto-created `AsyncMock` coroutines no longer leak warnings.

The broader unlocked read-merge-replace serialization problem and the two sibling writers remain tracked by #6308.

## Tests

- Focused file: 10 passed serial and 10 passed with xdist.
- Related provenance, turn-resilience, persistence, and reap-race matrix: 128 passed.
- Independent final serial run: 10 passed.
- Mutation coverage proves that a single re-await, a second nonblocking recovery writer, and an unretrieved abandoned exception all fail the new tests.
- Black, isort, Flake8, compileall, and diff checks passed.

The tests use `asyncio.Event` gates and a loop-callback scheduling barrier. Drain expiry uses a test-only zero deadline. They do not use polling, fixed sleep, real-time thresholds, retry, timeout relaxation, or warning filters.

## Manual verification

N/A — the concurrency order, repeated cancellation, expiry, recovery suppression, and exception retrieval are exercised directly with deterministic event barriers.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes backend cancellation handling and tests only; it has no rendered UI effect.

## Related Issues

Fixes #6288
Follow-up risk tracked by #6308.