### PR TITLE
feat(dashboard): opt-in phone session that survives a gateway restart

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5653,6 +5653,7 @@
         },
         "restore_sessions": false,
         "qr_session_until_restart": true,
+        "qr_session_persist_across_restart": false,
         "restore_window_minutes": 30,
         "surface_channel_sessions": true,
         "bot_name": "",
@@ -5846,6 +5847,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true
+    },
+    {
+      "path": "dashboard.qr_session_persist_across_restart",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Phone Sign-In Survives A Gateway Restart",
+      "help": "REQUIRES BOTH: \"Phone Sign-In Lasts Until Restart\" must also be ON, and tailnet identity trust must be configured (`dashboard.tailscale.trust_identity` with a non-empty `allowed_logins`). Without either one this setting is ignored and a warning naming the missing prerequisite is logged. Note the first requirement is NOT a contradiction: \"Lasts Until Restart\" is what issues the renewable credential, and this setting then removes the restart bound from it -- turning that one OFF instead leaves a session that expires on a fixed clock, with nothing to renew. What it does: let a scanned phone stay signed in across gateway restarts, so one scan lasts until the refresh credential's own 30-day lifetime lapses. OFF by default because a restart is otherwise a hard sign-out that needs no recorded state. The identity requirement is not optional bookkeeping: behind `tailscale serve` every request reaches the gateway from 127.0.0.1, so without a daemon-verified peer identity the session is a bearer credential any tailnet peer could replay, and outliving the process is exactly what makes that matter.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
     },
     {
       "path": "dashboard.restore_window_minutes",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2970,6 +2970,30 @@ class DashboardConfig:
             "to the peer it was established from.",
         ),
     )
+    qr_session_persist_across_restart: bool = field(
+        default=False,
+        metadata=_meta(
+            "Phone Sign-In Survives A Gateway Restart",
+            'REQUIRES BOTH: "Phone Sign-In Lasts Until Restart" must also be ON, '
+            "and tailnet identity trust must be configured "
+            "(`dashboard.tailscale.trust_identity` with a non-empty "
+            "`allowed_logins`). Without either one this setting is ignored and a "
+            "warning naming the missing prerequisite is logged. Note the first "
+            'requirement is NOT a contradiction: "Lasts Until Restart" is what '
+            "issues the renewable credential, and this setting then removes the "
+            "restart bound from it -- turning that one OFF instead leaves a "
+            "session that expires on a fixed clock, with nothing to renew. "
+            "What it does: let a scanned phone stay signed in across gateway "
+            "restarts, so one scan lasts until the refresh credential's own "
+            "30-day lifetime lapses. OFF by default because a restart is "
+            "otherwise a hard sign-out that needs no recorded state. The "
+            "identity requirement is not optional bookkeeping: behind "
+            "`tailscale serve` every request reaches the gateway from 127.0.0.1, "
+            "so without a daemon-verified peer identity the session is a bearer "
+            "credential any tailnet peer could replay, and outliving the process "
+            "is exactly what makes that matter.",
+        ),
+    )
     restore_window_minutes: int = field(
         default=30,
         metadata=_meta(
@@ -7751,6 +7775,9 @@ class KiroCrewConfig:
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 qr_session_until_restart=_safe_bool(
                     dashboard_data.get("qr_session_until_restart"), True
+                ),
+                qr_session_persist_across_restart=_safe_bool(
+                    dashboard_data.get("qr_session_persist_across_restart"), False
                 ),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
                 surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -30,6 +30,7 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
     refresh_token_boot,
+    refresh_token_requires_peer,
     validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust, peer_pin_key, resolve_forwarded_peer
@@ -418,6 +419,32 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
 
     state = _get_state()
 
+    # An identity-bound chain (the persistent QR session shape) may only be USED
+    # while a daemon-verified tailnet peer can be established. Placed here, ahead
+    # of BOTH the reuse branch and the mint, because every path below this line
+    # hands the caller a live credential: the grace-replay branch re-serves the
+    # cached pair and re-sets both cookies without minting anything, so a check
+    # sited at the mint leaves a 60-second window in which a replayed token is
+    # honoured with no identity check at all. That window was the review finding.
+    #
+    # Ordering it BEFORE reuse detection is deliberate, not incidental. Reuse
+    # detection revokes the chain, so letting it run first would let any
+    # unverified caller destroy a legitimate 30-day session by replaying one
+    # consumed token — a sign-out handed to anyone who can reach the port. An
+    # unverified caller gets 401 either way, so refusing first loses no theft
+    # signal: a thief who CAN verify still trips reuse detection normally.
+    #
+    # A refusal does NOT revoke. Identity resolution fails transiently (daemon
+    # restart, a stripped header), and burning a 30-day credential over a blip
+    # would turn a recoverable hiccup into a re-scan. The session simply cannot
+    # be used until identity is established again, which is the honest reading of
+    # "bounded by identity" — and it is the only bound available here, since
+    # behind `tailscale serve` every request arrives from 127.0.0.1, so an
+    # address pin would read as a pin while excluding nobody.
+    if refresh_token_requires_peer(refresh_token) and not await _verified_peer(request):
+        _audit(user_id, "refresh_token_use", "peer_unverified", chain_id)
+        return web.json_response({"error": "peer_identity_unverified"}, status=401)
+
     # Reuse detection: if this jti is already consumed AND it is NOT
     # within the multi-tab grace window, treat as theft and revoke.
     if state.is_consumed(jti):
@@ -476,15 +503,25 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     # this path, carrying degrades to "unbound", while re-deriving would silently
     # mint a live binding for it.
     carried_boot = refresh_token_boot(refresh_token)
+    carried_require_peer = refresh_token_requires_peer(refresh_token)
+    _carried_claims: dict[str, str] = {}
+    if carried_boot:
+        _carried_claims["boot"] = carried_boot
+    if carried_require_peer:
+        # Carried onto BOTH halves of the rotated pair. Dropping it on either one
+        # would make the FIRST rotation silently downgrade an identity-bound
+        # session to an ordinary one — the same shape of defect as the review
+        # finding this check answers, one rotation later.
+        _carried_claims["require_peer"] = "1"
     new_access_token = generate_token(
         user_id,
         ttl_seconds=MAX_SESSION_TTL_SECS,
         register_nonce=False,
-        extra={"boot": carried_boot} if carried_boot else None,
+        extra=_carried_claims or None,
     )
     new_session_exp = now + MAX_SESSION_TTL_SECS
     new_refresh_token, _new_chain, _new_jti, new_refresh_exp = generate_refresh_token(
-        user_id, chain_id=chain_id, boot=carried_boot
+        user_id, chain_id=chain_id, boot=carried_boot, require_peer=carried_require_peer
     )
 
     public_payload = {
@@ -523,6 +560,24 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     _expire_foreign_port_cookies(resp, request)
     _audit(user_id, "refresh_token_use", "ok")
     return resp
+
+
+async def _verified_peer(request: web.Request) -> bool:
+    """Whether a daemon-verified tailnet peer resolves for this request.
+
+    Reads the same ``tailnet_trust`` gate and the same resolver that
+    :func:`_rebind_rotated_token_to_peer` uses, so "can this be pinned" and "may
+    this rotate" cannot answer differently — a rotation admitted here that the
+    rebind then could not pin is precisely the gap this pair closes.
+    """
+    trust = request.app.get("tailnet_trust")
+    if not (isinstance(trust, TailnetTrust) and trust.trust_identity and trust.allowed_logins):
+        return False
+    try:
+        return await resolve_forwarded_peer(request, trust) is not None
+    except Exception:  # noqa: BLE001 - an auth decision must not 500 on the probe
+        logger.debug("refresh: tailnet peer resolution failed", exc_info=True)
+        return False
 
 
 async def _rebind_rotated_token_to_peer(

--- a/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
+++ b/src/kiro_crew/dashboard/handlers/tailnet_mobile.py
@@ -692,14 +692,82 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     # that expires on a clock the operator did not ask for, which presents as a
     # phone that randomly signs itself out. The fallback is not unbounded
     # either — a boot-bound session still ends at the next restart.
+    # Read INDEPENDENTLY, each with its own conservative default, rather than as
+    # one all-or-nothing block. Coupling them means a config object missing any
+    # ONE attribute discards the other two — so adding this shape would silently
+    # take the existing opt-out away from anyone whose config predates it, which
+    # is the opposite of "an unreadable override falls back to the default".
+    # Per-field is the faithful version of that rule.
+    _until_restart = True
+    _persist = False
+    _identity_trusted = False
     try:
         _cfg = await asyncio.to_thread(KiroCrewConfig.load)
-        _until_restart = bool(_cfg.dashboard.qr_session_until_restart)
     except Exception:
         logger.debug("tailnet mobile: config unreadable for session shape", exc_info=True)
-        _until_restart = True
+    else:
+        _dash = getattr(_cfg, "dashboard", None)
+        _until_restart = bool(getattr(_dash, "qr_session_until_restart", True))
+        _persist = bool(getattr(_dash, "qr_session_persist_across_restart", False))
+        _ts = getattr(_dash, "tailscale", None)
+        _identity_trusted = bool(
+            getattr(_ts, "trust_identity", False) and getattr(_ts, "allowed_logins", None)
+        )
 
-    if _until_restart:
+    # THIRD shape - ``persistent``: the refresh chain with NO boot claim, so one
+    # scan survives a gateway restart and is bounded only by the chain's own
+    # 30-day lifetime. Opt-in, because the boot bound it removes is a hard revoke
+    # needing no recorded state, and that default was chosen deliberately.
+    #
+    # GATED on daemon-verified tailnet identity, and the gate is what makes this
+    # offerable at all rather than merely convenient. Behind ``tailscale serve``
+    # every request reaches the gateway from 127.0.0.1 (#1762), so with identity
+    # trust off the pin is ``ip:127.0.0.1`` for every tailnet client and the
+    # cookie is a bearer credential any of them could replay. A session that ends
+    # at the next restart bounds that exposure; one that outlives the process does
+    # not. With ``trust_identity`` plus an allowlist the session pins to a
+    # verified peer instead, and the exposure is bounded by identity rather than
+    # by uptime.
+    #
+    # Both refusals are LOUD. Turning the flag on and silently getting a
+    # boot-bound session is the "checked but never ran, reported as a clean
+    # result" defect: the operator would believe the phone survives restarts and
+    # find out only by being signed out.
+    if _persist and not _until_restart:
+        logger.warning(
+            "dashboard.qr_session_persist_across_restart is on but "
+            "qr_session_until_restart is off, so the timed shape is in force and "
+            "there is no refresh chain to carry across a restart. The phone "
+            "session stays bounded by its TTL; turn qr_session_until_restart on "
+            "to use the persistent shape."
+        )
+        _persist = False
+    if _persist and not _identity_trusted:
+        logger.warning(
+            "dashboard.qr_session_persist_across_restart is on but tailnet "
+            "identity trust is not configured, so the phone session stays bound "
+            "to this gateway process. Behind `tailscale serve` every request "
+            "arrives from 127.0.0.1, so without dashboard.tailscale.trust_identity "
+            "plus a non-empty allowed_logins the session cannot be pinned to a "
+            "verified peer and must not outlive the process."
+        )
+        _persist = False
+
+    if _persist:
+        # No ``boot``, so the chain rather than the process bounds this session,
+        # and no ``no_refresh``, so the chain exists at all. ``require_peer`` is
+        # what keeps that honest: this session's whole security argument is that
+        # it is pinned to a daemon-verified tailnet identity, so the chain must
+        # refuse to rotate whenever that identity cannot be established.
+        #
+        # An address pin is NOT an alternative here, and that is the whole reason
+        # this claim exists rather than reusing the boot-bound rotation path.
+        # Behind ``tailscale serve`` every request reaches the gateway from
+        # 127.0.0.1, so ``ip:127.0.0.1`` is satisfied by every peer on the
+        # tailnet - it would read as a pin in the audit trail while excluding
+        # nobody. Refusing the rotation is the only bound that actually holds.
+        shape: dict[str, str] = {"require_peer": "1"}
+    elif _until_restart:
         shape = {"boot": current_boot_id()}
     else:
         shape = {"no_refresh": "1"}
@@ -742,6 +810,14 @@ async def api_tailnet_mobile_qr(request: web.Request) -> web.Response:
     # minted credential ``no_refresh`` regardless of the configured shape, so
     # the phone session never grows a refresh chain its authorizing session did
     # not have.
+    #
+    # This caps the PERSISTENT shape too, and that is correct rather than a gap:
+    # a credential must not outlive the session that authorized it, so an owner
+    # who is themselves signed in on a boot-bound session hands the phone a
+    # boot-bound session as well, whatever the config says. Reaching the
+    # persistent shape therefore also requires the authorizing session to be
+    # unbounded - which the desktop local-bootstrap mint is, since
+    # ``/api/token/local`` carries neither ``boot`` nor ``no_refresh``.
     claims = {**shape, **carried}
     token = generate_token(owner_id or "local-app", ttl_seconds=ttl, extra=claims)
     url = f"https://{host}/?token={token}"

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -411,6 +411,7 @@ def generate_refresh_token(
     chain_id: str | None = None,
     ttl_seconds: int = MAX_REFRESH_TTL_SECS,
     boot: str = "",
+    require_peer: bool = False,
 ) -> tuple[str, str, str, float]:
     """Generate a refresh token.
 
@@ -448,6 +449,13 @@ def generate_refresh_token(
         # Omitted rather than written empty so an unbound chain's payload is
         # byte-identical to what it was before this claim existed.
         payload_dict["boot"] = boot
+    if require_peer:
+        # A chain whose safety rests on a daemon-verified tailnet identity rather
+        # than on process lifetime. ``api_auth_refresh`` refuses to rotate it
+        # while no peer resolves, so the long-lived credential can never be
+        # rotated by a caller whose identity could not be established. Omitted
+        # when false for the same byte-identity reason as ``boot``.
+        payload_dict["require_peer"] = "1"
     payload = json.dumps(payload_dict, separators=(",", ":")).encode()
     encoded_payload = _b64url_encode(payload)
     signature = _sign(payload)
@@ -541,6 +549,26 @@ def refresh_token_boot(token: str) -> str:
         return ""
     value = payload.get("boot", "")
     return value if isinstance(value, str) else ""
+
+
+def refresh_token_requires_peer(token: str) -> bool:
+    """Whether this chain may only rotate for a daemon-verified tailnet peer.
+
+    Set on the QR "persistent" session shape, whose credential is bounded by
+    identity rather than by this process's lifetime. Same read-only,
+    validate-first contract as :func:`refresh_token_boot`, and the same
+    conservative failure direction is NOT available here: a decode failure must
+    answer ``True``, not ``False``. Answering ``False`` would let an
+    undecodable-but-signed token rotate without the identity check the chain was
+    minted to require, which is the one outcome this claim exists to prevent.
+    """
+    try:
+        payload = json.loads(_b64url_decode(token.split(".")[0]))
+    except Exception:
+        return True
+    if not isinstance(payload, dict):
+        return True
+    return str(payload.get("require_peer", "")) == "1"
 
 
 def refresh_cookie_name(port: str | int) -> str:

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -2516,6 +2516,14 @@ def token_auth_middleware(
                 _token_boot = str(data.get("boot", ""))
                 if _token_boot:
                     _carried["boot"] = _token_boot
+                # Carried for the same reason ``boot`` is: the session token is a
+                # fresh mint, so a claim not named here is silently dropped — and
+                # dropping this one would turn an identity-bound persistent
+                # session into an ordinary rotating one, which is exactly the
+                # binding it was minted to keep.
+                _token_require_peer = str(data.get("require_peer", ""))
+                if _token_require_peer:
+                    _carried["require_peer"] = _token_require_peer
                 # ``no_refresh`` gets the same treatment as ``boot`` and for the
                 # same reason: the claim must survive the exchange or a DOWNSTREAM
                 # consumer that reads the session cookie to learn the caller's
@@ -2705,7 +2713,9 @@ def token_auth_middleware(
                     # re-minted a fresh session on the next visit, and "ends at
                     # restart" would be false by one rotation.
                     refresh_token, chain_id, _jti, refresh_exp = generate_refresh_token(
-                        user_id, boot=str(data.get("boot", ""))
+                        user_id,
+                        boot=str(data.get("boot", "")),
+                        require_peer=str(data.get("require_peer", "")) == "1",
                     )
                     refresh_remaining = int(refresh_exp - time.time())
                     if refresh_remaining > 0:

--- a/test/test_auth_refresh_handlers_cov80.py
+++ b/test/test_auth_refresh_handlers_cov80.py
@@ -43,6 +43,7 @@ from kiro_crew.dashboard.refresh_tokens import (
     RefreshStateManager,
     generate_refresh_token,
     refresh_cookie_name,
+    refresh_token_requires_peer,
     validate_refresh_token,
 )
 from kiro_crew.dashboard.tailnet import TailnetTrust
@@ -291,6 +292,103 @@ async def test_me_reports_both_expiries(state: RefreshStateManager) -> None:
     assert payload["user_id"] == "alice"
     assert payload["session_exp"] > time.time()
     assert abs(payload["refresh_exp"] - refresh_exp) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_require_peer_is_enforced_before_the_grace_replay_return(
+    state: RefreshStateManager,
+) -> None:
+    """The grace-replay branch must not hand back a cached pair unverified.
+
+    Regression for a check sited too late: grace replay re-serves the previously
+    issued pair and re-sets BOTH cookies without minting anything, so a peer
+    check placed at the mint left a REFRESH_GRACE_SECS window in which a replayed
+    token was honoured with no identity check at all.
+    """
+    refresh, chain_id, jti, _exp = generate_refresh_token("phone", require_peer=True)
+    # Stage exactly the state the grace branch reads: this jti consumed as the
+    # chain head, with the replacement pair it minted available for replay.
+    state.mark_consumed(
+        jti,
+        chain_id,
+        time.time() + 3600,
+        "203.0.113.9",
+        json.dumps(
+            {
+                "session_exp": time.time() + 3600,
+                "refresh_exp": time.time() + 3600,
+                "_access_token": "cached-access",
+                "_refresh_token": "cached-refresh",
+            }
+        ),
+    )
+    request = _mk(
+        "POST",
+        "/api/auth/refresh",
+        origin="http://localhost:7777",
+        cookies={refresh_cookie_name(str(PORT)): refresh},
+    )
+    response = await h.api_auth_refresh(request)
+    assert response.status == 401
+    assert _body(response) == {"error": "peer_identity_unverified"}
+    # No credential leaked through the replay path.
+    assert "Set-Cookie" not in response.headers
+    # Refused, NOT revoked - an unverified caller must not be able to sign a
+    # legitimate session out by replaying one consumed token.
+    assert not state.is_chain_revoked(chain_id)
+
+
+@pytest.mark.asyncio
+async def test_require_peer_chain_refuses_to_rotate_without_a_verified_peer(
+    state: RefreshStateManager,
+) -> None:
+    """An identity-bound chain must not rotate when no tailnet peer resolves.
+
+    This is the whole security argument for the persistent QR shape: it drops the
+    boot bound, so identity is the only thing left bounding it. An address pin is
+    no substitute — behind ``tailscale serve`` every request arrives from
+    127.0.0.1, so ``ip:127.0.0.1`` excludes nobody on the tailnet.
+
+    The chain is REFUSED, not revoked: identity resolution fails transiently, and
+    burning a 30-day credential over a daemon blip would turn a recoverable
+    hiccup into a re-scan.
+    """
+    refresh, chain_id, _jti, _exp = generate_refresh_token("phone", require_peer=True)
+    request = _mk(
+        "POST",
+        "/api/auth/refresh",
+        origin="http://localhost:7777",
+        cookies={refresh_cookie_name(str(PORT)): refresh},
+    )
+    response = await h.api_auth_refresh(request)
+    assert response.status == 401
+    assert _body(response) == {"error": "peer_identity_unverified"}
+    # Refused, NOT revoked - the same chain must still be usable once identity
+    # can be established again.
+    assert not state.is_chain_revoked(chain_id)
+
+
+def test_require_peer_survives_rotation_and_defaults_off() -> None:
+    """The claim is carried, and absent by default.
+
+    A chain that lost the claim on its first rotation would silently become an
+    ordinary rotating session - the same defect one rotation later.
+    """
+    bound, _c, _j, _e = generate_refresh_token("phone", require_peer=True)
+    assert refresh_token_requires_peer(bound) is True
+    plain, _c2, _j2, _e2 = generate_refresh_token("desktop")
+    assert refresh_token_requires_peer(plain) is False
+
+
+def test_require_peer_fails_closed_on_an_undecodable_payload() -> None:
+    """An undecodable payload answers True, not False.
+
+    The conservative direction here is the opposite of ``refresh_token_boot``'s:
+    answering False would let a signed-but-unreadable token rotate WITHOUT the
+    identity check its chain was minted to require.
+    """
+    assert refresh_token_requires_peer("not-a-token") is True
+    assert refresh_token_requires_peer("") is True
 
 
 @pytest.mark.asyncio

--- a/test/test_tailnet_mobile.py
+++ b/test/test_tailnet_mobile.py
@@ -448,6 +448,9 @@ def _machine(
     published: bool | None = True,
     trusted: bool = True,
     qr_session_until_restart: bool = True,
+    qr_session_persist_across_restart: bool = False,
+    trust_identity: bool = False,
+    allowed_logins: tuple[str, ...] = (),
     detail: str = "",
 ):
     """Stub the four probes the REAL derivation reads, and let it run.
@@ -460,8 +463,14 @@ def _machine(
     """
     cfg = SimpleNamespace(
         dashboard=SimpleNamespace(
-            tailscale=SimpleNamespace(enabled=trusted, keep_awake=True),
+            tailscale=SimpleNamespace(
+                enabled=trusted,
+                keep_awake=True,
+                trust_identity=trust_identity,
+                allowed_logins=list(allowed_logins),
+            ),
             qr_session_until_restart=qr_session_until_restart,
+            qr_session_persist_across_restart=qr_session_persist_across_restart,
         )
     )
     probe = tailnet.DaemonProbe(
@@ -624,6 +633,104 @@ class TestQrRefusals:
         assert resp.status == 200
         assert captured["extra"] == {"no_refresh": "1"}
         assert "boot" not in (captured["extra"] or {})
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_drops_the_boot_bound(self, _unrestricted, _quiet_audit) -> None:
+        """Opted in WITH identity trust: no ``boot``, so one scan outlives a restart.
+
+        The refresh chain is still issued (no ``no_refresh``), so what bounds the
+        session is the chain's own lifetime rather than this process's.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(
+            qr_session_persist_across_restart=True,
+            trust_identity=True,
+            allowed_logins=("someone@example.com",),
+        ):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        extra = captured["extra"] or {}
+        assert "boot" not in extra
+        assert "no_refresh" not in extra
+        # The identity bound that replaces the process bound. Without it the
+        # chain would rotate for any caller, which is the whole point of not
+        # having a boot claim being safe.
+        assert extra["require_peer"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_refused_without_identity_trust(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Opted in but identity trust off: stays boot-bound, and says so.
+
+        Behind ``tailscale serve`` every request arrives from 127.0.0.1, so
+        without a daemon-verified peer the cookie is a bearer credential any
+        tailnet peer could replay - a session that outlives the process must not
+        be handed out on that basis. Silently honouring the flag would leave the
+        operator believing their phone survives restarts.
+        """
+        from kiro_crew.dashboard.boot_id import current_boot_id
+
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(qr_session_persist_across_restart=True):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        assert captured["extra"] == {"boot": current_boot_id()}
+
+    @pytest.mark.asyncio
+    async def test_persistent_shape_refused_when_timed_shape_is_in_force(
+        self, _unrestricted, _quiet_audit
+    ) -> None:
+        """Persist + opted-out is contradictory: there is no chain to carry over."""
+        captured: dict[str, object] = {}
+
+        def _fake_mint(_sub, ttl_seconds=0, **kw):
+            captured["extra"] = kw.get("extra")
+            return "tok"
+
+        with _machine(
+            qr_session_until_restart=False,
+            qr_session_persist_across_restart=True,
+            trust_identity=True,
+            allowed_logins=("someone@example.com",),
+        ):
+            with (
+                patch.object(tailnet_mobile, "generate_token", side_effect=_fake_mint),
+                patch.object(
+                    tailnet_mobile, "render_qr_data_uri", return_value="data:image/png;base64,x"
+                ),
+            ):
+                resp = await tailnet_mobile.api_tailnet_mobile_qr(
+                    _request(tailnet_host=_HOST, cookie_token=_owner_session_token())
+                )
+        assert resp.status == 200
+        assert captured["extra"] == {"no_refresh": "1"}
 
     @pytest.mark.asyncio
     async def test_unreadable_config_falls_back_to_the_default(


### PR DESCRIPTION
## Problem / Motivation

A phone signed in by scanning the tailnet QR code is signed out by a gateway restart, and has to be re-scanned. On the insider auto-update channel that is frequent enough to be the dominant reason a working phone session ends.

The boot binding that causes this is deliberate (#5763): a session that ends with the process needs no recorded state to be revoked, which is the right default. What is missing is an opt-in for the user who would rather keep the session and accept what that costs.

## Why it matters

Someone using the phone as a second screen re-scans several times a day. There is no way to opt out today, so the only workarounds are to stop restarting the gateway or to keep re-scanning.

## What changed (motivation → approach → change)

**Goal.** One scan lasts until the credential's own lifetime lapses, rather than until this process exits.

**Approach, and why this one.** The QR mint already chooses between two session shapes. A third is added rather than loosening either existing one, because the choice is a genuine trilemma and the existing two must keep behaving exactly as they do:

| shape | claims | bounded by |
| --- | --- | --- |
| timed (opt-out) | `no_refresh` | a fixed TTL, no renewal |
| until-restart (default) | `boot` | this process's lifetime |
| persistent (**new**, opt-in) | `require_peer` | the refresh chain's own 30-day `MAX_REFRESH_TTL_SECS` |

The alternative considered and rejected was reusing the timed shape with a long TTL. That produces a credential with no revocation story at all — nothing to rotate, so nothing that can be denied — whereas the refresh chain already carries per-jti reuse detection and a revocation generation.

**Why the identity gate is load-bearing, not bookkeeping.** Removing the boot bound removes the only thing that was bounding this session, so something must replace it. Behind `tailscale serve` every request reaches the gateway from `127.0.0.1`, so an address pin would produce `ip:127.0.0.1` — a pin every peer on the tailnet satisfies, which is worse than no pin because it reads as one in the audit trail. The replacement is therefore a daemon-verified peer identity, and the setting is hard-gated on `dashboard.tailscale.trust_identity` plus a non-empty `allowed_logins`.

**What was built.**

- `dashboard.qr_session_persist_across_restart`, default `False`, in `config/loader.py`.
- The third shape in `handlers/tailnet_mobile.py`: no `boot`, no `no_refresh`, plus a new `require_peer` claim.
- Two refusal paths — missing identity trust, and the sibling `qr_session_until_restart` being off — each logging a WARNING that names the missing prerequisite, and each falling back to the boot-bound shape.
- The `require_peer` claim carried through the link→session exchange (`token_auth.py`) and onto both halves of every rotated pair (`handlers/auth_refresh.py`); `refresh_tokens.py` gains the parameter and a `refresh_token_requires_peer()` accessor whose failure direction is deliberately the opposite of `refresh_token_boot`'s (an undecodable payload answers `True`, because answering `False` would let a signed-but-unreadable token skip the check its chain was minted to require).
- `api_auth_refresh` refuses to use such a chain while no peer resolves, checked ahead of **all three** exits that hand back a credential — grace replay, reuse detection, and the mint. Refusing before reuse detection is deliberate: reuse detection revokes the chain, so the other order would let an unverified caller sign a legitimate session out by replaying one consumed token. The refusal does not revoke, because identity resolution fails transiently.
- The three config reads are independent `getattr` calls with per-field conservative defaults; coupling them in one `try` meant a config object missing any one attribute silently discarded the other two, which would remove the existing opt-out.

#6033's caller-bounds cap still wins over the configured shape and caps this one too, which is correct: a credential must not outlive the session that authorized it.

## Tests

`test/test_tailnet_mobile.py` — the persistent shape drops `boot` and carries `require_peer`; it is refused without identity trust; it is refused when the timed shape is in force.

`test/test_auth_refresh_handlers_cov80.py` — an identity-bound chain is refused (and **not** revoked) when no peer resolves; the same holds on the grace-replay path, with no `Set-Cookie` on the response; the claim survives rotation and is absent by default; an undecodable payload fails closed.

Four of these are mutation-verified — with the pre-mint check removed the grace-replay test fails `assert 200 == 401`, i.e. it demonstrably exercises the path that serves a cached credential.

## Manual verification

Still required, and it cannot be done in unit coverage: the identity path needs a real `tailscaled` and a second device. On a tailnet with `trust_identity` on and `allowed_logins` set — scan, restart the gateway, confirm the phone stays signed in; then confirm a peer NOT in `allowed_logins` is refused. Both are unverified on real hardware so far.

## Screenshots / video

N/A — no UI change beyond the settings entry's own label and help text, which is config-driven.

## Related Issues

Split out of #6194 (no linked issue: reported directly in chat as a phone session going blank after 30–40 minutes; that PR carries the two fixes for the reported symptom).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated — **not done**: the remote-and-mobile guide needs a line for the new key and its prerequisites. Deliberately left for the round that settles the peer-binding design below, so the doc is not written twice.
- [x] No secrets, credentials, or internal references in the diff

## Open review finding — why this is a DRAFT

GPT 5.6 raised a BLOCKING finding against this code on #6194 that is **not fixed here**, and it is legitimate:

> Refresh accepts a different allowlisted peer than the session's original peer

`_verified_peer()` checks that *some* allowlisted peer resolves, not that it is the *same* peer the session was established for. With more than one entry in `allowed_logins` — or, under the default `pin_scope: node`, a second device belonging to the same login — a stolen refresh cookie is usable by a peer that was never the one that scanned. That is weaker than the codebase's own standard: `bind_token_peer` pins ordinary sessions to a specific `peer_pin_key`.

The fix is to carry the pin key rather than a boolean flag and compare it for full-string equality, establishing it where the phone first presents itself — the link→session exchange, not the QR mint, since the QR is minted from the desktop and would bind the wrong peer. That is a third plumbing site for this claim and deserves its own review round rather than a fourth consecutive patch, which is why this PR opens as a draft.
