### PR TITLE
fix(sessions): escape untrusted names in the remaining trash logs (#6344)

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1227,7 +1227,7 @@ def _unlisted_files(batch: Path) -> list[Path]:
                 unlisted.append(path)
     if failures:
         raise SessionStorageError(
-            f"could not read all of {batch.name}, so it is not known whether it "
+            f"could not read all of {batch.name!r}, so it is not known whether it "
             f"holds files nothing lists: {failures[0]}"
         )
     return unlisted
@@ -1244,12 +1244,12 @@ def _discard_restored_batch(batch: Path, header: dict[str, Any]) -> None:
         leftovers = _unlisted_files(batch)
     except SessionStorageError as exc:
         # Not knowing is treated exactly like finding leftovers: keep the batch.
-        logger.warning("keeping trash batch %s: %s", batch.name, exc)
+        logger.warning("keeping trash batch %r: %s", batch.name, exc)
         _rewrite_manifest(batch, header, [])
         return
     if leftovers:
         logger.warning(
-            "keeping trash batch %s: %d staged file(s) are absent from its manifest, "
+            "keeping trash batch %r: %d staged file(s) are absent from its manifest, "
             "so removing it would delete the only copy",
             batch.name,
             len(leftovers),
@@ -1528,7 +1528,7 @@ def _move_to_trash_locked(
                 try:
                     _append_entry(manifest, {"uid": uid, "files": files})
                 except OSError:
-                    logger.warning("could not record session %s in the manifest; rolling back", uid)
+                    logger.warning("could not record session %r in the manifest; rolling back", uid)
                     try:
                         manifest.truncate(mark)
                         manifest.seek(mark)
@@ -1669,7 +1669,7 @@ def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
                 # A record we cannot read is a file we cannot place. Restoring the
                 # rest would leave the session split with that file staged and
                 # unreferenced, so the whole session stays put.
-                logger.warning("manifest record for %s is not an object", uid)
+                logger.warning("manifest record for %r is not an object", uid)
                 blocked = True
                 break
             rel = str(record.get("rel") or "")
@@ -1710,7 +1710,7 @@ def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
                     # entry retained — restoring the rest would splice two
                     # generations of one session together.
                     logger.warning(
-                        "session %s was recreated while being restored; leaving it " "staged",
+                        "session %r was recreated while being restored; leaving it " "staged",
                         uid,
                     )
                     lost_race = True
@@ -1721,7 +1721,7 @@ def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
                 remaining.append(entry)
                 continue
         except OSError:
-            logger.warning("could not fully restore session %s", uid, exc_info=True)
+            logger.warning("could not fully restore session %r", uid, exc_info=True)
             # Without this the session is split *and* wedged: the files that did
             # move are gone from the batch while the manifest still lists them, so
             # every later retry fails its own "staged file present" check and the
@@ -1901,7 +1901,7 @@ def _incomplete_if_present(batch: Path) -> str | None:
     """
     try:
         if batch.exists():
-            logger.warning("emptying %s did not remove it", batch.name)
+            logger.warning("emptying %r did not remove it", batch.name)
             return SKIP_INCOMPLETE
     except OSError:
         return SKIP_INCOMPLETE
@@ -2016,7 +2016,7 @@ def _empty_trash_locked(
         except OSError:
             continue
         if resolved == root or not resolved.is_relative_to(root):
-            logger.warning("refusing to empty %s: outside the trash root", target)
+            logger.warning("refusing to empty %r: outside the trash root", target)
             _skipped(SKIP_OUTSIDE_ROOT)
             continue
         # A batch can hold files no manifest line mentions, left by an interruption
@@ -2028,12 +2028,12 @@ def _empty_trash_locked(
         except SessionStorageError as exc:
             # Skip, not abort: one unreadable batch must not make the whole trash
             # un-emptyable. Skipping deletes nothing, which is the safe direction.
-            logger.warning("refusing to empty %s: %s", target.name, exc)
+            logger.warning("refusing to empty %r: %s", target.name, exc)
             _skipped(SKIP_UNREADABLE)
             continue
         if leftovers:
             logger.warning(
-                "refusing to empty %s: %d staged file(s) are absent from its "
+                "refusing to empty %r: %d staged file(s) are absent from its "
                 "manifest, so this would delete the only copy",
                 target.name,
                 len(leftovers),

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -909,6 +909,284 @@ class TestTrashBatchNamesAreLogSafe:
             assert all("\n" not in message for message in rendered)
 
 
+class TestUntrustedNamesAreLogSafeOutsideListTrash:
+    """The forgery primitive of :class:`TestTrashBatchNamesAreLogSafe`, at the
+    sibling sites outside ``list_trash`` (refs #6344, the #6281 class).
+
+    Two operands carry it, and they are not equally reachable. A manifest-supplied
+    ``uid`` is read off disk with no validation, so its sites take a forged value
+    end to end. A batch DIRECTORY name reaches its sites only through
+    :func:`_batch_dir`, whose id pattern rejects a newline, so those conversions
+    are defence in depth and are pinned at the seam each helper already offers —
+    which is also what keeps them covered on Windows shards, where a hostile
+    directory name cannot be created at all.
+    """
+
+    _FORGED_UID = "aaaa1111\nWARNING forged: session restored by operator"
+    _FORGED_NAME = "20240101T000000-deadbeef\nWARNING forged: batch cleared by operator"
+
+    @staticmethod
+    def _staged(kiro_home: Path) -> tuple[str, Path]:
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        return batch.batch_id, session_storage.trash_root() / batch.batch_id
+
+    @classmethod
+    def _forge_uid(cls, batch: Path, *, files: object | None = None) -> None:
+        """Rewrite the batch's one manifest entry under a forged uid.
+
+        The uid is JSON-escaped on the way to disk, so the manifest itself stays
+        one line — the forgery only materializes if a log renders the value raw.
+        """
+        manifest = batch / session_storage.MANIFEST_NAME
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        entry = json.loads(lines[1])
+        entry["uid"] = cls._FORGED_UID
+        if files is not None:
+            entry["files"] = files
+        manifest.write_text(f"{lines[0]}\n{json.dumps(entry)}\n", encoding="utf-8")
+
+    @staticmethod
+    def _carrying(caplog: pytest.LogCaptureFixture, needle: str) -> list[str]:
+        return [record.getMessage() for record in caplog.records if needle in record.getMessage()]
+
+    def _assert_escaped(self, messages: list[str], value: str, site: str) -> None:
+        assert messages, f"the {site} site did not log at all"
+        # One record stays one record: the value appears repr'd, so the injected
+        # second line never starts a record of its own.
+        assert all("\n" not in message for message in messages)
+        assert any(repr(value) in message for message in messages)
+
+    def test_a_forged_uid_is_escaped_when_a_manifest_record_is_not_an_object(
+        self, stores: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        self._forge_uid(batch, files=["not-an-object"])
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.restore(batch_id) == 0
+
+        self._assert_escaped(
+            self._carrying(caplog, "is not an object"), self._FORGED_UID, "unreadable-record"
+        )
+
+    def test_a_forged_uid_is_escaped_when_the_session_was_recreated(
+        self,
+        stores: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        self._forge_uid(batch)
+        # The occupant-wins branch: the session came back between the preflight
+        # and the move, so the batch keeps its entry.
+        monkeypatch.setattr(session_storage, "_move_file_exclusive", lambda src, dst: False)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.restore(batch_id) == 0
+
+        self._assert_escaped(
+            self._carrying(caplog, "was recreated while being restored"),
+            self._FORGED_UID,
+            "lost-race",
+        )
+
+    def test_a_forged_uid_is_escaped_when_the_restore_cannot_finish(
+        self,
+        stores: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        self._forge_uid(batch)
+
+        def _refuse(src: Path, dst: Path) -> bool:
+            raise OSError("the store is read-only")
+
+        monkeypatch.setattr(session_storage, "_move_file_exclusive", _refuse)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.restore(batch_id) == 0
+
+        self._assert_escaped(
+            self._carrying(caplog, "could not fully restore session"),
+            self._FORGED_UID,
+            "restore-failed",
+        )
+
+    def test_the_manifest_rollback_site_escapes_the_session_id(
+        self,
+        stores: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """This uid comes from the caller's validated list, so the conversion is
+        defence in depth; the test pins it rather than claiming reachability.
+        """
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+
+        def _refuse(handle: object, entry: dict[str, object]) -> None:
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(session_storage, "_append_entry", _refuse)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            with pytest.raises(SessionStorageError):
+                session_storage.move_to_trash(
+                    ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+                )
+
+        self._assert_escaped(
+            self._carrying(caplog, "could not record session"), "aaaa1111", "manifest-rollback"
+        )
+
+    def test_the_discard_and_incomplete_sites_escape_the_batch_name(
+        self,
+        stores: tuple[Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Both keep-the-batch branches and the still-on-disk branch, at the
+        ``_unlisted_files`` seam — no hostile directory has to exist on disk.
+        """
+        forged = session_storage.trash_root() / self._FORGED_NAME
+        # Neither branch may write: the point under test is the log line.
+        monkeypatch.setattr(session_storage, "_rewrite_manifest", lambda *a, **k: None)
+
+        def _refuse(batch: Path) -> list[Path]:
+            raise SessionStorageError(f"could not read all of {batch.name!r}")
+
+        monkeypatch.setattr(session_storage, "_unlisted_files", _refuse)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._discard_restored_batch(forged, {})
+        self._assert_escaped(
+            self._carrying(caplog, "keeping trash batch"), self._FORGED_NAME, "unreadable-scan"
+        )
+
+        caplog.clear()
+        monkeypatch.setattr(
+            session_storage, "_unlisted_files", lambda batch: [forged / "orphan.jsonl"]
+        )
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            session_storage._discard_restored_batch(forged, {})
+        self._assert_escaped(
+            self._carrying(caplog, "keeping trash batch"), self._FORGED_NAME, "leftover-files"
+        )
+
+        caplog.clear()
+
+        class _ForgedBatch:
+            name = self._FORGED_NAME
+
+            @staticmethod
+            def exists() -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert (
+                session_storage._incomplete_if_present(_ForgedBatch())
+                == session_storage.SKIP_INCOMPLETE
+            )
+        self._assert_escaped(
+            self._carrying(caplog, "did not remove it"), self._FORGED_NAME, "still-present"
+        )
+
+    def test_the_empty_trash_sites_escape_what_they_name(
+        self,
+        stores: tuple[Path, Path],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The three refusals in the sweep, at the ``_batch_dir`` seam."""
+        session_storage.trash_root().mkdir(parents=True, exist_ok=True)
+        forged = session_storage.trash_root() / self._FORGED_NAME
+
+        class _Batch:
+            batch_id = "20240101T000000-deadbeef"
+
+        monkeypatch.setattr(session_storage, "list_trash", lambda: [_Batch()])
+        monkeypatch.setattr(session_storage, "_batch_dir", lambda batch_id: forged)
+
+        def _refuse(batch: Path) -> list[Path]:
+            raise SessionStorageError("could not read all of it")
+
+        monkeypatch.setattr(session_storage, "_unlisted_files", _refuse)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.empty_trash() == 0
+        self._assert_escaped(
+            self._carrying(caplog, "refusing to empty"), self._FORGED_NAME, "unreadable-batch"
+        )
+
+        caplog.clear()
+        monkeypatch.setattr(
+            session_storage, "_unlisted_files", lambda batch: [forged / "orphan.jsonl"]
+        )
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.empty_trash() == 0
+        self._assert_escaped(
+            self._carrying(caplog, "refusing to empty"), self._FORGED_NAME, "leftover-files"
+        )
+
+        # The outside-the-root refusal names the PATH, so its repr is the Path's.
+        caplog.clear()
+        outside = tmp_path / self._FORGED_NAME
+        monkeypatch.setattr(session_storage, "_batch_dir", lambda batch_id: outside)
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            assert session_storage.empty_trash() == 0
+        messages = self._carrying(caplog, "outside the trash root")
+        assert messages, "the outside-the-root site did not log at all"
+        assert all("\n" not in message for message in messages)
+        assert any(repr(outside) in message for message in messages)
+
+    def test_the_unreadable_scan_error_escapes_the_batch_name(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The two refusal sites render this exception with ``%s``, so the name has
+        to be escaped where the exception is BUILT or the escape at the log site is
+        undone by the text it carries.
+        """
+        forged = session_storage.trash_root() / self._FORGED_NAME
+
+        # The error carries a hostile .filename, which is the half the batch-name
+        # escape does not cover: its string form is interpolated into the same
+        # message.
+        planted = OSError(13, "Permission denied", str(forged / self._FORGED_NAME))
+
+        # ``session_storage.os`` is the global module, so this patch is also seen
+        # by ``shutil.rmtree`` during fixture teardown (which passes ``topdown=``
+        # on Windows).  Accept the real signature and divert only the walk of the
+        # forged batch, delegating every other call to the genuine ``os.walk``.
+        real_walk = os.walk
+
+        def _walk(top, *args, onerror=None, **kwargs):  # type: ignore[no-untyped-def]
+            if Path(top) == forged:
+                assert callable(onerror)
+                onerror(planted)
+                return iter(())
+            return real_walk(top, *args, onerror=onerror, **kwargs)
+
+        monkeypatch.setattr(session_storage.os, "walk", _walk)
+        monkeypatch.setattr(session_storage, "_manifest_rels", lambda batch: [])
+
+        with pytest.raises(SessionStorageError) as raised:
+            session_storage._unlisted_files(forged)
+
+        # Both halves of the message are newline-free: the name because this call
+        # site reprs it, and the interpolated OSError because ``OSError.__str__``
+        # reprs its own ``.filename``. The second half is why the error operand is
+        # correctly left as %s at the sites that render it.
+        assert "\n" not in str(raised.value)
+        assert repr(self._FORGED_NAME) in str(raised.value)
+        assert "Permission denied" in str(raised.value)
+
+
 class TestScanCache:
     """The cache must save disk without ever answering a refusal from stale state."""
 


### PR DESCRIPTION
## Problem / Motivation

PR #6333 escaped the trash batch directory name inside `list_trash`, but the same
log-forgery primitive was left at eight sibling sites in
`src/kiro_crew/session_storage.py`: an untrusted string interpolated with a plain
`%s`, so an embedded newline renders as a second, forged log record.

Two operands carry it:

- a manifest-supplied `uid`, read off disk in `_restore_locked` with **no**
  validation, so a tampered manifest reaches three sites end to end;
- an agent-influenced batch directory name at the `_discard_restored_batch`,
  `_incomplete_if_present` and `_empty_trash_locked` sites.

## Why it matters

A forged record is written by the same logger, at the same level, in the same
format as a real one. Anyone reading the log to work out what happened to a
user's sessions — the person deciding whether a batch was cleared deliberately —
is reading attacker-authored text as if the runtime had said it.

## What changed (motivation → approach → change)

Every untrusted **string** operand at those sites now uses `%r`, which is this
file's established convention for an agent-influenced value (see the two `%r`
uses `list_trash` already had). `%d` and exception operands are untouched, and no
message was reworded.

Two additions beyond the eight sites the issue lists, both the identical
primitive rather than new scope:

- `refusing to empty %s: %s` and `refusing to empty %s: outside the trash root`
  sit two and four lines from a site the issue does name, inside the same
  function. Escaping one and leaving its neighbours is what produced this issue in
  the first place.
- `_unlisted_files` built its `SessionStorageError` with the batch name raw, and
  two of the newly-escaped sites render that exception with `%s`. Escaping the log
  site while the text it carries stays raw does not close the path, so the name is
  now repr'd where the exception is built.

Reachability differs between the two vectors, and the tests say so rather than
implying more than is true: the `uid` sites take a forged value through the public
API, while every batch-name site sits behind `_batch_dir`, whose id pattern
rejects a newline — those conversions are defence in depth.

## Tests

`TestUntrustedNamesAreLogSafeOutsideListTrash`, mirroring the existing
`TestTrashBatchNamesAreLogSafe`:

| test | locks in |
|---|---|
| `..._when_a_manifest_record_is_not_an_object` | a forged manifest `uid` is escaped on the unreadable-record path (real restore, no seam) |
| `..._when_the_session_was_recreated` | the lost-race site escapes the same forged `uid` |
| `..._when_the_restore_cannot_finish` | the restore-failed site escapes it |
| `test_the_manifest_rollback_site_escapes_the_session_id` | the `move_to_trash` rollback site (validated uid, so this pins the conversion) |
| `test_the_discard_and_incomplete_sites_escape_the_batch_name` | both keep-the-batch branches and the still-on-disk branch, at the `_unlisted_files` seam |
| `test_the_empty_trash_sites_escape_what_they_name` | all three refusals in the sweep, at the `_batch_dir` seam |
| `test_the_unreadable_scan_error_escapes_the_batch_name` | the exception text itself, with a hostile `.filename` planted in the underlying `OSError` |

Each asserts the rendered record carries the escaped repr and holds **no raw
newline** — that assertion is what goes red before the fix. Red-before proven:
reverting only the production hunks fails all seven.

The two seam-based tests exist because a batch-name site cannot be reached with a
hostile on-disk name on Windows shards (the filesystem refuses the name), so the
mutation coverage would otherwise be Linux/macOS-only. They reuse the seams the
existing class already leans on rather than inventing a new one.

## Manual verification

N/A — the assertions are on the rendered log record, which is the whole behaviour
under test.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no frontend path is touched.

## Related Issues

Closes #6344

Refs #6281 for the general class, #6315 / #6333 for the `list_trash` instance.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
