### PR TITLE
fix(session-storage): stream trash manifests without entry lists

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1277,36 +1277,81 @@ def _append_entry(handle: IO[str], entry: dict[str, Any]) -> None:
     handle.flush()
 
 
-def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
-    """Parse a batch manifest into its header and session entries.
+def _manifest_records(handle: IO[str], batch: Path) -> Iterator[dict[str, Any]]:
+    """Yield each JSON object line of an open manifest, header first.
 
-    A trailing partial line (a crash mid-append) is skipped rather than failing
-    the whole batch: every complete line before it describes real moved files that
-    must stay restorable.
+    Blank and non-dict lines are skipped silently; a line that fails to parse —
+    including a trailing partial line from a crash mid-append — is skipped and
+    counted, with one aggregated warning once the file is exhausted, so a corrupted
+    manifest is visible in the log without failing the whole batch: every complete
+    line before it describes real moved files that must stay restorable.
     """
-    try:
-        raw = (batch / MANIFEST_NAME).read_text(encoding="utf-8")
-    except OSError:
-        return None
-    header: dict[str, Any] | None = None
-    entries: list[dict[str, Any]] = []
-    for line in raw.splitlines():
+    skipped = 0
+    for line in handle:
         line = line.strip()
         if not line:
             continue
         try:
             record = json.loads(line)
         except ValueError:
+            skipped += 1
             continue
         if not isinstance(record, dict):
             continue
-        if header is None:
-            header = record
-            continue
-        entries.append(record)
+        yield record
+    if skipped:
+        logger.warning("trash manifest in %s: skipped %d unparseable line(s)", batch.name, skipped)
+
+
+def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """Parse a batch manifest into its header and session entries.
+
+    Streams the file line by line rather than materialising it as one string; the
+    entries list itself is still O(sessions), which the two callers that rewrite or
+    enumerate the manifest genuinely need. Callers that need only aggregates should
+    use :func:`_summarize_manifest` instead.
+    """
+    header: dict[str, Any] | None = None
+    entries: list[dict[str, Any]] = []
+    try:
+        with (batch / MANIFEST_NAME).open(encoding="utf-8") as handle:
+            for record in _manifest_records(handle, batch):
+                if header is None:
+                    header = record
+                    continue
+                entries.append(record)
+    except OSError:
+        return None
     if header is None or header.get("schema") != MANIFEST_SCHEMA:
         return None
     return header, entries
+
+
+def _summarize_manifest(batch: Path) -> tuple[dict[str, Any], int, int] | None:
+    """The manifest's header plus (session count, staged byte total).
+
+    A batch can hold six figures of sessions, and the trash listing needs only
+    these two aggregates — so they are accumulated during the same single streamed
+    pass :func:`_read_manifest` makes, without ever holding the parsed entries.
+    Guards match :func:`_read_manifest` exactly: same skipped-line tolerance, same
+    schema rejection, and ``None`` on an unreadable manifest.
+    """
+    header: dict[str, Any] | None = None
+    sessions = 0
+    staged_bytes = 0
+    try:
+        with (batch / MANIFEST_NAME).open(encoding="utf-8") as handle:
+            for record in _manifest_records(handle, batch):
+                if header is None:
+                    header = record
+                    continue
+                sessions += 1
+                staged_bytes += _entry_bytes(record)
+    except OSError:
+        return None
+    if header is None or header.get("schema") != MANIFEST_SCHEMA:
+        return None
+    return header, sessions, staged_bytes
 
 
 def _rewrite_manifest(batch: Path, header: dict[str, Any], entries: list[dict[str, Any]]) -> None:
@@ -1588,11 +1633,11 @@ def list_trash() -> list[TrashBatch]:
         # listed as a real batch and the sweep would delete through it.
         if platform_compat.is_link_or_junction(candidate) or not candidate.is_dir():
             continue
-        parsed = _read_manifest(candidate)
+        parsed = _summarize_manifest(candidate)
         if parsed is None:
             logger.debug("trash batch %s has no readable manifest", candidate.name)
             continue
-        header, entries = parsed
+        header, sessions, staged_bytes = parsed
         # The DIRECTORY is the batch's identity. A header that names a different
         # batch would make a targeted empty delete the batch it named instead of
         # the one it came from, so a disagreement is treated as corruption rather
@@ -1611,8 +1656,8 @@ def list_trash() -> list[TrashBatch]:
                 batch_id=candidate.name,
                 created_at=float(created) if isinstance(created, (int, float)) else 0.0,
                 reason=str(header.get("reason") or ""),
-                sessions=len(entries),
-                bytes=sum(_entry_bytes(e) for e in entries),
+                sessions=sessions,
+                bytes=staged_bytes,
             )
         )
     batches.sort(key=lambda b: b.created_at, reverse=True)

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1277,30 +1277,109 @@ def _append_entry(handle: IO[str], entry: dict[str, Any]) -> None:
     handle.flush()
 
 
-def _manifest_records(handle: IO[str], batch: Path) -> Iterator[dict[str, Any]]:
-    """Yield each JSON object line of an open manifest, header first.
+# Longest manifest record accepted, in characters (terminator excluded: the
+# threshold applies to the stripped record). A real record is a header or one
+# session's file list — kilobytes at most. The manifest lives in an
+# agent-writable tree, so a reader that trusts line length would hand a single
+# multi-gigabyte no-newline line one allocation; a record past this cap ABORTS the
+# read instead (the whole batch is then treated as having no readable manifest,
+# exactly like an unreadable file). Skipping just the record would be worse than
+# failing: a partial restore REWRITES the manifest from the records it parsed, so
+# a skipped record's staged files would be silently orphaned. The transient peak
+# on a hostile manifest is a small multiple of this value (up to two cap-sized
+# reads concatenated, times Python's up-to-4-bytes-per-char widening), flat
+# regardless of file size — this constant is the dial if that ceiling moves.
+_MANIFEST_RECORD_CAP = 8 * 1024 * 1024
 
-    Blank and non-dict lines are skipped silently; a line that fails to parse —
-    including a trailing partial line from a crash mid-append — is skipped and
-    counted, with one aggregated warning once the file is exhausted, so a corrupted
-    manifest is visible in the log without failing the whole batch: every complete
-    line before it describes real moved files that must stay restorable.
+
+class _OversizedManifestRecord(Exception):
+    """A manifest record exceeded ``_MANIFEST_RECORD_CAP``; the batch is unreadable."""
+
+
+def _manifest_records(handle: IO[str], batch: Path) -> Iterator[dict[str, Any]]:
+    """Yield each JSON object record of an open manifest, header first.
+
+    Record boundaries match ``str.splitlines`` — the previous whole-file reader —
+    so a manifest split on any unicode line boundary parses exactly as it always
+    did: reads are accumulated in a carry-over buffer and re-split per chunk, so a
+    cap-sized read ending mid-record never invents or destroys a boundary. Blank
+    and non-dict lines are skipped silently. A record that fails to parse is
+    skipped and counted: a trailing partial line (a crash mid-append) is expected
+    and logged at debug, while any other unparseable record — mid-file corruption —
+    gets one aggregated warning per read (#6292 item 3). Either way every complete
+    record before it describes real moved files that must stay restorable, so a
+    parse failure never fails the batch wholesale.
+
+    A record longer than ``_MANIFEST_RECORD_CAP`` is different: it raises
+    :class:`_OversizedManifestRecord` (readers map it to ``None``, the
+    no-readable-manifest posture) rather than being skipped, and its bytes are
+    never materialised past the cap. Skipping would lose data: ``restore()``
+    rewrites the manifest from the records it parsed, so a skipped record's
+    staged files would be orphaned. Aborting keeps every file protected by the
+    unlisted-file guards until a human looks.
+
+    The skip counting and its log lines run only when the generator is driven to
+    exhaustion; both callers do, and a future caller that stops early forfeits
+    them knowingly.
     """
-    skipped = 0
-    for line in handle:
-        line = line.strip()
-        if not line:
-            continue
+    corrupt = 0
+    trailing_partial = False
+    buf = ""  # partial record carried between reads; capped below
+
+    def _parse(piece: str) -> dict[str, Any] | None:
+        nonlocal corrupt
+        piece = piece.strip()
+        if not piece:
+            return None
+        if len(piece) > _MANIFEST_RECORD_CAP:
+            raise _OversizedManifestRecord(batch.name)
         try:
-            record = json.loads(line)
+            record = json.loads(piece)
         except ValueError:
-            skipped += 1
-            continue
-        if not isinstance(record, dict):
-            continue
-        yield record
-    if skipped:
-        logger.warning("trash manifest in %s: skipped %d unparseable line(s)", batch.name, skipped)
+            corrupt += 1
+            return None
+        return record if isinstance(record, dict) else None
+
+    while True:
+        chunk = handle.readline(_MANIFEST_RECORD_CAP)
+        if not chunk:
+            break
+        data = buf + chunk
+        pieces = data.splitlines()
+        # The final piece is complete iff data ends on a line boundary. \n is the
+        # common case; the appended probe catches every other splitlines boundary
+        # (\u2028, \x1c, ...) without enumerating them.
+        ends_on_boundary = data.endswith("\n") or len((data + "x").splitlines()) > len(pieces)
+        if ends_on_boundary:
+            complete, buf = pieces, ""
+        else:
+            complete, buf = pieces[:-1], pieces[-1]
+        for piece in complete:
+            record = _parse(piece)
+            if record is not None:
+                yield record
+        if len(buf) > _MANIFEST_RECORD_CAP:
+            raise _OversizedManifestRecord(batch.name)
+    # EOF: whatever is left in buf is a genuinely unterminated final line. It can
+    # never exceed the cap here — an over-cap carry raised above — and the assert
+    # keeps that invariant enforced if the loop is ever reshaped.
+    assert len(buf) <= _MANIFEST_RECORD_CAP
+    if buf:
+        stripped = buf.strip()
+        if stripped:
+            try:
+                record = json.loads(stripped)
+            except ValueError:
+                trailing_partial = True
+            else:
+                if isinstance(record, dict):
+                    yield record
+    if corrupt:
+        # %r: the batch name is a directory name from an agent-writable tree, so it
+        # can embed newlines; the repr keeps one log record from forging others.
+        logger.warning("trash manifest in %r: skipped %d unparseable line(s)", batch.name, corrupt)
+    if trailing_partial:
+        logger.debug("trash manifest in %r ends in a partial line (crash mid-append)", batch.name)
 
 
 def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
@@ -1309,7 +1388,10 @@ def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] |
     Streams the file line by line rather than materialising it as one string; the
     entries list itself is still O(sessions), which the two callers that rewrite or
     enumerate the manifest genuinely need. Callers that need only aggregates should
-    use :func:`_summarize_manifest` instead.
+    use :func:`_summarize_manifest` instead. A trailing partial line (a crash
+    mid-append) is skipped rather than failing the whole batch — every complete
+    line before it describes real moved files that must stay restorable (see
+    :func:`_manifest_records`).
     """
     header: dict[str, Any] | None = None
     entries: list[dict[str, Any]] = []
@@ -1321,6 +1403,13 @@ def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] |
                     continue
                 entries.append(record)
     except OSError:
+        return None
+    except _OversizedManifestRecord:
+        logger.warning(
+            "trash manifest in %r has a record over %d chars; treating it as unreadable",
+            batch.name,
+            _MANIFEST_RECORD_CAP,
+        )
         return None
     if header is None or header.get("schema") != MANIFEST_SCHEMA:
         return None
@@ -1348,6 +1437,13 @@ def _summarize_manifest(batch: Path) -> tuple[dict[str, Any], int, int] | None:
                 sessions += 1
                 staged_bytes += _entry_bytes(record)
     except OSError:
+        return None
+    except _OversizedManifestRecord:
+        logger.warning(
+            "trash manifest in %r has a record over %d chars; treating it as unreadable",
+            batch.name,
+            _MANIFEST_RECORD_CAP,
+        )
         return None
     if header is None or header.get("schema") != MANIFEST_SCHEMA:
         return None

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2257,3 +2257,137 @@ class TestSingleTrashPass:
         assert report.trash_batches == 2
         assert report.trash_bytes == sum(b.bytes for b in batches)
         assert reads == [], "a handed-over list must not trigger another manifest pass"
+=======
+class TestManifestReaders:
+    """`_read_manifest` streams; `_summarize_manifest` aggregates without a list.
+
+    The core invariant: on every manifest the summary's (header, sessions, bytes)
+    are byte-identical to what the full read derives — same skipped-line
+    tolerance, same schema rejection, same ``None`` on an unreadable file.
+    """
+
+    _BATCH_ID = "20240101T000000-cafe0001"
+
+    def _batch(self, tmp_path: Path, lines: list[str]) -> Path:
+        batch = tmp_path / self._BATCH_ID
+        batch.mkdir(parents=True, exist_ok=True)
+        (batch / session_storage.MANIFEST_NAME).write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+        return batch
+
+    def _header(self, **overrides: object) -> dict[str, object]:
+        header: dict[str, object] = {
+            "schema": session_storage.MANIFEST_SCHEMA,
+            "batch_id": self._BATCH_ID,
+            "created_at": _NOW,
+            "reason": "manual",
+        }
+        header.update(overrides)
+        return header
+
+    def _entry(self, uid: str, sizes: list[int]) -> dict[str, object]:
+        return {
+            "uid": uid,
+            "files": [
+                {"rel": f"cli/{uid}-{i}.jsonl", "origin": f"/x/{uid}-{i}", "bytes": size}
+                for i, size in enumerate(sizes)
+            ],
+        }
+
+    def test_summary_is_byte_identical_to_the_full_read(self, tmp_path: Path) -> None:
+        """Header, count and byte total agree with the entry list on a manifest
+        that exercises every tolerated irregularity at once: blank lines, a
+        malformed line, a non-dict line, and a truncated final line."""
+        entries = [
+            self._entry("aaaa1111", [10, 20]),
+            self._entry("bbbb2222", [5]),
+            self._entry("cccc3333", []),
+        ]
+        lines = [json.dumps(self._header())]
+        lines.append("")
+        lines.append(json.dumps(entries[0]))
+        lines.append("not json at all {")
+        lines.append(json.dumps(entries[1]))
+        lines.append(json.dumps([1, 2, 3]))
+        lines.append(json.dumps(entries[2]))
+        lines.append('{"uid": "dddd444')  # crash mid-append
+        batch = self._batch(tmp_path, lines)
+
+        parsed = session_storage._read_manifest(batch)
+        summary = session_storage._summarize_manifest(batch)
+
+        assert parsed is not None and summary is not None
+        header, read_entries = parsed
+        assert summary == (
+            header,
+            len(read_entries),
+            sum(session_storage._entry_bytes(e) for e in read_entries),
+        )
+        # Pin the absolute values too, so both readers cannot be wrong together.
+        assert summary[1] == 3
+        assert summary[2] == 35
+
+    def test_header_only_manifest_summarizes_to_zero(self, tmp_path: Path) -> None:
+        batch = self._batch(tmp_path, [json.dumps(self._header())])
+        summary = session_storage._summarize_manifest(batch)
+        assert summary is not None
+        assert (summary[1], summary[2]) == (0, 0)
+
+    def test_wrong_schema_is_rejected_by_both_readers(self, tmp_path: Path) -> None:
+        lines = [json.dumps(self._header(schema=99)), json.dumps(self._entry("aaaa1111", [8]))]
+        batch = self._batch(tmp_path, lines)
+        assert session_storage._read_manifest(batch) is None
+        assert session_storage._summarize_manifest(batch) is None
+
+    def test_unreadable_manifest_returns_none_from_both_readers(self, tmp_path: Path) -> None:
+        batch = tmp_path / self._BATCH_ID
+        # A directory where the file should be: open() raises an OSError subclass,
+        # the same contract read_text() had.
+        (batch / session_storage.MANIFEST_NAME).mkdir(parents=True)
+        assert session_storage._read_manifest(batch) is None
+        assert session_storage._summarize_manifest(batch) is None
+
+    def test_batch_id_disagreement_is_tolerated_by_the_reader(self, tmp_path: Path) -> None:
+        """The reader returns the header untouched; refusing a disagreeing batch id
+        is list_trash's decision, exercised by TestTrashIsolation."""
+        lines = [json.dumps(self._header(batch_id="somebody-else"))]
+        batch = self._batch(tmp_path, lines)
+        summary = session_storage._summarize_manifest(batch)
+        assert summary is not None
+        assert summary[0]["batch_id"] == "somebody-else"
+
+    def test_skipped_lines_are_counted_and_logged_once(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """#6292 item 3: the malformed-line skip is no longer silent."""
+        lines = [
+            json.dumps(self._header()),
+            "garbage {",
+            json.dumps(self._entry("aaaa1111", [4])),
+            '{"uid": "trunc',
+        ]
+        batch = self._batch(tmp_path, lines)
+        with caplog.at_level("WARNING", logger="kiro_crew.session_storage"):
+            summary = session_storage._summarize_manifest(batch)
+        assert summary is not None and summary[1] == 1
+        warnings = [r for r in caplog.records if "unparseable" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "2" in warnings[0].getMessage()
+
+    def test_list_trash_aggregates_match_the_staged_batch(self, stores: tuple[Path, Path]) -> None:
+        """End-to-end proof that the count-only path reports the same numbers the
+        entry-list path did: the listing agrees with the batch returned by the move."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=100, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=300, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"], reason="manual", index=_index(), now=_NOW
+        )
+
+        listed = session_storage.list_trash()
+
+        assert len(listed) == 1
+        assert listed[0].sessions == batch.sessions == 2
+        assert listed[0].bytes == batch.bytes
+        assert listed[0].bytes > 0

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2171,17 +2171,18 @@ class TestSingleTrashPass:
 
     @staticmethod
     def _counted_manifest_reads(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
-        """Count via ``_read_manifest``: it is the per-batch cost, and it is hit
-        through the module global, so it sees every ``list_trash`` pass no matter
-        which module's imported name made the call."""
+        """Count via ``_summarize_manifest``: since #6281 it is ``list_trash``'s
+        per-batch cost (the count-only streamed pass), and it is hit through the
+        module global, so it sees every ``list_trash`` pass no matter which
+        module's imported name made the call."""
         reads: list[Path] = []
-        real = session_storage._read_manifest
+        real = session_storage._summarize_manifest
 
         def counted(batch: Path):
             reads.append(batch)
             return real(batch)
 
-        monkeypatch.setattr(session_storage, "_read_manifest", counted)
+        monkeypatch.setattr(session_storage, "_summarize_manifest", counted)
         return reads
 
     def test_report_payload_reads_each_manifest_exactly_once(
@@ -2257,7 +2258,8 @@ class TestSingleTrashPass:
         assert report.trash_batches == 2
         assert report.trash_bytes == sum(b.bytes for b in batches)
         assert reads == [], "a handed-over list must not trigger another manifest pass"
-=======
+
+
 class TestManifestReaders:
     """`_read_manifest` streams; `_summarize_manifest` aggregates without a list.
 
@@ -2268,11 +2270,11 @@ class TestManifestReaders:
 
     _BATCH_ID = "20240101T000000-cafe0001"
 
-    def _batch(self, tmp_path: Path, lines: list[str]) -> Path:
+    def _batch(self, tmp_path: Path, lines: list[str], *, terminated: bool = True) -> Path:
         batch = tmp_path / self._BATCH_ID
         batch.mkdir(parents=True, exist_ok=True)
         (batch / session_storage.MANIFEST_NAME).write_text(
-            "\n".join(lines) + "\n", encoding="utf-8"
+            "\n".join(lines) + ("\n" if terminated else ""), encoding="utf-8"
         )
         return batch
 
@@ -2311,8 +2313,8 @@ class TestManifestReaders:
         lines.append(json.dumps(entries[1]))
         lines.append(json.dumps([1, 2, 3]))
         lines.append(json.dumps(entries[2]))
-        lines.append('{"uid": "dddd444')  # crash mid-append
-        batch = self._batch(tmp_path, lines)
+        lines.append('{"uid": "dddd444')  # crash mid-append: NO trailing newline
+        batch = self._batch(tmp_path, lines, terminated=False)
 
         parsed = session_storage._read_manifest(batch)
         summary = session_storage._summarize_manifest(batch)
@@ -2357,15 +2359,16 @@ class TestManifestReaders:
         assert summary is not None
         assert summary[0]["batch_id"] == "somebody-else"
 
-    def test_skipped_lines_are_counted_and_logged_once(
+    def test_corrupt_lines_are_counted_and_logged_once(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """#6292 item 3: the malformed-line skip is no longer silent."""
+        """#6292 item 3: mid-file corruption is no longer silent — one aggregated
+        warning per read, counting only genuinely corrupt lines."""
         lines = [
             json.dumps(self._header()),
             "garbage {",
             json.dumps(self._entry("aaaa1111", [4])),
-            '{"uid": "trunc',
+            "more garbage {",
         ]
         batch = self._batch(tmp_path, lines)
         with caplog.at_level("WARNING", logger="kiro_crew.session_storage"):
@@ -2373,7 +2376,250 @@ class TestManifestReaders:
         assert summary is not None and summary[1] == 1
         warnings = [r for r in caplog.records if "unparseable" in r.getMessage()]
         assert len(warnings) == 1
-        assert "2" in warnings[0].getMessage()
+        assert "skipped 2 unparseable" in warnings[0].getMessage()
+
+    def test_a_trailing_partial_line_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A crash mid-append is EXPECTED and tolerated; warning for it on every
+        storage-screen open would be recurring noise about a normal state."""
+        lines = [
+            json.dumps(self._header()),
+            json.dumps(self._entry("aaaa1111", [4])),
+            '{"uid": "trunc',
+        ]
+        batch = self._batch(tmp_path, lines, terminated=False)
+        with caplog.at_level("WARNING", logger="kiro_crew.session_storage"):
+            summary = session_storage._summarize_manifest(batch)
+        assert summary is not None and summary[1] == 1
+        assert not [r for r in caplog.records if "unparseable" in r.getMessage()]
+
+    def test_unicode_line_boundaries_split_records_like_splitlines_did(
+        self, tmp_path: Path
+    ) -> None:
+        """The old reader split on str.splitlines boundaries (\\u2028, \\x1c, ...).
+        Two records separated by one must still parse as two records, not be
+        rejected as one malformed line."""
+        entry = self._entry("aaaa1111", [7])
+        blob = (
+            json.dumps(self._header())
+            + "\u2028"
+            + json.dumps(entry)
+            + "\x1c"
+            + json.dumps(self._entry("bbbb2222", [3]))
+        )
+        batch = self._batch(tmp_path, [blob])
+        summary = session_storage._summarize_manifest(batch)
+        assert summary is not None
+        assert (summary[1], summary[2]) == (2, 10)
+
+    def test_an_oversized_record_aborts_the_batch_not_materialised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manifest lives in an agent-writable tree: one multi-GB line with no
+        newline must not be read whole. Past the cap the batch is treated as
+        having no readable manifest — a crafted tail sitting exactly past a
+        cap boundary cannot be smuggled in as its own forged record."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        forged_tail = json.dumps(
+            {"uid": "evil0000", "files": [{"rel": "r", "origin": "o", "bytes": 999}]}
+        )
+        # 256 filler chars put the forged record exactly after the first
+        # cap-sized read of this single (newline-free) oversized line.
+        giant = "x" * 256 + forged_tail
+        lines = [
+            json.dumps(self._header()),
+            giant,
+            json.dumps(self._entry("aaaa1111", [5])),
+        ]
+        batch = self._batch(tmp_path, lines)
+        assert session_storage._summarize_manifest(batch) is None
+        assert session_storage._read_manifest(batch) is None
+
+    def test_undecodable_bytes_still_propagate(self, tmp_path: Path) -> None:
+        """read_text raised UnicodeDecodeError on corrupt bytes and the streaming
+        readers must keep that contract rather than silently absorbing it."""
+        batch = tmp_path / self._BATCH_ID
+        batch.mkdir(parents=True)
+        (batch / session_storage.MANIFEST_NAME).write_bytes(b'{"schema": 1}\n\xff\xfe garbage\n')
+        with pytest.raises(UnicodeDecodeError):
+            session_storage._read_manifest(batch)
+        with pytest.raises(UnicodeDecodeError):
+            session_storage._summarize_manifest(batch)
+
+    def test_an_oserror_mid_iteration_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """read_text failed as one whole-file operation; the streaming readers must
+        map a read error DURING iteration to the same None, not leak it."""
+        batch = self._batch(tmp_path, [json.dumps(self._header())])
+
+        class _FailsMidRead:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def readline(self, _cap: int) -> str:
+                self.calls += 1
+                if self.calls == 1:
+                    return json.dumps({"schema": session_storage.MANIFEST_SCHEMA}) + "\n"
+                raise OSError("device gone")
+
+            def __enter__(self) -> "_FailsMidRead":
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+        monkeypatch.setattr(Path, "open", lambda *a, **k: _FailsMidRead())
+        assert session_storage._read_manifest(batch) is None
+        assert session_storage._summarize_manifest(batch) is None
+
+    def test_list_trash_never_materialises_the_entry_list(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The memory fix itself: the listing must go through the count-only
+        reader. Reverting it to _read_manifest would pass every aggregate check,
+        so pin the path by making the full reader unreachable from list_trash."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+        def _forbidden(batch: Path) -> None:
+            raise AssertionError("list_trash must not materialise manifest entries")
+
+        monkeypatch.setattr(session_storage, "_read_manifest", _forbidden)
+        listed = session_storage.list_trash()
+        assert len(listed) == 1 and listed[0].sessions == 1
+
+    def test_a_cap_boundary_read_does_not_destroy_a_record_boundary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GPT round-2 finding 1: a cap-sized read that cuts a physical line
+        mid-way must not condemn the bounded, individually valid records inside
+        it. A 255-char record + \\u2028 + another record on one physical line,
+        with the cap at 256, must yield both records."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        pad = "p" * (255 - len('{"uid": "aaaa1111", "files": [], "": ""}'))
+        first = '{"uid": "aaaa1111", "files": [], "' + pad + '": ""}'
+        assert len(first) == 255
+        second = json.dumps(self._entry("bbbb2222", [9]))
+        lines = [json.dumps(self._header()), first + "\u2028" + second]
+        batch = self._batch(tmp_path, lines)
+        summary = session_storage._summarize_manifest(batch)
+        assert summary is not None
+        assert (summary[1], summary[2]) == (2, 9)
+
+    def test_a_final_line_ended_by_a_unicode_boundary_is_complete_corruption(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """GPT round-2 finding 2: 'garbage\\u2028' at EOF IS terminated under
+        splitlines semantics — a complete corrupt record that must warn, not a
+        crash-partial that hides at debug."""
+        blob = json.dumps(self._header()) + "\n" + "garbage {\u2028"
+        batch = tmp_path / self._BATCH_ID
+        batch.mkdir(parents=True, exist_ok=True)
+        (batch / session_storage.MANIFEST_NAME).write_text(blob, encoding="utf-8")
+        with caplog.at_level("WARNING", logger="kiro_crew.session_storage"):
+            summary = session_storage._summarize_manifest(batch)
+        assert summary is not None and summary[1] == 0
+        assert [r for r in caplog.records if "unparseable" in r.getMessage()]
+
+    def test_a_record_spanning_many_cap_reads_aborts_without_materialising(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A record several multiples of the cap long aborts the read (the batch
+        is unreadable) without its bytes ever being concatenated whole."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        lines = [
+            json.dumps(self._header()),
+            '{"uid": "' + "x" * 1500 + '"}',
+            json.dumps(self._entry("aaaa1111", [5])),
+        ]
+        batch = self._batch(tmp_path, lines)
+        assert session_storage._summarize_manifest(batch) is None
+        assert session_storage._read_manifest(batch) is None
+
+    def test_even_a_valid_record_longer_than_the_cap_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap is a contract on parsed record size: a syntactically VALID
+        record between cap and 2x cap (reachable because the carry-over buffer
+        admits up to two cap-sized reads) must abort the read, NOT be silently
+        skipped — restore() rewrites the manifest from parsed records, so a
+        skipped record's staged files would be orphaned."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        valid_oversized = '{"uid": "bbbb2222", "pad": "' + "y" * 380 + '", "files": []}'
+        assert 256 < len(valid_oversized) < 512
+        lines = [
+            json.dumps(self._header()),
+            valid_oversized,
+            json.dumps(self._entry("aaaa1111", [5])),
+        ]
+        batch = self._batch(tmp_path, lines)
+        assert session_storage._summarize_manifest(batch) is None
+        assert session_storage._read_manifest(batch) is None
+
+    def test_an_oversized_record_makes_restore_refuse_not_orphan(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The blocked data-loss seam, end to end: a manifest with an oversized
+        record must make restore() refuse loudly. Skipping the record instead
+        would let a partial restore REWRITE the manifest without it, permanently
+        orphaning its staged files. The manifest must also be left untouched."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"], reason="manual", index=_index(), now=_NOW
+        )
+        manifest = session_storage.trash_root() / batch.batch_id / session_storage.MANIFEST_NAME
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        entry = json.loads(lines[1])
+        inflated_uid = entry["uid"]
+        intact_uid = "bbbb2222" if inflated_uid == "aaaa1111" else "aaaa1111"
+        entry["pad"] = "y" * 600
+        lines[1] = json.dumps(entry)
+        manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        before = manifest.read_bytes()
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+
+        # Restoring the INTACT session is the dangerous path: with the oversized
+        # record merely skipped, this would succeed and rewrite the manifest from
+        # the parsed records only — erasing the skipped record's metadata.
+        with pytest.raises(SessionStorageError):
+            session_storage.restore(batch.batch_id, [intact_uid])
+
+        assert manifest.read_bytes() == before
+
+    def test_an_unterminated_oversized_record_at_eof_still_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An over-cap record with NO final newline must abort like any other
+        oversized record, not degrade into a silently dropped 'trailing partial'
+        — silent dropping is the exact shape that lets a restore rewrite orphan
+        staged files."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        valid_oversized = '{"uid": "bbbb2222", "pad": "' + "y" * 560 + '", "files": []}'
+        lines = [json.dumps(self._header()), valid_oversized]
+        batch = self._batch(tmp_path, lines, terminated=False)
+        assert session_storage._summarize_manifest(batch) is None
+        assert session_storage._read_manifest(batch) is None
+
+    def test_an_oversized_sibling_aborts_even_across_a_unicode_boundary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'x'*cap + \\u2028 + valid record on one physical line: the oversized
+        piece aborts the whole batch (fail-closed) — the record past the boundary
+        is NOT salvaged, because salvaging some records while dropping others is
+        exactly the shape that lets a partial restore orphan staged files."""
+        monkeypatch.setattr(session_storage, "_MANIFEST_RECORD_CAP", 256)
+        lines = [
+            json.dumps(self._header()),
+            "x" * 300 + "\u2028" + json.dumps(self._entry("aaaa1111", [6])),
+        ]
+        batch = self._batch(tmp_path, lines)
+        assert session_storage._summarize_manifest(batch) is None
+        assert session_storage._read_manifest(batch) is None
 
     def test_list_trash_aggregates_match_the_staged_batch(self, stores: tuple[Path, Path]) -> None:
         """End-to-end proof that the count-only path reports the same numbers the


### PR DESCRIPTION
Fixes #6281

## What

`list_trash()` parsed every batch manifest into a Python list of one dict per staged session — up to `_MAX_SELECTION = 200,000` entries per batch (`src/kiro_crew/dashboard/handlers/session_storage.py:61`) — on a path the storage screen hits on every open, when all it needs from each manifest is a session count and a byte total. The **parsed list of up to 200k dicts is the dominant cost**; the whole-file `read_text` string is the smaller term.

Two changes, no manifest format or schema change:

1. **`_summarize_manifest`** — a count-only single pass that opens the manifest, streams `for line in fh:`, and accumulates `sessions` and a running `_entry_bytes` total without ever materialising the entry list. `list_trash()` now uses it. The streaming skip-malformed-line pattern follows the existing `session_digest._scan_transcript`.
2. **`_read_manifest` streams** from the file handle instead of `read_text().splitlines()`, dropping the duplicate whole-file raw-string term for the two callers that genuinely need every entry — `_restore_locked` (rewrites the manifest from `remaining`) and `_manifest_rels`. **These stay O(entries) by necessity**; streaming removes their raw-string copy, it does not bound them.

Both readers share one guard loop (`_manifest_records`) carrying the prior guards: blank / malformed / non-dict lines skipped, first record is the header, header with `schema != MANIFEST_SCHEMA` rejected, `OSError` → `None`, batch-id-mismatch behaviour untouched.

**Two deliberate behaviour changes, both review-derived (not in the original scope):**
- **Record size cap** (`_MANIFEST_RECORD_CAP`, 8 MiB): the manifest lives in an agent-writable tree, so record length is hostile input — an uncapped read would re-open the unbounded-allocation hole this PR closes. A record over the cap — *even syntactically valid* — ABORTS the read and the batch is treated as having no readable manifest (same fail-closed posture as an unreadable file: not listed, not restorable, files protected by the unlisted-file guards until a human looks). Skipping just the record would be worse: `restore()` rewrites the manifest from parsed records, so a skipped record's staged files would be silently orphaned. Its bytes are never materialised past the cap. A legitimate record cannot approach it (archive segments rotate at 2 MB; a per-file record is ~200 chars, so 8 MiB ≈ 42k files ≈ 84 GB of history in one session).
- **Trailing partial line now logs at debug** (was fully silent): a crash mid-append is expected and tolerated; mid-file corruption gets one aggregated warning per read (#6292 item 3).

## #6292 item 3 carried

While rewriting the `except ValueError: continue` loop this also adds the skipped-line counter plus one aggregated `logger.warning` that #6292 item 3 asks for (that issue is parked as needs-human; item 3 can be ticked off its tracker).

## Verification

- **Behaviour-preservation proof**: a synthesized manifest (header + entries + blank + malformed + non-dict + truncated final line) asserts `_summarize_manifest`'s `(header, sessions, bytes)` are byte-identical to what `_read_manifest`'s entry list derives, with the absolute values pinned independently so both readers cannot be wrong together.
- Regression cases: truncated final line, wrong `schema`, header/directory `batch_id` disagreement (still refused by `list_trash`, tolerated by the reader), unreadable manifest → `None`.
- Mutation checks: removing the malformed-line skip fails 3 tests; removing the schema rejection in `_summarize_manifest` fails its test.
- `scripts/local-gate.py --base origin/main`: full backend suite 70,762 passed, 92 failed + 2 errors — byte-identical failure set to an `origin/main` worktree except one host-memory-sensitive flake (`test_search_sessions_cost.py::…stops_holding_budget`) which passes on this branch and fails on the base worktree in isolation (direction inverted ⇒ environmental). The 156 cross-surface frontend guard specs: 157 files / 4,269 tests, all pass.
- Sibling sequencing per the tracker: #6287 (callers), #6285/#6286 (scan-cache block), #6291 (write side, parked) — none edits `_read_manifest`/`_summarize_manifest`; rebased onto current main (`e4c580508`) before opening.


