### PR TITLE
fix(mcp): stop logging abrupt client disconnects as handler crashes

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -405,6 +405,11 @@ async def run_gatewayd(
         except asyncio.CancelledError:
             # Normal on shutdown — propagate for the gather() below.
             raise
+        except ConnectionError:
+            # Abrupt peer disconnect (ECONNRESET / EPIPE from a hard-killed
+            # client) is routine — the clean-EOF sibling is already handled
+            # inside _handle_connection — so don't log it as a crash.
+            logger.debug("client disconnected abruptly", exc_info=True)
         except Exception:
             logger.exception("connection handler crashed")
         finally:

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -1023,3 +1023,48 @@ class TestRunGatewaydLifecycle:
             await asyncio.wait_for(daemon, timeout=15)
 
         assert any("connection handler crashed" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_an_abrupt_client_disconnect_is_not_logged_as_a_crash(
+        self, short_sock_dir, monkeypatch, caplog
+    ):
+        socket_path = short_sock_dir / "gw-reset.sock"
+        handled = asyncio.Event()
+
+        async def _reset(*args, **kwargs):
+            handled.set()
+            raise ConnectionResetError(104, "Connection reset by peer")
+
+        monkeypatch.setattr(gw, "_handle_connection", _reset)
+
+        stop_event = asyncio.Event()
+        daemon = asyncio.create_task(
+            gw.run_gatewayd(
+                socket_path,
+                max_backends=2,
+                idle_timeout_secs=300,
+                stop_event=stop_event,
+                target_resolver=_resolver,
+            )
+        )
+        try:
+            for _ in range(500):
+                if socket_path.exists():
+                    break
+                await asyncio.sleep(0.02)
+            assert socket_path.exists(), "the daemon never bound its endpoint"
+            with caplog.at_level(logging.ERROR, logger=gw.logger.name):
+                _, writer = await asyncio.open_unix_connection(str(socket_path))
+                writer.close()
+                await asyncio.wait_for(handled.wait(), timeout=10)
+                # A reset peer is routine: the accept loop still serves.
+                _, writer2 = await asyncio.open_unix_connection(str(socket_path))
+                writer2.close()
+                await asyncio.sleep(0.05)
+        finally:
+            stop_event.set()
+            await asyncio.wait_for(daemon, timeout=15)
+
+        assert not any(
+            "connection handler crashed" in rec.message for rec in caplog.records
+        )


### PR DESCRIPTION
## Problem / Motivation

A client that drops its gateway socket without a clean shutdown (killed mid-request, crashed, or hard-restarted) raises `ConnectionResetError` inside the per-connection handler. The handler's generic `except Exception` branch logs this as `ERROR connection handler crashed` with a full traceback. On a busy gateway this is pure noise — one long-running install accumulated 44 identical tracebacks in a single `mcp-gatewayd.stdout`.

## Why it matters

Every abrupt client disconnect pollutes the log with an ERROR-level traceback, drowning out real errors and making log-based triage (and any alerting keyed on ERROR) noisy. Anyone running the gateway for more than a few days hits it.

## What changed (motivation → approach → change)

Observed symptom: repeated `connection handler crashed` ERROR tracebacks whose innermost exception is `ConnectionResetError: [Errno 104]`. Root cause: `_handle_connection` already treats clean EOF (`asyncio.IncompleteReadError`) as a routine disconnect, but its abrupt sibling — the peer resetting the socket — escapes to the generic `except Exception` in `_handle` and is misclassified as a handler crash. Change: catch `ConnectionError` (covers `ConnectionResetError` / `BrokenPipeError`, matching the style used elsewhere in this file, e.g. the backend write path) before the generic branch and log it at DEBUG. Genuine handler bugs still log at ERROR with a traceback.

## Tests

- New `test_an_abrupt_client_disconnect_is_not_logged_as_a_crash` (test/test_gatewayd_more_coverage.py) mirrors the existing crash-logging test: it drives `run_gatewayd` with a handler raising `ConnectionResetError`, asserts no ERROR `connection handler crashed` record is emitted, and asserts the accept loop still serves a second connection.
- Mutation-proved: with the production hunk reverted the new test fails at assertion (not collection).
- `pytest test/test_gatewayd_more_coverage.py`: 45 passed. `mypy src/kiro_crew/` clean; isort/flake8/black clean.

## Manual verification

N/A — unit coverage sufficient: the regression test exercises the real daemon accept loop over a unix socket; the only behavior change is the log level of one exception class.

## Related Issues

No linked issue: found by auditing gateway logs on a long-running install; no existing upstream issue tracks this.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, internal log-level change
- [x] No secrets, credentials, or internal references in the diff

<!-- readiness recompute nudge: all lanes green, status stuck pending (dropped workflow_run event) -->