### PR TITLE
refactor(dashboard): extract shared malformed-entry preservation helper across sibling stores

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -7304,15 +7304,9 @@ class DashboardState:
                         and not isinstance(f.get("order"), bool)
                     )
 
-                valid = [f for f in loaded if _is_valid(f)]
-                unparsed = [f for f in loaded if not _is_valid(f)]
-                if unparsed:
-                    logger.warning(
-                        "Preserving %d malformed entr(ies) while loading %s "
-                        "(kept verbatim, not active)",
-                        len(unparsed),
-                        self._CRON_FOLDERS_FILE,
-                    )
+                valid, unparsed = self._partition_preserving(
+                    loaded, _is_valid, "entr(ies)", self._CRON_FOLDERS_FILE
+                )
                 self._cron_folders = valid
                 self._unparsed_cron_folder_entries = unparsed
         except Exception:
@@ -7489,14 +7483,9 @@ class DashboardState:
                 and bool(pin.get("pinned_at"))
             )
 
-        valid = [pin for pin in raw if _is_valid(pin)]
-        unparsed = [pin for pin in raw if not _is_valid(pin)]
-        if unparsed:
-            logger.warning(
-                "Preserving %d malformed chat pin record(s) while loading "
-                "chat_pins.json (kept verbatim, not active)",
-                len(unparsed),
-            )
+        valid, unparsed = self._partition_preserving(
+            raw, _is_valid, "chat pin record(s)", self._CHAT_PINS_FILE
+        )
         self._chat_pins = valid
         self._unparsed_chat_pin_entries = unparsed
 
@@ -7666,18 +7655,16 @@ class DashboardState:
             if file_existed:
                 raw = json.loads(tags_path.read_text(encoding="utf-8"))
                 if isinstance(raw, list):
-                    self._tags = [t for t in raw if isinstance(t, dict) and t.get("id")]
                     # Keep rows the active list dropped verbatim so the seed/
                     # back-fill save below (and every later save) round-trips
                     # them back instead of erasing a hand-edited-but-typo'd row
                     # at boot with no user action (#5792).
-                    unparsed = [t for t in raw if not (isinstance(t, dict) and t.get("id"))]
-                    if unparsed:
-                        logger.warning(
-                            "Preserving %d malformed tag entr(ies) while loading "
-                            "tags.json (kept verbatim, not active)",
-                            len(unparsed),
-                        )
+                    self._tags, unparsed = self._partition_preserving(
+                        raw,
+                        lambda t: isinstance(t, dict) and bool(t.get("id")),
+                        "tag entr(ies)",
+                        self._TAGS_FILE,
+                    )
                     self._unparsed_tag_entries = unparsed
                 else:
                     # Valid JSON but not a list (e.g. {}): the vocabulary
@@ -7717,17 +7704,15 @@ class DashboardState:
             if columns_path.exists():
                 raw = json.loads(columns_path.read_text(encoding="utf-8"))
                 if isinstance(raw, list):
-                    self._tag_boards = [c for c in raw if isinstance(c, dict) and c.get("id")]
                     # Preserve dropped columns verbatim so a later save
                     # round-trips them rather than erasing a hand-edited-but-
                     # typo'd column (#5792).
-                    unparsed_cols = [c for c in raw if not (isinstance(c, dict) and c.get("id"))]
-                    if unparsed_cols:
-                        logger.warning(
-                            "Preserving %d malformed sidebar column(s) while "
-                            "loading tag_boards.json (kept verbatim, not active)",
-                            len(unparsed_cols),
-                        )
+                    self._tag_boards, unparsed_cols = self._partition_preserving(
+                        raw,
+                        lambda c: isinstance(c, dict) and bool(c.get("id")),
+                        "sidebar column(s)",
+                        self._TAG_BOARDS_FILE,
+                    )
                     self._unparsed_tag_board_entries = unparsed_cols
                     # Prune column tag_ids missing from the vocabulary: tag
                     # deletion commits the vocab write first (crash-atomic),
@@ -7784,7 +7769,8 @@ class DashboardState:
         """
         unparsed = getattr(self, "_unparsed_tag_board_entries", [])
         self._atomic_write_json(
-            config_dir() / self._TAG_BOARDS_FILE, [*self._tag_boards, *unparsed]
+            config_dir() / self._TAG_BOARDS_FILE,
+            [*self._tag_boards, *unparsed],
         )
 
     def save_tag_boards_snapshot(self, snapshot: list[dict]) -> None:
@@ -7805,6 +7791,42 @@ class DashboardState:
         """
         unparsed = getattr(self, "_unparsed_tag_board_entries", [])
         self._atomic_write_json_strict(config_dir() / self._TAG_BOARDS_FILE, [*snapshot, *unparsed])
+
+    @staticmethod
+    def _partition_preserving(
+        raw: list[Any],
+        predicate: Callable[[Any], bool],
+        noun: str,
+        source_file: str,
+    ) -> tuple[list[Any], list[Any]]:
+        """Split ``raw`` into ``(active, unparsed)`` by ``predicate``.
+
+        The shared "partition malformed rows at load, keep them verbatim so a
+        later save round-trips them back" mechanic behind ``load_cron_folders``,
+        ``load_chat_pins``, ``load_tags`` and the tag-board load (all #5792).
+        A row is active when ``predicate`` returns truthy; every other row is
+        collected into ``unparsed`` so the caller's save path can re-append it
+        (``[*active, *unparsed]``) at write time rather than silently erasing
+        bytes a hand-edit left in a shape the loader could not validate.
+
+        When any row is preserved, logs the shared preserving-N warning at
+        WARNING level. ``noun`` supplies the per-store wording (``"entr(ies)"``,
+        ``"chat pin record(s)"``, ``"tag entr(ies)"``, ``"sidebar column(s)"``)
+        and ``source_file`` names the file, so the emitted messages stay
+        identical to the hand-rolled copies this replaced.
+        """
+        active: list[Any] = []
+        unparsed: list[Any] = []
+        for row in raw:
+            (active if predicate(row) else unparsed).append(row)
+        if unparsed:
+            logger.warning(
+                "Preserving %d malformed %s while loading %s " "(kept verbatim, not active)",
+                len(unparsed),
+                noun,
+                source_file,
+            )
+        return active, unparsed
 
     @staticmethod
     def _atomic_write_json_strict(path: Path, data: Any) -> None:

--- a/test/test_state_store_preservation.py
+++ b/test/test_state_store_preservation.py
@@ -260,3 +260,61 @@ class TestTagBoardsPreservation:
         st.save_tag_boards()
         on_disk = json.loads(path.read_text(encoding="utf-8"))
         assert [c["id"] for c in on_disk] == ["c1"]
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers (#6326) — the partition/append mechanics all four stores share
+# --------------------------------------------------------------------------- #
+class TestPartitionPreserving:
+    """Direct coverage of the extracted ``_partition_preserving`` helper.
+
+    The four stores keep their own predicates; this asserts the shared
+    mechanics: order-preserving split into (active, unparsed), and a single
+    preserving-N warning emitted only when a row is dropped.
+    """
+
+    def test_splits_preserving_order(self):
+        raw = [{"id": "a"}, "bad", {"id": "b"}, {"no": "id"}]
+        active, unparsed = DashboardState._partition_preserving(
+            raw,
+            lambda r: isinstance(r, dict) and bool(r.get("id")),
+            "entr(ies)",
+            "tags.json",
+        )
+        assert active == [{"id": "a"}, {"id": "b"}]
+        assert unparsed == ["bad", {"no": "id"}]
+
+    def test_all_valid_produces_no_unparsed_and_no_warning(self, caplog):
+        raw = [{"id": "a"}, {"id": "b"}]
+        with caplog.at_level("WARNING", logger="kiro_crew.dashboard.state"):
+            active, unparsed = DashboardState._partition_preserving(
+                raw, lambda r: bool(r.get("id")), "entr(ies)", "tags.json"
+            )
+        assert active == raw
+        assert unparsed == []
+        assert not [r for r in caplog.records if "Preserving" in r.message]
+
+    def test_warns_once_with_count_noun_and_file(self, caplog):
+        raw = ["x", {"id": "ok"}, "y"]
+        with caplog.at_level("WARNING", logger="kiro_crew.dashboard.state"):
+            _, unparsed = DashboardState._partition_preserving(
+                raw,
+                lambda r: isinstance(r, dict) and bool(r.get("id")),
+                "chat pin record(s)",
+                "chat_pins.json",
+            )
+        assert unparsed == ["x", "y"]
+        warnings = [r.message for r in caplog.records if "Preserving" in r.message]
+        assert len(warnings) == 1
+        assert (
+            "Preserving 2 malformed chat pin record(s) while loading chat_pins.json" in warnings[0]
+        )
+
+    def test_empty_input_is_noop(self, caplog):
+        with caplog.at_level("WARNING", logger="kiro_crew.dashboard.state"):
+            active, unparsed = DashboardState._partition_preserving(
+                [], lambda r: True, "entr(ies)", "tags.json"
+            )
+        assert active == []
+        assert unparsed == []
+        assert not [r for r in caplog.records if "Preserving" in r.message]


### PR DESCRIPTION
Fixes #6326

## Problem / Motivation

After #6275 landed, `src/kiro_crew/dashboard/state.py` carried **four** hand-rolled copies of the same "partition malformed rows at load" step across its preservation stores:

- `load_cron_folders` (#5768)
- `load_chat_pins` (#5792)
- `load_tags` (#5792)
- the tag-board load (#5792)

Each independently filtered `raw` into an active list + an `_unparsed_*` list by a per-store predicate and logged a near-identical "Preserving N malformed" warning. Design Review on #6275 flagged this duplication and noted small drifts had already appeared between the copies.

## Why it matters

Four copies of the same partition-and-warn step drift under copy-paste (the #6275 review already saw it start). Pinning that step in one helper removes the drift surface and gives the whole-file/parse-error contract a single future edit point for these four stores.

Scope note: a **fifth** preservation store, `ScriptHookStore` in `src/kiro_crew/hooks.py`, runs the same preserve-and-reappend intent but with a genuinely different partition mechanism (per-entry `try/except` rather than a predicate over a parsed list), so it cannot share this helper and is intentionally out of scope. This PR converges the four list-predicate stores, not all five.

## What changed

Extracted one shared helper on `DashboardState` and converged the four list-predicate load paths onto it:

```
_partition_preserving(raw, predicate, noun, source_file) -> (active, unparsed)
    # order-preserving split by predicate; logs the shared preserving-N warning
```

- **Four load paths** (`load_cron_folders`, `load_chat_pins`, the `tags` vocab load, the tag-board load) now call `_partition_preserving`.
- **Per-store predicates stay local** — they genuinely differ (pins need id+slot_key+identity+preview+pinned_at; tags/boards need id; cron folders need id+name+order). Only the partition mechanics and the warning are shared.
- **The warning text is byte-identical** — `noun` (`"entr(ies)"` / `"chat pin record(s)"` / `"tag entr(ies)"` / `"sidebar column(s)"`) and the file name are the only parameters, and the file constants already equal the previously-hardcoded filenames.
- **The write side keeps its inline `[*active, *unparsed]` spreads.** The first revision also extracted an `_append_unparsed` wrapper for the six save paths; First Principles review correctly observed that is a named alias for a one-expression language builtin whose "single edit point" value a fifth divergent store already undercuts, so it was dropped — the six spreads stay inline. The duplication and drift that justified extraction lived entirely in the load/partition step.
- **`load_folders` is deliberately NOT folded in.** Its #5768 docstring argues a folder row with no usable id can never be the row a request addresses, so its drop-and-log contract is correct; it is intentionally not a preservation store.

Behavior-preserving refactor: no store's observable load/save behavior changes.

## Tests

- **All existing preservation tests pass unchanged** — `test_state_store_preservation.py`, `test_dashboard_chat_pins.py`, `test_chat_tags.py`, `test_cron_load_malformed_entry.py`, `test_tag_session.py` — which is the proof the extraction is mechanical.
- **Added direct unit coverage** for `_partition_preserving` in `test_state_store_preservation.py` (`TestPartitionPreserving` × 4): order-preserving split, no-warning-when-all-valid, single-warning-with-count/noun/file, empty-input no-op.
- Local gates green: `pytest` (touched suites), `black` (baselined gate, py310), `isort`, `flake8`, `mypy src/kiro_crew/dashboard/state.py`.

## Manual verification

Backend-only change verified via the test suites above. The four stores' load/save round-trips (malformed row preserved through an unrelated write) are covered by `test_state_store_preservation.py`, which passes unchanged against the refactored code.

## Contribution License Agreement

<!-- Leave this section as-is; the maintainer CLA check populates it. -->
