### PR TITLE
fix: make task planning rollback cancellation-safe

### DIFF
--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -690,15 +690,20 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
                 name=state.task_runner._auto_name(original_input),
             )
             state.task_runner._runs[new_id] = run
-            await state.task_runner._workflow_begin(run)
             try:
+                await state.task_runner._workflow_begin(run)
                 run = await state.task_runner.update_plan(new_id, steps)
-            except ValueError:
-                await state.task_runner.delete_run(new_id)
+            except BaseException:
+                cleanup_task = asyncio.create_task(state.task_runner.delete_run(new_id))
                 try:
-                    task_dir.rmdir()
-                except OSError:
-                    logger.warning("Failed to remove rejected chat plan directory %s", task_dir)
+                    await asyncio.shield(cleanup_task)
+                except asyncio.CancelledError:
+                    await asyncio.shield(cleanup_task)
+                finally:
+                    try:
+                        task_dir.rmdir()
+                    except OSError:
+                        logger.warning("Failed to remove rejected chat plan directory %s", task_dir)
                 raise
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -625,7 +625,15 @@ class TaskRunner:
                 source=workflow_source or None,
             )
             self._runs[task_id] = run
-            await self._apersist_runs()
+            persist_task = asyncio.create_task(self._apersist_runs())
+            try:
+                await asyncio.shield(persist_task)
+            except BaseException:
+                # The off-thread atomic write cannot be cancelled once it has
+                # started. Drain it before rollback so its stale snapshot cannot
+                # land after the project and linked workflow have been removed.
+                await asyncio.shield(persist_task)
+                raise
             committed = True
             return run
         except BaseException:
@@ -633,6 +641,17 @@ class TaskRunner:
                 if self._runs.get(task_id) is run:
                     self._runs.pop(task_id, None)
                 self._run_session_keys.pop(task_id, None)
+                cleanup_persist = asyncio.create_task(self._apersist_runs())
+                try:
+                    await asyncio.shield(cleanup_persist)
+                except asyncio.CancelledError:
+                    await asyncio.shield(cleanup_persist)
+                except Exception:
+                    logger.warning(
+                        "Failed to persist cancelled plan removal for %s",
+                        task_id,
+                        exc_info=True,
+                    )
                 await asyncio.shield(self._workflow_delete_link(run))
                 if created_task_dir:
                     try:

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -1038,6 +1038,33 @@ class TestFromChat:
         runner.delete_run.assert_awaited_once()
         assert list(runner._work_dir.glob("plan_*")) == []
 
+    @pytest.mark.asyncio
+    async def test_cancelled_new_plan_is_rolled_back(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        update_started = asyncio.Event()
+
+        async def block_update(_task_id: str, _steps: list[Any]) -> TaskRun:
+            update_started.set()
+            await asyncio.Future()
+
+        runner.update_plan = AsyncMock(side_effect=block_update)
+        request_task = asyncio.create_task(
+            api_taskrunner_from_chat(
+                _request(_state(runner), json_body={"steps": [{"title": "first"}]})
+            )
+        )
+        await asyncio.wait_for(update_started.wait(), timeout=1)
+        created = next(iter(runner._runs.values()))
+        created.workflow_run_id = "workflow-orphan-candidate"
+        request_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        runner.delete_run.assert_awaited_once_with(created.task_id)
+        assert runner._runs == {}
+        assert list(runner._work_dir.glob("plan_*")) == []
+
 
 # ── refine ──
 

--- a/test/test_taskrunner.py
+++ b/test/test_taskrunner.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import kiro_crew.taskrunner as taskrunner_module
 from conftest import requires_git
 from kiro_crew.task_models import PROGRESS_FILE
 from kiro_crew.taskrunner import (
@@ -165,6 +167,70 @@ class TestWorkflowRunIntegration:
         assert runner._runs == {}
         assert workflows.list_runs() == []
         assert WorkflowService(sessions=sessions, store=workflow_store).list_runs() == []
+        assert list(tmp_path.glob("plan_*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_plan_drains_persist_before_rollback(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        sessions = _make_mock_sessions()
+        workflow_store = WorkflowRunStore(tmp_path / "workflow-store")
+        workflows = WorkflowService(sessions=sessions, store=workflow_store)
+        runner = TaskRunner(
+            sessions=sessions,
+            auto_test=False,
+            work_dir=tmp_path,
+            workflow_service=workflows,
+        )
+        runner._decompose = AsyncMock(
+            return_value=[Step(index=1, title="Implement", description="make the change")]
+        )
+        persist_started = threading.Event()
+        allow_persist = threading.Event()
+        persist_finished = threading.Event()
+        lifecycle: list[str] = []
+        original_atomic_write = taskrunner_module.atomic_write
+        first_write = True
+
+        def block_first_write(path, content, *, fsync=False):  # type: ignore[no-untyped-def]
+            nonlocal first_write
+            if first_write and path == runner._runs_path():
+                first_write = False
+                lifecycle.append("persist_started")
+                persist_started.set()
+                assert allow_persist.wait(timeout=5)
+                lifecycle.append("persist_finished")
+                persist_finished.set()
+            original_atomic_write(path, content, fsync=fsync)
+
+        original_delete = runner._workflow_delete_link
+
+        async def observe_delete(run: TaskRun) -> None:
+            lifecycle.append("workflow_deleted")
+            await original_delete(run)
+
+        monkeypatch.setattr(taskrunner_module, "atomic_write", block_first_write)
+        runner._workflow_delete_link = observe_delete  # type: ignore[method-assign]
+
+        planning = asyncio.create_task(runner.plan("implement the feature"))
+        assert await asyncio.to_thread(persist_started.wait, 2)
+        planning.cancel()
+
+        async def release_after_rollback_gets_one_turn() -> None:
+            await asyncio.sleep(0)
+            allow_persist.set()
+
+        release = asyncio.create_task(release_after_rollback_gets_one_turn())
+        with pytest.raises(asyncio.CancelledError):
+            await planning
+        await release
+        assert await asyncio.to_thread(persist_finished.wait, 2)
+
+        assert lifecycle.index("persist_finished") < lifecycle.index("workflow_deleted")
+        assert runner._runs == {}
+        assert workflows.list_runs() == []
+        assert WorkflowService(sessions=sessions, store=workflow_store).list_runs() == []
+        assert json.loads((tmp_path / "runs.json").read_text(encoding="utf-8")) == []
         assert list(tmp_path.glob("plan_*")) == []
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

PR #5951 merged before its final GPT review completed. That review identified two cancellation windows where a TaskRunner project or linked workflow run could survive rollback.

## Why it matters

A cancelled planning request must not leave durable orphan state or resurrect a project after its workflow run has been deleted. Either outcome makes recovery and the unified workflow history inconsistent.

## What changed

- drain an in-flight TaskRunner registry write before persisting rollback, preventing cancelled planning from resurrecting a project linked to a deleted workflow run
- persist project removal before deleting its linked workflow
- clean up chat-created TaskRunner projects and workflow runs when request cancellation interrupts initial publication or plan update
- add deterministic regressions for both cancellation windows

This changes cancellation cleanup only; TaskRunner planning, approval, retry, tests, git/worktree, replan, and recovery behavior remain unchanged.

## Tests

- 1,018 TaskRunner/workflow/handler tests passed
- focused Linux-parity mypy passed
- touched-file flake8 passed
- Black formatting gate passed
- isort and `git diff --check` passed

## Screenshots

Not applicable: this is a backend cancellation/durability fix with no UI change.