### PR TITLE
fix(sessions): escape co-tenant names in cotenant_sids logs (#6371)

### DIFF
--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -1860,7 +1860,11 @@ def safe_read_file(path: str) -> str:
     """
     resolved = os.path.realpath(os.path.expanduser(path))
     if is_sensitive_path(resolved):
-        raise PermissionError(f"Blocked: access to sensitive path: {resolved}")
+        # {resolved!r}, not {resolved}: the resolved target is caller/attacker
+        # influenced (a symlink target is chosen by whoever wrote the link) and
+        # this text reaches log records via ``exc_info`` — a raw newline in it
+        # would forge a second record.
+        raise PermissionError(f"Blocked: access to sensitive path: {resolved!r}")
     try:
         fd = os.open(resolved, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
     except OSError as exc:
@@ -1868,7 +1872,7 @@ def safe_read_file(path: str) -> str:
         # swap of the final component into a symlink — refuse it. Any other
         # OSError (ENOENT, EACCES) is a normal read error; re-raise as-is.
         if exc.errno in (errno.ELOOP, getattr(errno, "EMLINK", -1)):
-            raise PermissionError(f"Blocked: refusing to follow symlink at {resolved}") from exc
+            raise PermissionError(f"Blocked: refusing to follow symlink at {resolved!r}") from exc
         raise
     with os.fdopen(fd, "r", encoding="utf-8") as fh:
         return fh.read()
@@ -1939,7 +1943,7 @@ def safe_read_file_bytes_with_identity(
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
     except OSError as exc:
         if exc.errno in (errno.ELOOP, getattr(errno, "EMLINK", -1)):
-            raise PermissionError(f"Blocked: refusing to follow symlink at {path}") from exc
+            raise PermissionError(f"Blocked: refusing to follow symlink at {path!r}") from exc
         return None
     try:
         st = os.fstat(fd)

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -827,13 +827,15 @@ def cotenant_sids() -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
             # escape past the parse guard below and reach the caller. All four
             # mean the same thing here — which sessions this instance claims
             # cannot be established — so fail closed on it.
-            logger.warning("co-tenant %s has an unreadable session map", name, exc_info=True)
+            # %r, not %s: the directory name is agent-influenced and passes no
+            # identifier gate, so a newline in it would forge a second record.
+            logger.warning("co-tenant %r has an unreadable session map", name, exc_info=True)
             refusals.append((name, "its session map could not be read"))
             continue
         try:
             data = json.loads(raw)
         except ValueError:
-            logger.warning("co-tenant %s has a malformed session map", name)
+            logger.warning("co-tenant %r has a malformed session map", name)
             refusals.append((name, "its session map could not be parsed"))
             continue
         if not isinstance(data, dict):

--- a/test/test_hooks_coverage.py
+++ b/test/test_hooks_coverage.py
@@ -403,6 +403,47 @@ class TestSafeReadFile:
         with pytest.raises(FileNotFoundError):
             safe_read_file(str(tmp_path / "nope.txt"))
 
+    def test_sensitive_refusal_message_escapes_the_path(self, monkeypatch):
+        """The refused path is caller/attacker influenced and the message reaches
+        log records via ``exc_info``; a raw newline in it would forge a second
+        record (refs #6371, the #6281/#6315 log-forgery class).
+        """
+        forged = "/tmp/pods/wt-evil\nWARNING forged: reclaim authorized"
+        # The message carries the RESOLVED path (drive-lettered and
+        # backslashed on Windows), so compute the expectation the same way
+        # production does.
+        resolved = os.path.realpath(os.path.expanduser(forged))
+        monkeypatch.setattr(hooks_mod, "is_sensitive_path", lambda p: True)
+        with pytest.raises(PermissionError, match="sensitive path") as excinfo:
+            safe_read_file(forged)
+        message = str(excinfo.value)
+        assert "\n" not in message
+        assert repr(resolved) in message
+
+    def test_symlink_refusal_message_escapes_the_path(self, tmp_path, monkeypatch):
+        """The ELOOP arm keeps the pre-race resolved path — including any
+        newline-bearing directory name — so its message must escape it too.
+        """
+        import errno as _errno
+
+        f = tmp_path / "map.json"
+        f.write_text("{}", encoding="utf-8")
+        resolved = os.path.realpath(str(f))
+
+        real_open = os.open
+
+        def _eloop(path, flags, *args, **kwargs):
+            if str(path) == resolved:
+                raise OSError(_errno.ELOOP, "symlink swapped in")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", _eloop)
+        with pytest.raises(PermissionError, match="refusing to follow symlink") as excinfo:
+            safe_read_file(str(f))
+        message = str(excinfo.value)
+        assert "\n" not in message
+        assert repr(resolved) in message
+
 
 class TestSafeReadFileBytes:
     def test_reads_bytes(self, tmp_path):

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -1987,6 +1987,128 @@ class TestSharedStoreRefusal:
         assert "sits outside it" in report.reclaim_blocked_reason
 
 
+class TestCotenantNamesAreLogSafe:
+    """A co-tenant directory name is agent-influenced and can embed a newline;
+    both ``cotenant_sids`` log sites that carry it must escape it, or one record
+    forges additional records (refs #6371, the #6281/#6315 log-forgery class).
+    """
+
+    _FORGED = "wt-evil\nWARNING forged: reclaim authorized by operator"
+
+    def _pod_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        pod_root = tmp_path / "pods"
+        pod_root.mkdir()
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        return pod_root
+
+    def _make_forged_pod(self, pod_root: Path) -> Path:
+        pod = pod_root / self._FORGED
+        try:
+            pod.mkdir()
+        except OSError:
+            pytest.skip("this filesystem refuses a newline in a directory name")
+        return pod
+
+    @staticmethod
+    def _carrying(caplog: pytest.LogCaptureFixture, marker: str) -> list[str]:
+        return [record.getMessage() for record in caplog.records if marker in record.getMessage()]
+
+    def test_malformed_map_log_escapes_the_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pod = self._make_forged_pod(self._pod_root(tmp_path, monkeypatch))
+        (pod / "session_map.json").write_text("not json{", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            _protected, refusals = session_storage.cotenant_sids()
+
+        assert [name for name, _why in refusals] == [self._FORGED]
+        messages = self._carrying(caplog, "malformed session map")
+        assert messages, "the malformed-map site did not log at all"
+        # The rendered record stays one line: the name appears repr'd, and the
+        # injected second line never starts a record of its own.
+        assert all("\n" not in message for message in messages)
+        assert any(repr(self._FORGED) in message for message in messages)
+
+    def test_unreadable_map_log_escapes_the_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pod = self._make_forged_pod(self._pod_root(tmp_path, monkeypatch))
+        # Invalid UTF-8 makes ``safe_read_file`` raise ``UnicodeDecodeError``,
+        # which is exactly the unreadable-map warning path under test.
+        (pod / "session_map.json").write_bytes(b"\xff\xfe\xfa")
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            _protected, refusals = session_storage.cotenant_sids()
+
+        assert [name for name, _why in refusals] == [self._FORGED]
+        messages = self._carrying(caplog, "unreadable session map")
+        assert messages, "the unreadable-map site did not log at all"
+        assert all("\n" not in message for message in messages)
+        assert any(repr(self._FORGED) in message for message in messages)
+
+    def test_exc_info_rendering_does_not_carry_a_raw_newline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The unreadable-map site logs with ``exc_info=True``, and
+        ``safe_read_file``'s refusal messages embed the resolved path — which
+        keeps a newline-bearing directory name. The FULL rendered record
+        (message plus exception text) must stay forge-free, not just the
+        ``getMessage()`` line the other tests pin.
+        """
+        pod = self._make_forged_pod(self._pod_root(tmp_path, monkeypatch))
+        (pod / "session_map.json").write_text("{}", encoding="utf-8")
+        # Force the refusal arm so the raised PermissionError carries the real
+        # resolved path (newline included) into the traceback rendering.
+        monkeypatch.setattr(session_storage.hooks, "is_sensitive_path", lambda p: True)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+            _protected, refusals = session_storage.cotenant_sids()
+
+        assert [name for name, _why in refusals] == [self._FORGED]
+        assert "unreadable session map" in caplog.text
+        # The injected payload never lands at the start of a rendered line,
+        # which is what a forged record would need.
+        assert not [line for line in caplog.text.splitlines() if line.startswith("WARNING forged")]
+
+    def test_both_sites_escape_without_touching_the_filesystem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Windows refuses a newline in a real directory name, which would skip
+        the two filesystem tests above on those shards. Injecting the forged
+        name at the candidate-list seam pins both log sites on every platform.
+        """
+        self._pod_root(tmp_path, monkeypatch)
+        monkeypatch.setattr(session_storage, "_replay_store_cotenants", lambda: [self._FORGED])
+
+        reads: dict[str, object] = {
+            "unreadable": PermissionError("refused"),
+            "malformed": "not json{",
+        }
+        for label, outcome in reads.items():
+
+            def _read(path: str, outcome: object = outcome) -> str:
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return str(outcome)
+
+            caplog.clear()
+            monkeypatch.setattr(session_storage.hooks, "safe_read_file", _read)
+
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.session_storage"):
+                _protected, refusals = session_storage.cotenant_sids()
+
+            assert [name for name, _why in refusals] == [self._FORGED]
+            rendered = [record.getMessage() for record in caplog.records]
+            carrying = [message for message in rendered if repr(self._FORGED) in message]
+            assert carrying, f"the {label}-map site did not log the name repr'd"
+            assert all("\n" not in message for message in rendered)
+
+
 class TestBuckets:
     def test_split_on_the_documented_edges(self, stores: tuple[Path, Path]) -> None:
         _, kiro_home = stores


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

`cotenant_sids()` in `src/kiro_crew/session_storage.py` logs a co-tenant pod directory `name` with a plain `%s` at two warning sites (unreadable session map, malformed session map). The name comes from `_replay_store_cotenants()`, which returns raw directory names under the pod root filtered only by `is_dir()` and `not startswith(".")` — no `_UNIT_ID_RE`-style identifier gate. A directory name containing a newline therefore renders as a second, forged log record indistinguishable from a real one (same logger, level, and format). This is the same log-forgery primitive already closed for trash batch names by #6315 and the wider class tracked by #6281.

Pre-push review surfaced a second carrier at the same site: the unreadable-map warning logs with `exc_info=True`, and `hooks.safe_read_file()`'s refusal messages (`PermissionError` f-strings) interpolate the resolved path **raw**. The resolved path keeps a newline-bearing directory name (the ELOOP/TOCTOU-swap arm preserves the pre-race resolved path verbatim), so the traceback rendering would re-open the exact forgery the message-line escape closed.

## Why it matters

Log records are the audit surface an operator reads to understand what the reclaim machinery refused and why. An agent-influenced directory name that can forge a `WARNING`-level record (e.g. "reclaim authorized by operator") poisons that surface — a human or tooling reading the log cannot distinguish the forged record from a real one. The pod root is writable host-side state, so the prerequisite (creating a directory with a crafted name) is within reach of an agent-influenced workflow.

## What changed (motivation → approach → change)

Symptom → root cause → fix, in two mechanically-derivable steps:

1. **Message line**: both `cotenant_sids()` warning sites now interpolate `name` with `%r` instead of `%s`, so a newline/control-char-bearing name renders as a quoted single-line Python repr. This matches the file's existing convention for agent-influenced values (`list_trash` sites, `candidate.name` at the scan-cache site) and mirrors the merged #6315 / #6344 sibling changes.
2. **Exception text reached via `exc_info`**: rather than dropping the diagnostically useful `exc_info=True`, the fix goes to the carrier's root: the three `PermissionError` f-strings in `hooks.py` (`safe_read_file`'s sensitive-path and symlink-refusal arms, plus the same-class symlink refusal in `safe_read_file_bytes_with_identity`) now repr the path (`{resolved!r}` / `{path!r}`). This defuses every caller that logs these exceptions, not just this one, and keeps the log sites' wording, levels, and `exc_info` unchanged.

## Tests

All in the existing suites, mirroring the #6315 sibling test shape:

- `TestCotenantNamesAreLogSafe::test_malformed_map_log_escapes_the_name` — real forged-name pod directory with invalid JSON; asserts the rendered record stays one line with the name repr'd.
- `TestCotenantNamesAreLogSafe::test_unreadable_map_log_escapes_the_name` — invalid UTF-8 map drives the real `UnicodeDecodeError` arm; same single-line + repr assertions.
- `TestCotenantNamesAreLogSafe::test_exc_info_rendering_does_not_carry_a_raw_newline` — full-record pin: forces the refusal arm so the real `PermissionError` (resolved path with newline) flows through `exc_info`, and asserts no rendered line starts with the forged payload.
- `TestCotenantNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem` — filesystem-free seam test so both sites stay individually pinned on Windows shards, where a newline in a real directory name is refused (the two filesystem tests `pytest.skip` there).
- `TestSafeReadFile::test_sensitive_refusal_message_escapes_the_path` and `test_symlink_refusal_message_escapes_the_path` — unit pins on both `hooks.py` refusal messages: no raw newline, path present repr'd.

All three regression tests were verified red against the pre-fix production code and green with the fix.

## Manual verification

N/A — unit coverage sufficient: the tests drive the real `cotenant_sids()` / `safe_read_file()` paths end-to-end through the actual logger, including the exception-rendering path.

## Related Issues

Closes #6371

Refs #6281 / #6315 for the log-forgery class.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff
