### PR TITLE
fix(store): restore activeSlot on transient switchSlot rejection (#6309)

### DIFF
--- a/website/src/store/chatSlice.switchSlotRestore.test.ts
+++ b/website/src/store/chatSlice.switchSlotRestore.test.ts
@@ -1,0 +1,196 @@
+/**
+ * switchSlot.rejected restore behavior (#6309).
+ *
+ * When a non-404 rejection fires while the failed target is still active, the
+ * reducer restores activeSlot to the pre-switch value and re-hydrates its
+ * cached message page rather than leaving an empty pane. A 404 (slot genuinely
+ * gone) keeps the existing clear behavior since there is nothing safe to
+ * restore to.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+vi.mock('../api/client', () => ({ api: { chatSlotDetail: vi.fn() } }))
+
+import chatReducer, { switchSlot } from './chatSlice'
+import { api } from '../api/client'
+
+const detail = vi.mocked(api.chatSlotDetail)
+
+/** Structural ApiError shape -- same pattern as chatSlice.switchSlotRejection.test.ts */
+const apiError = (status: number, message: string) =>
+  Object.assign(new Error(message), { status })
+
+function makeStore(extra: Record<string, unknown> = {}) {
+  const base = chatReducer(undefined, { type: '@@INIT' })
+  return configureStore({
+    reducer: { chat: chatReducer },
+    preloadedState: { chat: { ...base, ...extra } as typeof base },
+    middleware: (getDefault) => getDefault({ immutableCheck: false }),
+  })
+}
+
+const msg = (content: string, mid: string) =>
+  ({ role: 'assistant' as const, content, cls: '', ts: '2026-01-01T00:00:00Z', meta: { mid } })
+
+describe('switchSlot.rejected -- restore on transient failure (#6309)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('a transient rejection (500) restores activeSlot and messages', async () => {
+    const cachedMessages = [msg('hello from origin', 'm-1')]
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: cachedMessages,
+      slotMessages: { 'slot-origin': cachedMessages },
+      slotHistory: [],
+    })
+
+    detail.mockRejectedValue(apiError(500, 'internal error'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    expect(state.activeSlot).toBe('slot-origin')
+    expect(state.messages).toEqual(cachedMessages)
+    expect(state.slotLoading).toBe(false)
+    // Origin is activeSlot again, so it must not appear in history
+    expect(state.slotHistory).not.toContain('slot-origin')
+  })
+
+  it('a 404 rejection does NOT restore -- existing clear behavior', async () => {
+    const cachedMessages = [msg('hello from origin', 'm-1')]
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: cachedMessages,
+      slotMessages: { 'slot-origin': cachedMessages },
+      slotHistory: [],
+    })
+
+    detail.mockRejectedValue(apiError(404, 'slot unavailable'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    // 404: target stays active, messages cleared (slot is genuinely gone)
+    expect(state.activeSlot).toBe('slot-target')
+    expect(state.messages).toEqual([])
+    expect(state.slotLoading).toBe(false)
+  })
+
+  it('a superseded switch (activeSlot already moved) early-returns', async () => {
+    const cachedMessages = [msg('original', 'm-1')]
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: cachedMessages,
+      slotMessages: { 'slot-origin': cachedMessages },
+      slotHistory: [],
+    })
+
+    // First switch will reject with a delay; second switch will resolve immediately
+    let rejectFirst!: (reason: unknown) => void
+    detail.mockImplementationOnce(
+      () => new Promise((_, reject) => { rejectFirst = reject }),
+    )
+    detail.mockResolvedValueOnce({
+      key: 'slot-c',
+      messages: [msg('from C', 'm-c')],
+      running: false,
+      has_more: false,
+      total: 1,
+      queue: [],
+      next_before: 0,
+    })
+
+    const firstSwitch = store.dispatch(switchSlot('slot-b'))
+    // Immediately switch again -- this makes activeSlot = 'slot-c'
+    await store.dispatch(switchSlot('slot-c'))
+
+    // Now reject the first switch
+    rejectFirst(apiError(500, 'timeout'))
+    await firstSwitch
+
+    const state = store.getState().chat
+    // The early-return guard fires: activeSlot !== 'slot-b', so no restore occurs
+    expect(state.activeSlot).toBe('slot-c')
+  })
+
+  it('restore with no cached messages falls back to empty gracefully', async () => {
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: [msg('live message', 'm-1')],
+      // No cached entry in slotMessages for origin
+      slotMessages: {},
+      slotHistory: [],
+    })
+
+    detail.mockRejectedValue(apiError(500, 'transient'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    // Restore fires: activeSlot goes back, but messages default to [] since
+    // there was nothing in slotMessages for the origin key.
+    expect(state.activeSlot).toBe('slot-origin')
+    expect(state.messages).toEqual([])
+    expect(state.slotLoading).toBe(false)
+  })
+
+  it('slotHistory is unwound on restore (origin removed from history)', async () => {
+    const cachedMessages = [msg('hello', 'm-1')]
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: cachedMessages,
+      slotMessages: { 'slot-origin': cachedMessages },
+      slotHistory: ['slot-x', 'slot-y'],
+    })
+
+    detail.mockRejectedValue(apiError(502, 'bad gateway'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    expect(state.activeSlot).toBe('slot-origin')
+    // Origin must NOT be in history (it is the activeSlot)
+    expect(state.slotHistory).not.toContain('slot-origin')
+    // The pending handler pushed origin and removed target from history;
+    // after restore, origin is filtered out since it is activeSlot again.
+    // slot-x and slot-y should still be present in some form.
+    // The pending handler does: filter out target ('slot-target' was not in
+    // history anyway), then pushHistory(origin). So history becomes
+    // ['slot-x', 'slot-y', 'slot-origin']. Then rejected filters out origin:
+    // ['slot-x', 'slot-y'].
+    expect(state.slotHistory).toEqual(['slot-x', 'slot-y'])
+  })
+
+  it('slotSwitchOrigin is null after rejection settles', async () => {
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: [],
+      slotMessages: {},
+      slotHistory: [],
+    })
+
+    detail.mockRejectedValue(apiError(500, 'fail'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    expect(state.slotSwitchOrigin).toBeNull()
+    expect(state.slotSwitchRequestId).toBeNull()
+    expect(state.slotSwitchTarget).toBeNull()
+  })
+
+  it('a status-less failure (no status field) triggers restore path', async () => {
+    const cachedMessages = [msg('cached', 'm-1')]
+    const store = makeStore({
+      activeSlot: 'slot-origin',
+      messages: cachedMessages,
+      slotMessages: { 'slot-origin': cachedMessages },
+      slotHistory: [],
+    })
+
+    // No status property -- a network error, for example
+    detail.mockRejectedValue(new TypeError('Failed to fetch'))
+    await store.dispatch(switchSlot('slot-target'))
+
+    const state = store.getState().chat
+    // Not a 404, so restore fires
+    expect(state.activeSlot).toBe('slot-origin')
+    expect(state.messages).toEqual(cachedMessages)
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -638,6 +638,9 @@ interface ChatState {
   slotSwitchRequestId: string | null
   /** Slot the in-flight switch targets; it only installs a cursor for that one. */
   slotSwitchTarget: string | null
+  /** The activeSlot at the moment switchSlot.pending fired; used by the
+   *  rejected handler to restore the previous selection on transient failures. */
+  slotSwitchOrigin: string | null
   loadingOlder: boolean
   /** Last older-history fetch was rejected; surfaced on the top-of-transcript bar. */
   slotOlderError: boolean
@@ -860,6 +863,7 @@ const initialState: ChatState = {
   slotCursorKey: null,
   slotSwitchRequestId: null,
   slotSwitchTarget: null,
+  slotSwitchOrigin: null,
   loadingOlder: false,
   slotOlderError: false,
   lastChunkSeq: undefined,
@@ -4424,6 +4428,7 @@ const chatSlice = createSlice({
         state.slotCursorKey = null
         state.slotSwitchRequestId = action.meta?.requestId ?? null
         state.slotSwitchTarget = action.meta?.arg ?? null
+        state.slotSwitchOrigin = state.activeSlot
         // Save current slot's activity
         if (state.activeSlot) {
           state.slotActivity[state.activeSlot] = { toolLog: state.toolLog, subagents: state.subagents, activityTab: state.activityTab, activityOpen: state.activityOpen }
@@ -4473,7 +4478,7 @@ const chatSlice = createSlice({
       .addCase(switchSlot.fulfilled, (state, action) => {
         // Before the guards below, so an early return still ends this claim. Keyed
         // on requestId, which a hand-rolled dispatch may omit, so read it safely.
-        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
+        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null; state.slotSwitchOrigin = null }
         const { key, messages, running, hasMore, queue, nextBefore } = action.payload
         if (isUnsafeKey(key)) return
         if (state.activeSlot !== key) return  // user switched away during fetch
@@ -4615,13 +4620,40 @@ const chatSlice = createSlice({
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(switchSlot.rejected, (state, action) => {
-        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null }
+        const origin = state.slotSwitchOrigin
+        if (state.slotSwitchRequestId !== null && state.slotSwitchRequestId === action.meta?.requestId) { state.slotSwitchRequestId = null; state.slotSwitchTarget = null; state.slotSwitchOrigin = null }
         if (state.activeSlot !== action.meta.arg) return
-        state.messages = []
-        state.slotRunning = false
-        state.slotStopping = false
-        setPagingCursor(state, false, 0)
-        state.slotLoading = false
+
+        const is404 = action.payload?.status === 404
+
+        if (!is404 && origin) {
+          // Transient failure: restore the previous selection and re-hydrate its
+          // cached page so the user never sees an empty pane for a slot that
+          // could not be loaded.
+          state.activeSlot = origin
+          state.messages = state.slotMessages[safeKey(origin)] ?? []
+          // Undo history: origin is activeSlot again, so remove it from history.
+          state.slotHistory = state.slotHistory.filter(k => k !== origin)
+          // Restore the origin slot's activity state
+          const cached = state.slotActivity[origin]
+          if (cached) {
+            state.toolLog = cached.toolLog ?? []
+            state.subagents = cached.subagents ?? {}
+            state.activityTab = cached.activityTab ?? 'changes'
+            state.activityOpen = cached.activityOpen ?? false
+          }
+          // Restore paging cursor for the origin slot
+          const hasMore = state.slotPaneHasMore[safeKey(origin)] ?? false
+          setPagingCursor(state, hasMore, hasMore ? state.slotOldestIndex : 0)
+          state.slotLoading = false
+        } else {
+          // 404 (slot genuinely gone) or no origin to restore: clear as before.
+          state.messages = []
+          state.slotRunning = false
+          state.slotStopping = false
+          setPagingCursor(state, false, 0)
+          state.slotLoading = false
+        }
       })
       .addCase(refreshSlot.fulfilled, (state, action) => {
         if (!action.payload) return


### PR DESCRIPTION
## Summary

Fixes #6309. When `switchSlot` is rejected with a transient error (non-404), the reducer now restores the previous `activeSlot` and re-hydrates its cached message page, rather than leaving an empty pane pointing at a slot that could not be loaded.

## Changes

### `website/src/store/chatSlice.ts`
- Added `slotSwitchOrigin` to ChatState, capturing the outgoing `activeSlot` in `switchSlot.pending`
- In `switchSlot.rejected`:
  - **Transient (non-404):** restores `activeSlot` to origin, re-hydrates messages from `slotMessages` cache, unwinds `slotHistory`, and restores activity state (toolLog, subagents, activityTab, activityOpen) and paging cursor
  - **404 (slot genuinely gone):** preserves existing clear-to-empty behavior
- Clears `slotSwitchOrigin` alongside existing `slotSwitchTarget`/`slotSwitchRequestId` bookkeeping

### `website/src/store/chatSlice.switchSlotRestore.test.ts` (new)
7 test cases covering:
- Transient 500 rejection restores activeSlot and messages
- 404 rejection preserves existing clear behavior
- Superseded switch (activeSlot already moved) early-returns
- Empty cache fallback (no slotMessages entry for origin)
- slotHistory unwinding on restore
- `slotSwitchOrigin` cleanup after rejection settles
- Status-less errors (e.g. network TypeError) trigger restore path

## Testing Notes
Tests were written but could not be executed in-sandbox due to network restrictions (`node_modules` not available). The implementation follows established patterns from existing `switchSlot` test files and should pass in CI.