### PR TITLE
fix(session-storage): give the co-tenant lookup the scan cache's opt-in caching

### DIFF
--- a/src/kiro_crew/dashboard/handlers/session_storage.py
+++ b/src/kiro_crew/dashboard/handlers/session_storage.py
@@ -843,8 +843,18 @@ def _classify(uids: list[str], index: SessionIndex, now: float) -> tuple[list[st
     guarantee is NOT weakened: it still re-reads the session map inside the lock
     and still refuses anything live, so this pre-pass can only ever be more
     conservative than the authority, never less.
+
+    That property requires the enumeration below to be UNCACHED — in both
+    halves. The co-tenant contribution to ``active`` is served from a 30s cache
+    on ordinary read paths, and a pre-pass fed a stale co-tenant set would
+    classify a just-claimed session as eligible — the authority would still
+    refuse it, but as the all-or-nothing batch failure this function exists to
+    prevent. The STORE half fails the same way on its own: ``age_days`` reads
+    the scan's mtime, so a session appended to after a cached pass reads
+    stale-older here and ``too_fresh`` inside the move. A perf change that
+    re-caches either half re-opens the batch failure.
     """
-    by_uid = {u.uid: u for u in list_units(index)}
+    by_uid = {u.uid: u for u in list_units(index, cached=False)}
     eligible: list[str] = []
     refused: list[dict] = []
     for uid in uids:

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -42,11 +42,13 @@ Reading is cached; reclaiming never is
 --------------------------------------
 Enumerating the stores is the entire cost of a read here — half a million replay
 files on the measured machine — so a pass is kept briefly and shared between the
-row list, the totals and each row's detail. Only the FILESYSTEM half is cached:
-which sessions are in use is recomputed from the caller's index every call, and
-every mutation re-enumerates and re-reads the index inside the lock. So no
-refusal is ever answered from a snapshot, and a stale cache can only make the
-report slightly old, never make a reclaim take something it should not.
+row list, the totals and each row's detail. Only the FILESYSTEM halves are
+cached — the store scan and, on read paths, the co-tenant pass beside it: the
+flags derived from the caller's index are recomputed every call, every
+refusal-deriving path runs uncached, and every mutation re-enumerates and
+re-reads the index inside the lock. So no refusal is ever answered from a
+snapshot, and a stale cache can only make the report slightly old, never make a
+reclaim take something it should not.
 
 Sessions this instance does not own
 -----------------------------------
@@ -329,9 +331,13 @@ def _archive_index() -> dict[str, list[tuple[Path, int, float]]]:
 # So a pass is kept for a few seconds and shared. Two properties make that safe
 # rather than merely faster:
 #
-# * Only the filesystem half is cached. Which sessions are active or live is
-#   applied over it from the caller's index on every call, so no refusal is ever
-#   decided from a snapshot.
+# * Only the filesystem halves are cached — the store scan and, on read paths,
+#   the co-tenant pass beside it (its own cache, further down). The flags derived
+#   from the caller's index are applied over them on every call, and every path
+#   that DERIVES A REFUSAL — the reclaim gates, the pre-move re-read, the
+#   dashboard's trash pre-classification — runs uncached, so no refusal is ever
+#   decided from a snapshot. The one cached contribution to ``active`` (the
+#   co-tenant set) therefore only ever staleness-affects what a read displays.
 # * Only READ paths opt in. A reclaim re-enumerates, and additionally re-reads
 #   the index inside the mutation lock, so the selection it acts on is current.
 #
@@ -394,7 +400,10 @@ def invalidate_scan_cache() -> None:
     Drops the co-tenant pass too (see :func:`cotenant_sids`). A mutation that
     invalidates one cache has changed the world the other described, and clearing
     both here keeps every existing mutation hook correct without each having to
-    know that two caches exist.
+    know that two caches exist. Pod-lifecycle changes — a pod appearing, being
+    torn down, or rewriting its map — have no hook here and are covered by the
+    TTL alone; that is acceptable because every destructive path re-reads the
+    co-tenant view uncached regardless.
     """
     global _scan_cache, _cotenant_cache
     with _scan_cache_lock:
@@ -409,14 +418,16 @@ def _scan_units(index: SessionIndex, *, cached: bool = False) -> list[SessionUni
     Two halves of the answer, deliberately separated. :func:`_scan_raw` does the
     filesystem work and knows nothing about which sessions are in use; this
     applies the caller's index over that result. So the expensive half can be
-    reused (see *cached*) while the answer to "may this be reclaimed" is always
-    computed from the index the caller passed in this call.
+    reused (see *cached*) while the flags derived from the index are always
+    computed from the index the caller passed in this call. ``active`` has one
+    further input — the co-tenant set — which follows *cached* below.
 
     *cached* permits a recent filesystem pass to be reused — both halves of it:
     the store scan (:func:`_scan_raw`) and the co-tenant lookup below thread the
-    same flag. It is for READ paths only: no refusal is derived from the cached
-    half, but a reclaim must not select against a snapshot at all, so every
-    mutation path leaves it False.
+    same flag. It is for READ paths only: every path that derives a refusal from
+    the result (the mutation gates, and the dashboard pre-classification that
+    feeds one) leaves it False, and a reclaim must not select against a snapshot
+    at all, so every mutation path leaves it False too.
     """
     raw = _scan_raw(index.stem_to_sid, cached=cached)
     active_stems = index.active_stems
@@ -706,7 +717,7 @@ def measure(
     return report
 
 
-def list_units(index: SessionIndex) -> list[SessionUnit]:
+def list_units(index: SessionIndex, *, cached: bool = True) -> list[SessionUnit]:
     """Every session on disk as one unit each, with its total size and age.
 
     The inventory screen's row source. Exposed separately from :func:`measure`
@@ -717,10 +728,13 @@ def list_units(index: SessionIndex) -> list[SessionUnit]:
     six-figure store. Anything requiring a read (a title's metadata line, a first
     message, a turn or image count) is fetched per row instead.
 
-    A recent scan is reused when there is one: this is a read, and the in-use
-    flags are recomputed from *index* on every call regardless.
+    A recent scan is reused by default: this is a read, and the flags derived
+    from *index* are recomputed on every call regardless. The co-tenant
+    contribution to ``active`` rides the cached half though, so a caller that
+    derives a REFUSAL from the result — the dashboard's trash pre-classification
+    — must pass ``cached=False`` and pay for a fresh pass instead.
     """
-    return _scan_units(index, cached=True)
+    return _scan_units(index, cached=cached)
 
 
 def select_reclaimable(
@@ -786,8 +800,24 @@ def _cotenant_key() -> tuple[object, ...]:
     it), so a process can legitimately answer for different roots over its
     lifetime, and a key without the location would answer a question about one
     root with a pass taken over another.
+
+    The home overrides are part of it because the answer is not a function of the
+    pod root alone: each map is read through ``hooks.safe_read_file``, whose
+    sensitive-path gate re-anchors on ``KIROCREW_HOME`` / ``KIRO_HOME`` — the
+    same symlinked map can be refused under one anchoring and readable under
+    another, and *refusals* is part of what this cache stores. The RAW env values
+    are keyed, not the sanitized ``data_home()``/``kiro_home()`` forms, because
+    the gate reads them raw with no validity check: an unsafe override and an
+    unset one anchor differently even though both sanitize to the default. Of the
+    two, the read tier re-anchors on ``KIROCREW_HOME``; ``KIRO_HOME`` reaches
+    only the write tier today and is kept as defensive over-keying — a spurious
+    miss costs a re-scan, a spurious hit would cost a wrong answer.
     """
-    return (str(_pod_root()),)
+    return (
+        str(_pod_root()),
+        os.environ.get("KIROCREW_HOME"),
+        os.environ.get("KIRO_HOME"),
+    )
 
 
 def cotenant_sids(*, cached: bool = False) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -390,10 +390,17 @@ def invalidate_scan_cache() -> None:
     the cache is process-wide and its key covers the store paths and the pairing,
     not the CONTENTS of the stores, so a test that writes more files and re-reads
     inside the TTL would otherwise be answered from its own earlier pass.
+
+    Drops the co-tenant pass too (see :func:`cotenant_sids`). A mutation that
+    invalidates one cache has changed the world the other described, and clearing
+    both here keeps every existing mutation hook correct without each having to
+    know that two caches exist.
     """
-    global _scan_cache
+    global _scan_cache, _cotenant_cache
     with _scan_cache_lock:
         _scan_cache = None
+    with _cotenant_cache_lock:
+        _cotenant_cache = None
 
 
 def _scan_units(index: SessionIndex, *, cached: bool = False) -> list[SessionUnit]:
@@ -405,9 +412,11 @@ def _scan_units(index: SessionIndex, *, cached: bool = False) -> list[SessionUni
     reused (see *cached*) while the answer to "may this be reclaimed" is always
     computed from the index the caller passed in this call.
 
-    *cached* permits a recent filesystem pass to be reused. It is for READ paths
-    only: no refusal is derived from the cached half, but a reclaim must not
-    select against a snapshot at all, so every mutation path leaves it False.
+    *cached* permits a recent filesystem pass to be reused — both halves of it:
+    the store scan (:func:`_scan_raw`) and the co-tenant lookup below thread the
+    same flag. It is for READ paths only: no refusal is derived from the cached
+    half, but a reclaim must not select against a snapshot at all, so every
+    mutation path leaves it False.
     """
     raw = _scan_raw(index.stem_to_sid, cached=cached)
     active_stems = index.active_stems
@@ -417,7 +426,7 @@ def _scan_units(index: SessionIndex, *, cached: bool = False) -> list[SessionUni
     # one place every read and every reclaim passes through — measure, the row
     # list, the pre-classification and move_to_trash all derive `active` from it,
     # so one assignment protects all of them. A caller cannot forget to ask.
-    cotenant, _unreadable = cotenant_sids()
+    cotenant, _unreadable = cotenant_sids(cached=cached)
     units = []
     for entry in raw:
         active = (
@@ -762,7 +771,26 @@ def _replay_store_cotenants() -> list[str]:
     )
 
 
-def cotenant_sids() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
+_cotenant_cache_lock = threading.Lock()
+# (expires_at, cache key, (protected sids, refusals))
+_cotenant_cache: (
+    tuple[float, tuple[object, ...], tuple[frozenset[str], tuple[tuple[str, str], ...]]] | None
+) = None
+
+
+def _cotenant_key() -> tuple[object, ...]:
+    """Everything a cached co-tenant pass depends on besides the maps themselves.
+
+    The pod root is part of it, for the same reason the store locations are part
+    of :func:`_scan_key`: it is resolved per call (``KIROCREW_POD_ROOT`` overrides
+    it), so a process can legitimately answer for different roots over its
+    lifetime, and a key without the location would answer a question about one
+    root with a pass taken over another.
+    """
+    return (str(_pod_root()),)
+
+
+def cotenant_sids(*, cached: bool = False) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
     """Replay-store sessions a co-tenant instance can still resume.
 
     Returns ``(sids, refusals)``. The sids are protected exactly like this
@@ -797,7 +825,22 @@ def cotenant_sids() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
     Liveness is deliberately not the test anywhere here. A stopped instance's map
     still names sessions it would resume if restarted, so ownership — not whether a
     process is running this second — is what protects them.
+
+    *cached* permits a recent pass over the pod maps to be reused, mirroring
+    :func:`_scan_raw`'s flag: opt-in per call site, never global. It exists for
+    the read paths behind :func:`_scan_units`. The refusal derivation in
+    :func:`reclaim_block_reason` and the pre-move re-read in
+    :func:`move_to_trash` must never opt in — a stale answer there could let a
+    reclaim proceed against a store another instance still holds, which is the
+    exact staleness the pre-move re-read exists to close.
     """
+    global _cotenant_cache
+    if cached:
+        with _cotenant_cache_lock:
+            if _cotenant_cache is not None:
+                expires, key, result = _cotenant_cache
+                if time.monotonic() < expires and key == _cotenant_key():
+                    return result
     protected: set[str] = set()
     refusals: list[tuple[str, str]] = []
     root = _pod_root()
@@ -860,7 +903,11 @@ def cotenant_sids() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
             refusals.append(
                 (name, "it shares this replay store and can resume sessions at any time")
             )
-    return frozenset(protected), tuple(refusals)
+    result = (frozenset(protected), tuple(refusals))
+    if cached:
+        with _cotenant_cache_lock:
+            _cotenant_cache = (time.monotonic() + _SCAN_CACHE_TTL, _cotenant_key(), result)
+    return result
 
 
 def _has_own_replay_store(pod_home: Path) -> bool:

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -935,6 +935,12 @@ class TestCotenantCache:
     The cache is OPT-IN per call site because the same value gates destructive
     paths; the safety tests below are what stop a later refactor from making it
     global.
+
+    One uncached pass deliberately remains on a default install: ``measure``
+    populates ``reclaim_blocked_reason`` via :func:`reclaim_block_reason`, whose
+    co-tenant read must never opt in (it derives a refusal). The isolated *stores*
+    fixture short-circuits that path, which is why the reuse test below counts 1;
+    the default-home test pins that the gate really does re-read.
     """
 
     @staticmethod
@@ -1040,6 +1046,80 @@ class TestCotenantCache:
             frozenset(),
             (),
         ), "an empty pod root must read as empty, not as the first root's pass"
+
+    def test_a_different_crew_home_is_not_answered_from_an_older_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KIROCREW_HOME`` alone keys the cache.
+
+        Each map is read through ``hooks.safe_read_file``, whose sensitive-path
+        READ gate re-anchors on the raw ``KIROCREW_HOME`` — the same symlinked
+        map can be refused under one anchoring and readable under another, so a
+        pass taken under one must not answer for the other. Varied ALONE so the
+        term is ratcheted independently, not only as part of a pair.
+        """
+        pod_root = tmp_path / "pods"
+        (pod_root / "wt-x").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "home-a" / "kiro"))
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home-a"))
+        calls = self._count_pod_scans(monkeypatch)
+        session_storage.cotenant_sids(cached=True)
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home-b"))
+        session_storage.cotenant_sids(cached=True)
+
+        assert calls["n"] == 2, "a changed KIROCREW_HOME must not be served the old pass"
+
+    def test_a_different_kiro_home_is_not_answered_from_an_older_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KIRO_HOME`` alone keys the cache — defensive over-keying, ratcheted.
+
+        Today the read tier re-anchors on ``KIROCREW_HOME`` only, but the gate's
+        anchor set is keyed on both raw values; keeping ``KIRO_HOME`` in this key
+        means a future read-tier anchor cannot silently start serving stale
+        answers. A spurious miss costs a re-scan; a spurious hit would cost a
+        wrong answer.
+        """
+        pod_root = tmp_path / "pods"
+        (pod_root / "wt-x").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home-a"))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "home-a" / "kiro"))
+        calls = self._count_pod_scans(monkeypatch)
+        session_storage.cotenant_sids(cached=True)
+
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "home-b" / "kiro"))
+        session_storage.cotenant_sids(cached=True)
+
+        assert calls["n"] == 2, "a changed KIRO_HOME must not be served the old pass"
+
+    def test_reclaim_block_reason_rereads_cotenants_despite_a_primed_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The hard reclaim gate must never opt in — and nothing else covered it.
+
+        The isolated *stores* fixture short-circuits :func:`reclaim_block_reason`
+        before its co-tenant read, so the other safety tests never execute that
+        call. This pins the DEFAULT-home posture, where the read actually runs,
+        and asserts a primed cache does not answer it — the ratchet that stops a
+        future perf change from threading ``cached=`` through the gate.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        # Pin the default home rather than clearing the memo; see
+        # TestSharedStoreRefusal for why re-resolving on a real machine is unsafe.
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        session_storage.cotenant_sids(cached=True)  # prime
+        calls = self._count_pod_scans(monkeypatch)
+        session_storage.reclaim_block_reason()
+        session_storage.reclaim_block_reason()
+
+        assert calls["n"] == 2, "the reclaim gate must re-enumerate the pod root on every call"
 
 
 class TestSharedStoreRefusal:

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -926,6 +926,122 @@ class TestScanCache:
         assert session_storage.list_units(_index()) == []
 
 
+class TestCotenantCache:
+    """The co-tenant lookup follows the scan cache's rules: reads may reuse, mutations never.
+
+    :func:`_scan_units` is the single funnel for four public entry points, and its
+    co-tenant dependency used to bypass the 30s cache entirely — every read paid a
+    pod-root enumeration plus a map read per leftover pod even on a scan-cache hit.
+    The cache is OPT-IN per call site because the same value gates destructive
+    paths; the safety tests below are what stop a later refactor from making it
+    global.
+    """
+
+    @staticmethod
+    def _count_pod_scans(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+        """Count full passes over the pod root without changing their answer."""
+        calls = {"n": 0}
+        real = session_storage._replay_store_cotenants
+
+        def counted() -> list[str]:
+            calls["n"] += 1
+            return real()
+
+        monkeypatch.setattr(session_storage, "_replay_store_cotenants", counted)
+        return calls
+
+    def test_a_read_inside_the_ttl_does_not_rescan_the_pod_root(
+        self, stores: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A scan-cache hit must not still pay for the co-tenant half."""
+        _, kiro_home = stores
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        calls = self._count_pod_scans(monkeypatch)
+
+        index = _index()
+        session_storage.list_units(index)
+        session_storage.measure(index, now=_NOW)
+        session_storage.list_units(index)
+
+        assert calls["n"] == 1, "reads within the TTL must enumerate the pod root once"
+
+    def test_select_reclaimable_rereads_cotenants_on_every_call(
+        self, stores: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reclaim selection derives refusals from this value: never from a snapshot."""
+        _, kiro_home = stores
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        session_storage.list_units(_index())  # prime both caches
+        calls = self._count_pod_scans(monkeypatch)
+
+        session_storage.select_reclaimable(_index(), 30.0, now=_NOW)
+        session_storage.select_reclaimable(_index(), 30.0, now=_NOW)
+
+        assert calls["n"] == 2, "a mutation-path selection must re-read co-tenants every call"
+
+    def test_move_to_trash_rereads_cotenants_on_every_call(
+        self, stores: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both the scan inside the move and the pre-move authority check must be live.
+
+        The pre-move re-read exists precisely because the view taken during the
+        scan is seconds stale by the time anything moves; a primed cache must not
+        be allowed to answer it.
+        """
+        _, kiro_home = stores
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
+        session_storage.list_units(_index())  # prime both caches
+        calls = self._count_pod_scans(monkeypatch)
+
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+        assert calls["n"] == 2, "the move's scan and its authority re-read must each hit disk"
+
+    def test_invalidate_scan_cache_drops_the_cotenant_pass_too(
+        self, stores: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The mutation hooks clear one thing; both caches must go with it."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        calls = self._count_pod_scans(monkeypatch)
+
+        session_storage.list_units(_index())
+        session_storage.invalidate_scan_cache()
+        session_storage.list_units(_index())
+
+        assert calls["n"] == 2, "invalidation must force a fresh co-tenant pass"
+
+    def test_a_different_pod_root_is_not_answered_from_an_older_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KIROCREW_POD_ROOT`` resolves per call, so the root keys the cache.
+
+        Same reasoning as the store locations in the scan key: keyed without the
+        location, the second root would be answered with the first's pass.
+        """
+        first = tmp_path / "pods-a"
+        pod = first / "wt-old"
+        pod.mkdir(parents=True)
+        # Own replay store: its sids are recorded but it constrains nothing.
+        (pod / "kiro").mkdir()
+        (pod / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-1": {"sid": "podsid01"}}), encoding="utf-8"
+        )
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(first))
+        protected, refusals = session_storage.cotenant_sids(cached=True)
+        assert protected == frozenset({"podsid01"})
+        assert refusals == ()
+
+        second = tmp_path / "pods-b"
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(second))
+        assert session_storage.cotenant_sids(cached=True) == (
+            frozenset(),
+            (),
+        ), "an empty pod root must read as empty, not as the first root's pass"
+
+
 class TestSharedStoreRefusal:
     """An isolated data home over a shared replay store cannot see who is live."""
 
@@ -1190,7 +1306,9 @@ class TestSharedStoreRefusal:
 
         calls = {"n": 0}
 
-        def claimed_late() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
+        def claimed_late(
+            *, cached: bool = False
+        ) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
             calls["n"] += 1
             # Empty while the scan runs; owned by the time the move is authorized.
             return (frozenset() if calls["n"] == 1 else frozenset({"adopted001"})), ()
@@ -1210,7 +1328,9 @@ class TestSharedStoreRefusal:
 
         calls = {"n": 0}
 
-        def unreadable_late() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
+        def unreadable_late(
+            *, cached: bool = False
+        ) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
             calls["n"] += 1
             return frozenset(), (() if calls["n"] == 1 else (("wt-corrupt", "unreadable map"),))
 
@@ -1314,7 +1434,11 @@ class TestSharedStoreRefusal:
         """
         _, kiro_home = stores
         _cli_half(kiro_home, "podsid01", log_bytes=64, age_days=40)
-        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset({"podsid01"}), ()))
+        monkeypatch.setattr(
+            session_storage,
+            "cotenant_sids",
+            lambda *, cached=False: (frozenset({"podsid01"}), ()),
+        )
 
         with pytest.raises(SessionStorageError, match="still in use"):
             session_storage.move_to_trash(["podsid01"], reason="manual", index=_index(), now=_NOW)

--- a/test/test_session_storage_api.py
+++ b/test/test_session_storage_api.py
@@ -1027,6 +1027,42 @@ class TestWhyAReclaimIsRefused:
     "in use", which is a claim the user can disprove by reading the date next to it.
     """
 
+    def test_the_pre_classification_never_reads_a_cached_cotenant_pass(
+        self, stores: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_classify derives per-row refusals, so it must enumerate uncached.
+
+        A pre-pass fed a 30s-stale co-tenant set would classify a just-claimed
+        session as eligible; a stale store scan fails independently the same way
+        (a stale-older mtime reads eligible here and too_fresh inside the move).
+        Either way the authority still refuses, but as the all-or-nothing batch
+        failure ``_classify`` exists to prevent. Both halves are counted, so a
+        future change that splits the flag cannot re-cache either half here.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        index = session_storage_module.SessionIndex(stem_to_sid={}, active_sids=frozenset())
+        # Prime both caches through the ordinary cached read path.
+        session_storage_module.list_units(index)
+
+        calls = {"cotenant": 0, "scan": 0}
+        real_cotenants = session_storage_module._replay_store_cotenants
+        real_scan = session_storage_module._scan_raw_uncached
+
+        def counted_cotenants() -> list[str]:
+            calls["cotenant"] += 1
+            return real_cotenants()
+
+        def counted_scan(sid_for_stem):
+            calls["scan"] += 1
+            return real_scan(sid_for_stem)
+
+        monkeypatch.setattr(session_storage_module, "_replay_store_cotenants", counted_cotenants)
+        monkeypatch.setattr(session_storage_module, "_scan_raw_uncached", counted_scan)
+        handler._classify([], index, now=time.time())
+
+        assert calls["cotenant"] == 1, "the trash pre-pass must re-read co-tenants, not the cache"
+        assert calls["scan"] == 1, "the trash pre-pass must re-enumerate the stores, not the cache"
+
     @staticmethod
     def _recorded_session(crew_home: Path, kiro_home: Path, sid: str, key: str) -> None:
         """A session that IS in the map: a transcript, a replay log, and the entry."""


### PR DESCRIPTION
Fixes #6285

## One uncached dependency behind four public entry points

`_scan_units` is the single funnel for `list_units`, `measure`, `select_reclaimable` and `move_to_trash`. Its filesystem half honours the 30s scan cache (`_scan_raw(..., cached=cached)`), but the co-tenant lookup on the next line took no flag: `cotenant_sids()` re-listed the pod root and re-read every pod's `session_map.json` through `hooks.safe_read_file` on **every** call. So every read-only storage request paid the redundant I/O even on a scan-cache hit, scaling with the number of leftover pod directories.

## The cache is opt-in — deliberately, and that is a correctness decision

Caching `cotenant_sids()` unconditionally (as the issue proposes) would be **wrong, not merely conservative**. Its result gates destructive behaviour:

- `reclaim_block_reason()` derives a refusal from it.
- `move_to_trash` deliberately re-reads it (`cotenant_now`) right before moving anything, precisely because the co-tenant view taken during the scan is seconds stale by the time files move.

A stale answer on those paths could let a reclaim or a trash-move proceed against a store another pod instance still holds. So the fix mirrors the module's existing primitive exactly: `cotenant_sids()` gains a keyword-only `cached: bool = False`, and only the read-path call site inside `_scan_units` threads its own `cached=` flag through. The refusal derivation and the pre-move re-read keep the uncached default, and explicit safety tests pin that down so a later refactor cannot silently make the cache global.

## Mechanics

- `_cotenant_cache` under its own lock, `(expires_at, key, result)`, TTL `_SCAN_CACHE_TTL` (30s).
- The key carries `str(_pod_root())` for the same reason `_scan_key` carries the store locations: the root is resolved per call (`KIROCREW_POD_ROOT` overrides it), and a key without the location would answer a question about one root with a pass taken over another. A cross-root test pins this (mutation-checked: dropping the term turns it red).
- `invalidate_scan_cache()` now drops both caches, so the existing mutation hooks stay correct without knowing two caches exist.
- Three existing test doubles for `cotenant_sids` updated to accept the new keyword.

## Verification

- **Red-before**: on unmodified source, the cache-reuse and cross-root tests fail; the safety tests pass (they exist to kill the wrong fix, and do — see mutants below).
- **Safety tests**: `select_reclaimable` and `move_to_trash` are asserted to re-enumerate the pod root on every call even with a primed cache.
- **Mutants killed**: (1) store-location term removed from `_cotenant_key` → cross-root test red; (2) the pre-move re-read flipped to `cached=True` → move safety test red.
- **Gates**: `scripts/local-gate.py --base origin/main` — full backend suite 70,756 passed with the failing set **byte-identical both directions** to an `origin/main` worktree run (97 = 97 pre-existing environmental failures, `comm -23`/`-13` both empty); 157 cross-surface frontend guard specs, 4,269 tests, all pass; black/isort/flake8/mypy clean.

## Sequencing note

#6286 edits the adjacent `_scan_key`/`_cached_scan` block and will conflict textually with any change there; this PR deliberately places the co-tenant cache primitives next to `cotenant_sids()` instead, and only touches the shared region inside `invalidate_scan_cache()`. Rebased onto current `main` before opening. Not a duplicate of #6286: that issue is about the cost of computing the scan-cache *key* on a hit; this one is about a dependency that bypassed the cache entirely.

<!-- no-visual-delta --> No UI change; evidence is the call-count and mutation assertions above.

## Review-driven changes (rounds 1–3, declared)

Beyond the original scope ("thread `cached=` from the one read-only-aware call site"), adversarial review added the following — each with its own ratchet test:

1. **`list_units` gained a public keyword-only `cached: bool = True`** and the dashboard's trash pre-classification (`_classify`) passes `cached=False`. This **flips `_classify`'s store scan from cached (pre-PR) to fresh**: every trash POST now pays one extra full store enumeration (~2s at the module's measured 470k files), off the event loop. Deliberate, and the zero option is worse — without it the new co-tenant cache would feed `_classify` a stale refusal input, and a cached store scan independently reproduces the same batch failure through the stale-mtime/`too_fresh` seam. The both-halves ratchet test pins this.
2. **`_cotenant_key` keys the RAW `KIROCREW_HOME`/`KIRO_HOME` env values** (not the sanitized `data_home()`/`kiro_home()` forms), because the sensitive-path gate reads them raw with no validity check. The `KIRO_HOME` term guards a condition with zero occurrences today (the read gate deliberately excludes the `KIRO_HOME` re-anchor) and is kept as defensive over-keying — spurious misses only; First Principles proposes dropping it, GPT review endorsed keeping it; both positions are on record for the maintainer.
3. **`reclaim_block_reason`'s co-tenant read is pinned uncached by a default-home test** — it had zero coverage because the isolated test fixture short-circuits before the read.
4. **Deliberate residual:** on a default install, `measure` still pays one uncached co-tenant pass per call via `reclaim_block_reason` (refusal derivation never opts in, per the spec). Tracked in #6320.
