### PR TITLE
fix(chat): restore [OPTIONS:] pills after a failed turn

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -257,6 +257,7 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     CRON_NOTIFICATION_KIND,
     SUBAGENT_COMPLETION_KIND,
     SYNTHETIC_RECOVERY_KIND,
+    TRANSIENT_RETRY_KIND,
     RecoveryPayload,
     has_leaked_tool_call,
     is_promise_only_terminal,
@@ -8032,12 +8033,15 @@ async def _run_chat(
         if _stop_reason == STOP_REASON_STALE_RECOVER:
             needs_session_reset = True  # checked in finally block (reset + resume)
 
-            def _emit_stale(msg: str) -> None:
-                slot.append("error", msg, "msg msg-err")
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "error", "content": msg},
+            def _emit_stale(msg: str, *, will_retry: bool = False) -> None:
+                slot.append(
+                    "error",
+                    msg,
+                    "msg msg-err",
+                    meta={"kind": TRANSIENT_RETRY_KIND} if will_retry else None,
                 )
+                # No explicit chat_message: slot.append already emits ONE, and it
+                # carries `meta` -- a second frame here would arrive untagged.
 
             if _prompt_depth == 0 and slot._stale_recovery_retries < 3:
                 slot._stale_recovery_retries += 1
@@ -8047,7 +8051,7 @@ async def _run_chat(
                     kind=SYNTHETIC_RECOVERY_KIND,
                     payload=RecoveryPayload.CONTINUATION,
                 )
-                _emit_stale("⟳ Recovering a stalled turn…")
+                _emit_stale("⟳ Recovering a stalled turn…", will_retry=True)
             elif slot._stale_recovery_retries >= 3:
                 # Budget exhausted — terminal for this slot until a turn
                 # actually completes. The budget is deliberately NOT reset
@@ -8081,12 +8085,15 @@ async def _run_chat(
         # from pipe-death so a stall can never burn the reconnect budget.
         if _stop_reason == STOP_REASON_TOOL_STALL:
 
-            def _emit_stall(msg: str) -> None:
-                slot.append("error", msg, "msg msg-err")
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "error", "content": msg},
+            def _emit_stall(msg: str, *, will_retry: bool = False) -> None:
+                slot.append(
+                    "error",
+                    msg,
+                    "msg msg-err",
+                    meta={"kind": TRANSIENT_RETRY_KIND} if will_retry else None,
                 )
+                # No explicit chat_message: slot.append already emits ONE, and it
+                # carries `meta` -- a second frame here would arrive untagged.
 
             _idle_m = re.search(r"idle_secs=(\d+)", _stall_evidence or "")
             _idle_secs = int(_idle_m.group(1)) if _idle_m else 0
@@ -8105,7 +8112,7 @@ async def _run_chat(
                     kind=SYNTHETIC_RECOVERY_KIND,
                     payload=RecoveryPayload.CONTINUATION,
                 )
-                _emit_stall("⟳ Tool appeared stalled — recovering…")
+                _emit_stall("⟳ Tool appeared stalled — recovering…", will_retry=True)
             elif slot._tool_stall_retries >= 3:
                 # Budget exhausted — mirrors the stale_recover branch above:
                 # budget left alone (a wedged slot must not re-enter a fresh
@@ -8143,12 +8150,15 @@ async def _run_chat(
             _rc = getattr(client, "exit_code", None)
             _rc_suffix = f" (exit {_rc})" if _rc is not None else ""
 
-            def _emit_error(msg: str) -> None:
-                slot.append("error", msg, "msg msg-err")
-                state.broadcast_ws(
-                    "chat_message",
-                    {"slot": slot.key, "role": "error", "content": msg},
+            def _emit_error(msg: str, *, will_retry: bool = False) -> None:
+                slot.append(
+                    "error",
+                    msg,
+                    "msg msg-err",
+                    meta={"kind": TRANSIENT_RETRY_KIND} if will_retry else None,
                 )
+                # No explicit chat_message: slot.append already emits ONE, and it
+                # carries `meta` -- a second frame here would arrive untagged.
 
             if _prompt_depth == 0 and slot._acp_pipe_death_retries < 3:
                 slot._acp_pipe_death_retries += 1
@@ -8164,7 +8174,7 @@ async def _run_chat(
                     kind=SYNTHETIC_RECOVERY_KIND,
                     payload=_requeue_payload,
                 )
-                _emit_error(f"⟳ Connection lost{_rc_suffix} — retrying...")
+                _emit_error(f"⟳ Connection lost{_rc_suffix} — retrying...", will_retry=True)
             elif slot._acp_pipe_death_retries >= 3:
                 _emit_error(f"Session stuck{_rc_suffix} — please start a new chat.")
             else:
@@ -9060,7 +9070,7 @@ async def _run_chat(
             # also broadcast_ws("chat_message") or the UI renders a duplicate card
             # until the post-turn history refresh reconciles it.
             _retry_msg = "⟳ Connection lost — retrying…"
-            slot.append("error", _retry_msg, "msg msg-err")
+            slot.append("error", _retry_msg, "msg msg-err", meta={"kind": TRANSIENT_RETRY_KIND})
             _requeue_text, _requeue_payload = build_recovery_requeue(
                 message,
                 _turn_emitted,
@@ -9097,7 +9107,7 @@ async def _run_chat(
             # via _on_message (see the AcpProcessDied note above); no explicit
             # broadcast_ws or the UI shows a duplicate card.
             _retry_msg = "⟳ Session busy — retrying…"
-            slot.append("error", _retry_msg, "msg msg-err")
+            slot.append("error", _retry_msg, "msg msg-err", meta={"kind": TRANSIENT_RETRY_KIND})
             _requeue_text, _requeue_payload = build_recovery_requeue(
                 message,
                 _turn_emitted,
@@ -9191,7 +9201,7 @@ async def _run_chat(
                     _is_pipe_death,
                     slot._acp_pipe_death_retries if _is_pipe_death else slot._prompt_busy_retries,
                 )
-                slot.append("error", _status, "msg msg-err")
+                slot.append("error", _status, "msg msg-err", meta={"kind": TRANSIENT_RETRY_KIND})
                 _requeue_text, _requeue_payload = build_recovery_requeue(
                     message,
                     _turn_emitted,
@@ -9261,7 +9271,14 @@ async def _run_chat(
                 # broadcasts one chat_message; no explicit broadcast_ws. Back off,
                 # then re-queue — the finally block dequeues onto the SAME live
                 # session (no reset), preserving conversation state.
-                slot.append("error", "⟳ Backend hiccup — retrying…", "msg msg-err")
+                # A recovery is queued below unconditionally, so this notice is NOT
+                # terminal: the tag stops the UI re-offering a choice that re-runs itself.
+                slot.append(
+                    "error",
+                    "⟳ Backend hiccup — retrying…",
+                    "msg msg-err",
+                    meta={"kind": TRANSIENT_RETRY_KIND},
+                )
                 await asyncio.sleep(_delay)
                 _queue_recovery(
                     0,
@@ -9425,9 +9442,16 @@ async def _run_chat(
                 _safe, _ = redact_credentials(_safe)
                 slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
-            # Surface a brief recovery notice (one append).
-            slot.append("error", "⟳ Backend hiccup — recovering…", "msg msg-err")
-            if not _should_suppress_requeue(slot) and _prompt_depth == 0:
+            # Surface a brief recovery notice (one append). Tag it ONLY when the
+            # requeue below will actually happen, or a terminal notice reads as pending.
+            _will_recover = not _should_suppress_requeue(slot) and _prompt_depth == 0
+            slot.append(
+                "error",
+                "⟳ Backend hiccup — recovering…",
+                "msg msg-err",
+                meta={"kind": TRANSIENT_RETRY_KIND} if _will_recover else None,
+            )
+            if _will_recover:
                 _delay = transient_retry_delay(1)  # single short backoff (one-shot)
                 logger.info(
                     "Transient backend 5xx AFTER emit in slot %s — one-shot "
@@ -9618,6 +9642,7 @@ async def _run_chat(
                     "messages are kept; the model rebuilds its working "
                     "context from them)…",
                     "msg msg-err",
+                    meta={"kind": TRANSIENT_RETRY_KIND},
                 )
                 _queue_recovery(0, message, kind=SYNTHETIC_RECOVERY_KIND)
                 # Fresh conversation ⇒ fresh ladder for the recovery cycle.

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -2095,6 +2095,10 @@ def is_system_injection(content: str) -> bool:
 #: Structural queue-entry kind for runner-injected recovery instructions.
 SYNTHETIC_RECOVERY_KIND = "synthetic_recovery"
 
+#: Row-level kind for the `error` notice appended when a recovery has ALREADY
+#: been queued, so the frontend can tell a pending retry from a terminal failure.
+TRANSIENT_RETRY_KIND = "transient_retry"
+
 #: Structural queue-entry kinds for system injections.  Classification by kind
 #: tag — set at enqueue time — is unforgeable: a user typing the same prefix
 #: text will not have the kind tag and will correctly classify as plain input.

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -7746,6 +7746,42 @@ class TestRunChatModelRefusal:
         return state
 
     @pytest.mark.asyncio
+    async def test_stale_recover_notice_is_tagged_and_emits_one_frame(self, tmp_path, monkeypatch):
+        """The LIVE frame must carry the retry tag, and there must be exactly one."""
+        from kiro_crew.acp.types import STOP_REASON_STALE_RECOVER
+        from kiro_crew.dashboard.chat_utils import TRANSIENT_RETRY_KIND
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        events = [LLMEvent(kind=EVENT_COMPLETE, stop_reason=STOP_REASON_STALE_RECOVER)]
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = self._make_mock_client(events)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        _notices = [
+            m
+            for m in slot.messages
+            if m.get("role") == "error" and "Recovering a stalled turn" in m.get("content", "")
+        ]
+        assert _notices, "stale-recovery notice not emitted"
+        assert all((m.get("meta") or {}).get("kind") == TRANSIENT_RETRY_KIND for m in _notices)
+        # slot.append already emits ONE tagged chat_message; an explicit frame here is an
+        # untagged duplicate, and a client rendering it re-offers the executing choice.
+        _dupes = [
+            c
+            for c in state.broadcast_ws.call_args_list
+            if c.args
+            and c.args[0] == "chat_message"
+            and isinstance(c.args[1], dict)
+            and "Recovering a stalled turn" in str(c.args[1].get("content", ""))
+        ]
+        assert not _dupes, f"untagged explicit chat_message duplicate(s): {_dupes}"
+
+    @pytest.mark.asyncio
     async def test_refusal_shows_declined_card_and_does_not_retry(self, tmp_path, monkeypatch):
         from kiro_crew.acp.types import STOP_REASON_REFUSAL
         from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
@@ -14021,6 +14057,24 @@ class TestAcpProcessDiedRecovery:
         assert slot._prompt_busy_retries == 0
         error_msgs = [m for m in slot.messages if m.get("role") == "error"]
         assert any("Connection lost" in m.get("content", "") for m in error_msgs)
+        # A recovery IS queued here, so the notice must be tagged: an untagged row is
+        # indistinguishable from a terminal failure and re-offers an executing choice.
+        from kiro_crew.dashboard.chat_utils import TRANSIENT_RETRY_KIND
+
+        _retrying = [m for m in error_msgs if "retrying" in m.get("content", "").lower()]
+        assert _retrying, "no retrying notice to inspect"
+        assert all((m.get("meta") or {}).get("kind") == TRANSIENT_RETRY_KIND for m in _retrying)
+        # LIVE path: slot.append already emits one tagged chat_message, so an explicit
+        # frame here would be an untagged duplicate that re-arms the pills mid-backoff.
+        _dupes = [
+            c
+            for c in state.broadcast_ws.call_args_list
+            if c.args
+            and c.args[0] == "chat_message"
+            and isinstance(c.args[1], dict)
+            and "retrying" in str(c.args[1].get("content", "")).lower()
+        ]
+        assert not _dupes, f"untagged explicit chat_message frame(s): {_dupes}"
 
     @pytest.mark.asyncio
     async def test_acperror_already_in_progress_uses_busy_counter(self, tmp_path: Path) -> None:
@@ -14083,6 +14137,11 @@ class TestAcpProcessDiedRecovery:
         assert any("Connection lost" in m.get("content", "") for m in error_msgs)
         assert any("please retry" in m.get("content", "").lower() for m in error_msgs)
         assert not slot._queue, "depth>0 must not re-queue"
+        # Discriminating control: nothing is queued, so this notice is genuinely terminal
+        # and must NOT be tagged -- tagging it would hide pills a user still needs.
+        from kiro_crew.dashboard.chat_utils import TRANSIENT_RETRY_KIND
+
+        assert all((m.get("meta") or {}).get("kind") != TRANSIENT_RETRY_KIND for m in error_msgs)
 
 
 class TestEmptyResponseRetry:
@@ -14640,6 +14699,21 @@ class TestRunChatTransientRetry:
         assert not any(t.startswith("❌") for t in self._err_texts(slot))
         # The transient branch fired (status surfaced) ...
         assert any("Backend hiccup" in t for t in self._err_texts(slot))
+        # ... and the notice is TAGGED, which is the only thing telling the UI a
+        # recovery is pending; without it a stale pill re-runs the queued choice.
+        from kiro_crew.dashboard.chat_utils import TRANSIENT_RETRY_KIND
+
+        _hiccups = [
+            m
+            for m in slot.messages
+            if m.get("role") == "error" and "Backend hiccup" in m.get("content", "")
+        ]
+        assert _hiccups, "no hiccup row to inspect"
+        assert all((m.get("meta") or {}).get("kind") == TRANSIENT_RETRY_KIND for m in _hiccups)
+        # Negative control: a TERMINAL error row must NOT carry the tag, or the
+        # discriminator would classify every failure as a pending retry.
+        slot.append("error", "❌ terminal for the control", "msg msg-err")
+        assert (slot.messages[-1].get("meta") or {}).get("kind") != TRANSIENT_RETRY_KIND
         # ... and the live session was NOT reset.
         state.sessions.reset.assert_not_awaited()
         # Budget reset to 0 after the successful turn.

--- a/website/src/app-sdk/protocol/options.ts
+++ b/website/src/app-sdk/protocol/options.ts
@@ -90,11 +90,11 @@ const rowIdentity = (m: ChatMessage, i: number): string =>
  *
  * Three messages short-circuit the scan:
  *  - a `user` message ends the previous turn, so its options no longer apply →
- *    return none.
+ *    return none. UNLESS the turn it began failed: see `sawError` below.
  *  - a `queued` message means the user already acted (Quick Send while the
  *    slot was busy). The optimistic user bubble was suppressed, but the intent
  *    is identical — hide options immediately so they don't linger until the
- *    queue drains.
+ *    queue drains. Same failed-turn exception applies.
  *  - a `compaction` notice is skipped. Auto-compaction appends a
  *    "✅ Conversation compacted" message with the `assistant` role but tagged
  *    `kind="compaction"` (see `chat_utils._broadcast_compaction_result`). It
@@ -102,6 +102,17 @@ const rowIdentity = (m: ChatMessage, i: number): string =>
  *    real options-bearing turn it follows and the buttons would vanish after a
  *    compaction. The marker is read from `kind` (live websocket path) or
  *    `meta.kind` (history-reload path).
+ *
+ * A `user`/`queued` row is only a valid stop because it means "the user has
+ * answered, so the question is closed". A row whose turn FAILED answered
+ * nothing — the question is still open and the choices still apply — but the
+ * row stays in the feed forever, so an unconditional stop hid the pills
+ * permanently and the user had to retype the choice by hand. `sawError` tracks
+ * an error row seen while scanning backward and lets exactly ONE such row be
+ * crossed, re-arming per error so repeated failed attempts each get crossed.
+ * `error` is the single role to key on: the backend routes every terminal turn
+ * error through one `slot.append("error", …)` call site, so matching the role
+ * covers every cause — timeout, transport, refusal — with no message parsing.
  *
  * `questionPending` suppresses the pills while an `ask_question` card is on
  * screen for the same slot, so the user is never offered the same choice twice
@@ -118,9 +129,19 @@ export function deriveFollowUpOptions(
   questionPending = false,
 ): FollowUpDerivation {
   if (isStreaming || questionPending) return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
+  // Errors were already transparent here (no branch matched them); the flag is
+  // what makes that transparency mean something.
+  let sawError = false
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]
-    if (m.role === 'user' || m.role === 'queued') return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
+    if (m.role === 'error') { sawError = true; continue }
+    if (m.role === 'user' || m.role === 'queued') {
+      if (!sawError) return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
+      // Cross this failed turn and keep looking. Re-armed only by another error,
+      // so a SUCCESSFUL turn further back still stops the scan.
+      sawError = false
+      continue
+    }
     if (isSystemNoticeKind(m.kind ?? (m.meta?.kind as string | undefined))) continue
     // A note may carry options, so a zero-token cron can offer an action without an LLM turn.
     // `isNoteRow` also matches a rehydrated note, whose class the history format drops.

--- a/website/src/app-sdk/protocol/options.ts
+++ b/website/src/app-sdk/protocol/options.ts
@@ -1,5 +1,7 @@
 import type { ChatMessage } from '../../types'
 import { isSystemNoticeKind } from '../../lib/systemNotice'
+import { isStopEvent } from '../../lib/stopEvent'
+import { isRetryNotice } from '../../lib/retryNotice'
 import { isNoteRow } from '../../lib/noteContract'
 import { OPTION_MARKER_RE } from './optionMarker'
 
@@ -94,7 +96,10 @@ const rowIdentity = (m: ChatMessage, i: number): string =>
  *  - a `queued` message means the user already acted (Quick Send while the
  *    slot was busy). The optimistic user bubble was suppressed, but the intent
  *    is identical — hide options immediately so they don't linger until the
- *    queue drains. Same failed-turn exception applies.
+ *    queue drains. This stop is UNCONDITIONAL: no failed-turn exception.
+ *  - a `stop_event` card is an UNCONDITIONAL stop too. A deliberate Stop ends
+ *    the turn rather than interrupting it, so the question is closed by the
+ *    user's own cancellation and no error may license reaching back past it.
  *  - a `compaction` notice is skipped. Auto-compaction appends a
  *    "✅ Conversation compacted" message with the `assistant` role but tagged
  *    `kind="compaction"` (see `chat_utils._broadcast_compaction_result`). It
@@ -104,15 +109,37 @@ const rowIdentity = (m: ChatMessage, i: number): string =>
  *    `meta.kind` (history-reload path).
  *
  * A `user`/`queued` row is only a valid stop because it means "the user has
- * answered, so the question is closed". A row whose turn FAILED answered
+ * answered, so the question is closed". A `user` row whose turn FAILED answered
  * nothing — the question is still open and the choices still apply — but the
  * row stays in the feed forever, so an unconditional stop hid the pills
  * permanently and the user had to retype the choice by hand. `sawError` tracks
  * an error row seen while scanning backward and lets exactly ONE such row be
  * crossed, re-arming per error so repeated failed attempts each get crossed.
- * `error` is the single role to key on: the backend routes every terminal turn
- * error through one `slot.append("error", …)` call site, so matching the role
- * covers every cause — timeout, transport, refusal — with no message parsing.
+ * A `queued` row is NEVER crossed: unlike a `user` row it leaves a live entry
+ * in `slot._queue`, which only a hard kill clears, so the choice still runs
+ * when the queue drains — re-offering the pill would run it a second time.
+ * `error` is the role to key on, but NOT on its own: the backend reaches the feed
+ * with role `error` for a terminal failure AND for an auto-retry notice whose
+ * recovery is already queued, so only a row without `TRANSIENT_RETRY_KIND` may
+ * license a crossing — otherwise the pill re-runs a choice already re-running.
+ * A failed turn can also flush the text it streamed as a real assistant row
+ * before the error, so an option-less assistant row under a live `sawError` is
+ * crossed too — otherwise a partial answer shadows the question that is still
+ * open. The trade is deliberate: nothing on the row marks it partial rather
+ * than complete, so an error arriving after a genuinely finished option-less
+ * reply reads the same way and can re-offer the previous turn's choices. A
+ * PLAN row reached that way is therefore offered NOTHING: the plan may already
+ * have advanced, and demoting to the composer path would not help because
+ * Quick Send sends a pill in one click regardless of `followUpIsPlan`. Cost:
+ * a plan turn that flushed a partial before failing gets no chips back.
+ *
+ * The same suppression covers a plan row reached across a failed `user` row.
+ * That row records a click already DISPATCHED, and `usePlanActionMutation`
+ * treats any 5xx, 408/429 or transport rejection as possibly-committed, so the
+ * stage may have advanced before the turn failed. Its go-latch blocks the
+ * second Go only within one page load — the latch is a module-level Map — so it
+ * cannot cover the rehydrated transcript this exception creates. Plan chips are
+ * the narrow case: a Go advances server state by itself, a text pill does not.
  *
  * `questionPending` suppresses the pills while an `ask_question` card is on
  * screen for the same slot, so the user is never offered the same choice twice
@@ -132,14 +159,25 @@ export function deriveFollowUpOptions(
   // Errors were already transparent here (no branch matched them); the flag is
   // what makes that transparency mean something.
   let sawError = false
+  // Set by EITHER crossing: both leave a plan row that may already have advanced (see above).
+  let crossedFailedTurn = false
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]
-    if (m.role === 'error') { sawError = true; continue }
-    if (m.role === 'user' || m.role === 'queued') {
+    // A deliberate Stop ENDS the turn rather than interrupting it, so the choice is closed
+    // by the user's own cancellation — the error licence below must not reach back past it.
+    if (isStopEvent(m)) return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
+    // Only a TERMINAL error licenses a crossing. A retry notice means the recovery is
+    // already queued, so re-offering the pill would run the same choice a second time.
+    if (m.role === 'error') { if (!isRetryNotice(m)) sawError = true; continue }
+    // `queued` is an UNCONDITIONAL stop: its queue entry OUTLIVES the error (only a hard
+    // kill clears the queue), so re-offering the pill would run the choice a second time.
+    if (m.role === 'queued') return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
+    if (m.role === 'user') {
       if (!sawError) return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
       // Cross this failed turn and keep looking. Re-armed only by another error,
       // so a SUCCESSFUL turn further back still stops the scan.
       sawError = false
+      crossedFailedTurn = true
       continue
     }
     if (isSystemNoticeKind(m.kind ?? (m.meta?.kind as string | undefined))) continue
@@ -158,6 +196,13 @@ export function deriveFollowUpOptions(
     }
     if (m.role === 'assistant' && m.content) {
       const { options, isPlan } = parseOptions(m.content)
+      // A failed turn can flush the text it streamed as a real assistant row before the
+      // error, and that option-less row shadowed the question exactly as the `user` row did.
+      // Crossing does NOT consume the error licence: the `user` row below still needs it.
+      if (!options.length && sawError) { crossedFailedTurn = true; continue }
+      // Offer NOTHING for a plan row reached that way. Demoting to the composer path is not
+      // enough: with Quick Send on, one click still sends `Go All` as orchestrator-run text.
+      if (isPlan && crossedFailedTurn) return { followUpOptions: [], followUpIsPlan: false, followUpSourceKey: null }
       const followUpSourceKey = options.length > 0 ? rowIdentity(m, i) : null
       return { followUpOptions: options, followUpIsPlan: isPlan, followUpSourceKey }
     }

--- a/website/src/lib/retryNotice.ts
+++ b/website/src/lib/retryNotice.ts
@@ -1,0 +1,14 @@
+import type { ChatMessage } from '../types'
+
+/**
+ * True for the `error` row the backend appends when it has ALREADY queued the
+ * recovery that re-runs the turn.
+ *
+ * Role alone cannot answer this: a terminal failure and an auto-retry notice both
+ * arrive as role `error` with `cls="msg msg-err"`, so a scan keying on the role
+ * treats a pending retry as a finished failure and re-offers a choice that is
+ * already re-running. Both carriers are load-bearing for the same reason as
+ * `isStopEvent` -- the live broadcast ships `kind`, a rebuilt transcript `meta.kind`.
+ */
+export const isRetryNotice = (m: ChatMessage): boolean =>
+  m.kind === 'transient_retry' || (m.meta as { kind?: string } | undefined)?.kind === 'transient_retry'

--- a/website/src/lib/stopEvent.ts
+++ b/website/src/lib/stopEvent.ts
@@ -1,0 +1,13 @@
+import type { ChatMessage } from '../types'
+
+/**
+ * True for the card the backend appends when a turn is stopped by the user.
+ *
+ * Two forms are load-bearing: the websocket path sets `kind` AND `meta.kind`,
+ * while a transcript rehydrated from disk carries only the JSON-encoded `cls`
+ * that `parse_cls_meta()` unpacks into `meta`. Lives in `lib/` rather than the
+ * store so the protocol-layer scans can share the one definition instead of
+ * re-checking half of it.
+ */
+export const isStopEvent = (m: ChatMessage): boolean =>
+  m.kind === 'stop_event' || (m.meta as { kind?: string } | undefined)?.kind === 'stop_event'

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -4,6 +4,7 @@ import { addSlotOptimistic, updateSlot, removeSlotOptimistic, markSlotRead, fetc
 import { resolveDefaultColor } from '../utils/sessionColors'
 import { isChatPageSurface } from '../utils/channelOrigin'
 import { isSystemNoticeKind } from '../lib/systemNotice'
+import { isStopEvent } from '../lib/stopEvent'
 import { gcSessionStorage } from '../utils/storageGc'
 import type { RootState } from './index'
 import type { ChatMessage, ChatSlot, SessionInfo, SubagentActivity, ToolActivity, WorkflowRunSummary } from '../types'
@@ -2689,19 +2690,6 @@ export const selectContinuable = (state: RootState): boolean => {
   }
   return false
 }
-
-/**
- * True when *m* is the card recorded because the USER pressed Stop.
- *
- * Two forms exist and both are load-bearing: the websocket path sets `kind` AND
- * `meta.kind` (see the stop_event branch in the message reducer), while a
- * transcript rehydrated from disk carries only the JSON-encoded `cls` that
- * `parse_cls_meta()` unpacks into `meta`. `ChatPage` and `ChatMessageList`
- * already test both; this is the same predicate named once so a fourth caller
- * cannot check only half of it.
- */
-export const isStopEvent = (m: ChatMessage): boolean =>
-  m.kind === 'stop_event' || (m.meta as { kind?: string } | undefined)?.kind === 'stop_event'
 
 /**
  * True when the transcript SHOWS the last turn ending without the assistant

--- a/website/src/test/ChatSliceCoverage.test.tsx
+++ b/website/src/test/ChatSliceCoverage.test.tsx
@@ -29,7 +29,6 @@ import chatReducer, {
   editQueuedMessage,
   fetchHistory,
   hydrateSlotMessages,
-  isStopEvent,
   loadOlderMessages,
   markSubagentApproving,
   mcpAppKey,
@@ -78,6 +77,7 @@ import chatReducer, {
   switchSlot,
   warmSlotCache,
 } from '../store/chatSlice'
+import { isStopEvent } from '../lib/stopEvent'
 import dashboardReducer, { sseSlots } from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
 import instancesReducer from '../store/instancesSlice'

--- a/website/src/test/deriveFollowUpOptions.test.ts
+++ b/website/src/test/deriveFollowUpOptions.test.ts
@@ -16,6 +16,12 @@ const note = (content: string): ChatMessage => ({ role: 'inject', content, cls: 
 // rehydrated note carries no class and `meta.noteSession` is the surviving provenance.
 const rehydratedNote = (content: string): ChatMessage =>
   ({ role: 'inject', content, cls: '', meta: { noteSession: 'chat-1844-1787619403' } })
+// Every terminal turn error reaches the feed as role="error", so the role is the whole
+// contract and the text is deliberately irrelevant to the derivation.
+const errorRow = (content = '❌ Request session/new timed out after 90s'): ChatMessage =>
+  ({ role: 'error', content, cls: 'msg msg-err' })
+const queuedRow = (content: string, queueId = 'q1'): ChatMessage =>
+  ({ role: 'queued', content, cls: 'msg msg-queued', meta: { queueId } })
 
 const OPTIONS_MSG = 'Pick one [OPTIONS: Alpha | Beta | Gamma]'
 
@@ -305,6 +311,135 @@ describe('deriveFollowUpOptions', () => {
         false,
       ).followUpSourceKey
       expect(a).not.toBe(b)
+    })
+  })
+
+  // A pill click appends the optimistic `user` bubble BEFORE the network call, and a failed
+  // turn never removes it — so the unconditional stop hid the pills for good.
+  describe('options survive a failed turn', () => {
+    it('keeps options when the turn the user started failed', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('keeps the plan flag too, so a failed plan turn can still be approved', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Approve | Revise]')
+      const derived = deriveFollowUpOptions([user('go'), plan, user('Approve'), errorRow()], false)
+      expect(derived.followUpOptions).toEqual(['Approve', 'Revise'])
+      expect(derived.followUpIsPlan).toBe(true)
+    })
+
+    // Quick Send while busy echoes a `queued` row instead of the user bubble (#2409), and a
+    // failed turn strands the pills identically — so the exception must cover BOTH stop roles.
+    it('keeps options when a QUEUED send failed', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), queuedRow('Beta'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('keeps options across two stacked failed attempts', () => {
+      // Re-arming per error is what makes this work: each error licenses exactly one crossing.
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        user('Alpha'), errorRow(),
+        user('Alpha'), errorRow('❌ Connection error'),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('keeps options across three stacked failed attempts', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        queuedRow('Alpha', 'q1'), errorRow(),
+        user('Alpha'), errorRow('❌ Send failed'),
+        user('Alpha'), errorRow('⏱️ timed out'),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // The text is not consulted at all, so a cause the derivation has never heard of is
+    // covered for free. This is what "every error" rests on.
+    it.each([
+      '⏱️ Request session/new timed out after 90s',
+      '❌ Connection error',
+      '⟳ Session busy — please retry.',
+      'Session stuck — please start a new chat.',
+      '',
+      'some cause invented after this test was written',
+    ])('keeps options whatever the error text says (%j)', text => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), { ...errorRow(), content: text }]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('still clears options when the turn succeeded with an option-less reply', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), assistant('Done, no options here')]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // THE load-bearing control: an error arms exactly ONE crossing, so a turn that completed
+    // between the old options and the failure still stops the scan.
+    it('does not reach back past a turn that succeeded before the failure', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        user('Alpha'), assistant('Done, no options here'),
+        user('next'), errorRow(),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // #2409 must not regress: a queued send with no error after it still hides the pills.
+    it('still clears options for a queued send that has not failed', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), queuedRow('Alpha')]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('offers the NEWER options when the retried turn succeeded with its own marker', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        user('Alpha'), errorRow(),
+        user('Alpha'), assistant('Retried fine [OPTIONS: Delta | Epsilon]'),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Delta', 'Epsilon'])
+    })
+
+    it('still suppresses options while streaming, even after a failed turn', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, true).followUpOptions).toEqual([])
+    })
+
+    it('still suppresses options while a question card is pending, even after a failed turn', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false, true).followUpOptions).toEqual([])
+    })
+
+    it('crosses a failed turn whose feed also carries a compaction notice', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), compactionLive(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('crosses a failed turn whose feed also carries an option-less note', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), note('FYI: nothing to do'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('lets a note claim the pills over an older assistant turn after a failure', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow(), note('Retry? [OPTIONS: Yes | No]')]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Yes', 'No'])
+    })
+
+    // An error with no user/queued row after it was ALREADY transparent (it matched no
+    // branch and fell through). Pinned so the explicit `error` branch cannot change it.
+    it('leaves a bare error row transparent to the scan', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('returns no options when a failed turn has no options-bearing turn behind it', () => {
+      const msgs = [user('go'), assistant('no marker here'), user('again'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('returns no options when the feed is nothing but a failed send', () => {
+      expect(deriveFollowUpOptions([user('go'), errorRow()], false).followUpOptions).toEqual([])
     })
   })
 })

--- a/website/src/test/deriveFollowUpOptions.test.ts
+++ b/website/src/test/deriveFollowUpOptions.test.ts
@@ -22,6 +22,18 @@ const errorRow = (content = '❌ Request session/new timed out after 90s'): Chat
   ({ role: 'error', content, cls: 'msg msg-err' })
 const queuedRow = (content: string, queueId = 'q1'): ChatMessage =>
   ({ role: 'queued', content, cls: 'msg msg-queued', meta: { queueId } })
+// An auto-retry notice: role `error` like any failure, but carrying the kind the
+// backend stamps when it has already queued the recovery that re-runs the turn.
+const retryNoticeLive = (content = '⟳ Backend hiccup — retrying…'): ChatMessage =>
+  ({ role: 'error', content, cls: 'msg msg-err', kind: 'transient_retry', meta: { kind: 'transient_retry' } })
+const retryNoticeReload = (content = '⟳ Backend hiccup — retrying…'): ChatMessage =>
+  ({ role: 'error', content, cls: 'msg msg-err', meta: { kind: 'transient_retry' } })
+// Both forms are load-bearing (see `isStopEvent`): the live path sets `kind`, a rehydrated
+// transcript carries only `meta.kind` unpacked from `cls`.
+const stopEventLive = (content = '⏹️ Stopped by user'): ChatMessage =>
+  ({ role: 'system', content, cls: 'msg msg-sys', kind: 'stop_event', meta: { kind: 'stop_event' } })
+const stopEventReload = (content = '⏹️ Stopped by user'): ChatMessage =>
+  ({ role: 'system', content, cls: 'msg msg-sys', meta: { kind: 'stop_event' } })
 
 const OPTIONS_MSG = 'Pick one [OPTIONS: Alpha | Beta | Gamma]'
 
@@ -322,18 +334,96 @@ describe('deriveFollowUpOptions', () => {
       expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
     })
 
-    it('keeps the plan flag too, so a failed plan turn can still be approved', () => {
+    // Was `keeps the plan flag too` until validation found the double-advance: the pill's click
+    // was dispatched, and a dispatch that fails ambiguously may already have committed.
+    it('drops the plan flag, because a failed plan turn may already have advanced', () => {
       const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Approve | Revise]')
       const derived = deriveFollowUpOptions([user('go'), plan, user('Approve'), errorRow()], false)
-      expect(derived.followUpOptions).toEqual(['Approve', 'Revise'])
-      expect(derived.followUpIsPlan).toBe(true)
+      expect(derived.followUpOptions).toEqual([])
+      expect(derived.followUpIsPlan).toBe(false)
     })
 
-    // Quick Send while busy echoes a `queued` row instead of the user bubble (#2409), and a
-    // failed turn strands the pills identically — so the exception must cover BOTH stop roles.
-    it('keeps options when a QUEUED send failed', () => {
+    // Asserted the opposite until validation found the double-run: a `queued` row's QUEUE
+    // ENTRY survives the error, so re-offering the pill runs the choice twice, not once.
+    it('clears options when a QUEUED send failed', () => {
       const msgs = [user('go'), assistant(OPTIONS_MSG), queuedRow('Beta'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // The exact reported path: Quick Send while busy, an AUTH error, then sign-in. The queue
+    // entry is still pending, so offering the pill would be the second of two executions.
+    it('offers nothing after a queued send hit an auth-error boundary', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        queuedRow('Beta', 'q1'), errorRow('🔒 Authentication required — please sign in'),
+      ]
+      const derived = deriveFollowUpOptions(msgs, false)
+      // No pill to click, so the pending queue entry remains the ONLY execution of 'Beta'.
+      expect(derived.followUpOptions).toEqual([])
+      expect(derived.followUpSourceKey).toBe(null)
+    })
+
+    // A `user` row carries no queue entry, so crossing it re-offers a choice that never ran.
+    it('still keeps options when a USER send failed, which strands no queue entry', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Beta'), errorRow()]
       expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // A deliberate Stop ENDS the turn rather than interrupting it — the same reading
+    // `selectTurnInterrupted` already applies — so the error licence must not cross it.
+    it('offers nothing when the user pressed Stop after the failure', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow(), stopEventLive()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // The rehydrated form carries only `meta.kind`; a guard reading just `kind` would
+    // restore the pills after a reload and re-open a choice the user cancelled.
+    it('offers nothing for a rehydrated Stop row after the failure', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow(), stopEventReload()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('offers nothing when Stop precedes the error row in the feed', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), stopEventLive(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // Pins a behaviour CHANGE with no failure involved: a stopped injected or Continue turn
+    // has no `user` row, and the stop card was transparent to the scan before this PR.
+    it('hides options for a stopped turn with no user row', () => {
+      expect(deriveFollowUpOptions([user('go'), assistant(OPTIONS_MSG), stopEventLive()], false).followUpOptions).toEqual([])
+      expect(deriveFollowUpOptions([user('go'), assistant(OPTIONS_MSG), stopEventReload()], false).followUpOptions).toEqual([])
+    })
+
+    it('keeps options when a failed turn carries no Stop row at all', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // The backend queues the recovery that re-runs the turn BEFORE the user can click, so
+    // re-offering the pill here executes the same choice twice.
+    it('offers nothing while an automatic retry is pending', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), retryNoticeLive()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // The rehydrated row carries only `meta.kind`; a guard reading just `kind` would re-offer
+    // the pill after a reload, which is when the double-execution actually bites.
+    it('offers nothing for a rehydrated retry notice', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), retryNoticeReload()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // The retry ran and then failed for good, so the question is open again and nothing is
+    // pending that could re-run the choice.
+    it('restores options when a retry notice is followed by a terminal error', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), retryNoticeLive(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('offers nothing for a plan row reached across a pending retry', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      expect(deriveFollowUpOptions([user('go'), plan, user('Go'), retryNoticeLive()], false).followUpOptions).toEqual([])
     })
 
     it('keeps options across two stacked failed attempts', () => {
@@ -346,10 +436,22 @@ describe('deriveFollowUpOptions', () => {
       expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
     })
 
-    it('keeps options across three stacked failed attempts', () => {
+    // The queued row now STOPS the scan, so the two `user` failures above it are still
+    // crossed but the older options row behind the queued row is deliberately out of reach.
+    it('stops at a queued row even with later failed user attempts', () => {
       const msgs = [
         user('go'), assistant(OPTIONS_MSG),
         queuedRow('Alpha', 'q1'), errorRow(),
+        user('Alpha'), errorRow('❌ Send failed'),
+        user('Alpha'), errorRow('⏱️ timed out'),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('keeps options across three stacked failed USER attempts', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        user('Alpha'), errorRow(),
         user('Alpha'), errorRow('❌ Send failed'),
         user('Alpha'), errorRow('⏱️ timed out'),
       ]
@@ -440,6 +542,123 @@ describe('deriveFollowUpOptions', () => {
 
     it('returns no options when the feed is nothing but a failed send', () => {
       expect(deriveFollowUpOptions([user('go'), errorRow()], false).followUpOptions).toEqual([])
+    })
+  })
+
+  // A turn that streamed text before dying flushes it as a REAL assistant row ahead of the
+  // error row, and that option-less row shadowed the question just as the `user` row did.
+  describe('options survive a failed turn that emitted partial text', () => {
+    const partial = (content = 'Working on it, here is what I found so far…'): ChatMessage =>
+      assistant(content)
+
+    it('keeps options when the failed turn flushed partial text first', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), partial(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // Same double-run reason as the non-partial queued case: the queue entry outlives the
+    // error, so the partial flush does not change whether the pill may be re-offered.
+    it('clears options when a queued send failed after emitting partial text', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), queuedRow('Beta'), partial(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('keeps options across several partial-then-error segments in one failed turn', () => {
+      // The recovery path appends [partial] [notice] repeatedly before the terminal error.
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG), user('Alpha'),
+        partial('first chunk'), errorRow('⟳ Backend hiccup — recovering…'),
+        partial('second chunk'), errorRow('❌ gave up'),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    it('prefers a partial that itself carries a marker over the older turn', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG), user('Alpha'),
+        assistant('Partway there [OPTIONS: Retry | Abandon]'), errorRow(),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Retry', 'Abandon'])
+    })
+
+    it('still clears options when the partial turn ultimately succeeded', () => {
+      // No error at all: the option-less reply is the final word and closes the question.
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), partial(), assistant('All done')]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    it('does not reach past a completed turn to a failure two turns back', () => {
+      const msgs = [
+        user('go'), assistant(OPTIONS_MSG),
+        user('Alpha'), assistant('All done'),
+        user('next'), partial(), errorRow(),
+      ]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // The accepted trade-off, pinned so it stays a decision on record: nothing marks an
+    // assistant row partial rather than complete, so a busy-slot refused send reads the same.
+    it('re-offers earlier choices when an error follows a completed option-less reply', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), assistant('All done'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // Demotion was tried first and was not enough: Quick Send sends a pill in one click
+    // whatever `followUpIsPlan` says, so the ambiguous plan case is offered nothing at all.
+    it('offers nothing for a re-offered PLAN row after a completed reply', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      const msgs = [user('go'), plan, user('Go'), assistant('Stage 1 complete.'), errorRow()]
+      const derived = deriveFollowUpOptions(msgs, false)
+      expect(derived.followUpOptions).toEqual([])
+      expect(derived.followUpIsPlan).toBe(false)
+      expect(derived.followUpSourceKey).toBe(null)
+    })
+
+    // Was `keeps the plan flag when only a failed user row was crossed`: that rested on the plan
+    // not having advanced, but the go-latch is per page load, so a reload re-exposes the Go.
+    it('offers nothing for a PLAN row reached by crossing a failed user turn', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      const derived = deriveFollowUpOptions([user('go'), plan, user('Go'), errorRow()], false)
+      expect(derived.followUpOptions).toEqual([])
+      expect(derived.followUpIsPlan).toBe(false)
+      expect(derived.followUpSourceKey).toBe(null)
+    })
+
+    it('offers nothing for a PLAN row across two stacked failed attempts', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      const msgs = [user('go'), plan, user('Go'), errorRow(), user('Go'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+    })
+
+    // Scoping control: suppression is PLAN-only, so a blanket regression fails here.
+    it('still restores NON-plan options across the same failed user turn', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), errorRow()]
+      expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual(['Alpha', 'Beta', 'Gamma'])
+    })
+
+    // Control: plan chips are not blanket-suppressed. With no failed turn crossed, one-tap
+    // approval is still correct and `followUpIsPlan` must survive.
+    it('keeps a PLAN row offered when no failed turn was crossed', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      const derived = deriveFollowUpOptions([user('go'), plan], false)
+      expect(derived.followUpOptions).toEqual(['Go', 'Go All', 'Cancel'])
+      expect(derived.followUpIsPlan).toBe(true)
+    })
+
+    // Control for the tests above: without it, they still pass if the
+    // derivation stops keying on the error row at all.
+    it('does not re-offer a PLAN row when the completed reply was not followed by an error', () => {
+      const plan = assistant('📋 Plan for: ship it\nStage 1: build\n[OPTIONS: Go | Go All | Cancel]')
+      const msgs = [user('go'), plan, user('Go'), assistant('Stage 1 complete.')]
+      const derived = deriveFollowUpOptions(msgs, false)
+      expect(derived.followUpOptions).toEqual([])
+      expect(derived.followUpIsPlan).toBe(false)
+    })
+
+    it('still suppresses a crossed partial while streaming or a card is pending', () => {
+      const msgs = [user('go'), assistant(OPTIONS_MSG), user('Alpha'), partial(), errorRow()]
+      expect(deriveFollowUpOptions(msgs, true).followUpOptions).toEqual([])
+      expect(deriveFollowUpOptions(msgs, false, true).followUpOptions).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## Problem / Motivation

The agent ends a message with `[OPTIONS: A | B | C]` and the composer renders those
choices as pills. The user taps one, **the turn fails**, and the pills are gone. The
choice they picked is sitting right there in the feed as a sent user bubble and the
question is still unanswered, but the choices are not offered again.

One affordance does survive, and the severity here should be read minus it:
`selectTurnInterrupted` (`website/src/store/chatSlice.ts:2628`) already gates a Resume
button on exactly this `user → error` tail. Resume re-drives the same pick the user
already made rather than restoring the choice, so the pre-change floor is "re-run the
identical choice with one tap", not "retype the label by hand". Retyping remains the only
route to a *different* answer, and that is worst exactly where a dropped turn is most
likely: on mobile, with a long option label.

The error bubble is not what hides them. `deriveFollowUpOptions` scans backward for the
last options-bearing assistant turn and stops unconditionally at the first `user` or
`queued` row. The pill click *itself* appends that `user` row before the network call,
and a failed turn never removes it — so the stop is permanent. `grep -n error` over
`options.ts` returned zero hits before this change: the derivation had no notion of a
turn having failed.

## Why it matters

Every failed turn that began with a pill click loses the choices. The row is durable, so
this is not a transient glitch — the pills never come back for that question, not on
reconnect and not on reload, because the persisted history carries the same
`user` + `error` tail and the derivation re-runs over it identically.

It hits hardest exactly where retyping is worst: a phone, a long option label, or a plan
approval where the labels are `Go | Go All | Cancel` and the user has to reproduce one
verbatim. Turns fail for ordinary reasons — a backend timeout, a dropped transport, a
busy slot — so this is a routine path, not an edge case.

## What changed (motivation → approach → change)

**Symptom** → pills vanish for good after a failed turn.
**Root cause** → a `user`/`queued` row is treated as "the user has answered, so the
question is closed". A row whose turn *failed* answered nothing, but it is
indistinguishable from one that did, so the scan stops there forever.
**Change** → make the stop conditional on the turn having completed.

`sawError` tracks an `error` row seen while scanning backward and licenses crossing
exactly **one** `user` row, re-arming per error so repeated failed attempts each get
crossed -- but only a **terminal** error licenses that crossing. The backend reaches the
feed with role `error` for a terminal failure AND for an auto-retry notice whose recovery
it has already queued, so keying on the role alone re-offered a choice that was already
re-running by itself, executing it twice. The notice now carries a row-level
`transient_retry` kind, set at the two append sites where a recovery is genuinely queued
(and deliberately NOT at the nested-turn notice, which does not requeue and so is
terminal), and the derivation refuses to cross on it. A `queued` row is **never** crossed:
its entry survives in `slot._queue` (only a hard kill clears it), so the choice still runs
when the queue drains and re-offering the pill would run it twice. Two further rows are unconditional stops: a `stop_event` card,
because a deliberate Stop closes the question by the user's own cancellation, and that
predicate now lives in `website/src/lib/stopEvent.ts` so the protocol scan and the store
share one definition instead of each checking half of its two forms (`kind` on the live
path, `meta.kind` after a reload).

**Behaviour change worth calling out, because it fires with no failure involved.** The
`stop_event` stop is unconditional, so `assistant(OPTIONS) → stop_event` with **no** `user`
row -- a stopped injected or Continue turn -- now hides the pills where the stop card was
previously transparent to the scan and they survived. That is intended: a deliberate Stop
closes the question. The licence-scoped alternative is unsound, because a backward scan
meets the stop before the error and so cannot gate on `sawError`. Pinned by a test. Keying on `role === 'error'` rather than message text is deliberate and is
what makes this cover *every* cause: the backend routes every terminal turn error through
the same `slot.append("error", …)` path (stated in as many words at
`src/kiro_crew/dashboard/chat_runner.py`, and 22 production call sites agree), so the role
match covers timeout, transport and refusal alike — including causes added after this
patch. `error` is also the only role that needs it: there is no `aborted`/`cancelled`/
`interrupted` chat role in the SPA.

The crossing is narrow by construction. An error licenses one crossing and nothing
re-arms it but another error, so a turn that genuinely completed between the old options
and the failure still stops the scan. That is pinned by a test.

**Second commit — the partial-reply case.** A failing turn can flush the text it already
streamed as a real `assistant` row *before* the error (three sites do this; the
recovery-notice comment spells the user-visible order out as `[partial] [recover notice]
[continued answer]`). The scan then stops at that option-less assistant row and the pills
still do not return, so commit 1 alone does not finish the job. Commit 2 crosses an
option-less assistant row under a live `sawError` too.

It is a separate commit because it carries a residual mode commit 1 does not, and the
honest thing is to let you drop it independently. **Nothing on an assistant row marks it
partial rather than complete** — all 8 append sites use a bare
`slot.append("assistant", …, "msg msg-a")` — so a genuinely finished option-less reply
followed by a client-side send failure reads the same way and can re-offer the previous
turn's choices. That sequence is reachable: when the slot is busy the optimistic `user`
row is suppressed (#2409) and a refused send gets no `queued` row either, so the feed can
read `assistant("all done", no options) → error(send failed)` with nothing between.

**The sharp tier of that residual is now fixed in code, not merely declared.** A plan
re-offer reached by crossing an option-less assistant row would otherwise have been *one
tap* on a stale stage: `ChatPage`'s `onFollowUpSelect` (and `ChatPane`'s) dispatches
`/plan-action` and returns *before* any `setInput` when `followUpIsPlan && isPlanAction(o)`,
and `usePlanActionMutation`'s stale-click guard cannot catch it — that guard compares
`clickedSourceKey` against the *currently derived* row, and here the derivation itself
makes the stale row current, so the keys match and the guard passes.

So the derivation now offers **nothing at all** for a plan row reached that way. Demoting
it to the composer path was tried first and is not sufficient: with Quick Send enabled a
pill sends in one click regardless of `followUpIsPlan`, so a stale `Go All` would still
have gone out as orchestrator-run text.

The suppression covers **both** crossings, and an earlier revision of this PR was wrong to
scope it to one. A crossed option-less assistant row may be a *completed* reply, so the plan
may have moved on. A crossed `user` row is no safer: it records a click already dispatched,
and `usePlanActionMutation` treats any 5xx, 408/429 or transport rejection as
possibly-committed, so the stage may have advanced before the turn failed. Its go-latch
would block the second Go, but that latch is a module-level `Map`, so a reload clears it
while the row still re-offers `Go` — a same-page-load defence cannot cover the rehydrated
transcript this exception creates.

**Accepted cost, stated plainly:** a plan question whose turn flushed a partial before
failing does not get its chips back. That is the honest outcome for a case where we cannot
tell whether the plan advanced, and it now applies to any plan row reached across a failed
turn rather than only a flushed-partial one. Restoration for regular (non-plan) options is
unaffected. The change that would retire the underlying
ambiguity — a `meta.partial` stamp at the three flush sites, so a flushed partial is
distinguishable from a completed reply — is a backend plus history-format change and is
deliberately not in this PR.

## Tests

34 new cases in `website/src/test/deriveFollowUpOptions.test.ts` (35 → 69), following the
existing `compaction`-shadowing block, which is the same bug class with a different
shadowing role.

Restoration:
- pills survive `assistant(OPTIONS) → user → error`
- pills do **not** survive `assistant(OPTIONS) → queued → error`: the queue entry outlives
  the error, so re-offering would run the choice twice
- pills do **not** survive a deliberate Stop after the failure, in both the live and the
  rehydrated `stop_event` form
- two and three stacked failed `user` attempts
- parametrised over six error texts including an empty string and an invented cause —
  the text is never read, which is what "every error" rests on
- crossing still works with a `compaction` notice or an option-less note in the feed
- a note after the error still claims the pills over an older assistant turn
- commit 2: an option-less partial reply before the error is crossed
- the plan suppression: a completed option-less reply plus an error offers nothing at all
  for the earlier plan row — no options, no plan flag, no source key — because Quick Send
  would otherwise send a stale `Go All` in one click regardless of `followUpIsPlan`
- a plan row reached by crossing a failed `user` row is offered nothing either — same
  assertion, because that click may already have advanced the stage
- the suppression stays PLAN-scoped: a non-plan turn crossed the same way still restores its
  pills, and a plan row with no failed turn crossed still keeps its labels and plan flag
- their negative control: the identical feed *without* the error row yields no options, so
  neither assertion can pass if the derivation stopped keying on the error at all

Guards that must not regress, all asserted:
- pills do **not** survive `assistant(OPTIONS) → user → assistant(no options)`
- pills do **not** reach back past a turn that succeeded before the failure — the
  load-bearing control for "one crossing per error"
- #2409 holds: a `queued` send with no error after it still hides the pills
- `isStreaming` and `questionPending` still suppress, even after a failed turn
- a bare error row stays transparent to the scan (it already was; now pinned)
- a newer successful retry's own options win over the older set

Results in this environment: target suite **69 passed** on the branch vs **35** on the
unmodified base. Full frontend suite **23639 passed**; its failing-file set is a strict
subset of the unmodified base's, so this adds no failures. The residual failures are
local dependency gaps (`@pierre/*`, `tailwindcss-animate`, `graphology-layout-forceatlas2`
unresolvable here) and reproduce identically on the base commit. `npx tsc -b` emits the
same 22 pre-existing errors as the base, byte-identical, none in the touched files.
`scripts/scrub-lint.sh --no-history` and `scripts/check_brand_name.py` both pass.
Commit 1 alone: 58 passed.

## Manual verification

N/A — no new or changed UI surface. The pills render through the existing `FollowUpBar`
via the existing `followUpOptions` prop; only the predicate deciding *when* they are
offered changed, and it is a pure function fully covered above.

To be explicit about what was **not** done: I did not drive a live failed turn in the
dashboard end to end. The behaviour is asserted at the derivation, which is where the bug
is, and §4-equivalent reasoning holds that the options-bearing row is already in
persisted history — no protocol or backend change is needed for the pills to come back.

## Related Issues

None to fix — I searched open and closed issues and found no report of this. Closest
relatives, none of them this bug: #2409 (chips *persist* after Quick Send when busy — the
issue that added the `queued` stop, which this PR keeps unconditional; its behaviour is
pinned by a test here), #5870 / #5893 / #6057 (host panes not passing the options through),
#5897 (unselect splices by `indexOf`).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the function's doc comment explains the
      failed-turn exception and commit 2's trade-off
- [x] No secrets, credentials, or internal references in the diff





