### PR TITLE
fix(test): migrate missed _read_manifest stub to _summarize_manifest

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -886,9 +886,9 @@ class TestTrashBatchNamesAreLogSafe:
             def is_dir() -> bool:
                 return True
 
-        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+        manifests: dict[str, tuple[dict[str, object], int, int] | None] = {
             "missing": None,
-            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0),
         }
         for label, parsed in manifests.items():
             caplog.clear()
@@ -897,7 +897,7 @@ class TestTrashBatchNamesAreLogSafe:
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )
             monkeypatch.setattr(
-                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+                session_storage, "_summarize_manifest", lambda batch, parsed=parsed: parsed
             )
 
             with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):


### PR DESCRIPTION
## Problem / Motivation

main is red: `test_session_storage.py::TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem` fails on every branch based on current main with `TypeError: unsupported operand type(s) for /: '_ForgedDir' and 'str'` (Backend Tests shard 3, all Python versions and Windows).

## Why it matters

Every open PR rebased or merged onto current main inherits the red shard, blocking unrelated work from reaching green (first observed on PR #6396's CI).

## What changed (motivation → approach → change)

PR #6312 switched `list_trash()` from `_read_manifest` to the new `_summarize_manifest` and migrated the other test stubs, but missed this one — the test still stubs `_read_manifest`, so its forged directory object reaches the REAL `_summarize_manifest`, which does `batch / MANIFEST_NAME` and explodes on the fake. Fix: stub `_summarize_manifest` instead, with its `(header, sessions, staged_bytes)` return shape (`([], …)` entry list → `0, 0` aggregates). Test-only change; no production code touched.

## Tests

`pytest test/test_session_storage.py` — all 147 pass (previously 1 failed on pristine main eaeb5076e).

## Manual verification

N/A — unit coverage sufficient: the change is a test stub migration, verified by the full test file run above.

No linked issue: main-breakage unblocker, found while babysitting PR #6396; filing an issue would outlive the fix.
