### PR TITLE
fix(sessions): pin the trash log-forgery test to the reader list_trash uses

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -886,9 +886,12 @@ class TestTrashBatchNamesAreLogSafe:
             def is_dir() -> bool:
                 return True
 
-        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+        # The seam is whatever ``list_trash`` reads the manifest through, which is
+        # the summarising reader (#6312) -- patching the streaming one instead
+        # leaves the real read running against this stub and fails on ``batch /``.
+        manifests: dict[str, tuple[dict[str, object], int, int] | None] = {
             "missing": None,
-            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0),
         }
         for label, parsed in manifests.items():
             caplog.clear()
@@ -897,7 +900,7 @@ class TestTrashBatchNamesAreLogSafe:
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )
             monkeypatch.setattr(
-                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+                session_storage, "_summarize_manifest", lambda batch, parsed=parsed: parsed
             )
 
             with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):


### PR DESCRIPTION
## What

`test/test_session_storage.py::TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem` fails on `main` with:

```
TypeError: unsupported operand type(s) for /: '_ForgedDir' and 'str'
```

## Why it happens

This is a mid-air collision between two PRs that merged four hours apart, not a flake:

- #6333 (02:03) added the guard. It injects an agent-controlled batch name carrying an embedded newline by patching `session_storage._read_manifest`, so both log sites can be pinned on Windows shards too (a real directory cannot hold a newline there).
- #6312 (06:06) re-routed `list_trash` from `_read_manifest` to the new `_summarize_manifest` streaming reader.

After #6312 nothing is patched on the path `list_trash` actually takes, so the real `_summarize_manifest` runs against the test's stub directory object and dies on `batch / MANIFEST_NAME` before either log site is reached. Both PRs were green alone; only the merged tree fails. It reproduces on every run.

## Fix

Patch the seam `list_trash` reads through, using that reader's `(header, sessions, bytes)` shape instead of `_read_manifest`'s `(header, entries)`.

## Verification

- `test/test_session_storage.py`: 147 passed (was 1 failed / 146 passed).
- Revert-verified the guard is still load-bearing: mutating `%r` → `%s` at the missing-manifest site fails the test, mutating it at the batch-id-disagreement site fails the test, and the restored tree passes. Both mutations applied and reverted from an in-memory snapshot.
- `black --check`, `flake8`, `isort --check-only` clean on the touched file.
