### PR TITLE
fix(desktop): never steal focus on gateway reconnect (#6373)

### DIFF
--- a/website/electron/gateway-recovery.js
+++ b/website/electron/gateway-recovery.js
@@ -1,8 +1,9 @@
 "use strict";
 //
-// Pure, injectable recovery-strategy decision, extracted from main.js so it can
+// Injectable recovery-strategy decisions, extracted from main.js so they can
 // be unit-tested without Electron (mirrors gateway-liveness.js / gateway-wait.js
-// / gateway-stop.js).
+// / gateway-stop.js). Most exports are pure; revealWindowForConnect drives an
+// injected window and is testable with a fake.
 //
 // PROBLEM: the post-handoff liveness monitor fires onUnresponsive whenever
 // /api/status stops answering. main.js used to react ONE way — assume a wedged
@@ -227,9 +228,37 @@ function unrecoverableGatewayDialog({
   };
 }
 
+/**
+ * Reveal a window for a connect/loading flow, raising ONLY when the user asked
+ * for it. Effectful (it drives the injected window) but injectable, so the
+ * raise-vs-silent rule is unit-testable without Electron.
+ *
+ * Cold launch and user-initiated connects (app start, dialog Retry, a new
+ * connection window) keep the historical raise-and-focus `show()`.
+ *
+ * Liveness-recovery reconnects touch NOTHING: the user did nothing, so the
+ * app must not raise, focus, un-minimize, or re-surface itself (the
+ * remote-tunnel setup reconnects on every screen lock/unlock — see #6373).
+ * The splash and dashboard load fine into a background, minimized, or hidden
+ * window; a window the user hid to tray stays hidden until THEY reopen it.
+ * The escalation rule lives in main.js: silent while self-healing, but any
+ * state that needs input (token prompt, failure dialog, the terminal
+ * unrecoverable-gateway dialog) does a full reveal via revealForUserDecision
+ * at the point it is reached.
+ *
+ * @param {object} win  BrowserWindow-like: show().
+ * @param {object} [o]
+ * @param {boolean} [o.reconnect=false]  true on liveness-recovery paths.
+ */
+function revealWindowForConnect(win, { reconnect = false } = {}) {
+  if (reconnect) return;
+  win.show();
+}
+
 module.exports = {
   chooseRecoveryStrategy,
   classifyAdoptedGateway,
+  revealWindowForConnect,
   GATEWAY_OWNERSHIP_STATES,
   waitForServiceRebind,
   waitForProcessExit,

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -74,6 +74,7 @@ const { createLivenessMonitor } = require("./gateway-liveness");
 const {
   chooseRecoveryStrategy,
   classifyAdoptedGateway,
+  revealWindowForConnect,
   waitForServiceRebind,
   waitForProcessExit,
   snapshotPortPids,
@@ -2774,11 +2775,11 @@ function startLivenessMonitor(win) {
  * Recover a gateway that is alive-but-unresponsive (wedged event loop). A
  * graceful /api/shutdown can't help — that endpoint runs on the very loop that
  * is frozen — so SIGKILL the child, clear the port, respawn, and re-run the
- * boot flow. showLoadingThenConnect shows the loading screen + status (a visible
- * "restarting" state instead of an eternal spinner) and starts a fresh monitor
- * on success; its own catch handles a restart that fails.
+ * boot flow. showLoadingThenConnect loads the loading screen + status into the
+ * window (without raising it — this is a liveness reconnect, see #6373) and
+ * starts a fresh monitor on success; its own catch handles a restart that fails.
  */
-async function recoverWedgedGateway(win) {
+async function recoverWedgedGateway(win, { userInitiated = false } = {}) {
   // We only OWN (and may kill/respawn) a gateway we spawned. On the reuse path
   // the port-holder is someone else's process — in the remote-tunnel setup it is
   // our own SSH forward, whose backend lives on a remote host. An unresponsive
@@ -2847,7 +2848,12 @@ async function recoverWedgedGateway(win) {
   gatewayStartFailure = null; // re-arm so waitForGateway doesn't fail-fast on the kill we just did
   await startGateway(); // spawn a fresh child before re-waiting
   if (win.isDestroyed() || isQuitting) return;
-  return showLoadingThenConnect(win, BACKEND_URL);
+  // A user-initiated recovery (failed update install — the user clicked
+  // Install and is watching) keeps the raise; a liveness-triggered one stays
+  // silent (#6373). The reconnect fork branches above are liveness-only in
+  // practice (an install only ever stops a gateway we spawned) and stay
+  // silent either way — their needs-user states escalate on their own.
+  return showLoadingThenConnect(win, BACKEND_URL, { reconnect: !userInitiated });
 }
 
 /**
@@ -2863,8 +2869,11 @@ async function recoverWedgedGateway(win) {
 async function reconnectExternalGateway(win) {
   const wc = win.webContents;
   try { wc.loadFile(path.join(__dirname, "loading.html")); } catch { /* window may be mid-teardown */ }
-  if (!win || win.isDestroyed() || isQuitting) return; // loadFile may have thrown on a torn-down window; show() would too
-  win.show();
+  if (!win || win.isDestroyed() || isQuitting) return; // loadFile may have thrown on a torn-down window
+  // Deliberately NO reveal here: this is liveness-triggered, not user-initiated,
+  // so the window must not be raised, focused, or re-surfaced (#6373 — every
+  // tunnel drop stole focus on reconnect). The splash above loads fine into a
+  // background or hidden window.
   sendStatus("Connection lost — waiting for the gateway to come back…");
   for (;;) {
     if (!win || win.isDestroyed() || isQuitting) return;
@@ -2876,7 +2885,7 @@ async function reconnectExternalGateway(win) {
   if (!win || win.isDestroyed() || isQuitting) return;
   glog("liveness: external gateway reachable again — refetching token and reconnecting");
   gatewayStartFailure = null;
-  return showLoadingThenConnect(win, BACKEND_URL);
+  return showLoadingThenConnect(win, BACKEND_URL, { reconnect: true });
 }
 
 // How long recovery waits for an ADOPTED local gateway to answer again before
@@ -2903,7 +2912,7 @@ async function reconnectOrRespawnAdoptedGateway(win) {
   const wc = win.webContents;
   try { wc.loadFile(path.join(__dirname, "loading.html")); } catch { /* window may be mid-teardown */ }
   if (!win || win.isDestroyed() || isQuitting) return;
-  win.show();
+  // Deliberately NO reveal: liveness-triggered, not user-initiated (#6373).
   sendStatus("Gateway stopped responding — waiting for it to recover…");
   const deadline = Date.now() + ADOPTED_RECOVERY_WAIT_MS;
   while (Date.now() < deadline) {
@@ -2911,9 +2920,12 @@ async function reconnectOrRespawnAdoptedGateway(win) {
     let healthy = false;
     try { await checkBackend(HEALTH_URL); healthy = true; } catch { /* still down */ }
     if (healthy) {
+      // The probe just awaited — the window may have been torn down meanwhile,
+      // and showLoadingThenConnect would loadFile against a destroyed window.
+      if (!win || win.isDestroyed() || isQuitting) return;
       glog("liveness: adopted local gateway answering again — reconnecting");
       gatewayStartFailure = null;
-      return showLoadingThenConnect(win, BACKEND_URL);
+      return showLoadingThenConnect(win, BACKEND_URL, { reconnect: true });
     }
     await new Promise((r) => setTimeout(r, 2500));
   }
@@ -2956,11 +2968,13 @@ async function reconnectOrRespawnAdoptedGateway(win) {
       const health = await fetchHealthInfo();
       const decision = decideGatewayAction(app.getVersion(), health, { localOwner: owner });
       const readiness = await fetchGatewayReadiness();
+      // Three awaits since the last check — re-verify before touching the window.
+      if (win.isDestroyed() || isQuitting) return;
       if (decision.action === "reuse" && readiness !== "shutting-down") {
         glog(`liveness: service manager re-bound :${PORT} (owner=${owner}, reason=${decision.reason}, readiness=${readiness}) — reconnecting to the restarted gateway`);
         gatewayOwnership = classifyAdoptedGateway({ reason: decision.reason, localOwner: owner });
         gatewayStartFailure = null;
-        return showLoadingThenConnect(win, BACKEND_URL);
+        return showLoadingThenConnect(win, BACKEND_URL, { reconnect: true });
       }
       glog(`liveness: :${PORT} was re-bound by an unusable holder (owner=${owner}, action=${decision.action}, readiness=${readiness}) — cannot reconnect or spawn over it`);
       return showUnrecoverableGatewayError(win, PORT, "held");
@@ -2974,7 +2988,28 @@ async function reconnectOrRespawnAdoptedGateway(win) {
   gatewayStartFailure = null;
   await startGateway(); // spawn a fresh child (port is confirmed free)
   if (win.isDestroyed() || isQuitting) return;
-  return showLoadingThenConnect(win, BACKEND_URL);
+  return showLoadingThenConnect(win, BACKEND_URL, { reconnect: true });
+}
+
+/**
+ * Reveal a window because recovery reached a state that NEEDS the user (token
+ * prompt, terminal failure dialog). Silent reconnects (#6373) deliberately
+ * leave the window hidden/minimized while self-healing, so an escalation must
+ * do the full reveal the repo's other show paths do: cancel a deferred
+ * tray-hide first (hide-to-tray.js: every show expressing intent to see the
+ * window must, or the pending hide re-hides it — exitImmersiveModes can fire
+ * that very listener), un-minimize, show + focus, and on macOS steal app
+ * activation — the app is in the background by definition here, and without
+ * activation the window rises behind the frontmost app without keyboard
+ * focus (see the global-hotkey summon path). Idempotent on a visible window.
+ */
+function revealForUserDecision(win) {
+  if (!win || win.isDestroyed() || isQuitting) return;
+  cancelPendingTrayHide(win);
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  if (IS_MAC) app.focus({ steal: true });
 }
 
 /**
@@ -2995,6 +3030,12 @@ async function showUnrecoverableGatewayError(win, port, options = {}) {
     ? { variant: options }
     : options;
   if (!win || win.isDestroyed()) return;
+  // Terminal needs-the-user state: the dialog below is a modal child of `win`,
+  // and a modal child of a hidden parent is ordered out with it. Liveness
+  // paths reach here with the window deliberately un-revealed (#6373's silent
+  // reconnect), so reveal it now — every branch of this dialog requires a
+  // human decision and quits afterwards, so raising is always right here.
+  revealForUserDecision(win);
   let logTail = "";
   try { logTail = tailLines(fs.readFileSync(gatewayLogPath(), "utf8"), 60); } catch { /* no log yet */ }
   const action = await showGatewayErrorDialog(win, {
@@ -3017,7 +3058,7 @@ async function showUnrecoverableGatewayError(win, port, options = {}) {
   if (win === mainWindow) { isQuitting = true; app.quit(); } else { win.destroy(); }
 }
 
-async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
+async function showLoadingThenConnect(win, backendUrl = BACKEND_URL, { reconnect = false } = {}) {
   const healthUrl = `${backendUrl}/api/status`;
   const wc = win.webContents;
   // Paint the splash in the user's chosen accent (persisted from a prior session
@@ -3025,7 +3066,9 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
   wc.loadFile(path.join(__dirname, "loading.html"), {
     query: { accent: currentThemeAccent() },
   });
-  win.show();
+  // Cold launch and user-initiated connects raise as before; liveness-recovery
+  // reconnects (reconnect: true) stay silent — no raise, no focus steal (#6373).
+  revealWindowForConnect(win, { reconnect });
 
   try {
     await waitForBackend(win, healthUrl, { watchSpawn: backendUrl === BACKEND_URL });
@@ -3106,6 +3149,14 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
       // `window.close()` in the page would destroy the VIEW and leave a blank
       // shell behind. A keyboard exit has to go through the main process
       // (windowForWebContents) to close the host window.
+      // A prompt is a state that genuinely NEEDS the user, whatever path led
+      // here: a silent reconnect leaves the window hidden (#6373), and even a
+      // cold boot's window can be hidden/minimized by the time a slow install
+      // reaches this point. Reveal unconditionally — idempotent when already
+      // visible. BEFORE exitImmersiveModes: leaving fullscreen fires a
+      // deferred tray-hide's listener, so the cancel inside the reveal must
+      // come first.
+      revealForUserDecision(win);
       exitImmersiveModes(win);
       wc.loadFile(path.join(__dirname, "token-prompt.html"), {
         query: { port: promptPort, kind, host: remoteHost },
@@ -3196,6 +3247,11 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
     }
 
     // Loop so "Reveal Log" can re-show the dialog after opening Finder.
+    // The dialog is a modal child of `win` and needs the user: a hidden parent
+    // orders the modal out with it. Reveal unconditionally, whatever path led
+    // here — a silent reconnect leaves the window hidden (#6373), and even a
+    // cold boot's window can be hidden by now. Idempotent when visible.
+    revealForUserDecision(win);
     for (;;) {
       const action = await showGatewayErrorDialog(win, {
         title, message, logTail, logPath, portConflict, port: PORT, localGatewayOff,
@@ -3236,7 +3292,9 @@ async function showLoadingThenConnect(win, backendUrl = BACKEND_URL) {
         }
         // The dialog, force-stop, and respawn above are all async — the user may
         // have closed the window meanwhile. Re-check before showLoadingThenConnect,
-        // which calls win.show()/loadFile and would throw on a destroyed window.
+        // which reveals the window / calls loadFile and would throw on a destroyed one.
+        // Deliberately NOT flagged as a reconnect: every path here goes through a
+        // dialog button the user just clicked, so the re-entry may raise (#6373).
         if (win.isDestroyed()) return;
         return showLoadingThenConnect(win, backendUrl);
       }
@@ -4115,7 +4173,7 @@ app.whenReady().then(async () => {
       if (!installingUpdate) return; // deferred-quit path: app is quitting anyway
       installingUpdate = false;
       glog("update install failed — restoring gateway and liveness recovery");
-      recoverWedgedGateway(mainWindow).catch((e) => glog(`post-install-failure recovery failed: ${e && e.message}`));
+      recoverWedgedGateway(mainWindow, { userInitiated: true }).catch((e) => glog(`post-install-failure recovery failed: ${e && e.message}`));
     },
     onUpdateState: broadcastUpdateState,
     log: makeUpdaterLogger(glog),

--- a/website/electron/test/reconnect-focus.test.js
+++ b/website/electron/test/reconnect-focus.test.js
@@ -1,0 +1,201 @@
+// Regression tests for #6373: the desktop app stole window focus on every
+// gateway reconnect. The liveness-recovery paths (remote-tunnel reconnect,
+// adopted-gateway recovery, wedged-gateway respawn) called win.show()
+// unconditionally, and on macOS BrowserWindow.show() raises AND focuses — so
+// every screen lock/unlock (which drops an SSH tunnel) yanked the app over
+// whatever the user was working in.
+//
+// The rule under test:
+//   - cold launch / user-initiated connects keep the historical raise (show()),
+//   - liveness reconnects touch NOTHING while self-healing — no raise, no
+//     focus, no un-minimize, no re-surfacing of a window the user hid to tray
+//     (the splash loads fine into a background/hidden window),
+//   - ESCALATION: any state that genuinely needs the user (token prompt,
+//     failure dialog, terminal unrecoverable-gateway dialog) does a FULL
+//     reveal at the point it is reached, on any path — an invisible prompt
+//     would park recovery forever.
+// revealWindowForConnect (gateway-recovery.js) carries the silent-vs-raise
+// decision; source-level pins verify main.js wires every liveness path through
+// it and keeps the escalation reveals reconnect-guarded.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { revealWindowForConnect } = require("../gateway-recovery");
+
+function fakeWin() {
+  const calls = [];
+  return {
+    calls,
+    show: () => calls.push("show"),
+    showInactive: () => calls.push("showInactive"),
+    focus: () => calls.push("focus"),
+    restore: () => calls.push("restore"),
+  };
+}
+
+describe("revealWindowForConnect", () => {
+  // Cold launch and user-initiated connects (app boot, dialog Retry, a new
+  // connection window) must keep raising exactly as before the fix.
+  it("raises via show() when not a reconnect (explicit false)", () => {
+    const win = fakeWin();
+    revealWindowForConnect(win, { reconnect: false });
+    assert.deepEqual(win.calls, ["show"]);
+  });
+
+  it("raises via show() when opts are omitted (default is the cold path)", () => {
+    const win = fakeWin();
+    revealWindowForConnect(win);
+    assert.deepEqual(win.calls, ["show"]);
+  });
+
+  // The reported bug, closed as a class: a liveness reconnect must not touch
+  // window state AT ALL — no show/showInactive/focus/restore. This also pins
+  // that a tray-hidden window stays hidden and a minimized one stays minimized
+  // (revealing "inactively" would still re-surface a deliberately hidden
+  // window on every screen lock/unlock).
+  it("touches nothing on a reconnect", () => {
+    const win = fakeWin();
+    revealWindowForConnect(win, { reconnect: true });
+    assert.deepEqual(win.calls, []);
+  });
+});
+
+describe("main.js wiring (source pins)", () => {
+  const MAIN_JS = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+
+  // Extract a top-level function body: from its declaration to the first
+  // closing brace at column 0 (same technique as hide-to-tray.test.js).
+  const fnBody = (name) => {
+    const m = MAIN_JS.match(new RegExp(`async function ${name}\\([\\s\\S]*?\\n\\}`));
+    assert.ok(m, `main.js must define async function ${name}`);
+    return m[0];
+  };
+
+  // Assert a function body performs no window reveal/raise of any kind —
+  // including through the escalation helper (the self-healing stretch of a
+  // liveness path must stay fully silent; escalation belongs to the
+  // needs-user states inside showLoadingThenConnect / the terminal dialog).
+  const assertNoReveal = (body, name) => {
+    for (const call of ["show()", "showInactive()", "focus()", "restore()"]) {
+      assert.ok(
+        !body.includes(`win.${call}`),
+        `${name} must not call win.${call} on a liveness path`,
+      );
+    }
+    assert.ok(
+      !body.includes("revealForUserDecision("),
+      `${name} must not invoke the escalation reveal while self-healing`,
+    );
+  };
+
+  it("imports revealWindowForConnect from gateway-recovery", () => {
+    assert.match(MAIN_JS, /revealWindowForConnect,[\s\S]*?\} = require\("\.\/gateway-recovery"\)/);
+  });
+
+  it("reconnectExternalGateway performs no reveal at all", () => {
+    assertNoReveal(fnBody("reconnectExternalGateway"), "reconnectExternalGateway");
+  });
+
+  it("reconnectOrRespawnAdoptedGateway performs no reveal at all", () => {
+    assertNoReveal(fnBody("reconnectOrRespawnAdoptedGateway"), "reconnectOrRespawnAdoptedGateway");
+  });
+
+  it("showLoadingThenConnect routes its initial reveal through the helper", () => {
+    const body = fnBody("showLoadingThenConnect");
+    assert.match(body, /async function showLoadingThenConnect\(win, backendUrl = BACKEND_URL, \{ reconnect = false \} = \{\}\)/);
+    assert.match(body, /revealWindowForConnect\(win, \{ reconnect \}\)/);
+  });
+
+  // ESCALATION: inside showLoadingThenConnect the needs-user states (token
+  // prompt, failure dialog) must do a FULL reveal — reconnect-guarded — via
+  // revealForUserDecision. No bare win.show() may remain (it would skip the
+  // deferred-tray-hide cancel and the un-minimize). The token-prompt reveal
+  // must precede exitImmersiveModes: leaving fullscreen fires a deferred
+  // tray-hide's listener, so the cancel inside the reveal has to come first.
+  // ESCALATION: inside showLoadingThenConnect the needs-user states (token
+  // prompt, failure dialog) must do a FULL reveal — unconditional, because a
+  // window can be hidden on any path by the time input is needed, and the
+  // reveal is idempotent when visible. No bare win.show() may remain (it
+  // would skip the deferred-tray-hide cancel and the un-minimize). The
+  // token-prompt reveal must precede exitImmersiveModes: leaving fullscreen
+  // fires a deferred tray-hide's listener, so the cancel has to come first.
+  it("showLoadingThenConnect escalates needs-user states via the full reveal", () => {
+    const body = fnBody("showLoadingThenConnect");
+    assert.ok(!body.includes("win.show()"), "no bare win.show() inside showLoadingThenConnect");
+    const REVEAL = "revealForUserDecision(win);";
+    // One reveal in the token-prompt branch, BEFORE exitImmersiveModes.
+    const immersive = body.indexOf("exitImmersiveModes(win);");
+    const tokenReveal = body.indexOf(REVEAL);
+    assert.ok(tokenReveal !== -1 && immersive !== -1 && tokenReveal < immersive,
+      "token-prompt reveal must exist and run before exitImmersiveModes");
+    // And one in the failure-dialog branch: inside the catch, before the modal
+    // actually opens (match the awaited call, not comment mentions of it).
+    const catchStart = body.indexOf("} catch (err) {");
+    const dialog = body.indexOf("await showGatewayErrorDialog(", catchStart);
+    const dialogReveal = body.indexOf(REVEAL, catchStart);
+    assert.ok(catchStart !== -1 && dialogReveal !== -1 && dialog !== -1 && dialogReveal < dialog,
+      "failure-dialog reveal must sit in the catch branch, before the modal opens");
+  });
+
+  // The escalation reveal must follow the repo's full show idiom
+  // (hide-to-tray.js contract): cancel the deferred hide, un-minimize, show,
+  // focus, and steal macOS app activation (a background app's window rises
+  // without keyboard focus otherwise — same as the global-hotkey summon).
+  it("revealForUserDecision performs the full reveal idiom", () => {
+    const m = MAIN_JS.match(/function revealForUserDecision\(win\) \{[\s\S]*?\n\}/);
+    assert.ok(m, "main.js must define revealForUserDecision");
+    const body = m[0];
+    const order = [
+      "cancelPendingTrayHide(win)",
+      "if (win.isMinimized()) win.restore()",
+      "win.show()",
+      "win.focus()",
+      "if (IS_MAC) app.focus({ steal: true })",
+    ].map((s) => body.indexOf(s));
+    assert.ok(order.every((i) => i !== -1), `full reveal idiom missing a step: ${body}`);
+    assert.deepEqual([...order].sort((a, b) => a - b), order, "reveal steps out of order");
+    assert.match(body, /isQuitting\) return;/, "reveal must bail during app quit");
+  });
+
+  // Terminal escalation: showUnrecoverableGatewayError is called DIRECTLY from
+  // liveness paths (not through showLoadingThenConnect), presents a modal
+  // child of `win`, and every branch needs a human decision. It must fully
+  // reveal its parent first — a modal under a tray-hidden parent parks
+  // invisibly, and every button on that dialog quits the app.
+  it("showUnrecoverableGatewayError reveals its parent before the modal", () => {
+    const body = fnBody("showUnrecoverableGatewayError");
+    const reveal = body.indexOf("revealForUserDecision(win)");
+    const dialog = body.indexOf("showGatewayErrorDialog");
+    assert.ok(reveal !== -1, "terminal error dialog must reveal its parent window");
+    assert.ok(dialog !== -1 && reveal < dialog, "reveal must happen before the modal opens");
+  });
+
+  // Every liveness-recovery re-entry into the boot flow must be flagged as a
+  // reconnect: an unflagged own-port call site would raise+focus on a
+  // background reconnect. All liveness paths call with the BACKEND_URL
+  // literal, so any such call missing the flag fails here.
+  it("every liveness recovery path re-enters the boot flow with reconnect: true", () => {
+    const unflagged = MAIN_JS.match(/showLoadingThenConnect\(win, BACKEND_URL\)/g) || [];
+    assert.deepEqual(unflagged, [], "own-port showLoadingThenConnect call sites must pass a reconnect flag");
+    const flagged = MAIN_JS.match(/showLoadingThenConnect\(win, BACKEND_URL, \{ reconnect: true \}\)/g) || [];
+    assert.ok(flagged.length >= 4, `expected the liveness call sites to stay flagged, saw ${flagged.length}`);
+  });
+
+  // recoverWedgedGateway has two callers: the liveness monitor (silent) and
+  // the failed-update-install path, where the user clicked Install and is
+  // watching — that one must keep the raise. The flag is threaded through to
+  // the boot-flow re-entry, and the install path must actually pass it.
+  it("recoverWedgedGateway raises for user-initiated recovery, stays silent for liveness", () => {
+    const body = fnBody("recoverWedgedGateway");
+    assert.match(body, /async function recoverWedgedGateway\(win, \{ userInitiated = false \} = \{\}\)/);
+    assert.match(body, /showLoadingThenConnect\(win, BACKEND_URL, \{ reconnect: !userInitiated \}\)/);
+    assert.match(MAIN_JS, /recoverWedgedGateway\(mainWindow, \{ userInitiated: true \}\)/);
+  });
+
+  // The cold-boot path must NOT be flagged — initial launch keeps its raise.
+  it("cold launch still raises (boot call carries no reconnect flag)", () => {
+    assert.match(MAIN_JS, /await showLoadingThenConnect\(win\);/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6373

Every liveness-recovery reconnect (remote SSH-tunnel drop, adopted-gateway recovery, wedged-gateway respawn) called `win.show()` unconditionally; on macOS `show()` raises AND focuses, so each screen lock/unlock yanked the desktop app over the user's foreground work.

**The rule this PR installs:**

- **Self-healing is silent.** A liveness reconnect touches nothing — no raise, no focus, no un-minimize, no re-surfacing of a tray-hidden window. The loading splash loads fine into a background/hidden window. The decision lives in an injectable helper, `revealWindowForConnect(win, { reconnect })` in `gateway-recovery.js`, unit-tested with a fake window.
- **Cold launch and user-initiated connects keep their raise** (app boot, dialog Retry, new connection windows, tray/dock/hotkey). The failed-update-install recovery threads `userInitiated: true` through `recoverWedgedGateway` so its raise survives too.
- **Escalation: needs-the-user states always reveal.** The token prompt, the gateway failure dialog, and the terminal unrecoverable-gateway dialog do a full reveal (`revealForUserDecision`: cancel deferred tray-hide → un-minimize → show → focus → macOS `app.focus({steal:true})`) at the point they are reached — a modal child of a hidden parent is ordered out with it, so recovery could otherwise park invisibly. The token-prompt reveal is ordered before `exitImmersiveModes`, whose fullscreen exit fires a deferred tray-hide's listener.
- Also adds destroyed-window rechecks after the async probes on the adopted-gateway branches.

## Testing

- `npm test` in `website/electron` (node test runner): full suite green including the new `test/reconnect-focus.test.js` — behavioral tests of the reveal helper with a fake window, plus source-level wiring pins (same idiom as `hide-to-tray.test.js`: `main.js` cannot be `require`d in the suite) covering: no reveal anywhere on the self-healing stretch, all liveness re-entries flagged, cold boot unflagged, both escalation reveals branch-scoped and ordered before their modals, the full reveal idiom order, and the `userInitiated` threading.
- `website/src` untouched — no tsc/vitest churn expected.

No screenshots: this is Electron main-process window-behavior work (behavioral, not visual); the fix is pinned by tests instead.

## Adversarial review (pre-push)

5 rounds of dual blind review (GPT `gpt-5.6-sol` mirroring codex lane + Opus `claude-opus-5` mirroring claude lane), fresh reviewers each round. ~30 findings; 14 fixed across 4 fix rounds (incl. 2 High: invisible token-prompt parking, terminal dialog modal under hidden parent; and the user-initiated install-recovery raise). Final round: both PASS, zero Critical/High.

**Documented residuals (below block bar, deliberate):**
- Foreign-gateway token mint has no retry budget on reconnect, so one failed SSH mint right after wake escalates to a (correct but intrusive) reveal; a bounded reconnect-gated retry would narrow it further — follow-up candidate, kept out to stay minimal.
- `startGateway()`'s `resolveGatewayConflict` parentless dialog on a narrow port-rebind race is reachable from a background app without a reveal (pre-existing shape).
- `userInitiated` is threaded only to the respawn tail of `recoverWedgedGateway`; the two forked strategies drop it (unreachable from the install path in practice — an install only stops a gateway we spawned).
- Hidden-window reconnects can settle on the loading screen's 8s fade backstop (background timer throttling) — latency only, recovery completes.
