### PR TITLE
fix(store): restore the pre-switch slot when switchSlot rejects with a gone target (#6309)

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -9,7 +9,7 @@ import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNoti
 import { dispatchMcNotification, TURN_DONE_KIND, APPROVAL_KIND, shouldChimeOnTurnDone } from './notificationEvent'
 import { emitThemeSound } from './themeSound'
 import {
-  fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, setFolderSuggestion, sseMcpAppRender, setGoalLoops, sseGoalLoop, sseSideQueue, reconcileWorkflowRuns
+  fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, clearSlotCache, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, setFolderSuggestion, sseMcpAppRender, setGoalLoops, sseGoalLoop, sseSideQueue, reconcileWorkflowRuns
 } from '../store/chatSlice'
 import { anchorForSlot, loadLayout, sessionSlots } from './splitLayoutStore'
 import { TAB_ID } from '../api/tabId'
@@ -1133,9 +1133,13 @@ export function useWebSocket() {
             break
           }
           case 'slot_clear': {
-            // /clear command — clear messages in active slot; backend already appended confirmation
+            // /clear command — backend already appended its confirmation row.
+            // Active slot clears the live pane; a background slot clears its
+            // cached page instead, so neither a grid pane nor a failed-switch
+            // restore can resurrect the discarded transcript (#6364 review).
             const clearSlot = data.slot as string
             if (clearSlot === store.getState().chat.activeSlot) dispatch(clearMessages())
+            else dispatch(clearSlotCache(clearSlot))
             break
           }
           case 'slot_agent_switch': {

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1384,7 +1384,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       errorHandoffActiveDurableRef.current = true
       persistErrorHandoffClaims()
       try {
-        await dispatch(switchSlot(slotKey)).unwrap()
+        // `keepTargetOnMissing`: this slot was JUST created, so a 404 from its
+        // detail fetch is a create/fetch race on a slot that exists -- the
+        // reducer keeps it selected (with the seeded composer) atomically
+        // instead of unwinding to the previous chat (#6309), and this catch
+        // stays a no-op rather than patching state back from the caller.
+        await dispatch(switchSlot({ key: slotKey, keepTargetOnMissing: true })).unwrap()
       } catch {
         // switchSlot.pending already activated the fresh slot. Its detail fetch
         // may fail independently; keep the seeded composer usable in that slot.

--- a/website/src/store/chatSlice.switchSlotRejection.test.ts
+++ b/website/src/store/chatSlice.switchSlotRejection.test.ts
@@ -15,7 +15,8 @@ import { configureStore } from '@reduxjs/toolkit'
 
 vi.mock('../api/client', () => ({ api: { chatSlotDetail: vi.fn() } }))
 
-import chatReducer, { switchSlot } from './chatSlice'
+import chatReducer, { switchSlot, warmSlotCache, setActiveSlot, setSlotState, setSlotRunning, startLocalTurn, sseChatMessage, clearMessages, clearSlotCache } from './chatSlice'
+import { fetchSlots } from './dashboardSlice'
 import { api } from '../api/client'
 import { isMissingSlotError } from '../utils/thunkError'
 
@@ -77,5 +78,398 @@ describe('switchSlot — the rejection carries the numeric status (#6199)', () =
     expect(e).toMatchObject({ message: 'Failed to fetch' })
     expect(e instanceof Error).toBe(false)
     expect(isMissingSlotError(e)).toBe(false)
+  })
+})
+
+/**
+ * switchSlot.rejected must not strand the store on a slot that could not load
+ * (#6309). `pending` assigns `activeSlot` synchronously; when the fetch then
+ * 404s the target is GONE, so the reducer restores the pre-switch selection —
+ * activeSlot, its cached message page, its paging cursor — and leaves the MRU
+ * as if no switch happened (in particular the gone key must NOT return to the
+ * stack: that is regression 3 of the three that caller-side compensation
+ * shipped on #6260). A transient failure keeps the target selected so a retry
+ * can succeed. Exercised end to end: real thunk, real store, mocked transport.
+ */
+describe('switchSlot.rejected — a gone target restores the pre-switch selection (#6309)', () => {
+  // Braces matter: `mockReset()` returns the mock (a function), and a hook
+  // that RETURNS a function hands vitest a teardown callback — the mock then
+  // gets invoked argument-less after each test and its rejected promise fails
+  // the test from the outside. Return void instead.
+  beforeEach(() => { detail.mockReset() })
+
+  type Page = { messages: Array<{ role: string; content: string; ts: string }>; has_more: boolean; total: number; next_before: number }
+  const msg = (role: string, content: string, i: number) =>
+    ({ role, content, ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString() })
+  const PAGES: Record<string, Page> = {
+    C: { messages: [msg('user', 'c0', 0)], has_more: false, total: 1, next_before: 0 },
+    // has_more + a non-zero cursor, so the test can tell "restored" from
+    // "reset to zero" on every cursor field, not just the key.
+    A: { messages: [msg('user', 'hello', 0), msg('assistant', 'hi', 1)], has_more: true, total: 42, next_before: 7 },
+  }
+
+  /** Store selecting A with a loaded pane, MRU ['C'], via real switches. */
+  async function primedStore() {
+    detail.mockImplementation((key: string) => {
+      if (key in PAGES) return Promise.resolve(PAGES[key])
+      if (key === 'flaky') return Promise.reject(apiError(500, 'gateway hiccup'))
+      return Promise.reject(apiError(404, 'slot unavailable'))
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('C'))
+    await store.dispatch(switchSlot('A'))
+    return store
+  }
+
+  it('404: restores the prior activeSlot, its exact cached page, and its paging cursor', async () => {
+    const store = await primedStore()
+    await store.dispatch(switchSlot('gone'))
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // The page itself, not merely "non-empty": the re-hydrate must hand back
+    // A's cached transcript, not some other slot's or a placeholder.
+    expect(s.messages.map(m => [m.role, m.content])).toEqual([['user', 'hello'], ['assistant', 'hi']])
+    expect(s.slotLoading).toBe(false)
+    // The cursor trio is re-keyed to the restored slot with its captured
+    // values — `pending` voided the key, and without the restore older-history
+    // paging refuses forever on a pane that plainly has more.
+    expect(s.slotCursorKey).toBe('A')
+    expect(s.slotHasMore).toBe(true)
+    expect(s.slotOldestIndex).toBe(7)
+    // The claim is released either way.
+    expect(s.slotSwitchRequestId).toBeNull()
+    expect(s.slotSwitchOrigin).toBeNull()
+  })
+
+  it('404: the MRU ends as if no switch happened, and the gone key does not return to it', async () => {
+    let goneDeleted = false
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return goneDeleted ? Promise.reject(apiError(404, 'slot unavailable')) : Promise.resolve(PAGES.C)
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    // Visit gone → C → A, so 'gone' sits on the MRU like any real past slot.
+    await store.dispatch(switchSlot('gone'))
+    await store.dispatch(switchSlot('C'))
+    await store.dispatch(switchSlot('A'))
+    expect(store.getState().chat.slotHistory).toEqual(['gone', 'C'])
+    goneDeleted = true
+    await store.dispatch(switchSlot('gone'))
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // Exact array: A (restored, active ∉ history) is back out, C is untouched,
+    // and the DELETED key stayed stripped rather than being pushed back on —
+    // Alt+` must never aim at a session that no longer exists.
+    expect(s.slotHistory).toEqual(['C'])
+  })
+
+  it('a transient failure keeps the target selected with a cleared pane, so a retry can succeed', async () => {
+    const store = await primedStore()
+    await store.dispatch(switchSlot('flaky'))
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('flaky')
+    expect(s.messages).toEqual([])
+    expect(s.slotLoading).toBe(false)
+  })
+
+  it('a 404 landing after the user already switched on does not yank the selection', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const inflight = store.dispatch(switchSlot('gone')) // held open
+    await store.dispatch(switchSlot('C')) // user moved on; C owns the claim now
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('C')
+    expect(s.messages.map(m => [m.role, m.content])).toEqual([['user', 'c0']])
+  })
+
+  it('a same-key 404 (the active slot itself was deleted) falls back to the cleared pane', async () => {
+    const store = await primedStore()
+    detail.mockImplementation(() => Promise.reject(apiError(404, 'slot unavailable')))
+    await store.dispatch(switchSlot('A'))
+    const s = store.getState().chat
+    // There is nothing earlier to restore to — the origin IS the failed target —
+    // so this keeps the pre-#6309 behavior rather than "restoring" to the dead slot.
+    expect(s.activeSlot).toBe('A')
+    expect(s.messages).toEqual([])
+    expect(s.slotLoading).toBe(false)
+  })
+
+  it('a rapid A→B→C chain whose C 404s falls back to settled A, not half-loaded B', async () => {
+    let releaseB!: (v: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'B') return new Promise((resolve) => { releaseB = resolve })
+      if (key === 'gone') return Promise.reject(apiError(404, 'slot unavailable'))
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const inflightB = store.dispatch(switchSlot('B')) // held open: B never settles
+    await store.dispatch(switchSlot('gone'))
+    const s = store.getState().chat
+    // The provisional B view is not a selection worth restoring — pending kept
+    // the settled origin, so the fallback is A with its real page and cursor.
+    expect(s.activeSlot).toBe('A')
+    expect(s.messages.map(m => [m.role, m.content])).toEqual([['user', 'hello'], ['assistant', 'hi']])
+    expect(s.slotCursorKey).toBe('A')
+    expect(s.slotHasMore).toBe(true)
+    // B rides the MRU as a transit (the navigation-stack contract: the MRU
+    // records where the user aimed; a jump to it re-fetches). A is back out
+    // (active ∉ history) and the gone key never enters.
+    expect(s.slotHistory).toEqual(['B'])
+    releaseB(PAGES.C); await inflightB // settle the orphan: it must not clobber A
+    expect(store.getState().chat.activeSlot).toBe('A')
+  })
+
+  it('an origin that never had a valid cursor restores with paging honestly un-keyed', async () => {
+    detail.mockImplementation((key: string) =>
+      key === 'gone' ? Promise.reject(apiError(404, 'slot unavailable')) : Promise.resolve(PAGES.C))
+    const store = makeStore()
+    // Selected directly (no switch settled for it), so no cursor describes A.
+    store.dispatch(setActiveSlot('A'))
+    await store.dispatch(switchSlot('gone'))
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.messages).toEqual([])
+    // No guessed cursor: paging stays refused until a real fetch re-keys it.
+    expect(s.slotCursorKey).toBeNull()
+  })
+
+  it('a run that began mid-flight lands on the restored composer', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const inflight = store.dispatch(switchSlot('gone'))
+    // A starts streaming while it is non-active: the frame lands in slotRun.
+    store.dispatch(sseChatMessage({ slot: 'A', role: 'chunk', content: 'x' }))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.slotRunning).toBe(true)
+    expect(s.slotState).toBe('streaming')
+  })
+
+  it('a run that ended mid-flight is not resurrected onto the restored composer', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    store.dispatch(setSlotState('streaming')) // A is running when the switch starts
+    const inflight = store.dispatch(switchSlot('gone'))
+    // The turn finishes while A is non-active; pending's slotRun seed is what
+    // lets this _done frame overwrite the stale pre-switch mirror.
+    store.dispatch(sseChatMessage({ slot: 'A', role: '_done', content: '' }))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.slotRunning).toBe(false)
+    expect(s.slotState).toBe('idle')
+  })
+
+  it('a cleared pane does not resurrect its pre-clear transcript through the restore', async () => {
+    const store = await primedStore()
+    // The backend confirmed a clear for the active slot: the cached page is
+    // evicted with the live pane, so no stale copy survives to be restored.
+    store.dispatch(clearMessages())
+    await store.dispatch(switchSlot('gone'))
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.messages).toEqual([])
+  })
+
+  it('keepTargetOnMissing: a just-created slot stays selected through its own 404', async () => {
+    const store = await primedStore()
+    await store.dispatch(switchSlot({ key: 'gone', keepTargetOnMissing: true }))
+    const s = store.getState().chat
+    // The caller vouched the target exists (it just created it): the reducer
+    // keeps it selected with the cleared-pane retry state instead of unwinding.
+    expect(s.activeSlot).toBe('gone')
+    expect(s.messages).toEqual([])
+    expect(s.slotLoading).toBe(false)
+  })
+
+  it('a provisional switch does not clobber the half-loaded slot\'s live run entry', async () => {
+    let releaseB!: (v: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'B') return new Promise((resolve) => { releaseB = resolve })
+      if (key === 'gone') return Promise.reject(apiError(404, 'slot unavailable'))
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A')) // A settled, idle
+    // B is streaming in the background (its frames landed in slotRun).
+    store.dispatch(sseChatMessage({ slot: 'B', role: 'chunk', content: 'x' }))
+    const inflightB = store.dispatch(switchSlot('B')) // held open
+    await store.dispatch(switchSlot('gone')) // provisional pending: no seed
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // The provisional pending must NOT have copied A's idle mirror into B:
+    // B's turn is still live and its entry still says so.
+    expect(s.slotRun['B'].state).toBe('streaming')
+    releaseB(PAGES.C); await inflightB
+  })
+
+  it('a running-but-not-yet-streaming turn survives the restore round trip', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    // The queued-turn window: the turn is in flight but no chunk has arrived,
+    // so the fine-grained slotState still reads 'idle' while slotRunning is true.
+    store.dispatch(setSlotRunning(true))
+    const inflight = store.dispatch(switchSlot('gone'))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // slotRun never moved mid-flight, so the SNAPSHOT wins -- deriving from
+    // the seeded 'idle' alone would have dropped this live turn.
+    expect(s.slotRunning).toBe(true)
+  })
+
+  it('a queued turn that COMPLETES mid-flight is not resurrected as busy (same-value round trip)', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    // Queued-turn window: running true while the fine-grained state is 'idle'.
+    store.dispatch(setSlotRunning(true))
+    const inflight = store.dispatch(switchSlot('gone'))
+    // The queued turn completes while A is non-active. slotRun goes idle→idle
+    // (same value), so only the event-time sync can record the completion.
+    store.dispatch(sseChatMessage({ slot: 'A', role: '_done', content: '' }))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.slotRunning).toBe(false)
+    expect(s.slotState).toBe('idle')
+  })
+
+  it('a locally-sent turn that ends mid-flight releases the pending-turn guard on restore', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    store.dispatch(startLocalTurn('A')) // local send awaiting server confirmation
+    const inflight = store.dispatch(switchSlot('gone'))
+    store.dispatch(sseChatMessage({ slot: 'A', role: '_done', content: '' })) // turn ends while non-active
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.slotRunning).toBe(false)
+    // The guard fell with the turn: leaving it set would hide Continue and
+    // make running=false snapshots for A be ignored indefinitely.
+    expect(s.pendingTurnSlot).toBeNull()
+  })
+
+  it('an UNCONFIRMED local send keeps its pending-turn guard through the restore', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    store.dispatch(startLocalTurn('A'))
+    const inflight = store.dispatch(switchSlot('gone'))
+    rejectGone(apiError(404, 'slot unavailable')) // no _done arrived
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // The send is still awaiting confirmation: the guard (and running) survive
+    // so a stale server snapshot cannot clobber the just-started turn.
+    expect(s.slotRunning).toBe(true)
+    expect(s.pendingTurnSlot).toBe('A')
+  })
+
+  it('a background slot_clear during the switch does not resurrect through the restore', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A')) // A loaded and cached on the way out
+    const inflight = store.dispatch(switchSlot('gone'))
+    // The backend confirms a /clear for A while it is NOT the active view:
+    // the cached page is evicted, exactly like the active-slot clearMessages.
+    store.dispatch(clearSlotCache('A'))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    expect(s.messages).toEqual([]) // cleared, not the pre-clear transcript
+  })
+
+  it('a stale warm fulfillment cannot unlock a mid-turn origin through the restore', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    store.dispatch(setSlotRunning(true)) // a turn is in flight on A
+    const inflight = store.dispatch(switchSlot('gone'))
+    // A stale warm snapshot (running:false, taken before the turn) lands while
+    // the switch is in flight. It must NOT mark the origin idle: it is an
+    // unordered point-in-time read, not a run event.
+    store.dispatch(warmSlotCache.fulfilled(
+      { key: 'A', messages: [], queue: [], hasMore: false, total: 0, running: false, stopping: false, nextBefore: 0, warmSeq: 1, context: undefined } as never,
+      'warm-req', 'A'))
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    expect(s.activeSlot).toBe('A')
+    // The composer stays locked: the turn never emitted a _done frame.
+    expect(s.slotRunning).toBe(true)
+  })
+
+  it('an origin evicted by an authoritative slots snapshot is not restored', async () => {
+    let rejectGone!: (e: unknown) => void
+    detail.mockImplementation((key: string) => {
+      if (key === 'gone') return new Promise((_resolve, reject) => { rejectGone = reject })
+      return Promise.resolve(PAGES[key] ?? PAGES.C)
+    })
+    const store = makeStore()
+    await store.dispatch(switchSlot('A'))
+    const inflight = store.dispatch(switchSlot('gone'))
+    // The authoritative list drops A while the switch is in flight (activeSlot
+    // 'gone' is protected by the reconcile, A is not).
+    store.dispatch(fetchSlots.fulfilled([], 'req-evict', undefined) as never)
+    rejectGone(apiError(404, 'slot unavailable'))
+    await inflight
+    const s = store.getState().chat
+    // Restoring deleted A would re-create the dead-slot selection this fix
+    // exists to unwind — the rejection falls back to the clearing path instead.
+    expect(s.activeSlot).toBe('gone')
+    expect(s.messages).toEqual([])
+    expect(s.slotSwitchOrigin).toBeNull()
   })
 })

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -10,7 +10,7 @@ import type { ChatMessage, ChatSlot, SessionInfo, SubagentActivity, ToolActivity
 import { SOFT_STOP_DEBOUNCE_MS, SPAWN_LAUNCH_MARKER } from '../pages/chat/types'
 import { mergePreservedPastes } from '../utils/pasteTokens'
 import { safeSetItem } from '../utils/safeStorage'
-import { errMessage, type StatusRejection } from '../utils/thunkError'
+import { errMessage, isMissingSlotError, type StatusRejection } from '../utils/thunkError'
 import { jsonEqual } from '../utils/structuralEqual'
 import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
 import { i18nT } from '../i18n/t'
@@ -345,6 +345,10 @@ const evictSlotState = (state: ChatState, slotKey: string): void => {
   }
   evictMcpApps(state, slotKey)
   state.slotHistory = (state.slotHistory ?? []).filter(k => k !== slotKey)
+  // An evicted slot cannot serve as the failed-switch fallback either: an
+  // authoritative snapshot said it is gone, and restoring it would re-create
+  // exactly the dead-slot selection the origin exists to unwind (#6309).
+  if (state.slotSwitchOrigin && spellings.includes(state.slotSwitchOrigin.key)) state.slotSwitchOrigin = null
 }
 
 /** Read one slot's pending question card, or null.
@@ -638,6 +642,39 @@ interface ChatState {
   slotSwitchRequestId: string | null
   /** Slot the in-flight switch targets; it only installs a cursor for that one. */
   slotSwitchTarget: string | null
+  /** Pre-switch selection, recorded by `switchSlot.pending` so `rejected` can
+   *  restore it when the target turns out to be GONE (404). `pending` mutates
+   *  four things atomically -- `activeSlot`, the outgoing slot's activity, its
+   *  message page, and the MRU -- and the large majority of dispatch sites
+   *  never `.unwrap()`, so the unwind must live here, where the pre-switch
+   *  state is still in hand (#6309; caller-side compensation re-derived three
+   *  distinct bugs on #6260). When the outgoing view is itself PROVISIONAL
+   *  (its own switch never settled), `pending` keeps the previous settled
+   *  origin instead of recording the half-loaded key, so a rapid A→B→C chain
+   *  whose C fails falls back to A, not to a B that never finished loading.
+   *  `cursor` is the outgoing slot's paging cursor when it described that slot
+   *  at capture time, else null (no valid cursor existed, so a restore
+   *  honestly leaves paging un-keyed rather than guessing); `olderError` rides
+   *  along so the origin's top-of-transcript retry bar survives the round trip.
+   *  MAINTENANCE: this snapshot is a manual enumeration of the live-pane
+   *  fields. A new per-pane field must join BOTH halves of the pair -- capture
+   *  here (or seed its per-slot map, as `slotRun` does) in `pending`, restore
+   *  in `rejected` -- or it silently leaks across a failed switch. */
+  slotSwitchOrigin: {
+    key: string
+    cursor: { hasMore: boolean; nextBefore: number; olderError: boolean } | null
+    /** The active run mirror at capture time, restored verbatim. Kept CURRENT
+     *  by the non-active run writers themselves (`syncOriginRun` at every
+     *  `slotRun` state write), so a transition mid-flight lands in the
+     *  snapshot as an event rather than being inferred afterwards -- inference
+     *  by comparing `slotRun` cannot distinguish a same-value round trip (a
+     *  queued turn completing writes idle over idle) from "never moved", and
+     *  restoring the stale snapshot on that path resurrects a finished turn's
+     *  busy composer. `running` is carried separately from `state`: a
+     *  running-but-not-yet-streaming turn legitimately reads state 'idle'
+     *  while running is true, so deriving one from the other drops it. */
+    run: { state: SlotState; running: boolean; stopping: boolean }
+  } | null
   loadingOlder: boolean
   /** Last older-history fetch was rejected; surfaced on the top-of-transcript bar. */
   slotOlderError: boolean
@@ -860,6 +897,7 @@ const initialState: ChatState = {
   slotCursorKey: null,
   slotSwitchRequestId: null,
   slotSwitchTarget: null,
+  slotSwitchOrigin: null,
   loadingOlder: false,
   slotOlderError: false,
   lastChunkSeq: undefined,
@@ -915,6 +953,39 @@ function pushHistory(history: string[], key: string): string[] {
   return deduped.length > 50 ? deduped.slice(-50) : deduped
 }
 
+/** Mirror a NON-ACTIVE slot's run transition into the failed-switch origin
+ *  snapshot, when that slot is the origin. The snapshot is captured by
+ *  `switchSlot.pending` and applied verbatim by `rejected`'s restore; without
+ *  this event-time write, a turn that settles mid-switch through a SAME-VALUE
+ *  round trip (idle -> [runs and completes] -> idle for a queued turn) is
+ *  indistinguishable from "never moved" after the fact, and the restore would
+ *  resurrect the stale busy state (#6364 review). Every `slotRun` state
+ *  writer for non-active slots routes through here, so the snapshot ages the
+ *  same way the per-slot entry does. */
+function syncOriginRun(state: ChatState, slot: string, runState: SlotState): void {
+  const o = state.slotSwitchOrigin
+  if (!o || safeKey(o.key) !== safeKey(slot)) return
+  o.run = { state: runState, running: runState !== 'idle', stopping: runState === 'stopping' }
+}
+
+/** Load a slot's cached activity-panel state (or the empty defaults) into the
+ *  live view. Shared by `switchSlot.pending` (entering the target) and
+ *  `switchSlot.rejected` (falling back to the origin when the target is gone,
+ *  #6309), so the two entry paths cannot drift apart. */
+function loadSlotActivity(state: ChatState, key: string): void {
+  const cached = state.slotActivity[key]
+  state.toolLog = cached?.toolLog ?? []
+  state.subagents = cached?.subagents ?? {}
+  // Inline expansion replaced the old 'tools' tab, and 'files' is no
+  // longer one of this viewer's tabs (the file browser is its own pinned
+  // panel now, and this viewer hosts 'links' instead). Any of those
+  // legacy cached values fall back to 'changes'.
+  const legacyTab = (t: unknown) => t === 'tools' || t === 'nav' || t === 'files'
+  state.activityTab = (cached?.activityTab && !legacyTab(cached.activityTab)) ? cached.activityTab : 'changes'
+  // Panel open/closed is per-chat; a chat we've never opened defaults to closed.
+  state.activityOpen = cached?.activityOpen ?? false
+}
+
 /**
  * Path B (native session grid): apply a WS chat frame for a NON-active slot
  * into the per-slot store so a pane rendering that slot streams live. The
@@ -948,6 +1019,7 @@ function applyNonActiveFrame(
   }
   if (role === 'chunk') {
     run.state = 'streaming'
+    syncOriginRun(state, slot, 'streaming')
     // Drop only the EMPTY thinking placeholder (mirror the active
     // sseChatMessage path at chatSlice ~998), keeping content-bearing reasoning
     // blocks so a background pane's hydrated reasoning isn't silently deleted by
@@ -991,12 +1063,13 @@ function applyNonActiveFrame(
   if (role === '_done') {
     run.state = 'idle'
     run.lastChunkSeq = undefined
+    syncOriginRun(state, slot, 'idle')
     for (let i = msgs.length - 1; i >= 0; i--) {
       if (msgs[i].role === 'streaming') { msgs[i].role = 'assistant'; msgs[i].rawText = msgs[i].content; break }
     }
     return
   }
-  if (role === 'compacting') { run.state = 'compacting'; return }
+  if (role === 'compacting') { run.state = 'compacting'; syncOriginRun(state, slot, 'compacting'); return }
   // Permission rows carry request_id/tool_input inside `cls` (JSON); lift it
   // here — BEFORE the guard — so the identity comparison sees the same
   // `tool_call_id` the stored row has.
@@ -1019,6 +1092,7 @@ function applyNonActiveFrame(
   dropStaleStatelessQuestion(state, slot, role)
   if (role === 'tool') {
     run.state = 'tool_running'
+    syncOriginRun(state, slot, 'tool_running')
     let insertIdx = msgs.length
     if (insertIdx > 0 && msgs[insertIdx - 1]?.role === 'streaming') insertIdx--
     msgs.splice(insertIdx, 0, ensureMsgId({ role, content, cls: cls || '', ts, meta }))
@@ -1416,13 +1490,30 @@ function seedContextUsage(
   if (context.window) state.slotContextTokens[k] = { used: context.used, window: context.window }
 }
 
+/** `switchSlot`'s argument. The plain-string spelling is the overwhelmingly
+ *  common one; the object form exists for the ONE caller class that must NOT
+ *  have a 404 unwound: a switch into a slot the caller just created (e.g. the
+ *  error handoff), where a 404 is a create/fetch race on a slot that exists
+ *  and the seeded composer must stay visible. Handling it as a per-call option
+ *  keeps the decision inside the reducer's atomic unwind instead of a caller
+ *  patching half the state back afterwards -- the exact #6260 failure class
+ *  this fix removes. */
+export type SwitchSlotArg = string | { key: string; keepTargetOnMissing?: boolean }
+
+/** The slot key of a `switchSlot` argument, in either spelling. Non-object
+ *  values pass through untouched: a hand-rolled test dispatch can omit
+ *  `meta.arg` entirely (see the fulfilled reducer's requestId note), and the
+ *  reducers' pre-existing tolerance of that must survive this indirection. */
+const switchSlotKey = (arg: SwitchSlotArg): string => typeof arg === 'object' && arg !== null ? arg.key : arg
+
 export const switchSlot = createAsyncThunk<
   Awaited<ReturnType<typeof fetchSlotDetail>>,
-  string,
+  SwitchSlotArg,
   { rejectValue: StatusRejection }
 >(
   'chat/switchSlot',
-  async (key, { dispatch, getState, rejectWithValue }) => {
+  async (arg, { dispatch, getState, rejectWithValue }) => {
+    const key = switchSlotKey(arg)
     // Safe unconditionally: this fetch resets the pane's messages and cursor, so
     // any older page still in flight is superseded even when the key is unchanged.
     _abortLoadOlder?.()
@@ -3138,7 +3229,20 @@ const chatSlice = createSlice({
       if (isUnsafeKey(slot)) return
       state.slotStatusDetail[safeKey(slot)] = detail
     },
-    clearMessages(state) { state.messages = []; setPagingCursor(state, false, 0); state.voiceAudio = null; state.voicePlaying = false; if (state.activeSlot) delete state.thinkingOrphans?.[safeKey(state.activeSlot)]; if (state.activeSlot) evictMcpApps(state, state.activeSlot) },
+    clearMessages(state) { state.messages = []; setPagingCursor(state, false, 0); state.voiceAudio = null; state.voicePlaying = false; if (state.activeSlot) delete state.thinkingOrphans?.[safeKey(state.activeSlot)]; if (state.activeSlot) evictMcpApps(state, state.activeSlot); if (state.activeSlot) writeSlotPage(state, state.activeSlot, [], false) },
+    /** A server-confirmed clear for a slot that is NOT the active view. The
+     *  active-slot case routes through `clearMessages`; this one exists so a
+     *  background slot's cached page cannot outlive its authoritative clear --
+     *  the failed-switch restore re-hydrates from that cache, and a grid pane
+     *  reads it directly, so a survivor resurrects a transcript the backend
+     *  already discarded (#6364 review). */
+    clearSlotCache(state, action: PayloadAction<string>) {
+      const slot = action.payload
+      if (isUnsafeKey(slot)) return
+      writeSlotPage(state, slot, [], false)
+      delete state.thinkingOrphans?.[safeKey(slot)]
+      evictMcpApps(state, slot)
+    },
     truncateAfterIndex(state, action: PayloadAction<number>) { state.messages = state.messages.slice(0, action.payload) },
     replaceMessages(state, action: PayloadAction<ChatMessage[]>) { state.messages = action.payload },
     /** Path B: seed a non-active slot's message history into the per-slot store
@@ -4403,14 +4507,32 @@ const chatSlice = createSlice({
         state.historyOffset = offset + sessions.length
       })
       .addCase(switchSlot.pending, (state, action) => {
+        const target = switchSlotKey(action.meta.arg)
         // Must precede the reassignment below: true while the active slot's own
         // switch is in flight, i.e. while `slotHasMore` is still the old chat's.
         const viewIsProvisional = state.slotSwitchRequestId !== null && state.slotSwitchTarget === state.activeSlot
+        // Remember the outgoing selection BEFORE the cursor is voided below, so
+        // `rejected` can restore it when the target turns out to be gone (#6309).
+        // A PROVISIONAL view (its own switch never settled) is not a selection
+        // worth restoring -- falling back to a half-loaded slot re-creates the
+        // empty-pane failure -- so the previous settled origin is kept instead:
+        // a rapid A→B→C chain whose C 404s falls back to A. The cursor is
+        // captured only when it still describes the outgoing slot; otherwise
+        // null keeps the restore honest about never having had one.
+        if (!viewIsProvisional) {
+          state.slotSwitchOrigin = state.activeSlot === null ? null : {
+            key: state.activeSlot,
+            cursor: state.slotCursorKey === state.activeSlot
+              ? { hasMore: state.slotHasMore, nextBefore: state.slotOldestIndex, olderError: state.slotOlderError }
+              : null,
+            run: { state: state.slotState, running: state.slotRunning, stopping: state.slotStopping },
+          }
+        }
         // This fetch replaces the cursor, so it is stale from here until it lands
         // -- including a same-key switch, where the key alone still looks valid.
         state.slotCursorKey = null
         state.slotSwitchRequestId = action.meta?.requestId ?? null
-        state.slotSwitchTarget = action.meta?.arg ?? null
+        state.slotSwitchTarget = target
         // Save current slot's activity
         if (state.activeSlot) {
           state.slotActivity[state.activeSlot] = { toolLog: state.toolLog, subagents: state.subagents, activityTab: state.activityTab, activityOpen: state.activityOpen }
@@ -4425,29 +4547,24 @@ const chatSlice = createSlice({
             viewIsProvisional ? state.slotPaneBounded?.[k] : undefined)
         }
         // Always strip target from history: activeSlot ∉ slotHistory
-        state.slotHistory = state.slotHistory.filter(k => k !== action.meta.arg)
-        if (state.activeSlot && state.activeSlot !== action.meta.arg) {
+        state.slotHistory = state.slotHistory.filter(k => k !== target)
+        // A PROVISIONAL outgoing view is pushed too: the MRU records where the
+        // user aimed, not what finished loading (pinned by the navigation-stack
+        // suite), and an MRU jump dispatches a fresh switchSlot that loads the
+        // slot regardless. Only a GONE key must stay off the stack, which the
+        // rejected-restore below owns.
+        if (state.activeSlot && state.activeSlot !== target) {
           state.slotHistory = pushHistory(state.slotHistory, state.activeSlot)
         }
         // Restore target slot's activity (or empty)
-        const cached = state.slotActivity[action.meta.arg]
-        state.toolLog = cached?.toolLog ?? []
-        state.subagents = cached?.subagents ?? {}
-        // Inline expansion replaced the old 'tools' tab, and 'files' is no
-        // longer one of this viewer's tabs (the file browser is its own pinned
-        // panel now, and this viewer hosts 'links' instead). Any of those
-        // legacy cached values fall back to 'changes'.
-        const legacyTab = (t: unknown) => t === 'tools' || t === 'nav' || t === 'files'
-        state.activityTab = (cached?.activityTab && !legacyTab(cached.activityTab)) ? cached.activityTab : 'changes'
-        // Panel open/closed is per-chat; a chat we've never opened defaults to closed.
-        state.activityOpen = cached?.activityOpen ?? false
+        loadSlotActivity(state, target)
         // Set activeSlot immediately so WS events for the new slot are accepted.
         // Restore cached messages if available (instant switch), otherwise show loading.
-        state.activeSlot = action.meta.arg
+        state.activeSlot = target
         // The older-history error belongs to the outgoing chat and ownership moves
         // here, so it must clear now rather than when the fetch settles.
         state.slotOlderError = false
-        const cachedMsgs = state.slotMessages[action.meta.arg]
+        const cachedMsgs = state.slotMessages[target]
         if (cachedMsgs) {
           state.messages = cachedMsgs
           state.slotLoading = false
@@ -4460,7 +4577,7 @@ const chatSlice = createSlice({
       .addCase(switchSlot.fulfilled, (state, action) => {
         // Before the guards below, so an early return still ends this claim. Keyed
         // on requestId, which a hand-rolled dispatch may omit, so read it safely.
-        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
+        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null; state.slotSwitchOrigin = null }
         const { key, messages, running, hasMore, queue, nextBefore } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away during fetch
@@ -4602,8 +4719,67 @@ const chatSlice = createSlice({
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(switchSlot.rejected, (state, action) => {
-        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
-        if (state.activeSlot !== action.meta.arg) return
+        // Only the CURRENT claim may unwind: a stale rejection (a newer switch
+        // already took the requestId) must not fight the switch in flight.
+        const target = switchSlotKey(action.meta.arg)
+        const claimed = state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId
+        const origin = claimed ? state.slotSwitchOrigin : null
+        if (claimed) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null; state.slotSwitchOrigin = null }
+        if (state.activeSlot !== target) return
+        // A caller that just CREATED the target may opt out of the unwind: its
+        // 404 is a create/fetch race on a slot that exists, and bouncing away
+        // would hide the composer state seeded there (see SwitchSlotArg).
+        const keepTarget = typeof action.meta.arg !== 'string' && action.meta.arg.keepTargetOnMissing === true
+        // A 404 means the target is GONE (isMissingSlotError is authoritative on
+        // a numeric status, #6199): keeping it selected would leave the store on
+        // a slot that cannot exist, and the global shortcuts aiming at it. Put
+        // the selection back where it was (#6309). Any other failure is treated
+        // as transient below: the target is real, so keeping it selected with an
+        // empty pane lets a retry succeed.
+        if (!keepTarget && origin && origin.key !== target && isMissingSlotError(action.payload ?? action.error)) {
+          state.activeSlot = origin.key
+          // Re-hydrate the cached page when one exists, [] otherwise. The cache
+          // can be older than the pane was (a cleared or transiently-failed pane
+          // caches nothing but does not evict a prior entry) -- the older page
+          // is still the closest honest answer, and the next refresh heals it.
+          state.messages = state.slotMessages[safeKey(origin.key)] ?? []
+          state.slotLoading = false
+          // `pending` pushed the origin onto the MRU; take it back out so the
+          // `activeSlot ∉ slotHistory` invariant holds again. Net effect of the
+          // whole failed switch on the MRU: nothing, except the gone target
+          // stays stripped -- restoring a deleted key onto the stack is the
+          // regression #6260 shipped and this reducer exists to avoid.
+          state.slotHistory = state.slotHistory.filter(k => k !== origin.key)
+          // Swap the origin's cached activity back in (pending loaded the target's).
+          loadSlotActivity(state, origin.key)
+          // Run mirror: the snapshot applies verbatim. It was captured at
+          // pending and kept CURRENT by `syncOriginRun` at every non-active
+          // run write, so a transition mid-flight is already in it -- and a
+          // same-value round trip (queued turn completing: idle over idle)
+          // downgraded `running` at event time, which no after-the-fact
+          // comparison of `slotRun` could have detected.
+          state.slotState = origin.run.state
+          state.slotRunning = origin.run.running
+          state.slotStopping = origin.run.stopping
+          // The local-turn guard: a send the origin made before leaving was
+          // awaiting server confirmation. If that turn ENDED while the origin
+          // was non-active (the event-synced snapshot says not running), the
+          // guard must fall with it -- the active-path _done that normally
+          // clears it never ran because the view was elsewhere, and left
+          // standing it hides Continue and makes syncSlotRunningFromServer
+          // ignore idle snapshots for this slot indefinitely. A still-running
+          // (or still-unconfirmed) turn keeps its guard.
+          if (state.pendingTurnSlot === origin.key && !origin.run.running) state.pendingTurnSlot = null
+          // Re-key the paging cursor when the captured one described the origin;
+          // no valid cursor existed otherwise, and guessing pages the wrong chat.
+          if (origin.cursor) {
+            setPagingCursor(state, origin.cursor.hasMore, origin.cursor.nextBefore)
+            // setPagingCursor clears the flag for a fresh fetch; this is a
+            // RESTORE, so the origin's real retry-bar state comes back instead.
+            state.slotOlderError = origin.cursor.olderError
+          }
+          return
+        }
         state.messages = []
         state.slotRunning = false
         state.slotStopping = false
@@ -4822,6 +4998,12 @@ const chatSlice = createSlice({
           const run = (state.slotRun[safeKey(key)] ??= { state: 'idle' })
           run.state = 'idle'
           run.lastChunkSeq = undefined
+          // Deliberately NOT synced into the failed-switch origin snapshot:
+          // this write comes from a point-in-time HTTP snapshot racing the
+          // ordered live-frame writers (the block comment above), so a stale
+          // fulfillment landing mid-switch could mark a mid-turn origin idle
+          // and the restore would unlock its composer. Only the ORDERED frame
+          // writers in applyNonActiveFrame feed syncOriginRun.
         }
         seedContextUsage(state, key, action.payload.context)
       })
@@ -4970,7 +5152,7 @@ const chatSlice = createSlice({
 
 export const {
   setActiveSlot, clearSlotState, setPendingInput, setAgentSwitchNotice, setQuestionCard, retireStatelessQuestion, clearQuestionCard, setQuestionDraft, resolveQuestionCard, setFollowupCard, clearFollowupCard, dismissFollowupItem, setFolderSuggestion, clearFolderSuggestion, ageFolderSuggestion, appendMessage, appendSlotMessage, updateStreamingMessage, finalizeAssistant,
-  removeThinking, confirmOptimisticSend, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages,
+  removeThinking, confirmOptimisticSend, removeByApprovalId, resolveByApprovalId, clearPendingPermissions, setSlotRunning, setSlotStopping, startLocalTurn, syncSlotRunningFromServer, setSlotState, setSlotStatusDetail, setStopPressedAt, clearMessages, clearSlotCache, truncateAfterIndex, replaceMessages, hydrateSlotMessages, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages,
   sseContextUsage, setVoicePlaying, setVoiceAudio,
   toggleActivity, openActivityToTab, openActivityPanel, openActivityToTool, clearFocusToolCallId, requestSlotReveal, clearSlotReveal, clearSubagentsForSnapshot, sseSubagentPending, markSubagentApproving, sseSubagentSpawn, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentQueued,
   sseSubagentBatchUpdate, sseSubagentBatchChunks, selectSubagent, clearTerminalSubagents,


### PR DESCRIPTION
## Summary

`switchSlot.pending` assigns `activeSlot` synchronously; when the detail fetch then rejects, the `rejected` reducer cleared the pane but left the failed slot selected. For a 404 the store ended up selecting a session that does not exist, with an empty transcript, and the Alt+` MRU toggle (fed from `slotHistory`, written in `pending`) aimed at the dead slot. 92 of the dispatch sites never `.unwrap()`, so caller-side compensation cannot reach this — the unwind lives in the reducer, where the pre-switch state is atomically available (#6260 demonstrated three distinct caller-side attempts each shipping a new defect).

## What changed

- `switchSlot.pending` records the outgoing selection in a new `slotSwitchOrigin` field (key + paging-cursor snapshot + retry-bar flag) alongside the existing `slotSwitchTarget`/`slotSwitchRequestId` bookkeeping. A **provisional** view (its own switch never settled) keeps the previous settled origin, so a rapid A→B→C chain whose C fails falls back to A, never to a half-loaded B.
- `switchSlot.rejected`, when the rejection is a 404 (`isMissingSlotError` on the `StatusRejection` payload, #6199) and still holds the requestId claim: restores `activeSlot`, re-hydrates the cached page, swaps back the cached activity (via a `loadSlotActivity` helper hoisted from `pending` so the two paths cannot drift), reads the run mirror back from `slotRun`, re-keys the paging cursor from the snapshot, and strips the restored key from the MRU. The gone target is **not** pushed back onto the MRU (regression 3 of #6260). Non-404 failures keep the previous clearing behavior so a retry can succeed.
- `pending` seeds `slotRun[outgoing]` from the active mirror, so a run that ends (or begins) while the switch is in flight lands on the restored composer instead of a stale snapshot.
- `clearMessages` now evicts the slot's cached page, so a cleared transcript cannot resurface through the restore.
- **Behavior change beyond the failed-switch path (deliberate):** a server-confirmed `/clear` for a BACKGROUND chat now empties its cached page too (new `clearSlotCache` reducer, dispatched from the WS `slot_clear` handler). Previously a background clear evicted nothing, so a grid pane kept rendering the discarded transcript and a failed-switch restore could resurrect it. This is always-on, not restore-scoped: the cache outliving an authoritative clear was the root cause, and both consumers of that cache (grid panes and the restore) inherit the fix.
- `evictSlotState` invalidates a matching `slotSwitchOrigin`: a slot removed by an authoritative snapshot is never restored.
- The `ChatPage` error-handoff caller re-asserts its fresh-slot selection in its `catch`, since it depends on the seeded composer staying visible (its comment documented the old contract; a create-then-fetch 404 race would otherwise silently drop the diagnostic prompt).

## Pre-push review

Two model-pinned read-only reviewers ran on the initial commit (GPT `gpt-5.6-sol`, Opus `claude-opus-5`). All findings were verified against the code and fixed in this squashed commit: provisional-origin race, mid-flight run-state staleness, cleared-cache resurrection, evicted-origin restore, the ChatPage handoff dependency, plus comment-accuracy and assertion-coverage advisories. One out-of-scope observation (the gone target's residue stays in the slot list until the next reconcile — pre-existing) is left for a follow-up issue.

## Tests

`website/src/store/chatSlice.switchSlotRejection.test.ts` — 19 new cases exercising the real thunk against a real store with a mocked transport: 404 restores the exact prior page + cursor; MRU end-state pinned as an exact array (gone key stripped, never re-pushed); transient 500 keeps the target selected; a late 404 after the user moved on does not yank the selection; same-key 404 falls back to the clearing path; A→B→C provisional chain restores settled A; cursor-less origin restores with paging honestly un-keyed; run began / ended mid-flight both land correctly; cleared pane does not resurrect; evicted origin is not restored.

Local gates: `npx tsc -b` clean; full website vitest **25213 passed / 1597 files**; backend isort/flake8/mypy clean at CI-pinned versions (backend untouched).

Closes #6309


<!-- no-visual-delta -->
**Why no screenshots:** This is a Redux reducer + error-recovery change with no rendered output. The `ChatPage.tsx` hunk only swaps a comment and re-asserts the already-designed selection inside an existing `catch` branch — no JSX, styles, or layout are touched; every visible surface renders exactly as before. Behavior is pinned by 11 store-level regression tests instead.

