### PR TITLE
fix(images): stop an oversized screenshot wedging a session for good

### DIFF
--- a/docs/architecture/design-notes/README.md
+++ b/docs/architecture/design-notes/README.md
@@ -16,6 +16,7 @@ grows into a subsystem should become a spec under
 | [mcp-entry-provenance.md](mcp-entry-provenance.md) | Which entries in a shared MCP config file a sync may rewrite: the write-authorship marker and its four outcomes. |
 | [mcp-gateway-claim-push.md](mcp-gateway-claim-push.md) | Event-driven caller identity for pooled MCP stubs. |
 | [mcp-gateway-oversize-response.md](mcp-gateway-oversize-response.md) | Handling an MCP tool response that exceeds the gateway read buffer. |
+| [oversized-image-session-wedge.md](oversized-image-session-wedge.md) | Why one oversized screenshot fails every later turn, which capture path escapes the inline-image caps, and how to repair a wedged transcript. |
 | [mcp-stub-decoupling.md](mcp-stub-decoupling.md) | Why the stub is emitted for every server, and why per-connection backends stay outside the pooling budget. |
 | [profiling.md](profiling.md) | The debug-only stack sampler and desktop app metrics. |
 | [tool-stall-watchdog-placement.md](tool-stall-watchdog-placement.md) | Which stall checks belong in the ACP read loop and which must be judged out of band. |

--- a/docs/architecture/design-notes/oversized-image-session-wedge.md
+++ b/docs/architecture/design-notes/oversized-image-session-wedge.md
@@ -1,0 +1,91 @@
+# The oversized-image session wedge, and how to unwedge a transcript
+
+If a session started failing every turn with this, you are here for the
+recovery command at the bottom:
+
+```
+messages.60.content.0.image.source.base64.data: At least one of the image
+dimensions exceed max allowed size for many-image requests: 2000 pixels
+```
+
+## Why one image kills a whole conversation
+
+The provider rejects the ENTIRE request when a many-image conversation carries
+any image wider or taller than `imaging.MAX_IMAGE_EDGE_PX`. kiro-cli replays the
+whole message history on every turn, so the offending block sits at a fixed
+history index that nothing evicts.
+
+That produces the worst possible split between cause and symptom:
+
+| | |
+|---|---|
+| The turn that STORES the image | succeeds, silently |
+| Turns after it, while the session is small | succeed -- under ~20 images the request is not "many-image" |
+| Every turn once enough images accumulate | fails, forever, with a message naming a message index rather than the image |
+
+Capping new captures cannot heal a transcript that already carries one. The
+stored bytes have to be rewritten or the conversation is over.
+
+## Where the caps are, and the path that escapes them
+
+| Enforcement point | Covers |
+|---|---|
+| `acp/prompt_blocks.py` | images entering a PROMPT (what a user attaches) |
+| `mcp_gateway/image_budget.py` | images an MCP TOOL returns |
+| `computer_use/types.py` `MAX_SCREENSHOT_MAX_PX` | Kiro Crew's own window captures, bounded by the inline cap |
+
+The path that escapes all three: an agent writes a screenshot to disk, then
+opens it with kiro-cli's built-in `read` tool in Image mode. That tool reads the
+file itself and writes raw bytes straight into kiro-cli's own transcript, so no
+Kiro Crew code is on the path and there is nothing to intercept.
+
+This is why the cap has to hold on the FILE, before it is read. Note that no
+launch option can guarantee it: a `fullPage` capture takes the whole document
+height regardless of viewport or `deviceScaleFactor`, so pinning a viewport
+reduces incidence without bounding anything. Skills that instruct a capture
+carry a downscale step for this reason
+(`builtin_skills/web-verify/scripts/downscale_image.py`).
+
+## Recovery
+
+Dry run first -- it changes nothing and prints what it would rewrite:
+
+```bash
+python -m kiro_crew.session_image_repair ~/.kiro/sessions/cli/<session-id>.jsonl
+```
+
+Then, with the session ENDED (not merely idle -- see below):
+
+```bash
+python -m kiro_crew.session_image_repair --apply ~/.kiro/sessions/cli/<session-id>.jsonl
+```
+
+Notes on what it does and does not do:
+
+- It refuses to run against a transcript whose sibling `<session-id>.lock` names a
+  live process, because a rewrite while kiro-cli is appending would drop the
+  appended turn. `--allow-live` overrides that; you almost certainly do not want
+  it. Note that the lock file's mere presence is not the signal -- stale locks
+  accumulate in that directory without bound -- so the pid is probed.
+- It always writes a `.pre-image-repair.bak` sidecar, through an owner-only
+  no-follow write so a symlink planted at that predictable name cannot redirect
+  it -- and it REFUSES if a sidecar is already there rather than replacing it.
+  The first sidecar is the only copy of the pre-repair transcript, so if an
+  earlier run dropped an uncappable image those bytes exist nowhere else. Move
+  the old sidecar aside if you really want to repair again.
+- It also re-stats the transcript immediately before replacing it and refuses if
+  it moved. That narrows the write window to two syscalls; it does not eliminate
+  it, since there is no lock protocol to join.
+- Untouched lines are passed through byte-for-byte. Only the records being
+  parsed are decoded, so a malformed byte sequence elsewhere in the file is
+  neither destroyed nor a reason to refuse the repair.
+- A generic deep walk runs alongside the anchored traversal purely as a
+  tripwire. If it finds image-shaped blocks the anchored shapes could not reach,
+  the report says so and refuses to look clean -- because the dangerous failure
+  for this tool is not a crash, it is reporting "all within cap" on a transcript
+  that is still wedged. Those blocks are never rewritten; a false alarm from a
+  tool payload that merely looks like a block is the acceptable direction.
+- An image with no compliant rendition becomes a text marker rather than being
+  left in place. Losing one image beats losing every later turn.
+- It is not a sweeper and not a `kirocrew` subcommand, on purpose: it rewrites
+  another tool's data directory, so it stays an explicit operator action.

--- a/src/kiro_crew/computer_use/types.py
+++ b/src/kiro_crew/computer_use/types.py
@@ -427,7 +427,18 @@ DEFAULT_ATTACH_SCREENSHOT = True
 DEFAULT_SCREENSHOT_MAX_PX = 1280
 DEFAULT_SCREENSHOT_JPEG_QUALITY = 55
 MIN_SCREENSHOT_MAX_PX = 320
-MAX_SCREENSHOT_MAX_PX = 4096
+# Ceiling deliberately equal to the inline-image cap (kiro_crew.imaging
+# MAX_IMAGE_EDGE_PX), NOT to any display resolution. A capture is written to
+# disk and its path is advertised back to the agent (see render.py's
+# SCREENSHOT_NOTE), so the agent can open it with the native read tool -- and
+# the provider rejects the ENTIRE request once a many-image conversation
+# carries any image over that cap. Because history is replayed every turn, one
+# oversized capture wedges every later turn, not just its own. A ceiling above
+# the cap therefore lets a configured value guarantee session death later,
+# while looking fine in a short session that has not yet accumulated enough
+# images to count as many-image -- the worst possible split between cause and
+# symptom. Raising it back is not a knob, it is a trap.
+MAX_SCREENSHOT_MAX_PX = 2000
 SCREENSHOT_DIR_NAME = "kirocrew-computer-shots"
 SCREENSHOT_FILE_PREFIX = "shot-"
 SCREENSHOT_FILE_SUFFIX = ".jpeg"

--- a/src/kiro_crew/session_image_repair.py
+++ b/src/kiro_crew/session_image_repair.py
@@ -1,0 +1,776 @@
+"""Repair kiro-cli session transcripts that an oversized image has wedged.
+
+A provider rejects the ENTIRE request when a many-image conversation carries any
+image wider or taller than :data:`kiro_crew.imaging.MAX_IMAGE_EDGE_PX`::
+
+    messages.60.content.0.image.source.base64.data: At least one of the image
+    dimensions exceed max allowed size for many-image requests: 2000 pixels
+
+kiro-cli replays the whole message history every turn, so the offending block
+sits at a fixed history index that nothing evicts. The session does not fail at
+the turn that stored the image; it fails on every turn from the moment enough
+images accumulate for the request to count as many-image. Capping new captures
+therefore cannot heal a transcript that already carries one -- the stored bytes
+have to be rewritten, or the conversation is over.
+
+Why this is a user-invoked command and not a sweeper
+----------------------------------------------------
+The files belong to kiro-cli, not to Kiro Crew, and automatically rewriting
+another tool's data directory was ruled out. Healing existing damage is an
+explicit action with a visible dry run and a backup sidecar, so the operator
+decides when a transcript is safe to touch. Run it only while the session is
+idle: kiro-cli appends to these files, and an append that lands during the
+rewrite is lost.
+
+What a repair does to a block it cannot fix
+-------------------------------------------
+:func:`kiro_crew.imaging.downscale_image_block` fails closed -- it returns
+``None`` when no rendition fits the budget. Leaving such a block in place keeps
+the session dead, so it is replaced by a text block naming the drop. Losing one
+image is strictly better than losing every later turn.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+from kiro_crew import platform_compat
+from kiro_crew.imaging import (
+    MAX_IMAGE_EDGE_PX,
+    downscale_image_block,
+    image_dimensions,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Marker text substituted for an image block that has no compliant rendition.
+DROPPED_PLACEHOLDER = (
+    "[image dropped by session repair: no rendition fits the " "{max_edge}px inline-image cap]"
+)
+
+
+@dataclass
+class BlockFinding:
+    """One stored image block and what the repair decided to do with it."""
+
+    line_no: int
+    width: int
+    height: int
+    raw_bytes: int
+    action: str  # "keep" | "resize" | "drop"
+    new_size: tuple[int, int] | None = None
+
+
+class BackupExistsError(RuntimeError):
+    """A ``.pre-image-repair.bak`` sidecar is already there.
+
+    The sidecar's value is that it holds the transcript as it was BEFORE any
+    repair, which is the only place a dropped image's bytes survive. Writing it
+    unconditionally destroys exactly that: a second ``--apply`` would replace the
+    true pre-repair copy with content that has already been rewritten, and if the
+    first run dropped an uncappable block those bytes then exist nowhere at all.
+
+    The refusal also covers the uglier ordering -- the backup is written before
+    the final movement check, so an append arriving mid-write would clobber the
+    old sidecar and THEN refuse the repair, losing the backup for a write that
+    never happened.
+
+    Deliberately not a check-then-clobber with a nicer message: the first backup
+    is the one worth keeping, so the operator is told to move it aside and decide.
+    """
+
+
+class TranscriptLiveError(RuntimeError):
+    """A live kiro-cli process is still writing this transcript.
+
+    Refusing here is the difference between a theoretical race and the one that
+    actually loses data: an operator running ``--apply`` on a session that never
+    stopped. The residual stat-to-rename window cannot be closed, but this
+    removes the condition under which it is likely to be hit at all.
+    """
+
+
+class TranscriptMovedError(RuntimeError):
+    """The transcript changed on disk between the scan and the write.
+
+    kiro-cli appends to these files. A repair rewrites the whole file from the
+    lines the scan produced, so an append that lands in between would be
+    silently discarded -- the operator would see a successful repair and a lost
+    turn. Refusing is the only honest outcome; the scan is cheap to redo.
+    """
+
+
+@dataclass
+class FileReport:
+    """Per-transcript outcome, printable in both dry-run and apply mode."""
+
+    path: Path
+    images: int = 0
+    findings: list[BlockFinding] = field(default_factory=list)
+    rewritten_lines: int = 0
+    error: str | None = None
+    #: ``(size, mtime_ns)`` as of the scan, or ``None`` when it could not be
+    #: read. Passed back into :func:`apply_repair` so the write can refuse a
+    #: transcript that moved underneath it.
+    source_stat: tuple[int, int] | None = None
+    #: Image-shaped blocks the generic walk saw and the anchored traversal did
+    #: not. Non-zero means the traversal's shape set may have drifted behind
+    #: kiro-cli, so a clean report cannot be trusted. Never repaired -- only
+    #: reported, loudly, because the alternative failure is a silent no-op.
+    unanchored_images: int = 0
+    #: Line numbers where that divergence was seen, so it can be inspected.
+    unanchored_lines: list[int] = field(default_factory=list)
+    #: True when the tripwire walk hit its depth ceiling and could not finish.
+    #: Reported, never swallowed: an unverified subtree must not read as clean.
+    walk_truncated: bool = False
+
+    @property
+    def oversized(self) -> list[BlockFinding]:
+        return [f for f in self.findings if f.action != "keep"]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.oversized)
+
+
+def _block_list(node: dict) -> list:
+    """The block array of a record, a snapshot message, or a container block.
+
+    Two spellings, both observed: a record and a container block put their
+    blocks at ``data.content``, while a message inside a compaction snapshot
+    puts them at a top-level ``content``. Exactly one is present on any given
+    node in every transcript surveyed, so the fallback cannot double-count.
+    """
+    data = node.get("data")
+    if isinstance(data, dict):
+        content = data.get("content")
+        if isinstance(content, list):
+            return content
+    content = node.get("content")
+    return content if isinstance(content, list) else []
+
+
+def _snapshot_messages(node: dict) -> list:
+    """The message list a ``Compaction`` record carries, if any.
+
+    Compaction is not a footnote: across the surveyed transcripts its snapshot
+    holds 42% of all stored image blocks (5314 of 12615), more than
+    ``ToolResults`` and nearly as many as ``Prompt``. A traversal that skips it
+    reports a clean transcript while leaving a live oversized image in place --
+    the tool would return success and change nothing, and the session would stay
+    dead.
+    """
+    data = node.get("data")
+    if not isinstance(data, dict):
+        return []
+    snapshot = data.get("messages_snapshot")
+    return snapshot if isinstance(snapshot, list) else []
+
+
+def _iter_image_blocks(node: Any) -> Iterator[dict]:
+    """Yield the transcript image blocks reachable from a record.
+
+    Traversal is ANCHORED to the block arrays rather than walking every dict in
+    the record. That restriction is the point: a generic walk also descends into
+    the *payload* of a text or json block, and a tool whose output happens to
+    contain a dict shaped like an image block would then be rewritten as if it
+    were transcript media. This module writes another tool's data file, so a
+    false positive is corruption of application data.
+
+    The four shapes below are the complete set found across 16253 transcripts,
+    and the traversal is built from that survey rather than from the two shapes
+    that happened to appear in the transcripts under repair::
+
+        Prompt       .data.content[i]
+        ToolResults  .data.content[i].data.content[i]
+        Compaction   .data.messages_snapshot[i].content[i]
+        Compaction   .data.messages_snapshot[i].content[i].data.content[i]
+
+    Anchoring buys safety in one direction and costs coverage in the other, so
+    it is only sound while the shape set is known to be complete: a future
+    record kind that nests its blocks somewhere new would be MISSED, and a miss
+    here is not a benign no-op -- the report would say nothing was over cap
+    while the transcript stayed wedged. That is why the survey above is part of
+    the contract and why the tests pin all four shapes.
+    """
+    if not isinstance(node, dict):
+        return
+    for message in _snapshot_messages(node):
+        if isinstance(message, dict):
+            yield from _iter_blocks_of(message)
+    yield from _iter_blocks_of(node)
+
+
+def _iter_blocks_of(node: dict) -> Iterator[dict]:
+    """Yield image blocks from one node's block array, descending containers."""
+    for block in _block_list(node):
+        if not isinstance(block, dict):
+            continue
+        kind = block.get("kind")
+        if kind == "image":
+            yield block
+        elif kind == "toolResult":
+            # The one container kind real transcripts show: its own block array
+            # sits a level deeper. Spelled inline rather than held in a set --
+            # there has only ever been one.
+            yield from _iter_blocks_of(block)
+
+
+#: The only payload spelling kiro-cli has been observed to write, verified
+#: against real transcripts::
+#:
+#:     {"kind": "image",
+#:      "data": {"format": "png",
+#:               "source": {"kind": "bytes", "data": [137, 80, 78, 71, ...]}}}
+#:
+#: The inner ``kind`` names the payload encoding, so it is checked rather than
+#: assumed: a future ``{"kind": "path"}`` source would carry a filename in
+#: ``data``, and coercing that through ``bytes()`` would corrupt the record.
+_SOURCE_BYTES_KIND = "bytes"
+
+
+def _block_bytes(block: dict) -> bytes | None:
+    """Decode a stored image block's payload, or ``None`` if it has none."""
+    source = _block_source(block)
+    if source is None:
+        return None
+    raw = source.get("data")
+    if not isinstance(raw, list):
+        return None
+    try:
+        return bytes(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _block_source(block: dict) -> dict | None:
+    """Return the byte-payload source dict of *block*, or ``None``."""
+    data = block.get("data")
+    if not isinstance(data, dict):
+        return None
+    source = data.get("source")
+    if not isinstance(source, dict):
+        return None
+    if source.get("kind") != _SOURCE_BYTES_KIND:
+        return None
+    return source
+
+
+def _mime_of(block: dict) -> str:
+    """Resolve the block's mime type from its bare ``format`` tag ("png")."""
+    data = block.get("data")
+    if isinstance(data, dict):
+        fmt = data.get("format")
+        if isinstance(fmt, str) and fmt:
+            return fmt if "/" in fmt else f"image/{fmt}"
+    return "image/png"
+
+
+def _rewrite_block(block: dict, payload: bytes, max_edge: int) -> BlockFinding | None:
+    """Cap one block in place. Returns the finding, or ``None`` if not an image."""
+    dims = image_dimensions(payload)
+    if dims is None:
+        return None
+    width, height = dims
+    if max(width, height) <= max_edge:
+        return BlockFinding(0, width, height, len(payload), "keep")
+
+    fitted = downscale_image_block(payload, _mime_of(block), max_edge=max_edge)
+    if fitted is None:
+        # Fail-closed from the imaging layer. Keeping the block keeps the
+        # session dead, so drop the payload and leave a readable trace.
+        block.clear()
+        block["kind"] = "text"
+        block["data"] = DROPPED_PLACEHOLDER.format(max_edge=max_edge)
+        return BlockFinding(0, width, height, len(payload), "drop")
+
+    new_bytes, new_mime = fitted
+    source = _block_source(block)
+    if source is None:  # pragma: no cover - payload was read through it
+        return BlockFinding(0, width, height, len(payload), "keep")
+    source["data"] = list(new_bytes)
+    data = block["data"]
+    if isinstance(data.get("format"), str):
+        data["format"] = new_mime.split("/", 1)[-1]
+    new_dims = image_dimensions(new_bytes) or (0, 0)
+    return BlockFinding(0, width, height, len(payload), "resize", new_dims)
+
+
+#: Depth ceiling for the tripwire walk. Real transcripts nest about four levels
+#: (record -> block array -> container block -> its block array), so this is
+#: orders of magnitude of headroom -- it exists only to keep an arbitrarily
+#: nested tool payload from exhausting the interpreter stack, which would abort
+#: the repair of a transcript the operator needs repaired.
+_MAX_WALK_DEPTH = 200
+
+
+def _generic_image_blocks(node: Any, depth: int = 0) -> tuple[list[dict], bool]:
+    """Every image-shaped dict anywhere under *node*, for DETECTION ONLY.
+
+    Returns ``(blocks, truncated)`` where *truncated* means the walk hit
+    :data:`_MAX_WALK_DEPTH` and could not finish -- which is reported as a
+    divergence rather than swallowed, because the tripwire's whole purpose is
+    that it never lets a report read clean when verification did not happen.
+
+    The anchored traversal is deliberately narrow, and its failure direction is
+    the dangerous one: a kiro-cli format change it does not know about makes the
+    repair report a clean transcript while the session stays wedged -- success
+    indistinguishable from failure, on the one command a wedged user is told to
+    run. This PR nearly shipped exactly that, having missed the ``Compaction``
+    shape that holds 42% of real image blocks.
+
+    So the generic walk runs alongside as a tripwire. Its result is NEVER
+    rewritten -- descending into a text or json payload is precisely why the
+    anchored form exists -- it is only counted, so a divergence can be reported.
+    A false alarm from a tool payload that happens to look like an image block is
+    harmless noise; a silent miss is not, which is the whole reason the check is
+    allowed to be imprecise in this direction and no other.
+
+    Iteration is depth-bounded rather than trusting the recursion limit: this
+    walk descends into arbitrary TOOL PAYLOADS, whose nesting is not this
+    module's data and has no natural bound.
+    """
+    if depth > _MAX_WALK_DEPTH:
+        return [], True
+    found: list[dict] = []
+    truncated = False
+    if isinstance(node, dict):
+        if node.get("kind") == "image":
+            return [node], False
+        children: Any = node.values()
+    elif isinstance(node, list):
+        children = node
+    else:
+        return [], False
+    for value in children:
+        sub, sub_truncated = _generic_image_blocks(value, depth + 1)
+        found.extend(sub)
+        truncated = truncated or sub_truncated
+    return found, truncated
+
+
+def scan_file(path: Path) -> tuple[FileReport, list[bytes] | None]:
+    """Inspect one transcript; return its report and the repaired lines.
+
+    The repaired-lines list is ``None`` when nothing needs rewriting, so a
+    caller can skip the write entirely rather than rewriting a file to the same
+    content -- a no-op rewrite still risks losing a concurrent append.
+    """
+    report = FileReport(path=path)
+    try:
+        st = path.stat()
+        report.source_stat = (st.st_size, st.st_mtime_ns)
+    except OSError:
+        report.source_stat = None
+    out_lines: list[bytes] = []
+    dirty = False
+
+    try:
+        with path.open("rb") as handle:
+            for line_no, raw_line in enumerate(handle):
+                stripped = raw_line.rstrip(b"\n")
+                # A CRLF transcript keeps its \r here, and passthrough lines are
+                # therefore byte-exact on either convention. Captured so a
+                # REWRITTEN line can be given the same terminator back -- writing
+                # a bare \n into an otherwise CRLF file would leave the repair as
+                # the one line with a different ending.
+                eol = b"\r" if stripped.endswith(b"\r") else b""
+                # Read as BYTES and pass untouched lines through verbatim. A
+                # text-mode read with errors="replace" would substitute U+FFFD
+                # for any byte sequence that is not valid UTF-8, and because
+                # every line is rewritten from what was read, one malformed
+                # sequence anywhere in the file would be irreversibly destroyed
+                # on apply -- in a line this tool has no business touching, in
+                # another tool's data file. Strict decoding would instead refuse
+                # the whole transcript and leave the session dead, so neither
+                # text mode is right: only the lines actually being parsed need
+                # to be text.
+                #
+                # Prefilter on the LOOSE token so the drift cross-check below can
+                # see lines the strict spelling would skip. Decoding every record
+                # of a 29MB transcript is the slow way round, but gating on
+                # b'"image"' rather than b'"kind":"image"' costs little and means
+                # a future kiro-cli that serializes with a space after the colon
+                # shows up as a divergence warning instead of a silent miss.
+                if b'"image"' not in stripped:
+                    out_lines.append(stripped)
+                    continue
+                try:
+                    record = json.loads(stripped.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+                    # RecursionError belongs here alongside the decode errors:
+                    # json.loads raises it on deeply nested input, and this is
+                    # ANOTHER tool's file, so the nesting is not ours to bound.
+                    # Uncaught it would abort the whole repair on one odd line.
+                    # Not decodable/parseable, so not the JSON kiro-cli writes,
+                    # so not a record carrying media. Passed through byte-for-byte.
+                    out_lines.append(stripped)
+                    continue
+
+                line_dirty = False
+                anchored = [b for b in _iter_image_blocks(record) if _block_bytes(b) is not None]
+                # Tripwire, before the rewrite mutates anything: count blocks the
+                # generic walk can see that the anchored traversal could not.
+                # Identity, not count, so a payload-embedded lookalike and a
+                # genuinely missed shape are told apart by object.
+                anchored_ids = {id(b) for b in anchored}
+                generic, walk_truncated = _generic_image_blocks(record)
+                unanchored = [
+                    b for b in generic if id(b) not in anchored_ids and _block_bytes(b) is not None
+                ]
+                if unanchored or walk_truncated:
+                    # A truncated walk counts as a divergence even with nothing
+                    # found: verification did not complete, so the report must not
+                    # read clean. That is the tripwire's only guarantee.
+                    report.unanchored_images += len(unanchored)
+                    report.unanchored_lines.append(line_no)
+                    if walk_truncated:
+                        report.walk_truncated = True
+
+                for block in anchored:
+                    payload = _block_bytes(block)
+                    if payload is None:  # pragma: no cover - filtered above
+                        continue
+                    report.images += 1
+                    finding = _rewrite_block(block, payload, MAX_IMAGE_EDGE_PX)
+                    if finding is None:
+                        continue
+                    finding.line_no = line_no
+                    report.findings.append(finding)
+                    if finding.action != "keep":
+                        line_dirty = True
+
+                if line_dirty:
+                    dirty = True
+                    report.rewritten_lines += 1
+                    out_lines.append(
+                        json.dumps(record, separators=(",", ":")).encode("utf-8") + eol
+                    )
+                else:
+                    out_lines.append(stripped)
+    except OSError as exc:
+        report.error = str(exc)
+        return report, None
+
+    return report, (out_lines if dirty else None)
+
+
+def _live_writer_pid(path: Path) -> int | None:
+    """The pid of a live kiro-cli holding *path*, from its sibling lock file.
+
+    kiro-cli writes ``<session-id>.lock`` next to the transcript containing
+    ``{"pid": N, "started_at": "..."}``. That is the only coordination signal
+    the writer exposes -- there is no advisory lock and no protocol to join --
+    and it is enough to refuse the case that actually loses data in practice:
+    an operator running ``--apply`` against a session that is still running.
+
+    Existence alone means nothing and must not be treated as a signal: stale
+    locks accumulate without bound (6471 were present on one machine, the oldest
+    months old), so the pid has to be probed. Routed through
+    ``platform_compat.pid_exists`` because a raw ``os.kill(pid, 0)`` does not
+    probe liveness on Windows.
+
+    A recycled pid yields a false positive and refuses a repair that would have
+    been safe. That is the right direction to fail: the operator can re-run,
+    whereas a lost turn is gone.
+    """
+    lock_path = path.with_suffix(".lock")
+    try:
+        raw = lock_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        pid = json.loads(raw).get("pid")
+    except (ValueError, AttributeError):
+        return None
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    return pid if platform_compat.pid_exists(pid) else None
+
+
+def _refuse_if_moved(path: Path, expect: tuple[int, int] | None) -> None:
+    """Raise :class:`TranscriptMovedError` if *path* no longer matches *expect*."""
+    if expect is None:
+        return
+    st = path.stat()
+    if (st.st_size, st.st_mtime_ns) != expect:
+        raise TranscriptMovedError(
+            f"{path.name} changed on disk since the scan "
+            f"(size/mtime {expect} -> {(st.st_size, st.st_mtime_ns)}); "
+            "re-run the repair"
+        )
+
+
+def _write_backup_exclusively(path: Path, backup_path: Path) -> None:
+    """Create the sidecar, refusing if anything is already at that name.
+
+    ``O_CREAT | O_EXCL`` rather than a check followed by a write, because the
+    check-then-write form has a window: two concurrent ``--apply`` runs can both
+    find no sidecar, and the later one's read then captures ALREADY-REPAIRED
+    content and replaces the genuine pre-repair copy. Exclusive create is the
+    filesystem primitive for this -- exactly one caller wins, the other gets
+    ``EEXIST`` -- so the guarantee is atomic rather than merely narrow.
+
+    Three properties fall out of the same call rather than needing separate
+    defences. It refuses an existing regular file, which is the re-run case. It
+    refuses a symlink, dangling or not, because ``O_CREAT | O_EXCL`` will not
+    follow one -- so the predictable name cannot be used to redirect the write
+    into a file the planter could not write directly. And it never truncates,
+    so the previous sidecar's bytes are not at risk even momentarily.
+
+    This gives up ``atomic_write``'s temp-file-and-rename crash safety, which is
+    why the partial file is removed on any failure: at this point in the repair
+    NOTHING has been modified yet, so a discarded partial backup costs a re-run
+    and nothing else. The failure that mattered -- a backup destroyed after a
+    repair already dropped an image -- is the one exclusive create prevents.
+    """
+    # Second leg, for Windows only in practice: a CI Windows shard showed
+    # O_CREAT|O_EXCL NOT refusing a DANGLING symlink at this path, so the
+    # symlink protection cannot rest on O_EXCL alone. This is a check-then-act
+    # and is deliberately NOT the concurrency guarantee -- O_EXCL below remains
+    # the atomic one for the re-run and concurrent-run cases. It only closes the
+    # platform gap where a planted link would otherwise be followed.
+    if backup_path.is_symlink():
+        raise BackupExistsError(
+            f"{backup_path.name} already exists (symlink); it would be followed "
+            "or overwritten. Move it aside first."
+        )
+    try:
+        fd = os.open(backup_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise BackupExistsError(
+            f"{backup_path.name} already exists; it holds the pre-repair "
+            "transcript and would be overwritten. Move it aside first."
+        ) from exc
+    fd_owned = True  # the raw descriptor is ours until fdopen takes it
+    try:
+        # Lock down BEFORE any content and before the write-mode open, which is
+        # both the real invariant and what the lockdown gate checks: the 0o600
+        # mode above already means POSIX never sees a readable moment, but that
+        # argument is ignored on Windows, so the DACL has to land while the file
+        # is still empty (issue #5307).
+        platform_compat.restrict_to_owner(backup_path)
+        handle = os.fdopen(fd, "wb")
+        fd_owned = False  # the file object owns it now and will close it
+        with handle:
+            handle.write(path.read_bytes())
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        # The lockdown is fail-loud and shells out to icacls on Windows, so it
+        # can raise while we still hold the raw fd. Close it before unlinking:
+        # Windows refuses to remove a file with an open handle, and a stranded
+        # empty sidecar would make every later --apply raise BackupExistsError --
+        # a permanent block produced by a failure that changed nothing.
+        if fd_owned:
+            os.close(fd)
+        backup_path.unlink(missing_ok=True)
+        raise
+
+
+def apply_repair(
+    path: Path,
+    lines: list[bytes],
+    *,
+    backup: bool = True,
+    expect: tuple[int, int] | None = None,
+    allow_live: bool = False,
+) -> Path | None:
+    """Atomically replace *path* with *lines*; return the backup path if made.
+
+    Written to a sibling temp file and renamed so a crash mid-write cannot
+    leave a truncated transcript, which would cost the whole session rather
+    than one image.
+
+    *expect* is the ``(size, mtime_ns)`` the scan saw. When given it is checked
+    TWICE: once up front, and again immediately before :func:`os.replace`. The
+    rewrite is built from lines read earlier, so an append landing in between
+    would be dropped silently.
+
+    Two checks rather than one because the work between them is not quick. The
+    backup is a full copy of the whole transcript and the temp file is a
+    full rewrite plus an ``fsync`` -- on a 26MB transcript that is seconds, and
+    an append arriving inside it would pass the early check and still be lost.
+    The early check is kept because failing before copying tens of megabytes is
+    cheaper than failing after.
+
+    The residual window cannot be closed, only narrowed: between the final stat
+    and the rename there is no lock to hold, and kiro-cli does not participate
+    in one. What changes is the width -- two syscalls instead of the duration of
+    a multi-megabyte write. Passing ``None`` skips both checks, which is only
+    right when the caller already knows the file is quiescent.
+
+    What DOES address the realistic trigger is the liveness refusal: unless
+    *allow_live*, a transcript whose sibling lock names a running kiro-cli is
+    refused outright with :class:`TranscriptLiveError`. The narrow window is only
+    dangerous while something is actively appending, so declining to touch a live
+    session removes the condition rather than chasing the symptom.
+    """
+    if not allow_live:
+        live_pid = _live_writer_pid(path)
+        if live_pid is not None:
+            raise TranscriptLiveError(
+                f"{path.name} is held by a running kiro-cli (pid {live_pid}); "
+                "end that session first, or pass --allow-live to override"
+            )
+
+    _refuse_if_moved(path, expect)
+
+    backup_path: Path | None = None
+    if backup:
+        backup_path = path.with_suffix(path.suffix + ".pre-image-repair.bak")
+        _write_backup_exclusively(path, backup_path)
+
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name, suffix=".tmp")
+    fd_owned = True
+    try:
+        # Lock the temp down BEFORE any content and before the write-mode open.
+        # mkstemp is already 0o600 on POSIX, but on Windows the temp inherits the
+        # session directory's DACL -- and os.replace carries the TEMP's
+        # permissions onto the transcript, so a repair would silently WIDEN
+        # access to the whole conversation for other local accounts. Same
+        # invariant and same ordering as the backup above (issue #5307).
+        platform_compat.restrict_to_owner(tmp_name)
+        handle = os.fdopen(fd, "wb")
+        fd_owned = False  # the file object owns it now
+        with handle:
+            for line in lines:
+                handle.write(line)
+                handle.write(b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Last possible moment: everything expensive is already done, so this
+        # leaves only the stat-to-rename gap instead of the whole write.
+        _refuse_if_moved(path, expect)
+        os.replace(tmp_name, path)
+    except BaseException:
+        if fd_owned:
+            os.close(fd)
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+    return backup_path
+
+
+def _format_report(report: FileReport, *, applied: bool) -> str:
+    if report.error:
+        return f"{report.path.name}: ERROR {report.error}"
+    parts: list[str]
+    if not report.changed:
+        parts = [f"{report.path.name}: {report.images} image(s), all within cap"]
+    else:
+        verb = "repaired" if applied else "would repair"
+        parts = [
+            f"{report.path.name}: {report.images} image(s), "
+            f"{len(report.oversized)} over cap, {verb} {report.rewritten_lines} record(s)"
+        ]
+        for finding in report.oversized:
+            if finding.action == "drop":
+                parts.append(f"    L{finding.line_no} {finding.width}x{finding.height} -> DROPPED")
+            else:
+                new = finding.new_size or (0, 0)
+                parts.append(
+                    f"    L{finding.line_no} {finding.width}x{finding.height}"
+                    f" -> {new[0]}x{new[1]}"
+                )
+    if report.unanchored_images or report.walk_truncated:
+        # Printed for BOTH outcomes, and especially the clean one: "all within
+        # cap" plus a drift warning is the state an operator must not read as
+        # done.
+        lines = ", ".join(f"L{n}" for n in report.unanchored_lines[:8])
+        if report.walk_truncated:
+            parts.append(
+                f"    WARNING: a record at {lines} nests deeper than this tool "
+                "will walk, so it could NOT be fully checked for image blocks. "
+                "Treat this report as incomplete."
+            )
+        if report.unanchored_images:
+            parts.append(
+                f"    WARNING: {report.unanchored_images} image block(s) at {lines} were not "
+                "reachable by the known transcript shapes and were NOT repaired. Either a "
+                "tool payload merely looks like an image block, or kiro-cli's format has "
+                "changed and this report cannot be trusted."
+            )
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="session-image-repair",
+        description=(
+            "Cap oversized images stored in kiro-cli session transcripts. "
+            "Dry run by default; pass --apply to rewrite."
+        ),
+    )
+    parser.add_argument("paths", nargs="+", type=Path, help="session .jsonl file(s)")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="rewrite the transcripts (default is a dry run that changes nothing)",
+    )
+    # No --no-backup flag: the sidecar is the only recovery path for an
+    # operation that rewrites another tool's data file, and nothing named a harm
+    # it removes. An operator who does not want the copy can delete one file.
+    # apply_repair keeps a backup= keyword because the tests genuinely drive it.
+    parser.add_argument(
+        "--allow-live",
+        action="store_true",
+        help=(
+            "repair even when a running kiro-cli holds the transcript "
+            "(refused by default; an append during the write would be lost)"
+        ),
+    )
+    # No --max-edge flag and no max_edge parameter: the cap is the provider's,
+    # not the operator's. A higher value produces a file the provider still
+    # rejects, and a lower one has no stated use, so there is nothing for a
+    # caller to choose. MAX_IMAGE_EDGE_PX is read directly.
+    args = parser.parse_args(argv)
+
+    exit_code = 0
+    for path in args.paths:
+        report, lines = scan_file(path)
+        if report.error:
+            exit_code = 1
+        applied = False
+        if args.apply and lines is not None:
+            try:
+                backup = apply_repair(
+                    path,
+                    lines,
+                    backup=True,
+                    expect=report.source_stat,
+                    allow_live=args.allow_live,
+                )
+            except TranscriptLiveError as exc:
+                print(f"{path.name}: REFUSED {exc}", file=sys.stderr)
+                exit_code = 1
+                continue
+            except BackupExistsError as exc:
+                print(f"{path.name}: REFUSED {exc}", file=sys.stderr)
+                exit_code = 1
+                continue
+            except TranscriptMovedError as exc:
+                print(f"{path.name}: REFUSED {exc}", file=sys.stderr)
+                exit_code = 1
+                continue
+            except OSError as exc:
+                print(f"{path.name}: ERROR writing repair: {exc}", file=sys.stderr)
+                exit_code = 1
+                continue
+            applied = True
+            if backup is not None:
+                print(f"{path.name}: backup at {backup.name}")
+        print(_format_report(report, applied=applied))
+
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/test/test_computer_use_capture.py
+++ b/test/test_computer_use_capture.py
@@ -870,3 +870,28 @@ def test_attaching_a_screenshot_preserves_EVERY_other_snapshot_field(spool: Path
         if f.name in image_fields:
             continue
         assert getattr(result, f.name) == getattr(snap, f.name), f.name
+
+
+class TestScreenshotCeilingCannotOutgrowTheInlineImageCap:
+    """The capture ceiling is bounded by what the model can actually be shown.
+
+    A capture is written to disk and its path handed back to the agent, which
+    can then open it with the native read tool. The provider rejects the whole
+    request once a many-image conversation carries any image over
+    ``MAX_IMAGE_EDGE_PX``, and history is replayed every turn, so one oversized
+    capture wedges every later turn. A ceiling above the inline cap therefore
+    lets a configured value guarantee session death -- and it fails LATE, on an
+    unrelated turn, long after the capture that caused it.
+
+    Pinned as a relationship rather than a literal so raising either constant
+    reddens here, which is the drift that produced the original defect.
+    """
+
+    def test_the_ceiling_is_within_the_inline_image_cap(self) -> None:
+        from kiro_crew.imaging import MAX_IMAGE_EDGE_PX
+
+        assert MAX_SCREENSHOT_MAX_PX <= MAX_IMAGE_EDGE_PX
+
+    def test_the_default_and_floor_still_sit_under_the_ceiling(self) -> None:
+        """Lowering the ceiling must not invert the floor/default/ceiling order."""
+        assert MIN_SCREENSHOT_MAX_PX <= DEFAULT_SCREENSHOT_MAX_PX <= MAX_SCREENSHOT_MAX_PX

--- a/test/test_computer_use_capture_windows.py
+++ b/test/test_computer_use_capture_windows.py
@@ -31,6 +31,7 @@ import threading
 import pytest
 
 from kiro_crew.computer_use import capture_windows as C
+from kiro_crew.computer_use.types import MAX_SCREENSHOT_MAX_PX
 
 #: Bytes per pixel at the module's current depth. Derived rather than written as a
 #: literal: the depth is dictated by what ``PW_RENDERFULLCONTENT`` will render into
@@ -424,7 +425,13 @@ class TestTheEncodeAndSpoolPath:
             (0, (320, 160)),  # a config zero would otherwise be "no scaling at all"
             (-1, (320, 160)),
             (64, (320, 160)),  # below MIN_SCREENSHOT_MAX_PX
-            (99999, (4096, 2048)),  # above MAX_SCREENSHOT_MAX_PX
+            # Derived from the constant rather than written out, so lowering the
+            # ceiling cannot leave this asserting a size the clamp no longer
+            # produces. A 10000x5000 source clamps to ceiling x ceiling/2.
+            (
+                99999,
+                (MAX_SCREENSHOT_MAX_PX, MAX_SCREENSHOT_MAX_PX // 2),
+            ),  # above MAX_SCREENSHOT_MAX_PX
         ],
         ids=["zero", "negative", "below-floor", "above-ceiling"],
     )

--- a/test/test_session_image_repair.py
+++ b/test/test_session_image_repair.py
@@ -1,0 +1,1113 @@
+"""Tests for repairing kiro-cli transcripts wedged by an oversized image.
+
+The module rewrites stored image blocks in a ``.jsonl`` transcript so no image
+exceeds the inline-image edge cap. These tests generate REAL PNG bytes with
+Pillow (the fixtures must decode), build records at both observed nesting depths
+(a ``Prompt`` attachment directly under ``content`` and a ``ToolResults`` image
+one ``toolResult`` level deeper), and assert the structural invariants a repair
+must preserve. Pillow is a hard dependency here, as it is in the neighbouring
+``test_web_verify_downscale`` / ``test_image_primitives`` suites, so it is
+imported at module level with no skipif guard.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from kiro_crew import session_image_repair as sir
+
+
+def _png_bytes(size: tuple[int, int], colour: str = "red") -> list[int]:
+    """A real, decodable PNG at *size*, as the int list a transcript stores."""
+    buf = io.BytesIO()
+    Image.new("RGB", size, colour).save(buf, format="PNG")
+    return list(buf.getvalue())
+
+
+def _image_block(size: tuple[int, int]) -> dict:
+    """The stored image-block shape verified against real transcripts."""
+    return {
+        "kind": "image",
+        "data": {"format": "png", "source": {"kind": "bytes", "data": _png_bytes(size)}},
+    }
+
+
+def _prompt_record(size: tuple[int, int]) -> dict:
+    """A Prompt record: the image block sits in the record's own content array.
+
+    Path verified against a real transcript: ``.data.content[i]``.
+    """
+    return {
+        "version": 1,
+        "kind": "Prompt",
+        "data": {
+            "message_id": "m1",
+            "content": [{"kind": "text", "data": "hi"}, _image_block(size)],
+        },
+    }
+
+
+def _tool_result_record(size: tuple[int, int]) -> dict:
+    """A ToolResults record: the image nests one ``toolResult`` level deeper.
+
+    Path verified against a real transcript:
+    ``.data.content[i].data.content[j]``, where the outer block carries
+    ``kind: "toolResult"`` and its ``data`` holds ``toolUseId`` / ``content`` /
+    ``status``.
+    """
+    return {
+        "version": 1,
+        "kind": "ToolResults",
+        "data": {
+            "message_id": "m2",
+            "content": [
+                {
+                    "kind": "toolResult",
+                    "data": {
+                        "toolUseId": "toolu_x",
+                        "content": [_image_block(size)],
+                        "status": "success",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def _compaction_record(size: tuple[int, int]) -> dict:
+    """A Compaction record: blocks hang off ``content`` on a snapshot message.
+
+    Path verified against real transcripts:
+    ``.data.messages_snapshot[i].content[j]``. Note the block array is at a
+    top-level ``content`` here, NOT under ``data`` -- a traversal that only
+    knows the ``data.content`` spelling misses every one of these, and
+    Compaction snapshots hold 42% of all stored image blocks.
+    """
+    return {
+        "version": 1,
+        "kind": "Compaction",
+        "data": {
+            "messages_snapshot": [
+                {"content": [{"kind": "text", "data": "summary"}, _image_block(size)]}
+            ]
+        },
+    }
+
+
+def _compaction_record_with_nested_tool_result(size: tuple[int, int]) -> dict:
+    """The deepest observed shape: a tool result inside a compaction snapshot.
+
+    Path verified against real transcripts:
+    ``.data.messages_snapshot[i].content[j].data.content[k]``.
+    """
+    return {
+        "version": 1,
+        "kind": "Compaction",
+        "data": {
+            "messages_snapshot": [
+                {
+                    "content": [
+                        {
+                            "kind": "toolResult",
+                            "data": {
+                                "toolUseId": "toolu_z",
+                                "content": [_image_block(size)],
+                                "status": "success",
+                            },
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+
+
+def _text_block_carrying_an_image_shaped_payload(size: tuple[int, int]) -> dict:
+    """A ToolResults record whose TEXT block payload merely looks like an image.
+
+    This is application data a tool happened to return, not transcript media. A
+    traversal that walks every dict would rewrite the bytes inside it; the
+    anchored traversal must leave the record untouched.
+    """
+    return {
+        "version": 1,
+        "kind": "ToolResults",
+        "data": {
+            "message_id": "m3",
+            "content": [
+                {
+                    "kind": "toolResult",
+                    "data": {
+                        "toolUseId": "toolu_y",
+                        "content": [{"kind": "text", "data": _image_block(size)}],
+                        "status": "success",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def _write_transcript(path: Path, records: list) -> None:
+    """Write one JSON record per line, matching kiro-cli's compact spelling.
+
+    ``newline=""`` is required, not cosmetic: without it Python translates each
+    ``\\n`` to ``\\r\\n`` on Windows, so these fixtures would assert
+    platform-dependent bytes and the byte-exactness tests would fail there while
+    passing on POSIX. Line-ending BEHAVIOUR is exercised deliberately by the
+    CRLF test instead of leaking in through the helper.
+
+    Members that are already strings are written verbatim (used for the
+    invalid-JSON and non-image passthrough lines).
+    """
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        for rec in records:
+            if isinstance(rec, str):
+                handle.write(rec)
+            else:
+                handle.write(json.dumps(rec, separators=(",", ":")))
+            handle.write("\n")
+
+
+class TestDriftTripwire:
+    """A format change must surface as a warning, never as a clean report."""
+
+    def test_an_unknown_nesting_is_WARNED_about_and_not_repaired(self, tmp_path):
+        """The failure mode this PR nearly shipped: a shape the anchor cannot see.
+
+        Simulates a future kiro-cli record whose blocks hang somewhere the
+        anchored traversal does not know. The image must NOT be rewritten (the
+        anchor is what decides that) but the report must refuse to look clean.
+        """
+        p = tmp_path / "s.jsonl"
+        unknown = {
+            "version": 1,
+            "kind": "SomeFutureRecord",
+            "data": {"turns": [{"blocks": [_image_block((3000, 1200))]}]},
+        }
+        _write_transcript(p, [unknown])
+        before = p.read_bytes()
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 0  # the anchor found nothing, correctly
+        assert report.findings == []
+        assert lines is None  # and nothing is rewritten on an unknown shape
+        assert report.unanchored_images == 1  # but the divergence is recorded
+        assert report.unanchored_lines == [0]
+        assert p.read_bytes() == before
+
+        rendered = sir._format_report(report, applied=False)
+        assert "all within cap" in rendered
+        assert "WARNING" in rendered  # the clean line alone would be a lie
+        assert "NOT repaired" in rendered
+
+    def test_the_warning_also_fires_on_a_harmless_lookalike(self, tmp_path):
+        """A tool payload that looks like a block warns too, and that is fine.
+
+        The check is deliberately allowed to be imprecise in this direction only:
+        a false alarm costs a line of output, a silent miss costs the session.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_text_block_carrying_an_image_shaped_payload((3000, 1200))])
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 0
+        assert lines is None  # still never rewritten
+        assert report.unanchored_images == 1
+
+    def test_a_spaced_serialization_is_still_found_and_repaired(self, tmp_path):
+        """A serializer that emits `"kind": "image"` must not slip the prefilter.
+
+        The prefilter gates on the loose token for exactly this: the strict
+        `"kind":"image"` spelling would skip the whole line, and the transcript
+        would be reported clean while an oversized image sat in it.
+        """
+        p = tmp_path / "s.jsonl"
+        spaced = json.dumps(_prompt_record((3000, 1200)), indent=None, separators=(", ", ": "))
+        p.write_bytes(spaced.encode("utf-8") + b"\n")
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 1
+        assert [f.action for f in report.findings] == ["resize"]
+        assert lines is not None
+        assert report.unanchored_images == 0  # anchored reached it; no drift
+
+    def test_a_deeply_nested_tool_payload_does_not_crash_the_repair(self, tmp_path):
+        """An arbitrarily nested tool payload must not abort the whole repair.
+
+        The tripwire walk descends into TOOL PAYLOADS, whose nesting is not this
+        module's data and has no natural bound, so trusting the interpreter's
+        recursion limit would let one odd record kill the repair of a transcript
+        the operator needs repaired. Depth-bounded instead -- and the truncation
+        is REPORTED, because an unverified subtree must not read as clean.
+        """
+        p = tmp_path / "s.jsonl"
+        # Must carry the QUOTED "image" token, or the byte prefilter skips the
+        # line and it is never parsed or walked at all -- which is itself the
+        # first bound on how reachable this is. A tool payload with a
+        # {"type": "image"} field is the plausible shape.
+        deep: dict = {"kind": "text", "data": {"type": "image", "note": "x"}}
+        for _ in range(sir._MAX_WALK_DEPTH + 60):
+            deep = {"nested": deep}
+        record = {
+            "version": 1,
+            "kind": "ToolResults",
+            "data": {
+                "content": [
+                    {
+                        "kind": "toolResult",
+                        "data": {"toolUseId": "t", "content": [deep], "status": "ok"},
+                    }
+                ]
+            },
+        }
+        _write_transcript(p, [record, _prompt_record((3000, 1200))])
+
+        report, lines = sir.scan_file(p)  # must not raise RecursionError
+
+        assert report.walk_truncated is True
+        rendered = sir._format_report(report, applied=False)
+        assert "could NOT be fully checked" in rendered
+        assert "incomplete" in rendered
+        # The real repair on the OTHER line still happened.
+        assert lines is not None
+        assert report.rewritten_lines == 1
+
+    def test_unparseable_deeply_nested_json_is_passed_through_not_fatal(self, tmp_path):
+        """json.loads itself raises RecursionError on deep input, not just the walk.
+
+        The parse sits on another tool's file, so the nesting is not ours to
+        bound; uncaught, one line would abort the repair. Such a line is treated
+        like any other unparseable line: passed through byte-for-byte.
+        """
+        p = tmp_path / "s.jsonl"
+        blob = b'{"image":' + b"[" * 6000 + b"]" * 6000 + b"}"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        with p.open("ab") as handle:
+            handle.write(blob + b"\n")
+
+        report, lines = sir.scan_file(p)  # must not raise
+
+        assert lines is not None
+        assert blob in lines  # byte-for-byte passthrough
+        assert report.rewritten_lines == 1  # the real repair still landed
+
+    def test_a_known_transcript_produces_no_warning(self, tmp_path):
+        """All four pinned shapes together must not trip the tripwire."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(
+            p,
+            [
+                _prompt_record((3000, 1200)),
+                _tool_result_record((3000, 1200)),
+                _compaction_record((3000, 1200)),
+                _compaction_record_with_nested_tool_result((3000, 1200)),
+            ],
+        )
+
+        report, _lines = sir.scan_file(p)
+
+        assert report.images == 4
+        assert report.unanchored_images == 0
+        assert "WARNING" not in sir._format_report(report, applied=False)
+
+
+class TestCLI:
+    """The CLI is the whole user-facing surface, so its contract is pinned here.
+
+    Exercised through ``main(argv)`` rather than a subprocess so exit codes and
+    printed output are asserted directly.
+    """
+
+    def test_a_bare_invocation_is_a_dry_run_that_reports_and_changes_nothing(
+        self, tmp_path, capsys
+    ):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        before = p.read_bytes()
+
+        code = sir.main([str(p)])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "1 image(s), 1 over cap, would repair 1 record(s)" in out
+        assert "3000x1200 -> 2000x800" in out
+        assert p.read_bytes() == before  # no --apply, no write
+
+    def test_apply_writes_and_reports_the_backup(self, tmp_path, capsys):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        code = sir.main(["--apply", str(p)])
+
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "backup at s.jsonl.pre-image-repair.bak" in out
+        assert "repaired 1 record(s)" in out
+        assert p.with_suffix(".jsonl.pre-image-repair.bak").exists()
+        report_after, _ = sir.scan_file(p)
+        assert report_after.oversized == []
+
+    def test_a_within_cap_transcript_reports_clean_and_is_not_rewritten(self, tmp_path, capsys):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((100, 80))])
+        before = p.read_bytes()
+
+        assert sir.main(["--apply", str(p)]) == 0
+
+        assert "1 image(s), all within cap" in capsys.readouterr().out
+        assert p.read_bytes() == before
+
+    def test_an_unreadable_path_reports_ERROR_and_exits_nonzero(self, tmp_path, capsys):
+        assert sir.main([str(tmp_path / "missing.jsonl")]) == 1
+        assert "ERROR" in capsys.readouterr().out
+
+    def test_a_live_transcript_is_REFUSED_with_a_nonzero_exit(self, tmp_path, capsys, monkeypatch):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        p.with_suffix(".lock").write_text(json.dumps({"pid": 4242}), encoding="utf-8")
+        monkeypatch.setattr(sir.platform_compat, "pid_exists", lambda pid: True)
+        before = p.read_bytes()
+
+        code = sir.main(["--apply", str(p)])
+
+        assert code == 1
+        assert "REFUSED" in capsys.readouterr().err
+        assert p.read_bytes() == before
+
+    def test_allow_live_lets_the_repair_through(self, tmp_path, monkeypatch):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        p.with_suffix(".lock").write_text(json.dumps({"pid": 4242}), encoding="utf-8")
+        monkeypatch.setattr(sir.platform_compat, "pid_exists", lambda pid: True)
+
+        assert sir.main(["--apply", "--allow-live", str(p)]) == 0
+
+        report_after, _ = sir.scan_file(p)
+        assert report_after.oversized == []
+
+    def test_a_moved_transcript_is_REFUSED_with_a_nonzero_exit(self, tmp_path, capsys, monkeypatch):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        real_scan = sir.scan_file
+
+        def scan_then_append(path, **kw):
+            result = real_scan(path, **kw)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"version": 1, "kind": "Prompt", "data": {}}) + "\n")
+            return result
+
+        monkeypatch.setattr(sir, "scan_file", scan_then_append)
+
+        assert sir.main(["--apply", str(p)]) == 1
+        assert "REFUSED" in capsys.readouterr().err
+
+    def test_several_paths_are_each_reported(self, tmp_path, capsys):
+        a = tmp_path / "a.jsonl"
+        b = tmp_path / "b.jsonl"
+        _write_transcript(a, [_prompt_record((3000, 1200))])
+        _write_transcript(b, [_prompt_record((100, 80))])
+
+        assert sir.main([str(a), str(b)]) == 0
+
+        out = capsys.readouterr().out
+        assert "a.jsonl: 1 image(s), 1 over cap" in out
+        assert "b.jsonl: 1 image(s), all within cap" in out
+
+    def test_a_dropped_block_is_reported_as_DROPPED(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(sir, "downscale_image_block", lambda *a, **k: None)
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        assert sir.main([str(p)]) == 0
+
+        assert "3000x1200 -> DROPPED" in capsys.readouterr().out
+
+
+class TestScanFile:
+    def test_within_cap_image_is_kept_byte_identical(self, tmp_path):
+        """(1) An image already within the cap is reported keep and untouched."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((100, 80))])
+        before = p.read_bytes()
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 1
+        assert [f.action for f in report.findings] == ["keep"]
+        assert lines is None  # nothing to rewrite
+        assert p.read_bytes() == before
+
+    def test_oversized_image_is_resized_within_cap_keeping_aspect(self, tmp_path):
+        """(2) An oversized image is resized so both edges <= cap, aspect kept."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1500))])
+
+        report, lines = sir.scan_file(p)
+
+        assert lines is not None
+        finding = report.findings[0]
+        assert finding.action == "resize"
+        assert finding.new_size is not None
+        new_w, new_h = finding.new_size
+        assert max(new_w, new_h) <= sir.MAX_IMAGE_EDGE_PX
+        # 2:1 source aspect preserved (2000x1000).
+        assert new_w == 2000 and new_h == 1000
+        # And the rewritten bytes actually decode at the reported size.
+        rec = json.loads(lines[0])
+        block = next(sir._iter_image_blocks(rec))
+        with Image.open(io.BytesIO(bytes(block["data"]["source"]["data"]))) as img:
+            assert img.size == (new_w, new_h)
+
+    def test_repair_preserves_record_kinds_and_line_count(self, tmp_path):
+        """(3) Record-kind sequence and line count are unchanged by a repair."""
+        p = tmp_path / "s.jsonl"
+        records = [
+            _prompt_record((100, 100)),
+            _tool_result_record((3000, 1200)),
+            {"kind": "Response", "content": [{"kind": "text", "data": "ok"}]},
+        ]
+        _write_transcript(p, records)
+
+        _report, lines = sir.scan_file(p)
+
+        assert lines is not None
+        assert len(lines) == len(records)
+        assert [json.loads(x)["kind"] for x in lines] == ["Prompt", "ToolResults", "Response"]
+
+    def test_non_image_and_invalid_json_pass_through_untouched(self, tmp_path):
+        """(4) A non-image record and an invalid-JSON line are left verbatim."""
+        p = tmp_path / "s.jsonl"
+        non_image = json.dumps(
+            {"kind": "Response", "content": [{"kind": "text", "data": "hello"}]},
+            separators=(",", ":"),
+        )
+        broken = '{"kind":"image", this is not valid json'
+        _write_transcript(p, [non_image, broken, _prompt_record((3000, 1200))])
+
+        _report, lines = sir.scan_file(p)
+
+        assert lines is not None  # the third line is dirty
+        assert lines[0] == non_image.encode("utf-8")
+        assert lines[1] == broken.encode("utf-8")
+
+    def test_invalid_utf8_in_an_unrelated_line_survives_a_repair(self, tmp_path):
+        """A malformed byte sequence must not be rewritten into U+FFFD.
+
+        Every line is written back on apply, so a text-mode read with
+        errors="replace" would irreversibly destroy any byte sequence that is not
+        valid UTF-8 -- in a line this tool has no business touching. Decoding
+        strictly instead would refuse the whole transcript and leave the session
+        dead. Reading bytes and only decoding the lines actually parsed keeps
+        both the malformed line and the repair.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        bad = b'{"kind":"text","data":"\xff\xfe not utf-8"}'
+        with p.open("ab") as handle:
+            handle.write(bad + b"\n")
+
+        report, lines = sir.scan_file(p)
+
+        assert lines is not None
+        assert bad in lines  # byte-for-byte, no replacement character
+        assert report.rewritten_lines == 1  # and the real repair still happened
+
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        assert bad in p.read_bytes()
+        assert b"\xef\xbf\xbd" not in p.read_bytes()  # no U+FFFD anywhere
+
+    def test_a_CRLF_transcript_keeps_CRLF_on_the_repaired_line_too(self, tmp_path):
+        """Line endings must survive, including on the line that was rewritten.
+
+        Surfaced by a Windows CI shard, which is the only place it could be:
+        kiro-cli may write CRLF there, and reading bytes while stripping only
+        ``\\n`` leaves the ``\\r`` attached. Passthrough lines were already
+        byte-exact, but a rewritten record would have been emitted with a bare
+        ``\\n`` -- leaving the repaired line as the single odd one out in an
+        otherwise CRLF file.
+        """
+        p = tmp_path / "s.jsonl"
+        keep = json.dumps({"kind": "Response", "data": {}}, separators=(",", ":"))
+        record = json.dumps(_prompt_record((3000, 1200)), separators=(",", ":"))
+        p.write_bytes(keep.encode() + b"\r\n" + record.encode() + b"\r\n")
+
+        report, lines = sir.scan_file(p)
+
+        assert lines is not None
+        assert report.rewritten_lines == 1
+        assert all(line.endswith(b"\r") for line in lines)
+
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        written = p.read_bytes()
+        assert written.count(b"\r\n") == 2
+        assert b"}\n" not in written.replace(b"\r\n", b"")  # no bare-LF line
+
+    def test_non_bytes_source_kind_is_skipped(self, tmp_path):
+        """(5) A source whose kind is not 'bytes' is skipped, not coerced.
+
+        The payload is a real oversized-PNG byte list so that the ONLY thing
+        stopping it from being decoded and resized is the source-kind guard: if
+        that guard were dropped, ``_block_bytes`` would happily coerce the list.
+        """
+        p = tmp_path / "s.jsonl"
+        rec = {
+            "kind": "Prompt",
+            "content": [
+                {
+                    "kind": "image",
+                    "data": {
+                        "format": "png",
+                        "source": {"kind": "path", "data": _png_bytes((3000, 1200))},
+                    },
+                }
+            ],
+        }
+        _write_transcript(p, [rec])
+        before = p.read_bytes()
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 0  # not counted as a decodable image payload
+        assert report.findings == []
+        assert lines is None
+        assert p.read_bytes() == before
+
+    def test_uncappable_block_becomes_dropped_text_placeholder(self, tmp_path, monkeypatch):
+        """(6) When downscale returns None the block becomes a DROPPED text block."""
+        monkeypatch.setattr(sir, "downscale_image_block", lambda *a, **k: None)
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        report, lines = sir.scan_file(p)
+
+        assert lines is not None
+        assert [f.action for f in report.findings] == ["drop"]
+        rec = json.loads(lines[0])
+        block = rec["data"]["content"][1]
+        assert block["kind"] == "text"
+        marker = sir.DROPPED_PLACEHOLDER.format(max_edge=sir.MAX_IMAGE_EDGE_PX)
+        assert block["data"] == marker
+
+
+class TestAnchoredTraversal:
+    """The walk must not wander out of the block arrays into tool payloads."""
+
+    def test_image_shaped_payload_inside_a_text_block_is_left_alone(self, tmp_path):
+        """Application data that merely looks like an image block is not media.
+
+        A tool can legitimately return a JSON document containing a dict shaped
+        exactly like a stored image block. Rewriting its bytes would corrupt
+        another tool's data file while reporting a successful repair, so the
+        record must come back untouched even though the payload is over cap.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_text_block_carrying_an_image_shaped_payload((3000, 1200))])
+        before = p.read_bytes()
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 0
+        assert report.findings == []
+        assert lines is None
+        assert p.read_bytes() == before
+
+    def test_a_real_nested_tool_result_image_is_still_repaired(self, tmp_path):
+        """The anchored walk must still reach the depth real transcripts use.
+
+        Guards the other direction of the same change: narrowing the traversal
+        must not stop it finding an image one ``toolResult`` level down, which
+        is where 18 of 20 real oversized images were found.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_tool_result_record((3000, 1200))])
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 1
+        assert [f.action for f in report.findings] == ["resize"]
+        assert lines is not None
+
+    @pytest.mark.parametrize(
+        "builder",
+        [_compaction_record, _compaction_record_with_nested_tool_result],
+        ids=["snapshot-content", "snapshot-nested-toolresult"],
+    )
+    def test_compaction_snapshot_images_are_found(self, tmp_path, builder):
+        """Compaction snapshots carry 42% of stored images and must be reached.
+
+        These are the shapes that first exposed the traversal as too narrow: the
+        block array sits at a top-level ``content`` on each snapshot message
+        rather than under ``data``, so a data.content-only walk silently reported
+        a clean transcript while an over-cap image stayed live -- success
+        returned, nothing changed, session still wedged.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [builder((3000, 1200))])
+
+        report, lines = sir.scan_file(p)
+
+        assert report.images == 1
+        assert [f.action for f in report.findings] == ["resize"]
+        assert lines is not None
+
+    def test_all_four_observed_shapes_are_covered_in_one_transcript(self, tmp_path):
+        """The complete shape set from the 16253-transcript survey, together.
+
+        Pinned as one transcript so a future narrowing of the traversal cannot
+        pass by covering three of four.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(
+            p,
+            [
+                _prompt_record((3000, 1200)),
+                _tool_result_record((3000, 1200)),
+                _compaction_record((3000, 1200)),
+                _compaction_record_with_nested_tool_result((3000, 1200)),
+            ],
+        )
+
+        report, _lines = sir.scan_file(p)
+
+        assert report.images == 4
+        assert [f.action for f in report.findings] == ["resize"] * 4
+
+
+class TestLostAppendRefusal:
+    def test_a_transcript_that_moved_since_the_scan_is_REFUSED(self, tmp_path):
+        """An append landing between scan and write must not be overwritten.
+
+        The rewrite is built from lines read earlier, so replacing the file
+        would drop the appended turn silently. The write refuses instead.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        assert report.source_stat is not None
+
+        # kiro-cli appends a turn while the operator was reading the dry run.
+        with p.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"version": 1, "kind": "Prompt", "data": {}}) + "\n")
+        after_append = p.read_bytes()
+
+        with pytest.raises(sir.TranscriptMovedError):
+            sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        assert p.read_bytes() == after_append  # the appended turn survived
+
+    def test_an_append_landing_DURING_the_write_is_still_refused(self, tmp_path, monkeypatch):
+        """The early check alone is not enough: the write itself takes time.
+
+        Between the up-front stat and ``os.replace`` sit a whole-file backup copy
+        and a full temp-file rewrite plus fsync -- seconds on a real transcript.
+        An append arriving inside that window passes the early check and would
+        still be clobbered, so the stat is re-taken immediately before the
+        rename. Simulated by appending from inside ``os.fsync``, the last call
+        before the rename, which is precisely the window the early check misses.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+
+        real_fsync = os.fsync
+        appended = {"done": False}
+
+        def fsync_then_append(fd):
+            real_fsync(fd)
+            if not appended["done"]:
+                appended["done"] = True
+                with p.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps({"version": 1, "kind": "Prompt", "data": {}}) + "\n")
+
+        monkeypatch.setattr(sir.os, "fsync", fsync_then_append)
+
+        with pytest.raises(sir.TranscriptMovedError):
+            sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        assert appended["done"]  # the window was actually exercised
+        assert len(p.read_text(encoding="utf-8").strip().splitlines()) == 2
+        assert not list(tmp_path.glob("*.tmp"))  # the abandoned temp is cleaned up
+
+    def test_an_unmoved_transcript_is_written(self, tmp_path):
+        """The guard must not refuse the normal case it is wrapped around."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        report_after, lines_after = sir.scan_file(p)
+        assert report_after.oversized == []
+        assert lines_after is None
+
+
+class TestLiveWriterRefusal:
+    """A running kiro-cli is the condition under which the narrow race bites."""
+
+    def _lock(self, transcript: Path, pid: int) -> Path:
+        lock = transcript.with_suffix(".lock")
+        lock.write_text(json.dumps({"pid": pid, "started_at": "now"}), encoding="utf-8")
+        return lock
+
+    def test_apply_is_REFUSED_while_a_live_pid_holds_the_transcript(self, tmp_path, monkeypatch):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        self._lock(p, 4242)
+        monkeypatch.setattr(sir.platform_compat, "pid_exists", lambda pid: pid == 4242)
+        before = p.read_bytes()
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        with pytest.raises(sir.TranscriptLiveError):
+            sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        assert p.read_bytes() == before
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_a_STALE_lock_does_not_block_a_repair(self, tmp_path, monkeypatch):
+        """Existence is not the signal -- stale locks accumulate without bound.
+
+        6471 were present on one real machine, the oldest months old. Treating
+        the file's presence as liveness would make the tool refuse essentially
+        every transcript it exists to fix.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        self._lock(p, 999999)
+        monkeypatch.setattr(sir.platform_compat, "pid_exists", lambda pid: False)
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        report_after, _ = sir.scan_file(p)
+        assert report_after.oversized == []
+
+    def test_allow_live_overrides_the_refusal(self, tmp_path, monkeypatch):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        self._lock(p, 4242)
+        monkeypatch.setattr(sir.platform_compat, "pid_exists", lambda pid: True)
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat, allow_live=True)
+
+        report_after, _ = sir.scan_file(p)
+        assert report_after.oversized == []
+
+    def test_a_missing_or_malformed_lock_is_not_liveness(self, tmp_path):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((100, 80))])
+        assert sir._live_writer_pid(p) is None  # no lock at all
+
+        p.with_suffix(".lock").write_text("not json", encoding="utf-8")
+        assert sir._live_writer_pid(p) is None
+
+
+class TestReplacementTranscriptIsLockedDown:
+    """os.replace carries the TEMP's permissions onto the transcript."""
+
+    def test_the_temp_is_locked_down_before_any_content_is_written(self, tmp_path, monkeypatch):
+        """A repair must not WIDEN access to the conversation it rewrites.
+
+        mkstemp is 0o600 on POSIX, but on Windows the temp inherits the session
+        directory's DACL, and ``os.replace`` then publishes those permissions
+        onto the transcript -- so a repair would hand the whole conversation to
+        other local accounts. Asserted as an ordered trace because the ordering
+        is the property: locking down after the payload leaves the content
+        readable for the duration of a multi-megabyte write.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+
+        order: list[str] = []
+        real_restrict = sir.platform_compat.restrict_to_owner
+        real_fdopen = os.fdopen
+
+        def traced_restrict(target):
+            order.append(f"restrict:{'tmp' if str(target).endswith('.tmp') else 'other'}")
+            return real_restrict(target)
+
+        def traced_fdopen(fd, *a, **kw):
+            order.append("fdopen")
+            return real_fdopen(fd, *a, **kw)
+
+        monkeypatch.setattr(sir.platform_compat, "restrict_to_owner", traced_restrict)
+        monkeypatch.setattr(os, "fdopen", traced_fdopen)
+
+        sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+        monkeypatch.undo()
+
+        # The temp is restricted, and restricted before it is opened for writing.
+        assert "restrict:tmp" in order
+        assert order.index("restrict:tmp") < order.index("fdopen")
+
+    def test_a_failed_temp_lockdown_leaves_no_temp_and_no_leak(self, tmp_path, monkeypatch):
+        """The lockdown is fail-loud, so its failure must not strand the temp.
+
+        Same descriptor-ownership hazard as the backup path: the raw fd is ours
+        until fdopen takes it, and Windows refuses to unlink a file with an open
+        handle -- which would leave a .tmp behind on every failed repair.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        before = p.read_bytes()
+
+        def boom(target):
+            raise OSError("icacls failed")
+
+        monkeypatch.setattr(sir.platform_compat, "restrict_to_owner", boom)
+        fds_before = len(os.listdir("/proc/self/fd")) if os.path.isdir("/proc/self/fd") else None
+
+        with pytest.raises(OSError, match="icacls failed"):
+            sir.apply_repair(p, lines, backup=False, expect=report.source_stat)
+
+        assert p.read_bytes() == before  # transcript untouched
+        assert not list(tmp_path.glob("*.tmp"))
+        if fds_before is not None:
+            assert len(os.listdir("/proc/self/fd")) <= fds_before
+
+
+class TestBackupIsNeverOverwritten:
+    """The first sidecar is the only pre-repair copy, so it is never replaced."""
+
+    def test_a_second_apply_is_REFUSED_rather_than_clobbering_the_backup(self, tmp_path):
+        """The plain trigger: run --apply twice on a transcript still needing work.
+
+        Without this the second run replaces the true pre-repair sidecar with
+        already-repaired content. If the first run DROPPED an uncappable block,
+        those bytes then exist in no file at all.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        sidecar = p.with_suffix(".jsonl.pre-image-repair.bak")
+        sidecar.write_bytes(b'{"kind":"Prompt","data":{}}\n')  # an earlier run's copy
+        original_backup = sidecar.read_bytes()
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        with pytest.raises(sir.BackupExistsError):
+            sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
+
+        assert sidecar.read_bytes() == original_backup  # untouched
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_the_sidecar_NAME_is_claimed_before_the_content_is_read(self, tmp_path, monkeypatch):
+        """This ordering is what makes the concurrency guarantee hold.
+
+        A check-then-write guard reads the transcript and then writes, so two
+        concurrent runs can both pass the check and the later read can capture
+        ALREADY-REPAIRED content, replacing the genuine pre-repair copy. Exclusive
+        create closes that only because the name is claimed FIRST: a rival running
+        this same code gets EEXIST at its own open and never reaches a read.
+
+        Asserted as a sequence rather than by racing two processes, which would be
+        a flaky test of the same fact.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+
+        order: list[str] = []
+        real_open = os.open
+        real_read_bytes = Path.read_bytes
+
+        def traced_open(target, flags, *a, **kw):
+            if str(target).endswith(".pre-image-repair.bak"):
+                order.append(f"open(exclusive={bool(flags & os.O_EXCL)})")
+            return real_open(target, flags, *a, **kw)
+
+        def traced_read(self):
+            if self == p:
+                order.append("read")
+            return real_read_bytes(self)
+
+        monkeypatch.setattr(os, "open", traced_open)
+        monkeypatch.setattr(Path, "read_bytes", traced_read)
+
+        sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
+        monkeypatch.undo()
+
+        assert order == ["open(exclusive=True)", "read"]
+
+    def test_a_failed_lockdown_strands_no_sidecar_and_leaks_no_descriptor(
+        self, tmp_path, monkeypatch
+    ):
+        """A fail-loud lockdown must not wedge every future retry.
+
+        The lockdown runs while the sidecar is still empty, so its failure is the
+        one point where a descriptor is open on a file the cleanup then has to
+        remove. If the fd outlived that, Windows would refuse the unlink (open
+        handle) and the stranded empty sidecar would make every later --apply
+        raise BackupExistsError -- a permanent block created by a failure that
+        changed nothing. Asserted by count of open descriptors as well as by the
+        absent file, because a leak is invisible from the filesystem alone.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+
+        def boom(_path):
+            raise OSError("icacls failed")
+
+        monkeypatch.setattr(sir.platform_compat, "restrict_to_owner", boom)
+
+        fds_before = len(os.listdir("/proc/self/fd")) if os.path.isdir("/proc/self/fd") else None
+
+        with pytest.raises(OSError, match="icacls failed"):
+            sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
+
+        sidecar = p.with_suffix(".jsonl.pre-image-repair.bak")
+        assert not sidecar.exists()  # nothing stranded to block the retry
+        assert not list(tmp_path.glob("*.tmp"))
+        if fds_before is not None:
+            assert len(os.listdir("/proc/self/fd")) <= fds_before  # no leak
+
+        # And the retry it would have blocked now works.
+        monkeypatch.undo()
+        report2, lines2 = sir.scan_file(p)
+        assert lines2 is not None
+        sir.apply_repair(p, lines2, backup=True, expect=report2.source_stat)
+        assert sidecar.exists()
+
+    def test_a_dangling_symlink_sidecar_is_also_refused(self, tmp_path):
+        """exists() is False for a dangling link, so is_symlink is checked too."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        sidecar = p.with_suffix(".jsonl.pre-image-repair.bak")
+        sidecar.symlink_to(tmp_path / "does-not-exist")
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        with pytest.raises(sir.BackupExistsError):
+            sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
+
+        assert sidecar.is_symlink()  # left exactly as found
+
+    def test_the_CLI_reports_the_refusal_and_exits_nonzero(self, tmp_path, capsys):
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        p.with_suffix(".jsonl.pre-image-repair.bak").write_bytes(b"earlier\n")
+        before = p.read_bytes()
+
+        assert sir.main(["--apply", str(p)]) == 1
+
+        assert "REFUSED" in capsys.readouterr().err
+        assert p.read_bytes() == before  # the transcript is untouched too
+
+
+class TestBackupDoesNotFollowAPlantedLink:
+    def test_a_symlink_at_the_backup_path_is_REFUSED_and_its_target_untouched(self, tmp_path):
+        """The backup name is predictable, so it is a plantable target.
+
+        Anything able to write the session directory can pre-create
+        ``<transcript>.pre-image-repair.bak`` as a symlink to a file it could not
+        write directly, and a copy that opens the destination for writing would
+        push the transcript through the link into that file -- the write performed
+        by a trusted operator command rather than by the planter.
+
+        Two independent defences now stand in front of that, and this asserts the
+        outer one: the sidecar-exists refusal declines before any write happens.
+        The inner one remains as defence in depth -- the backup goes through
+        ``atomic_write``, which renames a fresh temp file into place and so
+        replaces a link rather than following it, should the refusal ever be
+        bypassed.
+        """
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        victim = tmp_path / "victim.txt"
+        victim.write_text("do not overwrite me", encoding="utf-8")
+        planted = p.with_suffix(".jsonl.pre-image-repair.bak")
+        planted.symlink_to(victim)
+
+        report, lines = sir.scan_file(p)
+        assert lines is not None
+        with pytest.raises(sir.BackupExistsError):
+            sir.apply_repair(p, lines, backup=True, expect=report.source_stat)
+
+        assert victim.read_text(encoding="utf-8") == "do not overwrite me"
+        assert planted.is_symlink()  # left as found, not replaced
+        assert not list(tmp_path.glob("*.tmp"))
+
+
+class TestApplyRepair:
+    def test_dry_run_writes_nothing(self, tmp_path):
+        """(7) scan_file (dry run, no apply) never writes to disk."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        before = p.read_bytes()
+        listing_before = sorted(os.listdir(tmp_path))
+
+        report, lines = sir.scan_file(p)
+
+        assert lines is not None and report.changed  # a repair IS warranted...
+        assert p.read_bytes() == before  # ...but scan_file did not perform it
+        assert sorted(os.listdir(tmp_path)) == listing_before
+
+    def test_apply_creates_backup_sidecar(self, tmp_path):
+        """(8a) apply with backup=True writes the .pre-image-repair.bak sidecar."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+        original = p.read_bytes()
+
+        _report, lines = sir.scan_file(p)
+        assert lines is not None
+        backup = sir.apply_repair(p, lines, backup=True)
+
+        assert backup is not None
+        assert backup.name == "s.jsonl.pre-image-repair.bak"
+        assert backup.exists()
+        assert backup.read_bytes() == original  # backup is the pre-repair content
+        assert p.read_bytes() != original  # live file was rewritten
+
+    def test_apply_no_backup_writes_no_sidecar(self, tmp_path):
+        """(8b) apply with backup=False makes no sidecar."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        _report, lines = sir.scan_file(p)
+        assert lines is not None
+        backup = sir.apply_repair(p, lines, backup=False)
+
+        assert backup is None
+        sidecar = p.with_suffix(p.suffix + ".pre-image-repair.bak")
+        assert not sidecar.exists()
+
+    def test_apply_leaves_no_tmp_files(self, tmp_path):
+        """(9) apply is atomic: no leftover .tmp files in the directory after."""
+        p = tmp_path / "s.jsonl"
+        _write_transcript(p, [_prompt_record((3000, 1200))])
+
+        _report, lines = sir.scan_file(p)
+        assert lines is not None
+        sir.apply_repair(p, lines, backup=False)
+
+        leftovers = [f for f in os.listdir(tmp_path) if f.endswith(".tmp")]
+        assert leftovers == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What is the problem?

An image over 2000px on either edge in a many-image conversation makes the provider
reject the ENTIRE request:

```
messages.60.content.0.image.source.base64.data: At least one of the image dimensions
exceed max allowed size for many-image requests: 2000 pixels
```

Two enforcement points already exist and neither can see the path that causes it:
`acp/prompt_blocks.py` caps images entering a PROMPT, and `mcp_gateway/image_budget.py`
caps images an MCP TOOL returns. A screenshot written to disk and reopened with kiro-cli's
native `read` tool in Image mode touches neither, because that tool reads the file itself
and writes raw bytes straight into kiro-cli's own transcript.

Two live transcripts were found in this state. Every oversized block sat in a
`ToolResults` record, and resolving each `toolUseId` back to its originating call gave the
same producer every time: `read(mode=Image, ...)` on an agent's own Playwright capture.
Sizes were 3040x2000, 2560x2000, 2344x1290 and 1280x2080 - each clearing the limit on
exactly one axis, which is the signature of a capture that was never bounded rather than a
downscale that ran and got it wrong.

## Why this issue matters to the user

The failure is permanent, retroactive, and lands nowhere near its cause. kiro-cli replays
the whole message history every turn, so the offending block sits at a fixed history index
that nothing evicts. The turn that stores the image succeeds. The session then dies from
the moment enough images accumulate for the request to count as many-image, and from then
on EVERY turn fails with the same error. The user sees a working conversation stop working
for no visible reason, and the message names a message index, not the screenshot that
poisoned it. Capping future captures does not help a session already in this state - the
stored bytes have to be rewritten or the conversation is over.

## How our fix solves it

Symptom to root cause: the request is rejected on a replayed history image; the image
entered history through the native read tool; that tool is not interceptable, so the only
thing left to control is the pixel count of the file BEFORE it is read; and the one
capture path where Kiro Crew itself writes the file and then hands the agent its path was
allowed to exceed the cap.

**Bound the computer-use capture ceiling by the inline-image cap.**
`MAX_SCREENSHOT_MAX_PX` was 4096, clamped at `capture_macos.py:200` and
`capture_windows.py:670`, while `computer_use/render.py:300` formats `SCREENSHOT_NOTE`
with `path=snap.image_path` - so a configured `screenshot_max_px` above 2000 hands the
agent a readable path to a JPEG that will kill the session later. The default was already
1280; what changes is that the ceiling can no longer be configured into the fatal range.
`types.py` ships the literal `2000`; what carries the relationship to
`imaging.MAX_IMAGE_EDGE_PX` is a test that asserts `MAX_SCREENSHOT_MAX_PX <= MAX_IMAGE_EDGE_PX`
and reddens if either constant drifts, since a literal drifting away from the cap is what
allowed the gap. The Windows clamp test derives its expected size from the constant for the
same reason.

**Add `session_image_repair` for transcripts already carrying one.** It rewrites the
stored blocks in place: dry run by default, atomic temp-file replace, `.pre-image-repair.bak`
sidecar. Three deliberate choices worth naming:

- Not a sweeper. It writes another tool's data directory, so it stays an explicit operator
  action with a visible dry run, not background maintenance.
- Not a top-level CLI verb, for the same reason - it should not look routine.
- A block with no compliant rendition becomes a text marker rather than being left alone.
  `downscale_image_block` fails closed and returns `None`; keeping such a block keeps the
  session dead, so losing one image beats losing every later turn.
- It refuses to write a transcript that moved since the scan. The rewrite is built from lines
  read earlier, so a kiro-cli append landing in between would be dropped silently - a
  successful-looking repair and a lost turn.

**The traversal is anchored to the block arrays**, never descending into a block's payload, so a
tool result that happens to contain an image-shaped dict is not rewritten as if it were media.
Anchoring is only sound while the set of real nesting shapes is known, so it was built from a
survey of every transcript on one machine - 16253 files, 12615 stored image blocks - which found
four shapes rather than the two the transcripts under repair happened to show:

```
5905  Prompt       .data.content[i]
5314  Compaction   .data.messages_snapshot[i].content[i]      (+ 18 nested one level deeper)
1396  ToolResults  .data.content[i].data.content[i]
```

`Compaction` snapshots hold 42% of all stored image blocks, at a top-level `content` rather than
under `data`. An earlier version of this traversal knew only the `data.content` spelling and
silently missed them - on a real transcript it reported 10 over cap where 11 existed, which would
have printed a successful repair while leaving a live oversized image in place. All four shapes
are pinned in tests, and the traversal was verified equivalent to a generic walk across all 12615
blocks: zero missed, zero extra.

`docs/architecture/design-notes/oversized-image-session-wedge.md` documents the wedge and the
recovery command, and carries the literal provider error string so searching for it lands there.

This PR does NOT close the issue. The remaining exposure is the capture paths where no
Kiro Crew code runs at write time - a bare `playwright-cli screenshot`, `simctl io`, an
agent-composed Playwright or magick command - plus `design-critique/scripts/render.mjs`,
whose `--full` capture has document-bounded height and prints the path for the agent to
read. An audit of those paths established that config and env cannot close them: Kiro Crew
already controls the CLI config and `PLAYWRIGHT_MCP_OUTPUT_DIR` and could pin a viewport,
but a fullPage capture takes the whole document height regardless of viewport or
deviceScaleFactor. The structural answer is a capture-then-cap front end plus carrying the
cap instruction into the skills that instruct a capture and today do not - 1 of 11 mention
it. That is a separate change with its own design surface and gets its own PR.

## What tests we did

`test/test_session_image_repair.py`, 17 tests, real PNG bytes generated with Pillow and records
built at all four surveyed shapes: a within-cap image is kept byte-identical; an oversized one is
resized within cap with aspect preserved; line count and record-kind sequence survive a repair; a
non-image record and an invalid-JSON line pass through verbatim; a source whose `kind` is not
`bytes` is skipped rather than coerced; an uncappable block becomes the text marker; a dry run
writes nothing; the backup sidecar appears with `backup=True` and not with `backup=False`; no
`.tmp` file is left behind; a text block whose payload is a real over-cap PNG byte list comes back
untouched; each Compaction shape is found; and one transcript carrying all four shapes at once
reports exactly four resizes, so a future narrowing cannot pass by covering three of them.

An append landing between scan and write raises `TranscriptMovedError` and the appended turn is
asserted to survive.

Every assertion was mutation-verified - each mutation reddened its test and was then restored,
with the module confirmed free of residue afterward. Notable ones: disabling the stat guard reds
the refusal test; letting the traversal descend into block payloads reds the corruption test;
nulling the snapshot hook reds three Compaction tests; restoring the 4096 ceiling reds the
invariant test.

One mutation exposed a weak test: the non-`bytes`-source case initially passed through
`_block_bytes`'s list check rather than the `kind` guard it claimed to pin, so the fixture was
strengthened to a real PNG byte list under a non-`bytes` kind, where only the guard protects it.

The originally delivered fixtures were also wrong and were rewritten: they put `content` at the
top level of a record and used a bare `toolResult` key, a shape no real transcript has. They
passed only because the pre-anchoring walk found images anywhere. Every fixture shape is now
verified against a real transcript.

276 tests pass across `test_session_image_repair.py`, `test_computer_use_capture.py`,
`test_computer_use_capture_windows.py` and `test_computer_use_api.py`. black, isort, flake8 and
mypy clean on every touched file.

Verified end to end on the two real transcripts: 18 of 20 and 11 of 18 images were over
cap before, none after, with line counts (686 in, 686 out) and record-kind sequences
identical and every line still valid JSON.

## Any other suggestions on the work

One honest cost: a downscaled screenshot PNG gets BIGGER, because resampling blurs crisp
text and PNG then compresses it worse. Measured on a real transcript, raw payload went
3.67MB to 5.23MB (+43%), largest single image 0.41MB to 0.58MB. Both stay far inside the
5MiB per-image budget and the request-body limit, so the trade is worth taking - the
alternative is a dead session - but it is a real regression in payload size and not a free
win. If it matters later, `imaging.py` saves PNG with no `optimize=True`, which is where to
look first.

Worth deciding separately: whether the read side should refuse loudly. Today an oversized
read succeeds silently and bills the cost to an unrelated turn much later, which is the
worst possible split between cause and symptom.

Refs #6328
