### PR TITLE
fix(issue-radar): require confirm before re-investigating a resolved record

### DIFF
--- a/website/src/apps/issue-radar/components/AgentSessionButton.tsx
+++ b/website/src/apps/issue-radar/components/AgentSessionButton.tsx
@@ -6,7 +6,10 @@ import { i18nT } from '../../../i18n/t'
  * identical in every respect except their icon and labels, so the markup lives
  * here once. Reflects the item's saved record:
  *   * no record   → the primary label ("Investigate" / "Review")
- *   * has session → "Resume" + a status pill (in-progress / done + verdict)
+ *   * has session, unresolved → "Resume" + a status pill
+ *   * has session, resolved   → "Re-investigate" + a status pill (a re-run
+ *     replaces the verdict already on the record, so the action is gated on a
+ *     window.confirm prompt before calling onClick)
  * The owning component supplies the click handler and busy/error state. */
 export default function AgentSessionButton({
   icon: Icon, label, record, busy, error, onClick,
@@ -42,10 +45,25 @@ export default function AgentSessionButton({
   const verdict = record?.findings?.verdict
   const summary = record?.findings?.summary
 
+  const handleClick = () => {
+    // A resolved record already has a verdict on it; re-running overwrites
+    // it. Make the user confirm before that happens — the "Resume" affordance
+    // is for picking up a paused/in-progress session, not silently re-doing
+    // finished work. The label above (Re-investigate) is the visible signal;
+    // the confirm prompt is the deliberate-action gate.
+    if (resolved) {
+      const ok = window.confirm(
+        i18nT('apps.issueRadar.components.agentSessionButton.reinvestigate_confirm'),
+      )
+      if (!ok) return
+    }
+    onClick()
+  }
+
   return (
     <span className="inline-flex items-center gap-1.5">
       <button
-        onClick={onClick}
+        onClick={handleClick}
         disabled={busy || disabled}
         title={hasSession ? resumeHint : startHint}
         className={
@@ -61,7 +79,11 @@ export default function AgentSessionButton({
         {busy
           ? <Loader2 size={13} className="animate-spin" />
           : <Icon size={13} />}
-        {hasSession ? i18nT('apps.issueRadar.components.agentSessionButton.resume') : label}
+        {resolved
+          ? i18nT('apps.issueRadar.components.agentSessionButton.reinvestigate')
+          : hasSession
+            ? i18nT('apps.issueRadar.components.agentSessionButton.resume')
+            : label}
       </button>
 
       {showStatus && record && (

--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -1713,7 +1713,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "শুরু করা যায়নি",
-          "resume": "আবার শুরু করো"
+          "resume": "আবার শুরু করো",
+          "reinvestigate": "পুনঃ তদন্ত",
+          "reinvestigate_confirm": "এই তদন্তের ইতিমধ্যে একটি রায় রয়েছে। পুনঃ চালালে এটি প্রতিস্থাপিত হবে। চালিয়ে যেতে চান?"
         },
         "aiSummaryCard": {
           "ai_summary": "AI সারসংক্ষেপ",

--- a/website/src/i18n/locales/de.json
+++ b/website/src/i18n/locales/de.json
@@ -1757,7 +1757,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "konnte nicht starten",
-          "resume": "Fortsetzen"
+          "resume": "Fortsetzen",
+          "reinvestigate": "Erneut untersuchen",
+          "reinvestigate_confirm": "Diese Untersuchung hat bereits ein Ergebnis. Ein erneuter Durchlauf überschreibt es. Fortfahren?"
         },
         "aiSummaryCard": {
           "ai_summary": "KI-Zusammenfassung",

--- a/website/src/i18n/locales/en-XA.json
+++ b/website/src/i18n/locales/en-XA.json
@@ -1741,7 +1741,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "[çøùĺðñ'ţ şţàŕţ ·············]",
-          "resume": "[Ŕèşùɱè ·········]"
+          "resume": "[Ŕèşùɱè ·········]",
+          "reinvestigate": "Re-investigate",
+          "reinvestigate_confirm": "This investigation already has a verdict. Re-running will overwrite it. Continue?"
         },
         "aiSummaryCard": {
           "ai_summary": "[ÀÌ şùɱɱàŕý ···············]",

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -307,6 +307,8 @@
       },
       "components": {
         "agentSessionButton": {
+          "reinvestigate": "Re-investigate",
+          "reinvestigate_confirm": "This investigation already has a verdict. Re-running will overwrite it. Continue?",
           "resume": "Resume"
         },
         "aiSummaryCard": {

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -1749,7 +1749,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "no se pudo iniciar",
-          "resume": "Reanudar"
+          "resume": "Reanudar",
+          "reinvestigate": "Reinvestigar",
+          "reinvestigate_confirm": "Esta investigación ya tiene un veredicto. Volver a ejecutarla lo sobrescribirá. ¿Continuar?"
         },
         "aiSummaryCard": {
           "ai_summary": "Resumen de IA",

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -1793,7 +1793,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "impossible à démarrer",
-          "resume": "Reprendre"
+          "resume": "Reprendre",
+          "reinvestigate": "Réexaminer",
+          "reinvestigate_confirm": "Cette enquête a déjà un verdict. La relancer l'écrasera. Continuer ?"
         },
         "aiSummaryCard": {
           "ai_summary": "Résumé IA",

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -1713,7 +1713,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "शुरू नहीं हो सका",
-          "resume": "फिर शुरू करें"
+          "resume": "फिर शुरू करें",
+          "reinvestigate": "पुनः जाँच",
+          "reinvestigate_confirm": "इस जाँच का पहले से एक निर्णय है। पुनः चलाने पर यह अधिलेखित हो जाएगा। जारी रखें?"
         },
         "aiSummaryCard": {
           "ai_summary": "AI सारांश",

--- a/website/src/i18n/locales/it.json
+++ b/website/src/i18n/locales/it.json
@@ -1749,7 +1749,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "non è stato possibile avviare",
-          "resume": "Riprendi"
+          "resume": "Riprendi",
+          "reinvestigate": "Reindaga",
+          "reinvestigate_confirm": "Questa indagine ha già un verdetto. Riavviandola verrà sovrascritto. Continuare?"
         },
         "aiSummaryCard": {
           "ai_summary": "Riepilogo IA",

--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -1721,7 +1721,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "開始できませんでした",
-          "resume": "再開"
+          "resume": "再開",
+          "reinvestigate": "再調査",
+          "reinvestigate_confirm": "この調査にはすでに結論があります。再実行すると上書きされます。続行しますか？"
         },
         "aiSummaryCard": {
           "ai_summary": "AI要約",

--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -1721,7 +1721,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "시작하지 못했습니다",
-          "resume": "재개"
+          "resume": "재개",
+          "reinvestigate": "재조사",
+          "reinvestigate_confirm": "이 조사에는 이미 결론이 있습니다. 재실행하면 덮어씌워집니다. 계속하시겠습니까?"
         },
         "aiSummaryCard": {
           "ai_summary": "AI 요약",

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -1749,7 +1749,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "não foi possível iniciar",
-          "resume": "Retomar"
+          "resume": "Retomar",
+          "reinvestigate": "Reinvestigar",
+          "reinvestigate_confirm": "Esta investigação já tem um veredicto. Executá-la novamente irá sobrescrevê-lo. Continuar?"
         },
         "aiSummaryCard": {
           "ai_summary": "Resumo por IA",

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -1785,7 +1785,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "не удалось запустить",
-          "resume": "Продолжить"
+          "resume": "Продолжить",
+          "reinvestigate": "Пересмотреть",
+          "reinvestigate_confirm": "У этого расследования уже есть вердикт. Повторный запуск перезапишет его. Продолжить?"
         },
         "aiSummaryCard": {
           "ai_summary": "ИИ-сводка",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -1677,7 +1677,9 @@
       "components": {
         "agentSessionButton": {
           "couldn_t_start": "无法启动",
-          "resume": "恢复"
+          "resume": "恢复",
+          "reinvestigate": "重新调查",
+          "reinvestigate_confirm": "此调查已有结论。重新运行将覆盖该结论。是否继续？"
         },
         "aiSummaryCard": {
           "ai_summary": "AI 摘要",

--- a/website/src/test/IssueRadarInvestigateButtonCov80.test.tsx
+++ b/website/src/test/IssueRadarInvestigateButtonCov80.test.tsx
@@ -119,4 +119,39 @@ describe('InvestigateButton', () => {
     await userEvent.click(button)
     await waitFor(() => expect(investigate).toHaveBeenCalledWith(REF, ISSUE, existing))
   })
+
+  it('shows Re-investigate (not Resume) for a resolved record', async () => {
+    const resolved = { slot_key: 'zzq-existing', status: 'resolved', findings: { verdict: 'zzq-verdict' } }
+    api.getInvestigation.mockResolvedValue({
+      owner: REF.owner, repo: REF.repo, number: ISSUE.number, investigation: resolved,
+    })
+    renderButton()
+
+    // Resolved records must not advertise a plain Resume affordance — the
+    // verdict already on the record would be silently replaced if the user
+    // clicked that.
+    const button = await screen.findByRole('button', { name: /Re-investigate/ })
+    expect(button).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Resume$/ })).not.toBeInTheDocument()
+  })
+
+  it('requires a confirm prompt before re-investigating a resolved record', async () => {
+    const resolved = { slot_key: 'zzq-existing', status: 'resolved', findings: { verdict: 'zzq-verdict' } }
+    api.getInvestigation.mockResolvedValue({
+      owner: REF.owner, repo: REF.repo, number: ISSUE.number, investigation: resolved,
+    })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    renderButton()
+
+    const button = await screen.findByRole('button', { name: /Re-investigate/ })
+    await userEvent.click(button)
+    // The user said no — nothing should be investigated.
+    expect(investigate).not.toHaveBeenCalled()
+    expect(confirmSpy).toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    investigate.mockResolvedValue(resolved)
+    await userEvent.click(button)
+    await waitFor(() => expect(investigate).toHaveBeenCalledWith(REF, ISSUE, resolved))
+  })
 })


### PR DESCRIPTION
﻿## Problem / Motivation

`AgentSessionButton` (`website/src/apps/issue-radar/components/AgentSessionButton.tsx`) shows "Resume" whenever a record has a `slot_key`, including records already marked `status: "resolved"`. Clicking it on a resolved record silently starts a brand-new full investigation that overwrites the verdict already on the record — closing the chat (the common "I'm done" path) leaves a Resume button that redoes the work.

The status pill next to the button already shows the verdict, so the two surfaces disagree: the pill says "done with verdict X" while the button says "Resume" (implying pick-up, not restart).

## What changed

When `status === "resolved"`, the button now:

1. Shows "Re-investigate" instead of "Resume" (visible signal)
2. Gates the click on a `window.confirm` prompt warning the verdict will be overwritten (deliberate-action gate)

The `Resume` affordance remains unchanged for in-progress records (where it is the right call).

## Why a confirm prompt and not just a label change

The label change alone would still make the action one click — the user can still misclick on "Re-investigate" expecting it to behave like Resume. The confirm prompt is what makes the action deliberate rather than the default meaning of the button.

## Tests

Two new tests in `IssueRadarInvestigateButtonCov80.test.tsx`:
- `shows Re-investigate (not Resume) for a resolved record` — verifies the label flips
- `requires a confirm prompt before re-investigating a resolved record` — verifies the click is gated (cancel → no investigate; accept → investigate)

All 9 tests in the file pass. All 29 i18n keyReference tests pass. All 15 issueRadarStickyHeader tests pass.

## i18n

Added two new keys (`reinvestigate`, `reinvestigate_confirm`) in 13 catalogs (en.manual.json + 12 other locales). Translations are placeholders / machine-translated for non-English locales — same posture as the rest of the catalog.

## Related Issues

Fixes #6259
