### PR TITLE
fix(session-storage): pin the trash log-safety test to the seam list_trash reads

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -886,9 +886,13 @@ class TestTrashBatchNamesAreLogSafe:
             def is_dir() -> bool:
                 return True
 
-        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+        # Shaped for `_summarize_manifest` — (header, sessions, staged_bytes) —
+        # because that is the seam `list_trash` reads since #6312. Patching
+        # `_read_manifest` instead lets the real `_summarize_manifest` run, and it
+        # does `batch / MANIFEST_NAME`, which a name-only double cannot support.
+        manifests: dict[str, tuple[dict[str, object], int, int] | None] = {
             "missing": None,
-            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0),
         }
         for label, parsed in manifests.items():
             caplog.clear()
@@ -897,7 +901,7 @@ class TestTrashBatchNamesAreLogSafe:
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )
             monkeypatch.setattr(
-                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+                session_storage, "_summarize_manifest", lambda batch, parsed=parsed: parsed
             )
 
             with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):


### PR DESCRIPTION
## Problem / Motivation

`TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem`
fails on `main`:

```
FAILED test/test_session_storage.py::TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem
  - TypeError: unsupported operand type(s) for /: '_ForgedDir' and 'str'
```

The test drives `list_trash()` with a `_ForgedDir` double — a `name` and an
`is_dir()`, nothing else — so a forged directory name reaches both log sites
without needing a hostile name on disk, which Windows will not create. For that
to work the manifest read has to be stubbed, and the test stubs `_read_manifest`.

#6312 changed `list_trash()` to call `_summarize_manifest()` instead
(`session_storage.py:1732`). The stub now intercepts nothing: the real
`_summarize_manifest` runs and evaluates `batch / MANIFEST_NAME` against the
double, which has no `__truediv__`. The test was left pointing at a seam its
subject had stopped using.

## Why it matters

It is not an isolated red. The failure is platform-independent — it reproduces on
backend shard 3 for **3.10, 3.12 and Windows** — and it takes **Coverage Gate**
down with it, because that shard then publishes no coverage and the gate fails
closed in a few seconds.

So every open PR whose CI merges against `main` inherits four red checks from one
broken test double, and each of those PRs pays a full CI cycle to rediscover it.
I hit it while driving an unrelated fork PR to green and had to reproduce it on
pristine `main` to establish it was not mine.

## What changed (motivation → approach → change)

**Symptom** → the stub and the subject disagree about which function reads the
manifest. **Root cause** → `list_trash()` moved from `_read_manifest` to
`_summarize_manifest` in #6312 without the test following. **Change** → point the
stub at `_summarize_manifest` and give it that function's return shape,
`(header, sessions, staged_bytes)` instead of `(header, entries)`.

No production change. The escaping this test pins was already correct — the test
simply could not reach it any more. Fixing it at the seam keeps the property that
made this test worth having: it exercises both log sites on **every** platform,
including the Windows shards where the two filesystem-based siblings are skipped
because the OS refuses a newline in a directory name.

I deliberately did not "fix" it by giving `_ForgedDir` a `__truediv__` — that
would let the real manifest reader run against a fake path and turn a focused
log-escaping test into an accidental filesystem test.

## Tests

No new test. This repairs an existing one, so the meaningful evidence is that it
still fails for the right reason:

- `test/test_session_storage.py` — **147 passed** (was 1 failed, 146 passed).
- **Mutation-checked in both directions.** Reverting either log site's `%r` to
  `%s` in `list_trash()` makes the repaired test fail with
  `AssertionError: the missing-manifest site did not log the name repr'd`. So it
  still catches the unescaped-name regression it exists to catch, rather than
  passing vacuously now that the stub lines up.

## Manual verification

N/A — a test-only change to a unit test, verified by running it. Reproduced the
failure on pristine `main` (`55a1880ea`) before the change and confirmed green
after, in the same checkout.

<!-- no-visual-delta -->
**Why no screenshot:** test-only change; no frontend file is touched and nothing
rendered changes.

## Related Issues

No linked issue: this is a follow-up repair to #6312, filed directly as a fix
because it is currently red on `main` and blocking unrelated PRs.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff
