### PR TITLE
fix(issue-radar): stop the workflow-runs 502 echoing gh's raw stderr

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/routes.py
@@ -4443,6 +4443,13 @@ def _pr_action_error(op: str, target: str, exc: Exception) -> web.Response:
     the client could fix is 400, and anything else upstream is 502 — the same
     taxonomy the label/state routes use, so one action behaving differently is not
     something a caller has to discover.
+
+    The 502 relays ``str(exc)`` rather than a fixed string, unlike the read routes.
+    A PR action fails for a reason the caller can usually FIX — "Allow auto-merge is
+    off for this repository", "the base branch is protected" — and that reason lives
+    only in the provider's own text. Withholding it here would leave the operator
+    retrying a button that can never work. The read routes carry no such actionable
+    text, so they sanitize (see ``_handle_pull_runs``).
     """
     if isinstance(exc, GhPermissionError):
         _audit(op, target, "denied", error=str(exc))
@@ -5075,7 +5082,12 @@ async def _handle_pull_runs(request: web.Request) -> web.Response:
             )
         )
     except GhCliError as exc:
-        return web.json_response({"error": str(exc), "code": "provider_error"}, status=502)
+        # Fixed string, not `str(exc)`: the message is gh's stderr tail (command,
+        # exit code, upstream body). Logged for us, withheld from the caller.
+        logger.warning("issue-radar list_pr_workflow_runs provider error: %s", exc)
+        return web.json_response(
+            {"error": "upstream provider error", "code": "provider_error"}, status=502
+        )
     return web.json_response({**_identity(key), "number": number, "runs": runs})
 
 

--- a/test/test_issue_radar_routes_coverage.py
+++ b/test/test_issue_radar_routes_coverage.py
@@ -1478,6 +1478,18 @@ class TestPullRuns(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(res.status, 502)
         self.assertEqual(_body(res)["code"], "provider_error")
 
+    async def test_the_502_body_withholds_the_raw_cli_diagnostic(self):
+        raw = "gh api repos/o/r/actions/runs failed (exit 1): connection refused"
+        with _connected(), mock.patch.object(
+            gh, "list_pr_workflow_runs", side_effect=gh.GhCliError(raw)
+        ):
+            res = await self._call({"owner": "o", "repo": "r", "sha": SHA})
+        body = _body(res)
+        self.assertEqual(body["error"], "upstream provider error")
+        self.assertNotIn(raw, body["error"])
+        self.assertNotIn("gh ", body["error"])
+        self.assertNotIn("exit ", body["error"])
+
 
 class TestPullRunAction(unittest.IsolatedAsyncioTestCase):
     async def _call(self, body: dict):


### PR DESCRIPTION
## What

`GET /api/apps/issue-radar/pull/runs` returned `str(exc)` from a `GhCliError` directly in its 502 body. That message is gh's stderr tail — the command invoked, the exit code, the upstream status — which tells the caller about our internals and nothing they can act on. It now returns the same fixed `"upstream provider error"` string every other read route in this app already returns, and the detail goes to the logger.

## Why this one and not the others

This came out of auditing the remaining `GhCliError` -> response paths after the assignees-route leak was closed in #5334. Five sites return a 502 with `provider_error`. Three were already sanitized. Two were not:

- `_handle_pull_runs` — a pure read. No actionable provider text exists, so it sanitizes. **Fixed here.**
- `_pr_action_error` — the shared mapper for PR *actions*. **Deliberately left as-is.** A write action fails for a reason the operator can usually fix ("Allow auto-merge is off for this repository", "the base branch is protected"), and that reason lives only in the provider's own message. `test_a_provider_refusal_is_relayed_verbatim` already pins it. Sanitizing it would leave someone retrying a button that can never work. The docstring now states the split so it reads as a decision rather than an inconsistency.

## Testing

- New: `TestPullRuns::test_the_502_body_withholds_the_raw_cli_diagnostic` — asserts the body is the fixed string and contains neither the raw message nor the `gh ` / `exit ` fragments.
- Revert-verified: restoring `str(exc)` fails the new test; restoring it also fails nothing else, confirming the assertion is load-bearing and not incidentally satisfied.
- `test_issue_radar_routes_coverage.py` + `test_issue_radar_routes_ai_coverage.py`: 455 passed.
- flake8 and isort clean on both touched files.
