### PR TITLE
fix(acp): revalidate entitlement before refusing an explicit model pick

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -67,6 +67,7 @@ from kiro_crew.acp.session_handle import (
     AcpRuntimeProtocol,
     AcpSessionHandle,
     _load_watchdog_settings,
+    parse_advertised_models,
 )
 from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
@@ -315,6 +316,16 @@ _DROP_NO_SESSION = "-"
 # string: an absent `method`, or a value of the wrong JSON type (see
 # _drop_key_part).
 _DROP_KEY_PLACEHOLDER = "?"
+
+# Entitlement probe (probe_advertised_models). The probe session carries no MCP
+# servers and activates no mode, so it is far cheaper than a real session start;
+# the timeout is still generous because the probe runs exactly when something is
+# already wrong (a rejection is being revalidated) and a loaded host must not
+# turn a recoverable verdict into a spurious probe failure.
+_ENTITLEMENT_PROBE_TIMEOUT = 30.0
+# A fresh answer is reused for this window so a burst of rejections (several
+# chats revalidating at once) costs one round-trip, not one per rejection.
+_ENTITLEMENT_PROBE_TTL_SECS = 20.0
 
 
 KIRO_CLI_BIN = "kiro-cli"
@@ -718,6 +729,11 @@ class AcpRuntime:
         # Empty until the handshake completes, so callers fail CLOSED and send
         # text-only rather than guessing a modality the agent never advertised.
         self._prompt_capabilities: dict = {}
+        # Entitlement probe state (probe_advertised_models): single-flight lock
+        # plus a short-TTL cache of the last non-empty answer.
+        self._entitlement_probe_lock = asyncio.Lock()
+        self._entitlement_probe_at = 0.0
+        self._entitlement_probe_result: list[dict[str, str]] = []
         self._dead = False
         self._last_activity: float = 0.0
         self._stderr_lines: list[str] = []
@@ -2773,6 +2789,64 @@ class AcpRuntime:
 
         logger.info("Created session %s on runtime PID %d", session_id, self._pid or 0)
         return handle
+
+    async def probe_advertised_models(self) -> list[dict[str, str]]:
+        """Fetch a fresh advertised-model (entitlement) snapshot from this backend.
+
+        A session's ``availableModels`` is captured once, from its own
+        ``session/new`` response, and the backend resolves that answer from the
+        account state it holds at that instant — a lookup racing a token refresh
+        or a cold start can answer with the default (free-tier) set. A long-lived
+        session holding such an answer refuses models the account actually has,
+        and nothing ever corrects it. This re-asks the question on the SAME live
+        process with a throwaway minimal session (no MCP servers, no mode
+        activation), terminated before returning.
+
+        Single-flight + short TTL: concurrent callers share one probe, and a
+        fresh non-empty answer is reused for :data:`_ENTITLEMENT_PROBE_TTL_SECS`
+        so a burst of rejections costs one round-trip.
+
+        Returns the normalized advertised list, or ``[]`` when the probe fails
+        or advertises nothing. An empty return is NOT evidence about
+        entitlement — callers must keep whatever snapshot they already hold.
+        """
+        async with self._entitlement_probe_lock:
+            now = time.monotonic()
+            if (
+                self._entitlement_probe_result
+                and now - self._entitlement_probe_at < _ENTITLEMENT_PROBE_TTL_SECS
+            ):
+                return list(self._entitlement_probe_result)
+            if not self._initialized or self._dead or self._process is None:
+                return []
+            params = build_session_new_params(self._work_dir, mcp_servers=[])
+            session_id = ""
+            self._session_inits_in_flight += 1
+            try:
+                try:
+                    resp = await self._send_and_await(
+                        METHOD_SESSION_NEW, params, timeout=_ENTITLEMENT_PROBE_TIMEOUT
+                    )
+                    session_id = str(resp.get("sessionId") or "")
+                finally:
+                    # Close the init scope even on failure so staged init
+                    # notifications from this probe never leak into a later
+                    # real session's queue.
+                    self._finish_session_init(session_id)
+            except Exception:
+                logger.debug("entitlement probe session/new failed", exc_info=True)
+                return []
+            try:
+                fresh = parse_advertised_models(resp)
+            finally:
+                if session_id:
+                    # Evict the probe session from the shared process; never
+                    # raises (best-effort by contract).
+                    await self.terminate_session(session_id)
+            if fresh:
+                self._entitlement_probe_result = list(fresh)
+                self._entitlement_probe_at = time.monotonic()
+            return fresh
 
     async def load_session(
         self,

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -363,6 +363,26 @@ _MCP_DRAIN_REPORT_ACTIONS = frozenset(
 _SENTINEL = object()
 
 
+def parse_advertised_models(resp: dict[str, Any]) -> list[dict[str, str]]:
+    """The normalized advertised-model list from a ``session/new``/``session/load``
+    response (``[]`` when the backend advertised nothing).
+
+    Accepts both response shapes: a ``models`` object
+    ``{availableModels: [...], currentModelId}`` and a bare list under either
+    key. Normalization matches :meth:`AcpSessionHandle._normalize_models`, so a
+    probe's answer and a session-init snapshot are directly comparable.
+    """
+    models = resp.get("models") or resp.get("availableModels")
+    if isinstance(models, dict):
+        avail = models.get("availableModels", [])
+        if isinstance(avail, list):
+            return AcpSessionHandle._normalize_models(avail)
+        return []
+    if isinstance(models, list):
+        return AcpSessionHandle._normalize_models(models)
+    return []
+
+
 class AcpRuntimeError(Exception):
     """Base error for AcpRuntime operations."""
 
@@ -413,6 +433,11 @@ class AcpRuntimeProtocol(Protocol):
         ...
 
     async def send_request(self, method: str, params: dict[str, Any]) -> int:
+        ...
+
+    async def probe_advertised_models(self) -> list[dict[str, str]]:
+        """Fresh advertised-model snapshot from a throwaway ``session/new``
+        (``[]`` = probe failed / advertised nothing — never evidence)."""
         ...
 
     async def send_notification(self, method: str, params: dict[str, Any]) -> None:
@@ -1689,6 +1714,28 @@ class AcpSessionHandle:
                 "description": str(m.get("description") or ""),
             })
         return captured
+
+    async def refresh_available_models(self) -> list[dict[str, str]]:
+        """Re-resolve the advertised-model snapshot against the live backend.
+
+        ``_available_models`` is otherwise written once, from this session's own
+        ``session/new`` — an answer the backend resolved from the account state
+        it held at that instant. When that answer was degraded (a lookup racing
+        a token refresh answers with the default tier), the session refuses
+        models the account actually has, for its whole life. Every consumer of
+        entitlement — the explicit-pick refusal, the prompt-time pin withhold,
+        the dashboard picker filter — reads through this handle's snapshot, so
+        one refresh heals them all.
+
+        The snapshot is replaced only by a NON-EMPTY probe result: a failed or
+        empty probe is not evidence about entitlement, so the prior snapshot is
+        kept. Returns the probe result either way, so callers can distinguish
+        "revalidated" from "could not revalidate".
+        """
+        fresh = await self._runtime.probe_advertised_models()
+        if fresh:
+            self._available_models = list(fresh)
+        return fresh
 
     def _sync_effort_levels(self) -> None:
         """Push ACP-reported effort levels to the global validation set (parity

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -586,10 +586,23 @@ class AcpSessionProvider(LLMProvider):
         Raises :class:`AcpModelUnavailable` so the caller surfaces it as a user
         error instead of recovering with a session reset — a reset here would
         destroy the live conversation and still land on a different model.
+
+        A refusal is never issued on the session-init snapshot alone. That
+        snapshot is one answer, captured at one instant, and a lookup racing a
+        token refresh can answer with the default tier — freezing a
+        false "not entitled" verdict into the session for its whole life. So a
+        would-be refusal first revalidates against a fresh backend probe
+        (:meth:`AcpSessionHandle.refresh_available_models`) and only stands if
+        the fresh answer ALSO lacks the model. A failed probe keeps the stale
+        verdict (fail-safe: no evidence, no entitlement granted).
         """
         advertised = advertised_model_ids(self._handle.available_models)
         if model_is_unusable(model_id, advertised):
-            raise AcpModelUnavailable(model_id, advertised)
+            fresh = advertised_model_ids(
+                await self._guarded(self._handle.refresh_available_models())
+            )
+            if model_is_unusable(model_id, fresh or advertised):
+                raise AcpModelUnavailable(model_id, fresh or advertised)
         await self._guarded(self._handle.set_model(model_id))
 
     async def set_mode(self, agent_name: str) -> None:

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -3891,6 +3891,15 @@ class TestAcpRuntimeLoadSession:
             return out
 
         builders = {**_builders(rt_mod), **_builders(client_mod)}
+        # Exempt: builders whose session exists only to read the session/new
+        # response and is terminated before any prompt. Such a session never
+        # calls a tool, so pooled broker stubs would add per-probe MCP boot
+        # churn without pooling anything. Everything a REAL conversation runs
+        # through must stay in the ratchet.
+        _NEVER_PROMPTS = {"probe_advertised_models"}
+        for name in _NEVER_PROMPTS:
+            assert name in builders, f"{name} no longer issues session/new — remove its exemption"
+            builders.pop(name)
         # The four known builders; a new one is included automatically.
         assert {
             "create_session",
@@ -7567,3 +7576,184 @@ def test_store_session_config_leaves_model_empty_when_ambiguous():
     )
     assert handle._resolved_model_id == ""
     assert handle.served_model == ""
+
+
+# ── probe_advertised_models (entitlement revalidation) ──
+
+
+_PROBE_RESP = {
+    "sessionId": "probe-1",
+    "models": {
+        "currentModelId": "claude-opus-5",
+        "availableModels": [
+            {"modelId": "auto", "name": "auto"},
+            {"modelId": "claude-opus-5", "name": "claude-opus-5"},
+        ],
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_fresh_set_and_terminates_probe_session():
+    """The probe re-asks entitlement with a throwaway minimal session/new
+    (mcpServers present-but-empty — kiro-cli treats a missing field as
+    malformed), reads the advertised set, and evicts the probe session so it
+    never accumulates in the shared process."""
+    rt, _, _ = _make_runtime()
+    rt._send_and_await = AsyncMock(side_effect=[_PROBE_RESP, {}])  # type: ignore[method-assign]
+    fresh = await rt.probe_advertised_models()
+    assert [m["modelId"] for m in fresh] == ["auto", "claude-opus-5"]
+    calls = rt._send_and_await.call_args_list
+    assert calls[0].args[0] == METHOD_SESSION_NEW
+    assert calls[0].args[1]["mcpServers"] == []
+    assert calls[1].args[0] == METHOD_SESSION_TERMINATE
+    assert calls[1].args[1] == {"sessionId": "probe-1"}
+    # Init scope closed — staged init notifications cannot leak into a later
+    # real session.
+    assert rt._session_inits_in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_returns_empty_and_closes_init_scope():
+    """A failed probe is not evidence: it returns [] (caller keeps its prior
+    snapshot) and must not leave the init-notification scope open."""
+    rt, _, _ = _make_runtime()
+    rt._send_and_await = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AcpRuntimeError("boom")
+    )
+    assert await rt.probe_advertised_models() == []
+    assert rt._session_inits_in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_probe_advertising_nothing_returns_empty_but_still_terminates():
+    """A session/new that omits models yields [] — and the probe session is
+    still evicted, and the empty answer is NOT cached (the next call probes
+    again rather than repeating a non-answer)."""
+    rt, _, _ = _make_runtime()
+    rt._send_and_await = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[{"sessionId": "probe-2"}, {}, {"sessionId": "probe-3"}, {}]
+    )
+    assert await rt.probe_advertised_models() == []
+    assert rt._send_and_await.call_args_list[1].args[0] == METHOD_SESSION_TERMINATE
+    assert await rt.probe_advertised_models() == []
+    news = [c for c in rt._send_and_await.call_args_list if c.args[0] == METHOD_SESSION_NEW]
+    assert len(news) == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_result_reused_within_ttl():
+    """A fresh non-empty answer is served from cache inside the TTL, so a burst
+    of rejections costs one round-trip."""
+    rt, _, _ = _make_runtime()
+    rt._send_and_await = AsyncMock(side_effect=[_PROBE_RESP, {}])  # type: ignore[method-assign]
+    first = await rt.probe_advertised_models()
+    second = await rt.probe_advertised_models()
+    assert second == first
+    # One session/new + one terminate total: the second call never hit the wire.
+    assert rt._send_and_await.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_single_flight_concurrent_callers_share_one_probe():
+    rt, _, _ = _make_runtime()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_send(method, params, timeout=None):
+        if method == METHOD_SESSION_NEW:
+            started.set()
+            await release.wait()
+            return dict(_PROBE_RESP)
+        return {}
+
+    rt._send_and_await = AsyncMock(side_effect=slow_send)  # type: ignore[method-assign]
+    t1 = asyncio.ensure_future(rt.probe_advertised_models())
+    t2 = asyncio.ensure_future(rt.probe_advertised_models())
+    await started.wait()
+    release.set()
+    r1, r2 = await asyncio.gather(t1, t2)
+    assert r1 == r2 != []
+    news = [c for c in rt._send_and_await.call_args_list if c.args[0] == METHOD_SESSION_NEW]
+    assert len(news) == 1
+
+
+@pytest.mark.asyncio
+async def test_probe_on_dead_or_uninitialized_runtime_returns_empty():
+    rt, _, _ = _make_runtime()
+    rt._dead = True
+    assert await rt.probe_advertised_models() == []
+    rt2, _, _ = _make_runtime()
+    rt2._initialized = False
+    assert await rt2.probe_advertised_models() == []
+
+
+# ── AcpSessionHandle.refresh_available_models ──
+
+
+@pytest.mark.asyncio
+async def test_refresh_replaces_snapshot_on_nonempty_probe():
+    """One refresh heals every consumer of the handle's snapshot: the fresh
+    probe answer replaces the session-init availableModels in place."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.store_session_config(
+        {
+            "models": {
+                "availableModels": [
+                    {"modelId": "claude-sonnet-4"},
+                    {"modelId": "claude-sonnet-4.5"},
+                ]
+            }
+        }
+    )
+    fresh_set = [
+        {"modelId": "auto", "name": "auto", "description": ""},
+        {"modelId": "claude-opus-5", "name": "claude-opus-5", "description": ""},
+    ]
+    rt.probe_advertised_models = AsyncMock(return_value=fresh_set)  # type: ignore[method-assign]
+    fresh = await handle.refresh_available_models()
+    assert fresh == fresh_set
+    assert [m["modelId"] for m in handle.available_models] == [
+        "auto",
+        "claude-opus-5",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_snapshot_on_empty_probe():
+    """A failed/empty probe is not evidence — the prior snapshot survives so a
+    flaky probe can never WIDEN or clear entitlement."""
+    rt, _, _ = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.store_session_config({"models": {"availableModels": [{"modelId": "claude-sonnet-4"}]}})
+    rt.probe_advertised_models = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    assert await handle.refresh_available_models() == []
+    assert [m["modelId"] for m in handle.available_models] == ["claude-sonnet-4"]
+
+
+class TestParseAdvertisedModels:
+    """Both response shapes normalize identically, so a probe answer and a
+    session-init snapshot are directly comparable."""
+
+    def test_models_object_shape(self):
+        from kiro_crew.acp.session_handle import parse_advertised_models
+
+        out = parse_advertised_models(_PROBE_RESP)
+        assert [m["modelId"] for m in out] == ["auto", "claude-opus-5"]
+        assert all(set(m) == {"modelId", "name", "description"} for m in out)
+
+    def test_bare_list_shape(self):
+        from kiro_crew.acp.session_handle import parse_advertised_models
+
+        out = parse_advertised_models({"availableModels": [{"modelId": "claude-sonnet-4"}]})
+        assert [m["modelId"] for m in out] == ["claude-sonnet-4"]
+
+    def test_absent_or_malformed_yields_empty(self):
+        from kiro_crew.acp.session_handle import parse_advertised_models
+
+        assert parse_advertised_models({}) == []
+        assert parse_advertised_models({"models": {"availableModels": "nope"}}) == []
+        assert parse_advertised_models({"models": 7}) == []

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -1130,6 +1130,10 @@ class TestLivePathModelEntitlement:
         handle = _make_handle()
         handle.available_models = [{"modelId": m, "name": m} for m in advertised]
         handle.set_model = AsyncMock()
+        # Default: the revalidation probe cannot confirm anything (returns []),
+        # so a stale-snapshot refusal stands. Tests exercising the heal path
+        # override this with a side_effect that also updates available_models.
+        handle.refresh_available_models = AsyncMock(return_value=[])
         return AcpSessionProvider(handle, MagicMock()), handle
 
     @pytest.mark.asyncio
@@ -1173,6 +1177,73 @@ class TestLivePathModelEntitlement:
 
         await provider.set_model("claude-opus-4.8")
 
+        handle.set_model.assert_awaited_once_with("claude-opus-4.8")
+
+    @pytest.mark.asyncio
+    async def test_stale_refusal_revalidates_and_allows(self):
+        """A would-be refusal on the session-init snapshot is revalidated
+        against a fresh probe; when the fresh answer advertises the model, the
+        switch proceeds instead of freezing a false 'not entitled' verdict."""
+        provider, handle = self._provider(["claude-sonnet-4", "claude-sonnet-4.5"])
+        fresh = [
+            {"modelId": "auto", "name": "auto", "description": ""},
+            {"modelId": "claude-opus-5", "name": "claude-opus-5", "description": ""},
+        ]
+
+        async def _refresh():
+            handle.available_models = fresh
+            return fresh
+
+        handle.refresh_available_models = AsyncMock(side_effect=_refresh)
+
+        await provider.set_model("claude-opus-5")
+
+        handle.refresh_available_models.assert_awaited_once()
+        handle.set_model.assert_awaited_once_with("claude-opus-5")
+
+    @pytest.mark.asyncio
+    async def test_refusal_stands_when_fresh_probe_still_lacks_model(self):
+        """A real downgrade survives revalidation — and the error names the
+        FRESH advertised set, not the stale one."""
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        provider, handle = self._provider(["claude-sonnet-4.6"])
+        handle.refresh_available_models = AsyncMock(
+            return_value=[
+                {"modelId": "claude-sonnet-4", "name": "s4", "description": ""},
+                {"modelId": "claude-sonnet-4.5", "name": "s45", "description": ""},
+            ]
+        )
+
+        with pytest.raises(AcpModelUnavailable) as excinfo:
+            await provider.set_model("claude-opus-4.8")
+
+        handle.set_model.assert_not_awaited()
+        assert "claude-sonnet-4.5" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_refusal_names_stale_set_when_probe_fails(self):
+        """An empty probe result is not evidence: the stale verdict stands and
+        the error names the only set we actually have."""
+        from kiro_crew.acp.client import AcpModelUnavailable
+
+        provider, handle = self._provider(["claude-sonnet-4.6"])
+
+        with pytest.raises(AcpModelUnavailable) as excinfo:
+            await provider.set_model("claude-opus-4.8")
+
+        handle.refresh_available_models.assert_awaited_once()
+        assert "claude-sonnet-4.6" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_advertised_pick_never_probes(self):
+        """The probe runs only on a would-be refusal — an allowed switch costs
+        no extra round-trip."""
+        provider, handle = self._provider(["claude-opus-4.8"])
+
+        await provider.set_model("claude-opus-4.8")
+
+        handle.refresh_available_models.assert_not_awaited()
         handle.set_model.assert_awaited_once_with("claude-opus-4.8")
 
 


### PR DESCRIPTION
## Problem / Motivation

A dashboard chat can get permanently stuck on the free-tier model set even though the signed-in account holds a full entitlement. A session's `availableModels` is captured once, from its own `session/new` response; the backend resolves that answer from the account state it holds at that instant, so an entitlement lookup racing token/profile resolution at gateway startup can answer with the default (free-tier) set. The session then refuses models the account actually has — for its entire life — the dashboard picker narrows chat-wide (the filter reads the newest live session's snapshot), and pinned models are silently withheld at prompt time. Observed live 2026-08-27: a startup-window session captured `[claude-sonnet-4, claude-sonnet-4.5]` while a fresh handshake against the same binary and account advertised all 20 models (details in #6355).

## Why it matters

The failure is sticky and invisible: nothing ever corrects the snapshot, so one unlucky `session/new` locks a user out of the models they pay for until they happen to start a new chat — and explicit picks fail with a terminal "not available on your account" error that misattributes a transient backend fallback to the user's plan. Chats left on `auto` quietly run on the free default with no error at all.

## What changed (motivation → approach → change)

Symptom → root cause: the refusal path (`AcpSessionProvider.set_model` → `model_is_unusable`) treats the single session-init snapshot as permanent ground truth; `store_session_config()` writes `_available_models` once and nothing updates it. Approach: revalidate-before-terminal — never issue an entitlement refusal on an unconfirmed snapshot alone, and make the snapshot refreshable so one revalidation heals every consumer. Change:

- `AcpRuntime.probe_advertised_models()` — re-asks entitlement on the same live process with a throwaway minimal `session/new` (no MCP servers, no mode activation), terminated before returning. Single-flight + 20s TTL so a burst of rejections costs one round-trip. A failed/empty probe returns `[]`, which is never treated as evidence.
- `AcpSessionHandle.refresh_available_models()` — replaces the session-init snapshot from a non-empty probe. Every entitlement consumer (explicit-pick refusal, prompt-time pin withhold, picker filter) reads through the handle, so one refresh heals them all.
- `AcpSessionProvider.set_model` — a would-be refusal first revalidates and only stands if the fresh answer also lacks the model; the error then names the fresh set. An empty probe keeps the stale verdict (fail-safe: no evidence never widens entitlement). Allowed switches never probe. A real downgrade still fails terminally — one probe later.

Design notes: the probe session carries `mcpServers: []` deliberately (it never prompts or calls a tool, so pooled broker stubs would add per-probe MCP boot churn without pooling anything); the #3528 un-pooling contract test gains a documented `_NEVER_PROMPTS` exemption that self-deletes if the probe stops issuing `session/new`. Scoped to the shared-runtime path — direct-spawn `AcpClient` sessions get a fresh `session/new` per spawn by construction. The silent `auto` flavor has no rejection to trigger a probe; surfacing a sharp advertised-set shrink is follow-up material, noted in #6355.

## Tests

13 new tests:

- Probe: returns the fresh normalized set and evicts the probe session; failure returns `[]` and closes the init-notification scope; nothing-advertised returns `[]`, still terminates, and is not cached; TTL reuse (one wire round-trip for a burst); single-flight coalescing of concurrent callers; dead/uninitialized runtime returns `[]`.
- Handle refresh: non-empty probe replaces the snapshot in place; empty probe keeps it (a flaky probe can never widen or clear entitlement).
- Provider: stale refusal revalidates and allows when the fresh set advertises the model; refusal stands on a fresh miss and the error names the fresh set; probe failure keeps the stale verdict and names the stale set; an advertised pick never probes.
- `parse_advertised_models` shape coverage (models-object and bare-list responses, malformed input).

Mutation probes (planted, named test failed, restored byte-identical): regressing `fresh or advertised` to bare `fresh` in the refusal (the fail-open trap) is caught by `test_refusal_names_stale_set_when_probe_fails`; an unconditional snapshot replace is caught by `test_refresh_keeps_snapshot_on_empty_probe`.

Full local floor: pytest 71,022 passed (8 pre-existing environmental failures reproduced identically on `origin/main` with a separate venv: `test_xdist_host_budget.py` and the host-isolation/venv-symlink tests read host state), isort/flake8/mypy clean, black ratchet green, `tsc -b` clean, vitest 1593/1593 files passed.

## Manual verification

Reproduced the live comparison that motivated the fix: a minimal stdio `initialize` + `session/new` probe against the same kiro-cli binary and signed-in account returned the full 20-model set with `currentModelId: claude-opus-5`, while the stale session still held the 2-model free-tier snapshot and refused explicit picks. The degraded answer itself is a startup race and not deterministically reproducible on demand; the revalidation path is exercised by the unit tests above.

## Related Issues

Fixes #6355

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
