### PR TITLE
chore: bump main to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.5.0"
+version = "0.6.0"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 
 class _LazyShutdownEvent:

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",


### PR DESCRIPTION
## Problem / Motivation

`release/0.5.0` was just cut from `main` to start the next insider line. `main` must stay one minor ahead of the active insider line so every nightly sorts strictly above any RC of the shipping line, and a nightly user is never offered what looks like a downgrade to an RC.

## What changed

Bumps the bare in-code version from `0.5.0` to `0.6.0` in the three declaration files:

- `src/kiro_crew/__init__.py`
- `pyproject.toml`
- `website/electron/package.json`

Does not touch `website/electron/package-lock.json` (its root `version` field is pre-existing drift at `0.4.0`, unrelated to this bump and not pinned by any test).

## Tests

- `test/test_config_meta_stamp.py`, `test/test_nightly_version_contract.py`, `test/test_release_channel.py`: 50 passed.