### PR TITLE
fix: persist per-session tool trust across gateway restart

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -51,6 +51,7 @@ from kiro_crew.dashboard.chat_persistence import (
     COLOR_HEX_RE,
     _attach_variants,
     _rehydrate_slot_title,
+    _rehydrate_slot_trust,
     get_reasoning_effort_values,
     save_slot_off_loop,
 )
@@ -5765,6 +5766,7 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         # Resuming from History must carry the filing marker forward, or the
         # next save of this slot drops it and the conversation is re-filed.
         slot._channel_folder_filed = True
+    _rehydrate_slot_trust(slot, meta)
     if meta.get("folder_id"):
         slot.folder_id = meta["folder_id"]
         # Re-engaging a hidden empty folder (Model B) un-hides it so it stays

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -37,6 +37,7 @@ from kiro_crew.dashboard.state import (
     durable_row_count,
     row_mid,
 )
+from kiro_crew.dashboard.trust_sig import sign_trust, verify_trust
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
     SLOT_OWNED_META_KEYS,
@@ -102,6 +103,58 @@ def _rehydrate_title_refresh_mark(stored: object) -> int:
     if isinstance(stored, int) and not isinstance(stored, bool) and stored > 0:
         return stored
     return 0
+
+
+def _rehydrate_slot_trust(slot: _ChatSlot, metadata: Mapping[str, object]) -> None:
+    """Restore a slot's explicit session-wide auto-approve grant from metadata.
+
+    Only the deliberate "Trust this session" grant (``_trust`` — set by the
+    api_chat_mode ``mode:trust`` toggle or the card "Trust this session" button,
+    both of which flip the slot's approval policy to auto) is persisted and
+    restored. It was previously in-memory only, so a gateway restart silently
+    revoked it and the user had to re-toggle trust on every restored
+    conversation (#6379). The grant keys to the same session it was made in —
+    the meta line IS that session's record — while a fork/restore into a NEW
+    session key never carries it, because that path writes a fresh meta line the
+    user never trusted.
+
+    ``_trust_reads`` and ``_trusted_patterns`` are AD-HOC per-prompt approvals
+    (approve read-only / trust one command, on a single tool-call card). They
+    are never persisted, so they always restore cleared and re-prompt after a
+    restart — the safe default, and the behavior the review pipeline requires
+    (ad-hoc trust must not silently survive process shutdown).
+
+    AUTHENTICATED + BOUNDED restore. ``dashboard_*.jsonl`` is agent-writable, so
+    the grant is honored only when its ``trust_sig`` HMAC (see
+    ``trust_sig.sign_trust``) verifies against this session's history key AND
+    the signed ``trust_at`` is within the freshness window — otherwise an agent
+    that got a single arbitrary write approved could write a well-formed
+    ``"trust": true`` into its own line and self-escalate to durable blanket
+    trust on the next restart. Every failure mode restores NO trust (fail-closed):
+    a missing/bad signature, an expired or future-dated grant, or an
+    absent/short SEL trust root in this process.
+
+    The session-level approval policy is NOT set here — it is re-derived from
+    ``slot._trust`` when the session's next turn starts (see ``chat_handlers``
+    policy resolution), so restoring the slot flag is sufficient and avoids
+    resurrecting a session object at restore time.
+    """
+    # Restore ONLY the explicit session-wide trust grant. ``_trust_reads`` and
+    # ``_trusted_patterns`` are ad-hoc per-prompt approvals that are never
+    # persisted (see _save_slot_to_history), so they always start cleared and
+    # re-prompt after a restart — the safe default.
+    trust = metadata.get("trust") is True
+    if trust and verify_trust(
+        slot_history_key(slot),
+        trust=True,
+        signature=metadata.get("trust_sig"),
+        issued_at=metadata.get("trust_at"),
+    ):
+        slot._trust = True
+    else:
+        slot._trust = False
+    slot._trust_reads = False
+    slot._trusted_patterns = set()
 
 
 def _rehydrate_slot_title(
@@ -980,6 +1033,11 @@ def _rehydrate_slot_from_history(
             # Skipped, the slot would answer from a dashboard-only session and the
             # channel thread would stop seeing its replies.
             slot.linked_session_key = str(meta["linked_session_key"])
+        # AFTER linked_session_key: the trust signature is bound to the session's
+        # history key, which for a channel-origin slot derives from
+        # linked_session_key. Verifying before the rebind above would compute the
+        # dashboard-only key and reject a genuine grant (fail-closed no-op).
+        _rehydrate_slot_trust(slot, meta)
         # Restore the persisted tab_id so cross-restart fork chaining survives.
         # get_or_create_slot (called by our caller) assigns a fresh random uuid to
         # slot._tab_id; if we don't overwrite it here, the next _flush_dirty_slots
@@ -1449,6 +1507,10 @@ def _apply_recent_session(
         real_key = state.sessions.channel_key_for_stem(key)
         if real_key:
             slot.linked_session_key = real_key
+    # AFTER linked_session_key (both branches): trust verification binds to the
+    # session's history key, which for a channel-origin slot derives from
+    # linked_session_key — verifying earlier rejects a genuine grant.
+    _rehydrate_slot_trust(slot, meta)
     tab_id = meta.get("tab_id")
     if not tab_id:
         tab_id = uuid.uuid4().hex[:12]
@@ -2562,6 +2624,48 @@ def _save_slot_to_history(
                 # makes that whole class of omission harmless — same reason
                 # rotation_generation is carried forward above.
                 meta_line["channel_folder_filed"] = True
+            # Per-session auto-approve trust — persisted so a "trust this
+            # session" / "trust read-only bash" grant, and the per-command
+            # fnmatch grants, survive a gateway restart instead of forcing the
+            # user to re-approve every restored conversation. The grant is keyed
+            # to this session (this meta line IS the session's record); a
+            # fork/restore into a new session key writes its own line and never
+            # Persist ONLY the explicit session-wide "Trust this session" grant
+            # (``_trust``) — the deliberate mode toggle (api_chat_mode mode:trust)
+            # or the card "Trust this session" button, both of which set the
+            # slot's approval policy to auto. This is the grant #6379 is about
+            # (a restart should not force re-toggling trust on every chat).
+            #
+            # ``_trust_reads`` and ``_trusted_patterns`` are DELIBERATELY NOT
+            # persisted: both are reachable as AD-HOC, in-the-moment approvals on
+            # an individual tool-call card ("approve read-only for this session",
+            # "trust this command") — a transient reaction to one prompt, not a
+            # durable policy. Ad-hoc approvals re-prompt after a restart, which is
+            # the safe default the user expects (addresses the review finding
+            # that ad-hoc trust must not silently survive process shutdown).
+            #
+            # NOT written on an explicit CLOSE: closing is a deliberate teardown,
+            # so reopening from History is a fresh engagement that must
+            # re-prompt — fail-closed.
+            #
+            # AUTHENTICATED: dashboard_*.jsonl is agent-writable (not a
+            # sensitive-path root), so a bare `trust: true` would be a grant the
+            # agent could write for itself — one approved arbitrary write would
+            # self-escalate into durable blanket trust across a restart. The
+            # grant is HMAC-signed (``trust_sig``) with a subkey derived from the
+            # agent-unreadable SEL trust root and bound to this session's history
+            # key; rehydrate restores trust ONLY when the signature verifies.
+            # Keys are omitted when untrusted OR unsignable, so such a session's
+            # line stays clean and restores to no trust.
+            if not closed and slot._trust:
+                _signed = sign_trust(history_key, trust=True)
+                if _signed is not None:
+                    _trust_sig, _trust_at = _signed
+                    meta_line["trust"] = True
+                    meta_line["trust_sig"] = _trust_sig
+                    # issued_at is inside the MAC and re-checked on restore to
+                    # bound the grant's lifetime; persist it alongside the sig.
+                    meta_line["trust_at"] = _trust_at
             if slot._app:
                 meta_line["app"] = slot._app
             # Slot ORIGIN (user / app / cron) must round-trip with ``app``:

--- a/src/kiro_crew/dashboard/trust_sig.py
+++ b/src/kiro_crew/dashboard/trust_sig.py
@@ -1,0 +1,254 @@
+"""Authenticated persistence of a chat session's auto-approve trust grant.
+
+A dashboard "trust this session" / "trust read-only bash" grant, plus the
+per-command fnmatch grants, are session-scoped auto-approve state. Persisting
+them on the session's history meta line lets the grant survive a gateway
+restart (the whole point) — but ``dashboard_*.jsonl`` lives in the same-uid,
+**agent-writable** history dir (it is NOT on ``security._SENSITIVE_HOME_DIRS``),
+so a bare ``"trust": true`` on the line is a grant an agent could WRITE FOR
+ITSELF. Once any single arbitrary write is approved (e.g. via prompt injection),
+the agent could edit its own session's meta line and the next routine restart
+would silently convert that one approval into a durable, session-wide
+auto-approve — disabling the containment prompt itself, not merely influencing
+it. Type-validating the fields (bool / list-of-str) does not close this: a
+well-formed ``true`` is exactly what the tamperer writes.
+
+This module makes the persisted grant AUTHENTICATED, mirroring
+``session_pid_sig`` (the same trust root, the same threat model):
+
+* :func:`sign_trust` — the meta-line writer calls this to produce a
+  ``trust_sig`` HMAC over the grant, bound to the session's history key and
+  keyed with a subkey **derived from** the SEL trust root (``sel_hmac.key``,
+  whose reads are deny-listed for agent shells in ``security.py``) via a
+  domain-separation label. The raw root key never signs directly, so this
+  protocol and the SEL audit chain never share a signing key.
+* :func:`verify_trust` — the rehydrate path calls this. It returns the grant
+  ONLY when the sidecar signature verifies against the same history key;
+  missing/short key, absent signature, or mismatch all fail closed to "no
+  trust". So a forged or tampered grant rehydrates as untrusted.
+
+Why forgery dies: the agent cannot read ``sel_hmac.key`` (deny-listed), so it
+cannot produce a valid ``trust_sig`` for a grant it writes into its own line.
+Binding the history key into the MAC also stops replaying one session's signed
+grant onto another session's line. Residual risk (an agent evading the deny-list
+to read the key) is identical to the existing SEL tamper-evidence threat model.
+
+Currency, not just origin — bounded by a signed TTL: the MAC would otherwise
+authenticate *origin* without *currency*, so a grant signed once would be
+honored identically forever, across unlimited restarts. To keep the durable
+grant materially narrower than "trust this machine forever", the signer folds a
+tamper-proof ``issued_at`` unix timestamp into the signed payload, and
+:func:`verify_trust` refuses any grant older than :data:`_MAX_AGE_SECONDS`
+(currently 7 days) or one dated in the future beyond a small clock-skew
+allowance. Because ``issued_at`` is inside the MAC, an agent cannot forward-date
+it to extend the window without the deny-listed root key; a stale grant simply
+fails closed to no-trust and the user re-approves. This converts the feature
+from "auto-approval survives restart forever" into "auto-approval survives
+restart for a bounded window", which is the behavior a user actually expects and
+a much smaller blast radius than an unbounded persisted grant.
+
+Residual risk — same-window re-write: within that window an agent that RETAINED
+its own session's earlier signed line could re-write it after a revocation and
+regain trust until the TTL lapses (the signature stays genuine). The TTL caps
+how long that can persist; fully closing it needs a non-agent-writable
+revocation generation folded into the payload — the same class of residual as
+the deny-list evasion above, and tracked as a follow-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from collections.abc import Iterable
+
+from kiro_crew.sel import _sel_hmac_key_bytes, sel_hmac_key_path
+
+logger = logging.getLogger(__name__)
+
+# Mirrors sel.py / session_pid_sig.py: a shorter key on disk means
+# truncation/corruption/tampering; signing with it yields a predictable,
+# forgeable MAC, so both sign and verify treat a short key as absent (fail
+# closed on the verify side — no trust restored).
+_HMAC_KEY_MIN_BYTES = 32
+
+# Domain-separation label. ``sel_hmac.key`` anchors several independent
+# protocols (the SEL audit chain, the session_pid sidecar, and now this trust
+# sidecar). We NEVER sign with the raw root key: a purpose-specific subkey is
+# derived via one HMAC step keyed by this label, so a MAC minted under one
+# protocol can never be presented as valid for another. Versioned — bumping the
+# suffix rotates every trust sidecar's effective key without touching the SEL
+# root or the on-disk key file.
+_SUBKEY_DOMAIN = b"kirocrew.session_trust.sig.v1"
+
+# A restored grant is honored only within this window of its signed issued_at.
+# Bounds the durable grant to "survives restart for about a week" rather than
+# "forever across unlimited restarts" — the currency bound GPT's review calls
+# for. 7 days is long enough that the persist-across-restart feature is useful
+# (a routine restart mid-work keeps trust) yet finite. issued_at is inside the
+# MAC, so an agent cannot extend it without the deny-listed root key.
+_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+# Tolerate modest clock skew / non-monotonic wall clocks so a grant signed on a
+# slightly-fast clock is not rejected as "future-dated"; beyond this a future
+# issued_at is treated as malformed (fail closed).
+_CLOCK_SKEW_SECONDS = 5 * 60
+
+
+def _load_hmac_key() -> bytes | None:
+    """Load the SEL trust-root key; None when absent/short (never creates).
+
+    Prefers the on-disk FILE (the anchor every process resolves independently),
+    falling back to the live ``SecurityEventLog`` singleton's validated in-memory
+    copy — identical ordering to ``session_pid_sig._load_hmac_key``, which owns
+    the rule that the file is preferred so a signer and a verifier never diverge.
+    Only ``SecurityEventLog`` creates the key, so this never writes one.
+    """
+    try:
+        raw = sel_hmac_key_path().read_bytes()
+    except OSError:
+        raw = b""
+    if len(raw) >= _HMAC_KEY_MIN_BYTES:
+        return raw
+    return _sel_hmac_key_bytes()
+
+
+def _derive_subkey(root: bytes) -> bytes:
+    """Domain-separated one-way derivation of the trust-sidecar signing key."""
+    return hmac.new(root, _SUBKEY_DOMAIN, hashlib.sha256).digest()
+
+
+def _canonical_payload(
+    history_key: str,
+    *,
+    trust: bool,
+    trust_reads: bool,
+    patterns: Iterable[str],
+    issued_at: int,
+) -> bytes:
+    """Deterministic byte payload the MAC covers.
+
+    Binds the SESSION (``history_key``) so a signed grant cannot be replayed
+    onto another session's meta line, covers all three grant fields so flipping
+    any of them (or adding a pattern) invalidates the signature, and binds
+    ``issued_at`` so the freshness window cannot be forward-dated without the
+    root key. Patterns are sorted and newline-joined; ``\\x1f`` (unit separator)
+    delimits fields so a pattern containing the delimiter cannot shift framing.
+    """
+    pat = "\n".join(sorted(patterns))
+    parts = [
+        history_key,
+        "1" if trust else "0",
+        "1" if trust_reads else "0",
+        pat,
+        str(int(issued_at)),
+    ]
+    return "\x1f".join(parts).encode("utf-8")
+
+
+def sign_trust(
+    history_key: str,
+    *,
+    trust: bool,
+    trust_reads: bool = False,
+    patterns: Iterable[str] = (),
+    issued_at: int | None = None,
+) -> tuple[str, int] | None:
+    """Return ``(trust_sig, issued_at)`` for a grant, or None when unsignable.
+
+    ``issued_at`` is a unix timestamp folded into the MAC; the caller MUST
+    persist the returned value alongside the signature so :func:`verify_trust`
+    can re-check freshness. It defaults to "now" and is exposed as a parameter
+    only so tests can sign a grant at a chosen age.
+
+    None means the SEL trust root is absent/short in THIS process; the caller
+    must then persist NO trust keys (an unsigned grant would fail verification
+    and rehydrate as untrusted anyway, so writing it is pointless and would look
+    like a silently-dropped grant). Never raises.
+    """
+    key = _load_hmac_key()
+    if key is None:
+        logger.debug(
+            "session-trust signing unavailable (SEL trust root absent/short at %s); "
+            "persisting grant unsigned is refused",
+            sel_hmac_key_path(),
+        )
+        return None
+    stamp = int(time.time()) if issued_at is None else int(issued_at)
+    subkey = _derive_subkey(key)
+    payload = _canonical_payload(
+        history_key,
+        trust=trust,
+        trust_reads=trust_reads,
+        patterns=patterns,
+        issued_at=stamp,
+    )
+    return hmac.new(subkey, payload, hashlib.sha256).hexdigest(), stamp
+
+
+def verify_trust(
+    history_key: str,
+    *,
+    trust: bool,
+    trust_reads: bool = False,
+    patterns: Iterable[str] = (),
+    signature: object,
+    issued_at: object,
+) -> bool:
+    """True iff *signature* authenticates this grant for this session AND the
+    grant is still within its freshness window.
+
+    Fails closed (returns False) on: a non-string/empty signature; a missing or
+    short SEL key; a MAC mismatch; a malformed/negative/future-dated
+    ``issued_at``; or a grant older than :data:`_MAX_AGE_SECONDS`. The freshness
+    check runs only AFTER the MAC verifies, so an attacker cannot probe the TTL
+    boundary with forged timestamps — ``issued_at`` is inside the MAC, so any
+    value that verifies is one the legitimate signer stamped. The caller then
+    restores NO trust. Never raises.
+    """
+    if not isinstance(signature, str) or not signature:
+        return False
+    # issued_at must be an int-like unix stamp. bool is an int subclass but is
+    # never a valid timestamp, so reject it explicitly.
+    if isinstance(issued_at, bool) or not isinstance(issued_at, int):
+        return False
+    key = _load_hmac_key()
+    if key is None:
+        # Distinct from a mismatch: the verifier's own trust root is
+        # absent/short (e.g. a publisher/verifier split), NOT forgery. Fail
+        # closed either way, but say which so a trust-root drift is diagnosable
+        # rather than looking like universal tampering.
+        logger.warning(
+            "SEL trust-root key absent/short at %s — refusing persisted session "
+            "trust (restores untrusted; if trust never survives restart, check "
+            "for a signer/verifier trust-root split)",
+            sel_hmac_key_path(),
+        )
+        return False
+    subkey = _derive_subkey(key)
+    payload = _canonical_payload(
+        history_key,
+        trust=trust,
+        trust_reads=trust_reads,
+        patterns=patterns,
+        issued_at=issued_at,
+    )
+    expected = hmac.new(subkey, payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        return False
+    # MAC is authentic → issued_at is a value the signer stamped. Enforce the
+    # bounded freshness window so a durable grant cannot outlive it.
+    now = int(time.time())
+    if issued_at > now + _CLOCK_SKEW_SECONDS:
+        # Future-dated beyond skew: treat as malformed, fail closed.
+        return False
+    if now - issued_at > _MAX_AGE_SECONDS:
+        logger.debug(
+            "persisted session trust expired (issued_at=%d, age=%ds > %ds) — "
+            "restoring untrusted; user re-approves",
+            issued_at,
+            now - issued_at,
+            _MAX_AGE_SECONDS,
+        )
+        return False
+    return True

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -184,6 +184,18 @@ SLOT_OWNED_META_KEYS: frozenset[str] = frozenset(
         "forked_from",
         "linked_session_key",
         "tab_id",
+        # Per-session auto-approve trust (dashboard/trust_sig.py). Owned so
+        # "absence means cleared" applies: a save that omits them — because the
+        # user revoked trust (mode:normal -> flags False) or CLOSED the tab
+        # (write is gated on `not closed`) — must ERASE the prior signed grant,
+        # not let carry_unowned_metadata resurrect it. Without ownership a
+        # once-trusted session's still-valid signature is copied forward and
+        # re-verifies on restart, silently restoring a revoked/closed grant.
+        "trust",
+        "trust_reads",
+        "trusted_patterns",
+        "trust_sig",
+        "trust_at",
     }
 )
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3219,7 +3219,10 @@ class TestHistorySaveOnClose:
         assert meta.get("mode") == "orchestrator"
 
     def test_close_does_not_persist_trust(self, tmp_path, monkeypatch):
-        """Trust flags are ephemeral — not written to session metadata."""
+        """A CLOSE is a deliberate teardown, so it does NOT write trust — a
+        session reopened from History re-prompts. (A normal save DOES persist
+        trust so it survives a gateway restart; see
+        test_normal_save_persists_trust.)"""
         from kiro_crew.dashboard.chat import _save_slot_to_history
 
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
@@ -3233,6 +3236,35 @@ class TestHistorySaveOnClose:
         meta = state.conversation_log._read_metadata("dashboard:t1")
         assert meta.get("trust") is None
         assert meta.get("trust_reads") is None
+
+    def test_normal_save_persists_trust(self, tmp_path, monkeypatch):
+        """A normal (non-close) save persists the session-scoped grant so it
+        survives a gateway restart — the fix for re-trusting every conversation
+        after `kirocrew restart`. The grant is HMAC-signed so a restore can
+        distinguish it from an agent-forged line."""
+        from unittest.mock import patch
+
+        from kiro_crew.dashboard import trust_sig
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        (tmp_path / "sel_hmac.key").write_bytes(b"\x04" * 32)
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "sel_hmac.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            state = _make_state(tmp_path)
+            slot = state.get_or_create_slot("t2")
+            slot._trust = True
+            slot._trust_reads = True  # ad-hoc — must not persist
+            slot.append("user", "hi")
+            slot.drain()
+            _save_slot_to_history(state, slot)
+            meta = state.conversation_log._read_metadata("dashboard:t2")
+            assert meta.get("trust") is True
+            assert len(meta.get("trust_sig", "")) == 64
+            # Ad-hoc per-prompt approval is not persisted.
+            assert "trust_reads" not in meta
 
 
 # ── Resume deduplication ──

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -2347,8 +2347,14 @@ class TestHmacKeyTrustDirMigration:
 
     def test_key_bytes_accessor_has_exactly_one_production_caller(self) -> None:
         """Handing out raw trust-root bytes is safe only under the file-first
-        ordering its ONE caller enforces; a second caller would inherit none of
-        it. Pin the caller set rather than trusting the underscore."""
+        ordering its callers enforce; a caller that reached for memory first
+        would inherit none of it. Pin the caller set rather than trusting the
+        underscore. Sanctioned callers, each mirroring
+        ``session_pid_sig._load_hmac_key``'s file-first-then-memory fallback:
+        ``session_pid_sig.py`` (pid->session sidecar) and ``dashboard/trust_sig.py``
+        (per-session trust sidecar). Adding a caller here is a deliberate review
+        gate, not a formality — the new caller MUST prefer the file and use the
+        in-memory bytes only as a fallback."""
         root = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
         callers = {
             path
@@ -2358,9 +2364,10 @@ class TestHmacKeyTrustDirMigration:
             # cannot decode the non-ASCII bytes several sources contain.
             and "_sel_hmac_key_bytes" in path.read_text(encoding="utf-8")
         }
-        assert callers == {root / "session_pid_sig.py"}, (
-            f"_sel_hmac_key_bytes gained a caller outside session_pid_sig: {callers}"
-        )
+        assert callers == {
+            root / "session_pid_sig.py",
+            root / "dashboard" / "trust_sig.py",
+        }, f"_sel_hmac_key_bytes caller set changed unexpectedly: {callers}"
 
     def test_concurrent_first_construction_initializes_once(self, tmp_path: Path) -> None:
         """``__new__`` publishes the instance BEFORE ``__init__`` runs, so two

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -123,20 +123,45 @@ class TestRestoreRecentSessions:
         restore_recent_sessions(state, window_minutes=60)
         assert state._slots["nomode"].mode == ""
 
-    def test_trust_flags_not_restored(self, tmp_path, monkeypatch):
-        """Trust flags in metadata are NOT restored — security boundary."""
+    def test_trust_flags_restored(self, tmp_path, monkeypatch):
+        """Per-session trust flags ARE restored on bulk startup restore when the
+        grant carries a valid signature.
+
+        Previously these were dropped so the user re-approved every restored
+        conversation after a gateway restart. The grant is session-scoped (the
+        meta line IS this session's record) and now round-trips; a forged or
+        unsigned grant still fails closed (see TestSessionTrustPersistence)."""
+        from unittest.mock import patch
+
+        from kiro_crew.dashboard import trust_sig
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-        _write_session(
-            tmp_path,
-            "dashboard_trusted",
-            [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
-            meta={"title": "Trusted", "trust": True, "trust_reads": True},
-        )
-        (tmp_path / "dashboard_trusted.jsonl").touch()
-        state = _make_state(tmp_path)
-        restore_recent_sessions(state, window_minutes=60)
-        assert state._slots["trusted"]._trust is False
-        assert state._slots["trusted"]._trust_reads is False
+        (tmp_path / "sel_hmac.key").write_bytes(b"\x03" * 32)
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "sel_hmac.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            hk = slot_history_key(_ChatSlot("trusted"))
+            sig, at = trust_sig.sign_trust(hk, trust=True)
+            _write_session(
+                tmp_path,
+                "dashboard_trusted",
+                [{"role": "user", "content": "hi", "ts": "2026-03-23T10:00:00"}],
+                meta={
+                    "title": "Trusted",
+                    "trust": True,
+                    "trust_sig": sig,
+                    "trust_at": at,
+                },
+            )
+            (tmp_path / "dashboard_trusted.jsonl").touch()
+            state = _make_state(tmp_path)
+            restore_recent_sessions(state, window_minutes=60)
+            assert state._slots["trusted"]._trust is True
+            # Ad-hoc trust_reads is never persisted → restores cleared.
+            assert state._slots["trusted"]._trust_reads is False
 
     def test_skips_old_sessions(self, tmp_path, monkeypatch):
         """Sessions older than the window are not restored."""
@@ -1649,3 +1674,420 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         assert not (
             tmp_path / "dashboard_vanished.jsonl"
         ).exists(), "the deleted transcript came back"
+
+
+# ── per-session trust persistence (issue: re-trust after every restart) ──
+
+
+def _sign_trusted_slot_meta(
+    history_key: str,
+    *,
+    trust: bool = True,
+    issued_at: int | None = None,
+) -> dict:
+    """Build a signed trust meta fragment for direct-write restore tests.
+
+    Only the explicit session-wide ``_trust`` grant is persisted, so the
+    fragment carries just ``trust`` + ``trust_sig`` + ``trust_at``.
+    """
+    from kiro_crew.dashboard.trust_sig import sign_trust
+
+    sig, at = sign_trust(history_key, trust=trust, issued_at=issued_at)
+    frag: dict = {"trust_sig": sig, "trust_at": at}
+    if trust:
+        frag["trust"] = True
+    return frag
+
+
+class TestSessionTrustPersistence:
+    """A "trust this session" grant, a "trust read-only bash" grant, and the
+    per-command fnmatch grants are session-scoped auto-approve state that used
+    to be in-memory only, so a gateway restart silently revoked them and the
+    user had to re-approve every restored conversation. These pin that the
+    grant now round-trips through the slot's persisted meta line — keyed to the
+    session it was made in — AND that it is HMAC-signed with the agent-unreadable
+    SEL trust root so a forged/tampered/replayed grant fails closed to no trust
+    (the GPT/Design finding on the agent-writable dashboard_*.jsonl)."""
+
+    @pytest.fixture(autouse=True)
+    def _sel_key(self, tmp_path):
+        """Give trust_sig a real, resolvable SEL trust-root key under tmp_path.
+
+        Mirrors test_session_pid_sig's cfg fixture: write sel_hmac.key, patch
+        the canonical path accessor, and stub the in-memory fallback to None so
+        the FILE is the single source of truth in-test."""
+        from unittest.mock import patch
+
+        from kiro_crew.dashboard import trust_sig
+
+        (tmp_path / "sel_hmac.key").write_bytes(b"\x02" * 32)
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "sel_hmac.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            yield
+
+    def test_only_explicit_trust_persisted_not_ad_hoc(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("trustslot")
+        slot._trust = True
+        # Ad-hoc approvals present in memory — these must NOT be persisted.
+        slot._trust_reads = True
+        slot._trusted_patterns = {"git status", "ls *"}
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        _save_slot_to_history(state, slot)
+
+        path = tmp_path / "dashboard_trustslot.jsonl"
+        meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
+        # Only the explicit session-wide grant persists.
+        assert meta["trust"] is True
+        assert len(meta["trust_sig"]) == 64
+        # Ad-hoc per-prompt approvals are deliberately dropped (re-prompt on restart).
+        assert "trust_reads" not in meta
+        assert "trusted_patterns" not in meta
+
+    def test_untrusted_session_writes_no_trust_keys(self, tmp_path, monkeypatch):
+        """A session the user never trusted leaves its meta line clean — no
+        trust keys, no signature — so its restore is unambiguously fail-closed."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("plainslot")
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        _save_slot_to_history(state, slot)
+
+        path = tmp_path / "dashboard_plainslot.jsonl"
+        meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
+        assert "trust" not in meta
+        assert "trust_reads" not in meta
+        assert "trusted_patterns" not in meta
+        assert "trust_sig" not in meta
+
+    def test_rehydrate_restores_signed_trust(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        hk = slot_history_key(_ChatSlot("trusted"))
+        _write_session(
+            tmp_path,
+            "dashboard_trusted",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={
+                "title": "Trusted",
+                **_sign_trusted_slot_meta(hk, trust=True),
+            },
+        )
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "trusted")
+        assert slot is not None
+        assert slot._trust is True
+        # Ad-hoc grants are never persisted, so they restore cleared.
+        assert slot._trust_reads is False
+        assert slot._trusted_patterns == set()
+
+    def test_rehydrate_untrusted_session_is_fail_closed(self, tmp_path, monkeypatch):
+        """A restored session with no trust keys comes back fully untrusted."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _write_session(
+            tmp_path,
+            "dashboard_plain",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Plain"},
+        )
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "plain")
+        assert slot is not None
+        assert slot._trust is False
+        assert slot._trust_reads is False
+        assert slot._trusted_patterns == set()
+
+    def test_rehydrate_rejects_unsigned_forged_grant(self, tmp_path, monkeypatch):
+        """THE core threat: an agent writes a well-formed `trust: true` into its
+        own agent-writable history line WITHOUT a valid signature (it cannot
+        read the SEL key to forge one). Restore must fail closed to no trust."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _write_session(
+            tmp_path,
+            "dashboard_forged",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={
+                "title": "Forged",
+                "trust": True,
+                "trust_reads": True,
+                "trusted_patterns": ["rm -rf /"],
+                # an attacker-guessed signature:
+                "trust_sig": "deadbeef" * 8,
+            },
+        )
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "forged")
+        assert slot is not None
+        assert slot._trust is False
+        assert slot._trust_reads is False
+        assert slot._trusted_patterns == set()
+
+    def test_rehydrate_rejects_grant_with_no_signature(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _write_session(
+            tmp_path,
+            "dashboard_nosig",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "NoSig", "trust": True},
+        )
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "nosig")
+        assert slot is not None
+        assert slot._trust is False
+
+    def test_rehydrate_rejects_tampered_field_after_signing(self, tmp_path, monkeypatch):
+        """Tampering any signed field (here the bound issued-at stamp) after
+        signing invalidates the MAC, so the whole grant fails closed."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        hk = slot_history_key(_ChatSlot("escalated"))
+        # Sign a genuine trust grant, then tamper a signed field (trust_at) so
+        # the persisted line no longer matches the MAC — fails closed.
+        frag = _sign_trusted_slot_meta(hk, trust=True)
+        frag["trust_at"] = int(frag["trust_at"]) - 1  # signed value the MAC covered
+        _write_session(
+            tmp_path,
+            "dashboard_escalated",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Escalated", **frag},
+        )
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "escalated")
+        assert slot is not None
+        assert slot._trust is False
+        assert slot._trust_reads is False
+
+    def test_rehydrate_rejects_expired_grant(self, tmp_path, monkeypatch):
+        """A genuinely-signed grant older than the freshness window restores NO
+        trust: persistence survives a restart for a bounded time, not forever.
+        The user simply re-approves after the window lapses."""
+        import time as _time
+
+        from kiro_crew.dashboard import trust_sig
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        hk = slot_history_key(_ChatSlot("stale"))
+        old = int(_time.time()) - (trust_sig._MAX_AGE_SECONDS + 3600)
+        frag = _sign_trusted_slot_meta(hk, trust=True, issued_at=old)
+        _write_session(
+            tmp_path,
+            "dashboard_stale",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "Stale", **frag},
+        )
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "stale")
+        assert slot is not None
+        assert slot._trust is False
+        assert slot._trust_reads is False
+
+    def test_rehydrate_rejects_cross_session_replay(self, tmp_path, monkeypatch):
+        """A grant signed for session A cannot be replayed onto session B's line:
+        the history key is bound into the MAC."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        other_hk = slot_history_key(_ChatSlot("victimA"))
+        stolen = _sign_trusted_slot_meta(other_hk, trust=True)  # signed for A
+        _write_session(
+            tmp_path,
+            "dashboard_victimB",  # replayed onto B's line
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "VictimB", **stolen},
+        )
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "victimB")
+        assert slot is not None
+        assert slot._trust is False
+
+    def test_fork_into_new_session_key_does_not_inherit_trust(self, tmp_path, monkeypatch):
+        """A fork/restore into a NEW session key writes its own meta line and
+        never carries the source session's grant."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        trusted = state.get_or_create_slot("source")
+        trusted._trust = True
+        trusted.append("user", "hello")
+        trusted.drain()
+
+        fork = state.get_or_create_slot("fork")
+        fork.append("user", "hello")
+        fork.drain()
+
+        from kiro_crew.dashboard.chat import _save_slot_to_history
+
+        _save_slot_to_history(state, trusted)
+        _save_slot_to_history(state, fork)
+
+        fork_meta = json.loads(
+            (tmp_path / "dashboard_fork.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert "trust" not in fork_meta
+
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+
+        state2 = _make_state(tmp_path)
+        restored_fork = _rehydrate_slot_from_history(state2, "fork")
+        assert restored_fork is not None
+        assert restored_fork._trust is False
+
+    def test_rehydrate_ignores_ad_hoc_keys_on_line(self, tmp_path, monkeypatch):
+        """Ad-hoc grants are never persisted, so even if a line carries
+        ``trust_reads``/``trusted_patterns`` (a legacy write, or a tampered line
+        adding them alongside a valid trust grant), rehydrate restores ONLY
+        ``_trust`` — the ad-hoc fields are not read."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
+        from kiro_crew.dashboard.chat_utils import slot_history_key
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        hk = slot_history_key(_ChatSlot("adhoc"))
+        frag = _sign_trusted_slot_meta(hk, trust=True)  # signs trust only
+        # Attacker/legacy line also carries ad-hoc grant keys — ignored on restore.
+        frag["trust_reads"] = True
+        frag["trusted_patterns"] = ["rm -rf /", "git status"]
+        _write_session(
+            tmp_path,
+            "dashboard_adhoc",
+            [{"role": "user", "content": "x", "ts": "2026-03-23T10:00:00"}],
+            meta={"title": "AdHoc", **frag},
+        )
+        state = _make_state(tmp_path)
+        slot = _rehydrate_slot_from_history(state, "adhoc")
+        assert slot is not None
+        assert slot._trust is True
+        assert slot._trust_reads is False
+        assert slot._trusted_patterns == set()
+
+    def test_trust_round_trips_through_save_and_rehydrate(self, tmp_path, monkeypatch):
+        """End-to-end: grant on a live slot, save (signs), then rehydrate a fresh
+        state from the same on-disk file (verifies) — the exact gateway-restart
+        path the user hits."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("rt")
+        slot._trust = True
+        slot._trusted_patterns = {"git diff"}  # ad-hoc — must not survive restart
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        _save_slot_to_history(state, slot)
+
+        state2 = _make_state(tmp_path)
+        restored = _rehydrate_slot_from_history(state2, "rt")
+        assert restored is not None
+        assert restored._trust is True
+        # Ad-hoc per-command grant is dropped; the user re-approves it.
+        assert restored._trusted_patterns == set()
+
+    def test_revoke_after_trusted_save_clears_on_restart(self, tmp_path, monkeypatch):
+        """Regression (GPT/Opus/Design BLOCK): a session saved TRUSTED, then
+        revoked (mode:normal -> flags False) and re-saved, must NOT restore trust
+        on restart. Without the four trust keys in SLOT_OWNED_META_KEYS,
+        carry_unowned_metadata copied the still-valid signed grant forward and it
+        re-verified — silently resurrecting a revoked grant."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("revoked")
+        slot._trust = True
+        slot._trust_reads = True
+        slot._trusted_patterns = {"git diff"}
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        _save_slot_to_history(state, slot)  # persists trust + sig (existing_meta now has them)
+        # User revokes (mode:normal): all trust flags cleared, slot re-saved.
+        slot._trust = False
+        slot._trust_reads = False
+        slot._trusted_patterns = set()
+        slot.append("user", "revoked now")
+        slot.drain()
+        _save_slot_to_history(state, slot)
+
+        # The on-disk meta line must no longer carry any trust key.
+        meta = json.loads(
+            (tmp_path / "dashboard_revoked.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert "trust" not in meta
+        assert "trust_reads" not in meta
+        assert "trusted_patterns" not in meta
+        assert "trust_sig" not in meta
+
+        state2 = _make_state(tmp_path)
+        restored = _rehydrate_slot_from_history(state2, "revoked")
+        assert restored is not None
+        assert restored._trust is False
+        assert restored._trust_reads is False
+        assert restored._trusted_patterns == set()
+
+    def test_close_after_trusted_save_clears_on_reopen(self, tmp_path, monkeypatch):
+        """Regression: a session saved TRUSTED during normal use, then CLOSED
+        (write gated on `not closed`), must NOT carry the grant forward — the old
+        signed keys are erased on the close save so reopening from History
+        re-prompts. Distinct from test_close_does_not_persist_trust, which closes
+        on the first-ever save (no existing_meta to carry)."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("closedtrust")
+        slot._trust = True
+        slot.append("user", "hello")
+        slot.drain()
+
+        from kiro_crew.dashboard.chat import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        _save_slot_to_history(state, slot)  # trusted line on disk
+        slot.append("user", "closing")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=True)  # close save omits trust keys
+
+        meta = json.loads(
+            (tmp_path / "dashboard_closedtrust.jsonl").read_text(encoding="utf-8").split("\n")[0]
+        )
+        assert "trust" not in meta
+        assert "trust_sig" not in meta
+
+        state2 = _make_state(tmp_path)
+        restored = _rehydrate_slot_from_history(state2, "closedtrust")
+        # closed sessions are skipped by rehydrate; if surfaced, trust is cleared.
+        assert restored is None or restored._trust is False

--- a/test/test_trust_sig.py
+++ b/test/test_trust_sig.py
@@ -1,0 +1,209 @@
+"""Unit tests for the authenticated session-trust sidecar (``trust_sig``).
+
+Mirrors ``test_session_pid_sig``: a real ``sel_hmac.key`` under a tmp dir, the
+canonical path accessor patched to it, and the in-memory fallback stubbed to
+None so the FILE is the single source of truth in-test.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.dashboard import trust_sig
+
+HK = "dashboard:chat-1-1785"
+
+
+@pytest.fixture
+def sel_key(tmp_path):
+    (tmp_path / "sel_hmac.key").write_bytes(b"\x07" * 32)
+    with (
+        patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "sel_hmac.key"),
+        patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+    ):
+        yield tmp_path
+
+
+class TestSignVerify:
+    def test_round_trip(self, sel_key):
+        sig, at = trust_sig.sign_trust(HK, trust=True, trust_reads=False, patterns={"git status"})
+        assert isinstance(sig, str) and len(sig) == 64
+        assert isinstance(at, int)
+        assert trust_sig.verify_trust(
+            HK,
+            trust=True,
+            trust_reads=False,
+            patterns={"git status"},
+            signature=sig,
+            issued_at=at,
+        )
+
+    def test_pattern_order_irrelevant(self, sel_key):
+        """A set signed in one order verifies in any order (canonical sorts)."""
+        sig, at = trust_sig.sign_trust(HK, trust=True, patterns=["ls *", "git status"])
+        assert trust_sig.verify_trust(
+            HK,
+            trust=True,
+            trust_reads=False,
+            patterns=["git status", "ls *"],
+            signature=sig,
+            issued_at=at,
+        )
+
+    def test_flip_trust_field_fails(self, sel_key):
+        sig, at = trust_sig.sign_trust(HK, trust=False, trust_reads=True, patterns=())
+        # Escalate trust=True: the MAC no longer matches.
+        assert not trust_sig.verify_trust(
+            HK, trust=True, trust_reads=True, patterns=(), signature=sig, issued_at=at
+        )
+
+    def test_add_pattern_fails(self, sel_key):
+        sig, at = trust_sig.sign_trust(HK, trust=True, patterns={"git status"})
+        assert not trust_sig.verify_trust(
+            HK,
+            trust=True,
+            trust_reads=False,
+            patterns={"git status", "rm -rf /"},
+            signature=sig,
+            issued_at=at,
+        )
+
+    def test_cross_session_replay_fails(self, sel_key):
+        sig, at = trust_sig.sign_trust(HK, trust=True, patterns=())
+        assert not trust_sig.verify_trust(
+            "dashboard:other-session",
+            trust=True,
+            trust_reads=False,
+            patterns=(),
+            signature=sig,
+            issued_at=at,
+        )
+
+    def test_empty_or_nonstring_signature_fails(self, sel_key):
+        for bad in ("", None, 123, b"abc"):
+            assert not trust_sig.verify_trust(
+                HK,
+                trust=True,
+                trust_reads=False,
+                patterns=(),
+                signature=bad,
+                issued_at=int(time.time()),
+            )
+
+    def test_guessed_signature_fails(self, sel_key):
+        assert not trust_sig.verify_trust(
+            HK,
+            trust=True,
+            trust_reads=False,
+            patterns=(),
+            signature="deadbeef" * 8,
+            issued_at=int(time.time()),
+        )
+
+
+class TestFreshnessWindow:
+    """issued_at is inside the MAC and re-checked as a bounded TTL, so a durable
+    grant survives restart only within the window — not forever."""
+
+    def test_recent_grant_verifies(self, sel_key):
+        at = int(time.time()) - 60  # a minute old
+        sig, _ = trust_sig.sign_trust(HK, trust=True, patterns=(), issued_at=at)
+        assert trust_sig.verify_trust(
+            HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+        )
+
+    def test_grant_just_inside_window_verifies(self, sel_key):
+        at = int(time.time()) - (trust_sig._MAX_AGE_SECONDS - 3600)  # 1h short of expiry
+        sig, _ = trust_sig.sign_trust(HK, trust=True, patterns=(), issued_at=at)
+        assert trust_sig.verify_trust(
+            HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+        )
+
+    def test_expired_grant_fails_closed(self, sel_key):
+        at = int(time.time()) - (trust_sig._MAX_AGE_SECONDS + 3600)  # 1h past expiry
+        sig, _ = trust_sig.sign_trust(HK, trust=True, patterns=(), issued_at=at)
+        # Signature is genuine, but the grant is stale → restore nothing.
+        assert not trust_sig.verify_trust(
+            HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+        )
+
+    def test_future_dated_beyond_skew_fails_closed(self, sel_key):
+        at = int(time.time()) + trust_sig._CLOCK_SKEW_SECONDS + 3600
+        sig, _ = trust_sig.sign_trust(HK, trust=True, patterns=(), issued_at=at)
+        assert not trust_sig.verify_trust(
+            HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+        )
+
+    def test_forward_dating_issued_at_without_resigning_fails(self, sel_key):
+        """An agent cannot extend the window by rewriting trust_at alone: the
+        timestamp is inside the MAC, so a bumped value fails verification."""
+        at = int(time.time()) - (trust_sig._MAX_AGE_SECONDS + 3600)  # expired
+        sig, _ = trust_sig.sign_trust(HK, trust=True, patterns=(), issued_at=at)
+        forged_now = int(time.time())  # try to present it as fresh
+        assert not trust_sig.verify_trust(
+            HK,
+            trust=True,
+            trust_reads=False,
+            patterns=(),
+            signature=sig,
+            issued_at=forged_now,
+        )
+
+    def test_malformed_issued_at_fails_closed(self, sel_key):
+        sig, at = trust_sig.sign_trust(HK, trust=True, patterns=())
+        for bad in (None, "1785", 17.5, True, [at]):
+            assert not trust_sig.verify_trust(
+                HK,
+                trust=True,
+                trust_reads=False,
+                patterns=(),
+                signature=sig,
+                issued_at=bad,
+            )
+
+
+class TestNoKey:
+    def test_sign_returns_none_without_key(self, tmp_path):
+        """No SEL key resolvable → sign_trust returns None (caller persists
+        nothing) rather than emitting an unverifiable signature."""
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "absent.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            assert trust_sig.sign_trust(HK, trust=True, trust_reads=False, patterns=()) is None
+
+    def test_short_key_treated_as_absent(self, tmp_path):
+        (tmp_path / "sel_hmac.key").write_bytes(b"\x07" * 16)  # < 32
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "sel_hmac.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            assert trust_sig.sign_trust(HK, trust=True, trust_reads=False, patterns=()) is None
+
+    def test_verify_fails_closed_without_key(self, tmp_path, sel_key):
+        # Sign with a real key...
+        sig, at = trust_sig.sign_trust(HK, trust=True, patterns=())
+        # ...then verify in a process where the key is gone: fail closed.
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "absent.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=None),
+        ):
+            assert not trust_sig.verify_trust(
+                HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+            )
+
+    def test_in_memory_fallback_used_when_file_absent(self, tmp_path):
+        """When the file is unreadable but the live SEL singleton has the key in
+        memory, signing still works (mirrors session_pid_sig recovery)."""
+        with (
+            patch.object(trust_sig, "sel_hmac_key_path", return_value=tmp_path / "absent.key"),
+            patch.object(trust_sig, "_sel_hmac_key_bytes", return_value=b"\x09" * 32),
+        ):
+            sig, at = trust_sig.sign_trust(HK, trust=True, patterns=())
+            assert sig is not None
+            assert trust_sig.verify_trust(
+                HK, trust=True, trust_reads=False, patterns=(), signature=sig, issued_at=at
+            )


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** Backend persistence + rehydrate change only; no rendered UI delta (the trust UI is unchanged — it just survives a restart now).

## Problem / Motivation

When a user clicks "Trust this session" (sets the slot's permission mode to auto), that session-wide grant lives only in memory on the gateway. After a `kirocrew restart`, every reopened conversation has lost it and the user must re-toggle trust on each chat again.

The session-wide grant is defined in-memory in `src/kiro_crew/dashboard/state.py`:

```python
self._trust: bool = False              # session-wide auto-approve for this slot
self._trust_reads: bool = False        # ad-hoc: approve read-only bash for this session
self._trusted_patterns: set[str] = set()  # ad-hoc: per-command fnmatch grants
```

The gateway reconstructs each slot with these reset on restart. This PR persists **only** the explicit session-wide grant (`_trust`); the two ad-hoc, per-prompt grants (`_trust_reads`, `_trusted_patterns`) stay in-memory-only and correctly re-prompt after a restart.

## Why it matters

A per-chat trust grant is correctly scoped to one conversation — but it should also be *durable for that conversation*. Today a routine `kirocrew restart` silently revokes every grant, turning a restart into a re-approve-everything chore across all open chats.

## What changed (motivation → approach → change)

- **Symptom:** the "Trust this session" grant re-prompts on every chat after a restart.
- **Root cause:** the slot's session-wide trust (`_trust`) is in-memory-only state, never written to the session's durable record, so a gateway restart drops it.
- **Change:** persist ONLY the explicit session-wide grant (`_trust`) on the slot's history meta line in `_save_slot_to_history`, and restore it on every rehydrate path — `_rehydrate_slot_from_history` (gateway restart / open-tab restore), `_apply_recent_session` (recent-session restore), and `api_chat_slot_resume` (History resume) — via one shared `_rehydrate_slot_trust` helper. Because `dashboard_*.jsonl` is agent-writable, the grant is **HMAC-signed** (new `src/kiro_crew/dashboard/trust_sig.py`) so a restore can tell a real grant from an agent-forged line. This mirrors `_artifact` / `_channel_folder_filed` round-tripping and the `session_pid_sig.py` signing pattern.

Design decisions (the security surface):
- **Only the explicit toggle persists; ad-hoc approvals do not.** `_trust` is the deliberate session-wide grant — set by the `mode:trust` toggle (`api_chat_mode`) or the card "Trust this session" button, both of which flip the slot's approval policy to auto. That is the grant #6379 is about. The per-prompt approvals — `_trust_reads` ("approve read-only for this session") and `_trusted_patterns` ("trust this command"), each reachable by clicking on a single tool-call card — are **ad-hoc**, in-the-moment reactions, and are **deliberately not persisted**. They re-prompt after a restart, which is the safe default a user expects and directly answers the review concern that ad-hoc trust must not silently survive process shutdown.
- **Authenticated, not just validated.** `dashboard_*.jsonl` is same-uid agent-writable (not on `security._SENSITIVE_HOME_DIRS`), so a bare `trust: true` would be a grant an agent could write for itself — one approved arbitrary write self-escalating into durable blanket trust across a restart. The grant is signed with a **domain-separated subkey derived from the SEL trust root** (`sel_hmac.key`, agent-deny-listed in `security.py`), bound to the session's history key. Rehydrate honors trust **only** when the signature verifies. This takes Design's suggested HMAC inversion.
- **Withheld trust stays withheld (revoke/close cannot resurrect).** `_save_slot_to_history` ends by carrying forward *unowned* metadata from the prior line. The trust keys (`trust`, `trust_reads`, `trusted_patterns`, `trust_sig`, `trust_at`) are all listed in `SLOT_OWNED_META_KEYS` (`src/kiro_crew/history.py`), so a save that omits them — a **revoke** (mode:normal → cleared) or a **close** — erases them instead of copying an old signed grant forward. (`trust_reads`/`trusted_patterns` are never written now, but keeping them owned still guarantees any legacy-written line is cleared on the next save.)
- **Verify after the session binding is restored.** `_rehydrate_slot_trust` runs *after* `slot.linked_session_key` is set in both restore paths, because the signature is bound to the session's history key — which for a channel-origin slot derives from `linked_session_key`. Verifying earlier computed the wrong key and rejected a genuine grant.
- **Fail-closed on restore:** a forged/unsigned/tampered/replayed/expired grant, or an absent/short SEL key, all restore **no trust**.
- The grant stays **keyed to the session it was made in**; a fork/restore into a **new** session key writes its own line and never inherits it (and can't replay another session's signature — the history key is bound into the MAC).
- A session the user **never trusted** writes no trust key and no signature.
- An explicit **CLOSE does not persist trust** — reopening from History re-prompts.
- The session-level approval policy is re-derived from `slot._trust` on the next turn, so restoring the flag is sufficient; no session object is resurrected at restore time.
- **Bounded lifetime — a durable grant is not a permanent one.** The signed payload also binds an `issued_at` timestamp, and `verify_trust` refuses any grant older than a 7-day TTL (or future-dated beyond a small skew). Because `issued_at` is inside the MAC, an agent cannot forward-date it to extend the window without the deny-listed root key. This bounds "survives restart" to a finite window rather than forever. The `trust_at` stamp is written alongside `trust_sig` and is one of the `SLOT_OWNED_META_KEYS`.
- **Residual risk (documented in `trust_sig.py`), bounded not unbounded:** within the TTL window, an agent that retained its own session's earlier signed line could re-write it post-revocation and regain the session-wide grant until the window lapses. The TTL caps how long that can persist; fully closing it needs a non-agent-writable revocation generation folded into the payload — a tracked follow-up. This is strictly narrower than the status quo (today's in-memory grant is likewise re-grantable by the same agent within the session).

## Tests

New `test/test_trust_sig.py` (the sign/verify helper): round-trip, pattern-order-independence, field-flip rejection, pattern-add rejection, cross-session-replay rejection, empty/non-string signature rejection, no-key/short-key → `None` (unsignable), verify fail-closed without key, in-memory-fallback signing. **Freshness window (`TestFreshnessWindow`):** a recent grant and a just-inside-window grant verify; an expired grant, a future-dated grant beyond skew, and a malformed `issued_at` all fail closed; and a genuinely-signed-but-expired grant presented with a forged-fresh `issued_at` still fails (the timestamp is inside the MAC, so it cannot be extended without the root key).

`TestSessionTrustPersistence` in `test/test_session_restore.py` (persistence + auth, keyed on a real SEL key):
- **`test_only_explicit_trust_persisted_not_ad_hoc`** — a trusted slot that also has ad-hoc `_trust_reads` / `_trusted_patterns` in memory persists ONLY `trust` + `trust_sig` (+ `trust_at`); the ad-hoc keys are absent from the line
- an untrusted session writes no trust key / no signature
- rehydrate restores a **signed** trust grant; ad-hoc reads/patterns restore cleared
- **rehydrate rejects** an unsigned/guessed-sig forged grant, a grant with no signature, a signed-then-tampered grant (a mutated `trust_at`), and a cross-session replay
- **`test_rehydrate_ignores_ad_hoc_keys_on_line`** — a line carrying `trust_reads`/`trusted_patterns` (legacy or tampered) restores only `_trust`; the ad-hoc fields are never read
- **`test_rehydrate_rejects_expired_grant`** — a genuinely-signed grant older than the TTL restores no trust (bounded-lifetime end-to-end)
- a fork into a new session key does not inherit trust
- full save → rehydrate round-trip persists `_trust` and drops an ad-hoc pattern (the gateway-restart path)
- **`test_revoke_after_trusted_save_clears_on_restart`** — trusted save → revoke → save asserts the on-disk line drops all trust keys and rehydrate restores none (pins the resurrection fix; would fail without the `SLOT_OWNED_META_KEYS` change)
- **`test_close_after_trusted_save_clears_on_reopen`** — trusted save → close asserts the same, distinct from `test_close_does_not_persist_trust` which closes on the first-ever save

In `test/test_dashboard_chat.py`: `test_close_does_not_persist_trust` clarified + `test_normal_save_persists_trust` (asserts the signature is written). Updated the pre-existing `test_trust_flags_not_restored` → `test_trust_flags_restored` in `test/test_session_restore.py` (it pinned the old drop-on-restart behavior this PR deliberately reverses; now uses a signed grant). In `test/test_sel.py`: added `trust_sig.py` to the sanctioned `_sel_hmac_key_bytes` caller allowlist (the guard test that pins the SEL key's production callers).

All affected-suite tests pass (SEL + session_restore + open_slots: 400; trust/persistence/dashboard-chat + freshness: 56 in the trust-scoped selection); flake8 + mypy + the repo black gate clean on the changed source files.

## Manual verification

N/A — unit coverage exercises the exact save→restart→rehydrate paths (all three rehydrate entry points), plus the revoke/close→save→rehydrate paths, that the user hits.

## Related Issues

Fixes #6379

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A (no doc/spec surface changed; behavior is inline-documented)
- [x] No secrets, credentials, or internal references in the diff