### PR TITLE
chore(release): stamp 0.5.0-rc.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.5.0"
+version = "0.5.0-rc.1"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.5.0"
+__version__ = "0.5.0-rc.1"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.5.0",
+  "version": "0.5.0-rc.1",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
## Problem / Motivation

`release/0.5.0` was just cut from `main` (which reads bare `0.5.0`). Per the version numbering policy, an insider release branch must declare the RC in its in-code version so a source/dev checkout reads as the candidate it is.

## What changed

Stamps all three declaration files to the dual-valid spelling `0.5.0-rc.1` (valid SemVer for `package.json`, valid non-canonical PEP 440 for `__init__.py`/`pyproject.toml`, normalizes to `0.5.0rc1`):

- `src/kiro_crew/__init__.py`
- `pyproject.toml`
- `website/electron/package.json`

The tag overrides all three at build time (`build-wheel.yml`/`build-desktop.yml` sed the tag-derived version in), so this only governs local/dev builds on the release branch, not the actual RC artifacts.

## Tests

- `test/test_config_meta_stamp.py`, `test/test_nightly_version_contract.py`, `test/test_release_channel.py`: 50 passed.