### PR TITLE
fix(session_storage): one trash pass per payload build

### DIFF
--- a/src/kiro_crew/dashboard/handlers/session_storage.py
+++ b/src/kiro_crew/dashboard/handlers/session_storage.py
@@ -175,7 +175,11 @@ async def _json_body(request: web.Request) -> dict[str, Any] | None:
 
 def _report_payload() -> dict[str, Any]:
     index = _build_index()
-    report = measure(index)
+    # One trash pass serves both the totals inside measure() and the wire array
+    # below: list_trash reads every batch manifest per call, and two calls could
+    # bracket a concurrent stage/empty and ship totals that contradict the array.
+    batches = list_trash()
+    report = measure(index, batches=batches)
     return {
         "total_bytes": report.total_bytes,
         "total_sessions": report.total_sessions,
@@ -203,7 +207,7 @@ def _report_payload() -> dict[str, Any]:
                     "sessions": batch.sessions,
                     "bytes": batch.bytes,
                 }
-                for batch in list_trash()
+                for batch in batches
             ],
         },
     }
@@ -679,7 +683,10 @@ def _inventory_payload(state: DashboardState) -> dict[str, Any]:
     # The same pass answers both halves of the screen. Measuring separately would
     # re-enumerate a store that reaches half a million files, and would let the
     # totals describe a different instant than the rows printed beneath them.
-    report = measure(index, units=units)
+    # The trash gets the identical treatment: one list_trash() pass feeds both
+    # the totals and the batches array, for the same one-instant reason.
+    batches = list_trash()
+    report = measure(index, units=units, batches=batches)
 
     # Replay-only units — subagent runs — are what a long-lived install accumulates
     # by the hundred thousand, and this screen folds every one of them into a single
@@ -779,7 +786,7 @@ def _inventory_payload(state: DashboardState) -> dict[str, Any]:
                     "sessions": batch.sessions,
                     "bytes": batch.bytes,
                 }
-                for batch in list_trash()
+                for batch in batches
             ],
         },
     }

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -657,6 +657,7 @@ def measure(
     *,
     now: float | None = None,
     units: list[SessionUnit] | None = None,
+    batches: list[TrashBatch] | None = None,
 ) -> StorageReport:
     """Measure session storage and report what is reclaimable.
 
@@ -664,6 +665,12 @@ def measure(
     rather than paying for a second pass. The inventory screen needs both the rows
     and these totals, and they must describe the same instant anyway — computing
     them from one pass makes agreement structural instead of coincidental.
+
+    *batches* is the same bargain for the trash, with one sharpening: unlike the
+    units fallback, which is answered from a 30s scan cache, ``list_trash`` reads
+    every batch manifest uncached on each call — so a caller that already has the
+    list should always hand it over, and a payload that lists the batches beside
+    these totals must not let the two describe different instants.
     """
     clock = time.time() if now is None else now
     units = _scan_units(index, cached=True) if units is None else units
@@ -671,7 +678,7 @@ def measure(
     # Sub-floor sessions are neither active nor offered: reporting them as
     # reclaimable would promise bytes no threshold can actually move.
     reclaimable = [u for u in units if not u.active and u.age_days(clock) >= MIN_RECLAIM_AGE_DAYS]
-    batches = list_trash()
+    batches = list_trash() if batches is None else batches
     report = StorageReport(
         total_bytes=sum(u.bytes for u in units),
         total_sessions=len(units),

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2147,3 +2147,113 @@ class TestTrashLocation:
     ) -> None:
         report = session_storage.measure(_index(), now=_NOW)
         assert report.trash_same_filesystem is True
+
+
+class TestSingleTrashPass:
+    """Each payload build reads each trash manifest exactly once.
+
+    ``list_trash`` is uncached and reads every batch manifest per call, so a
+    payload builder that calls it once for the totals (inside ``measure``) and
+    again for the wire array pays double I/O — and could ship totals that
+    contradict the array beside them if a stage/empty lands between the calls.
+    Both builders thread one list through ``measure(batches=...)`` instead,
+    mirroring the ``units=`` parameter and the counting test above.
+    """
+
+    @staticmethod
+    def _two_batches(kiro_home: Path) -> None:
+        """Two batches with DISTINCT created_at stamps, so an ordering assertion
+        on the payload array is falsifiable rather than satisfied by any order."""
+        _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=64, age_days=40)
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW - 60)
+        session_storage.move_to_trash(["bbbb2222"], reason="manual", index=_index(), now=_NOW)
+
+    @staticmethod
+    def _counted_manifest_reads(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+        """Count via ``_read_manifest``: it is the per-batch cost, and it is hit
+        through the module global, so it sees every ``list_trash`` pass no matter
+        which module's imported name made the call."""
+        reads: list[Path] = []
+        real = session_storage._read_manifest
+
+        def counted(batch: Path):
+            reads.append(batch)
+            return real(batch)
+
+        monkeypatch.setattr(session_storage, "_read_manifest", counted)
+        return reads
+
+    def test_report_payload_reads_each_manifest_exactly_once(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.dashboard.handlers import session_storage as handler
+
+        _, kiro_home = stores
+        self._two_batches(kiro_home)
+        reads = self._counted_manifest_reads(monkeypatch)
+
+        payload = handler._report_payload()
+
+        assert len(reads) == 2, "one payload build must read each batch manifest once"
+        assert len(set(reads)) == 2
+        # Newest first is list_trash's own contract; asserting it on the wire
+        # array proves the hoisted list reaches the payload unreordered. The
+        # helper gives the batches distinct stamps so this can actually fail.
+        assert [b["created_at"] for b in payload["trash"]["batches"]] == [_NOW, _NOW - 60]
+        assert len(payload["trash"]["batches"]) == 2
+        assert payload["trash"]["bytes"] == sum(b["bytes"] for b in payload["trash"]["batches"])
+
+    def test_inventory_payload_reads_each_manifest_exactly_once(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from kiro_crew.dashboard.handlers import session_storage as handler
+
+        _, kiro_home = stores
+        self._two_batches(kiro_home)
+        reads = self._counted_manifest_reads(monkeypatch)
+
+        # Explicit empty stubs, not a MagicMock: a bare mock answers
+        # running_session_keys() and list_sessions() via magic-method defaults,
+        # which silently weakens the test if either callee grows a real check.
+        state = SimpleNamespace(
+            running_session_keys=lambda: frozenset(),
+            conversation_log=SimpleNamespace(list_sessions=lambda: []),
+        )
+        payload = handler._inventory_payload(state)
+
+        assert len(reads) == 2, "one payload build must read each batch manifest once"
+        assert len(set(reads)) == 2
+        assert len(payload["trash"]["batches"]) == 2
+        assert payload["trash"]["bytes"] == sum(b["bytes"] for b in payload["trash"]["batches"])
+
+    def test_measure_without_batches_still_enumerates_the_trash(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default path is load-bearing: every existing ``measure(index)``
+        caller relies on it enumerating the trash itself."""
+        _, kiro_home = stores
+        self._two_batches(kiro_home)
+        reads = self._counted_manifest_reads(monkeypatch)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert report.trash_batches == 2
+        assert report.trash_bytes > 0
+        assert len(reads) == 2, "measure() with no batches= must do its own pass"
+
+    def test_measure_uses_the_handed_over_batches_without_a_second_pass(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, kiro_home = stores
+        self._two_batches(kiro_home)
+        batches = session_storage.list_trash()
+        reads = self._counted_manifest_reads(monkeypatch)
+
+        report = session_storage.measure(_index(), now=_NOW, batches=batches)
+
+        assert report.trash_batches == 2
+        assert report.trash_bytes == sum(b.bytes for b in batches)
+        assert reads == [], "a handed-over list must not trigger another manifest pass"


### PR DESCRIPTION
Fixes #6287

## Two call sites, not one

Building a storage payload enumerated the trash **twice**: once inside `measure()` for `trash_bytes`/`trash_batches`, once again in the handler for the wire `batches[]` array. `list_trash()` is uncached — `root.iterdir()` plus `_read_manifest()` for **every** batch, per call — so a multi-batch trash paid every manifest read twice per screen open.

The issue names `_report_payload`; the same defect stood next door in `_inventory_payload`, which already threads `units=` into `measure()` to avoid re-enumerating the session stores but still called `list_trash()` a second time. **Both** call sites are fixed here.

## The sharper motivation is consistency, not I/O

Nothing between the two calls holds a lock: a concurrent stage/empty landing in the interleaving window shipped a payload whose `trash.bytes`/`trash.batches` totals contradicted the `trash.batches[]` array beside them. One pass makes their agreement structural instead of coincidental — the exact reasoning `measure()`'s docstring already gives for its `units=` parameter.

## Change

- `measure()` gains a keyword-only `batches: list[TrashBatch] | None = None`, mirroring the existing `units=` precedent — no new pattern. Default (`None`) still enumerates the trash itself, so every existing `measure(index)`/`measure(index, now=...)` caller is unchanged.
- `_report_payload` and `_inventory_payload` each hoist a single `list_trash()` call, pass it via `batches=`, and build the wire array from the same list.
- Docstring notes the sharpening: unlike the units fallback (30 s scan cache), the trash fallback is uncached, so a caller that already has the list should always hand it over.

## Verification

- **Counting monkeypatch on `_read_manifest`** (the per-batch cost, resolved from module globals so it counts every pass regardless of caller): with two staged batches, one `_report_payload()` build reads each manifest **exactly once** (2 reads, was 4 on main); a separate test asserts the same for `_inventory_payload()`.
- **Default-path regression:** `measure(index)` with no `batches=` still does its own pass (2 reads, correct totals); a fourth test proves a handed-over list triggers **zero** additional manifest reads.
- **Mutation checks:** reverting the handler hoist turns the call-count test red (4 ≠ 2); breaking the `batches is None` default turns the default-path test red (0 ≠ 2).
- **Wire shape unchanged:** `test/test_session_storage_api.py` passes untouched (173 passed across both storage test files).
- **Gates:** `scripts/local-gate.py --base origin/main` — backend 70,753 passed; the 96 failed + 2 errors are byte-identical (both directions, `comm -23`/`-13` empty) to an `origin/main` worktree baseline, i.e. pre-existing environmental, zero regressions. The 156 cross-surface frontend guard specs: 4,269/4,269 passed.
- **Local review lanes** (gpt-5.6-sol, claude-opus-5): both PASS, two rounds.

## Advisory disposition (from local Opus review, Low, out of scope by its own framing)

`_report_payload` now snapshots the trash *before* the unit scan, while `_inventory_payload` keeps units-then-trash — an ordering asymmetry between the builders. Neither order is atomic and both self-correct on refetch; the units half was already up to 30 s stale relative to the trash half on main (scan-cache TTL), and both mutation paths invalidate the scan cache, so this is not a regression in kind. Unifying the builders (hoisting `units=` in `_report_payload` too) is a separable cleanup; left out to keep this diff on the two `list_trash()` sites.
