### PR TITLE
docs: plan AgentCore Identity and Gateway integration

### DIFF
--- a/docs/request-for-change/README.md
+++ b/docs/request-for-change/README.md
@@ -51,7 +51,7 @@ was added 2026-08-27 and verified against `152c00e99`.
 | [rfc-amend-tenets-everything-is-an-app.md](rfc-amend-tenets-everything-is-an-app.md) | `draft` | Nothing. `TENETS.md` still carries seven tenets on main. `git log --follow` on it shows two commits and no prior amendment, and `grep -i tenet` returns zero hits in `GOVERNANCE.md` |
 | [rfc-crew-projects.md](rfc-crew-projects.md) | `draft` | Nothing. Verified at `5cd92ff99`: no project manifest format exists, `slot.project` is a bare directory path, and `grep -ril "confluence\|servicenow" src/kiro_crew` returns zero hits |
 | [rfc-tool-derived-diff-cards.md](rfc-tool-derived-diff-cards.md) | `in-progress` | Ships with [#5012](https://github.com/kirodotdev/KiroCrew/pull/5012): dashboard diff-card/summary promotion + runtime-selected prompt rule. The messaging `OutputEvent` extension (§3.3) is unstarted |
-| [rfc-agentcore-identity-gateway.md](rfc-agentcore-identity-gateway.md) | `draft` | Nothing. Design only; no `agent_identity` CPP slot, no `capabilities.agentcore` row, no AgentCore import under `src/kiro_crew/` |
+| [rfc-agentcore-identity-gateway.md](rfc-agentcore-identity-gateway.md) | `draft` | Nothing. Design only; no `agent_identity` CPP slot, no `capabilities.agentcore` row, no `iam.agentcore_instance_policy_document`, no AgentCore import under `src/kiro_crew/` |
 
 Nothing in this directory is `implemented` or `superseded` today.
 

--- a/docs/request-for-change/README.md
+++ b/docs/request-for-change/README.md
@@ -18,7 +18,8 @@ were added
 not been re-audited since 2026-08-03. The durable-run-coordinator row was added
 2026-08-22 and the orchestrator-chat-sessions row was re-audited at
 `c4f253891`; the `rfc-token-efficient-monitors` row was added 2026-08-22 and
-verified against `6d3e30bbbd`.
+verified against `6d3e30bbbd`; the `rfc-agentcore-identity-gateway` row
+was added 2026-08-27 and verified against `152c00e99`.
 
 | Document | Status | What is actually on main |
 |---|---|---|
@@ -50,6 +51,7 @@ verified against `6d3e30bbbd`.
 | [rfc-amend-tenets-everything-is-an-app.md](rfc-amend-tenets-everything-is-an-app.md) | `draft` | Nothing. `TENETS.md` still carries seven tenets on main. `git log --follow` on it shows two commits and no prior amendment, and `grep -i tenet` returns zero hits in `GOVERNANCE.md` |
 | [rfc-crew-projects.md](rfc-crew-projects.md) | `draft` | Nothing. Verified at `5cd92ff99`: no project manifest format exists, `slot.project` is a bare directory path, and `grep -ril "confluence\|servicenow" src/kiro_crew` returns zero hits |
 | [rfc-tool-derived-diff-cards.md](rfc-tool-derived-diff-cards.md) | `in-progress` | Ships with [#5012](https://github.com/kirodotdev/KiroCrew/pull/5012): dashboard diff-card/summary promotion + runtime-selected prompt rule. The messaging `OutputEvent` extension (§3.3) is unstarted |
+| [rfc-agentcore-identity-gateway.md](rfc-agentcore-identity-gateway.md) | `draft` | Nothing. Design only; no `agent_identity` CPP slot, no `capabilities.agentcore` row, no AgentCore import under `src/kiro_crew/` |
 
 Nothing in this directory is `implemented` or `superseded` today.
 

--- a/docs/request-for-change/rfc-agentcore-identity-gateway.md
+++ b/docs/request-for-change/rfc-agentcore-identity-gateway.md
@@ -24,6 +24,18 @@ workload, vends tokens, and contributes the Gateway MCP endpoint. The
 public core grows generic, default-off seams so a standalone install
 stays byte-identical and never imports AWS.
 
+A fleet picks **exactly one** posture in `security_policy.json`, and
+that posture is what the copyable cloud **Policy.json pair** must
+match — the launcher document (`iam.policy_json()` / `kirocrew cloud
+iam-policy`) plus the instance-role fragment
+(`iam.agentcore_instance_policy_document`):
+
+- **`workload`** — a deployed Crew instance has an IAM identity and
+  can invoke Gateway at boot. No user login required to start.
+- **`login`** — only Gateway-approved MCP is vended. That catalog
+  **overrides Kiro's default MCP merge**. Tools stay absent until
+  the operator logs in.
+
 This is the **identity and credential** plane. It is not the sandbox /
 execution plane in the sibling AgentCore sandboxes design.
 
@@ -125,6 +137,14 @@ it calls Identity APIs.
   import, no new default-on egress, no Cognito/SSO reintroduction.
 - Fail closed. A missing companion, expired JWT, or Identity error
   denies the Gateway call. It does not fall back to a shared token.
+- Work with the existing cloud Policy.json pair: the launcher
+  document (`iam.policy_json`) and the instance permissions
+  boundary (`iam.boundary_policy_document`). A deployed Crew can
+  only reach Gateway when **both** the grant and the boundary
+  ceiling allow it.
+- Two exclusive postures (`workload` | `login`), selected by
+  `security_policy.json`. `login` withholds Kiro-global and
+  crew-store MCP at rebuild time, not only at the tool gate.
 
 ## Non-goals
 
@@ -144,6 +164,10 @@ it calls Identity APIs.
   `1`, matching `knowledge` / `dashboard` / `jail`.
 - A public `config.json` AgentCore block. Agent-writable config cannot
   be the trust root for workload name, gateway URL, or region.
+- Re-versioning the immutable `kirocrew-ec2-boundary` in place.
+  Widening that document is a new named boundary, opt-in at launch.
+- Running both postures at once. `workload` and `login` are
+  alternatives, not layers.
 
 ## Design
 
@@ -159,14 +183,15 @@ Kiro Crew gateway (local, ACP → kiro-cli)
         │     standalone AgentCore workload "kirocrew"
         │
         ├─ AgentIdentityProvider.vend_workload_access_token(principal)
-        │     Identity: GetWorkloadAccessTokenForJWT | ForUserId
+        │     Identity: GetWorkloadAccessToken*  (see posture)
         │     first-party token; never leaves the gateway process
         │
-        └─ AgentIdentityProvider.vend_gateway_inbound_token(principal)
-              user OIDC JWT (or companion-minted audience-bound JWT)
+        └─ inbound to AgentCore Gateway  (MCP)
+              posture=workload → instance IAM  (InvokeGateway)
+              posture=login    → user OIDC JWT after ensure-login
                     │
                     ▼
-         AgentCore Gateway  (MCP, CUSTOM_JWT)
+         AgentCore Gateway
                     │  Gateway's own workload token
                     ▼
          AgentCore Identity token vault
@@ -175,6 +200,10 @@ Kiro Crew gateway (local, ACP → kiro-cli)
          Gateway target (Slack, GitHub, internal API, MCP server)
 ```
 
+The diagram branches on `capabilities.agentcore.posture`. `workload`
+is the deployed-box path (IAM inbound, no login). `login` is the
+ensure-login path (CUSTOM_JWT, Gateway catalog only).
+
 Two tokens, two audiences, never interchangeable:
 
 | Token | Audience | Who mints it | Who holds it |
@@ -182,6 +211,216 @@ Two tokens, two audiences, never interchangeable:
 | Workload access token | AgentCore Identity APIs only | Identity (`GetWorkloadAccessToken*`) | Crew gateway process, in memory |
 | Gateway inbound JWT | Gateway `customJWTAuthorizer` | Companion IdP / SSO | Injected as `Authorization` on the Gateway MCP transport for that session |
 | Outbound resource token | Downstream API | Identity, **called by Gateway** | Gateway; Crew never sees it in v1 |
+
+### Two postures, one Policy.json
+
+The operator-facing document today is `iam.policy_json()` — the
+indented JSON the dashboard copies (`GET /api/cloud/iam-policy`) and
+`kirocrew cloud iam-policy` prints. It is the **launcher** policy
+(CloudFormation, tagged EC2, PassRole, SSM, source bucket, STS). It
+is **not** what the running instance can do.
+
+A deployed Crew process assumes the instance role. That role is
+capped by the content-fixed permissions boundary
+`kirocrew-ec2-boundary` (`iam.boundary_policy_document`): SSM-core +
+`s3:GetObject` on `kirocrew-src-<account>-*`. A boundary is a
+ceiling, not a grant. Adding `bedrock-agentcore:InvokeGateway` to
+the launcher Policy.json alone does nothing for a box that is
+already running: the boundary still denies it. The boundary is
+create-once and never re-versioned on purpose (a leaked launcher
+credential must not be able to `CreatePolicyVersion` it permissive).
+
+So "works with our Policy.json" means three documents stay in
+agreement, not one:
+
+| Document | Who applies it | What it is |
+|---|---|---|
+| `iam.policy_json()` | Operator pastes into IAM for the **launch** principal | Must be able to PassRole an instance role that *may* carry AgentCore |
+| Instance role grant (inline or attached) | Launch template / companion | The actual `InvokeGateway` / `GetWorkloadAccessToken*` allow |
+| `kirocrew-ec2-boundary` (or a new named successor) | Admin, once per account | Ceiling. Must list any AgentCore action the grant uses |
+| `security_policy.json` | Fleet trust root (keystone) | Picks the posture. Agent cannot weaken it |
+
+`capabilities.agentcore` grows an inner posture, still a data row
+(`SCOPE_CATALOG` append-only, evaluator untouched):
+
+```json
+{
+  "capabilities": {
+    "agentcore": {
+      "enabled": true,
+      "posture": "workload"
+    }
+  }
+}
+```
+
+`posture` is `"workload"` or `"login"`. Absent / unknown with
+`enabled: true` fails closed (boot abort if `boot.fail_closed`,
+else treat as disabled). The two postures are exclusive.
+
+#### Posture `workload` — deployed Crew can start
+
+Use this on a `kirocrew cloud launch` box (or any companion-managed
+host) that should reach Gateway **without** an interactive login.
+
+- Register a standalone workload identity `kirocrew` (not
+  Gateway-managed).
+- Gateway inbound is **IAM** (`authorizerType: AWS_IAM`). The
+  instance role is the caller. Action:
+  `bedrock-agentcore:InvokeGateway` on the Gateway ARN.
+- The instance role also needs
+  `bedrock-agentcore:GetWorkloadAccessToken` (and, for unattended
+  job-owner binding only,
+  `GetWorkloadAccessTokenForUserId`) scoped to
+  `workload-identity-directory/default/workload-identity/kirocrew`.
+- **Deny** `GetWorkloadAccessTokenForJWT` on this role: there is no
+  user JWT in this posture, and leaving ForJWT allowed invites a
+  planted-token confused deputy.
+- Kiro MCP defaults **still merge** (`~/.kiro/settings/mcp.json`,
+  crew store, apps). The fleet can still deny them with the
+  existing `mcp` ruleset. This posture answers "can the box start,"
+  not "is the catalog empty."
+- Cron / TaskRunner / injected envelopes run as the workload
+  identity. They may call M2M Gateway targets. They must not OBO as
+  an arbitrary user.
+
+The copyable **launcher** Policy.json (`iam.policy_json()`) does
+**not** grow `InvokeGateway` or `GetWorkloadAccessToken*`. Those
+belong on the instance role, not the laptop/CI principal that
+pastes the document. The launcher document grows only the verbs
+needed to *stand up* an AgentCore-capable box:
+
+- `iam:CreatePolicy` + `iam:GetPolicy` on the **new** boundary
+  ARN (`kirocrew-ec2-boundary-agentcore`), still no
+  `CreatePolicyVersion` / `Delete*`.
+- `iam:CreateRole` `ArnLike` on **either**
+  `kirocrew-ec2-boundary` or `kirocrew-ec2-boundary-agentcore`
+  (today the template `AllowedPattern` pins the original name
+  only — that pin must widen, or AgentCore launches cannot
+  attach the successor).
+- Existing tag-gated `PassRole` of `kirocrew-ec2-*` roles.
+
+The dashboard / `kirocrew cloud iam-policy` grows a **second,
+labeled** document — the instance-role fragment — from
+`iam.agentcore_instance_policy_document(posture)`. Copying the
+launcher JSON onto the instance role, or the instance JSON onto
+the launch principal, is a misconfiguration the copy UI must
+not invite.
+
+The instance boundary does **not** silently grow. A new named
+boundary (`kirocrew-ec2-boundary-agentcore`) is the **union**
+ceiling: existing SSM-core + source-bucket read, plus every
+AgentCore action either posture's instance grant may use
+(`GetWorkloadAccessToken`, `ForUserId`, `ForJWT`,
+`InvokeGateway`). A boundary does not grant; the instance
+document is still what turns a verb on. One successor name
+covers both postures so a fleet can switch `security_policy.json`
+without minting a third boundary. New launches opt in; existing
+instances stay on `kirocrew-ec2-boundary` and cannot reach
+Gateway. No `CreatePolicyVersion` of the original document.
+
+#### Posture `login` — Gateway catalog only, user must sign in
+
+Use this when the approved tool catalog *is* the Gateway, and a
+human has to be present.
+
+- Gateway inbound is **CUSTOM_JWT**. Crew attaches the operator's
+  IdP JWT after login. The instance role does **not** receive
+  `InvokeGateway` or `GetWorkloadAccessTokenForUserId`.
+- If Crew must mint a workload token after login, the role may have
+  `GetWorkloadAccessTokenForJWT` only, scoped to `kirocrew`.
+  ForUserId is **denied** in IAM.
+- **Override Kiro defaults at rebuild time.** When posture is
+  `login` and `capabilities.agentcore` is enabled,
+  `rebuild_agent_config()` withholds:
+
+  - `~/.kiro/settings/mcp.json` (Kiro global)
+  - seam-contributed provider globals
+  - `~/.kiro/crew/mcp.json` user servers
+  - leftover non-managed entries in the merge base
+
+  It still emits the managed Crew servers (`kirocrew-core`,
+  `kirocrew-cron`, `kirocrew-computer` when its spec_gate is open)
+  and the Gateway URL-only spec. Those are not "Kiro defaults";
+  they are Crew's own process. A `@server` ref whose entry was
+  withheld mounts nothing — same control as the computer-use
+  spec_gate (`mcp.md`).
+- Until `vend_gateway_inbound_token` returns a live JWT, the
+  Gateway server is **absent** (fail closed). The dashboard/CLI
+  login prompt is the only way to make it appear. Companion SSO
+  already owns `IdentityProvider` / `/api/sso-login`; this posture
+  consumes that login, it does not re-add Cognito to the core.
+- Unattended jobs cannot see Gateway tools. Cron on a login-posture
+  host is M2M-less and stays on managed Crew servers only.
+
+The login-mode instance document **omits** `InvokeGateway` and
+`GetWorkloadAccessTokenForUserId`. Copying the workload-mode
+fragment onto a login-mode fleet is a misconfiguration: the
+instance could IAM-invoke Gateway and skip the login. The core
+detects the mismatch (posture `login` but a successful IAM
+InvokeGateway probe, or vice versa) and refuses to emit the
+Gateway server, SEL-audited.
+
+#### How the two Policy.json shapes differ
+
+Workload-mode excerpt (instance grant + matching boundary ceiling;
+ARNs are fleet-pinned, never `*`):
+
+```json
+{
+  "Sid": "AgentCoreIdentity",
+  "Effect": "Allow",
+  "Action": [
+    "bedrock-agentcore:GetWorkloadAccessToken",
+    "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
+  ],
+  "Resource": [
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default",
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default/workload-identity/kirocrew"
+  ]
+},
+{
+  "Sid": "AgentCoreGateway",
+  "Effect": "Allow",
+  "Action": ["bedrock-agentcore:InvokeGateway"],
+  "Resource": "arn:aws:bedrock-agentcore:*:*:gateway/kirocrew-*"
+},
+{
+  "Sid": "DenyJwtPathOnWorkloadPosture",
+  "Effect": "Deny",
+  "Action": "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+  "Resource": "*"
+}
+```
+
+Login-mode excerpt:
+
+```json
+{
+  "Sid": "AgentCoreIdentityForJwt",
+  "Effect": "Allow",
+  "Action": ["bedrock-agentcore:GetWorkloadAccessTokenForJWT"],
+  "Resource": [
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default",
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default/workload-identity/kirocrew"
+  ]
+},
+{
+  "Sid": "DenyUserIdAndIamGateway",
+  "Effect": "Deny",
+  "Action": [
+    "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+    "bedrock-agentcore:InvokeGateway"
+  ],
+  "Resource": "*"
+}
+```
+
+`iam.policy_json()` stays the launcher document. A new helper
+`iam.agentcore_instance_policy_document(posture)` emits the
+instance-role fragment above so the dashboard can copy **the
+right Policy.json for the posture in `security_policy.json`**,
+not a single kitchen-sink document.
 
 ### Edition split
 
@@ -267,11 +506,11 @@ replace `subject` with a client-supplied user id.
 
 | Surface | `subject` | JWT available? |
 |---|---|---|
-| Dashboard (companion SSO) | `dashboard+{idp_sub}` | Yes — use `ForJWT` |
-| Dashboard (OSS token auth) | `dashboard+{local_owner}` | No — `ForUserId` only if companion is enabled and the local owner is the host principal |
-| Slack / Discord / … | `{channel}+{provider_user_id}` | Only if companion SSO has bound that channel user |
+| Dashboard (companion SSO) | `dashboard+{idp_sub}` | Yes — `ForJWT` (`login` posture) |
+| Dashboard (OSS token auth) | `dashboard+{local_owner}` | No JWT. `ForUserId` only in `workload` posture, and only if the local owner is the host principal |
+| Slack / Discord / … | `{channel}+{provider_user_id}` | JWT only if companion SSO has bound that channel user (`login`). Else `ForUserId` only in `workload` |
 | CLI | `cli+{os_user}` | Same as local owner |
-| Cron / TaskRunner | `cron+{job_owner}` (the operator who created the job, persisted at create time) | No interactive JWT. M2M Gateway targets only, or fail closed |
+| Cron / TaskRunner | `cron+{job_owner}` (the operator who created the job, persisted at create time) | No interactive JWT. `workload`: M2M Gateway only. `login`: Gateway absent |
 | Subagent | inherit parent principal | Same token audience as parent |
 | Injected cron / subagent-completion envelopes | **not a user** | Do not mint a user-bound token for an injected message |
 
@@ -279,14 +518,18 @@ replace `subject` with a client-supplied user id.
 Identity docs, so `slack+U0123` and `dashboard+U0123` cannot collide in
 the vault.
 
-IAM on the companion role denies `GetWorkloadAccessTokenForUserId` when
-a JWT path exists for that surface. The core still prefers `user_jwt`
-when `annotate_principal` set one.
+IAM on the instance role denies the path the other posture uses
+(`ForJWT` denied in `workload`; `ForUserId` and `InvokeGateway`
+denied in `login`). The core still prefers `user_jwt` when
+`annotate_principal` set one.
 
 ### Gateway attach and per-session header injection
 
 `gateway_mcp_spec()` / `extra_mcp_servers()` contribute a **URL-only**
-remote MCP entry: endpoint, protocol, no `Authorization`.
+remote MCP entry: endpoint, protocol, no `Authorization`. In
+`login` posture the rest of the MCP merge is withheld first
+(see *Two postures, one Policy.json*); Gateway is then the only
+non-managed remote server that rebuild may emit.
 
 The missing core seam is per-session header injection at MCP spawn,
 analogous to `mcp_gateway` declared-env forwarding
@@ -335,17 +578,21 @@ is refused.
 
 ### Unattended jobs
 
-Cron and TaskRunner have no interactive JWT.
+Cron and TaskRunner have no interactive JWT. Posture decides whether
+they can see Gateway at all.
 
 v1 policy:
 
-- Gateway targets whose credential provider is **M2M** (client
-  credentials, no user) may run unattended, under the job-owner
-  principal.
-- OBO / 3LO targets are **denied** on unattended sessions unless a
-  still-valid vaulted user token already exists for that
-  `(workload, job_owner)` pair. There is no silent refresh via a
-  guessed user id.
+- **`workload`.** Gateway targets whose credential provider is
+  **M2M** (client credentials, no user) may run unattended, under
+  the job-owner / instance identity. OBO / 3LO targets are
+  **denied** on unattended sessions unless a still-valid vaulted
+  user token already exists for that `(workload, job_owner)` pair.
+  There is no silent refresh via a guessed user id.
+- **`login`.** Unattended sessions never receive a Gateway inbound
+  JWT, so the Gateway server stays absent. Cron stays on managed
+  Crew servers only. That is the point of the posture: a human had
+  to log in.
 - Injected `[Cron notification]` / `[Subagent completion event]`
   messages do not mint a new principal. They run as the job/parent
   already bound.
@@ -354,10 +601,12 @@ v1 policy:
 
 - New `SCOPE_CATALOG` row `capabilities.agentcore` with
   `capability_default=False` (opt-in, like `capabilities.publish` /
-  `capabilities.messaging`). Data row only; evaluator untouched;
-  `CONTRACT_VERSION` untouched.
+  `capabilities.messaging`). The inner `posture` field
+  (`workload` | `login`) is policy data, not a second scope.
+  Data row only; evaluator untouched; `CONTRACT_VERSION` untouched.
 - The capability gates: contributing the Gateway MCP server, calling
-  either vend method, and surfacing 3LO consent. `network.egress` still
+  either vend method, and surfacing 3LO consent. `login` also
+  withholds the default MCP merge at rebuild. `network.egress` still
   bounds the Gateway host. `mcp` still bounds the server/tool identity.
 - No `agentcore.json` in public `config.json`. Companion configuration
   lives in the companion. If a later public opt-in needs a file, it is
@@ -369,13 +618,17 @@ v1 policy:
   never enter SEL payloads, transcripts, or `status()`.
 - SEL events (grant and deny): `agentcore.workload_token`,
   `agentcore.gateway_inbound`, `agentcore.consent_url`,
-  `agentcore.unattended_denied`. No token bytes, no raw JWT.
+  `agentcore.unattended_denied`, `agentcore.posture_mismatch`.
+  No token bytes, no raw JWT.
 
 ### Dashboard and CLI
 
-- Status only in v1: workload name, enabled, whether this session has a
-  bound principal, Gateway configured. No token display, no "copy
-  bearer."
+- Status only in v1: workload name, enabled, posture, whether this
+  session has a bound principal, Gateway configured. No token
+  display, no "copy bearer."
+- Copy Policy JSON offers the launcher document and, when
+  `capabilities.agentcore` is enabled, the posture-correct
+  instance fragment. Never one kitchen-sink document.
 - 3LO consent is a modal / channel prompt with the allowlisted URL.
 - User-facing strings go through the i18n catalog
   (`website/docs/i18n-catalog.md`). Backend non-2xx bodies carry a
@@ -405,13 +658,40 @@ instead of kiro-cli header injection.
 
 Add `AgentIdentityProvider`, `DefaultAgentIdentityProvider`,
 `PlatformContext.agent_identity`, bootstrap wiring, CPP coverage tests,
-`capabilities.agentcore` (default off), and spec updates
-(`platform-context.md`, `governance.md`). No AWS dependency. Standalone
-behavior byte-identical.
+`capabilities.agentcore` (default off, with a `posture` field), and
+spec updates (`platform-context.md`, `governance.md`). No AWS
+dependency. Standalone behavior byte-identical.
 
 Exit: `test_platform_cpp_seam_coverage.py` lists the new slot;
-`enabled()` is False; no `bedrock` / `agentcore` import under
+`enabled()` is False; unknown/absent posture with `enabled: true`
+fails closed; no `bedrock` / `agentcore` import under
 `src/kiro_crew/`.
+
+### Phase 1b — Policy.json pair, boundary successor, login withhold
+
+Public-core JSON only (no AgentCore SDK):
+
+- `iam.agentcore_instance_policy_document(posture)` emits the
+  instance-role fragment for `workload` or `login`.
+- New named boundary `kirocrew-ec2-boundary-agentcore` (SSM-core +
+  source-bucket read + the AgentCore ceiling for that posture).
+  Original `kirocrew-ec2-boundary` stays byte-identical.
+- Launcher Policy.json / CloudFormation `AllowedPattern` accept
+  **either** boundary name. Still no `CreatePolicyVersion`.
+- Dashboard / `kirocrew cloud iam-policy` can copy the
+  posture-correct instance document as a labeled sibling of the
+  launcher document.
+- `rebuild_agent_config()` withholds Kiro-global, seam-global,
+  crew-store, and leftover non-managed servers when posture is
+  `login` and the capability is on. Managed `kirocrew-*` still
+  emit. Gateway is absent until a live inbound token exists.
+- Posture-vs-IAM mismatch probe fails closed (no Gateway emit,
+  SEL-audited).
+
+Exit: copying `iam.policy_json()` never grants `InvokeGateway`;
+the instance helper for `login` denies `InvokeGateway` and
+`ForUserId`; a login-posture rebuild fixture contains no Kiro
+global server; the original boundary document is unchanged.
 
 ### Phase 2 — Session principal + Identity vend (companion)
 
@@ -515,11 +795,17 @@ Puts OAuth, 3LO, and per-target credential-provider config in Crew.
 Gateway already does this, plus Cedar policy and interceptors. Crew
 should present identity, not become a token broker.
 
-### F. IAM inbound to Gateway, no JWT (rejected as the primary path)
+### F. IAM inbound to Gateway, no JWT (adopted as posture `workload`)
 
-Works for M2M. Drops user `sub`, so OBO and per-user vault binding
-disappear. Allowed as a companion-only fallback for unattended M2M
-targets, not for interactive sessions.
+This is no longer a fallback: it **is** the deployed-box posture.
+IAM inbound lets a `kirocrew cloud launch` instance invoke Gateway
+at boot with no login. It drops user `sub`, so OBO and per-user
+vault binding are unavailable on that path — cron is M2M-only, and
+the instance Policy.json **Denies** `ForJWT`. Interactive
+per-user vending is the other posture (`login` / CUSTOM_JWT),
+not a layer on top of this one. A fleet that wants both must
+run two hosts (or switch `security_policy.json` and relaunch
+with the matching boundary + instance grant).
 
 ## Open questions
 
@@ -538,6 +824,17 @@ targets, not for interactive sessions.
 5. **Sibling sandboxes RFC.** If that design lands a Crew-driven
    Code Interpreter session, it must use this RFC's workload identity
    rather than minting a second one.
+6. **Boundary successor vs parameterized name.** v1 uses a second
+   exact name (`kirocrew-ec2-boundary-agentcore`) so the original
+   document stays immutable. Confirm the CloudFormation
+   `PermissionsBoundaryArn` `AllowedPattern` can list both names
+   without weakening the create-once story.
+7. **Launcher document vs instance document in the dashboard.**
+   Today `GET /api/cloud/iam-policy` returns one blob. v1 adds a
+   labeled sibling rather than merging AgentCore actions into the
+   launcher JSON. Confirm the copy UI copy can show two documents
+   without operators pasting the instance grant onto the launch
+   principal.
 
 ## Related
 
@@ -547,7 +844,11 @@ targets, not for interactive sessions.
   redaction, MCP env forwarding
 - [`governance.md`](../system-specs/modules/governance.md) —
   `SCOPE_CATALOG` append-only
-- [`mcp.md`](../architecture/mcp.md) — MCP merge, stateless tools
+- [`mcp.md`](../architecture/mcp.md) — MCP merge, `spec_gate`
+  withhold, stateless tools
+- [`cloud.md`](../system-specs/modules/cloud.md) — launcher
+  Policy.json, immutable `kirocrew-ec2-boundary`, create-once
+  `CreatePolicy` (never `CreatePolicyVersion`)
 - [`injected-messages.md`](../system-specs/common/injected-messages.md)
   — cron / subagent envelopes are not the user
 - [Get workload access token](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/get-workload-access-token.html)

--- a/docs/request-for-change/rfc-agentcore-identity-gateway.md
+++ b/docs/request-for-change/rfc-agentcore-identity-gateway.md
@@ -258,13 +258,39 @@ agreement, not one:
 `enabled: true` fails closed (boot abort if `boot.fail_closed`,
 else treat as disabled). The two postures are exclusive.
 
+#### Deploy assigns the AgentCore identity
+
+A remote Crew launch **creates** the standalone AgentCore identity
+in the same CloudFormation stack that creates the instance.
+
+- Resource: `AWS::BedrockAgentCore::WorkloadIdentity` (CDK L2:
+  `aws_bedrockagentcore.WorkloadIdentity`). Same resource, two
+  front-ends. The public wheel does not depend on `aws-cdk-lib`.
+- Name: `kirocrew-<StackTag>` so two crews in one account do not
+  collide. Hand-rolled fleets may still use the bare name
+  `kirocrew`.
+- The instance role receives the posture grant automatically
+  (`AWS::IAM::Policy`). Operators do not paste the instance
+  Policy.json onto a CFN-launched box.
+- systemd gets `KIROCREW_AGENTCORE_POSTURE` and
+  `KIROCREW_AGENTCORE_WORKLOAD_NAME`. The companion adapter reads
+  those; the public core never imports an AgentCore SDK.
+- Opt-in: `AgentCorePosture=none` (default) is the historical
+  launch. `kirocrew cloud launch --agentcore-posture workload`
+  and the Settings Remote Crew selector flip it.
+- Stack delete removes the identity. The launcher Policy.json
+  grows `CreateWorkloadIdentity` / `DeleteWorkloadIdentity` /
+  `GetWorkloadIdentity` / tag verbs, still scoped to
+  `kirocrew` / `kirocrew-*`. It still does **not** grow
+  `InvokeGateway`.
+
 #### Posture `workload` — deployed Crew can start
 
 Use this on a `kirocrew cloud launch` box (or any companion-managed
 host) that should reach Gateway **without** an interactive login.
 
-- Register a standalone workload identity `kirocrew` (not
-  Gateway-managed).
+- Register a standalone workload identity `kirocrew-<StackTag>`
+  (not Gateway-managed) via the CloudFormation resource above.
 - Gateway inbound is **IAM** (`authorizerType: AWS_IAM`). The
   instance role is the caller. Action:
   `bedrock-agentcore:InvokeGateway` on the Gateway ARN.
@@ -294,10 +320,9 @@ needed to *stand up* an AgentCore-capable box:
   ARN (`kirocrew-ec2-boundary-agentcore`), still no
   `CreatePolicyVersion` / `Delete*`.
 - `iam:CreateRole` `ArnLike` on **either**
-  `kirocrew-ec2-boundary` or `kirocrew-ec2-boundary-agentcore`
-  (today the template `AllowedPattern` pins the original name
-  only — that pin must widen, or AgentCore launches cannot
-  attach the successor).
+  `kirocrew-ec2-boundary` or `kirocrew-ec2-boundary-agentcore`.
+- `bedrock-agentcore:CreateWorkloadIdentity` (and Get/Delete/Tag)
+  on `workload-identity/kirocrew` and `kirocrew-*`.
 - Existing tag-gated `PassRole` of `kirocrew-ec2-*` roles.
 
 The dashboard / `kirocrew cloud iam-policy` grows a **second,

--- a/docs/request-for-change/rfc-agentcore-identity-gateway.md
+++ b/docs/request-for-change/rfc-agentcore-identity-gateway.md
@@ -277,7 +277,10 @@ in the same CloudFormation stack that creates the instance.
   those; the public core never imports an AgentCore SDK.
 - Opt-in: `AgentCorePosture=none` (default) is the historical
   launch. `kirocrew cloud launch --agentcore-posture workload`
-  and the Settings Remote Crew selector flip it.
+  creates the AWS identity at deploy time. See-and-configure
+  lives on **that crew's** Settings → Security → Agent identity
+  (`GET`/`PUT /api/agentcore/identity`), not on the hub's Remote
+  Crew launcher. A fleet override or signed policy is refused.
 - Stack delete removes the identity. The launcher Policy.json
   grows `CreateWorkloadIdentity` / `DeleteWorkloadIdentity` /
   `GetWorkloadIdentity` / tag verbs, still scoped to
@@ -840,9 +843,10 @@ with the matching boundary + instance grant).
 2. **One workload vs per-agent-config workloads.** v1 is one
    `kirocrew` workload. A later `kirocrew-<agent_id>` split is
    additive (new identities, same protocol).
-3. **Dashboard route.** Merge AgentCore status into `GET /api/sso-ttl`
-   vs a sibling `GET /api/agent-identity`. Prefer sibling so the SSO
-   TTL probe stays an SSO probe.
+3. **Dashboard route.** Resolved: sibling
+   `GET`/`PUT /api/agentcore/identity` on **this crew's** Settings →
+   Security. Not `GET /api/sso-ttl`, and not the hub Remote Crew
+   launcher. SSO TTL stays an SSO probe.
 4. **Channel-user SSO binding.** How the companion proves a Slack user
    *is* the IdP `sub` is a companion concern. This RFC only requires
    that the proof happen before `user_jwt` is set.

--- a/docs/request-for-change/rfc-agentcore-identity-gateway.md
+++ b/docs/request-for-change/rfc-agentcore-identity-gateway.md
@@ -1,0 +1,555 @@
+---
+title: AgentCore Identity and Gateway — Crew agent identity and token vending
+status: draft
+author: kyle
+created: 2026-08-27
+last-audited: 2026-08-27
+audited-at: 152c00e99
+doc-pr:
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
+
+# RFC: AgentCore Identity and Gateway — Crew agent identity and token vending
+
+## Summary
+
+Give each Kiro Crew agent a first-class **Amazon Bedrock AgentCore
+Identity** workload identity, and use **AgentCore Gateway** as the
+outbound token-vending plane for MCP tools. Crew does not implement
+OAuth, RFC 8693, or a token vault. The companion edition registers the
+workload, vends tokens, and contributes the Gateway MCP endpoint. The
+public core grows generic, default-off seams so a standalone install
+stays byte-identical and never imports AWS.
+
+This is the **identity and credential** plane. It is not the sandbox /
+execution plane in the sibling AgentCore sandboxes design.
+
+**Implementation plan:**
+[`../superpowers/plans/2026-08-27-agentcore-identity-gateway.md`](../superpowers/plans/2026-08-27-agentcore-identity-gateway.md)
+
+## Motivation
+
+### Current state (verified at `152c00e99`)
+
+Crew has an operator-identity seam and no agent-identity or token-vending
+seam.
+
+| Surface | What exists | What it is not |
+|---|---|---|
+| `IdentityProvider` (`platform/interfaces.py:306`) | SSO status, preflight, MCP credential-watch paths | Not consumed as a principal. `whoami` / `issuer` are **RESERVED** (`platform/context.py:150`) |
+| `DefaultIdentityProvider` | Delegates to `sso_status.py` stubs (`available: false`) | No SSO, no JWT, no workload |
+| `McpToolingProvider.extra_mcp_servers()` | ADD-only MCP specs merged into `kirocrew.json` | Static at rebuild time. No per-session `Authorization` |
+| `kiro_oauth_wire_entry` (`mcp_utils.py:160`) | Translates remote MCP OAuth hints for kiro-cli | Operator-managed client credentials, not AgentCore |
+| MCP `headers` on URL servers (`mcp_discovery.py`) | Static headers from config | A baked bearer is a live credential in an agent-readable file |
+| Dashboard tokens (`dashboard/token_auth.py`) | HMAC-SHA256, IP-pinned, single-use | Not an OIDC JWT. Cannot satisfy Gateway `CUSTOM_JWT` |
+| Channel session keys (`session.md`) | `slack:…`, `dashboard:…`, cron keys | Surface routing, not a cryptographic user identity |
+| Governance `SCOPE_CATALOG` | `mcp`, `network.egress`, `capabilities.*` | No AgentCore / token-vend row |
+| Credential redaction | AKIA/ASIA floor + bearer-header heuristics | No AgentCore workload-token shape |
+
+Grep of `src/`, `website/src/`, and `docs/` at `152c00e99` finds **no**
+`AgentCore`, `bedrock-agentcore`, `GetWorkloadAccessToken`, or
+`GetResourceOauth2Token` symbol.
+
+### Problems
+
+1. **The Crew agent has no identity AgentCore can name.** Gateway policy,
+   CloudTrail, and the Identity token vault key on a workload identity.
+   Today the caller is "whatever IAM role the host has," which cannot
+   distinguish `kirocrew` from a sibling agent, a cron job, or a
+   compromised local process.
+2. **Outbound tool credentials are operator-local secrets.** Slack bot
+   tokens, GitHub PATs, and static MCP `Authorization` headers live on
+   disk or in env. There is no on-behalf-of exchange, no per-user vault
+   binding, and no short-lived scoped token.
+3. **A static Gateway URL is not an integration.** An operator can paste
+   a Gateway MCP URL into `~/.kiro/crew/mcp.json` today. That carries no
+   agent identity, no refresh, no per-session principal, and no 3LO
+   consent surface. It also puts a bearer in an agent-readable spec.
+4. **Unattended work has no honest principal.** Cron, TaskRunner, and
+   subagents are not the operator at a keyboard. ForUserId without a
+   trusted derivation is impersonation.
+
+### What AgentCore actually is (product shape)
+
+Two AWS services, not one:
+
+**AgentCore Identity** is the workload identity directory and token
+vault.
+
+- A **workload identity** names an agent (`kirocrew`, later
+  `kirocrew-<agent_id>`).
+- `GetWorkloadAccessToken` / `ForJWT` / `ForUserId` mint an opaque
+  **workload access token** bound to `(workload, user)`.
+- That token is **first-party only**. It authorizes AgentCore Identity
+  APIs (`GetResourceOauth2Token`, vault reads). It is not a Gateway
+  inbound credential and must never be sent to a downstream MCP server.
+- `GetResourceOauth2Token` vends an OAuth token for a named credential
+  provider (`M2M`, authorization-code / 3LO, or `TOKEN_EXCHANGE` /
+  on-behalf-of).
+- Runtime-managed and Gateway-managed workload identities **cannot**
+  call `GetWorkloadAccessToken` themselves. A Crew-owned identity must
+  be a **standalone** workload, not the Gateway's.
+
+**AgentCore Gateway** is a hosted MCP endpoint.
+
+- Inbound: `CUSTOM_JWT` (OIDC discovery + JWKS) or `AWS_IAM`. JWT is
+  required for OBO; IAM is machine-to-machine and has no user `sub`.
+- The Gateway obtains its **own** workload access token and asks
+  Identity to vend the outbound credential for the target.
+- Outbound grant types: client credentials, authorization code, RFC 8693
+  token exchange (`TOKEN_EXCHANGE`).
+- Optional Cedar policy engine and request interceptors.
+
+The official [Kiro IDE + AgentCore Gateway](https://builder.aws.com/content/3CS1jTWHngGW3IxFXCjcP2T9l8B/govern-mcp-tools-at-scale-with-kiro-and-agentcore-gateway)
+pattern is "IDE presents a developer OIDC JWT; Gateway vends outbound
+tokens." Crew is a **local orchestrator**, not Kiro IDE and not AgentCore
+Runtime. Runtime auto-injects `WorkloadAccessToken` into hosted agent
+code; Crew never runs there, so it must mint its own workload token when
+it calls Identity APIs.
+
+## Goals
+
+- Register one standalone AgentCore workload identity for the Crew
+  agent, visible in Identity status, CloudTrail, and vault bindings.
+- Use AgentCore Gateway as the token-vending plane for approved MCP
+  targets. Crew does not implement RFC 8693.
+- Bind vault entries to a **trusted** `(workload, user)` pair. Prefer
+  `GetWorkloadAccessTokenForJWT`. Use `ForUserId` only with a
+  core-derived, partitioned subject.
+- Inject Gateway inbound credentials **per session**, never into
+  `~/.kiro/agents/kirocrew.json`.
+- Public edition remains complete standalone: no AWS SDK, no AgentCore
+  import, no new default-on egress, no Cognito/SSO reintroduction.
+- Fail closed. A missing companion, expired JWT, or Identity error
+  denies the Gateway call. It does not fall back to a shared token.
+
+## Non-goals
+
+- Hosting Crew on AgentCore Runtime, or treating Gateway as an
+  `agent.provider`. `agent.provider` stays `acp`.
+- A new OS-sandbox backend or Instances `connection_method`. That is
+  the sibling sandboxes RFC.
+- Re-adding enterprise SSO, Cognito, Midway, or device-posture tunnels
+  to the public core. `sso_status.py` stays a stub. Companion SSO lands
+  through the existing `IdentityProvider` slot.
+- Crew-side `GetResourceOauth2Token` for arbitrary local tools in v1.
+  Gateway vends. Direct Identity vending is a later, narrowly-scoped
+  follow-on.
+- Making `IdentityProvider.whoami` / `issuer` live. Those stay
+  RESERVED. Surface principal data through wired `status()` payloads.
+- Bumping `CONTRACT_VERSION`. Pre-launch field and method adds stay at
+  `1`, matching `knowledge` / `dashboard` / `jail`.
+- A public `config.json` AgentCore block. Agent-writable config cannot
+  be the trust root for workload name, gateway URL, or region.
+
+## Design
+
+### Target architecture
+
+```
+Operator / channel user
+        │  dashboard token, Slack user id, companion SSO JWT
+        ▼
+Kiro Crew gateway (local, ACP → kiro-cli)
+        │
+        ├─ AgentIdentityProvider.workload_identity()
+        │     standalone AgentCore workload "kirocrew"
+        │
+        ├─ AgentIdentityProvider.vend_workload_access_token(principal)
+        │     Identity: GetWorkloadAccessTokenForJWT | ForUserId
+        │     first-party token; never leaves the gateway process
+        │
+        └─ AgentIdentityProvider.vend_gateway_inbound_token(principal)
+              user OIDC JWT (or companion-minted audience-bound JWT)
+                    │
+                    ▼
+         AgentCore Gateway  (MCP, CUSTOM_JWT)
+                    │  Gateway's own workload token
+                    ▼
+         AgentCore Identity token vault
+                    │  GetResourceOauth2Token (M2M / 3LO / OBO)
+                    ▼
+         Gateway target (Slack, GitHub, internal API, MCP server)
+```
+
+Two tokens, two audiences, never interchangeable:
+
+| Token | Audience | Who mints it | Who holds it |
+|---|---|---|---|
+| Workload access token | AgentCore Identity APIs only | Identity (`GetWorkloadAccessToken*`) | Crew gateway process, in memory |
+| Gateway inbound JWT | Gateway `customJWTAuthorizer` | Companion IdP / SSO | Injected as `Authorization` on the Gateway MCP transport for that session |
+| Outbound resource token | Downstream API | Identity, **called by Gateway** | Gateway; Crew never sees it in v1 |
+
+### Edition split
+
+The public core defines the protocol, the session-principal derivation,
+the MCP header-injection site, governance, redaction, and SEL. It ships
+`DefaultAgentIdentityProvider` (all methods empty / `enabled() ==
+False`).
+
+The enterprise companion (separate package, `kirocrew.plugins` entry
+point) implements the protocol with `bedrock-agentcore` / boto3, holds
+region and workload ARN, talks to the operator IdP, and contributes the
+Gateway URL through `McpToolingProvider.extra_mcp_servers()`.
+
+Dependency stays one-way: companion depends on core. Core never imports
+`bedrock_agentcore`, never names Cognito, never hardcodes a discovery
+URL.
+
+### New CPP slot: `agent_identity`
+
+A new `AgentIdentityProvider` Protocol on `PlatformContext`, not more
+methods on `IdentityProvider`.
+
+`IdentityProvider` is operator SSO (status line, preflight, credential
+watch). Agent workload identity and token vending are a different
+edition concern. The same reason `AgentCatalogProvider` is not folded
+into `McpToolingProvider` applies here.
+
+Pre-launch, a new `PlatformContext` field does **not** bump
+`CONTRACT_VERSION` (pinned at `1`; `knowledge` / `dashboard` / `jail`
+landed the same way). `DefaultAgentIdentityProvider` keeps a standalone
+process byte-identical.
+
+```python
+@dataclass(frozen=True)
+class WorkloadIdentity:
+    name: str
+    arn: str
+
+@dataclass(frozen=True)
+class SessionPrincipal:
+    """Trusted caller. Core-derived; never taken from tool input."""
+    surface: str          # dashboard | slack | discord | telegram | …
+    subject: str          # already partitioned: "{surface}+{id}"
+    session_key: str
+    user_jwt: str | None  # set only by the companion after IdP verify
+
+@dataclass(frozen=True)
+class InboundToken:
+    scheme: str           # "bearer"
+    token: str
+    expires_at: float     # unix epoch seconds
+    audience: str
+
+class AgentIdentityProvider(Protocol):
+    def enabled(self) -> bool: ...
+    def workload_identity(self) -> WorkloadIdentity | None: ...
+    def status(self) -> dict[str, object]: ...
+    def gateway_mcp_spec(self) -> dict[str, object] | None: ...
+    async def annotate_principal(
+        self, principal: SessionPrincipal
+    ) -> SessionPrincipal: ...
+    async def vend_workload_access_token(
+        self, principal: SessionPrincipal
+    ) -> str | None: ...
+    async def vend_gateway_inbound_token(
+        self, principal: SessionPrincipal
+    ) -> InboundToken | None: ...
+```
+
+`status()` is display-only: `{enabled, workloadName, gatewayConfigured,
+principalBound}` and never token material. The dashboard merges it next
+to the existing `IdentityProvider.status()` payload (or a sibling
+`GET /api/agent-identity` if merging would confuse the SSO TTL probe).
+
+`whoami` / `issuer` on `IdentityProvider` stay RESERVED. Do not consume
+them to satisfy this RFC.
+
+### Session principal (core, trusted)
+
+The core builds `SessionPrincipal` from ground truth it already has.
+The adapter may **annotate** (attach a verified JWT). It may not
+replace `subject` with a client-supplied user id.
+
+| Surface | `subject` | JWT available? |
+|---|---|---|
+| Dashboard (companion SSO) | `dashboard+{idp_sub}` | Yes — use `ForJWT` |
+| Dashboard (OSS token auth) | `dashboard+{local_owner}` | No — `ForUserId` only if companion is enabled and the local owner is the host principal |
+| Slack / Discord / … | `{channel}+{provider_user_id}` | Only if companion SSO has bound that channel user |
+| CLI | `cli+{os_user}` | Same as local owner |
+| Cron / TaskRunner | `cron+{job_owner}` (the operator who created the job, persisted at create time) | No interactive JWT. M2M Gateway targets only, or fail closed |
+| Subagent | inherit parent principal | Same token audience as parent |
+| Injected cron / subagent-completion envelopes | **not a user** | Do not mint a user-bound token for an injected message |
+
+`ForUserId` subjects are partitioned `provider_id+user_id` per the
+Identity docs, so `slack+U0123` and `dashboard+U0123` cannot collide in
+the vault.
+
+IAM on the companion role denies `GetWorkloadAccessTokenForUserId` when
+a JWT path exists for that surface. The core still prefers `user_jwt`
+when `annotate_principal` set one.
+
+### Gateway attach and per-session header injection
+
+`gateway_mcp_spec()` / `extra_mcp_servers()` contribute a **URL-only**
+remote MCP entry: endpoint, protocol, no `Authorization`.
+
+The missing core seam is per-session header injection at MCP spawn,
+analogous to `mcp_gateway` declared-env forwarding
+(`security.md` § pooled-backend declared-env):
+
+1. Session start resolves `SessionPrincipal` and calls
+   `vend_gateway_inbound_token`.
+2. On miss or expiry, the Gateway server is **absent** for that session
+   (not present with an empty header). Fail closed.
+3. The bearer is written to a `0600` session sidecar that kiro-cli /
+   the MCP stub reads as transport headers. It is never merged into
+   `~/.kiro/agents/kirocrew.json`.
+4. The Gateway server is **unpooled** in v1 (`pool_identity` would have
+   to include the bearer, which re-partitions on every refresh and
+   leaks a credential into a hash input). Per-session spawn is the
+   honest cost.
+5. `IdentityProvider.credential_watch_paths()` (already wired) plus
+   inbound-token expiry drain the session's Gateway transport on
+   rotation.
+
+A local token-proxy MCP (Crew attaches the header, then forwards) is
+the fallback if kiro-cli cannot take per-session headers without a
+rebuild. Phase 0 of the implementation plan probes this and writes the
+verdict before Phase 3 ships.
+
+### Token vending path (Gateway, not Crew)
+
+v1 outbound vending is entirely Gateway + Identity:
+
+- Companion registers Gateway targets and OAuth credential providers
+  (M2M, 3LO, `TOKEN_EXCHANGE`) in the AgentCore control plane.
+- Crew presents the inbound JWT. Gateway exchanges and calls the
+  target.
+- Crew never calls `GetResourceOauth2Token` in v1.
+- Crew never logs, transcripts, or redacts the outbound token because
+  it never holds it.
+
+3LO / consent: when Identity returns `authorizationUrl` + `sessionUri`
+instead of a token, Gateway fails the MCP call. The companion must
+surface that URL on a **human** channel (dashboard modal or the
+originating chat thread), never as model-visible "click this" text.
+Reuse the existing operator-OAuth allowlist
+(`security.py` `_load_operator_oauth_endpoints` /
+`oauth_endpoints.json` keystone) so a consent URL to an unknown host
+is refused.
+
+### Unattended jobs
+
+Cron and TaskRunner have no interactive JWT.
+
+v1 policy:
+
+- Gateway targets whose credential provider is **M2M** (client
+  credentials, no user) may run unattended, under the job-owner
+  principal.
+- OBO / 3LO targets are **denied** on unattended sessions unless a
+  still-valid vaulted user token already exists for that
+  `(workload, job_owner)` pair. There is no silent refresh via a
+  guessed user id.
+- Injected `[Cron notification]` / `[Subagent completion event]`
+  messages do not mint a new principal. They run as the job/parent
+  already bound.
+
+### Governance, keystone, redaction
+
+- New `SCOPE_CATALOG` row `capabilities.agentcore` with
+  `capability_default=False` (opt-in, like `capabilities.publish` /
+  `capabilities.messaging`). Data row only; evaluator untouched;
+  `CONTRACT_VERSION` untouched.
+- The capability gates: contributing the Gateway MCP server, calling
+  either vend method, and surfacing 3LO consent. `network.egress` still
+  bounds the Gateway host. `mcp` still bounds the server/tool identity.
+- No `agentcore.json` in public `config.json`. Companion configuration
+  lives in the companion. If a later public opt-in needs a file, it is
+  a keystone path in `security._SENSITIVE_HOME_DIRS` (read **and**
+  write, including extract verbs), next to `oauth_endpoints.json`.
+- Workload access tokens and Gateway inbound JWTs are bearer material.
+  Existing HTTP-bearer redaction covers the wire shape; the companion
+  `CredentialPolicy` overlay may add AgentCore-specific prefixes. Tokens
+  never enter SEL payloads, transcripts, or `status()`.
+- SEL events (grant and deny): `agentcore.workload_token`,
+  `agentcore.gateway_inbound`, `agentcore.consent_url`,
+  `agentcore.unattended_denied`. No token bytes, no raw JWT.
+
+### Dashboard and CLI
+
+- Status only in v1: workload name, enabled, whether this session has a
+  bound principal, Gateway configured. No token display, no "copy
+  bearer."
+- 3LO consent is a modal / channel prompt with the allowlisted URL.
+- User-facing strings go through the i18n catalog
+  (`website/docs/i18n-catalog.md`). Backend non-2xx bodies carry a
+  machine-readable `code`.
+- No emojis. `lucide-react` + `lucide-inline`.
+
+## Migration plan
+
+Each phase is independently shippable and abandonable. Exit criteria
+are assertions, not dates.
+
+### Phase 0 — Probe (this repo, no product surface)
+
+Answer two questions and write the verdict into this RFC:
+
+1. Can kiro-cli take per-session `Authorization` headers for a URL MCP
+   server without writing them into the rendered agent JSON?
+2. Does a standalone (non-Gateway-managed) workload identity in the
+   target account accept `GetWorkloadAccessTokenForJWT` from the
+   companion's IAM principal?
+
+Exit: both answers recorded here. Phase 3 is blocked on (1). Phase 2
+is blocked on (2). If (1) is no, implement the local header-proxy MCP
+instead of kiro-cli header injection.
+
+### Phase 1 — Core seams, public no-ops
+
+Add `AgentIdentityProvider`, `DefaultAgentIdentityProvider`,
+`PlatformContext.agent_identity`, bootstrap wiring, CPP coverage tests,
+`capabilities.agentcore` (default off), and spec updates
+(`platform-context.md`, `governance.md`). No AWS dependency. Standalone
+behavior byte-identical.
+
+Exit: `test_platform_cpp_seam_coverage.py` lists the new slot;
+`enabled()` is False; no `bedrock` / `agentcore` import under
+`src/kiro_crew/`.
+
+### Phase 2 — Session principal + Identity vend (companion)
+
+Companion registers the standalone workload, implements
+`annotate_principal` / `vend_workload_access_token`, and fills
+`status()`. Core derives `SessionPrincipal` at session start and
+never accepts a tool-supplied user id.
+
+Exit: companion tests (out of this repo) mint a workload token with
+ForJWT; ForUserId subjects are partitioned; injected messages do not
+vend.
+
+### Phase 3 — Gateway MCP attach + inbound token injection
+
+Companion contributes the Gateway URL. Core injects the inbound JWT
+per session (or the header-proxy fallback). Unpooled. Expiry drains
+the transport. Fail closed on miss.
+
+Exit: a session with a valid JWT lists Gateway tools; a session
+without does not see the server; `kirocrew.json` contains no
+`Authorization` header.
+
+### Phase 4 — Human 3LO consent + unattended policy
+
+Consent URL allowlist + dashboard/channel prompt. Unattended jobs
+restricted to M2M or vaulted-owner tokens. SEL events land.
+
+Exit: an unknown consent host is refused; a cron job cannot OBO as an
+arbitrary user.
+
+### Phase 5 (follow-on, not v1) — Crew-direct `GetResourceOauth2Token`
+
+Only if a local tool cannot sit behind Gateway. Same workload token,
+same principal rules, same redaction. Do not start this phase to
+"complete" v1.
+
+## Backward compatibility
+
+- Standalone / public wheel: no new imports, no new MCP server, no new
+  default-on capability, no config migration.
+- Companion: additive. A companion that does not override
+  `agent_identity` inherits the Default (disabled).
+- Existing static remote MCP servers and `kiro_oauth_wire_entry` are
+  unchanged.
+- `IdentityProvider` signatures unchanged. RESERVED methods stay
+  reserved.
+
+## Security considerations
+
+- **Do not send a workload access token to Gateway.** Identity docs:
+  first-party only. Gateway inbound is a user JWT or IAM.
+- **Do not register a Gateway-managed workload as the Crew identity.**
+  Those identities refuse `GetWorkloadAccessToken` from the caller
+  ("WorkloadIdentity is linked to a service…").
+- **Do not put tokens in agent JSON, transcripts, SEL, or `status()`.**
+  Sidecar `0600`, process memory, then drop.
+- **Do not take `userId` from the model, a tool argument, or a query
+  string.** Core-derived principal only.
+- **Do not fail open** to a shared service-account token when JWT
+  vending fails.
+- **Do not re-introduce Cognito / RUM ids / enterprise SSO** into
+  `src/kiro_crew/`. Discovery URLs live in the companion.
+- Computer use stays ungoverned and in-band. This RFC does not add
+  `computer_use.*` scopes.
+- Sensitive-path matchers must cover any later keystone file on both
+  read and write/extract verbs.
+
+## Alternatives considered
+
+### A. Companion-only, no core seam (rejected as the long-term shape)
+
+The companion could inject a Gateway MCP server with a static header
+via `extra_mcp_servers()` today. That cannot do per-session OBO,
+refresh, or keep the bearer out of `kirocrew.json`. Acceptable as a
+manual operator escape hatch; not the integration.
+
+### B. boto3 AgentCore client in the public core (rejected)
+
+Violates the de-Amazoned fork rule, adds an AWS dependency to the
+public wheel, and invites hardcoded Cognito/discovery values. The CPP
+seam exists so the core never imports this.
+
+### C. Deploy Crew onto AgentCore Runtime (rejected for this RFC)
+
+Runtime auto-vends `WorkloadAccessToken` in the invocation payload.
+Crew is a local multi-surface gateway (dashboard, Slack, cron,
+subagents) that drives kiro-cli over ACP. Runtime has no inbound
+dashboard TCP and is a different product. Revisit only if a hosted
+Crew edition is separately designed.
+
+### D. Extend `IdentityProvider` instead of a new slot (viable, not recommended)
+
+v1 method adds on `IdentityProvider` would work and avoid a
+`PlatformContext` field. The slot is already SSO-shaped
+(`status_line`, `preflight_checks`). Token vending would overload it.
+A dedicated protocol matches "one edition concern, one interface."
+
+### E. Crew calls `GetResourceOauth2Token` and skips Gateway (rejected for v1)
+
+Puts OAuth, 3LO, and per-target credential-provider config in Crew.
+Gateway already does this, plus Cedar policy and interceptors. Crew
+should present identity, not become a token broker.
+
+### F. IAM inbound to Gateway, no JWT (rejected as the primary path)
+
+Works for M2M. Drops user `sub`, so OBO and per-user vault binding
+disappear. Allowed as a companion-only fallback for unattended M2M
+targets, not for interactive sessions.
+
+## Open questions
+
+1. **kiro-cli per-session headers (Phase 0).** If the rendered agent
+   JSON is the only header channel, v1 ships the local header-proxy
+   MCP. Verdict goes here before Phase 3.
+2. **One workload vs per-agent-config workloads.** v1 is one
+   `kirocrew` workload. A later `kirocrew-<agent_id>` split is
+   additive (new identities, same protocol).
+3. **Dashboard route.** Merge AgentCore status into `GET /api/sso-ttl`
+   vs a sibling `GET /api/agent-identity`. Prefer sibling so the SSO
+   TTL probe stays an SSO probe.
+4. **Channel-user SSO binding.** How the companion proves a Slack user
+   *is* the IdP `sub` is a companion concern. This RFC only requires
+   that the proof happen before `user_jwt` is set.
+5. **Sibling sandboxes RFC.** If that design lands a Crew-driven
+   Code Interpreter session, it must use this RFC's workload identity
+   rather than minting a second one.
+
+## Related
+
+- [`platform-context.md`](../system-specs/modules/platform-context.md) —
+  CPP seam, RESERVED methods, `CONTRACT_VERSION` pin
+- [`security.md`](../system-specs/modules/security.md) — keystone,
+  redaction, MCP env forwarding
+- [`governance.md`](../system-specs/modules/governance.md) —
+  `SCOPE_CATALOG` append-only
+- [`mcp.md`](../architecture/mcp.md) — MCP merge, stateless tools
+- [`injected-messages.md`](../system-specs/common/injected-messages.md)
+  — cron / subagent envelopes are not the user
+- [Get workload access token](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/get-workload-access-token.html)
+- [GetResourceOauth2Token](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_GetResourceOauth2Token.html)
+- [On-behalf-of token exchange](https://aws.amazon.com/blogs/machine-learning/implement-on-behalf-of-token-exchange-for-multi-tenant-agents-with-amazon-bedrock-agentcore-gateway/)

--- a/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
+++ b/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
@@ -1,0 +1,419 @@
+# AgentCore Identity and Gateway Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Crew agent a standalone AgentCore Identity workload
+and use AgentCore Gateway as the outbound token-vending plane, behind
+default-off CPP seams so the public edition stays byte-identical.
+
+**Architecture:** A new `AgentIdentityProvider` slot on
+`PlatformContext` holds workload identity and token vending. The public
+`Default` is empty. The companion talks to Identity (`GetWorkloadAccessToken*`)
+and contributes the Gateway MCP URL. The core derives a trusted
+`SessionPrincipal`, injects a per-session inbound JWT (never into
+`kirocrew.json`), and leaves outbound OAuth to Gateway. `CONTRACT_VERSION`
+stays `1`.
+
+**Tech Stack:** Python 3.10+, existing CPP (`platform/`), MCP gateway
+rewriter, governance `SCOPE_CATALOG`, pytest-asyncio. Companion-only:
+`boto3` / `bedrock-agentcore` (not a public-wheel dependency).
+
+**Spec:**
+[`../../request-for-change/rfc-agentcore-identity-gateway.md`](../../request-for-change/rfc-agentcore-identity-gateway.md)
+
+## Global Constraints
+
+- Core never imports `bedrock_agentcore`, `boto3` AgentCore clients, or
+  names Cognito / Midway / a discovery URL.
+- Do not consume `IdentityProvider.whoami` or `issuer` (RESERVED).
+- Do not write tokens into `~/.kiro/agents/kirocrew.json`, transcripts,
+  SEL payloads, or `status()`.
+- Do not take `userId` from the model, a tool argument, or a query
+  string.
+- Fail closed: missing companion, expired JWT, or vend error means the
+  Gateway server is absent for that session.
+- `capabilities.agentcore` defaults **off**. No new default-on egress.
+- `sso_status.py` stays a stub. No `CHANGELOG.md` edit.
+- Computer use stays ungoverned. No `computer_use.*` scopes.
+- Update the owning spec in the same commit as the code it covers.
+- Run `scripts/docs-lint.sh` after every docs change.
+- Frontend user-facing strings go through the i18n catalog. No emojis.
+
+---
+
+## Stack and file map
+
+| PR | Branch suffix | Primary files |
+|---|---|---|
+| 1 | `plan` (this PR) | RFC, this plan, RFC + plans indexes |
+| 2 | `seams` | `platform/interfaces.py`, `defaults.py`, `context.py`, `bootstrap.py`, CPP coverage tests, `SCOPE_CATALOG`, `platform-context.md`, `governance.md` |
+| 3 | `principal` | session-principal derivation, injected-message guard, unit tests, `session.md` |
+| 4 | `probe` | Phase 0 verdict written back into the RFC (kiro-cli headers + standalone workload) |
+| 5 | `inject` | per-session Gateway header sidecar **or** header-proxy MCP; `mcp.md`; unpooled Gateway server |
+| 6 | `consent-unattended` | 3LO allowlist + dashboard/channel prompt + cron/M2M policy + SEL; `security.md` |
+| 7 | companion (out of tree) | real `AgentIdentityProvider`, workload registration, IdP JWT, Gateway URL |
+
+PRs 2, 3, 5, and 6 are this repository. PR 4 is a research commit that
+only edits the RFC. PR 7 is the enterprise companion package.
+
+### Stable interfaces
+
+```python
+@dataclass(frozen=True)
+class WorkloadIdentity:
+    name: str
+    arn: str
+
+@dataclass(frozen=True)
+class SessionPrincipal:
+    surface: str
+    subject: str
+    session_key: str
+    user_jwt: str | None = None
+
+@dataclass(frozen=True)
+class InboundToken:
+    scheme: str
+    token: str
+    expires_at: float
+    audience: str
+
+class AgentIdentityProvider(Protocol):
+    def enabled(self) -> bool: ...
+    def workload_identity(self) -> WorkloadIdentity | None: ...
+    def status(self) -> dict[str, object]: ...
+    def gateway_mcp_spec(self) -> dict[str, object] | None: ...
+    async def annotate_principal(
+        self, principal: SessionPrincipal
+    ) -> SessionPrincipal: ...
+    async def vend_workload_access_token(
+        self, principal: SessionPrincipal
+    ) -> str | None: ...
+    async def vend_gateway_inbound_token(
+        self, principal: SessionPrincipal
+    ) -> InboundToken | None: ...
+```
+
+`DefaultAgentIdentityProvider`: `enabled() -> False`; all other methods
+return `None` / `{}` / the input principal unchanged.
+
+---
+
+### Task 1: PR 1 — record the design and this plan
+
+**Files:**
+
+- Create: `docs/request-for-change/rfc-agentcore-identity-gateway.md`
+- Create: `docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md`
+- Modify: `docs/request-for-change/README.md`
+- Modify: `docs/superpowers/plans/README.md`
+
+**Interfaces:**
+
+- Consumes: CPP slot table, RESERVED identity methods, MCP merge rules,
+  AgentCore Identity/Gateway product shape.
+- Produces: locked design + PR-sized implementation map.
+
+- [x] **Step 1: Write the RFC and this plan.**
+
+- [x] **Step 2: Index both documents.**
+
+  Add a `draft` row to `docs/request-for-change/README.md` naming the
+  commit they were verified against (`152c00e99`). Link this plan from
+  `docs/superpowers/plans/README.md`.
+
+- [x] **Step 3: Verify documentation.**
+
+  Run: `bash scripts/docs-lint.sh && git diff --check`
+  Expected: both exit zero.
+
+- [x] **Step 4: Commit.**
+
+  ```
+  docs: add AgentCore identity and gateway plan
+  ```
+
+---
+
+### Task 2: PR 2 — CPP slot and governance row (public no-ops)
+
+**Files:**
+
+- Modify: `src/kiro_crew/platform/interfaces.py` (add dataclasses + Protocol)
+- Modify: `src/kiro_crew/platform/defaults.py` (add `DefaultAgentIdentityProvider`)
+- Modify: `src/kiro_crew/platform/context.py` (add `agent_identity` field)
+- Modify: `src/kiro_crew/platform/bootstrap.py` (wire Default)
+- Modify: `src/kiro_crew/platform/__init__.py` (exports)
+- Modify: `src/kiro_crew/platform/governance.py` (`capabilities.agentcore`)
+- Modify: `test/test_platform_cpp_seam_coverage.py` (and any bootstrap/context tests the coverage file names)
+- Modify: `docs/system-specs/modules/platform-context.md`
+- Modify: `docs/system-specs/modules/governance.md`
+
+**Interfaces:**
+
+- Consumes: the Protocol above.
+- Produces: a composed `ctx.agent_identity` that is disabled in
+  standalone.
+
+- [ ] **Step 1: Write the failing coverage test.**
+
+  Assert `PlatformContext` has `agent_identity`, the default adapter's
+  `enabled()` is False, `workload_identity()` is None,
+  `gateway_mcp_spec()` is None, `status()` is a dict with no token-like
+  keys, and `capabilities.agentcore` exists with
+  `capability_default=False`.
+
+- [ ] **Step 2: Run the test and verify RED.**
+
+  Run: `python -m pytest test/test_platform_cpp_seam_coverage.py -n0 -q -k agent_identity`
+  Expected: FAIL because the field / scope does not exist.
+
+- [ ] **Step 3: Implement Default + catalog row.**
+
+  Follow existing v1 addition comments (`no CONTRACT_VERSION bump`).
+  `safe_context_call` fallback for every new method must be the disabled
+  answer (False / None / `{}` / unchanged principal), never a raised
+  error that degrades to "enabled."
+
+- [ ] **Step 4: Grep the public tree for AWS leakage.**
+
+  Run: `rg -n "bedrock.agentcore|bedrock_agentcore|GetWorkloadAccessToken|cognito-idp" src/kiro_crew website/src`
+  Expected: no matches.
+
+- [ ] **Step 5: Update specs and run gates.**
+
+  `platform-context.md` table gets an `agent_identity` row.
+  `governance.md` documents the new capability as opt-in.
+  Run: `black --target-version py310 <touched py>` then
+  `python3 scripts/check_black_formatting.py` and
+  `mypy --platform linux src/kiro_crew`.
+
+- [ ] **Step 6: Commit.**
+
+  ```
+  feat: add agent_identity CPP slot and agentcore capability
+  ```
+
+---
+
+### Task 3: PR 3 — trusted session principal
+
+**Files:**
+
+- Create: `src/kiro_crew/platform/agent_identity.py` (dataclasses if not
+  already in interfaces; `derive_session_principal(slot_or_session)`)
+- Create: `test/test_agent_identity_principal.py`
+- Modify: session start site(s) — the smallest existing hook that already
+  knows `session_key` + surface (likely `session` / chat runner / channel
+  dispatch). Do **not** invent a second session key.
+- Modify: `docs/system-specs/modules/session.md`
+
+**Interfaces:**
+
+- Consumes: existing session key and channel identity.
+- Produces: `SessionPrincipal` with partitioned `subject`.
+
+- [ ] **Step 1: Write failing derivation tests.**
+
+  ```python
+  def test_dashboard_owner_is_partitioned():
+      p = derive_session_principal(surface="dashboard", raw_id="alice", session_key="dashboard:1")
+      assert p.subject == "dashboard+alice"
+      assert p.user_jwt is None
+
+  def test_tool_input_cannot_supply_subject():
+      # whatever helper rejects kwargs from tool_input
+      ...
+
+  def test_injected_cron_envelope_does_not_derive_a_user():
+      assert derive_session_principal_for_injected("[Cron notification from \"job\"]") is None
+  ```
+
+- [ ] **Step 2: Run tests, verify RED, then implement.**
+
+  Run: `python -m pytest test/test_agent_identity_principal.py -n0 -q`
+
+- [ ] **Step 3: Call `annotate_principal` through `safe_context_call`.**
+
+  Fallback = the core-derived principal unchanged. Companion may set
+  `user_jwt`. It must not change `subject`. Add a test that a stub
+  adapter attempting to rewrite `subject` is ignored or rejected.
+
+- [ ] **Step 4: Commit.**
+
+  ```
+  feat: derive partitioned AgentCore session principals
+  ```
+
+---
+
+### Task 4: PR 4 — Phase 0 probe verdict
+
+**Files:**
+
+- Modify: `docs/request-for-change/rfc-agentcore-identity-gateway.md`
+  (Open question 1 + Phase 0)
+
+No product code. Record:
+
+1. Whether kiro-cli accepts per-session MCP headers without persisting
+   them in the rendered agent file (experiment against current kiro-cli;
+   cite version).
+2. Whether a standalone workload identity accepts
+   `GetWorkloadAccessTokenForJWT` from the companion IAM role (companion
+   repo or a scratch account; paste only the error string, no tokens).
+
+- [ ] **Step 1: Run the two probes.**
+
+- [ ] **Step 2: Write the verdict into the RFC Open questions section.**
+
+- [ ] **Step 3: Commit.**
+
+  ```
+  docs: record AgentCore Phase 0 header and workload verdicts
+  ```
+
+Phase 5 implements **exactly one** of: kiro-cli sidecar headers, or the
+local header-proxy MCP. Do not implement both.
+
+---
+
+### Task 5: PR 5 — Gateway attach and inbound injection
+
+**Files (sidecar path, if Phase 0 said yes):**
+
+- Modify: `src/kiro_crew/mcp_gateway/` rewriter / session spawn
+- Modify: `src/kiro_crew/agent.py` (`_extra_mcp_servers` merge of
+  `gateway_mcp_spec()`, URL only)
+- Create: `test/test_agentcore_gateway_inject.py`
+- Modify: `docs/architecture/mcp.md`
+
+**Files (proxy path, if Phase 0 said no):**
+
+- Create: `src/kiro_crew/mcp_gateway/agentcore_proxy.py` (stdio MCP that
+  forwards to the Gateway URL with the session inbound token)
+- Same tests and `mcp.md` update
+
+**Either path:**
+
+- [ ] **Step 1: Write failing tests.**
+
+  - `enabled() is False` → no Gateway server in the rebuilt agent config.
+  - `enabled() is True` but `vend_gateway_inbound_token` returns None →
+    server still absent (fail closed).
+  - Successful vend → transport has `Authorization: Bearer …` and
+    `~/.kiro/agents/kirocrew.json` does not.
+  - Two sessions with different principals do not share a backend
+    (unpooled).
+  - Token bytes never appear in a captured log / SEL fixture.
+
+- [ ] **Step 2: Implement the Phase 0-chosen path only.**
+
+  Gate contribution on `capabilities.agentcore` (fail closed when the
+  capability is off, even if the companion `enabled()` is True).
+
+- [ ] **Step 3: Commit.**
+
+  ```
+  feat: inject per-session AgentCore Gateway inbound tokens
+  ```
+
+---
+
+### Task 6: PR 6 — consent surface and unattended policy
+
+**Files:**
+
+- Modify: `src/kiro_crew/security.py` (consent-host allowlist reuse of
+  `oauth_endpoints.json`; do not add a second file unless the existing
+  keystone cannot express AgentCore consent hosts)
+- Modify: dashboard handler + a small Settings / modal component
+  (`website/src/…`) with i18n keys
+- Modify: cron / task start path to refuse OBO targets without a
+  vaulted owner token (companion reports "m2m" vs "user" on
+  `gateway_mcp_spec()` or status)
+- Modify: SEL event names from the RFC
+- Modify: `docs/system-specs/modules/security.md`
+- Test: `test/test_agentcore_consent.py`, `test/test_agentcore_unattended.py`
+
+- [ ] **Step 1: Write failing tests for unknown consent host, injected
+  envelope, and cron-without-JWT.**
+
+- [ ] **Step 2: Implement allowlist + fail-closed unattended policy.**
+
+  User-facing copy is cataloged. Backend errors include `code`.
+  No model-visible "click this URL" injection.
+
+- [ ] **Step 3: Verify dashboard strings and the unattended path.**
+
+  `cd website && npm run test` for the new modal/copy.
+  Backend: `python -m pytest test/test_agentcore_consent.py test/test_agentcore_unattended.py -n0 -q`
+
+- [ ] **Step 4: Commit.**
+
+  ```
+  feat: gate AgentCore 3LO consent and unattended vending
+  ```
+
+---
+
+### Task 7: Companion package (out of this repository)
+
+Not landed in KiroCrew. The companion implements
+`AgentIdentityProvider` against:
+
+- `bedrock-agentcore:GetWorkloadAccessToken`
+- `bedrock-agentcore:GetWorkloadAccessTokenForJWT`
+- `bedrock-agentcore:GetWorkloadAccessTokenForUserId` (denied in IAM
+  when a JWT exists for that surface)
+- A **standalone** workload identity named `kirocrew` (not
+  Gateway-managed, not Runtime-managed)
+- Gateway `CUSTOM_JWT` authorizer pointed at the operator IdP
+- `McpToolingProvider.extra_mcp_servers()` URL-only Gateway spec
+- `IdentityProvider` SSO JWT → `annotate_principal.user_jwt`
+
+Companion checklist (for the other repo's plan):
+
+- [ ] Create standalone workload; confirm `GetWorkloadAccessTokenForJWT`
+      works; confirm a Gateway-linked workload returns the "linked to a
+      service" error (negative test).
+- [ ] IAM resource-scoped to
+      `workload-identity-directory/default/workload-identity/kirocrew`.
+- [ ] Prefer ForJWT; partition ForUserId as `{surface}+{id}`.
+- [ ] Register Gateway targets + OAuth credential providers (M2M / 3LO /
+      `TOKEN_EXCHANGE`) in the control plane, not in Crew config.
+- [ ] `status()` contains no token material.
+- [ ] Redaction overlay for any AgentCore-specific prefix the core
+      bearer heuristic misses.
+
+---
+
+## Execution order and stop points
+
+1. Land PR 1 (this documentation).
+2. Land PR 2 before anything consumes the slot.
+3. Land PR 3 before any vend call.
+4. Run PR 4 **before** writing PR 5 code. If the header probe is
+   inconclusive, stop and update the RFC rather than guessing.
+5. PR 6 can overlap PR 5 once the injection tests exist, but do not
+   merge consent UI that points at a server the inject path cannot
+   attach.
+6. Do not start PR 7 (companion) until PR 2's Protocol is on the core
+   version the companion will pin.
+
+**Do not implement Phase 5 of the RFC** (Crew-direct
+`GetResourceOauth2Token`) in this stack.
+
+## Verification before calling a phase done
+
+- Public tree still has zero AgentCore SDK imports.
+- `DefaultAgentIdentityProvider.enabled()` is False and no Gateway
+  server appears in a standalone `rebuild_agent_config()`.
+- `kirocrew.json` fixtures contain no `Authorization` header.
+- Injected cron / subagent envelopes cannot vend a user token.
+- `scripts/docs-lint.sh` and
+  `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py`
+  are clean on the files you added.

--- a/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
+++ b/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
@@ -246,7 +246,9 @@ return `None` / `{}` / the input principal unchanged.
 - Modify: `src/kiro_crew/cloud/source.py` (create-once helper for the
   new boundary name; still never `CreatePolicyVersion`)
 - Modify: `src/kiro_crew/cloud/templates/kirocrew-ec2.yaml`
-  (`PermissionsBoundaryArn` `AllowedPattern` lists both names)
+  (`PermissionsBoundaryArn` `AllowedPattern` lists both names;
+  `AgentCorePosture` creates `AWS::BedrockAgentCore::WorkloadIdentity`
+  named `kirocrew-<StackTag>` and attaches the instance grant)
 - Modify: dashboard cloud IAM copy + `cli_cloud` `iam-policy` (labeled
   sibling document; query/flag `--instance --posture`)
 - Modify: `src/kiro_crew/agent.py` / MCP merge (`rebuild_agent_config`

--- a/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
+++ b/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
@@ -7,15 +7,32 @@
 
 **Goal:** Give the Crew agent a standalone AgentCore Identity workload
 and use AgentCore Gateway as the outbound token-vending plane, behind
-default-off CPP seams so the public edition stays byte-identical.
+default-off CPP seams so the public edition stays byte-identical. A
+fleet picks exactly one `security_policy.json` posture, and the
+copyable cloud Policy.json pair must match it.
 
 **Architecture:** A new `AgentIdentityProvider` slot on
 `PlatformContext` holds workload identity and token vending. The public
 `Default` is empty. The companion talks to Identity (`GetWorkloadAccessToken*`)
 and contributes the Gateway MCP URL. The core derives a trusted
-`SessionPrincipal`, injects a per-session inbound JWT (never into
-`kirocrew.json`), and leaves outbound OAuth to Gateway. `CONTRACT_VERSION`
-stays `1`.
+`SessionPrincipal` and leaves outbound OAuth to Gateway.
+`CONTRACT_VERSION` stays `1`.
+
+Two exclusive postures, selected by `capabilities.agentcore.posture`:
+
+- **`workload`** — deployed box. Instance IAM invokes Gateway at
+  boot. No login. Kiro MCP defaults still merge. Instance Policy.json
+  allows `InvokeGateway` + `GetWorkloadAccessToken` / `ForUserId` and
+  Denies `ForJWT`.
+- **`login`** — Gateway catalog only. Rebuild withholds Kiro-global,
+  seam-global, crew-store, and leftover non-managed MCP. Tools stay
+  absent until `ensure` login vends a CUSTOM_JWT. Instance Policy.json
+  allows `ForJWT` only and Denies `ForUserId` + `InvokeGateway`.
+
+The launcher `iam.policy_json()` never grows those instance actions.
+A new helper emits the instance fragment; a new named boundary
+(`kirocrew-ec2-boundary-agentcore`) is the ceiling. The original
+`kirocrew-ec2-boundary` is not re-versioned.
 
 **Tech Stack:** Python 3.10+, existing CPP (`platform/`), MCP gateway
 rewriter, governance `SCOPE_CATALOG`, pytest-asyncio. Companion-only:
@@ -33,9 +50,20 @@ rewriter, governance `SCOPE_CATALOG`, pytest-asyncio. Companion-only:
   SEL payloads, or `status()`.
 - Do not take `userId` from the model, a tool argument, or a query
   string.
-- Fail closed: missing companion, expired JWT, or vend error means the
-  Gateway server is absent for that session.
+- Fail closed: missing companion, expired JWT, vend error, unknown
+  posture, or posture-vs-IAM mismatch means the Gateway server is
+  absent for that session.
 - `capabilities.agentcore` defaults **off**. No new default-on egress.
+- Postures are exclusive. Do not layer `workload` IAM inbound on top
+  of `login` JWT inbound.
+- Do not `CreatePolicyVersion` `kirocrew-ec2-boundary`. AgentCore
+  ceiling is a new named boundary, opt-in at launch.
+- Do not put `InvokeGateway` / `GetWorkloadAccessToken*` on the
+  launcher Policy.json. Those belong on
+  `iam.agentcore_instance_policy_document(posture)`.
+- `login` withholds Kiro defaults at `rebuild_agent_config()` emit
+  time (same control as `kirocrew-computer` `spec_gate`), not only
+  at the tool gate.
 - `sso_status.py` stays a stub. No `CHANGELOG.md` edit.
 - Computer use stays ungoverned. No `computer_use.*` scopes.
 - Update the owning spec in the same commit as the code it covers.
@@ -49,15 +77,18 @@ rewriter, governance `SCOPE_CATALOG`, pytest-asyncio. Companion-only:
 | PR | Branch suffix | Primary files |
 |---|---|---|
 | 1 | `plan` (this PR) | RFC, this plan, RFC + plans indexes |
-| 2 | `seams` | `platform/interfaces.py`, `defaults.py`, `context.py`, `bootstrap.py`, CPP coverage tests, `SCOPE_CATALOG`, `platform-context.md`, `governance.md` |
+| 2 | `seams` | `platform/interfaces.py`, `defaults.py`, `context.py`, `bootstrap.py`, CPP coverage tests, `SCOPE_CATALOG` + `posture`, `platform-context.md`, `governance.md` |
+| 2b | `iam` | `cloud/iam.py` helper + new boundary name, launcher CreateRole pin widening, dashboard/CLI copy of the instance fragment, login-mode rebuild withhold, posture-mismatch probe, `cloud.md`, `mcp.md` |
 | 3 | `principal` | session-principal derivation, injected-message guard, unit tests, `session.md` |
 | 4 | `probe` | Phase 0 verdict written back into the RFC (kiro-cli headers + standalone workload) |
-| 5 | `inject` | per-session Gateway header sidecar **or** header-proxy MCP; `mcp.md`; unpooled Gateway server |
-| 6 | `consent-unattended` | 3LO allowlist + dashboard/channel prompt + cron/M2M policy + SEL; `security.md` |
-| 7 | companion (out of tree) | real `AgentIdentityProvider`, workload registration, IdP JWT, Gateway URL |
+| 5 | `inject` | per-session Gateway header sidecar **or** header-proxy MCP; unpooled Gateway server |
+| 6 | `consent-unattended` | 3LO allowlist + dashboard/channel prompt + posture-aware cron/M2M policy + SEL; `security.md` |
+| 7 | companion (out of tree) | real `AgentIdentityProvider`, both authorizer types, workload registration, IdP JWT, Gateway URL |
 
-PRs 2, 3, 5, and 6 are this repository. PR 4 is a research commit that
-only edits the RFC. PR 7 is the enterprise companion package.
+PRs 2, 2b, 3, 5, and 6 are this repository. PR 4 is a research commit
+that only edits the RFC. PR 7 is the enterprise companion package.
+PR 2b can land right after PR 2: the IAM helpers and the rebuild
+withhold do not need a live vend path.
 
 ### Stable interfaces
 
@@ -164,7 +195,9 @@ return `None` / `{}` / the input principal unchanged.
   `enabled()` is False, `workload_identity()` is None,
   `gateway_mcp_spec()` is None, `status()` is a dict with no token-like
   keys, and `capabilities.agentcore` exists with
-  `capability_default=False`.
+  `capability_default=False`. An `enabled: true` document with a
+  missing or unknown `posture` fails closed (treated as disabled,
+  or boot-abort when `boot.fail_closed`).
 
 - [ ] **Step 2: Run the test and verify RED.**
 
@@ -186,7 +219,8 @@ return `None` / `{}` / the input principal unchanged.
 - [ ] **Step 5: Update specs and run gates.**
 
   `platform-context.md` table gets an `agent_identity` row.
-  `governance.md` documents the new capability as opt-in.
+  `governance.md` documents the new capability as opt-in and names
+  the inner `posture` field (`workload` | `login`).
   Run: `black --target-version py310 <touched py>` then
   `python3 scripts/check_black_formatting.py` and
   `mypy --platform linux src/kiro_crew`.
@@ -195,6 +229,98 @@ return `None` / `{}` / the input principal unchanged.
 
   ```
   feat: add agent_identity CPP slot and agentcore capability
+  ```
+
+---
+
+### Task 2b: PR 2b — Policy.json pair, boundary successor, login withhold
+
+**Files:**
+
+- Modify: `src/kiro_crew/cloud/iam.py`
+  (`agentcore_instance_policy_document(posture)`,
+  `AGENTCORE_BOUNDARY_NAME = "kirocrew-ec2-boundary-agentcore"`,
+  `agentcore_boundary_policy_document(account, posture)`,
+  launcher `CreateRole` / `CreatePolicy` statements accept either
+  boundary name)
+- Modify: `src/kiro_crew/cloud/source.py` (create-once helper for the
+  new boundary name; still never `CreatePolicyVersion`)
+- Modify: `src/kiro_crew/cloud/templates/kirocrew-ec2.yaml`
+  (`PermissionsBoundaryArn` `AllowedPattern` lists both names)
+- Modify: dashboard cloud IAM copy + `cli_cloud` `iam-policy` (labeled
+  sibling document; query/flag `--instance --posture`)
+- Modify: `src/kiro_crew/agent.py` / MCP merge (`rebuild_agent_config`
+  withholds Kiro-global, seam-global, crew-store, leftover non-managed
+  when posture is `login` and the capability is on)
+- Create: `test/test_agentcore_iam_posture.py`
+- Modify: existing `test/test_cloud_*` / rebuild tests that pin
+  `BOUNDARY_NAME` or merge order
+- Modify: `docs/system-specs/modules/cloud.md`
+- Modify: `docs/architecture/mcp.md` (login withhold = emit-time
+  `spec_gate`, same as `kirocrew-computer`)
+
+**Interfaces:**
+
+- Consumes: `capabilities.agentcore.{enabled,posture}` from PR 2.
+- Produces: posture-correct instance Policy.json; a new immutable
+  boundary name; login-mode rebuild that emits only managed
+  `kirocrew-*` plus (later) a URL-only Gateway spec.
+
+- [ ] **Step 1: Write failing IAM + rebuild tests.**
+
+  ```python
+  def test_launcher_policy_json_has_no_invoke_gateway():
+      assert "InvokeGateway" not in iam.policy_json()
+      assert "GetWorkloadAccessToken" not in iam.policy_json()
+
+  def test_workload_instance_document_denies_for_jwt():
+      doc = iam.agentcore_instance_policy_document("workload")
+      ...
+
+  def test_login_instance_document_denies_userid_and_invoke():
+      doc = iam.agentcore_instance_policy_document("login")
+      ...
+
+  def test_original_boundary_document_unchanged():
+      # byte-compare the SSM-core + source-bucket shape; no AgentCore
+
+  def test_login_rebuild_withholds_kiro_global(tmp_path):
+      # seed ~/.kiro/settings/mcp.json with a dummy server
+      # posture=login + capability on → rebuilt kirocrew.json
+      # has kirocrew-core / kirocrew-cron, no dummy, no Gateway yet
+
+  def test_workload_rebuild_still_merges_kiro_global(tmp_path):
+      ...
+
+  def test_login_probe_succeeds_iam_invoke_fails_closed():
+      # posture=login + mock IAM InvokeGateway success
+      # → Gateway spec absent, SEL agentcore.posture_mismatch
+  ```
+
+- [ ] **Step 2: Run tests, verify RED.**
+
+  Run: `python -m pytest test/test_agentcore_iam_posture.py -n0 -q`
+
+- [ ] **Step 3: Implement helper, successor boundary, withhold, probe.**
+
+  Keep `BOUNDARY_NAME = "kirocrew-ec2-boundary"` as the default
+  launch path. AgentCore launches pass the successor ARN. The
+  successor document is the **union** ceiling (SSM-core +
+  source-bucket + every AgentCore action either posture may grant).
+  Resource ARNs in the instance fragment are fleet-pinned (workload
+  name `kirocrew`, gateway `kirocrew-*`), never `*`, except on the
+  explicit Deny SIDs.
+
+- [ ] **Step 4: Update cloud.md + mcp.md and run gates.**
+
+  Run: `bash scripts/docs-lint.sh` then
+  `black --target-version py310 <touched py>` then
+  `python3 scripts/check_black_formatting.py`.
+
+- [ ] **Step 5: Commit.**
+
+  ```
+  feat: add agentcore policy.json postures and login mcp withhold
   ```
 
 ---
@@ -289,7 +415,8 @@ local header-proxy MCP. Do not implement both.
 - Modify: `src/kiro_crew/agent.py` (`_extra_mcp_servers` merge of
   `gateway_mcp_spec()`, URL only)
 - Create: `test/test_agentcore_gateway_inject.py`
-- Modify: `docs/architecture/mcp.md`
+- Modify: `docs/architecture/mcp.md` only if the inject path needs a
+  new header-sidecar note (login withhold already landed in PR 2b)
 
 **Files (proxy path, if Phase 0 said no):**
 
@@ -302,10 +429,13 @@ local header-proxy MCP. Do not implement both.
 - [ ] **Step 1: Write failing tests.**
 
   - `enabled() is False` → no Gateway server in the rebuilt agent config.
-  - `enabled() is True` but `vend_gateway_inbound_token` returns None →
-    server still absent (fail closed).
-  - Successful vend → transport has `Authorization: Bearer …` and
-    `~/.kiro/agents/kirocrew.json` does not.
+  - `enabled() is True` / posture `login` but `vend_gateway_inbound_token`
+    returns None → server still absent (fail closed). Operator must
+    complete ensure-login.
+  - `enabled() is True` / posture `workload` → IAM inbound, no JWT
+    sidecar. Gateway URL-only spec is present at boot.
+  - Successful `login` vend → transport has `Authorization: Bearer …`
+    and `~/.kiro/agents/kirocrew.json` does not.
   - Two sessions with different principals do not share a backend
     (unpooled).
   - Token bytes never appear in a captured log / SEL fixture.
@@ -332,7 +462,8 @@ local header-proxy MCP. Do not implement both.
   keystone cannot express AgentCore consent hosts)
 - Modify: dashboard handler + a small Settings / modal component
   (`website/src/…`) with i18n keys
-- Modify: cron / task start path to refuse OBO targets without a
+- Modify: cron / task start path: `login` never attaches Gateway
+  (already withheld). `workload` refuses OBO targets without a
   vaulted owner token (companion reports "m2m" vs "user" on
   `gateway_mcp_spec()` or status)
 - Modify: SEL event names from the RFC
@@ -367,13 +498,16 @@ Not landed in KiroCrew. The companion implements
 
 - `bedrock-agentcore:GetWorkloadAccessToken`
 - `bedrock-agentcore:GetWorkloadAccessTokenForJWT`
-- `bedrock-agentcore:GetWorkloadAccessTokenForUserId` (denied in IAM
-  when a JWT exists for that surface)
+- `bedrock-agentcore:GetWorkloadAccessTokenForUserId` (`workload`
+  posture only; denied in IAM under `login`)
 - A **standalone** workload identity named `kirocrew` (not
   Gateway-managed, not Runtime-managed)
-- Gateway `CUSTOM_JWT` authorizer pointed at the operator IdP
+- Gateway authorizer matches posture: `AWS_IAM` for `workload`,
+  `CUSTOM_JWT` (operator IdP) for `login`. One Gateway, one
+  authorizer — do not flip in place; relaunch or run two hosts
 - `McpToolingProvider.extra_mcp_servers()` URL-only Gateway spec
 - `IdentityProvider` SSO JWT → `annotate_principal.user_jwt`
+  (`login` only; this is the ensure-login)
 
 Companion checklist (for the other repo's plan):
 
@@ -395,13 +529,17 @@ Companion checklist (for the other repo's plan):
 
 1. Land PR 1 (this documentation).
 2. Land PR 2 before anything consumes the slot.
-3. Land PR 3 before any vend call.
-4. Run PR 4 **before** writing PR 5 code. If the header probe is
+3. Land PR 2b next (Policy.json + boundary + login withhold). It
+   does not wait on a vend path.
+4. Land PR 3 before any vend call.
+5. Run PR 4 **before** writing PR 5 code. If the header probe is
    inconclusive, stop and update the RFC rather than guessing.
-5. PR 6 can overlap PR 5 once the injection tests exist, but do not
+   PR 5's `workload` IAM path does not depend on the header probe;
+   only the `login` JWT sidecar / proxy does.
+6. PR 6 can overlap PR 5 once the injection tests exist, but do not
    merge consent UI that points at a server the inject path cannot
    attach.
-6. Do not start PR 7 (companion) until PR 2's Protocol is on the core
+7. Do not start PR 7 (companion) until PR 2's Protocol is on the core
    version the companion will pin.
 
 **Do not implement Phase 5 of the RFC** (Crew-direct
@@ -412,6 +550,12 @@ Companion checklist (for the other repo's plan):
 - Public tree still has zero AgentCore SDK imports.
 - `DefaultAgentIdentityProvider.enabled()` is False and no Gateway
   server appears in a standalone `rebuild_agent_config()`.
+- `iam.policy_json()` still has no `InvokeGateway` /
+  `GetWorkloadAccessToken*` action.
+- `iam.boundary_policy_document()` is byte-stable vs the pre-PR
+  SSM-core + source-bucket shape.
+- Login-posture rebuild fixtures contain managed `kirocrew-*` only
+  (no Kiro global, no crew-store leftover).
 - `kirocrew.json` fixtures contain no `Authorization` header.
 - Injected cron / subagent envelopes cannot vend a user token.
 - `scripts/docs-lint.sh` and

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -3,4 +3,5 @@
 - [2026-08-22-durable-run-coordinator.md](2026-08-22-durable-run-coordinator.md)
   — additive durable run coordinator and subagent lifecycle extraction.
 - [2026-08-27-agentcore-identity-gateway.md](2026-08-27-agentcore-identity-gateway.md)
-  — AgentCore Identity workload for the Crew agent and Gateway token vending.
+  — AgentCore Identity workload for the Crew agent and Gateway token
+  vending, with exclusive `workload` / `login` Policy.json postures.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -2,3 +2,5 @@
 
 - [2026-08-22-durable-run-coordinator.md](2026-08-22-durable-run-coordinator.md)
   — additive durable run coordinator and subagent lifecycle extraction.
+- [2026-08-27-agentcore-identity-gateway.md](2026-08-27-agentcore-identity-gateway.md)
+  — AgentCore Identity workload for the Crew agent and Gateway token vending.


### PR DESCRIPTION
## Problem / Motivation

Kiro Crew has no first-class agent identity in Amazon Bedrock AgentCore, and no token-vending path for outbound MCP tools. Operator-local secrets and static MCP `Authorization` headers are the only options today. A pasted Gateway URL is not an integration: it has no workload identity, no per-session principal, no refresh, and no 3LO consent surface.

The copyable cloud Policy.json pair also cannot express either of the two exclusive fleet shapes we need: a deployed box that can reach Gateway at boot, or a login box whose approved catalog *is* Gateway (overriding Kiro's default MCP merge).

## Why it matters

Without a Crew workload identity, Gateway policy, CloudTrail, and the Identity token vault cannot name the agent. Without Gateway as the vending plane, Crew would have to implement OAuth / RFC 8693 itself — or keep sharing long-lived tool credentials.

Without binding that design to Policy.json, a launcher paste that looks like it grants `InvokeGateway` still fails: the instance is capped by the immutable `kirocrew-ec2-boundary` (SSM + source-bucket only). Re-versioning that boundary is forbidden; a leaked launcher credential must not be able to `CreatePolicyVersion` it permissive.

## What changed (motivation → approach → change)

Goal: plan the integration, not implement it.

Approach (over putting boto3 in the public core, hosting Crew on AgentCore Runtime, or extending the reserved `IdentityProvider.whoami` slot):

- New default-off CPP slot `AgentIdentityProvider` for a **standalone** AgentCore workload (`kirocrew-<StackTag>`).
- AgentCore Gateway as the outbound token-vending plane (M2M / 3LO / OBO). Crew never holds the downstream token.
- Trusted, core-derived `SessionPrincipal` (`{surface}+{id}`). Never take `userId` from the model.
- Public edition stays byte-identical: no AWS SDK, no Cognito/SSO reintroduction, `CONTRACT_VERSION` stays `1`.

Two exclusive postures in `security_policy.json` (`capabilities.agentcore.posture`), each with a matching instance Policy.json:

- **`workload`** — deployed Crew has an IAM identity and can `InvokeGateway` at boot. No login. Kiro MCP defaults still merge. Instance grant allows `GetWorkloadAccessToken` / `ForUserId` and **Denies** `ForJWT`.
- **`login`** — only Gateway-approved MCP is vended. `rebuild_agent_config()` withholds Kiro-global, seam-global, crew-store, and leftover non-managed servers (same emit-time control as `kirocrew-computer` `spec_gate`). Managed `kirocrew-*` stay. Gateway is absent until ensure-login vends a CUSTOM_JWT. Instance grant allows `ForJWT` only and **Denies** `ForUserId` + `InvokeGateway`.

**See-and-configure is on each crew's own gateway.** Settings → Security → Agent identity (`GET`/`PUT /api/agentcore/identity`) on the dashboard you are connected to. A hub launching another box is a different crew — identity does not live on Settings → Remote Crew. PUT writes only the standalone home `security_policy.json`; a fleet override or signed document is 409. App tokens are 403. The ceiling is boot-frozen, so a write returns `restart_required`.

**Deploy can still create the AWS identity.** The CloudFormation launcher (`kirocrew-ec2.yaml`) creates `AWS::BedrockAgentCore::WorkloadIdentity` named `kirocrew-<StackTag>` when `kirocrew cloud launch --agentcore-posture` is `workload` or `login`, attaches the matching `AWS::IAM::Policy` to the instance role, and writes `KIROCREW_AGENTCORE_POSTURE` / `KIROCREW_AGENTCORE_WORKLOAD_NAME` into systemd. CDK operators create the same resource via `aws_bedrockagentcore.WorkloadIdentity` (the public wheel does not depend on `aws-cdk-lib`). Default `none` is the historical launch and the dashboard launch path. Stack delete removes the identity. The launcher Policy.json grows only control-plane Create/Delete/Get/Tag verbs — never `InvokeGateway`.

Policy.json split:

- Launcher `iam.policy_json()` stays launch-only (CFN, PassRole, SSM, source bucket). It does **not** grow `InvokeGateway`.
- New helper `iam.agentcore_instance_policy_document(posture)` is the copyable instance fragment.
- New named boundary `kirocrew-ec2-boundary-agentcore` is the **union** ceiling. Original `kirocrew-ec2-boundary` is never re-versioned. CloudFormation `AllowedPattern` must accept either name.
- Posture-vs-IAM mismatch fails closed (no Gateway emit, SEL-audited).

This PR records that design as:

- [`docs/request-for-change/rfc-agentcore-identity-gateway.md`](docs/request-for-change/rfc-agentcore-identity-gateway.md)
- [`docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md`](docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md)

Implementation is a stacked series (seams → **Policy.json / boundary / login withhold** → principal → **CFN identity assignment** → **per-crew Settings identity** → Phase 0 probe → inject → consent/unattended → companion). Phase 0 must answer whether kiro-cli can take per-session headers before the `login` injection path lands. The `workload` IAM path does not wait on that probe.

This is the identity/credential plane. It is not the sibling AgentCore sandboxes execution-plane design.

Replaces #6331, which closed when the branch was renamed off the `cursor/` prefix.

## Tests

N/A — documentation only. `scripts/docs-lint.sh` passes.

## Manual verification

N/A — no runtime or UI change. Docs-lint and `git diff --check` were run on the branch.

## Related Issues

None linked. Companion implementation is out of this repository (plan Task 7).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — docs only)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff