### PR TITLE
feat(desktop): name the large binary allocation behind a renderer OOM

### DIFF
--- a/website/electron/big-alloc-log.js
+++ b/website/electron/big-alloc-log.js
@@ -1,0 +1,157 @@
+"use strict";
+//
+// In-memory ring buffer for the renderer's large-allocation reports (see
+// src/lib/allocWatch.ts), flushed to the log ONLY when the renderer dies.
+//
+// Same contract and rationale as pierre-perf-log.js: `glog` is a bare
+// appendFileSync with no rotation, so writing a line per large allocation would
+// grow the user's log without bound. Steady state writes NOTHING and keeps a
+// bounded history in memory; the render-process-gone path flushes it next to the
+// crash line, so every future OOM carries the binary allocations that preceded
+// it — on a normal install, with no env var armed ahead of time.
+//
+// The thing this answers: the native log shows a V8 cage OOM with a near-empty
+// JS heap, which means a large ArrayBuffer/TypedArray backing store, but V8
+// could not capture the allocation's stack. The last entries in this buffer are
+// that stack.
+//
+// KIROCREW_DEBUG opts into logging each event as it arrives, for watching a
+// reproduction live rather than reading it post-mortem.
+//
+// Best-effort, never throws, holds only plain numbers and short strings.
+//
+// REMOVAL CONDITION — deferred-deletion. Once a crash dump has reported the
+// allocation kind + size + stack behind the cage OOM, delete this module, its
+// IPC channel, its preload entry and the renderer's watcher rather than leaving
+// a permanent instrument behind a settled question.
+
+/** 32 large allocations of lead-up is plenty to name a culprit, and bounded on
+ *  purpose: this exists to diagnose runaway allocation, so it must not become a
+ *  leak itself. */
+const DEFAULT_CAPACITY = 32;
+
+/** The renderer is not trusted to send well-formed values — preload coerces too,
+ *  but this module decides what reaches a log line, so it re-checks. */
+const MAX_KIND_LEN = 40;
+const MAX_STACK_LEN = 4000;
+const MAX_ERROR_LEN = 200;
+
+function clampStr(v, max) {
+  if (typeof v !== "string") return "";
+  // Flatten control characters (newlines, tabs, DEL, ...) to a single space
+  // BEFORE length-bounding. A stack/error/kind carrying "\n" would otherwise be
+  // written verbatim into glog via renderEvent/renderSummary, letting a malformed
+  // report forge additional "[big-alloc] ..." lines and corrupt the very
+  // post-mortem this instrument exists to produce. This module is the
+  // authoritative trust boundary for what reaches a log line, so the strip lives
+  // here (preload only length-slices).
+  const flattened = v.replace(/[\u0000-\u001f\u007f]+/g, " ");
+  return flattened.length > max ? flattened.slice(0, max) : flattened;
+}
+
+/** Coerces one event into plain finite values, or null when it carries no real
+ *  allocation (non-positive/NaN bytes). */
+function normalizeEvent(ev) {
+  if (!ev || typeof ev !== "object") return null;
+  const bytes = Number(ev.bytes);
+  if (!Number.isFinite(bytes) || bytes <= 0) return null;
+  const outcome = ev.outcome === "failed" ? "failed" : "requested";
+  return {
+    kind: clampStr(ev.kind, MAX_KIND_LEN) || "?",
+    bytes,
+    outcome,
+    stack: clampStr(ev.stack, MAX_STACK_LEN),
+    error: outcome === "failed" ? clampStr(ev.error, MAX_ERROR_LEN) : "",
+  };
+}
+
+function mib(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+/** One log line for a single event. The stack is on the same line, arrow-joined
+ *  by the renderer, so one grep hit carries the allocation site. */
+function renderEvent(entry) {
+  const e = entry.event;
+  const err = e.outcome === "failed" ? ` error=${e.error}` : "";
+  const from = e.stack ? ` from=${e.stack}` : "";
+  return (
+    `[big-alloc] ${entry.at} kind=${e.kind} bytes=${e.bytes} (${mib(e.bytes)}MB) ` +
+    `outcome=${e.outcome}${err}${from}`
+  );
+}
+
+/** Aggregate across the buffered events. Put FIRST in the flush so a reader who
+ *  only sees the top of the dump still gets the verdict: the peak single
+ *  allocation is the prime cage-OOM suspect. */
+function renderSummary(entries) {
+  let peakBytes = 0;
+  let totalBytes = 0;
+  let failed = 0;
+  let peakKind = "?";
+  for (const e of entries) {
+    const ev = e.event;
+    totalBytes += ev.bytes;
+    if (ev.bytes > peakBytes) {
+      peakBytes = ev.bytes;
+      peakKind = ev.kind;
+    }
+    if (ev.outcome === "failed") failed += 1;
+  }
+  return (
+    `[big-alloc] pre-crash summary over ${entries.length} event(s): ` +
+    `peakBytes=${peakBytes} (${mib(peakBytes)}MB) peakKind=${peakKind} ` +
+    `totalBytes=${totalBytes} (${mib(totalBytes)}MB) failed=${failed}`
+  );
+}
+
+/**
+ * @param {object} [deps]
+ * @param {number} [deps.capacity]      events retained (default 32)
+ * @param {() => string} [deps.now]     timestamp source, injected for tests
+ */
+function createBigAllocLog({ capacity = DEFAULT_CAPACITY, now } = {}) {
+  const cap = Math.max(1, Number(capacity) || DEFAULT_CAPACITY);
+  const stamp = typeof now === "function" ? now : () => new Date().toISOString();
+  /** @type {{at: string, event: object}[]} */
+  let entries = [];
+
+  return {
+    /** Buffers one event. Returns the normalized event, or null when the report
+     *  was empty/malformed and nothing was recorded. */
+    record(ev) {
+      const event = normalizeEvent(ev);
+      if (!event) return null;
+      entries.push({ at: stamp(), event });
+      if (entries.length > cap) entries = entries.slice(entries.length - cap);
+      return event;
+    },
+
+    /** One line for the most recent event, for KIROCREW_DEBUG live logging. */
+    lastLine() {
+      if (entries.length === 0) return null;
+      return renderEvent(entries[entries.length - 1]);
+    },
+
+    /** Drains the buffer into log lines: summary first, then each event oldest to
+     *  newest. Returns [] when nothing was buffered, so a crash with no large
+     *  allocations adds no noise — itself a signal that points away from a
+     *  binary-buffer OOM. */
+    flush() {
+      if (entries.length === 0) return [];
+      const lines = [renderSummary(entries), ...entries.map(renderEvent)];
+      entries = [];
+      return lines;
+    },
+
+    size() {
+      return entries.length;
+    },
+  };
+}
+
+module.exports = {
+  createBigAllocLog,
+  normalizeEvent,
+  DEFAULT_CAPACITY,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -83,6 +83,7 @@ const {
 const { capturePySpyDump } = require("./pyspy-dump");
 const { createMetricsRecorder, profilingEnabled } = require("./perf-metrics");
 const { createPierrePerfLog } = require("./pierre-perf-log");
+const { createBigAllocLog } = require("./big-alloc-log");
 const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
 const { initMochi, shutdownMochi } = require("./mochi/index");
 const { borrowSessionToken } = require("./mochi-session-token");
@@ -419,6 +420,14 @@ function glog(line) {
 // the window's render-process-gone handler. Holds only plain numbers, bounded to
 // its capacity, and writes nothing until a crash.
 const pierrePerfLog = createPierrePerfLog();
+
+// Sibling of pierrePerfLog for large binary allocations (src/lib/allocWatch.ts):
+// the native log shows the renderer OOMs on the V8 cage with a near-empty JS
+// heap, i.e. on a big ArrayBuffer/TypedArray backing store whose stack V8 could
+// not capture. This buffers the allocation sites reported before each large
+// allocation and flushes them on render-process-gone. Bounded, writes nothing
+// until a crash.
+const bigAllocLog = createBigAllocLog();
 
 // ── Cross-app gateway ownership (shared ~/.kiro/crew, shared port) ─────────
 // The nightly app and the production app are different bundles sharing one
@@ -2356,6 +2365,11 @@ function createWindow() {
     // informative: no highlighting in the last two minutes points away from the
     // Pierre worker pool as the cause.
     for (const line of pierrePerfLog.flush()) glog(line);
+    // Then the large-allocation history: on a cage OOM the last entries name the
+    // binary buffer that pierre-perf's near-empty heap numbers cannot. Also
+    // unconditional, also empty-is-informative (no large allocation in the
+    // lead-up points away from a binary-buffer OOM).
+    for (const line of bigAllocLog.flush()) glog(line);
     rendererRecovery.handleGone(details || {});
   });
 
@@ -4007,6 +4021,23 @@ app.whenReady().then(async () => {
     if (!pierrePerfLog.record(w)) return;
     if (!profilingEnabled(process.env)) return;
     const line = pierrePerfLog.lastLine();
+    if (line) glog(line);
+  });
+
+  // Large binary-allocation reports (src/lib/allocWatch.ts). Buffered in memory
+  // and flushed on render-process-gone next to the crash line — the last entries
+  // name the ArrayBuffer/TypedArray behind a V8 cage OOM, which pierre-perf's
+  // heap numbers show but cannot attribute. Steady state writes nothing (glog has
+  // no rotation); KIROCREW_DEBUG logs each event as it arrives for a live repro.
+  ipcMain.on("big-alloc", (_event, ev) => {
+    // Same primary-renderer discipline as pierre-perf: the flush is triggered by
+    // THIS window's death, so a sibling window's report would be filed under the
+    // wrong process's crash history. Mis-attributed evidence is worse than none.
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (_event.sender !== mainWindow.webContents) return;
+    if (!bigAllocLog.record(ev)) return;
+    if (!profilingEnabled(process.env)) return;
+    const line = bigAllocLog.lastLine();
     if (line) glog(line);
   });
 

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -168,6 +168,7 @@
       "renderer-recovery.js",
       "native-logging.js",
     "pierre-perf-log.js",
+      "big-alloc-log.js",
       "pyspy-dump.js",
       "perf-metrics.js",
       "host-config.js",

--- a/website/electron/preload.js
+++ b/website/electron/preload.js
@@ -104,6 +104,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
       maxLen: Number(w && w.maxLen) || 0,
       heapMB: Number(w && w.heapMB) || -1,
     }),
+  // Large binary-allocation reports (see src/lib/allocWatch.ts). Coerced here
+  // because preload is the trust boundary: the main process writes these into a
+  // log line, so a renderer bug must not be able to put an object or an
+  // unbounded string there. The stack is capped hard — the main-side buffer caps
+  // again, but the cheapest place to bound it is before it crosses the wire.
+  // Fire-and-forget; the renderer never waits on a diagnostic.
+  reportBigAlloc: (e) =>
+    ipcRenderer.send("big-alloc", {
+      kind: String((e && e.kind) || "?").slice(0, 40),
+      bytes: Number(e && e.bytes) || 0,
+      outcome: e && e.outcome === "failed" ? "failed" : "requested",
+      stack: String((e && e.stack) || "").slice(0, 4000),
+      error: String((e && e.error) || "").slice(0, 200),
+    }),
   // The system-wide summon hotkey as ACTUALLY bound by main.js (registration
   // can degrade to the default or to nothing when a key is taken), so the
   // shortcuts UI advertises what really works. Resolves

--- a/website/electron/test/big-alloc-log.test.js
+++ b/website/electron/test/big-alloc-log.test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createBigAllocLog,
+  normalizeEvent,
+  DEFAULT_CAPACITY,
+} = require("../big-alloc-log");
+
+const seq = () => {
+  let n = 0;
+  return () => `t${n++}`;
+};
+
+test("normalizeEvent coerces and defaults", () => {
+  const e = normalizeEvent({ kind: "Uint8Array", bytes: 128, outcome: "requested", stack: "a <- b" });
+  assert.equal(e.kind, "Uint8Array");
+  assert.equal(e.bytes, 128);
+  assert.equal(e.outcome, "requested");
+  assert.equal(e.stack, "a <- b");
+  assert.equal(e.error, "");
+});
+
+test("normalizeEvent rejects non-positive / non-numeric bytes", () => {
+  assert.equal(normalizeEvent({ bytes: 0 }), null);
+  assert.equal(normalizeEvent({ bytes: -5 }), null);
+  assert.equal(normalizeEvent({ bytes: "big" }), null);
+  assert.equal(normalizeEvent({ bytes: NaN }), null);
+  assert.equal(normalizeEvent(null), null);
+  assert.equal(normalizeEvent("nope"), null);
+});
+
+test("normalizeEvent caps kind, stack, error and keeps error only when failed", () => {
+  const e = normalizeEvent({
+    kind: "x".repeat(100),
+    bytes: 10,
+    outcome: "failed",
+    stack: "s".repeat(9000),
+    error: "e".repeat(500),
+  });
+  assert.equal(e.kind.length, 40);
+  assert.equal(e.stack.length, 4000);
+  assert.equal(e.error.length, 200);
+  assert.equal(e.outcome, "failed");
+
+  const ok = normalizeEvent({ bytes: 10, outcome: "requested", error: "should be dropped" });
+  assert.equal(ok.error, "");
+});
+
+test("normalizeEvent flattens control characters to block log-line injection", () => {
+  const e = normalizeEvent({
+    kind: "Uint8Array",
+    bytes: 10,
+    outcome: "failed",
+    stack: "siteA\n[big-alloc] forged summary line\r\tmore",
+    error: "boom\nsecond line",
+  });
+  // No raw newline/tab/CR survives into a value that gets written to the log.
+  assert.doesNotMatch(e.stack, /[\r\n\t]/);
+  assert.doesNotMatch(e.error, /[\r\n\t]/);
+  assert.ok(e.stack.includes("forged summary line")); // content kept, control chars flattened
+});
+
+test("record + flush emits summary first then events oldest to newest", () => {
+  const log = createBigAllocLog({ now: seq() });
+  assert.equal(log.record({ kind: "ArrayBuffer", bytes: 100 * 1024 * 1024, outcome: "requested", stack: "siteA" }).bytes, 100 * 1024 * 1024);
+  log.record({ kind: "Uint8Array", bytes: 70 * 1024 * 1024, outcome: "failed", stack: "siteB", error: "RangeError" });
+
+  const lines = log.flush();
+  assert.equal(lines.length, 3);
+  assert.match(lines[0], /pre-crash summary over 2 event\(s\)/);
+  assert.match(lines[0], /peakBytes=104857600/);
+  assert.match(lines[0], /peakKind=ArrayBuffer/);
+  assert.match(lines[0], /failed=1/);
+  assert.match(lines[1], /kind=ArrayBuffer/);
+  assert.match(lines[1], /from=siteA/);
+  assert.match(lines[2], /kind=Uint8Array/);
+  assert.match(lines[2], /outcome=failed/);
+  assert.match(lines[2], /error=RangeError/);
+
+  // flush drains
+  assert.deepEqual(log.flush(), []);
+  assert.equal(log.size(), 0);
+});
+
+test("empty flush returns [] (no noise when nothing large was allocated)", () => {
+  const log = createBigAllocLog();
+  assert.deepEqual(log.flush(), []);
+});
+
+test("malformed reports are dropped and not recorded", () => {
+  const log = createBigAllocLog();
+  assert.equal(log.record({ bytes: 0 }), null);
+  assert.equal(log.size(), 0);
+});
+
+test("ring buffer is bounded to capacity", () => {
+  const log = createBigAllocLog({ capacity: 3, now: seq() });
+  for (let i = 1; i <= 10; i++) log.record({ kind: "ArrayBuffer", bytes: i * 1024 * 1024, stack: `s${i}` });
+  assert.equal(log.size(), 3);
+  const lines = log.flush();
+  // summary + 3 events
+  assert.equal(lines.length, 4);
+  // oldest retained is the 8th allocation
+  assert.match(lines[1], /from=s8/);
+  assert.match(lines[3], /from=s10/);
+});
+
+test("lastLine reflects the most recent event", () => {
+  const log = createBigAllocLog({ now: seq() });
+  assert.equal(log.lastLine(), null);
+  log.record({ kind: "Float64Array", bytes: 80 * 1024 * 1024, stack: "here" });
+  assert.match(log.lastLine(), /kind=Float64Array/);
+  assert.match(log.lastLine(), /from=here/);
+});
+
+test("DEFAULT_CAPACITY is exported and positive", () => {
+  assert.equal(typeof DEFAULT_CAPACITY, "number");
+  assert.ok(DEFAULT_CAPACITY > 0);
+});

--- a/website/src/lib/allocWatch.test.ts
+++ b/website/src/lib/allocWatch.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installAllocWatch, uninstallAllocWatch, DEFAULT_MIN_BYTES } from './allocWatch'
+
+type Reporter = ReturnType<typeof vi.fn>
+
+interface Scope {
+  ArrayBuffer: typeof ArrayBuffer
+  Uint8Array: typeof Uint8Array
+  Float64Array: typeof Float64Array
+  [k: string]: unknown
+}
+
+let reporter: Reporter
+let scope: Scope
+
+function freshScope(): Scope {
+  return { ArrayBuffer, Uint8Array, Float64Array } as Scope
+}
+
+beforeEach(() => {
+  reporter = vi.fn()
+  ;(window as unknown as { electronAPI?: unknown }).electronAPI = { reportBigAlloc: reporter }
+  // Small threshold so tiny allocations trip it deterministically.
+  ;(globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number }).__KIROCREW_BIG_ALLOC_BYTES__ = 1024
+  scope = freshScope()
+})
+
+afterEach(() => {
+  uninstallAllocWatch()
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI
+  delete (globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number }).__KIROCREW_BIG_ALLOC_BYTES__
+})
+
+describe('installAllocWatch', () => {
+  it('reports an ArrayBuffer allocation at or above the threshold', () => {
+    installAllocWatch(scope)
+    new scope.ArrayBuffer(2048)
+    expect(reporter).toHaveBeenCalledTimes(1)
+    const ev = reporter.mock.calls[0][0]
+    expect(ev.kind).toBe('ArrayBuffer')
+    expect(ev.bytes).toBe(2048)
+    expect(ev.outcome).toBe('requested')
+    expect(typeof ev.stack).toBe('string')
+    // Its own frames are stripped, so the site is the caller, not the watcher.
+    expect(ev.stack).not.toMatch(/allocWatch/)
+  })
+
+  it('does not report allocations below the threshold', () => {
+    installAllocWatch(scope)
+    new scope.ArrayBuffer(512)
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('sizes typed arrays by element count times BYTES_PER_ELEMENT', () => {
+    installAllocWatch(scope)
+    new scope.Float64Array(300) // 300 * 8 = 2400 bytes >= 1024
+    expect(reporter).toHaveBeenCalledTimes(1)
+    const ev = reporter.mock.calls[0][0]
+    expect(ev.kind).toBe('Float64Array')
+    expect(ev.bytes).toBe(2400)
+  })
+
+  it('ignores a typed array constructed as a view over an existing buffer', () => {
+    const buf = new ArrayBuffer(4096) // real global, pre-install
+    installAllocWatch(scope)
+    new scope.Uint8Array(buf) // first arg is a buffer, not a length: no fresh allocation
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed allocation and rethrows', () => {
+    installAllocWatch(scope)
+    expect(() => new scope.ArrayBuffer(Number.MAX_SAFE_INTEGER)).toThrow()
+    // one "requested" before, one "failed" after
+    expect(reporter).toHaveBeenCalledTimes(2)
+    expect(reporter.mock.calls[0][0].outcome).toBe('requested')
+    const failed = reporter.mock.calls[1][0]
+    expect(failed.outcome).toBe('failed')
+    expect(failed.error).toMatch(/RangeError|Invalid|length/i)
+  })
+
+  it('preserves instanceof for wrapped constructors', () => {
+    installAllocWatch(scope)
+    const ab = new scope.ArrayBuffer(8)
+    expect(ab instanceof ArrayBuffer).toBe(true)
+    const ta = new scope.Uint8Array(8)
+    expect(ta instanceof Uint8Array).toBe(true)
+  })
+
+  it('no-ops when electronAPI is absent (does not throw)', () => {
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI
+    installAllocWatch(scope)
+    expect(() => new scope.ArrayBuffer(2048)).not.toThrow()
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: a second install does not double-wrap', () => {
+    installAllocWatch(scope)
+    installAllocWatch(scope)
+    new scope.ArrayBuffer(2048)
+    expect(reporter).toHaveBeenCalledTimes(1)
+  })
+
+  it('uninstall restores the original constructors', () => {
+    installAllocWatch(scope)
+    uninstallAllocWatch()
+    expect(scope.ArrayBuffer).toBe(ArrayBuffer)
+    new scope.ArrayBuffer(2048)
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('caps reports per session to bound IPC against a runaway allocator', () => {
+    installAllocWatch(scope)
+    for (let i = 0; i < 4100; i++) new scope.ArrayBuffer(2048)
+    // MAX_REPORTS_PER_SESSION is 4096; anything past it is dropped.
+    expect(reporter).toHaveBeenCalledTimes(4096)
+  })
+
+  it('exports a sane default threshold', () => {
+    expect(DEFAULT_MIN_BYTES).toBe(64 * 1024 * 1024)
+  })
+})

--- a/website/src/lib/allocWatch.ts
+++ b/website/src/lib/allocWatch.ts
@@ -1,0 +1,194 @@
+// Names the large binary allocation that precedes a renderer OOM.
+//
+// Why this exists: the black-screen crashes are renderer V8 aborts, and the
+// always-on native log (native-logging.js) finally captured the fatal reason —
+// `V8 javascript OOM (CALL_AND_RETRY_LAST)` with `Heap: used=21.9MB
+// limit=4192.0MB`. The GC-managed JS heap was 0.5% full, so the limit hit was
+// NOT the object heap: it was the V8 pointer-compression cage/sandbox, the
+// bounded virtual region that also holds ArrayBuffer/TypedArray backing stores.
+// So the memory is being eaten by a large *binary buffer*, not by JS objects —
+// but V8 reported `stack trace capture may not succeed` and logged no JS stack,
+// so the log names the failure without naming the allocation.
+//
+// This fills that gap: it wraps the buffer-allocating constructors and, for an
+// allocation at or above a threshold, reports the requested size and a JS stack
+// to the main process BEFORE the allocation runs. Reporting first is the whole
+// point — a cage OOM aborts the process rather than throwing a catchable error,
+// so a post-hoc hook would die with the renderer. `ipcRenderer.send` posts the
+// message to the main-process pipe synchronously, so the culprit is on its way
+// to the log before the fatal allocation is attempted. The main process buffers
+// these in a bounded ring and flushes them next to the crash line (see
+// big-alloc-log.js), so a normal install writes nothing in steady state and
+// every future OOM carries the allocations that led up to it.
+//
+// Cost discipline, matching pierrePerf.ts: the wrappers add one numeric compare
+// on each buffer construction; the expensive part (capturing a stack, an IPC)
+// runs only at or above the threshold, which a normal session never reaches.
+// Nothing accumulates in the renderer — the ring buffer lives in main — and a
+// hard per-session report cap bounds the IPC even against a runaway allocator.
+//
+// Caveat, deliberately accepted: wrapping the global constructors with a Proxy
+// preserves `instanceof` and the statics (via the default get trap), but code
+// that compares `x.constructor === ArrayBuffer` sees the original constructor,
+// not the Proxy, so such an identity check would be false. That pattern is rare
+// (real code uses `instanceof` or `ArrayBuffer.isView`), and the value of naming
+// the OOM culprit outweighs it. The C++ side (structuredClone, transfer lists,
+// TypedArray internals) operates on the real object and is unaffected.
+//
+// REMOVAL CONDITION — deferred-deletion, not furniture. Once a crash dump has
+// reported the allocation kind + size + stack that precedes the cage OOM, the
+// culprit is named and the fix belongs where that allocation is made. Delete
+// this module, its IPC channel, its preload entry and the main-side log then,
+// rather than leaving a permanent constructor patch in the renderer.
+
+/** Report shape sent to the main process. Field names are the log line. */
+export interface BigAllocEvent {
+  /** The constructor that was called, e.g. "ArrayBuffer" or "Uint8Array". */
+  kind: string
+  /** Requested size in bytes (length × element size), best-effort. */
+  bytes: number
+  /** "requested" before the allocation; "failed" if the constructor threw. */
+  outcome: 'requested' | 'failed'
+  /** Trimmed JS stack naming the caller. */
+  stack: string
+  /** Present only when outcome === "failed". */
+  error?: string
+}
+
+/** Default threshold: 64 MiB. Large enough that a normal session never trips it
+ *  (icons, avatars, ordinary payloads are kilobytes), small enough to catch the
+ *  binary buffers that pressure a 4 GB cage. Overridable at runtime via
+ *  `globalThis.__KIROCREW_BIG_ALLOC_BYTES__` for tuning without a rebuild. */
+export const DEFAULT_MIN_BYTES = 64 * 1024 * 1024
+
+/** Bounds IPC even if something allocates large buffers in a loop. The main-side
+ *  ring only keeps the last N anyway, so past this cap the renderer stops
+ *  sending — a runaway allocator must not turn a diagnostic into a flood. */
+const MAX_REPORTS_PER_SESSION = 4096
+
+/** The buffer-allocating globals, held as constructor REFERENCES rather than
+ *  name-string literals — the i18n source-string gate flags any added string
+ *  literal that could be user-visible copy, and a constructor's own `.name`
+ *  carries the identity without a literal. Typed arrays are included because
+ *  `new Uint8Array(n)` allocates a backing store WITHOUT calling the JS
+ *  `ArrayBuffer` constructor, so wrapping ArrayBuffer alone would miss them.
+ *  SharedArrayBuffer is appended only where the runtime defines it. */
+const WATCHED_CTORS: Array<{ name: string }> = [
+  ArrayBuffer,
+  Int8Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Int16Array,
+  Uint16Array,
+  Int32Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
+]
+if (typeof SharedArrayBuffer !== 'undefined') {
+  WATCHED_CTORS.push(SharedArrayBuffer)
+}
+
+interface Patched {
+  target: Record<string, unknown>
+  name: string
+  original: unknown
+}
+
+let installed: Patched[] | null = null
+let reportCount = 0
+
+function minBytes(): number {
+  const override = (globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number })
+    .__KIROCREW_BIG_ALLOC_BYTES__
+  return typeof override === 'number' && override > 0 ? override : DEFAULT_MIN_BYTES
+}
+
+/** Best-effort requested size from the constructor arguments. A typed array or
+ *  buffer constructed OVER an existing buffer (first arg not a number) allocates
+ *  no fresh backing store, so it returns -1 and is skipped. */
+function requestedBytes(Ctor: unknown, args: unknown[]): number {
+  const first = args[0]
+  if (typeof first !== 'number' || !Number.isFinite(first) || first <= 0) return -1
+  const per = Number((Ctor as { BYTES_PER_ELEMENT?: number }).BYTES_PER_ELEMENT) || 1
+  return first * per
+}
+
+/** Captures the caller stack, dropping this module's own frames so the first
+ *  reported frame is the real allocation site. Bounded to keep the log line
+ *  readable; preload re-caps as the trust boundary. */
+function captureStack(): string {
+  const raw = new Error().stack || ''
+  const lines = raw.split('\n')
+  // Drop the "Error" header and any frame mentioning this module.
+  const frames = lines
+    .slice(1)
+    .filter((l) => !/allocWatch/.test(l))
+    .map((l) => l.trim())
+  return frames.slice(0, 8).join(' <- ')
+}
+
+function send(ev: BigAllocEvent): void {
+  if (reportCount >= MAX_REPORTS_PER_SESSION) return
+  const api = (window as unknown as {
+    electronAPI?: { reportBigAlloc?: (e: BigAllocEvent) => void }
+  }).electronAPI
+  const report = api && api.reportBigAlloc
+  if (typeof report !== 'function') return
+  reportCount += 1
+  try {
+    report(ev)
+  } catch {
+    // Never let a diagnostic break allocation.
+  }
+}
+
+function wrap(name: string, Original: unknown): unknown {
+  if (typeof Original !== 'function') return Original
+  return new Proxy(Original as new (...a: unknown[]) => unknown, {
+    construct(target, args, newTarget) {
+      const bytes = requestedBytes(target, args)
+      if (bytes >= minBytes()) {
+        const stack = captureStack()
+        // Report BEFORE constructing: a cage OOM aborts the process instead of
+        // throwing, so this may be the last thing this renderer does.
+        send({ kind: name, bytes, outcome: 'requested', stack })
+        try {
+          return Reflect.construct(target, args, newTarget)
+        } catch (e) {
+          send({ kind: name, bytes, outcome: 'failed', stack, error: String(e) })
+          throw e
+        }
+      }
+      return Reflect.construct(target, args, newTarget)
+    },
+  })
+}
+
+/**
+ * Patches the buffer-allocating globals. Idempotent — a second call is a no-op.
+ * Safe to call in any renderer: it only reports when `electronAPI.reportBigAlloc`
+ * exists, so a plain-browser dashboard patches the constructors but sends nothing.
+ */
+export function installAllocWatch(scope: Record<string, unknown> = globalThis as unknown as Record<string, unknown>): void {
+  if (installed) return
+  const patched: Patched[] = []
+  for (const Ctor of WATCHED_CTORS) {
+    const name = Ctor.name
+    const original = scope[name]
+    if (typeof original !== 'function') continue
+    scope[name] = wrap(name, original)
+    patched.push({ target: scope, name, original })
+  }
+  installed = patched
+}
+
+/** Test seam: restores the original globals and resets the session counter. */
+export function uninstallAllocWatch(): void {
+  if (!installed) return
+  for (const p of installed) p.target[p.name] = p.original
+  installed = null
+  reportCount = 0
+}

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -2,6 +2,7 @@
 // FIRST (before store/providers/App) so seam registrations run before render.
 // Empty in the stock build. See website/src/extensions.ts.
 import './extensions'
+import { installAllocWatch } from './lib/allocWatch'
 import React, { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
 import { withCommitProfiler, installCommitProfilerConsoleApi } from './lib/commitProfiler'
@@ -123,6 +124,13 @@ if (!isEmbeddedPane()) {
 }
 
 const WorldsPopout = lazy(() => import('./pages/WorldsPopout'))
+
+// Patch the buffer-allocating constructors before app code allocates, so a large
+// ArrayBuffer/TypedArray that precedes a V8 cage OOM is reported to the main
+// process (and flushed next to the crash line) instead of dying unnamed with the
+// renderer. Cheap, idempotent, and no-ops when there is no main process to
+// report to (a plain-browser dashboard).
+installAllocWatch()
 
 // Debug-only, and inert unless explicitly armed with ?profile=commits. When
 // disarmed withCommitProfiler returns the children untouched, so no Profiler


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** Pure diagnostic instrumentation — wraps buffer constructors and adds a main-process log flush. The touched `.tsx`/`.ts` files change no component, layout, style, or rendered string, so there is no pixel delta.

no linked issue: diagnostic instrumentation for the ongoing renderer-OOM investigation; no tracked issue to close.

## Problem
The dashboard renderer intermittently aborts (black screen, self-healed by `renderer-recovery.js`). The always-on native log (`native-logging.js`, #5959) finally captured the fatal reason:

```
<--- Near heap limit --->
Heap: used=21.9MB limit=4192.0MB
Near V8 cage limit; stack trace capture may not succeed
V8 javascript OOM (CALL_AND_RETRY_LAST).
```

The GC-managed JS heap was 0.5% full, so this is **not** a JS-object OOM — it is the V8 pointer-compression **cage/sandbox**, the bounded virtual region that also holds `ArrayBuffer`/`TypedArray` backing stores. So a large binary buffer is the culprit — but V8 logged `stack trace capture may not succeed` and emitted **no JS stack**, so the log names the failure without naming the allocation.

## Why it matters
This is the missing last link for the recurring renderer-crash investigation. `pierre-perf` already disproved the re-tokenize-churn hypothesis (`peakRepeatKeyCalls=0`, `peakKeysForOneSurface=1`, tiny `largestContent`), and the heap numbers rule out a JS-object leak. Without the allocation site we cannot fix the crash; with it, the fix belongs wherever that buffer is created.

## Fix
- **Symptom:** cage OOM with a near-empty JS heap and no captured stack.
- **Root cause (of the blind spot):** the fatal allocation aborts the process instead of throwing, so any post-hoc hook dies with the renderer, and V8 itself is too far into OOM to capture a stack.
- **Change:** `src/lib/allocWatch.ts` wraps the buffer-allocating constructors (`ArrayBuffer`, `SharedArrayBuffer`, the 11 typed arrays) with a `Proxy` `construct` trap. For an allocation `>= 64 MiB` it captures the JS stack and reports `{kind, bytes, outcome, stack}` to the main process **before** calling the constructor — `ipcRenderer.send` posts to the main pipe synchronously, so the culprit is on its way to the log before the fatal allocation runs. A throwing (catchable) allocation additionally reports `outcome=failed` then rethrows.
  - `electron/big-alloc-log.js` is the main-side bounded ring buffer (sibling of `pierre-perf-log.js`): steady state writes nothing (glog has no rotation), and `render-process-gone` flushes summary + per-event lines next to the crash line. An empty flush is itself a signal (no large allocation ⇒ points away from a binary-buffer OOM).
  - Wired through `preload.js` (`reportBigAlloc`, the coercion/trust boundary), `main.js` (IPC handler with the same primary-renderer discipline as `pierre-perf`, plus the flush), `main.tsx` (installed before app code allocates), and the `build.files` allowlist.
- **Cost:** one numeric compare per buffer construction; stack capture + IPC only at/above the threshold (a normal session never trips it); a hard per-session report cap bounds IPC against a runaway allocator; nothing accumulates in the renderer.
- **Accepted caveat:** the `Proxy` preserves `instanceof` and statics, but `x.constructor === ArrayBuffer` would see the original constructor, not the Proxy. That pattern is rare (real code uses `instanceof`/`ArrayBuffer.isView`); the C++ side (structuredClone, transfer lists, TypedArray internals) is unaffected.
- **Deferred-deletion:** once a crash dump names the allocation, remove the watcher, its IPC channel, its preload entry and the main-side log rather than leaving a permanent constructor patch behind.

## Tests
- `src/lib/allocWatch.test.ts` (vitest, 11): reports at/above threshold with size + a self-frame-stripped stack; silent below; typed-array sizing (`n × BYTES_PER_ELEMENT`); view-over-existing-buffer ignored; failed allocation reports `failed` then rethrows; `instanceof` preserved; no-op without `electronAPI`; idempotent install; uninstall restores originals; per-session report cap at 4096.
- `electron/test/big-alloc-log.test.js` (node:test, 9): normalize/coerce/reject; summary-first flush ordering; empty flush returns `[]`; capacity bound; caps on kind/stack/error length; `lastLine`.
- Local gates green: `tsc --noEmit`, `eslint --max-warnings 0` (changed files), `node --test big-alloc-log.test.js`, `shell-contract.test.js` (build.files + channel wiring).

## Manual verification
Steady state: no `[big-alloc]` lines in `~/Library/Logs/Kiro Crew/chromium.log` / `gateway-launch.log` (threshold never tripped). On a renderer death, the flush emits a `[big-alloc] pre-crash summary ...` line plus per-event `kind=... bytes=... (NNN MB) outcome=... from=<stack>` lines next to the crash line, so the next cage OOM carries the allocations that preceded it.

Note: cross-origin remote panes are separate renderers running the **remote** build, so they gain this only once the remote gateway is updated; the local dashboard renderer is instrumented immediately.

