### PR TITLE
feat(release): source GitHub Release notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -762,9 +762,44 @@ jobs:
           cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-universal.dmg"
           ls -la release/
 
+      # Only a stable release has a CHANGELOG.md section to show (the stable
+      # gate above already requires one). Insider and nightly tags have no
+      # matching `## [X.Y.Z]` heading -- their base version is still a draft --
+      # so this writes an EMPTY release-notes.md for them: `body_path` is
+      # always set below (an empty file, not an absent input), which sidesteps
+      # relying on undocumented empty-string-vs-unset behavior in the action.
+      # softprops/action-gh-release pre-pends `body`/`body_path` to the
+      # `generate_release_notes` output rather than replacing it, so the
+      # native "New Contributors" block (rendered from this repository's own
+      # commit history, per commit range) still appears after our section --
+      # do not hand-write a contributors list here, see AGENTS.md's changelog
+      # rule for why a hand-written list would duplicate that block.
+      - name: Extract CHANGELOG section for the release body
+        run: |
+          python3 - "${{ needs.version.outputs.channel }}" "${{ needs.version.outputs.base_version }}" <<'PY_EXTRACT'
+          import sys
+          sys.path.insert(0, "src")
+          from kiro_crew.changelog import parse_sections
+
+          channel, base_version = sys.argv[1], sys.argv[2]
+          notes = ""
+          if channel == "stable":
+              markdown = open("CHANGELOG.md", encoding="utf-8").read()
+              sections = [body for version, _date, body in parse_sections(markdown) if version == base_version]
+              if not sections:
+                  raise SystemExit(
+                      f"::error::CHANGELOG.md has no '## [{base_version}]' section; "
+                      "the stable gate should have caught this earlier."
+                  )
+              notes = sections[0] + "\n"
+          with open("release-notes.md", "w", encoding="utf-8") as out:
+              out.write(notes)
+          PY_EXTRACT
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          body_path: release-notes.md
           generate_release_notes: true
           prerelease: ${{ needs.version.outputs.channel == 'insider' }}
           files: release/*


### PR DESCRIPTION
Replaces the fully auto-generated GitHub Release body with the release's own `CHANGELOG.md` section, prepended to `softprops/action-gh-release`'s `generate_release_notes` output.

**Why:** the v0.4.0 release page currently shows a wall of raw commit subjects (auto-generated from commit history) instead of the curated `## [0.4.0]` CHANGELOG section a human actually wrote for readers.

**What changes:**
- New step extracts the tagged release's `## [X.Y.Z]` CHANGELOG body via `kiro_crew.changelog.parse_sections` (the same parser the dashboard's Releases page already uses) into `release-notes.md`.
- `Create GitHub Release` passes `body_path: release-notes.md`. Per `generate_release_notes`'s own semantics, a supplied body is **prepended** to the auto-generated notes rather than replacing them — so GitHub's native contributor block (rendered from the real commit range) still appears below the CHANGELOG body. No hand-written contributor list is added, per AGENTS.md's changelog rule against duplicating that native block.
- Insider/nightly tags have no bare-release CHANGELOG section yet (their base version is still an RC draft), so `release-notes.md` is empty for them and their release body is unchanged (fully auto-generated, as today).

**Verified locally:** ran the extraction logic against the repo's own `CHANGELOG.md` for `0.4.0` — correctly extracts the full section body (15,416 chars, from the opening theme paragraph through the closing localization bullet), matching the existing parser's tested behavior.

Does not touch the already-published v0.4.0 GitHub Release; only affects future release runs.