### PR TITLE
fix: explicit mcp identity provenance flag, hoist grant gate (#6233)

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -100,8 +100,12 @@ absent `rawInput`, so the params cache stays empty and every child permission
 request for such a tool is low-fidelity (`AcpEvent.child_low_fidelity`). The
 `_meta.kiro` identity caches are written unconditionally from the same frame, so
 the permission event still carries the verified `mcp_server_name`/`tool_name`
-pair; `AcpEvent.child_mcp_identity_trusted` exposes that verified-identity half
-(arguments unverified) for the unconditional grant paths documented in
+pair plus the explicit `mcp_identity_trusted` provenance flag (set only when
+BOTH cache reads hit — mirroring `raw_params_trusted`, so an inline fallback
+can never count as verified); `AcpEvent.child_mcp_identity_trusted` exposes
+that verified-identity half (arguments unverified) and
+`AcpEvent.child_unconditional_grant_eligible` hoists the grant-eligibility
+expression for the unconditional grant paths documented in
 `security.md` § Child-fidelity split.
 
 The handshake also branches on the backend:

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1470,13 +1470,27 @@ input. A remote (HTTP) MCP server legitimately streams empty `rawInput` on its
 frame's `_meta.kiro` server/tool identity is cache-provenance and
 non-model-authored. `AcpEvent.child_mcp_identity_trusted` isolates that half
 (requires: child origin, RESOLVED non-shell classification, canonical
-server+tool recovered from cache), and **unconditional** grants — session
-trust-all, global YOLO, `parent_policy=auto`, per-source auto-approve, the
-`--approval yolo` override — honor the grant for identity-verified events: the
-approve decision consumes no agent-authored event data, only the arguments
-remain unverified (the same blindness the interactive card has; the identity
-split changes WHO approves, not what any gate can scan). Shell events never
-qualify: their deny gates need the command bytes the event lacks.
+server+tool recovered from cache, AND the explicit `mcp_identity_trusted`
+provenance flag — set only when the trusted population actually happened: in
+`build_permission_event` it is derived from the origin-scoped cache reads
+HITTING (never from cache availability or field non-emptiness — a hit whose
+cached value is `""` still earns it), the `_meta.kiro` tool_call builders set
+it only when their extractors actually produced an identity pair (a frame
+without `_meta.kiro` populates nothing and asserts no provenance), and
+`_to_llm_event` copies it; it mirrors
+`raw_params_trusted`, so a future inline population path fails closed instead
+of counting as verified on non-emptiness alone). The grant-eligibility
+expression is hoisted to one place,
+`AcpEvent.child_unconditional_grant_eligible`
+(`not child_low_fidelity or child_mcp_identity_trusted`), consumed by all
+three approval surfaces (dashboard runner, Slack gateway, subagent manager):
+**unconditional** grants — session trust-all, global YOLO,
+`parent_policy=auto`, per-source auto-approve, the `--approval yolo` override —
+honor the grant for eligible events: the approve decision consumes no
+agent-authored event data, only the arguments remain unverified (the same
+blindness the interactive card has; the identity split changes WHO approves,
+not what any gate can scan). Shell events never qualify: their deny gates need
+the command bytes the event lacks.
 
 ### SEL Audit Logging (`sel.py`)
 

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -100,10 +100,13 @@ recoverable command) skips steps 2–3 and is handed to the interactive callback
 with an "UNVERIFIED child request" annotation (headless: rejected), because
 every field a shortcut would judge is agent-authored. One carve-out: when the
 event's canonical MCP identity IS verified (`child_mcp_identity_trusted` — the
-`_meta.kiro` server/tool pair resolved from the tool_call cache, resolved
+`_meta.kiro` server/tool pair resolved from the tool_call cache, carrying the
+explicit `mcp_identity_trusted` provenance flag those cache hits set, resolved
 non-shell; the shape a remote MCP server produces by streaming empty
 `rawInput`), the **unconditional** `parent_policy == "auto"` grant still
-auto-approves: its decision consumes no agent-authored event data, only the
+auto-approves — the call site reads the hoisted
+`AcpEvent.child_unconditional_grant_eligible` property: its decision consumes
+no agent-authored event data, only the
 arguments remain unverified. The hook auto-approve (title-pattern-matched) and
 every content-matching path stay fail-closed on the composite fidelity.
 

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -786,6 +786,33 @@ def build_permission_event(
         if isinstance(_inline, dict):
             _resolved_raw_params = _inline
 
+    # Trusted MCP server + tool identity recovered from the preceding tool_call
+    # (the permission payload carries no _meta). .get() (not .pop()) mirrors the
+    # is_shell cache: a later tool_call_update for the same id re-reads it; the
+    # per-turn dispatch .clear() handles cleanup. Empty on a miss (fail-closed
+    # for the app-own-server auto-approve). The tool name lets the app-own-server
+    # auto-approve govern the canonical mcp__<server>__<tool> on the permission
+    # path.
+    _cached_server = (
+        mcp_server_name_cache.get(_ck)
+        if (mcp_server_name_cache is not None and tool_call_id)
+        else None
+    )
+    _cached_tool = (
+        tool_name_cache.get(_ck) if (tool_name_cache is not None and tool_call_id) else None
+    )
+    _mcp_server_name = _cached_server or ""
+    _tool_name = _cached_tool or ""
+    # Explicit identity-provenance flag (mirrors _raw_params_trusted): True iff
+    # BOTH cache reads above actually HIT — a written entry may legitimately be
+    # "" for a non-MCP tool, so the hit is distinguished from a miss by the
+    # None default, never by the value. Deliberately derived from the reads
+    # themselves, not from cache availability or non-emptiness: a future
+    # inline fallback populating the identity fields from the permission
+    # payload would leave this False and fail closed in
+    # AcpEvent.child_mcp_identity_trusted.
+    _mcp_identity_trusted = _cached_server is not None and _cached_tool is not None
+
     event = AcpEvent(
         kind=EVENT_PERMISSION_REQUEST,
         request_id=request_id,
@@ -799,23 +826,9 @@ def build_permission_event(
         tool_call_id=tool_call_id,
         raw_tool_params=_resolved_raw_params,
         is_shell=is_shell,
-        # Trusted MCP server identity recovered from the preceding tool_call
-        # (the permission payload carries no _meta). .get() (not .pop()) mirrors
-        # the is_shell cache: a later tool_call_update for the same id re-reads
-        # it; the per-turn dispatch .clear() handles cleanup. Empty on a miss
-        # (fail-closed for the app-own-server auto-approve).
-        mcp_server_name=(
-            mcp_server_name_cache.get(_ck, "")
-            if (mcp_server_name_cache is not None and tool_call_id)
-            else ""
-        ),
-        # Trusted tool identity recovered from the preceding tool_call, mirroring
-        # mcp_server_name above. Lets the app-own-server auto-approve govern the
-        # canonical mcp__<server>__<tool> on the permission path (no _meta here).
-        # Empty on a miss (fail-closed: no trusted tool name → no auto-approve).
-        tool_name=(
-            tool_name_cache.get(_ck, "") if (tool_name_cache is not None and tool_call_id) else ""
-        ),
+        mcp_server_name=_mcp_server_name,
+        tool_name=_tool_name,
+        mcp_identity_trusted=_mcp_identity_trusted,
     )
     return event, recorded
 
@@ -937,6 +950,11 @@ def _build_tool_call_event(
         # Trusted identity from _meta.kiro (NOT the LLM-authored title).
         tool_name=_tool_name,
         mcp_server_name=_mcp_server_name,
+        # The pair above comes exclusively from the _kiro_* extractors over the
+        # frame's _meta.kiro (non-model-authored) — the trusted tool_call path.
+        # Earned only when an identity pair was actually extracted: a frame
+        # with no _meta.kiro populates nothing, so it asserts no provenance.
+        mcp_identity_trusted=bool(_mcp_server_name and _tool_name),
         diff_old_text=_diff_old_text,
         diff_path=_diff_path,
     )

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -5437,6 +5437,14 @@ class AcpClient:
                 is_shell=is_shell,
                 tool_name=_kiro_tool_name(update),
                 mcp_server_name=_kiro_mcp_server_name(update),
+                # The pair above comes exclusively from the _kiro_* extractors
+                # over the frame's _meta.kiro (non-model-authored) — the
+                # trusted tool_call path. Earned only when an identity pair was
+                # actually extracted: a frame with no _meta.kiro populates
+                # nothing, so it asserts no provenance.
+                mcp_identity_trusted=bool(
+                    _kiro_mcp_server_name(update) and _kiro_tool_name(update)
+                ),
             )
         return None
 

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -527,6 +527,15 @@ class AcpEvent:
     #: classification (cache hit), not the miss-default False.
     raw_params_trusted: bool = False
     shell_classified: bool = False
+    #: mcp_identity_trusted: mcp_server_name/tool_name below were populated
+    #: from a provenance-verified source — the origin-scoped tool_call caches
+    #: (permission path) or ``_meta.kiro`` on the tool_call frame itself —
+    #: never an inline/agent-authored fallback. Mirrors ``raw_params_trusted``:
+    #: ``child_mcp_identity_trusted`` requires this flag IN ADDITION to
+    #: non-empty identity fields, so a future population path that forgets it
+    #: fails CLOSED (identity not counted as verified) instead of silently
+    #: passing on non-emptiness alone.
+    mcp_identity_trusted: bool = False
     # Canonical, NON-model-authored tool identity from ``_meta.kiro`` (see
     # ``_dispatch._kiro_tool_name``). ``title`` is LLM-authored prose — for shell
     # tools ``select_tool_title`` even prefers the model's ``description`` — so a
@@ -652,19 +661,45 @@ class AcpEvent:
         (``sub_session_id``), a RESOLVED non-shell classification
         (``shell_classified`` and not ``is_shell`` — an unclassified event
         defaults to non-shell and must not pass as one; a shell tool's deny
-        gates need the command bytes this event lacks), and the canonical
+        gates need the command bytes this event lacks), the canonical
         ``mcp_server_name`` + ``tool_name`` pair recovered from the tool_call
         cache (empty on a miss, and populated only for genuinely MCP-served
-        tools — a host shell/builtin can never carry a server name). A
+        tools — a host shell/builtin can never carry a server name), and the
+        explicit ``mcp_identity_trusted`` provenance flag set by the trusted
+        population sites — non-emptiness alone is NOT proof of provenance, so
+        an identity pair written by any future inline/agent-authored fallback
+        stays untrusted until that site earns the flag. A
         non-child event returns False: parents never need the split.
         """
         return bool(
             self.sub_session_id
             and self.shell_classified
             and not self.is_shell
+            and self.mcp_identity_trusted
             and self.mcp_server_name
             and self.tool_name
         )
+
+    @property
+    def child_unconditional_grant_eligible(self) -> bool:
+        """True when an UNCONDITIONAL grant path may honor this event.
+
+        An unconditional grant is one whose approve decision consumes no
+        agent-authored event data: session trust-all, global YOLO / the
+        ``--approval yolo`` override, ``parent_policy=auto``, per-source
+        auto-approve. Such a grant is eligible when the event has full
+        fidelity (``not child_low_fidelity``) OR its canonical MCP identity is
+        verified (``child_mcp_identity_trusted``) — for the latter only the
+        ARGUMENTS remain unverified, which the grant never reads (the same
+        blindness the interactive card has; the identity split changes WHO
+        approves, not what any gate can scan). Content-MATCHING paths —
+        trusted patterns, trust-reads, title-keyed ``auto_approve_tools``, the
+        'reads' classification — must stay gated on the composite
+        ``child_low_fidelity`` instead: the agent-authored title or inline
+        params ARE their matched input, and a forged title must never satisfy
+        them. Non-child events are always eligible (never low-fidelity).
+        """
+        return not self.child_low_fidelity or self.child_mcp_identity_trusted
 
 
 @dataclass

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -6525,17 +6525,11 @@ async def _run_chat(
                 # to the interactive card. A child WITH full context takes the
                 # same branches as the main agent (mode parity).
                 _child_low_fidelity = event.child_low_fidelity
-                # Verified-identity half of the fidelity split (see
-                # AcpEvent.child_mcp_identity_trusted): a remote MCP server's
-                # tool_call frame streams no rawInput, so args provenance is
-                # unrecoverable — but the _meta.kiro server/tool identity DID
-                # arrive and is non-model-authored. UNCONDITIONAL grant paths
-                # below (trust-all / YOLO / native crew), whose approve decision
-                # consumes no agent-authored event data, honor the grant for
-                # such events; content-matching paths (trusted patterns,
-                # trust-reads) stay gated on the composite fidelity because the
-                # agent-authored title/params ARE their matched input.
-                _child_grant_eligible = not _child_low_fidelity or event.child_mcp_identity_trusted
+                # Verified-identity half of the fidelity split — see
+                # AcpEvent.child_unconditional_grant_eligible for which grant
+                # paths may honor it (unconditional grants: trust-all / YOLO /
+                # native crew) and which must not (content-matching paths).
+                _child_grant_eligible = event.child_unconditional_grant_eligible
                 if _child_low_fidelity:
                     # Diagnostic for a path that is otherwise invisible in
                     # logs: without it a trust-all session watching its

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -1225,9 +1225,12 @@ class AcpProvider(LLMProvider):
             # child_low_fidelity to True for EVERY child permission event that
             # crosses this provider — the full-fidelity half of the feature
             # (mode-parity auto-approval, unannotated card) would be inert on
-            # the primary interactive surface.
+            # the primary interactive surface. Same trap for
+            # mcp_identity_trusted: dropping it revokes the verified-identity
+            # half (child_mcp_identity_trusted) for every crossing event.
             raw_params_trusted=e.raw_params_trusted,
             shell_classified=e.shell_classified,
+            mcp_identity_trusted=e.mcp_identity_trusted,
             server_name=e.server_name,
             oauth_url=e.oauth_url,
             subagents=e.subagents,

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1752,18 +1752,19 @@ class GatewayOrchestrator:
             # or a foreign event type) must not accidentally enter the
             # restricted path on a truthy non-bool.
             _child_lf = getattr(event, "child_low_fidelity", False) is True
-            # Verified-identity half of the fidelity split (see
-            # AcpEvent.child_mcp_identity_trusted): grant-eligible when full
-            # fidelity OR the canonical MCP server/tool identity resolved from
-            # the tool_call cache (arguments unverified). UNCONDITIONAL
-            # shortcuts below — ones whose approve decision consumes no
-            # agent-authored event data (per-source auto-approve, --approval
-            # yolo, the YOLO override, slot trust) — honor their grant for
-            # such events; the 'reads' mode stays gated on the composite
-            # ``_child_lf`` because it MATCHES the agent-authored title.
-            # Same strict ``is True`` rationale as ``_child_lf``.
+            # Hoisted grant-eligibility — see
+            # AcpEvent.child_unconditional_grant_eligible for which shortcuts
+            # below may honor it (per-source auto-approve, --approval yolo,
+            # the YOLO override, slot trust) and which must not (the 'reads'
+            # mode MATCHES the agent-authored title). The outer
+            # ``not _child_lf`` short-circuit keeps a foreign event type or
+            # mock — which never entered the restricted path via the strict
+            # ``_child_lf`` probe — eligible without consulting an attribute
+            # it may not have; the property is only reached for a genuinely
+            # low-fidelity event, with the same strict ``is True`` rationale
+            # as ``_child_lf``.
             _child_grant_eligible = (not _child_lf) or (
-                getattr(event, "child_mcp_identity_trusted", False) is True
+                getattr(event, "child_unconditional_grant_eligible", False) is True
             )
             # Background callers pass the authoritative parent session key. Prefer it
             # over a request-ID resolver because tool permission IDs are opaque UUIDs,

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -6146,18 +6146,19 @@ class SubagentManager:
                     )
                     continue
                 if event.child_low_fidelity:
-                    # UNCONDITIONAL parent grant + verified canonical MCP
-                    # identity: parent_policy=auto approves regardless of
-                    # event content, and child_mcp_identity_trusted proves a
-                    # real MCP tool_call frame (non-model-authored _meta.kiro
-                    # identity, resolved non-shell) is behind this request —
-                    # only its ARGUMENTS are unverified, which this grant
-                    # never reads. Honor the grant instead of stalling a
-                    # trusted fan-out on an interactive card per call. The
-                    # hook auto-approve below stays fail-closed for these:
-                    # its auto_approve_tools patterns match the agent-authored
-                    # title, which a child could forge.
-                    if parent_policy == "auto" and event.child_mcp_identity_trusted:
+                    # UNCONDITIONAL parent grant: parent_policy=auto approves
+                    # regardless of event content, so it may honor a request
+                    # that is grant-eligible (see
+                    # AcpEvent.child_unconditional_grant_eligible — inside
+                    # this low-fidelity branch that means the canonical MCP
+                    # identity is verified and only the ARGUMENTS are
+                    # unverified, which this grant never reads). Honor the
+                    # grant instead of stalling a trusted fan-out on an
+                    # interactive card per call. The hook auto-approve below
+                    # stays fail-closed for these: its auto_approve_tools
+                    # patterns match the agent-authored title, which a child
+                    # could forge.
+                    if parent_policy == "auto" and event.child_unconditional_grant_eligible:
                         await self._approve_and_log(
                             client,
                             event.request_id,

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -1132,10 +1132,12 @@ def test_child_fidelity_aware_survives_client_replacement():
 
 
 def test_to_llm_event_preserves_provenance_flags():
-    """`AcpProvider._to_llm_event` reconstructs the event — dropping the two
-    provenance fields would zero them to False and flip child_low_fidelity to
-    True for EVERY child permission event on this surface, making the
-    full-fidelity half of the feature (mode-parity auto-approval) inert."""
+    """`AcpProvider._to_llm_event` reconstructs the event — dropping a
+    provenance field would zero it to False: for the params pair that flips
+    child_low_fidelity to True for EVERY child permission event on this
+    surface (making the full-fidelity half of the feature inert); for
+    mcp_identity_trusted it revokes the verified-identity half
+    (child_mcp_identity_trusted) the unconditional grant paths rely on."""
     from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
     from kiro_crew.providers.acp import AcpProvider
 
@@ -1154,3 +1156,43 @@ def test_to_llm_event_preserves_provenance_flags():
     assert out.raw_params_trusted is True
     assert out.shell_classified is True
     assert out.child_low_fidelity is False
+
+
+def test_to_llm_event_preserves_mcp_identity_trusted():
+    """The identity-provenance flag crosses the provider copy: dropping it
+    from the copy list silently reads False and revokes
+    child_mcp_identity_trusted for every crossing event (the drop-to-False
+    trap the explicit flag was added to guard against — it must fail closed
+    only for genuinely untrusted population, never for a copy)."""
+    from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+    from kiro_crew.providers.acp import AcpProvider
+
+    src = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        request_id=11,
+        title="@example-server/get-item",
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+        mcp_identity_trusted=True,
+    )
+    assert src.child_mcp_identity_trusted is True
+    out = AcpProvider._to_llm_event(src)
+    assert out.mcp_identity_trusted is True
+    assert out.child_mcp_identity_trusted is True
+    assert out.child_unconditional_grant_eligible is True
+    # And the flag is copied, not invented: an untrusted source stays False.
+    src_untrusted = AcpEvent(
+        kind=EVENT_PERMISSION_REQUEST,
+        request_id=12,
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    out_untrusted = AcpProvider._to_llm_event(src_untrusted)
+    assert out_untrusted.mcp_identity_trusted is False
+    assert out_untrusted.child_mcp_identity_trusted is False

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6740,6 +6740,7 @@ def test_child_mcp_identity_trusted_isolates_verified_identity():
             is_shell=False,
             mcp_server_name="example-server",
             tool_name="get-item",
+            mcp_identity_trusted=True,
         )
         base.update(overrides)
         return AcpEvent(**base)
@@ -6760,12 +6761,99 @@ def test_child_mcp_identity_trusted_isolates_verified_identity():
     # Cache-missed identity halves are each fail-closed.
     assert _ev(mcp_server_name="").child_mcp_identity_trusted is False
     assert _ev(tool_name="").child_mcp_identity_trusted is False
+    # THE HARDENING: non-empty identity fields alone are NOT provenance. An
+    # event populated by any path that did not earn the explicit flag (e.g. a
+    # future inline/agent-authored fallback) stays untrusted.
+    assert _ev(mcp_identity_trusted=False).child_mcp_identity_trusted is False
     # Full-fidelity child: the property may hold too, and grant callers use
-    # `not child_low_fidelity or child_mcp_identity_trusted` — both True is
-    # consistent, not contradictory.
+    # ``child_unconditional_grant_eligible`` — both True is consistent, not
+    # contradictory.
     full = _ev(raw_params_trusted=True, raw_tool_params={"itemId": "i-1"})
     assert full.child_low_fidelity is False
     assert full.child_mcp_identity_trusted is True
+
+
+def test_mcp_identity_trusted_defaults_false():
+    """The provenance flag is opt-in at trusted population sites only: a bare
+    construction (the shape any future untrusted path would produce) reads
+    False."""
+    from kiro_crew.acp.types import AcpEvent
+
+    assert AcpEvent(kind="permission_request").mcp_identity_trusted is False
+
+
+def test_child_unconditional_grant_eligible_matches_consumer_shapes():
+    """The hoisted grant-eligibility property is exactly
+    ``not child_low_fidelity or child_mcp_identity_trusted`` — pinned across
+    every fidelity/identity combination the three approval surfaces
+    (dashboard runner, Slack gateway, subagent manager) can see."""
+    from kiro_crew.acp.types import AcpEvent
+
+    # Full-fidelity child (low_fidelity False): eligible regardless of identity.
+    full = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        raw_params_trusted=True,
+        raw_tool_params={"k": "v"},
+    )
+    assert full.child_low_fidelity is False
+    assert full.child_unconditional_grant_eligible is True
+    # Low-fidelity child with verified identity: eligible.
+    identity = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+        mcp_identity_trusted=True,
+    )
+    assert identity.child_low_fidelity is True
+    assert identity.child_unconditional_grant_eligible is True
+    # Low-fidelity child, identity unverified: NOT eligible.
+    blind = AcpEvent(kind="permission_request", sub_session_id="child-a")
+    assert blind.child_low_fidelity is True
+    assert blind.child_unconditional_grant_eligible is False
+    # Non-empty identity WITHOUT the provenance flag: still NOT eligible (the
+    # hardening the flag buys, seen from the grant surface).
+    forged = AcpEvent(
+        kind="permission_request",
+        sub_session_id="child-a",
+        shell_classified=True,
+        is_shell=False,
+        mcp_server_name="example-server",
+        tool_name="get-item",
+    )
+    assert forged.child_low_fidelity is True
+    assert forged.child_unconditional_grant_eligible is False
+    # Non-child events are always eligible.
+    assert AcpEvent(kind="permission_request").child_unconditional_grant_eligible is True
+    # Exhaustive equivalence against the un-hoisted expression.
+    for lf_overrides in (
+        {},  # low fidelity (no trusted params)
+        {"raw_params_trusted": True, "raw_tool_params": {"k": "v"}},  # full fidelity
+    ):
+        for id_overrides in (
+            {},
+            {
+                "mcp_server_name": "example-server",
+                "tool_name": "get-item",
+                "mcp_identity_trusted": True,
+            },
+        ):
+            ev = AcpEvent(
+                kind="permission_request",
+                sub_session_id="child-a",
+                shell_classified=True,
+                is_shell=False,
+                **lf_overrides,
+                **id_overrides,
+            )
+            assert ev.child_unconditional_grant_eligible == (
+                not ev.child_low_fidelity or ev.child_mcp_identity_trusted
+            )
 
 
 def test_remote_mcp_empty_rawinput_keeps_identity_through_dispatch():
@@ -6817,7 +6905,88 @@ def test_remote_mcp_empty_rawinput_keeps_identity_through_dispatch():
         assert event.child_low_fidelity is True
         assert event.mcp_server_name == "example-server"
         assert event.tool_name == "get-item"
+        # The real permission builder earns the provenance flag: the identity
+        # pair resolved from the origin-scoped caches, never inline.
+        assert event.mcp_identity_trusted is True
         assert event.child_mcp_identity_trusted is True
+        assert event.child_unconditional_grant_eligible is True
+
+
+def test_permission_event_cache_miss_does_not_earn_identity_flag():
+    """The provenance flag is HIT-derived, never availability-derived: a
+    permission frame whose toolCallId has NO cache entry (wired caches, no
+    preceding tool_call) must read mcp_identity_trusted False — the flag
+    reports where the values CAME FROM, so a future inline fallback that
+    populates the identity fields on a miss stays untrusted."""
+    from kiro_crew.acp._dispatch import build_permission_event
+
+    class _Msg:
+        id = 91
+        method = "session/request_permission"
+        params = {
+            "sessionId": "child-a",
+            "toolCall": {
+                "toolCallId": "tc-never-seen",
+                "title": "@example-server/get-item",
+                "input": {"itemId": "item-0001"},
+            },
+            "options": [{"optionId": "allow_once", "name": "Allow", "kind": "allow_once"}],
+        }
+
+    event, _ = build_permission_event(
+        _Msg(),
+        tool_input_cache={},
+        shell_cache={},
+        raw_params_cache={},
+        mcp_server_name_cache={},
+        tool_name_cache={},
+        cache_scope="child-a",
+    )
+    assert event.mcp_server_name == ""
+    assert event.tool_name == ""
+    assert event.mcp_identity_trusted is False
+    # Asymmetric hit: BOTH reads must hit — a lone server-name entry (a
+    # partial/older writer) earns nothing.
+    event2, _ = build_permission_event(
+        _Msg(),
+        tool_input_cache={},
+        shell_cache={},
+        raw_params_cache={},
+        mcp_server_name_cache={"child-a|tc-never-seen": "example-server"},
+        tool_name_cache={},
+        cache_scope="child-a",
+    )
+    assert event2.mcp_server_name == "example-server"
+    assert event2.tool_name == ""
+    assert event2.mcp_identity_trusted is False
+    event3, _ = build_permission_event(
+        _Msg(),
+        tool_input_cache={},
+        shell_cache={},
+        raw_params_cache={},
+        mcp_server_name_cache={},
+        tool_name_cache={"child-a|tc-never-seen": "get-item"},
+        cache_scope="child-a",
+    )
+    assert event3.mcp_server_name == ""
+    assert event3.tool_name == "get-item"
+    assert event3.mcp_identity_trusted is False
+    # The None-vs-"" distinction is the load-bearing half: a written entry may
+    # legitimately be "" (host shell/builtin tool_call caches "" for both), and
+    # that HIT still earns the flag — deriving trust from value non-emptiness
+    # instead of the hit is exactly the conflation the flag exists to remove.
+    event4, _ = build_permission_event(
+        _Msg(),
+        tool_input_cache={},
+        shell_cache={},
+        raw_params_cache={},
+        mcp_server_name_cache={"child-a|tc-never-seen": ""},
+        tool_name_cache={"child-a|tc-never-seen": ""},
+        cache_scope="child-a",
+    )
+    assert event4.mcp_server_name == ""
+    assert event4.tool_name == ""
+    assert event4.mcp_identity_trusted is True
 
 
 @pytest.mark.asyncio

--- a/test/test_acp_tool_identity.py
+++ b/test/test_acp_tool_identity.py
@@ -88,6 +88,9 @@ class TestBuildToolCallEventIdentity:
         assert event.kind == EVENT_TOOL_CALL
         assert event.tool_name == "monitor_start"
         assert event.mcp_server_name == "kirocrew-core"
+        # This builder populates the identity pair exclusively from _meta.kiro
+        # (non-model-authored), so it earns the explicit provenance flag.
+        assert event.mcp_identity_trusted is True
 
     def test_identity_is_meta_not_title(self) -> None:
         """The title is LLM prose; a shell tool could title itself "monitor_start"
@@ -111,8 +114,73 @@ class TestBuildToolCallEventIdentity:
         event = _build_tool_call_event(shell_update, None)
         assert event.tool_name == ""
         assert event.mcp_server_name == ""
+        # No _meta.kiro → nothing was populated, so no provenance is asserted.
+        assert event.mcp_identity_trusted is False
         # is_shell must still be derived from the kind (unrelated to identity).
         assert event.is_shell is True
+
+
+class TestClientToolCallEventIdentityProvenance:
+    """``AcpClient._extract_tool_event``'s inline tool_call builder is the
+    legacy sibling of ``_build_tool_call_event``: it also populates the
+    identity pair exclusively from ``_meta.kiro`` and must earn the same
+    explicit ``mcp_identity_trusted`` provenance flag — a drop here would
+    silently revoke the verified-identity half on the legacy client path."""
+
+    def test_inline_tool_call_builder_sets_identity_flag(self) -> None:
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.acp.types import AcpPromptStats, JsonRpcMessage
+
+        client = AcpClient.__new__(AcpClient)  # avoid spawning a real process
+        client._tool_call_inputs = {}
+        client._tool_call_input_redacted = {}
+        client._tool_call_params = {}
+        client._tool_call_is_shell = {}
+        client._tool_call_mcp_server = {}
+        client._tool_call_tool_name = {}
+        client.last_prompt_stats = AcpPromptStats()
+        msg = JsonRpcMessage(
+            method="session/update",
+            params={
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "tc-meta-1",
+                    "kind": "other",
+                    "title": "Arming a monitor loop",
+                    "rawInput": {"message": "check PR"},
+                    "_meta": {
+                        "kiro": {
+                            "toolName": "monitor_start",
+                            "mcpServerName": "kirocrew-core",
+                        }
+                    },
+                }
+            },
+        )
+        event = client._extract_tool_event(msg)
+        assert event is not None
+        assert event.tool_name == "monitor_start"
+        assert event.mcp_server_name == "kirocrew-core"
+        assert event.mcp_identity_trusted is True
+        # Counterfactual: a frame with no _meta.kiro populates nothing, so the
+        # builder asserts no provenance.
+        msg_no_meta = JsonRpcMessage(
+            method="session/update",
+            params={
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "tc-no-meta",
+                    "kind": "execute",
+                    "title": "Running: echo hi",
+                    "rawInput": {"command": "echo hi"},
+                }
+            },
+        )
+        event_no_meta = client._extract_tool_event(msg_no_meta)
+        assert event_no_meta is not None
+        assert event_no_meta.tool_name == ""
+        assert event_no_meta.mcp_server_name == ""
+        assert event_no_meta.mcp_identity_trusted is False
 
 
 # ── Part 3: chat_runner directive gate (security regression, integration) ─────

--- a/test/test_background_approval_routing.py
+++ b/test/test_background_approval_routing.py
@@ -314,6 +314,9 @@ def _child_identity_event(request_id: str = "req-child-mcp-1") -> LLMEvent:
         is_shell=False,
         mcp_server_name="example-server",
         tool_name="get-item",
+        # Identity provenance flag: the real permission builder sets it when
+        # the pair above resolves from the origin-scoped caches.
+        mcp_identity_trusted=True,
     )
     assert ev.child_low_fidelity
     assert ev.child_mcp_identity_trusted

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -2090,6 +2090,9 @@ class TestIdentityTrustedChildParentPolicyAuto:
             is_shell=False,
             mcp_server_name="example-server",
             tool_name="get-item",
+            # Identity provenance flag: the real permission builder sets it
+            # when the pair above resolves from the origin-scoped caches.
+            mcp_identity_trusted=True,
         )
         base.update(overrides)
         return LLMEvent(**base)


### PR DESCRIPTION
## Problem / Motivation

Follow-up hardening from PR #6228's Design review (issue #6233). `AcpEvent.child_mcp_identity_trusted` — the property that lets UNCONDITIONAL grant paths (session trust-all, global YOLO, `parent_policy=auto`, per-source auto-approve) honor a low-fidelity child MCP permission request — infers cache provenance from mere NON-EMPTINESS of `mcp_server_name`/`tool_name`. That is sound today only because `build_permission_event` populates those fields solely from the origin-scoped tool_call caches. The sibling params concern got an explicit `raw_params_trusted` bit precisely because an inline fallback existed there; the identity half had no such bit, so a future inline population path would silently count as trusted. Separately, the grant-eligibility expression `not child_low_fidelity or child_mcp_identity_trusted` was re-derived inline at three consumers (dashboard runner, Slack gateway, subagent manager), each carrying its own copy of the rationale.

## Why it matters

The identity split is what stands between a forged server/tool pair and every unconditional auto-approve surface. A provenance guarantee that rests on "all population sites happen to be trusted today" degrades silently: the first inline fallback anyone adds turns agent-influenceable payload data into a trusted identity with no test going red. Three hand-copied eligibility expressions can likewise drift independently — a security-relevant expression should have exactly one definition.

## What changed (motivation → approach → change)

Goal: make identity provenance explicit and fail-closed, mirroring the landed `raw_params_trusted` precedent; give grant eligibility one owning definition.

- **Explicit provenance flag** — `AcpEvent.mcp_identity_trusted: bool = False` (`acp/types.py`). `child_mcp_identity_trusted` now requires the flag IN ADDITION to non-empty identity fields, so non-emptiness alone is never proof of provenance.
- **Flag-set sites** (the only trusted population paths):
  - `build_permission_event` (`acp/_dispatch.py`) derives it from the origin-scoped cache reads actually **hitting** (both caches, `None`-default distinguishes a hit whose value is legitimately `""` from a miss) — never from cache availability or field non-emptiness, exactly mirroring how `_raw_params_trusted` is hit-derived. A future inline fallback populating the fields from the permission payload leaves the flag False and fails closed.
  - Both `_meta.kiro` tool_call builders (`acp/_dispatch.py` `_build_tool_call_event`, `acp/client.py` `_extract_tool_event`) set it only when their extractors actually produced an identity pair — a frame without `_meta.kiro` populates nothing and asserts no provenance.
  - `providers/acp.py` `_to_llm_event` copies the flag (the drop-to-False trap the issue pre-names: a field missing from the copy list silently reads False and revokes trust). `LLMEvent` is an alias of `AcpEvent`, so the field/property mirror is inherent.
- **Hoisted grant eligibility** — new `AcpEvent.child_unconditional_grant_eligible` property (`not child_low_fidelity or child_mcp_identity_trusted`) carrying the consolidated rationale from the three per-site comments. All three consumers migrated: `dashboard/chat_runner.py` (only the eligibility expression touched — the resume-path literal-pin variable names are preserved), `slack/gateway.py` (the outer `not _child_lf` short-circuit is kept so a foreign/mock event type stays on the exact path its strict `is True` probe put it on), `subagent.py` (inside the low-fidelity branch the property reduces to the previous `child_mcp_identity_trusted` check). Pure extract-property refactor — zero behavior change, existing tests unchanged except the direct-construction fixtures that now (correctly) declare the flag their simulated trusted source would have set.
- **Docs** — `docs/system-specs/modules/security.md` "Child-fidelity split" updated for both changes; `subagent.md` and `acp-client.md` synced (they enumerate the property's requirements and name the consumer expression).

## Tests

- `test_acp_runtime.py`: flag defaults False; **the hardening** — non-empty identity fields WITHOUT the flag no longer count as trusted (`_ev(mcp_identity_trusted=False)` and the `forged` grant-surface shape); `child_unconditional_grant_eligible` pinned across every fidelity/identity combination plus exhaustive equivalence with the un-hoisted expression; end-to-end through real `parse_session_update` + `build_permission_event` the flag is earned on cache hit; a cache-**miss** frame does NOT earn it (hit-derived, not availability-derived), asymmetric single-cache hits do not earn it, and a both-caches-hit-with-`""` frame DOES earn it (the None-vs-`""` distinction that keeps the flag provenance, not value shape).
- `test_acp_tool_identity.py`: both tool_call builders earn the flag exactly when `_meta.kiro` yielded a pair (no-`_meta` shell frames assert no provenance), covering the legacy `AcpClient` inline builder too.
- `test_acp_provider.py`: `_to_llm_event` copies the flag (and copies, never invents — an untrusted source stays False).
- Existing per-surface behavioral suites (`test_background_approval_routing.py`, `test_subagent.py` parent-policy-auto, chat_runner literal-pin and parity source tests) stay green, pinning consumer equivalence.
- **Mutation-verified**: 12 mutants, all caught — property expression flips (each disjunct dropped), the flag requirement dropped from `child_mcp_identity_trusted`, permission-path flag reverted to availability-derived / value-non-emptiness / single-cache / never-set, each builder flag forced True and False, and the `_to_llm_event` copy dropped.

Adversarial review (2 rounds, cross-model, blind): GPT round 1 PASS 0 findings; Opus round 1 blocked on the flag being availability-derived rather than hit-derived (fixed + pinned + mutation-verified) and flagged the two spec-doc drifts (fixed); Opus round 2 PASS, its 3 advisory test-quality/consistency findings all applied.

## Manual verification

N/A — unit coverage sufficient: the change is dataclass fields, two pure properties, and expression-level consumer migration, all pinned end-to-end through the real dispatch parser; full backend suite green locally (86 pre-existing host-env failures identical on unmodified main).

## Related Issues

Closes #6233

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
