### PR TITLE
refactor: share one jsonl rotation helper; bound activity log (#6319)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -940,7 +940,6 @@ test/test_meetings_dictionary.py
 test/test_meetings_providers.py
 test/test_meetings_routes.py
 test/test_meetings_session.py
-test/test_members.py
 test/test_memory_benchmark_workflow.py
 test/test_memory_selfheal.py
 test/test_merge_queued_messages.py

--- a/src/kiro_crew/jsonl_util.py
+++ b/src/kiro_crew/jsonl_util.py
@@ -1,0 +1,62 @@
+"""Shared bounding helper for append-only JSONL logs.
+
+Several long-lived JSONL logs (the MCP stub's fallback audit log, the
+subagents' slow-command log, per-member activity logs) grow one appended
+record at a time from writers that must never stall an event loop. Each
+needs the same bound: once the live file reaches its cap, rename it to a
+single ``.1`` generation — O(1), no whole-file read — so total disk stays
+at roughly twice the cap while one generation of history is kept.
+
+This module owns only the rotation step. Each call site keeps its own
+append, record shape, size cap, and error contract, because those differ
+per log; what they share is exactly the rotate-by-rename.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from kiro_crew import platform_compat
+
+
+def rotate_jsonl_at(path: Path, max_bytes: int) -> None:
+    """Rotate ``path`` aside to ``<name>.1`` once it reaches ``max_bytes``.
+
+    Call immediately before appending a record. Keeps ONE previous
+    generation, replacing any older one, so total disk use stays bounded at
+    about twice the cap. The live file can overshoot the cap by the few
+    records written between a size check and the next rotation; callers
+    accept that slack in exchange for never blocking.
+
+    Rotation is guarded by a NON-BLOCKING try-lock on a sibling
+    ``<name>.lock`` file so that two writers hitting the cap together
+    cannot both rotate (the second would replace ``.1`` with the first's
+    fresh live file, discarding a generation). A loser skips rotating — it
+    never waits, so no caller can stall its event loop — and the next
+    writer rotates. Every current caller is (or must be treated as) a
+    multi-process writer, so the lock is unconditional; the cost to a
+    single writer is one fd and one non-blocking syscall.
+
+    Best-effort by contract: NEVER raises. Any failure — the lock file
+    unopenable (fd exhaustion, read-only or ACL-restricted dir), a
+    fresh-boot missing log, a Windows sharing violation rejecting the
+    rename, an unusable path value — degrades to not rotating, so the
+    caller's append still runs. Fd/disk exhaustion is a leading cause of
+    the very incidents these logs diagnose, so a rotation failure must
+    never cost the record; only a failure of the caller's own append may.
+    """
+    try:
+        lock_fd = os.open(path.with_name(path.name + ".lock"), os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            locked = platform_compat.try_acquire_lock(lock_fd, exclusive=True)
+            try:
+                if locked and path.stat().st_size >= max_bytes:
+                    os.replace(path, path.with_name(path.name + ".1"))
+            finally:
+                if locked:
+                    platform_compat.release_lock(lock_fd)
+        finally:
+            os.close(lock_fd)
+    except (OSError, ValueError):
+        pass

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -34,6 +34,7 @@ from typing import Any, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.jsonl_util import rotate_jsonl_at
 from kiro_crew.mcp_caller import CallerContext, _parent_pid
 from kiro_crew.mcp_gateway import transport
 from kiro_crew.mcp_gateway.hashing import hash_command, hash_effective_env
@@ -979,36 +980,17 @@ def log_fallback(
             "channel_id": args.channel_id or "",
             "target_command": args.target_command,
         }
-        # Rotation is guarded by a NON-BLOCKING try-lock on a sibling lock
-        # file: only the holder rotates, so two stubs hitting the size cap
-        # together can no longer both rotate (the second would replace ``.1``
-        # with the first's fresh live file, discarding a generation). A loser
-        # appends without rotating — never waits, so no log_fallback call can
-        # stall its stub's event loop — and the next writer rotates. Worst
-        # case the live file overshoots the cap by a few racing records.
-        lock_fd = os.open(
-            log_path.with_suffix(".jsonl.lock"), os.O_CREAT | os.O_RDWR, 0o600
-        )
-        locked = False
-        try:
-            locked = platform_compat.try_acquire_lock(lock_fd, exclusive=True)
-            if locked:
-                try:
-                    if log_path.stat().st_size >= _FALLBACK_LOG_MAX_BYTES:
-                        os.replace(log_path, log_path.with_suffix(".jsonl.1"))
-                except OSError:
-                    # Missing file (fresh boot) or a Windows sharing violation
-                    # (another process holds the log open, so the rename is
-                    # rejected). Rotation is best-effort; the append below must
-                    # still happen — letting this propagate to the outer
-                    # handler would silently DROP the record.
-                    pass
-            with open(log_path, "a", encoding="utf-8") as f:
-                f.write(json.dumps(record, separators=(",", ":")) + "\n")
-        finally:
-            if locked:
-                platform_compat.release_lock(lock_fd)
-            os.close(lock_fd)
+        # Rotation (shared helper): O(1) rotate-by-rename at the cap, guarded
+        # by a non-blocking try-lock so two stubs hitting the cap together
+        # cannot both rotate, and a loser never waits — no log_fallback call
+        # can stall its stub's event loop. The helper is best-effort by
+        # contract (a missing file, a Windows sharing violation, or an
+        # unopenable lock file degrades to not rotating), so the append below
+        # always still runs; only a failure of the append itself may drop the
+        # record, caught by this function's own handler.
+        rotate_jsonl_at(log_path, _FALLBACK_LOG_MAX_BYTES)
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, separators=(",", ":")) + "\n")
     except OSError:
         pass
 

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from kiro_crew.artifacts import slugify
 from kiro_crew.config.paths import data_home
+from kiro_crew.jsonl_util import rotate_jsonl_at
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,18 @@ MEMBERS_DIR_NAME = "members"
 
 #: Append-only pointer log inside a member's directory.
 ACTIVITY_FILE_NAME = "activity.jsonl"
+
+# Rotate a member's activity log once it exceeds this size, keeping ONE
+# previous generation (``.jsonl.1``) — the same 1 MiB cap / ~2 MiB total
+# shape as ``mcp_gateway.stub._FALLBACK_LOG_MAX_BYTES``. Entries are ~150
+# bytes, so the two generations together hold thousands of the most recent
+# pointers for :func:`read_activity`'s consumers (today the
+# ``dedupe_session`` probe inside :func:`record_activity`) — while an
+# unbounded log would grow forever (one append per participation event,
+# from multiple processes, and nothing ever pruned it). The dedupe probe
+# also reads this whole file synchronously on every deduped call, so the
+# cap bounds that read as well as the disk.
+_ACTIVITY_LOG_MAX_BYTES = 1024 * 1024
 
 # Same shape the artifact store enforces for its slugs: lowercase letters,
 # digits and hyphens, 1-80 chars, no leading or trailing hyphen. Kept here as a
@@ -201,6 +214,15 @@ def record_activity(
         # terminator and be absorbed by whatever came next. read_activity skips
         # the blank lines this produces.
         line = "\n" + json.dumps(entry, ensure_ascii=False) + "\n"
+        # Bound the log before appending. The helper's rotation is
+        # try-lock-guarded (the log is append-only from multiple processes, so
+        # unserialized rotation would let two writers hitting the cap together
+        # discard a generation), best-effort, and never raises; a lost
+        # try-lock skips rotating rather than waiting, so this call cannot
+        # stall the shared event loop any more than the append itself.
+        # History survives rotation: read_activity spans both generations, so
+        # the `dedupe_session` probe keeps seeing rotated-aside entries.
+        rotate_jsonl_at(path / ACTIVITY_FILE_NAME, _ACTIVITY_LOG_MAX_BYTES)
         # No fsync: this is an advisory pointer log, and a durability barrier is
         # a blocking kernel syscall that would stall the shared event loop for
         # every concurrent session. Losing the final entry to a crash is
@@ -216,30 +238,39 @@ def record_activity(
 def read_activity(slug: str, limit: int = 0) -> list[dict]:
     """Return a member's activity entries, oldest first.
 
-    Malformed lines are skipped rather than raising: the log is append-only from
-    multiple processes, and one torn line must not make the whole history
-    unreadable. ``limit`` > 0 returns only the most recent N.
+    Reads the one rotated generation (``.jsonl.1``, see
+    :data:`_ACTIVITY_LOG_MAX_BYTES`) before the live file — the same
+    two-generation read as the stub fallback log's aggregator — so a
+    rotation does not hide history from consumers: in particular the
+    ``dedupe_session`` probe keeps suppressing a session pair whose entry
+    was rotated aside. Malformed lines are skipped rather than raising: the
+    log is append-only from multiple processes, and one torn line must not
+    make the whole history unreadable. A generation that cannot be read is
+    likewise skipped rather than discarding what the other generation
+    yielded. ``limit`` > 0 returns only the most recent N across both
+    generations.
     """
     try:
-        path = member_dir(slug) / ACTIVITY_FILE_NAME
+        live = member_dir(slug) / ACTIVITY_FILE_NAME
     except MemberSlugError:
         return []
-    if not path.is_file():
-        return []
     out: list[dict] = []
-    try:
-        with open(path, encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except (ValueError, TypeError):
-                    continue
-                if isinstance(row, dict):
-                    out.append(row)
-    except OSError:
-        logger.debug("member activity log read failed for %r", slug, exc_info=True)
-        return []
+    for path in (live.with_name(live.name + ".1"), live):
+        if not path.is_file():
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except (ValueError, TypeError):
+                        continue
+                    if isinstance(row, dict):
+                        out.append(row)
+        except OSError:
+            logger.debug("member activity log read failed for %r", slug, exc_info=True)
+            continue
     return out[-limit:] if limit > 0 else out

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 
+from kiro_crew import platform_compat
 from kiro_crew.artifacts import slugify
 from kiro_crew.config.paths import data_home
 from kiro_crew.jsonl_util import rotate_jsonl_at
@@ -255,22 +257,44 @@ def read_activity(slug: str, limit: int = 0) -> list[dict]:
     except MemberSlugError:
         return []
     out: list[dict] = []
-    for path in (live.with_name(live.name + ".1"), live):
-        if not path.is_file():
-            continue
-        try:
-            with open(path, encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        row = json.loads(line)
-                    except (ValueError, TypeError):
-                        continue
-                    if isinstance(row, dict):
-                        out.append(row)
-        except OSError:
-            logger.debug("member activity log read failed for %r", slug, exc_info=True)
-            continue
+
+    # Hold a shared (non-blocking) lock on the rotation lock file while
+    # reading both generations.  This prevents a concurrent writer from
+    # rotating the live file into .1 between the two reads, which could
+    # cause records to be missed and duplicate session entries appended.
+    lock_fd: int = -1
+    lock_path = live.with_name(live.name + ".lock")
+    try:
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        if not platform_compat.try_acquire_lock(lock_fd, exclusive=False):
+            # Could not acquire; close and proceed without the lock.
+            os.close(lock_fd)
+            lock_fd = -1
+    except OSError:
+        lock_fd = -1
+
+    try:
+        for path in (live.with_name(live.name + ".1"), live):
+            if not path.is_file():
+                continue
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            row = json.loads(line)
+                        except (ValueError, TypeError):
+                            continue
+                        if isinstance(row, dict):
+                            out.append(row)
+            except OSError:
+                logger.debug("member activity log read failed for %r", slug, exc_info=True)
+                continue
+    finally:
+        if lock_fd != -1:
+            platform_compat.release_lock(lock_fd)
+            os.close(lock_fd)
+
     return out[-limit:] if limit > 0 else out

--- a/src/kiro_crew/subagent_persistence.py
+++ b/src/kiro_crew/subagent_persistence.py
@@ -16,9 +16,9 @@ import tempfile
 import time
 from pathlib import Path
 
-from kiro_crew import platform_compat
 from kiro_crew.acp.types import PROVIDER_LABEL_DEFAULT
 from kiro_crew.config.paths import data_home, kiro_sessions_dir
+from kiro_crew.jsonl_util import rotate_jsonl_at
 from kiro_crew.providers.cleanup import _is_safe_path
 
 logger = logging.getLogger(__name__)
@@ -283,37 +283,17 @@ def record_slow_command(agent_id: str, **fields: object) -> None:
     try:
         base.mkdir(parents=True, exist_ok=True)
         log_path = base / "slow_commands.jsonl"
-        # Rotation is guarded by a NON-BLOCKING try-lock on a sibling lock
-        # file: only the holder rotates, so two writers hitting the size cap
-        # together cannot both rotate (the second would replace ``.1`` with
-        # the first's fresh live file, discarding a generation). A loser
-        # appends without rotating — never waits, so no call can stall the
-        # event loop — and the next writer rotates. Worst case the live file
-        # overshoots the cap by a few racing records.
-        #
-        # The whole lock+rotate step has its own handler so that ANY of its
-        # failures — the lock file unopenable (fd exhaustion, read-only or
+        # Rotation (shared helper): O(1) rotate-by-rename at the cap, guarded
+        # by a non-blocking try-lock so two writers hitting the cap together
+        # cannot both rotate, and a loser never waits — no call can stall the
+        # gateway event loop. The helper is best-effort by contract: ANY of
+        # its failures — the lock file unopenable (fd exhaustion, read-only or
         # ACL-restricted dir), a fresh-boot missing log, a Windows sharing
         # violation rejecting the rename — degrades to appending without
         # rotating. Fd/disk exhaustion is a leading cause of the very stalls
         # this log diagnoses, so a rotation failure must never cost the
         # record; only a failure of the append itself may.
-        try:
-            lock_fd = os.open(
-                log_path.with_suffix(".jsonl.lock"), os.O_CREAT | os.O_RDWR, 0o600
-            )
-            try:
-                locked = platform_compat.try_acquire_lock(lock_fd, exclusive=True)
-                try:
-                    if locked and log_path.stat().st_size >= _SLOW_LOG_MAX_BYTES:
-                        os.replace(log_path, log_path.with_suffix(".jsonl.1"))
-                finally:
-                    if locked:
-                        platform_compat.release_lock(lock_fd)
-            finally:
-                os.close(lock_fd)
-        except OSError:
-            pass
+        rotate_jsonl_at(log_path, _SLOW_LOG_MAX_BYTES)
         with open(log_path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, default=str) + "\n")
     except OSError:

--- a/test/test_jsonl_util.py
+++ b/test/test_jsonl_util.py
@@ -1,0 +1,122 @@
+"""Tests for the shared JSONL rotation helper (``jsonl_util.rotate_jsonl_at``).
+
+The helper owns ONLY the rotate-by-rename step its call sites share (the MCP
+stub's fallback log, the subagents' slow-command log, member activity logs);
+each site keeps its own append and error contract. These tests pin the
+helper's contract directly; the per-site behavior stays pinned by each site's
+own rotation tests.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+from kiro_crew import platform_compat
+from kiro_crew.jsonl_util import rotate_jsonl_at
+
+CAP = 100  # bytes — small enough to cross with one write
+
+
+class TestRotateAtCap:
+    def test_rotates_once_the_cap_is_reached(self, tmp_path):
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * CAP)
+        rotate_jsonl_at(live, CAP)
+        rotated = tmp_path / "log.jsonl.1"
+        assert rotated.exists(), "previous generation not kept"
+        assert rotated.stat().st_size == CAP
+        assert not live.exists(), "live file must restart empty via the caller's append"
+
+    def test_does_not_rotate_under_the_cap(self, tmp_path):
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * (CAP - 1))
+        rotate_jsonl_at(live, CAP)
+        assert not (tmp_path / "log.jsonl.1").exists()
+        assert live.stat().st_size == CAP - 1
+
+    def test_keeps_exactly_one_generation(self, tmp_path):
+        """A second rotation replaces ``.1`` — total disk stays ~2x the cap."""
+        live = tmp_path / "log.jsonl"
+        rotated = tmp_path / "log.jsonl.1"
+        live.write_bytes(b"a" * CAP)
+        rotate_jsonl_at(live, CAP)
+        live.write_bytes(b"b" * CAP)
+        rotate_jsonl_at(live, CAP)
+        assert rotated.read_bytes() == b"b" * CAP
+        assert not live.exists()
+
+
+class TestBestEffort:
+    """NEVER raises: any failure degrades to not rotating, so the caller's
+    append still lands the record. Failures are induced with REAL ``OSError``s
+    (a directory squatting on the target path) — no stdlib patching, which
+    would leak process-wide to concurrent renamers."""
+
+    def test_missing_live_file_is_a_no_op(self, tmp_path):
+        rotate_jsonl_at(tmp_path / "absent.jsonl", CAP)  # must not raise
+        assert not (tmp_path / "absent.jsonl.1").exists()
+
+    def test_rename_failure_does_not_raise(self, tmp_path):
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * (CAP + 10))
+        (tmp_path / "log.jsonl.1").mkdir()
+        rotate_jsonl_at(live, CAP)  # must not raise
+        assert (tmp_path / "log.jsonl.1").is_dir()
+        assert live.exists(), "a failed rotation must leave the live file appendable"
+
+    def test_lock_open_failure_does_not_raise(self, tmp_path):
+        """An unopenable lock file (fd exhaustion, restrictive dir ACL) must
+        degrade to not rotating — fd/disk exhaustion is a leading cause of the
+        incidents these logs diagnose, so that is exactly when the caller's
+        append must still be reachable."""
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * (CAP + 10))
+        (tmp_path / "log.jsonl.lock").mkdir()
+        rotate_jsonl_at(live, CAP)  # must not raise
+        assert not (tmp_path / "log.jsonl.1").exists()
+        assert live.exists()
+
+    def test_unusable_path_value_does_not_raise(self, tmp_path):
+        """The contract covers ``ValueError`` too (e.g. an embedded NUL, which
+        ``os.open`` rejects as a value, not an OS failure) — the call sites'
+        own handlers narrow to ``OSError``, so the promise must hold here."""
+        rotate_jsonl_at(tmp_path / "log\x00name.jsonl", CAP)  # must not raise
+
+
+class TestTryLock:
+    def test_held_lock_skips_rotation_without_blocking(self, tmp_path):
+        """A caller that loses the try-lock skips rotating and never waits —
+        a blocking acquire would stall the caller's event loop for the
+        duration of another writer's rotation."""
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * (CAP + 10))
+        lock_fd = os.open(tmp_path / "log.jsonl.lock", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            assert platform_compat.try_acquire_lock(lock_fd, exclusive=True)
+            done = threading.Event()
+
+            def rotate() -> None:
+                rotate_jsonl_at(live, CAP)
+                done.set()
+
+            t = threading.Thread(target=rotate, daemon=True)
+            t.start()
+            t.join(timeout=10)
+            assert done.is_set(), "rotation blocked on a held try-lock"
+            assert not (tmp_path / "log.jsonl.1").exists()
+        finally:
+            platform_compat.release_lock(lock_fd)
+            os.close(lock_fd)
+
+    def test_lock_is_released_after_rotation(self, tmp_path):
+        """The winner releases the lock: a second writer can rotate next."""
+        live = tmp_path / "log.jsonl"
+        live.write_bytes(b"x" * CAP)
+        rotate_jsonl_at(live, CAP)
+        lock_fd = os.open(tmp_path / "log.jsonl.lock", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            assert platform_compat.try_acquire_lock(lock_fd, exclusive=True)
+        finally:
+            platform_compat.release_lock(lock_fd)
+            os.close(lock_fd)

--- a/test/test_members.py
+++ b/test/test_members.py
@@ -92,7 +92,9 @@ class TestMemberDir:
 
 class TestRecordActivity:
     def test_writes_a_pointer_entry(self):
-        assert record_activity("Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat")
+        assert record_activity(
+            "Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat"
+        )
         rows = read_activity("code-review")
         assert len(rows) == 1
         assert rows[0]["session"] == "dashboard_chat-1"
@@ -116,7 +118,9 @@ class TestRecordActivity:
         ]
 
     def test_entry_carries_no_content_only_pointers(self):
-        record_activity("Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat")
+        record_activity(
+            "Code Review", "dashboard_chat-1", "persistent", project="/repo", via="chat"
+        )
         assert set(read_activity("code-review")[0]) == {"ts", "member", "session", "project", "via"}
 
     def test_appends_rather_than_overwrites(self):
@@ -215,7 +219,9 @@ class TestRecordActivity:
     def test_reports_failure_instead_of_raising(self, monkeypatch):
         # Total by contract: the call sites have no guard, and one of them
         # (mcp_core) has no logger, so a raise here would surface as a tool error.
-        monkeypatch.setattr("kiro_crew.members.member_dir", lambda _s: (_ for _ in ()).throw(OSError("boom")))
+        monkeypatch.setattr(
+            "kiro_crew.members.member_dir", lambda _s: (_ for _ in ()).throw(OSError("boom"))
+        )
         assert record_activity("M", "s1", "persistent") is False
 
 
@@ -255,3 +261,111 @@ class TestReadActivity:
         for i in range(5):
             record_activity("M", f"s{i}", "persistent")
         assert [r["session"] for r in read_activity("m", limit=2)] == ["s3", "s4"]
+
+
+class TestRecordActivityRotation:
+    """The activity log rotates at the size cap — bounded disk, no lost record.
+
+    Mirrors the ``slow_commands.jsonl`` rotation tests in
+    ``test_subagent_persistence.py``: the shared ``rotate_jsonl_at`` helper
+    runs before the append, lock-guarded because this log is append-only from
+    multiple processes.
+    """
+
+    CAP = 400  # bytes — small enough to cross with a handful of records
+
+    @pytest.fixture(autouse=True)
+    def small_cap(self, monkeypatch):
+        monkeypatch.setattr("kiro_crew.members._ACTIVITY_LOG_MAX_BYTES", self.CAP)
+
+    def test_rotation_keeps_every_record(self):
+        """One rotation: older records land in ``.jsonl.1`` and stay visible
+        through :func:`read_activity`, which spans both generations."""
+        live = member_dir("m") / ACTIVITY_FILE_NAME
+        rotated = live.with_name(live.name + ".1")
+        n = 0
+        while not rotated.exists():
+            assert record_activity("M", f"s{n}", "persistent")
+            n += 1
+            assert n < 100, "cap never triggered a rotation"
+        # The rotated generation holds the pre-rotation records intact...
+        old = [
+            json.loads(row)
+            for row in rotated.read_text(encoding="utf-8").splitlines()
+            if row.strip()
+        ]
+        assert [r["session"] for r in old] == [f"s{i}" for i in range(n - 1)]
+        # ...the live file holds exactly the one record written after...
+        live_rows = [
+            json.loads(row) for row in live.read_text(encoding="utf-8").splitlines() if row.strip()
+        ]
+        assert [r["session"] for r in live_rows] == [f"s{n - 1}"]
+        assert live.stat().st_size < self.CAP
+        # ...and the PUBLIC reader still returns the full history, oldest
+        # first: rotation must not hide records from consumers.
+        assert [r["session"] for r in read_activity("m")] == [f"s{i}" for i in range(n)]
+
+    def test_read_activity_limit_spans_generations(self):
+        """``limit`` counts across both generations, newest last."""
+        live = member_dir("m") / ACTIVITY_FILE_NAME
+        rotated = live.with_name(live.name + ".1")
+        n = 0
+        while not rotated.exists():
+            assert record_activity("M", f"s{n}", "persistent")
+            n += 1
+            assert n < 100, "cap never triggered a rotation"
+        got = read_activity("m", limit=n)
+        assert [r["session"] for r in got] == [f"s{i}" for i in range(n)]
+
+    def test_dedupe_survives_rotation(self):
+        """A member/session pair whose entry was rotated aside must STILL be
+        suppressed: the dedupe probe reads both generations, so rotation
+        cannot re-inflate the counts it protects."""
+        live = member_dir("m") / ACTIVITY_FILE_NAME
+        rotated = live.with_name(live.name + ".1")
+        assert record_activity("M", "dedup-me", "persistent", via="chat", dedupe_session=True)
+        n = 0
+        while not rotated.exists():
+            assert record_activity("M", f"filler-{n}", "persistent")
+            n += 1
+            assert n < 100, "cap never triggered a rotation"
+        # The original entry now lives only in the rotated generation.
+        assert "dedup-me" in rotated.read_text(encoding="utf-8")
+        assert "dedup-me" not in live.read_text(encoding="utf-8")
+        assert (
+            record_activity("M", "dedup-me", "persistent", via="chat", dedupe_session=True) is False
+        )
+
+    def test_total_bytes_stay_bounded(self):
+        """The property the issue is about: many appends, bounded total disk.
+
+        One rotation alone does not prove boundedness — total bytes across
+        BOTH generations must stay bounded no matter how many records land.
+        """
+        for i in range(300):
+            record_activity("M", f"session-{i:04d}", "persistent")
+        live = member_dir("m") / ACTIVITY_FILE_NAME
+        rotated = live.with_name(live.name + ".1")
+        # Each generation may overshoot the cap by at most one record (the
+        # size check runs before the append), so bound each at CAP plus a
+        # generous one-record slack.
+        slack = 200
+        assert live.stat().st_size <= self.CAP + slack
+        assert rotated.exists()
+        assert rotated.stat().st_size <= self.CAP + slack
+        assert live.stat().st_size + rotated.stat().st_size <= 2 * (self.CAP + slack)
+
+    def test_rotation_failure_still_appends(self):
+        """Best-effort contract: a failing rotation never drops the record and
+        never breaks the ``record_activity`` return contract. A directory
+        squatting on the rotation target makes ``os.replace`` raise a REAL
+        ``OSError`` on both POSIX and Windows — no stdlib patching."""
+        record_activity("M", "seed", "persistent")
+        live = member_dir("m") / ACTIVITY_FILE_NAME
+        with open(live, "a", encoding="utf-8") as fh:
+            fh.write("x" * (self.CAP + 10) + "\n")
+        live.with_name(live.name + ".1").mkdir()
+
+        assert record_activity("M", "after-fail", "persistent") is True
+        assert live.with_name(live.name + ".1").is_dir()
+        assert "after-fail" in live.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #6319

## What

The repo carried three inline JSONL-bounding mechanisms (and one unbounded sibling of the same class). This PR extracts the shared rotate-by-rename step into one helper and closes the unbounded site:

- **New `src/kiro_crew/jsonl_util.py`** — `rotate_jsonl_at(path, max_bytes)`: O(1) rotate-by-rename at the size cap, guarded by a non-blocking try-lock on a sibling `.lock` file, best-effort by contract (never raises; any failure degrades to not rotating so the caller's append still lands the record).
- **`mcp_gateway/stub.py::log_fallback`** and **`subagent_persistence.py::record_slow_command`** re-pointed at the helper. Their pre-existing rotation tests pass **unchanged** as the extraction proof (rotate-at-cap, one-generation retention, lock-loser-never-blocks, rotation-failure-still-appends, lock-open-failure-still-appends).
- **`members.py::record_activity`** — the third unbounded-append sibling — now bounds `activity.jsonl` at the same 1 MiB cap / ~2 MiB total shape before each append. The log is append-only from multiple processes (per its own docstring), so it uses the same lock-guarded rotation.
- **`members.py::read_activity`** now reads the rotated generation plus the live file (the same two-generation read as `stub.fallback_counts`), so rotation never hides history from consumers — in particular the `dedupe_session` probe keeps suppressing a member/session pair whose entry was rotated aside.

## Design notes

- **Helper home**: a small new `jsonl_util.py` rather than `platform_compat.py` — the latter's charter is POSIX shims and it is already 5,100+ lines; a JSONL domain helper does not belong there. The new module imports only `os` + `platform_compat` (which `stub.py` already imports), so the stub's import budget is effectively unchanged.
- **Signature**: the issue sketched `rotate_jsonl_at(path, max_bytes, *, lock: bool)`. The `lock=False` variant would have zero production callers — all three sites are (or must be treated as) multi-process writers — so the lock is unconditional and the parameter is dropped. Cost to a hypothetical single writer is one fd and one non-blocking syscall; a dead branch plus a docstring describing a caller class that does not exist costs more.
- **Thresholds and formats unchanged**: each site keeps its own cap constant (`_FALLBACK_LOG_MAX_BYTES`, `_SLOW_LOG_MAX_BYTES`, new `_ACTIVITY_LOG_MAX_BYTES`), record shape, and error contract. `cron_history.py`'s last-N read-and-rewrite trim is a different shape (bounded by record count under a blocking lock) and is deliberately not folded in, as is `sel.py`'s hash-chained multi-segment rotation.
- **One declared semantic divergence for `stub.py`** (not observable by any existing test, benign): the append now runs after the try-lock is released instead of while holding it. Lock losers always appended unserialized, and rename-before-append ordering is preserved, so the lock never serialized appends to begin with. Additionally, a lock-file open failure previously dropped the stub's record (it propagated to the outer `except OSError`); it now degrades to append-without-rotating, matching `record_slow_command`'s (newer, #6310) containment — strictly fewer dropped records.

## Pre-push review

Two model-pinned read-only reviewers (GPT `gpt-5.6-sol`, Opus `claude-opus-5`) converged on one Medium — `read_activity` only read the live generation, so the first rotation would have silently halved the dedupe probe's history — fixed here with regression tests (`test_dedupe_survives_rotation`, `test_read_activity_limit_spans_generations`, and the rotation test now asserts the public reader returns both generations). Opus's advisory Lows: `lock=False` dead branch (dropped), `ValueError` outside the never-raises contract (now caught, pinned by `test_unusable_path_value_does_not_raise`), two stale comments (reworded), and the stub lock-scope divergence (declared above).

## Tests

- `test/test_jsonl_util.py` (new): rotate-at-cap, under-cap no-op, exactly-one-generation retention, never-raises on missing file / squatted rename target / squatted lock path / NUL path value, held-lock loser skips without blocking, lock released after rotation.
- `test/test_members.py`: new `TestRecordActivityRotation` mirroring #6284's `slow_commands.jsonl` shape — rotation keeps every record (visible through `read_activity`), total bytes stay bounded across 300 appends, rotation failure still appends, dedupe survives rotation, `limit` spans generations.
- Existing stub + subagent_persistence rotation tests: **unchanged, green**.
- Full backend gates: isort, flake8, mypy (CI-pinned versions), black baseline (one graduated entry pruned: `test/test_members.py` is now black-clean), subprocess-encoding, brand, harness-parity. Full `python -m pytest`: 71,068 passed; the 85 failures are host-environment (AF_UNIX path length, `gh` binary resolution, file-explorer host floor) and reproduce identically on pristine `main`.

## Post-open addition (commit 895fddd20, by a second pipeline instance)

A sibling pipeline instance pushed `fix: hold shared rotation lock in read_activity to prevent dedup bypass` in response to the GPT lane's first-round finding. Declared here for the record (the First Principles lane correctly flagged it as undeclared):

- `read_activity` now takes a **best-effort shared (non-blocking) lock** on `activity.jsonl.lock` around the two-generation read, so a concurrent rotation cannot slip between the `.1` read and the live read. This also means a pure read may create the `.lock` file.
- **Honest scope**: this narrows the dedupe race window; it does not close it. A reader that loses the try-lock proceeds unlocked (the never-stall contract forbids a blocking acquire), and the check-then-append gap in `record_activity` remains unserialized across processes. The dedupe stays best-effort by contract; the residual consequence is one duplicate pointer in an advisory count.
- A read failure in one generation now skips that generation instead of blanking the whole history (part of the same commit's restructure).
- The sibling two-generation reader, `stub.fallback_counts`, still reads unlocked against the same rotation shape — acceptable there because its consumer is a 24-hour aggregate count that tolerates a transient undercount, and unlike dedupe it feeds no write decision.
