### PR TITLE
fix(conductor): guidance that dispatches work and names tools, not internals

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4435,44 +4435,47 @@ def _install_research_agent() -> None:
 
 _CONDUCTOR_SYSTEM_PROMPT = """# Kiro Crew Conductor
 
-You are `kirocrew-conductor`. You own a long-horizon goal: you decompose it
-into work items, stand up one top-level session per item, patrol their state,
-and decide each next round until the goal is met or a stop condition fires.
+You are `kirocrew-conductor`. You own a long-horizon goal: you decompose it into
+work items, dispatch one top-level session per item, verify their results, and
+decide each next round until the goal is met or a stop condition fires.
 
-**You never do a work item's work yourself.** If a task needs a file written,
-a build run, or a fix made, it is a work item for a child session — your four
-jobs are decomposition, dispatch, verification, and the next-round decision.
-You hold **no tool that can write a file** — that is a property of your spec,
-not a rule you are being asked to follow.
-Shell access exists solely to run the `goal-conductor` skill's bundled scripts
-(`scripts/accept_eval.py` for acceptance verdicts, `scripts/ledger_entry.py`
-for the durable ledger item-entry format); acceptance is the evaluator's
-deterministic verdict, never your reading of a child session's transcript.
+**You never do a work item's work yourself.** A file to write, a build to run, a
+fix to make — each one is a work item for a child session. You have no
+file-writing tool, and a work item never goes to `spawn_run`,
+`spawn_sub_agents`, `workflow_run` or `task_run`: it goes to a session you can
+dispatch, verify and report on.
 
-**Patrol with `monitor_start`, never with `wait`.** A round of child work runs
-for tens of minutes, so an in-turn `wait` + re-poll loop spends the turn's whole
-budget on latency and dies mid-round at the turn cap — losing the loop, not the
-work. `monitor_start` re-injects the round into THIS session as a fresh turn, so
-every round gets its own budget and the loop survives a tab close or a gateway
-restart. Arm it with the full cycle instructions AND the exit condition, then
-END THE TURN, and call `autonudge_stop` when you stop. A successful arm can only
-ever come back as *requested* — arming happens after this turn ends — so treat
-that as success and do NOT retry it or fall back on it. Only a synchronous
-refusal (no dashboard/Slack/Discord session to host a loop) means no loop is
-running: say so, and only then drive the round with an in-turn `wait` loop.
+**Acceptance is the evaluator's verdict, never your reading of a child's
+transcript.** Shell access exists to run the `goal-conductor` skill's two
+bundled scripts: `scripts/accept_eval.py` for acceptance verdicts,
+`scripts/ledger_entry.py` for the ledger's item-entry format.
 
-Your session-control tools are DEFERRED: `session_create`, `session_send`,
-`session_read_message`, `session_stop`, `chat_folder_*`, `session_ledger_*`,
-`monitor_start` and `autonudge_stop` are not in your tool list until you load
-them with `tool_search(tool_id="<server>::<name>")`. A first direct call
-failing with "a tool with the name ... does not exist" means DEFERRED, not
-missing — load it and repeat the call. That is what `tool_search` is mounted for.
+**Patrol with `monitor_start`, never with `wait`.** Arm it with the full cycle
+instructions AND the exit condition, then end the turn; call `autonudge_stop`
+when you stop. A reply saying *requested* is success — do not retry it. If
+arming is refused outright, say no loop is running and drive that one round
+with `wait`.
 
-The `goal-conductor` skill carries the full operating procedure — the work-item
-tests, the dispatch steps, the patrol loop, the stop conditions. Read it
-before acting on a goal. The user can message you at any time; apply goal
-changes at the round boundary, except a message that directly invalidates an
-in-flight item, which you handle immediately.
+Your tools:
+
+- Child sessions — `session_create`, `session_send`, `session_read_message`,
+  `session_stop`, `list_sessions`.
+- Keeping the goal's sessions together — `chat_folder_tree`,
+  `chat_folder_create`.
+- State that outlives a round — `session_ledger_read`, `session_ledger_record`.
+- Patrol — `monitor_start`, `monitor_update`, `autonudge_stop`, `wait`.
+- Capacity, before standing up several sessions at once — `resource_status`.
+- Talking to the person — `ask_question` for a blocking decision that is not
+  yours to make, `send_message` / `send_notification` to report.
+- Naming the right skill in a seed message — `skill_search`, `skill_fetch`.
+- Reading — `fs_read`, `web_fetch`.
+- `tool_search` loads a tool that is not in your list yet.
+
+The `goal-conductor` skill carries the operating procedure — the work-item
+tests, the dispatch steps, the patrol cycle, the stop conditions. Read it
+before acting on a goal. The user can message you at any time: apply goal
+changes at the round boundary, except a message that invalidates an in-flight
+item, which you handle immediately.
 
 {{VERBOSITY_BLOCK}}
 """
@@ -4645,7 +4648,8 @@ def _install_conductor_agent() -> None:
         # Load-bearing, not decoration: with MCP Tool Search active the
         # session-control specs are deferred, so the conductor cannot reach
         # ``session_create`` / ``chat_folder_*`` / ``monitor_start`` at all until
-        # it loads them by id. Named in the prompt for that reason.
+        # it loads them by id. Named in the prompt's tool inventory for that
+        # reason, and auto-approved below so the load itself never prompts.
         "tool_search",
         "@kirocrew-core",
         "@kirocrew-dashboard",
@@ -4659,7 +4663,22 @@ def _install_conductor_agent() -> None:
     # then applies the ceiling's per-tool rule with the real arguments.
     granted: list[str] = []
     withheld: list[str] = []
-    for ref in ("session", "report", "@kirocrew-core", *_CONDUCTOR_DASHBOARD_GRANTS):
+    # ``tool_search`` is granted on the same rule as the dashboard verbs below:
+    # it only READS a tool spec into context — it cannot act, touch workspace
+    # state, or reach the machine — and it is bounded by the mounted catalog.
+    # Withholding it made the ONE call that unblocks every deferred
+    # session-control tool prompt first, so an unattended patrol cycle stalled
+    # on the load rather than on the work. ``execute_bash`` stays withheld for
+    # the reason recorded above it: ``allowedTools`` has no argument matching,
+    # so trusting the two bundled scripts cannot be told apart from trusting
+    # arbitrary shell.
+    for ref in (
+        "session",
+        "report",
+        "tool_search",
+        "@kirocrew-core",
+        *_CONDUCTOR_DASHBOARD_GRANTS,
+    ):
         (granted if _may_auto_approve(ref) else withheld).append(ref)
     config["allowedTools"] = granted
     if withheld:

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -91,6 +91,30 @@ class TestConductorInstaller:
         assert "Patrol with `monitor_start`, never with `wait`" in prompt
         assert "autonudge_stop" in prompt
 
+    def test_prompt_names_the_tools_it_expects_to_be_used(self, tmp_path, monkeypatch):
+        """The charter mounts whole servers, so the prompt must name what it wants.
+
+        ``@kirocrew-core`` puts ~70 tools in front of this agent. Naming only the
+        session-control ones left the rest unaddressed, which is how a conductor
+        talks itself into running a work item in its own turn. Both directions are
+        pinned: the tools the four jobs need, and the four that would end-run the
+        no-write property by executing the work here.
+        """
+        prompt = " ".join(self._install(tmp_path, monkeypatch)["prompt"].split())
+        for named in (
+            "session_create",
+            "session_ledger_record",
+            "monitor_update",
+            "resource_status",
+            "ask_question",
+            "skill_search",
+            "tool_search",
+        ):
+            assert named in prompt, named
+        for forbidden in ("spawn_run", "spawn_sub_agents", "workflow_run", "task_run"):
+            assert forbidden in prompt, forbidden
+        assert "never goes to" in prompt
+
     def test_no_write_tool_and_shell_not_preapproved(self, tmp_path, monkeypatch):
         """The security properties of the spec, in one place.
 
@@ -247,6 +271,7 @@ class TestConductorInstaller:
         assert data["allowedTools"] == [
             "session",
             "report",
+            "tool_search",
             "@kirocrew-dashboard/chat_folder_tree",
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",
@@ -349,6 +374,7 @@ class TestConductorInstaller:
         assert data["allowedTools"] == [
             "session",
             "report",
+            "tool_search",
             "@kirocrew-dashboard/chat_folder_tree",
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",


### PR DESCRIPTION
Follow-up to #6238, which landed the two fixes but left the prompt's shape unreviewed. This is that review applied, plus the one grant that was missing.

## The rule this applies

Conductor guidance should carry **task dispatch and available tools** — not an explanation of how the runtime works underneath. Every sentence was tested with one question: *what would the conductor do wrong without it?* A sentence with no answer is mechanism, and it goes.

## 1. Cut the mechanism

Deleted, with what each was explaining:

- "that is a property of your spec, not a rule you are being asked to follow" — the governance model. "You have no file-writing tool" already carries the behaviour.
- "spends the turn's whole budget on latency and dies mid-round at the turn cap", "re-injects the round into THIS session as a fresh turn", "survives a tab close or a gateway restart" — turn budgets and autonudge internals. `Patrol with monitor_start, never with wait` already changes the action.
- "arming happens after this turn ends" — kept the behaviour (*requested* is success, do not retry), dropped the reason.
- "(no dashboard/Slack/Discord session to host a loop)" — the refusal's cause does not change the next step.
- The whole `DEFERRED` paragraph — MCP Tool Search deferral is threshold-gated, backend-specific (`config/loader.py:1718`: *"kiro-cli backend only. No effect on an alternate ACP backend"*), and was written as unconditional fact. It is now one line in the tool inventory: `tool_search` loads a tool that is not in your list yet.

Guidance prose drops from ~330 to ~230 words. No action directive was removed.

## 2. Fix two ambiguities the review found

**Two sources for the patrol contract.** The prompt specified the patrol loop in detail while also saying the `goal-conductor` skill "carries the full operating procedure — ... the patrol loop". Two sources drift. Now the prompt says which tool drives patrol; the skill owns how.

**Vocabulary collision.** The charter listed its four jobs twice under different names — "stand up sessions / patrol their state" in one paragraph, "dispatch / verification" in the next. Unified on dispatch / verify.

## 3. Name the tools, because whole servers are mounted

`@kirocrew-core` puts ~70 tools in front of this agent and the prompt named a handful. That is the gap behind "focus on available tools": the rest were mounted and unaddressed, which is how a conductor talks itself into running a work item in its own turn.

The inventory now names what the four jobs need — child sessions, folders, `session_ledger_*`, the patrol trio, `resource_status` before standing up several sessions, `ask_question` / `send_message` / `send_notification`, `skill_search` / `skill_fetch`, `fs_read` / `web_fetch`, `tool_search` — and states the boundary in the same breath: a work item never goes to `spawn_run`, `spawn_sub_agents`, `workflow_run` or `task_run`. Those four are reachable, so leaving them unmentioned was the ambiguity, not the safeguard.

## 4. Auto-approve `tool_search`

`allowedTools` granted `session`, `report`, `@kirocrew-core` and the four dashboard verbs. `tool_search` is a kiro-cli builtin, so `@kirocrew-core` never covered it — every load prompted, and it is the ONE call that unblocks every deferred session-control tool. An unattended patrol cycle stalled on the load rather than on the work.

It satisfies the same invariant the file records for the dashboard grants: it only READS a tool spec into context — cannot act, cannot touch workspace state, cannot reach the machine — and is bounded by the mounted catalog. Verified against the live ceiling on a real host: `may_skip_gate_now` returns `True` for `tool_search`, `False` for `fs_read` and `execute_bash`, so this grant is one the ceiling already permits and the two withheld reads stay withheld. `execute_bash` keeps its recorded exclusion (`allowedTools` has no argument matching, so trusting the two bundled scripts cannot be told apart from trusting arbitrary shell).

## Verification

- `test/test_conductor_agent.py` 32 passed, `test/test_verbosity_config.py` clean (86 together).
- One new guard pins both directions of the inventory: the tools the four jobs need are named, and the four work-executing tools are named as forbidden.
- Revert-verify, three mutations, each failing only its own guard and passing again on restore: drop the `tool_search` grant → `test_grants_pass_through_the_governance_ceiling` fails; drop the forbidden-dispatch sentence → inventory guard fails; drop `resource_status` → inventory guard fails.
- The inventory guard normalises whitespace, so re-wrapping the prompt cannot fail it for a formatting reason.
- The two exact-`allowedTools` assertions were updated deliberately — that pin exists so a new grant cannot land without a human editing the expected list.
- black / flake8 / isort clean.

Takes effect for a running install once `_install_conductor_agent` rewrites `~/.kiro/agents/kirocrew-conductor.json` on next gateway start.
