### PR TITLE
fix(tests): make host-isolation floor tests shard-independent

### DIFF
--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -761,40 +761,68 @@ class TestTheWorkingDirectoryIsRestored:
         )
 
 
-_DYNAMIC_CREDENTIAL_ORDER: dict[str, bool] = {}
+# ── driving the floor's own between-test restores ─────────────────────────
 
 
-@pytest.mark.xdist_group(name="dynamic_credential_env_floor")
+def _autouse_floor_generator(name: str):
+    """The plain generator function behind one of the rootdir conftest's autouse fixtures.
+
+    The floor tests below drive one setup -> teardown cycle of the REAL fixture code,
+    which is what lets a SINGLE test observe the restore the floor performs between
+    tests. An injector/observer pair cannot do that reliably: pytest-split partitions
+    the collected suite into shard groups BEFORE xdist runs, so it can place the two
+    halves in different CI shards regardless of any ``xdist_group`` mark, and an
+    observer whose meaning depends on which test ran before it is unprovable in a
+    sharded run.
+
+    Asserts the attribute still IS an autouse fixture on the way through: the floor's
+    guarantee is that it fires around every test, and a fixture demoted to a plain
+    helper (or one whose ``autouse`` was dropped) would still pass a direct drive.
+    """
+    definition = getattr(_root, name)
+    marker = getattr(definition, "_fixture_function_marker", None) or getattr(
+        definition, "_pytestfixturefunction", None
+    )
+    assert marker is not None and marker.autouse, (
+        f"conftest.{name} is not an autouse fixture, so the floor it implements is unarmed"
+    )
+    return getattr(definition, "__wrapped__", definition)
+
+
 class TestDynamicCredentialEnvironmentIsRestored:
     """A dynamic per-host Jira token must not leak to the next test.
 
-    ``load_credentials`` propagates ``JIRA_TOKEN_<HEX>`` keys even though they
-    are not members of the fixed ``_CREDENTIAL_KEYS`` tuple. Keep these tests
-    adjacent on one worker so the second observes the first test's teardown.
+    ``load_credentials`` propagates ``JIRA_TOKEN_<HEX>`` keys even though they are
+    not members of the fixed ``_CREDENTIAL_KEYS`` tuple, so the floor's restore has
+    to recognise the dynamic shape too — a snapshot bounded to the fixed keys would
+    pass over it. The restore under test is ``conftest._no_credential_env_residue``'s
+    own teardown, driven directly (see ``_autouse_floor_generator``).
     """
 
-    def test_a_test_can_inject_a_dynamic_jira_token(self) -> None:
-        os.environ["JIRA_TOKEN_AABBCC"] = "token-from-previous-test"
-        _DYNAMIC_CREDENTIAL_ORDER["injected"] = True
+    def test_this_test_starts_without_the_dynamic_token(self) -> None:
+        """Which is only true if no earlier test on this worker leaked one."""
+        assert "JIRA_TOKEN_AABBCC" not in os.environ
 
-    def test_the_next_test_does_not_inherit_the_dynamic_token(self) -> None:
-        assert _DYNAMIC_CREDENTIAL_ORDER.get("injected"), (
-            "the injecting test did not run on this worker, so this assertion "
-            "would prove nothing"
-        )
+    def test_an_injected_dynamic_token_is_removed_by_the_floors_own_teardown(self) -> None:
+        """One full cycle of the real fixture: snapshot while absent, inject, restore.
+
+        A failure part-way cannot leak the token past this test: the live autouse
+        instance of the same fixture wraps this test too, and its snapshot predates
+        the injection.
+        """
+        cycle = _autouse_floor_generator("_no_credential_env_residue")()
+        next(cycle)  # the floor's setup: snapshot, taken while the token is absent
+
+        os.environ["JIRA_TOKEN_AABBCC"] = "token-from-this-test"
+
+        with pytest.raises(StopIteration):
+            next(cycle)  # the floor's teardown: the restore under test
         assert "JIRA_TOKEN_AABBCC" not in os.environ
 
 
 # ── the logging record factory ─────────────────────────────────────────────
 
 
-#: Written by one test and asserted by the next, for the same reason as ``_CWD_ORDER``:
-#: the restore this pins runs during teardown, so no finalizer of the leaking test can
-#: observe it -- the rootdir floor is the OUTER fixture and finalizes after them all.
-_FACTORY_ORDER: dict[str, object] = {}
-
-
-@pytest.mark.xdist_group(name="log_record_factory_floor")
 class TestTheLogRecordFactoryIsRestored:
     """``logging.setLogRecordFactory`` is ONE process-global slot, per worker.
 
@@ -804,45 +832,68 @@ class TestTheLogRecordFactoryIsRestored:
     different process and the pollution is invisible until an unsharded release run.
     ``conftest._restore_log_record_factory`` is what removes the class; without a test,
     an edit to it reverts silently and the failures reappear in files that have nothing
-    to do with the cause.
-
-    Grouped with ``xdist_group`` so the leaker and the observer stay on ONE worker:
-    ``--dist loadgroup`` honours that, and without it the two are distributed
-    independently and the observation passes vacuously.
+    to do with the cause. Its teardown is driven directly (see
+    ``_autouse_floor_generator``), so the proof needs no adjacent observer test.
     """
 
     def test_this_test_starts_with_the_stdlib_factory(self) -> None:
         """Which is only true if no earlier test on this worker left a wrapper installed."""
         assert logging.getLogRecordFactory() is logging.LogRecord
 
-    def test_a_leaked_wrapper_does_not_reach_the_next_test(self) -> None:
-        """Installs one and deliberately does NOT remove it -- the floor's job, not ours."""
+    def test_a_leaked_wrapper_is_removed_by_the_floors_own_teardown(self) -> None:
+        """One full cycle of the real fixture: snapshot, install and leave installed, restore.
+
+        The install is exactly the leak the floor absorbs in the wild — a test driving
+        the real ``cli.main()`` reaches ``_setup_cli_logging``, which installs this
+        wrapper and never removes it. A failure part-way cannot leak the wrapper past
+        this test: the live autouse instance of the same fixture wraps this test too,
+        and its snapshot predates the install.
+        """
+        cycle = _autouse_floor_generator("_restore_log_record_factory")()
+        next(cycle)  # the floor's setup: snapshot, taken while the stdlib factory holds
+
         install_log_redaction([])
-        _FACTORY_ORDER["installed"] = logging.getLogRecordFactory()
         assert logging.getLogRecordFactory() is not logging.LogRecord
 
-    def test_the_next_test_sees_the_slot_restored(self) -> None:
-        """Reads what the previous test recorded. Ordered by definition order in the file."""
-        assert _FACTORY_ORDER.get("installed") is not None, (
-            "the installing test did not run on this worker, so this assertion proves "
-            "nothing -- the xdist_group mark on the class is what keeps them together"
-        )
+        with pytest.raises(StopIteration):
+            next(cycle)  # the floor's teardown: the restore under test
         assert logging.getLogRecordFactory() is logging.LogRecord, (
             f"the record factory is still {logging.getLogRecordFactory()!r} -- a wrapper "
-            "left installed by an earlier test now rewrites every record on this worker"
+            "left installed by a test would rewrite every later record on its worker"
         )
+
+    def test_the_restore_target_is_what_the_test_inherited_not_the_stdlib(self) -> None:
+        """The floor restores the INHERITED factory, so a higher-scoped installer survives.
+
+        Pinned because it is the documented reason the floor is a fixture rather than a
+        ``pytest_runtest_setup`` hookimpl: a class- or module-scoped fixture that installs
+        a factory for its whole scope must not have it torn out after the first test.
+        """
+        sentinel_calls: list[str] = []
+
+        def sentinel(*args: object, **kwargs: object) -> logging.LogRecord:
+            sentinel_calls.append("made")
+            return logging.LogRecord(*args, **kwargs)  # type: ignore[arg-type]
+
+        before = logging.getLogRecordFactory()
+        logging.setLogRecordFactory(sentinel)
+        try:
+            cycle = _autouse_floor_generator("_restore_log_record_factory")()
+            next(cycle)  # snapshot taken while the sentinel is installed
+            install_log_redaction([])
+            with pytest.raises(StopIteration):
+                next(cycle)
+            assert logging.getLogRecordFactory() is sentinel, (
+                "the floor restored past the factory this cycle inherited, so a "
+                "higher-scoped installer would be torn out after its first test"
+            )
+        finally:
+            logging.setLogRecordFactory(before)
 
 
 # ── logger levels ──────────────────────────────────────────────────────────
 
 
-#: Written by the leaking test and read by the one after it, for the same reason as
-#: ``_FACTORY_ORDER``: the restore this pins runs in teardown, after every finalizer the
-#: leaking test itself could own.
-_LOGGER_ORDER: dict[str, object] = {}
-
-
-@pytest.mark.xdist_group(name="logger_level_floor")
 class TestLoggerLevelsAreRestored:
     """A logger's level is PROCESS-GLOBAL, per worker, and HIERARCHICAL.
 
@@ -856,34 +907,59 @@ class TestLoggerLevelsAreRestored:
 
     ``conftest._restore_logger_levels`` is what removes the class; without a test, an edit
     to it reverts silently and the failures reappear in files that have nothing to do with
-    the cause.
-
-    Grouped with ``xdist_group`` so the leaker and the observer stay on ONE worker:
-    ``--dist loadgroup`` honours that, and without it the two are distributed
-    independently and the observation passes vacuously.
+    the cause. Its teardown is driven directly (see ``_autouse_floor_generator``), so the
+    proof needs no adjacent observer test.
     """
 
     def test_this_test_starts_with_an_unconfigured_kiro_crew_logger(self) -> None:
         """Which is only true if no earlier test on this worker left a level on it."""
         assert logging.getLogger("kiro_crew").level == logging.NOTSET
 
-    def test_a_leaked_level_does_not_reach_the_next_test(self) -> None:
-        """Leaks one and deliberately restores nothing -- the floor's job, not ours."""
+    def test_a_leaked_level_is_removed_by_the_floors_own_teardown(self) -> None:
+        """One full cycle of the real fixture: snapshot, pin a level and leave it, restore.
+
+        The pin is exactly the leak the floor absorbs in the wild — ``_setup_cli_logging``
+        sets ``kiro_crew`` to WARNING once per process and never undoes it. A failure
+        part-way cannot leak the level past this test: the live autouse instance of the
+        same fixture wraps this test too, and its snapshot predates the pin.
+        """
+        cycle = _autouse_floor_generator("_restore_logger_levels")()
+        next(cycle)  # the floor's setup: snapshot, taken while the level is NOTSET
+
         logging.getLogger("kiro_crew").setLevel(logging.WARNING)
-        _LOGGER_ORDER["leaked"] = True
         assert logging.getLogger("kiro_crew").level == logging.WARNING
 
-    def test_the_next_test_sees_the_level_gone(self) -> None:
-        """Reads what the previous test recorded. Ordered by definition order in the file."""
-        assert _LOGGER_ORDER.get("leaked"), (
-            "the leaking test did not run on this worker, so this assertion proves "
-            "nothing -- the xdist_group mark on the class is what keeps them together"
-        )
+        with pytest.raises(StopIteration):
+            next(cycle)  # the floor's teardown: the restore under test
         level = logging.getLogger("kiro_crew").level
         assert level == logging.NOTSET, (
             f"kiro_crew is still pinned at {logging.getLevelName(level)} -- every "
-            "kiro_crew.* record below that level is now dropped before it reaches the "
-            "root handler caplog captures through"
+            "kiro_crew.* record below that level would be dropped before it reaches "
+            "the root handler caplog captures through"
+        )
+
+    def test_a_logger_created_during_the_test_is_restored_to_pristine(self) -> None:
+        """The gap a plain snapshot cannot see: a logger that did not exist at setup.
+
+        The floor restores a name missing from its "before" snapshot to the pristine
+        ``(NOTSET, enabled)`` state rather than passing over it, and this is the only
+        place that behaviour is exercised with a genuinely fresh name.
+        """
+        name = "kiro_crew._floor_probe_6351"
+        assert name not in logging.Logger.manager.loggerDict
+
+        cycle = _autouse_floor_generator("_restore_logger_levels")()
+        next(cycle)  # snapshot taken while the logger does not exist
+
+        probe = logging.getLogger(name)
+        probe.setLevel(logging.CRITICAL)
+        probe.disabled = True
+
+        with pytest.raises(StopIteration):
+            next(cycle)
+        assert probe.level == logging.NOTSET and probe.disabled is False, (
+            "a logger created mid-test kept its configuration -- the floor's "
+            "missing-from-snapshot branch no longer restores to pristine"
         )
 
     def test_a_debug_record_from_a_kiro_crew_logger_still_reaches_caplog(self, caplog) -> None:


### PR DESCRIPTION
## Problem / Motivation

Three test classes in `test/test_host_isolation_floor.py` were split into injector/observer pairs held together by `@pytest.mark.xdist_group`, with the observer carrying a self-nullifying guard that hard-FAILS (not skips) when the injecting test did not run first on its worker. The mark is insufficient in CI: pytest-split partitions the collected suite into shard groups BEFORE xdist runs, so it can place the injector in shard N and the observer in shard N+1 — at which point the guard fires deterministically and reds the shard. Observed on PR #5670, a frontend-only diff, where Backend Tests (3.10, 3) and (3.12, 3) plus the downstream Coverage Gate failed on the guard. The shard boundary is a function of the collected-test count (361 files on the reduced backend path vs 1741 for the full suite), so it moves unpredictably with unrelated diffs.

## Why it matters

Any PR can go red on tests its diff cannot have touched, purely because its collected-test count moved a shard boundary. That erodes trust in CI reds, burns triage time on phantom failures, and blocks unrelated work (a frontend-only PR was blocked by a backend isolation-floor guard).

## What changed (motivation → approach → change)

Symptom: cross-shard guard failures. Root cause: the observer tests' meaning depended on WHICH test ran before them on the worker — an adjacency no partitioning strategy guarantees. Fix (the issue's option 1): remove the adjacency requirement entirely by making each pair ONE self-contained test.

The observer's real subject is the *teardown* of the rootdir conftest's autouse isolation fixture. A new helper, `_autouse_floor_generator`, resolves the REAL fixture's underlying generator function (asserting on the way through that it still IS an autouse fixture, so a demoted floor cannot pass a direct drive) and each merged test drives one full setup → inject → teardown cycle of that real code within its own scope, then asserts the restoration:

- `TestDynamicCredentialEnvironmentIsRestored` — drives `_no_credential_env_residue`; injects a dynamic `JIRA_TOKEN_<HEX>` key and asserts the teardown removes it.
- `TestTheLogRecordFactoryIsRestored` — drives `_restore_log_record_factory`; installs the redaction wrapper (the exact leak the floor absorbs in the wild) and asserts the stdlib factory is restored. A new test also pins that the floor restores the INHERITED factory, not unconditionally the stdlib one, so a higher-scoped installer survives.
- `TestLoggerLevelsAreRestored` — drives `_restore_logger_levels`; pins a level, asserts NOTSET is restored. A new test pins the missing-from-snapshot branch: a logger created mid-test is restored to pristine `(NOTSET, enabled)`.

The module-level cross-test dicts (`_DYNAMIC_CREDENTIAL_ORDER`, `_FACTORY_ORDER`, `_LOGGER_ORDER`), the self-nullifying guards, and the now-purposeless `@pytest.mark.xdist_group` marks are deleted. A mid-test failure cannot leak state past a merged test: the live autouse instance of the same fixture wraps the test too, and its snapshot predates the injection.

Assertion substance is preserved or strengthened: every restoration the old observers proved is still proven, plus the two new invariant pins above.

**Follow-up scope (per the issue's sweep suggestion):** one adjacency-dependent pair remains in this file — `_CWD_ORDER` in `TestTheWorkingDirectoryIsRestored`. It is deliberately NOT in this PR: its observer has no hard guard (it passes vacuously when split across shards, so it cannot red a PR — it merely proves nothing), and its subject is `tryfirst pytest_runtest_teardown` hookimpl ordering relative to fixture finalizers, which genuinely runs only at pytest's between-test boundary and cannot be driven as a fixture generator. No other cross-test module-state pairs were found in the suite (`test/test_api_agents_order.py` and `test/metrics/test_context_blocks.py` use `_ORDER` constants, not cross-test channels).

## Tests

This PR is entirely tests. What each merged/added test locks in:
- `test_an_injected_dynamic_token_is_removed_by_the_floors_own_teardown` — the credential floor's restore recognises dynamic `JIRA_TOKEN_<HEX>` keys outside the fixed `_CREDENTIAL_KEYS` tuple.
- `test_a_leaked_wrapper_is_removed_by_the_floors_own_teardown` — the record-factory floor removes a wrapper a test left installed.
- `test_the_restore_target_is_what_the_test_inherited_not_the_stdlib` — NEW: the floor restores the inherited factory, the documented reason it is a fixture rather than a hookimpl.
- `test_a_leaked_level_is_removed_by_the_floors_own_teardown` — the logger-level floor restores a pinned level to NOTSET.
- `test_a_logger_created_during_the_test_is_restored_to_pristine` — NEW: the floor's missing-from-snapshot branch restores a mid-test-created logger to pristine.
- Each class keeps its `test_this_test_starts_...` canary, and `_autouse_floor_generator` asserts the fixture is still autouse, so a demoted floor fails loudly.

Verified: `pytest test/test_host_isolation_floor.py` — the 9 tests in the three changed classes pass; `--collect-only` collects 69 tests; the string "did not run on this worker" no longer appears in the file; full backend suite run locally (66,553 passed; the 83 failures are the known host-environment set, reproduced identically on pristine main, none in the changed classes).

## Manual verification

N/A — unit coverage sufficient: the change is test-only and the merged tests exercise the real conftest fixture generators directly.

## Related Issues

Fixes #6351

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
