### PR TITLE
docs(sandbox): replace the degrade-open enumeration with a rule that cannot drift

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1568,10 +1568,15 @@ def _mount_or_die(source, target, flags, what):
 
     So these refuse, matching what the rest of this launcher already does
     when a control cannot be established: both ``unshare`` calls, the
-    seccomp-BPF install, and the hardlink scan all ``sys.exit``. The
-    degrade-open decisions nearby are deliberately narrower -- the tmpfs
-    source-dir fallback and the hardlink scan's budget ceiling -- and
-    neither concerns the hiding itself.
+    seccomp-BPF install, and the hardlink scan all ``sys.exit``. What marks
+    those off from the decisions that DO degrade open is a rule, not a list:
+    a failed hiding mount is the one thing this helper exists to prevent,
+    nothing else here is one, and each of those others argues its case at
+    its own site -- the ``EXPOSE_FILES`` pre-read is one of them, named as
+    an example and not as a roster -- no count is kept here, since the count
+    is what goes stale. Read it narrowly: none is a failed hiding mount, NOT
+    the stronger claim that no credential can end up reachable. A degrade
+    elsewhere is never license to degrade a mount.
 
     ``sandbox_level`` is the explicit opt-out for a host that cannot mount;
     a silent unhidden credential is not.
@@ -2022,7 +2027,10 @@ def main():
         # for). On budget exhaustion the scan deliberately degrades OPEN with
         # a stderr warning rather than failing closed: /tmp on a busy host can
         # exceed any fixed budget from ordinary telemetry/cache churn, and
-        # exiting here would break every sandbox spawn on such hosts.
+        # exiting here would break every sandbox spawn on such hosts. The cost,
+        # plainly: an alias past the budget -- or past the quieter depth limit
+        # below -- is never stat'd, so a second path to a credential inode goes
+        # unchecked even though every mount held.
         #
         # REGULAR FILES ONLY, and that guard is what keeps the walk rare. Linux
         # does not allow a hardlink to a directory, so nlink > 1 says nothing


### PR DESCRIPTION
## Problem / Motivation

`_mount_or_die`'s docstring in `src/kiro_crew/sandbox.py` explains why every mount in the
namespace launcher refuses rather than degrades, then draws a boundary around the decisions
nearby that *do* degrade open. On `main` that boundary reads:

> The degrade-open decisions nearby are deliberately narrower -- the tmpfs source-dir fallback
> and the hardlink scan's budget ceiling -- and neither concerns the hiding itself.

There is a **third** degrade-open decision in the same launcher: the `EXPOSE_FILES` pre-read.
Its own inline comment already places it in that class, in those words:

> An expose source that cannot be READ degrades to "not exposed" with a stderr warning, the same
> way the Step 7 hardlink scan degrades open.

So the file currently contains a two-member enumeration and, ~110 lines below it, a third member
that self-identifies as belonging to it.

Neither author could have caught this. The docstring landed in `2bfa78f8b376`
("refuse to exec when a credential-hiding mount fails", #6074). The `EXPOSE_FILES` degrade
landed in `f65bd17ad4` ("let an unreadable cc expose source degrade, not abort", #5992), later
the same day. Each merged without the other in view.

## Why it matters

This docstring is the one place that states the launcher's fail-closed/fail-open policy, and it
is written to be read by the next person deciding whether some new failure path may degrade. An
enumeration that is short by one teaches that the exception list is closed when it is not, and
the closing clause — "neither concerns the hiding itself" — is the part a reader would lean on
to justify a *new* degrade. Left as is, it is a plausible-looking licence to degrade something
that should refuse.

Documentation only. No behaviour changes, so there is nothing to regress at runtime; the cost of
leaving it is entirely in what the next reader concludes.

## What changed (motivation → approach → change)

The obvious repair is to make the list three items long. That is not sufficient, and working out
why is most of this change.

I read all three sites before editing, and they do not degrade in the same relation to the
hiding:

- **tmpfs source-dir fallback** (`sandbox.py` L1661-1679). When no cross-fs tmpfs is available,
  `_tmpfs_src` stays `None` and the empty source inode comes from the default tempdir. The bind
  still runs through `_mount_or_die` (L1731, L1757) either way, so the hiding is established
  regardless; what is given up is cross-fs hardening against a teardown propagation race.
- **hardlink scan budget ceiling** (L2019-2022, warning at L2088-2093). Truncating the walk
  weakens *detection* of an alias that circumvents the hiding. Step 7 runs after the hiding
  loops, so the mounts themselves are already in place.
- **`EXPOSE_FILES` pre-read** (L1682-1717). On `OSError` the loop warns and does not populate
  `expose_data`; the restore loop is gated `if src_path in expose_data`, so the file is never
  written back into the empty mount. It therefore fails toward **more** hiding.

That last one is why adding a bullet alone would not have been enough — and, on the same logic,
why a three-item list is not enough either. `EXPOSE_FILES` **is** the deliberate exception to the
hiding, so the old closing clause ("neither concerns the hiding itself") was false of it. But a
list closed at three goes stale at the fourth degrade exactly as the list closed at two went stale
at the third, and the launcher already has more: the depth-5 walk truncation (`sandbox.py`
L2079-2083) and three silent `except OSError: pass` skips in the scan (L2057, L2065, L2095) each
abandon detection while every mount holds.

**So the shipped change removes the count rather than incrementing it.** The docstring now carries
a rule instead of a roster: a failed hiding mount is the one failure `_mount_or_die` exists to
prevent, nothing else in the launcher is one, and each of those others argues its case at its own
site. The `EXPOSE_FILES` pre-read is named there as an example, explicitly not as a roster, so a
fourth degrade-open decision cannot make the paragraph false. The rule is read narrowly on
purpose: it says none is a failed hiding mount, NOT the stronger claim that no credential can end
up reachable — a budget- or depth-truncated hardlink scan can leave an alias unchecked. A closing
norm keeps the boundary the original clause was reaching for: a degrade elsewhere is never license
to degrade a mount.

Exactly ONE site comment is edited — the hardlink budget comment at `sandbox.py` L2020 — which
gains that truncation cost explicitly, since it was the one consequence no site stated. The tmpfs
fallback and `EXPOSE_FILES` sites already carry their own rationale, so nothing was added there;
growing the diff to make a sentence true would be the wrong trade.

One file, `src/kiro_crew/sandbox.py`, prose only. No `mount`, pre-read, `raise`, `sys.exit`, or
control flow is touched. The docstring sits inside the `f'''...'''` launcher template, so the
edit deliberately introduces no `{` or `}`.

## Tests

No test changes. Nothing pins the edited prose:

- `test/test_sandbox_mount_checked.py` slices the helper region from `def _mount_or_die(` to
  `REAL_UID = `, which *contains* this docstring, but its `_LANDMARKS` are structural code
  markers only (deliberately so — see the comment above them) and its text assertions are on
  the four `_mount_or_die(...)` call forms. Its `script.count("_mount_or_die(") == 5` invariant
  still holds.
- A repo-wide search for the removed phrases (`deliberately narrower`,
  `neither concerns the hiding itself`) finds no test referencing them.

Existing coverage run:

- All 17 `test/test_sandbox*.py` suites: **523 passed, 1 skipped**.
- Full backend suite (`pytest -q -n auto --dist loadgroup`): see Manual verification.

## Manual verification

Because the docstring lives inside an f-string template, the real risk is a quoting or brace
error that would break launcher generation rather than a test assertion. Verified directly by
building the script from the edited module:

- `_build_launcher_script("strict")` returns 32506 chars.
- New prose present in the generated launcher: 1 occurrence.
- Old prose absent from the generated launcher: 0 occurrences.
- `_mount_or_die(` in the generated launcher: 5 (1 definition + 4 call sites).
- The docstring still opens immediately after the `def` line in the emitted source.
- A fabricated control token returns 0, confirming the probe can report absence.

## Related Issues

Follow-up to #6074 (which added the enumeration) and #5992 (which added the third member).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

