### PR TITLE
fix(chat): fold reasoning-only turns so bursts do not duplicate as rows

### DIFF
--- a/website/src/pages/chat/groupDisplayItems.ts
+++ b/website/src/pages/chat/groupDisplayItems.ts
@@ -81,8 +81,28 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
       (t.kind === 'single' && (t.msg.role === 'tool' || t.msg.role === 'assistant' || t.msg.role === 'streaming')) ||
       t.kind === 'group'
     )
+  // A batch that carries TWO OR MORE content-bearing reasoning bursts must be
+  // wrapped as a {kind:'turn'}, even when it has no tool/assistant "working
+  // steps" and even when it is short. The per-turn reasoning-burst dedup
+  // (mergeTurnThinking in TurnBlock) — which folds a turn's many `thinking`
+  // bursts into ONE row hoisted above the answer — runs ONLY on {kind:'turn'}
+  // items. Left as loose singles (the else branch), each burst renders as its
+  // own standalone "Thought process" row via ChatPage's renderMessage,
+  // bypassing the dedup entirely: the duplicate-row wall of #6376. This bites a
+  // reasoning-only trailing turn (a monitor/nudge cycle that has only emitted
+  // reasoning so far) and any turn whose reasoning bursts land as a short/
+  // answerless batch — and it became common because finer-grained models (e.g.
+  // claude-opus-5) emit many small bursts per turn. The threshold is TWO: a
+  // single burst renders as exactly one row whether loose or wrapped (nothing
+  // to dedup), so wrapping it would only re-home it needlessly. `thinking` is
+  // deliberately NOT counted in hasWorkingSteps (it is a reasoning trace, not a
+  // working step that gates the "Worked through N steps" collapse), so this is
+  // a separate predicate. Empty placeholder bursts do not count (they render
+  // nothing, and mergeTurnThinking ignores them too).
+  const contentThinkingCount = (items: TurnItem[]) =>
+    items.reduce((n, t) => n + (t.kind === 'single' && t.msg.role === 'thinking' && t.msg.content ? 1 : 0), 0)
   const flushTurn = (items: TurnItem[], complete: boolean) => {
-    if (hasWorkingSteps(items) && items.length > 2) {
+    if ((hasWorkingSteps(items) && items.length > 2) || contentThinkingCount(items) >= 2) {
       turns.push({ kind: 'turn', items, complete })
     } else {
       turns.push(...items)

--- a/website/src/test/groupDisplayItems.test.ts
+++ b/website/src/test/groupDisplayItems.test.ts
@@ -134,6 +134,58 @@ describe('groupDisplayItems', () => {
     const { turns } = groupDisplayItems([msg('user', 'a'), msg('user', 'b'), msg('user', 'c')])
     expect(turns.filter(isTurn)).toHaveLength(0)
   })
+
+  // #6376: two or more reasoning bursts must be wrapped as a {kind:'turn'} so
+  // TurnBlock's mergeTurnThinking can fold them into ONE "Thought process" row.
+  // Left as loose singles, each burst renders as its own duplicate row.
+  it('wraps a reasoning-only trailing turn into a collapsible turn (no answer/tool yet)', () => {
+    // A monitor/nudge cycle that has only emitted reasoning so far: no tool or
+    // assistant row, so hasWorkingSteps is false — but the bursts must still be
+    // grouped for the dedup, not spread as N loose "Thought process" rows.
+    const { turns, trailingTurnIdx } = groupDisplayItems([
+      msg('nudge', 'keep going'),
+      msg('thinking', 'burst 1'),
+      msg('thinking', 'burst 2'),
+      msg('thinking', 'burst 3'),
+    ])
+    const turnObjs = turns.filter(isTurn)
+    expect(turnObjs).toHaveLength(1)
+    expect(turnObjs[0].items).toHaveLength(3)
+    // The reasoning-only turn is the trailing turn, so the running state can
+    // land on it.
+    expect(trailingTurnIdx).toBeGreaterThanOrEqual(0)
+  })
+
+  it('wraps a two-burst reasoning-only batch that the working-steps rule would NOT catch', () => {
+    // Two reasoning bursts, no tool/assistant row: hasWorkingSteps is false and
+    // there are only 2 items, so the `hasWorkingSteps && length > 2` clause
+    // does NOT fire — this batch wraps ONLY on the burst-count rule, so the test
+    // fails if that rule is removed or its threshold raised (a real
+    // discriminator, unlike a batch that already carries an assistant).
+    const { turns } = groupDisplayItems([
+      msg('thinking', 'first thought'),
+      msg('thinking', 'second thought'),
+    ])
+    expect(turns.filter(isTurn)).toHaveLength(1)
+  })
+
+  it('leaves a SINGLE reasoning burst loose (nothing to dedup)', () => {
+    // One burst renders as exactly one row whether loose or wrapped, so it must
+    // not synthesize a turn — that would needlessly re-home a lone reasoning row
+    // (and regress ChatPage's renderMessage dispatch).
+    const { turns } = groupDisplayItems([msg('thinking', 'just one'), msg('assistant', 'answer')])
+    expect(turns.filter(isTurn)).toHaveLength(0)
+  })
+
+  it('does NOT count empty (placeholder) thinking rows toward the wrap threshold', () => {
+    // A bare "Thinking…" placeholder carries no content; two of them (or one
+    // content burst + a placeholder) must not synthesize a turn — mirrors
+    // mergeTurnThinking, which ignores empty bursts.
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'), msg('thinking', 'one real'), msg('thinking', ''),
+    ])
+    expect(turns.filter(isTurn)).toHaveLength(0)
+  })
 })
 
 describe('applyRunningState', () => {


### PR DESCRIPTION
## Problem / Motivation

A reasoning-heavy agent turn renders a **wall of duplicate collapsed "Thought process" rows** — one per reasoning burst — instead of the single merged reasoning row the UI is designed to show. The duplicates also render in the wrong place: **below** the assistant answer and the `model · credits · duration` footer, rather than hoisted above the answer. Reported in #6376 (five identical "Thought process ›" rows stacked under a `claude-opus-5` turn).

## Why it matters

The frontend already has `mergeTurnThinking()` (in `TurnBlock.tsx`) whose entire job is to fold a turn's reasoning bursts into ONE row hoisted to the turn top — its docstring explicitly calls out preventing "a WALL of a dozen-plus collapsed 'Thought process' rows". This bug is that dedup silently not applying, so the transcript is cluttered and reasoning is misplaced after the answer. It became common with finer-grained models (`claude-opus-5`) that emit many small reasoning bursts per turn, so it is increasingly visible on everyday turns.

## What changed (motivation → approach → change)

**Symptom:** N duplicate "Thought process" rows below the answer/footer.

**Root cause:** the reasoning-burst dedup lives only inside `TurnBlock`, and reasoning-only batches never reach it. `mergeTurnThinking()` runs only for display items of `kind: 'turn'` (mounted at `ChatPage.tsx` ~7283). A standalone `thinking` message otherwise renders as its own `<ThinkingBlock>` via `renderMessage` (`ChatPage.tsx` ~6278 / loose-single ~7331), one row per message, no dedup. `groupDisplayItems()` wraps a batch into a `{kind:'turn'}` object only when `hasWorkingSteps(items) && items.length > 2`, and `hasWorkingSteps()` counts only `tool`/`assistant`/`streaming`/group roles — `thinking` is deliberately excluded (it is a reasoning trace, not a "working step" that should gate the "Worked through N steps" collapse). So a batch of ≥2 reasoning bursts with no tool/assistant row (a monitor/nudge cycle that has only reasoned so far, or bursts that reload at the tail below the answer after the `chat_done` refresh) hits the `else` branch `turns.push(...items)` and spreads as loose `thinking` singles — each bypassing the dedup.

**Change:** in `groupDisplayItems()`, also wrap a batch that carries **two or more content-bearing reasoning bursts** as a `{kind:'turn'}`, so `mergeTurnThinking` runs and folds them into one row. The threshold is two because a single burst renders as exactly one row whether loose or wrapped (nothing to dedup), so it stays loose — no needless re-homing, and the existing `renderMessage` single-thinking dispatch is unaffected. Empty placeholder bursts do not count (they render nothing, mirroring `mergeTurnThinking`, which ignores them). `hasWorkingSteps` is left untouched; the reasoning check is a separate predicate.

## Tests

`website/src/test/groupDisplayItems.test.ts`:
- **reasoning-only trailing turn** (`[nudge, thinking×3]`) wraps into one collapsible turn and is the trailing turn (so the running state can land on it) — a real discriminator: on the base branch `hasWorkingSteps` is false, so the old clause never wraps it.
- **two-burst reasoning-only batch** (`[thinking, thinking]`, 2 items, no working step) wraps only on the new burst-count rule — fails if that rule is removed or its threshold raised.
- **single burst stays loose** (`[thinking, assistant]` → no turn) — guards the threshold boundary against over-wrapping / re-homing a lone reasoning row.
- **empty placeholder bursts don't count** toward the threshold.

## Manual verification

N/A for a live browser capture — see Screenshots. Behaviour is locked by the grouping unit tests above; local gates all green: `tsc -b`, `eslint` (changed files), and vitest across the changed spec plus the chat-grouping-adjacent specs (`groupDisplayItems`, `TurnBlock`, `ThinkingBlock`, `ChatPageCoverage`, `ChatPageW3Coverage`, `TurnBlock.disclosure*`, `chatThinkingSteerBoundary`, `chatSlice.switchSlotThinking`) — 197 tests pass.

## Screenshots / video

The visible delta is a reasoning-heavy turn rendering **one** collapsed "Thought process" row hoisted above the answer, instead of **N** duplicate rows stacked below the answer and the model/credits footer. The reported before-state is the screenshot in #6376.

A faithful live before/after needs a running gateway emitting a multi-burst reasoning turn (the trigger is model behaviour, not a fixed fixture), which is not deterministically stageable from a unit harness. The exact rendered change is instead pinned by the grouping tests above: a ≥2-burst reasoning batch now folds into a single wrapped turn, which `TurnBlock.mergeTurnThinking` renders as one row. I can stand up an isolated pod and capture a live before/after on request if a rendered pair is preferred over the maintainer `no-screenshots` waiver.

## Related Issues

Fixes #6376
