### PR TITLE
fix(autonudge): freeze the clock for every deadline-anchored delay assertion

### DIFF
--- a/test/test_autonudge.py
+++ b/test/test_autonudge.py
@@ -25,6 +25,24 @@ def svc(tmp_path):
     return AutoNudgeService(base_dir=tmp_path)
 
 
+_FROZEN_NOW = 1_000_000.0
+
+
+def _freeze_clock(monkeypatch) -> None:
+    """Pin ``autonudge``'s clock so a deadline-anchored first delay is exact.
+
+    ``add()`` anchors ``next_due_ts = now + idle_secs``, then AWAITS an fsync of
+    the state file before ``_arm_from_deadline`` re-reads ``time.time()`` to
+    derive ``remaining``. Unfrozen, the first delay comes out short by however
+    long that write took (2.4s on a loaded Windows shard), so any tolerance on it
+    is really asserting that the runner never stalls between two statements.
+    Frozen, ``remaining`` is exactly ``idle_secs``, so every assertion below can
+    be exact -- a tolerance there would only hide a regression that reintroduces
+    the wall-clock dependency.
+    """
+    monkeypatch.setattr(_an.time, "time", lambda: _FROZEN_NOW)
+
+
 @pytest.mark.asyncio
 async def test_add_and_fire_on_idle(svc, monkeypatch):
     """Arming a timer and letting it elapse triggers the fire callback."""
@@ -516,6 +534,7 @@ async def test_skip_when_delivery_returns_false(svc, monkeypatch):
         return None
 
     monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
+    _freeze_clock(monkeypatch)
 
     fired: list[NudgeLoop] = []
 
@@ -543,7 +562,7 @@ async def test_skip_when_delivery_returns_false(svc, monkeypatch):
     assert not svc._timers[loop.id].done()
     # First sleep used the (deadline-anchored) full idle; the re-arm used the
     # shorter backoff.
-    assert sleep_calls[0] == pytest.approx(60, abs=1)
+    assert sleep_calls[0] == 60
     assert _an._REARM_BACKOFF_SECS in sleep_calls
     svc._cancel_timer(loop.id)  # cleanup
 
@@ -612,13 +631,7 @@ async def test_rearm_backoff_escalates_on_consecutive_failures(svc, monkeypatch)
         await real_sleep(0)
 
     monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
-    # Freeze the clock for the arm. add() anchors next_due_ts = now + idle_secs,
-    # then AWAITS an fsync of the state file before _arm_from_deadline re-reads
-    # time.time() to derive `remaining`. Unfrozen, the first delay is short by
-    # however long that write took (1.8s on a loaded shard), so the assertion
-    # below was really asserting that the runner never stalls between two
-    # statements. Frozen, `remaining` is exactly idle_secs.
-    monkeypatch.setattr(_an.time, "time", lambda: 1_000_000.0)
+    _freeze_clock(monkeypatch)
 
     async def on_fire_skip(loop):
         return False
@@ -638,9 +651,6 @@ async def test_rearm_backoff_escalates_on_consecutive_failures(svc, monkeypatch)
             break
         task = nxt
     # First sleep = (deadline-anchored) full idle; then exponential backoff per failure.
-    # Exact, not approx: the frozen clock makes the first delay deterministic,
-    # so a tolerance here would only hide a regression that reintroduces the
-    # wall-clock dependency.
     assert sleep_calls == [10000, 15, 30, 60, 120]
     assert svc._loops[loop.id].active is True
     assert svc._rearm_fail_count[loop.id] == 4
@@ -706,6 +716,7 @@ async def test_failure_streak_resets_on_delivery(svc, monkeypatch):
         return None
 
     monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
+    _freeze_clock(monkeypatch)
 
     results = [False, False, True]  # third fire delivers
     idx = {"i": 0}
@@ -730,7 +741,7 @@ async def test_failure_streak_resets_on_delivery(svc, monkeypatch):
         task = nxt
     # 2 skips escalated (15, 30), then delivery bumped cycle_count and the
     # delivered happy-path does not re-arm, so the chain stops at 3 sleeps.
-    assert sleep_calls == [pytest.approx(10000, abs=1), 15, 30]
+    assert sleep_calls == [10000, 15, 30]
     assert svc._loops[loop.id].cycle_count == 1
     assert loop.id not in svc._rearm_fail_count  # streak cleared on delivery
 
@@ -751,6 +762,7 @@ async def test_fire_removed_loop_does_not_rearm_orphan(svc, monkeypatch):
         return None
 
     monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
+    _freeze_clock(monkeypatch)
 
     removed = _asyncio.Event()
 
@@ -773,7 +785,7 @@ async def test_fire_removed_loop_does_not_rearm_orphan(svc, monkeypatch):
     assert loop.id not in svc._timers
     assert loop.id not in svc._rearm_fail_count
     # Only the initial idle sleep ran; no backoff re-arm fired.
-    assert sleep_calls == [pytest.approx(60, abs=1)]
+    assert sleep_calls == [60]
 
 
 @pytest.mark.asyncio
@@ -931,6 +943,7 @@ async def test_unrouted_channel_namespace_degrades_instead_of_raising(svc, monke
         return None
 
     monkeypatch.setattr(_an.asyncio, "sleep", _sleep)
+    _freeze_clock(monkeypatch)
 
     removed = _asyncio.Event()
 
@@ -954,7 +967,7 @@ async def test_unrouted_channel_namespace_degrades_instead_of_raising(svc, monke
     assert loop.id not in svc._timers
     assert loop.id not in svc._rearm_fail_count
     # Only the initial idle sleep ran — no backoff re-arm was scheduled.
-    assert sleep_calls == [pytest.approx(60, abs=1)]
+    assert sleep_calls == [60]
     svc.stop()
 
 


### PR DESCRIPTION
## What

The three Windows-shard failures:

```
FAILED test/test_autonudge.py::test_skip_when_delivery_returns_false - assert 58.551576375961304 == 60 ± 1
FAILED test/test_autonudge.py::test_failure_streak_resets_on_delivery - assert [9997.65443944931, 15, 30] == [10000 ± 1, 15, 30]
FAILED test/test_autonudge.py::test_unrouted_channel_namespace_degrades_instead_of_raising - assert [58.82950949668884] == [60 ± 1]
```

## Why it happens

`add()` anchors the deadline and then awaits the state write before the timer is armed:

```python
next_due_ts=now + idle_secs,
...
await asyncio.get_running_loop().run_in_executor(None, self._write_state, payload)
self._arm_from_deadline(loop)      # remaining = next_due_ts - time.time()
```

`_write_state` fsyncs. The first delay is therefore `idle_secs` minus however long that write took — correct behaviour (the countdown is deadline-anchored, not restarted per arm), but it means a one-second tolerance on the delay is really asserting that the runner never stalls between those two statements. A loaded Windows shard stalls for 1.5–2.5s.

`test_rearm_backoff_escalates` already hit this and fixed it for itself by freezing the clock; four siblings were left on wall-clock tolerances.

## Fix

Lift that freeze into a shared `_freeze_clock` helper and apply it to all four. With the clock frozen `remaining` is exactly `idle_secs`, so the assertions become exact — strictly stronger than before: a delay of `idle_secs + 1` used to sit inside `abs=1` and now fails.

Deadline anchoring itself stays covered by `test/test_autonudge_deadline.py`, which derives its expectations from the same `now` and so cannot drift.

## Verification

- Reproduced the CI failure locally by injecting a 2s sleep into `_write_state`: all four drifting tests fail with the same shape (57.99 / 9997.99 / 57.98 / 57.99), the already-frozen one passes. With the fix, all five pass under the same injection.
- Revert-verified both properties these tests exist for: `_REARM_BACKOFF_SECS = 15 → 17` fails them, and replacing the deadline-derived delay with `idle_secs + 1` fails all five.
- `test_autonudge.py` + the four sibling autonudge files: 138 passed.
- `black --check`, `flake8`, `isort --check-only` clean.

## Unrelated, noted only

`TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved` fails identically on unmodified `main` on any machine whose home directory contains `.kiro/crew` (the test asserts a constructed path does not contain that marker). Not touched here.
