### PR TITLE
fix(subagent): size the sub-agent cap from real memory on Windows

### DIFF
--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -922,6 +922,8 @@ def _available_memory_gb() -> float:
         • macOS  — reclaimable memory via Mach ``host_statistics64`` (ctypes,
                    in-process, no subprocess); see ``_macos_available_memory_gb``.
                    No cgroups.
+        • Windows — ``GlobalMemoryStatusEx`` through
+                   ``platform_compat.host_available_mib``. No cgroups.
         • other  — no probe yet → ``-1.0`` (fail open).
 
     NOTE (adding a new OS): implement a ``_<os>_available_memory_gb()`` helper
@@ -939,8 +941,28 @@ def _available_memory_gb() -> float:
         return min(host_gb, cg_gb)
     if platform_compat.IS_MACOS:
         return _macos_available_memory_gb()
-    # Unsupported platform (e.g. Windows): no probe yet → fail open.
+    if platform_compat.IS_WINDOWS:
+        return _windows_available_memory_gb()
+    # Unsupported platform: no probe yet → fail open.
     return -1.0
+
+
+def _windows_available_memory_gb() -> float:
+    """Available memory (GB) on Windows, or ``-1.0`` when it cannot be read.
+
+    Delegates to ``platform_compat.host_available_mib`` instead of calling
+    ``GlobalMemoryStatusEx`` here. That shim is the single place the MiB unit
+    and the "0 means unreadable, never zero memory" contract are defined, and a
+    second reader would have to restate both to stay correct.
+
+    Without this branch the cap loses its memory term on Windows entirely and
+    falls open to ``_LEGACY_DEFAULT_MAX``, so a host with tens of GB free is
+    held to the same three concurrent sub-agents as an unmeasurable one.
+    """
+    available_mib = platform_compat.host_available_mib()
+    if available_mib <= 0:
+        return -1.0  # unreadable → caller fails open
+    return available_mib / 1024.0
 
 
 def _macos_vm_reclaimable_pages() -> Optional[int]:

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -506,9 +506,25 @@ class TestAvailableMemoryGb:
         monkeypatch.setattr(sa, "_macos_available_memory_gb", lambda: 3.5)
         assert sa._available_memory_gb() == 3.5
 
+    def test_windows_branch_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_WINDOWS", True, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "host_available_mib", lambda: 8192)
+        assert sa._available_memory_gb() == 8.0
+
+    def test_windows_unreadable_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``host_available_mib`` answers 0 for "cannot read", never "no memory"."""
+        monkeypatch.setattr(sa.platform_compat, "IS_LINUX", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_WINDOWS", True, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "host_available_mib", lambda: 0)
+        assert sa._available_memory_gb() == -1.0
+
     def test_unsupported_platform_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sa.platform_compat, "IS_LINUX", False, raising=False)
         monkeypatch.setattr(sa.platform_compat, "IS_MACOS", False, raising=False)
+        monkeypatch.setattr(sa.platform_compat, "IS_WINDOWS", False, raising=False)
         assert sa._available_memory_gb() == -1.0
 
 

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -799,12 +799,23 @@ class TestAvailableMemoryClamp:
         monkeypatch.setattr(sub, "_macos_available_memory_gb", lambda: 42.0)
         assert sub._available_memory_gb() == 42.0
 
-    def test_unsupported_platform_fails_open(self, monkeypatch) -> None:
-        """A platform with no probe yet (e.g. Windows) fails open to -1.0."""
+    def test_windows_reads_the_shared_host_probe(self, monkeypatch) -> None:
+        """Windows reads memory through ``platform_compat.host_available_mib``."""
         import kiro_crew.subagent as sub
 
         monkeypatch.setattr(sub.platform_compat, "IS_LINUX", False)
         monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(sub.platform_compat, "IS_WINDOWS", True)
+        monkeypatch.setattr(sub.platform_compat, "host_available_mib", lambda: 16384)
+        assert sub._available_memory_gb() == 16.0
+
+    def test_unsupported_platform_fails_open(self, monkeypatch) -> None:
+        """A platform with no probe yet fails open to -1.0."""
+        import kiro_crew.subagent as sub
+
+        monkeypatch.setattr(sub.platform_compat, "IS_LINUX", False)
+        monkeypatch.setattr(sub.platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(sub.platform_compat, "IS_WINDOWS", False)
         assert sub._available_memory_gb() == -1.0
 
 


### PR DESCRIPTION
## Problem / Motivation

`_available_memory_gb()` has no Windows branch. It returns the `-1.0`
"unmeasurable" sentinel on every Windows host, so `compute_max_subagents()`
fails open to `_LEGACY_DEFAULT_MAX` and the memory term drops out of the cap
entirely.

Measured on a 32-core Windows host with ~60 GB free:

```
platform            : win32
platform_compat MiB : 60315      <- the shared shim reads it fine
subagent own probe  : -1.0       <- no Windows branch, fails open
EFFECTIVE CAP       : 3          <- instead of ~25
```

## Why it matters

Every Windows user runs at three concurrent sub-agents regardless of hardware —
the same cap they had before auto-sizing was written, and roughly an eighth of
what the machine can support. It is silent: nothing logs that the memory bound
vanished, so the host simply looks slow.

`AGENTS.md` already anticipates this exact failure, naming
`host_available_mib()` as the shim to use for available host memory because a
bound built any other way "silently vanishes on macOS and Windows".

## What changed (motivation → approach → change)

Observed symptom: a 60 GB host capped at 3 sub-agents. Root cause:
`subagent.py` hand-rolls a per-OS memory probe with branches for Linux and
macOS only, while `platform_compat.host_available_mib()` already reads Windows
memory via `GlobalMemoryStatusEx`.

Approach: wire the existing shim in as one more branch rather than call the
Win32 API a second time. The shim is the single place the MiB unit and the
"0 means unreadable, never zero memory" contract are defined, so a second
reader would have to restate both to stay correct. The `_available_memory_gb()`
docstring already prescribes this shape for adding an OS, and the `-1.0`
fail-open contract is preserved for genuinely unreadable hosts.

Change: a `_windows_available_memory_gb()` helper delegating to the shim, one
branch in the dispatcher, and the docstring's OS list updated to match.

## Tests

Both copies of the unsupported-platform test asserted the fail-open sentinel
while patching only `IS_LINUX` and `IS_MACOS` — so they passed on Linux and
silently described Windows. Adding the branch made one fail with
`assert 61.814453125 == -1.0`, which is the fix working.

- `test_subagent_coverage.py` — `test_windows_branch_delegates` (shim value is
  converted MiB→GB) and `test_windows_unreadable_fails_open` (0 means
  unreadable, so the sentinel is preserved).
- `test_subagent_sizing.py` — `test_windows_reads_the_shared_host_probe`.
- Both `test_unsupported_platform_fails_open` cases now pin `IS_WINDOWS` too, so
  they describe a genuinely unsupported platform instead of passing by accident.

`328 passed, 5 skipped` across both files; `flake8` and `mypy` clean.

## Manual verification

Verified on Windows 10 Pro 19045 / Python 3.12.5 that
`platform_compat.host_available_mib()` returns a live reading (60315 MiB) while
`subagent._available_memory_gb()` returned `-1.0` before this change.

## Related Issues

N/A — found while running the gateway on Windows.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the probe's own docstring
- [x] No secrets, credentials, or internal references in the diff