### PR TITLE
fix(sessions): escape trash batch names in list_trash logs (#6315)

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1583,7 +1583,9 @@ def list_trash() -> list[TrashBatch]:
             continue
         parsed = _read_manifest(candidate)
         if parsed is None:
-            logger.debug("trash batch %s has no readable manifest", candidate.name)
+            # %r: the directory name is agent-controlled; repr keeps an embedded
+            # newline from forging additional log records.
+            logger.debug("trash batch %r has no readable manifest", candidate.name)
             continue
         header, entries = parsed
         # The DIRECTORY is the batch's identity. A header that names a different
@@ -1592,8 +1594,9 @@ def list_trash() -> list[TrashBatch]:
         # than resolved in the header's favour.
         claimed = header.get("batch_id")
         if isinstance(claimed, str) and claimed and claimed != candidate.name:
+            # %r on the name: agent-controlled, same forgery risk as above.
             logger.warning(
-                "trash batch %s has a manifest claiming batch id %r; not offering it",
+                "trash batch %r has a manifest claiming batch id %r; not offering it",
                 candidate.name,
                 claimed,
             )

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -800,6 +801,112 @@ class TestBatchIdentityIsTheDirectory:
 
         assert [b.batch_id for b in listed] == [batch.batch_id]
         assert (session_storage.trash_root() / listed[0].batch_id).is_dir()
+
+
+class TestTrashBatchNamesAreLogSafe:
+    """A batch directory name is agent-controlled and can embed a newline; every
+    ``list_trash`` log line that carries it must escape it, or one record forges
+    additional records (refs #6315, the #6281 log-forgery class).
+    """
+
+    _FORGED = "20240101T000000-deadbeef\nWARNING forged: batch cleared by operator"
+
+    @staticmethod
+    def _make_forged_dir(name: str) -> Path:
+        forged = session_storage.trash_root() / name
+        try:
+            forged.mkdir(parents=True)
+        except OSError:
+            pytest.skip("this filesystem refuses a newline in a directory name")
+        return forged
+
+    def test_missing_manifest_log_escapes_the_batch_name(
+        self, stores: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        self._make_forged_dir(self._FORGED)
+
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):
+            assert session_storage.list_trash() == []
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "no readable manifest" in record.getMessage()
+        ]
+        assert messages, "the missing-manifest site did not log at all"
+        # The rendered record stays one line: the name appears repr'd, and the
+        # injected second line never starts a record of its own.
+        assert all("\n" not in message for message in messages)
+        assert any(repr(self._FORGED) in message for message in messages)
+
+    def test_batch_id_disagreement_log_escapes_the_batch_name(
+        self, stores: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        # Renaming the directory makes its manifest header disagree with it,
+        # which is exactly the warning path under test.
+        original = session_storage.trash_root() / batch.batch_id
+        try:
+            original.rename(session_storage.trash_root() / self._FORGED)
+        except OSError:
+            pytest.skip("this filesystem refuses a newline in a directory name")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.list_trash() == []
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "claiming batch id" in record.getMessage()
+        ]
+        assert messages, "the batch-id-disagreement site did not log at all"
+        assert all("\n" not in message for message in messages)
+        assert any(repr(self._FORGED) in message for message in messages)
+
+    def test_both_sites_escape_without_touching_the_filesystem(
+        self,
+        stores: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Windows refuses a newline in a real directory name, which would skip
+        the two filesystem tests above on those shards. Injecting the forged
+        name at the manifest-read seam pins both log sites on every platform.
+        """
+        session_storage.trash_root().mkdir(parents=True)
+
+        class _ForgedDir:
+            name = self._FORGED
+
+            @staticmethod
+            def is_dir() -> bool:
+                return True
+
+        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+            "missing": None,
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+        }
+        for label, parsed in manifests.items():
+            caplog.clear()
+            monkeypatch.setattr(session_storage.Path, "iterdir", lambda self: iter([_ForgedDir()]))
+            monkeypatch.setattr(
+                session_storage.platform_compat, "is_link_or_junction", lambda p: False
+            )
+            monkeypatch.setattr(
+                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+            )
+
+            with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):
+                assert session_storage.list_trash() == []
+
+            rendered = [record.getMessage() for record in caplog.records]
+            carrying = [message for message in rendered if repr(self._FORGED) in message]
+            assert carrying, f"the {label}-manifest site did not log the name repr'd"
+            assert all("\n" not in message for message in rendered)
 
 
 class TestScanCache:


### PR DESCRIPTION
# Summary

Follow-up from PR #6312's Opus review. A trash batch directory name is agent-controlled and can embed newlines; two pre-existing log sites in `list_trash` (`src/kiro_crew/session_storage.py`) interpolated `candidate.name` with `%s`, letting one log record forge additional records. Both sites now use `%r`, matching the convention the file already uses for untrusted values (the adjacent `claimed` id was already `%r`).

Refs #6281 for the general log-forgery class.

Closes #6315

# Changes

- `list_trash` missing-manifest `logger.debug` and batch-id-disagreement `logger.warning`: `%s` → `%r` on the batch directory name, with a one-line rationale comment at each site.
- New `TestTrashBatchNamesAreLogSafe` in `test/test_session_storage.py`:
  - Two end-to-end forged-name tests (real directory / real rename with an embedded newline) asserting the rendered record stays one line and carries the name repr'd. They `pytest.skip` on filesystems that refuse a newline in a name (Windows shards).
  - One seam-injected test (monkeypatched `iterdir` / `_read_manifest`) that pins both sites on every platform, so the Windows shards keep mutation coverage despite the skips.

Sweep result: inside `list_trash` these two sites were the only unescaped agent-controlled interpolations; the trash-root warnings carry a fixed `data_home()`-derived path, and PR #6312's `_manifest_records` site is untouched (already correct).

# Testing

- All 3 new tests are mutation-verified: reverting either `%r` to `%s` fails all 3.
- Local gates green: isort, flake8, diff-scoped black gate, mypy, `test_session_storage.py` + `test_session_storage_api.py` (172 passed). Full-suite failures match the known host-env baseline (xdist worker budget, AF_UNIX path length), unrelated to this change.
- Pre-push blind dual-model review: GPT lane PASS (0 findings); Opus lane PASS with advisories — cross-platform seam test and comment symmetry adopted; a restore-path manifest-`uid` logging sibling was identified as out of scope and will be filed as a follow-up issue.

no screenshots: backend-only logging change, no user-visible UI.

# Blocked / follow-ups

- Follow-up (out of scope per the issue): `_restore_locked` logs the manifest-supplied `uid` with `%s` at three sites — same forgery class, different function; to be filed as a separate issue.
