### PR TITLE
fix(dashboard): stop chat search stacking on the editor's own find

### DIFF
--- a/website/src/hooks/useMessageSearch.ts
+++ b/website/src/hooks/useMessageSearch.ts
@@ -112,6 +112,12 @@ export function useMessageSearch(messages: ChatMessage[], activeSlot: string | n
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (hasCommandModifier(e) && e.key === 'f') {
+        // Yield to a surface that already answered the chord. In an edit
+        // session Pierre binds cmdOrCtrl+f on its own content element and calls
+        // preventDefault() without stopPropagation(), so this document-level
+        // handler still runs; opening chat search here would stack a
+        // transcript-scoped find on top of the editor's own find panel.
+        if (e.defaultPrevented) return
         // Yield Cmd/Ctrl+F to app surfaces that own their own in-file find
         // (e.g. the file explorer). Without this, an in-file search hijacks
         // the key and opens the chat message-search pane instead. This

--- a/website/src/test/useMessageSearch.test.ts
+++ b/website/src/test/useMessageSearch.test.ts
@@ -319,6 +319,41 @@ describe('useMessageSearch keyboard shortcuts', () => {
       document.body.removeChild(root)
     }
   })
+
+  it('Ctrl/Cmd+F is ignored when another surface already answered the chord', () => {
+    const { result } = renderHook(() => useMessageSearch(messages, 'slot-1'))
+    // Pierre's editor binds cmdOrCtrl+f on its own content element and calls
+    // preventDefault() without stopPropagation(), so this document-level
+    // handler still sees the event. Opening chat search here would stack a
+    // transcript-scoped find on top of the editor's own find panel.
+    const inner = document.createElement('div')
+    document.body.appendChild(inner)
+    inner.addEventListener('keydown', e => { e.preventDefault() })
+    try {
+      act(() => {
+        inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', metaKey: true, bubbles: true, cancelable: true }))
+      })
+      expect(result.current.isOpen).toBe(false)
+    } finally {
+      document.body.removeChild(inner)
+    }
+  })
+
+  it('still opens chat search when no other surface claimed the chord', () => {
+    const { result } = renderHook(() => useMessageSearch(messages, 'slot-1'))
+    // Control for the case above: an unclaimed chord must still reach chat
+    // search, so the bail cannot be satisfied by an always-yield handler.
+    const inner = document.createElement('div')
+    document.body.appendChild(inner)
+    try {
+      act(() => {
+        inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', metaKey: true, bubbles: true, cancelable: true }))
+      })
+      expect(result.current.isOpen).toBe(true)
+    } finally {
+      document.body.removeChild(inner)
+    }
+  })
 })
 
 describe('close() hands focus back to the composer', () => {


### PR DESCRIPTION
## Problem / Motivation

Open a file in the side panel, enter edit mode, press `Cmd/Ctrl+F`: **two find panes open.** Pierre's own find panel appears, and the chat transcript search opens on top of it and takes the keystrokes.

## Why it matters

Two competing find bars on one surface, and the one that ends up focused searches the conversation rather than the file being edited. The user has to notice the wrong pane is active, dismiss it, and try again.

## What changed (motivation → approach → change)

**Symptom → root cause.** `@pierre/diffs` binds `cmdOrCtrl+f` on its own content element and calls `preventDefault()` **without** `stopPropagation()` (`dist/editor/editor.js:922-935`). The chord therefore keeps bubbling to the document-level chat-search handler in `useMessageSearch`, which yielded only for a target inside the Files app's `.mc-fe-root` and never asked whether the event had already been answered. So it opened a second, transcript-scoped find.

**The change.** Bail when the chord is already handled:

```ts
if (e.defaultPrevented) return
```

This is the precise condition. It fires exactly when another surface claimed the key and never otherwise, so an unclaimed chord still reaches chat search with no behaviour change.

**Why not a `[data-mc-mdpanel]` ancestor test instead?** That was the first attempt and it does not work. The read-only code and diff bodies render nothing focusable and nothing moves focus into them on open (no `tabIndex`, no `autoFocus`, no `.focus()` in `ContentRenderer`, `PierreImpl` or `pierre/index`; both `data-mc-mdpanel` markers are plain divs). After the everyday sequence — click the file chip, press `Cmd/Ctrl+F` — the keydown target is still the transcript, so the ancestor test misses and nothing changes. Credit to the UX review on an earlier revision of this PR for catching that.

**Both guards are load-bearing; neither replaces the other.** `defaultPrevented` cannot cover the Files app, because that handler binds on `window` in bubble and therefore runs *after* this document-bubble handler — its `preventDefault()` is not yet visible here. Conversely `.mc-fe-root` cannot cover the editor, because Pierre is not in that subtree. `MarkdownPanel`'s markdown find needs neither: it binds in capture and always pairs `preventDefault()` with `stopImmediatePropagation()`, so this handler never runs when it claims the chord.

## Scope: what this deliberately does NOT fix

`Cmd/Ctrl+F` over a **read-only code file or diff** still opens chat transcript search. That is the wrong surface, it is pre-existing, and this PR leaves it exactly as it was rather than pretending to fix it. Making it right needs two things this change does not attempt:

1. **The right signal.** Not focus, but the pointerdown-region signal `MarkdownPanel` already keeps for its own find — `findActiveRef`, default-`true` on mount and re-armed whenever the panel becomes the visible tab.
2. **Something to fall through to.** Those views render a bare Pierre `<File>` with no `EditProvider` (`pierre/PierreImpl.tsx:304-310`), so Pierre's search panel does not exist there; and the existing DOM `TreeWalker` cannot substitute, because the side panel passes `scrollClassName` so Pierre virtualizes that scroller — `ContentRenderer.tsx:203` documents `previewRef` as a query root "while Pierre owns the scroller — which is what lets it window rows". A `TreeWalker` would under-report every match outside the viewport. The Electron shell also wires no `findInPage`, so there is no native find to defer to in the desktop app.

Both findings are recorded on #6383 for whoever picks that up.

## Tests

Two cases in `website/src/test/useMessageSearch.test.ts`:

- **A chord another surface already answered leaves chat search closed** — a child listener calls `preventDefault()` in the target phase, which precedes this document-bubble handler, reproducing Pierre's exact ordering.
- **An unclaimed chord still opens chat search** — the control, so the guard cannot be satisfied by an always-yield implementation.

Verified they discriminate rather than merely pass: replacing the guard with a comment fails the first and leaves the control passing (1 of 36), and restoring it returns 36/36.

## Manual verification

N/A — unit coverage sufficient. The change is a single guard on one boolean already carried by the event, and the tests reproduce the real propagation order (target-phase `preventDefault` before a document-bubble listener) rather than stubbing it.

The claim unit tests cannot make is that no *unrelated* handler preventDefaults this chord before the document handler, which would suppress chat search wrongly. Verified by enumerating the source instead: exactly three production handlers inspect the `f` key — this hook, `MarkdownPanel.tsx`, and `apps/file-explorer/FileExplorerPage.tsx`. MarkdownPanel always pairs `preventDefault()` with `stopImmediatePropagation()`; the file explorer binds on `window` in bubble, after this one. No handler preventDefaults `Cmd+F` key-agnostically ahead of `document`.

Gates run locally against base `f85826e64`: `tsc -b` clean; `eslint src` 0 errors; the i18n gate (`check-i18n-strings.mjs`) clean; vitest 1600 files / 25222 passed; electron 1378 passed; `mypy src/kiro_crew` clean over 1129 files; `isort` and `flake8` clean. No backend file is touched.

## Related Issues

Part of #6383 — intentionally **not** a closing reference. This lands only the edit-mode defect; find on read-only code and diff surfaces stays open there, along with the two findings above.

Context: #5995 (the hidden-tab half) and #6032 (its fix).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff
