### PR TITLE
feat(crew-companion): one avatar that moves between displays

### DIFF
--- a/website/electron/crew-companion/pet-preload.js
+++ b/website/electron/crew-companion/pet-preload.js
@@ -193,4 +193,127 @@ contextBridge.exposeInMainWorld("crewCompanion", {
     ipcRenderer.on("crew-companion:panel-opened", handler);
     return () => ipcRenderer.removeListener("crew-companion:panel-opened", handler);
   },
+
+  // ── Single-avatar / cross-display drag ──────────────────────────────────────
+  // The avatar lives on one display at a time. The main process tells each overlay
+  // whether it is the active one, and owns the handoff when the avatar is dragged
+  // across a screen boundary (only the global cursor crosses a window edge).
+
+  /**
+   * Begin a cross-display drag. offset = cursor screen point − sprite top-left, so
+   * the main process can place the avatar under the cursor as it leaves this window.
+   */
+  dragStart(offsetX, offsetY) {
+    ipcRenderer.send("crew-companion:drag-start", offsetX | 0, offsetY | 0);
+  },
+
+  /** Explicit drag end (e.g. window blur). */
+  dragEnd() {
+    ipcRenderer.send("crew-companion:drag-end");
+  },
+
+  /** A mouseup this overlay saw; ends the drag wherever the cursor now is. */
+  dragMouseUp() {
+    ipcRenderer.send("crew-companion:drag-mouseup");
+  },
+
+  /**
+   * This overlay became active or inactive. When active during a live handoff the
+   * callback also receives the entry point and isDragging, so the renderer can
+   * resume the drag in flight. cb(active, localX?, localY?, isDragging?).
+   */
+  onSetActive(cb) {
+    const handler = (_e, active, x, y, isDragging) => cb(active, x, y, isDragging);
+    ipcRenderer.on("crew-companion:set-active", handler);
+    return () => ipcRenderer.removeListener("crew-companion:set-active", handler);
+  },
+
+  /** Per-frame avatar position while dragging on this (active) display. */
+  onDragUpdate(cb) {
+    const handler = (_e, x, y) => cb(x, y);
+    ipcRenderer.on("crew-companion:drag-update", handler);
+    return () => ipcRenderer.removeListener("crew-companion:drag-update", handler);
+  },
+
+  /** Final avatar position when the drag ends; run the edge-snap animation. */
+  onDragEnded(cb) {
+    const handler = (_e, x, y) => cb(x, y);
+    ipcRenderer.on("crew-companion:drag-ended", handler);
+    return () => ipcRenderer.removeListener("crew-companion:drag-ended", handler);
+  },
+
+  /**
+   * Broadcast to every overlay at drag-start: listen for a global mouseup and
+   * report it via dragMouseUp, so the drag ends even if the cursor released over a
+   * different display than the one that started it.
+   */
+  onDragListenMouseUp(cb) {
+    const handler = () => cb();
+    ipcRenderer.on("crew-companion:drag-listen-mouseup", handler);
+    return () => ipcRenderer.removeListener("crew-companion:drag-listen-mouseup", handler);
+  },
+
+  /**
+   * Tell main this overlay's active-state listener is mounted, so main replies with
+   * set-active. This is the reliable half of the activation handshake: the main
+   * process's initial send may fire before this renderer subscribes.
+   */
+  petReady() {
+    ipcRenderer.send("crew-companion:pet-ready");
+  },
+
+  /**
+   * Notification OWNER role. The main process elects exactly one overlay as the
+   * owner; only it runs the WebSocket + reminder poll + bubble state machine. Every
+   * other overlay is a pure view. Decoupled from set-active so a drag hand-off (which
+   * moves the avatar) never disturbs the producing owner.
+   */
+  onSetOwner(cb) {
+    const handler = (_e, isOwner) => cb(Boolean(isOwner));
+    ipcRenderer.on("crew-companion:set-owner", handler);
+    return () => ipcRenderer.removeListener("crew-companion:set-owner", handler);
+  },
+
+  /** Owner → main: the single resolved bubble to show (or null), plus its slot snapshot and local seq. */
+  reportBubbleState(bubble, slot, seq) {
+    ipcRenderer.send("crew-companion:bubble-state", bubble ?? null, slot ?? null, seq ?? null);
+  },
+
+  /** Main → active overlay: render this bubble (or null). */
+  onRenderBubble(cb) {
+    const handler = (_e, bubble, playReaction) => cb(bubble ?? null, playReaction === true);
+    ipcRenderer.on("crew-companion:render-bubble", handler);
+    return () => ipcRenderer.removeListener("crew-companion:render-bubble", handler);
+  },
+
+  /** Active overlay → main → owner: a user action on the bubble (e.g. dismiss). */
+  bubbleAction(action) {
+    ipcRenderer.send("crew-companion:bubble-action", action || null);
+  },
+
+  /** Main → owner: a bubble action performed on the active overlay. */
+  onBubbleAction(cb) {
+    const handler = (_e, action) => cb(action ?? null);
+    ipcRenderer.on("crew-companion:bubble-action", handler);
+    return () => ipcRenderer.removeListener("crew-companion:bubble-action", handler);
+  },
+
+  /** Owner → main → active overlay: a window command (Open panel / Change avatar). */
+  reportWindowCommand(cmd) {
+    ipcRenderer.send("crew-companion:window-command", cmd || null);
+  },
+
+  /** Main → active overlay: run a window command at the avatar's position. */
+  onWindowCommand(cb) {
+    const handler = (_e, cmd) => cb(cmd ?? null);
+    ipcRenderer.on("crew-companion:window-command", handler);
+    return () => ipcRenderer.removeListener("crew-companion:window-command", handler);
+  },
+
+  /** Main → replacement brain: rehydrate the producer's recovery state ({slot, seq}) after a crash restart. */
+  onRehydrateSlot(cb) {
+    const handler = (_e, recovery) => cb(recovery ?? null);
+    ipcRenderer.on("crew-companion:rehydrate-slot", handler);
+    return () => ipcRenderer.removeListener("crew-companion:rehydrate-slot", handler);
+  },
 });

--- a/website/electron/crew-companion/petOverlay.js
+++ b/website/electron/crew-companion/petOverlay.js
@@ -12,9 +12,19 @@
  * `pointer-events: none` on the body, enabling it only on the companion itself.
  * `forward: true` is what still lets the renderer SEE the cursor move, which is how
  * it knows when the pointer is over the sprite.
+ *
+ * SINGLE AVATAR ACROSS DISPLAYS. There is still one overlay per display, but the
+ * avatar lives on exactly ONE of them at a time (`activeDisplayId`); every other
+ * overlay is told it is inactive and renders nothing, so a multi-monitor user sees
+ * one companion, not one per screen. The avatar is moved to another display ONLY by
+ * dragging it across the screen boundary — it does NOT follow the cursor at rest.
+ * The main process owns the cross-display handoff because mousemove events stop at a
+ * window edge and only `screen.getCursorScreenPoint()` can follow a drag between
+ * displays.
  */
 
 const path = require("path");
+const fs = require("fs");
 const { app, BrowserWindow, screen, ipcMain } = require("electron");
 const { companionPageUrl } = require("./pageUrl");
 
@@ -35,8 +45,65 @@ const lastIgnore = new Map();
 /** ~60fps, matching the desktop app's cursor poll. */
 const HITBOX_POLL_MS = 16;
 
+/** Pet box, matching the renderer's sprite size (shared constant PET_W/PET_H = 128). */
+const PET_W = 128;
+const PET_H = 128;
+
+/** Force-stop a drag that never saw a mouseup (window blur, lost event). */
+const DRAG_SAFETY_MS = 10_000;
+
 let pollTimer = null;
 let ipcRegistered = false;
+
+/** Which display currently hosts the single avatar. @type {number|null} */
+let activeDisplayId = null;
+
+/**
+ * The dedicated hidden window that owns notification production (the WebSocket, the
+ * reminder poll and the bubble state machine). It is NOT tied to any display, so its
+ * lifetime spans display churn (unplug/sleep/rearrange). A per-display owner had to
+ * be re-elected when its display went away, and during the interval before the new
+ * owner's socket connected a completion or approval had no subscriber and was lost;
+ * an app-lifetime owner removes that hand-off entirely. It renders nothing (never
+ * active); the visible overlays are pure views that draw whatever it reports,
+ * relayed through main.
+ * @type {Electron.BrowserWindow|null}
+ */
+let brainWin = null;
+
+/**
+ * True between openPetWindow() and closePetWindow(). Lets a crashed brain window
+ * self-heal (recreate) while the companion is on, without recreating it after a
+ * deliberate teardown.
+ */
+let companionEnabled = false;
+
+/**
+ * The bubble the owner last reported, cached in main so it can be pushed to a newly
+ * active overlay the instant it is elected (the owner need not re-report on every
+ * hand-off). null = nothing showing.
+ * @type {unknown}
+ */
+let currentBubble = null;
+// The brain's slot snapshot (count/at/sticky) plus its local sequence counter, cached
+// so a crash-replaced brain can rehydrate BOTH before it resumes producing — the render
+// bubble above lacks that bookkeeping, and a reset sequence would reuse a seq the active
+// overlay still keys its dismissal timer on.
+let currentSlot = null;
+let currentSeq = null;
+// Window commands (Open panel / Change avatar) that arrived before the active overlay
+// mounted its onWindowCommand listener, QUEUED (FIFO) until that overlay reports
+// pet-ready so every command drained during renderer setup is delivered in order rather
+// than the earlier ones being overwritten. readyOverlays tracks which overlays finished
+// that handshake, so a command goes straight through once the active overlay is ready.
+let pendingWindowCommands = [];
+const readyOverlays = new WeakSet();
+
+/** Cross-display drag state, owned entirely by the main process. */
+let dragPollTimer = null;
+let dragSafetyTimer = null;
+let dragOffsetX = 0;
+let dragOffsetY = 0;
 
 let baseUrl = "";
 let credential = "";
@@ -68,6 +135,316 @@ function assertHostStaysInDock() {
     app.dock?.show?.();
   } catch {
     /* older Electron / already regular */
+  }
+}
+
+// ── Position persistence ────────────────────────────────────────────────────
+// Remembered in Electron's userData dir (the shell cannot resolve the gateway's
+// data dir). Shape + 0600 mode mirror the reference implementation.
+
+function petPosPath() {
+  return path.join(app.getPath("userData"), "crew-companion-pet-position.json");
+}
+
+/** @type {{displayId?:number}|null} */
+let savedPetPos = null;
+try {
+  savedPetPos = JSON.parse(fs.readFileSync(petPosPath(), "utf-8"));
+} catch {
+  /* first run / unreadable — fall back to a computed start position */
+}
+
+// Only the DISPLAY the avatar lives on is persisted here, for restart election; its
+// on-screen x/y is owned by the renderer (petBridge.savePosition/getWindowPosition).
+function savePetPos(displayId) {
+  savedPetPos = { displayId };
+  try {
+    fs.writeFileSync(petPosPath(), JSON.stringify(savedPetPos), { mode: 0o600 });
+  } catch {
+    /* a failed position write must never break the companion */
+  }
+}
+
+// ── Display geometry (reference logic, verbatim) ─────────────────────────────
+
+function findDisplayAtPoint(sx, sy) {
+  return (
+    screen.getAllDisplays().find(
+      (d) =>
+        sx >= d.bounds.x &&
+        sx < d.bounds.x + d.bounds.width &&
+        sy >= d.bounds.y &&
+        sy < d.bounds.y + d.bounds.height,
+    ) || null
+  );
+}
+
+/** Nearest display by squared edge distance — the fallback for a cursor in a gap. */
+function findNearestDisplay(sx, sy) {
+  const displays = screen.getAllDisplays();
+  let best = displays[0];
+  let bestDist = Infinity;
+  for (const d of displays) {
+    const dx = Math.max(d.bounds.x - sx, 0, sx - (d.bounds.x + d.bounds.width));
+    const dy = Math.max(d.bounds.y - sy, 0, sy - (d.bounds.y + d.bounds.height));
+    const dist = dx * dx + dy * dy;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = d;
+    }
+  }
+  return best;
+}
+
+/** Clamp a local position: the avatar may hang half off left/right, never off top/bottom. */
+function clampLocal(localX, localY, bounds) {
+  return {
+    x: Math.max(-PET_W / 2, Math.min(bounds.width - PET_W / 2, localX)),
+    y: Math.max(0, Math.min(bounds.height - PET_H, localY)),
+  };
+}
+
+// ── The handoff ──────────────────────────────────────────────────────────────
+
+/**
+ * Move the avatar to another display's overlay. The old overlay is told it is no
+ * longer active (so it stops rendering) and returns to click-through — unless a
+ * drag is in flight, which manages ignore-mouse across every overlay itself.
+ */
+function transferActiveToDisplay(targetDisplayId, localX, localY, isDragging = false) {
+  const newWin = overlays.get(targetDisplayId);
+  // Never hand the avatar to a display with no live overlay — e.g. a monitor
+  // hot-plugged after startup that the drag poll selected. Deactivating the
+  // current overlay for a target that cannot render would leave NO avatar on
+  // screen, so keep it where it is until an overlay exists for that display.
+  if (!newWin || newWin.isDestroyed()) return;
+
+  if (activeDisplayId !== null && activeDisplayId !== targetDisplayId) {
+    const oldWin = overlays.get(activeDisplayId);
+    if (oldWin && !oldWin.isDestroyed()) {
+      oldWin.webContents.send("crew-companion:set-active", false);
+      if (!isDragging) oldWin.setIgnoreMouseEvents(true, { forward: true });
+    }
+  }
+
+  activeDisplayId = targetDisplayId;
+  // Drop any stale rect so the poll's null-hitbox safety net holds for the few
+  // frames until the renderer re-reports on the new display.
+  hitboxes.delete(newWin);
+  lastIgnore.delete(newWin);
+  newWin.webContents.send("crew-companion:set-active", true, localX, localY, isDragging);
+  // The new active overlay must draw whatever the owner is currently showing.
+  sendBubbleToActive();
+}
+
+// ── Cross-display drag poll ───────────────────────────────────────────────────
+// Runs only while a drag is in flight. It follows the GLOBAL cursor (the only thing
+// that crosses a window edge) and hands the avatar to whichever display the cursor
+// is over. There is no at-rest cursor following — this timer exists solely for the
+// duration of a drag.
+
+function startDragPolling(offsetX, offsetY) {
+  stopDragPolling();
+  dragOffsetX = offsetX;
+  dragOffsetY = offsetY;
+
+  // Every overlay must accept mouse events so whichever display the cursor ends
+  // over can report the mouseup that ends the drag.
+  for (const win of overlays.values()) {
+    if (win && !win.isDestroyed()) win.setIgnoreMouseEvents(false);
+  }
+  broadcastToPets("crew-companion:drag-listen-mouseup");
+
+  dragSafetyTimer = setTimeout(() => {
+    if (dragPollTimer !== null) stopDragPolling();
+  }, DRAG_SAFETY_MS);
+  dragSafetyTimer.unref?.();
+
+  dragPollTimer = setInterval(dragPollOnce, HITBOX_POLL_MS);
+  dragPollTimer.unref?.();
+}
+
+/**
+ * One cross-display drag tick: follow the GLOBAL cursor (the only thing that crosses
+ * a window edge) and hand the avatar to the display it is over, streaming the local
+ * position to the active overlay in between. Split out from the interval so a drag
+ * can be driven deterministically in tests.
+ */
+function dragPollOnce() {
+  let cursor;
+  try {
+    cursor = screen.getCursorScreenPoint();
+  } catch {
+    return;
+  }
+  const petScreenX = cursor.x - dragOffsetX;
+  const petScreenY = cursor.y - dragOffsetY;
+
+  const target =
+    findDisplayAtPoint(cursor.x, cursor.y) || findNearestDisplay(cursor.x, cursor.y);
+  const localX = petScreenX - target.bounds.x;
+  const localY = petScreenY - target.bounds.y;
+
+  // Crossing a screen boundary hands the avatar to the new display AT the crossing
+  // point — but only if that display actually has an overlay. A display hot-plugged
+  // after enable has none (nothing opens one), so transferring there would no-op
+  // while savePetPos hammered fs.writeFileSync ~60x/sec on the main thread and the
+  // avatar froze. In that case fall through and keep streaming to the active overlay,
+  // clamped to its OWN display's edge, so the avatar tracks the cursor instead.
+  if (target.id !== activeDisplayId && overlays.has(target.id)) {
+    transferActiveToDisplay(target.id, localX, localY, true);
+    savePetPos(target.id);
+    return;
+  }
+
+  const activeDisplay =
+    screen.getAllDisplays().find((d) => d.id === activeDisplayId) || target;
+  const clamped = clampLocal(
+    petScreenX - activeDisplay.bounds.x,
+    petScreenY - activeDisplay.bounds.y,
+    activeDisplay.bounds,
+  );
+  const win = overlays.get(activeDisplayId);
+  if (win && !win.isDestroyed()) {
+    win.webContents.send("crew-companion:drag-update", clamped.x, clamped.y);
+  }
+}
+
+function stopDragPolling() {
+  if (dragPollTimer === null) return;
+  // One last transfer check before stopping: an avatar released the instant it
+  // crosses to a new display would otherwise snap back to the last-polled display,
+  // because the interval is cleared before the next tick runs that final transfer.
+  try {
+    dragPollOnce();
+  } catch {
+    /* windows torn down mid-drag — nothing to transfer */
+  }
+  clearInterval(dragPollTimer);
+  dragPollTimer = null;
+  if (dragSafetyTimer !== null) {
+    clearTimeout(dragSafetyTimer);
+    dragSafetyTimer = null;
+  }
+
+  // Final position, so the renderer can run its edge-snap animation.
+  let cursor;
+  try {
+    cursor = screen.getCursorScreenPoint();
+  } catch {
+    cursor = null;
+  }
+  if (cursor && activeDisplayId !== null) {
+    const display = screen.getAllDisplays().find((d) => d.id === activeDisplayId);
+    if (display) {
+      const clamped = clampLocal(
+        cursor.x - dragOffsetX - display.bounds.x,
+        cursor.y - dragOffsetY - display.bounds.y,
+        display.bounds,
+      );
+      const win = overlays.get(activeDisplayId);
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("crew-companion:drag-ended", clamped.x, clamped.y);
+      }
+      savePetPos(activeDisplayId);
+    }
+  }
+
+  // CRITICAL: restore ignore-mouse on ALL overlays. The hitbox poll switches the
+  // active overlay back to interactive once the renderer reports a real rect.
+  for (const win of overlays.values()) {
+    if (win && !win.isDestroyed()) win.setIgnoreMouseEvents(true, { forward: true });
+    lastIgnore.set(win, true);
+  }
+}
+
+/**
+ * Send an overlay its current active state. Used for the initial reveal and —
+ * crucially — as the reply to `crew-companion:pet-ready`, which the renderer sends
+ * once its onSetActive listener is mounted. That handshake replaces a fixed timer:
+ * a slow renderer (e.g. a long theme load) could otherwise miss every set-active
+ * and stay hidden forever.
+ */
+function sendActiveStateTo(win, knownDisplayId = null) {
+  if (!win || win.isDestroyed()) return;
+  let displayId = knownDisplayId;
+  if (displayId === null) {
+    for (const [id, w] of overlays) {
+      if (w === win) {
+        displayId = id;
+        break;
+      }
+    }
+  }
+  if (displayId === null) return;
+  if (displayId !== activeDisplayId) {
+    win.webContents.send("crew-companion:set-active", false);
+    return;
+  }
+  // This overlay is the active one. If it is already mounted, drain any window
+  // commands that queued for a prior active overlay here — a re-elected survivor's
+  // pet-ready already fired, so this activation choke is the only place the queue
+  // reaches it. A not-yet-ready overlay drains on its own pet-ready instead.
+  if (readyOverlays.has(win) && pendingWindowCommands.length) {
+    for (const cmd of pendingWindowCommands) {
+      win.webContents.send("crew-companion:window-command", cmd);
+    }
+    pendingWindowCommands = [];
+  }
+  // During an active drag, stamp the activation with the LIVE drag coordinates and
+  // isDragging=true. A slow target renderer that missed the transfer IPC would
+  // otherwise treat a bare activation as at-rest and clear the carried bubble after
+  // the shared cursor already advanced past it (dropping the reminder). With the drag
+  // state attached the renderer adopts the in-flight drag instead of clearing.
+  if (dragPollTimer !== null) {
+    try {
+      const cursor = screen.getCursorScreenPoint();
+      const display = screen.getAllDisplays().find((d) => d.id === activeDisplayId);
+      if (display) {
+        win.webContents.send(
+          "crew-companion:set-active",
+          true,
+          cursor.x - dragOffsetX - display.bounds.x,
+          cursor.y - dragOffsetY - display.bounds.y,
+          true,
+        );
+        sendBubbleToActive();
+        return;
+      }
+    } catch {
+      /* cursor unavailable — fall through to a bare activation */
+    }
+  }
+  win.webContents.send("crew-companion:set-active", true);
+  sendBubbleToActive();
+}
+
+/**
+ * Tell one window whether it is the notification OWNER. Only the hidden brain window
+ * is; every visible overlay is a pure view. Sent on load and as part of a reveal /
+ * readiness reply.
+ */
+function sendOwnerStateTo(win) {
+  if (!win || win.isDestroyed()) return;
+  win.webContents.send("crew-companion:set-owner", win === brainWin);
+}
+
+/** Create the hidden brain window if it is absent (the permanent notification owner). */
+function ensureBrainWindow() {
+  if (brainWin && !brainWin.isDestroyed()) return;
+  brainWin = createBrainWindow();
+}
+
+/**
+ * Push the current bubble to the overlay drawing the avatar. `playReaction` is true
+ * ONLY for a freshly reported bubble (from bubble-state); a re-push on activation or
+ * a display hand-off passes false, so the newly-active overlay does not replay a
+ * reaction the previously-active overlay already played for the same bubble.
+ */
+function sendBubbleToActive(playReaction = false) {
+  const win = overlays.get(activeDisplayId);
+  if (win && !win.isDestroyed()) {
+    win.webContents.send("crew-companion:render-bubble", currentBubble, playReaction);
   }
 }
 
@@ -130,45 +507,172 @@ function createOverlayFor(display) {
   win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
   win.loadURL(companionPageUrl(baseUrl, "pet.html", credential));
-  win.once("ready-to-show", () => {
+  // Activation handshake. The renderer draws NOTHING until it receives
+  // set-active(true); we send the flag BEFORE revealing so the avatar only ever
+  // appears on the active overlay. This first send is a best-effort fast path — the
+  // RELIABLE delivery is the renderer's `crew-companion:pet-ready` (sent once its
+  // listener is mounted), answered via sendActiveStateTo. That replaces the old
+  // fixed 300ms re-send, which lost the event entirely if the renderer's effect
+  // mounted later (e.g. a slow theme load) and left the avatar hidden forever.
+  win.webContents.on("did-finish-load", () => {
     if (win.isDestroyed()) return;
-    win.showInactive();
+    // Route through the one drag-aware choke so a reveal landing mid-drag carries the
+    // drag state rather than a bare activation that would clear the carried bubble.
+    // Pass the known display id: the overlay is not in the map yet at did-finish-load.
+    sendActiveStateTo(win, display.id);
+    if (!win.isVisible()) win.showInactive();
     // Showing this accessory-shaped window demotes the app to a Dock-less accessory
     // on macOS; put the host back in the Dock (see assertHostStaysInDock).
     assertHostStaysInDock();
   });
   win.on("closed", () => {
-    for (const [id, w] of overlays) if (w === win) overlays.delete(id);
     hitboxes.delete(win);
     lastIgnore.delete(win);
+    readyOverlays.delete(win);
+    // A late 'closed' from an overlay already replaced for this display (turn-off
+    // racing an enabled reconcile) must not evict the live replacement — only touch
+    // the map slot and re-election when it still points at THIS window.
+    if (overlays.get(display.id) !== win) return;
+    overlays.delete(display.id);
+    // If the overlay hosting the avatar just closed (its display was unplugged or
+    // slept), re-elect a surviving overlay as active. Production is unaffected — the
+    // brain window owns it — but without this the avatar would be drawn on a gone
+    // display and every relayed bubble shown nowhere, and the reconcile loop only
+    // reopens overlays once the count hits zero, so a surviving overlay never heals it.
+    if (activeDisplayId === display.id) {
+      const survivorId = overlays.keys().next().value ?? null;
+      activeDisplayId = survivorId;
+      if (survivorId !== null) sendActiveStateTo(overlays.get(survivorId), survivorId);
+    }
   });
   return win;
 }
 
-/** Open an overlay on every display. Idempotent per display. */
+/**
+ * The hidden brain window: a headless page that runs the notification producer and
+ * draws nothing. It loads the SAME page as an overlay, so it inherits the gateway
+ * session on first load (see pageUrl.js), but it is never shown and never made
+ * active — its isOwner=true / isActive=false gates make it produce-only. Its lifetime
+ * is the companion's, not any display's, which is what removes the owner hand-off.
+ */
+function createBrainWindow() {
+  const win = new BrowserWindow({
+    width: 16,
+    height: 16,
+    show: false,
+    frame: false,
+    skipTaskbar: true,
+    webPreferences: {
+      preload: path.join(__dirname, "pet-preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      // Producer timers + socket must keep running while the window is hidden.
+      backgroundThrottling: false,
+    },
+  });
+  win.setContentProtection(true);
+  win.loadURL(companionPageUrl(baseUrl, "pet.html", credential));
+  // Best-effort fast path; the reliable owner/inactive send is the renderer's
+  // pet-ready reply (below), which lands after its listeners mount.
+  win.webContents.on("did-finish-load", () => {
+    if (win.isDestroyed()) return;
+    win.webContents.send("crew-companion:set-owner", true);
+    win.webContents.send("crew-companion:set-active", false);
+  });
+  // A crashed or closed brain would silently stop ALL notification production, so
+  // recreate it while the companion is enabled. A deliberate teardown clears the flag.
+  const recreate = () => {
+    if (brainWin !== win) return; // a stale handler for an already-replaced brain
+    brainWin = null;
+    // render-process-gone leaves the window open; destroy it so repeated crashes do
+    // not accumulate hidden windows. The identity guard above stops the resulting
+    // 'closed' from recreating twice.
+    if (!win.isDestroyed()) win.destroy();
+    if (!companionEnabled) return;
+    // Do NOT clear currentBubble/currentSlot: the replacement brain cannot reproduce a
+    // socket completion/approval (watchSessions sees only future frames) or an already-
+    // committed reminder, so clearing would silently drop the visible notification. The
+    // bubble stays, and the cached slot is replayed to the new brain on its pet-ready so
+    // the live slot's count/timestamp survive the restart.
+    ensureBrainWindow();
+  };
+  win.webContents.on("render-process-gone", recreate);
+  win.on("closed", recreate);
+  return win;
+}
+
+/**
+ * Open an overlay on every display, but designate exactly ONE as active (the avatar
+ * lives there). Active display = the one holding the saved position, else the
+ * display under the cursor, else the primary. Idempotent per display.
+ */
 function openPetWindow() {
   if (!baseUrl) {
     log("crew-companion: no gateway origin yet, deferring overlay");
     return;
   }
-  for (const display of screen.getAllDisplays()) {
+  // Set before creating windows so a brain that crashes during load self-heals.
+  companionEnabled = true;
+
+  const primary = screen.getPrimaryDisplay();
+  const displays = screen.getAllDisplays();
+
+  // Preserve an already-valid active display across re-invocations — openPetWindow is
+  // re-entered when a monitor is hot-plugged (the display-added listener). Only elect
+  // an active display when the current one is unset or gone; otherwise plugging in a
+  // monitor would silently move "active" WITHOUT deactivating the old overlay, drawing
+  // two avatars or routing bubbles to an overlay that believes it is inactive.
+  if (activeDisplayId === null || !displays.some((d) => d.id === activeDisplayId)) {
+    activeDisplayId = savedPetPos && typeof savedPetPos.displayId === "number"
+      ? savedPetPos.displayId
+      : null;
+    if (activeDisplayId === null || !displays.some((d) => d.id === activeDisplayId)) {
+      let cur = { x: primary.bounds.x, y: primary.bounds.y };
+      try {
+        cur = screen.getCursorScreenPoint();
+      } catch {
+        /* headless / test — fall back to primary */
+      }
+      activeDisplayId = (findDisplayAtPoint(cur.x, cur.y) || primary).id;
+    }
+  }
+  for (const display of displays) {
     const existing = overlays.get(display.id);
     if (existing && !existing.isDestroyed()) continue;
     try {
-      overlays.set(display.id, createOverlayFor(display));
-      log(`crew-companion: overlay opened on display ${display.id}`);
+      overlays.set(
+        display.id,
+        createOverlayFor(display),
+      );
+      log(
+        `crew-companion: overlay opened on display ${display.id}` +
+          (display.id === activeDisplayId ? " (active)" : ""),
+      );
     } catch (err) {
       log(`crew-companion: overlay failed on display ${display.id} — ${err && err.message}`);
     }
   }
+  ensureBrainWindow();
 }
 
-/** Close every overlay. Idempotent. */
+/** Close every overlay and the brain window. Idempotent. */
 function closePetWindow() {
+  // Clear first so the brain's 'closed' handler does not treat teardown as a crash.
+  companionEnabled = false;
+  stopDragPolling();
   for (const [id, win] of [...overlays]) {
     overlays.delete(id);
     if (win && !win.isDestroyed()) win.destroy();
   }
+  if (brainWin && !brainWin.isDestroyed()) brainWin.destroy();
+  brainWin = null;
+  activeDisplayId = null;
+  // Drop the cached bubble so re-enabling does not resurrect a notification from the
+  // previous companion lifetime (e.g. an approval that resolved while it was off).
+  currentBubble = null;
+  currentSlot = null;
+  currentSeq = null;
+  pendingWindowCommands = [];
 }
 
 function petWindowCount() {
@@ -266,17 +770,32 @@ function refreshOverlayInput(win, cursor) {
   return shouldIgnore;
 }
 
-/** One poll iteration across every overlay. The interval calls this. */
+/**
+ * One poll iteration. Only the ACTIVE overlay is interactive at rest; every other
+ * overlay stays click-through because it hosts no avatar. The drag poll owns
+ * ignore-mouse across all overlays while a drag is in flight, so this yields to it.
+ * There is no at-rest cursor following.
+ */
 function pollOverlayInputOnce() {
+  if (dragPollTimer !== null) return; // drag poll owns ignore-mouse during a drag
   let cursor;
   try {
     cursor = screen.getCursorScreenPoint();
   } catch {
     return; // no cursor available (e.g. under test) — nothing to do
   }
+  const activeWin = activeDisplayId !== null ? overlays.get(activeDisplayId) : null;
   for (const win of overlays.values()) {
     try {
-      refreshOverlayInput(win, cursor);
+      if (win === activeWin) {
+        refreshOverlayInput(win, cursor);
+      } else if (win && !win.isDestroyed()) {
+        // A non-active overlay never hosts the avatar, so it stays click-through.
+        if (lastIgnore.get(win) !== true) {
+          lastIgnore.set(win, true);
+          win.setIgnoreMouseEvents(true, { forward: true });
+        }
+      }
     } catch {
       /* window torn down between checks — skip it */
     }
@@ -298,9 +817,9 @@ function stopHitboxPoll() {
 }
 
 /**
- * Register the overlay's cursor-hitbox IPC and start the poll. Called once from
- * `initCrewCompanion`. Each renderer reports its own window's rects; the sender is
- * resolved back to its overlay so one display's report cannot describe another's.
+ * Register the overlay's cursor-hitbox and drag IPC and start the poll. Called once
+ * from `initCrewCompanion`. Each renderer reports its own window's rects; the sender
+ * is resolved back to its overlay so one display's report cannot describe another's.
  */
 function registerOverlayIpc() {
   if (ipcRegistered) return;
@@ -316,7 +835,120 @@ function registerOverlayIpc() {
     if (win && isPetWindow(win)) setWindowMenuHitbox(win, rect);
   });
 
+  // Cross-display drag: the renderer reports the drag start (with the cursor->sprite
+  // offset) and end; the main process follows the global cursor in between and hands
+  // the avatar between displays. ANY overlay reporting a mouseup ends the drag,
+  // because after a handoff the cursor may be over a different overlay than the one
+  // that started the gesture.
+  ipcMain.on("crew-companion:drag-start", (event, offsetX, offsetY) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win && isPetWindow(win)) startDragPolling(offsetX || 0, offsetY || 0);
+  });
+  ipcMain.on("crew-companion:drag-end", (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win && isPetWindow(win)) stopDragPolling();
+  });
+  ipcMain.on("crew-companion:drag-mouseup", (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win && isPetWindow(win) && dragPollTimer !== null) stopDragPolling();
+  });
+
+  // The renderer sends this once its onSetActive/onSetOwner listeners are mounted;
+  // reply with its role so a slow renderer never misses activation or ownership.
+  ipcMain.on("crew-companion:pet-ready", (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+    if (win === brainWin) {
+      // The brain owns production and is never active (it draws nothing).
+      win.webContents.send("crew-companion:set-owner", true);
+      win.webContents.send("crew-companion:set-active", false);
+      // Rehydrate a crash-replaced brain's producer state (slot + local sequence) from
+      // cached state before it resumes producing, so a live bubble's count/timestamp
+      // survive and the replacement never reissues a seq the active overlay still keys.
+      if (currentSlot || currentSeq !== null) {
+        win.webContents.send("crew-companion:rehydrate-slot", { slot: currentSlot, seq: currentSeq });
+      }
+      return;
+    }
+    if (isPetWindow(win)) {
+      sendOwnerStateTo(win); // false: overlays are pure views
+      // Mark ready BEFORE activating, so sendActiveStateTo's choke drains any window
+      // commands that queued while this overlay was loading (single drain site).
+      readyOverlays.add(win);
+      sendActiveStateTo(win);
+    }
+  });
+
+  // The brain window reports the single resolved bubble (or null). Main caches it and
+  // pushes it to whichever overlay is drawing the avatar, asking that overlay to play
+  // the reaction because this is a fresh bubble. Only the brain is honoured, so a
+  // stray overlay cannot inject a bubble.
+  ipcMain.on("crew-companion:bubble-state", (event, bubble, slot, seq) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win !== brainWin) return;
+    currentBubble = bubble ?? null;
+    currentSlot = slot ?? null;
+    currentSeq = typeof seq === "number" ? seq : null;
+    sendBubbleToActive(true);
+  });
+
+  // A user action on the bubble (dismiss, resolve) happens on the ACTIVE overlay but
+  // must mutate the brain's state machine, so main forwards it there.
+  ipcMain.on("crew-companion:bubble-action", (event, action) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || !isPetWindow(win)) return;
+    if (brainWin && !brainWin.isDestroyed()) {
+      brainWin.webContents.send("crew-companion:bubble-action", action);
+    }
+  });
+
+  // A window command (Open panel / Change avatar) is drained from /pending by the
+  // brain (the only poller) but must open at the AVATAR's position, so main relays it
+  // to the active overlay to execute. Only the brain is honoured as the source.
+  ipcMain.on("crew-companion:window-command", (event, cmd) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win !== brainWin) return;
+    const active = overlays.get(activeDisplayId);
+    if (active && !active.isDestroyed() && readyOverlays.has(active)) {
+      active.webContents.send("crew-companion:window-command", cmd);
+    } else {
+      // Active overlay not mounted yet: queue the command for its pet-ready. Appending
+      // (not overwriting) so two commands arriving before it is ready both survive and
+      // are delivered in order rather than the first being lost.
+      pendingWindowCommands.push(cmd);
+    }
+  });
+
   startHitboxPoll();
+
+  // Reconcile the overlay set with the physical display topology. Guarded by the
+  // enabled flag so these no-op while the companion is off. Removing the display that
+  // hosts the avatar, or adding a monitor, must not leave the avatar stranded or a
+  // display without an overlay — the reconcile loop cannot see this (it only reopens
+  // at zero overlays). `screen` is an EventEmitter in Electron; the guard is only for
+  // a test double without `.on`.
+  if (typeof screen.on === "function") {
+    screen.on("display-removed", () => {
+      if (!companionEnabled) return;
+      // Electron does not guarantee it closes a removed display's window; force any
+      // orphaned overlay closed and let its 'closed' handler re-elect the active one.
+      for (const [id, w] of [...overlays]) {
+        if (!screen.getAllDisplays().some((d) => d.id === id)) {
+          if (w && !w.isDestroyed()) w.destroy();
+          else overlays.delete(id);
+        }
+      }
+      // Belt and braces: if the active window did not fire 'closed', fix the pointer.
+      if (activeDisplayId !== null && !overlays.has(activeDisplayId)) {
+        const survivorId = overlays.keys().next().value ?? null;
+        activeDisplayId = survivorId;
+        if (survivorId !== null) sendActiveStateTo(overlays.get(survivorId), survivorId);
+      }
+    });
+    screen.on("display-added", () => {
+      if (companionEnabled) openPetWindow(); // idempotent: opens an overlay on the new display
+    });
+  }
 }
 
 module.exports = {
@@ -330,6 +962,10 @@ module.exports = {
   setOverlayTarget,
   registerOverlayIpc,
   stopHitboxPoll,
+  transferActiveToDisplay,
+  startDragPolling,
+  stopDragPolling,
+  dragPollOnce,
   // Exported for tests: they drive the toggle directly rather than through the
   // live cursor poll.
   pointInRect,
@@ -338,4 +974,10 @@ module.exports = {
   pollOverlayInputOnce,
   setWindowHitbox,
   setWindowMenuHitbox,
+  // Exported for tests: pure geometry decisions.
+  _findDisplayAtPoint: findDisplayAtPoint,
+  _findNearestDisplay: findNearestDisplay,
+  _clampLocal: clampLocal,
+  PET_W,
+  PET_H,
 };

--- a/website/electron/crew-companion/test/petHitbox.test.js
+++ b/website/electron/crew-companion/test/petHitbox.test.js
@@ -28,6 +28,11 @@ function stubElectron() {
       this.destroyed = false;
       this.ignoreMouse = null;
       this._events = {};
+      this.webContents = {
+        __win: this,
+        on: (ev, cb) => { if (ev === "did-finish-load") cb(); },
+        send: () => {},
+      };
       created.push(this);
     }
     setFocusable() {}
@@ -38,6 +43,7 @@ function stubElectron() {
     once(ev, cb) { this._events[ev] = cb; }
     on(ev, cb) { this._events[ev] = cb; }
     showInactive() {}
+    isVisible() { return false; }
     isDestroyed() { return this.destroyed; }
     destroy() { this.destroyed = true; }
     // The overlay lives at its display's origin; the poll converts screen->local
@@ -46,12 +52,14 @@ function stubElectron() {
   }
 
   const electron = {
+    app: { getPath: () => require("os").tmpdir(), on() {} },
     BrowserWindow: FakeWindow,
     screen: {
       getAllDisplays: () => [
         { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } },
         { id: 2, bounds: { x: 1440, y: 0, width: 1920, height: 1080 } },
       ],
+      getPrimaryDisplay: () => ({ id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } }),
       // Not used by the direct toggle tests, but present so the poll never throws.
       getCursorScreenPoint: () => ({ x: -1, y: -1 }),
     },

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -29,6 +29,13 @@ function stubElectron() {
       this.loadedUrl = "";
       this.shown = false;
       this._events = {};
+      this.sent = [];
+      // did-finish-load fires synchronously so the activation handshake in
+      // createOverlayFor runs and its set-active sends are observable.
+      this.webContents = {
+        on: (ev, cb) => { if (ev === "did-finish-load") cb(); },
+        send: (ch, ...args) => this.sent.push({ ch, args }),
+      };
       created.push(this);
     }
     setFocusable(v) { this.focusable = v; }
@@ -39,23 +46,38 @@ function stubElectron() {
     once(ev, cb) { this._events[ev] = cb; }
     on(ev, cb) { this._events[ev] = cb; }
     showInactive() { this.shown = true; }
+    isVisible() { return this.shown; }
     isDestroyed() { return this.destroyed; }
     destroy() { this.destroyed = true; }
   }
 
   const dockCalls = { setActivationPolicy: [], dockShow: 0 };
 
+  const displays = [
+    { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } },
+    { id: 2, bounds: { x: 1440, y: 0, width: 1920, height: 1080 } },
+  ];
+
+  // Mutable so a test can move the cursor between displays and drive a drag tick.
+  let cursor = { x: 0, y: 0 };
+
+  // A UNIQUE temp dir per stub so the persisted pet-position file (getPath() +
+  // crew-companion-pet-position.json) cannot leak drag/display state across runs.
+  const userDataDir = require("fs").mkdtempSync(
+    require("path").join(require("os").tmpdir(), "cc-pet-test-"),
+  );
   const electron = {
     app: {
+      getPath: () => userDataDir,
+      on() {},
       setActivationPolicy: (p) => dockCalls.setActivationPolicy.push(p),
       dock: { show: () => { dockCalls.dockShow += 1; } },
     },
     BrowserWindow: FakeWindow,
     screen: {
-      getAllDisplays: () => [
-        { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 } },
-        { id: 2, bounds: { x: 1440, y: 0, width: 1920, height: 1080 } },
-      ],
+      getAllDisplays: () => displays,
+      getPrimaryDisplay: () => displays[0],
+      getCursorScreenPoint: () => cursor,
     },
     ipcMain: {
       on: (ch, cb) => { ipcHandlers[ch] = cb; },
@@ -70,7 +92,10 @@ function stubElectron() {
     contextBridge: { exposeInMainWorld: () => {} },
     ipcRenderer: { send: () => {} },
   };
-  electron.BrowserWindow.fromWebContents = () => created[created.length - 1];
+  // Resolve the sender's own window when given one (matching real Electron), else
+  // fall back to the last-created window for tests that pass a bare sender.
+  electron.BrowserWindow.fromWebContents = (sender) =>
+    created.find((w) => w.webContents === sender) ?? created[created.length - 1];
 
   const realResolve = Module._resolveFilename;
   Module._resolveFilename = function (request, ...rest) {
@@ -84,6 +109,8 @@ function stubElectron() {
     ipcHandlers,
     dockCalls,
     ipcInvokers,
+    setCursor(x, y) { cursor = { x, y }; },
+    addDisplay(d) { displays.push(d); },
     restore() {
       Module._resolveFilename = realResolve;
       delete require.cache.electron;
@@ -419,8 +446,8 @@ test("showing an overlay re-asserts the host's Dock presence on macOS", () => {
     const { overlay } = loadModules();
     overlay.setOverlayTarget("http://localhost:5476", "");
     overlay.openPetWindow();
-    // Fire the ready-to-show that real Electron fires once the page is ready.
-    stub.created[0]._events["ready-to-show"]();
+    // The overlay's did-finish-load handler (the stub fires it synchronously) shows
+    // the window and re-asserts the Dock during openPetWindow.
 
     // Showing the accessory-shaped overlay demotes the app to a Dock-less
     // accessory; the overlay must put the host straight back in the Dock, or
@@ -858,6 +885,414 @@ test("the turn-off IPC closes every overlay immediately", () => {
     stub.ipcHandlers["crew-companion:turn-off"]();
     assert.strictEqual(overlay.petWindowCount(), 0, "overlay closed immediately on turn-off");
     index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a transfer to a display with no live overlay is a no-op — the avatar stays put", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // active = display 1
+    const winA = stub.created[0];
+    winA.sent.length = 0;
+    // A monitor hot-plugged after startup: an id with no overlay in the map. The
+    // transfer must NOT deactivate the current overlay (that would blank the avatar).
+    overlay.transferActiveToDisplay(999, 10, 10, false);
+    assert.ok(
+      !winA.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === false),
+      "the current overlay is not deactivated for a display that has no overlay",
+    );
+  } finally {
+    stub.restore();
+  }
+});
+
+test("pet-ready replies to the requesting overlay with its active state", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    overlay.registerOverlayIpc();
+    // The stub's fromWebContents resolves to the last-created window; clear its log,
+    // then fire the readiness handshake and assert main answered with a set-active.
+    const last = stub.created[stub.created.length - 1];
+    last.sent.length = 0;
+    stub.ipcHandlers["crew-companion:pet-ready"]({ sender: {} });
+    assert.ok(
+      last.sent.some((m) => m.ch === "crew-companion:set-active"),
+      "pet-ready triggers a set-active reply to the requesting overlay",
+    );
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("only ONE display's overlay is told to render the avatar; the rest are inactive", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+
+    // This is the two-ghosts fix at the main-process seam: the avatar lives on one
+    // display, so exactly one overlay receives set-active(true) and every other
+    // receives set-active(false).
+    const activeOn = stub.created.filter((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+    );
+    const inactiveOn = stub.created.filter((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === false),
+    );
+    assert.strictEqual(activeOn.length, 1, "exactly one avatar across all displays");
+    assert.strictEqual(
+      inactiveOn.length,
+      stub.created.length - 1,
+      "every other overlay is explicitly inactive",
+    );
+  } finally {
+    stub.restore();
+  }
+});
+
+test("the notification owner is a single hidden brain window, not a visible overlay", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    // Exactly one window is told it owns notifications, and it is a hidden (show:false)
+    // window with no display bounds — the brain — not one of the per-display overlays.
+    // The brain runs the producer; its app-lifetime is what removes the owner hand-off.
+    const owners = stub.created.filter((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-owner" && m.args[0] === true),
+    );
+    assert.strictEqual(owners.length, 1, "exactly one notification owner");
+    assert.notStrictEqual(owners[0].opts.transparent, true, "the owner is the non-overlay brain window");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a crash-replaced brain is rehydrated with the live slot on pet-ready", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    overlay.registerOverlayIpc();
+    const isBrain = (w) =>
+      w.opts.transparent !== true &&
+      w.sent.some((m) => m.ch === "crew-companion:set-owner" && m.args[0] === true);
+    const brain = stub.created.find(isBrain);
+    assert.ok(brain, "the brain window exists");
+    // The brain reports a live slot (two completions collapsed into a count) + its
+    // current negative local sequence.
+    const slot = { text: "2 jobs finished", sticky: false, count: 2, at: 111 };
+    stub.ipcHandlers["crew-companion:bubble-state"](
+      { sender: brain.webContents },
+      { seq: -3, kind: "session-done", text: "2 jobs finished" },
+      slot,
+      -3,
+    );
+    // Crash the brain — the 'closed' handler recreates a replacement (render-process-gone
+    // is not observable through the webContents stub, but both call the same recreate).
+    brain.destroyed = true;
+    brain._events.closed();
+    const replacement = stub.created.filter(isBrain).pop();
+    assert.ok(replacement && replacement !== brain, "a replacement brain was created");
+    replacement.sent.length = 0;
+    // On pet-ready the replacement must be handed the cached slot AND sequence, so the
+    // live count survives the restart and the replacement never reissues seq -3.
+    stub.ipcHandlers["crew-companion:pet-ready"]({ sender: replacement.webContents });
+    const rehydrate = replacement.sent.find((m) => m.ch === "crew-companion:rehydrate-slot");
+    assert.ok(rehydrate, "the replacement brain is sent rehydrate-slot");
+    assert.deepStrictEqual(rehydrate.args[0].slot, slot, "rehydrated with the cached slot");
+    assert.strictEqual(rehydrate.args[0].seq, -3, "rehydrated with the cached local sequence");
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a late 'closed' from a replaced overlay does not evict the live replacement", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    const d1 = (w) => w.opts.transparent === true && w.opts.x === 0; // display 1 (bounds.x=0)
+    assert.strictEqual(stub.created.filter(d1).length, 1, "one overlay for display 1 initially");
+    const orig = stub.created.filter(d1)[0];
+    // Display 1's overlay closes; its slot empties and a reconcile reopens a replacement.
+    orig.destroyed = true;
+    orig._events.closed();
+    overlay.openPetWindow();
+    assert.strictEqual(stub.created.filter(d1).length, 2, "a replacement opened for display 1");
+    // The ORIGINAL overlay's 'closed' now fires late (it raced the reconcile). It must
+    // not evict the live replacement: if it did, the slot would empty and the next
+    // reconcile would open a THIRD overlay for display 1.
+    orig._events.closed();
+    overlay.openPetWindow();
+    assert.strictEqual(
+      stub.created.filter(d1).length,
+      2,
+      "stale close left the replacement in place (no third overlay created)",
+    );
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a window command arriving before the active overlay is ready is delivered on pet-ready", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    overlay.registerOverlayIpc();
+    const isBrain = (w) =>
+      w.opts.transparent !== true &&
+      w.sent.some((m) => m.ch === "crew-companion:set-owner" && m.args[0] === true);
+    const brain = stub.created.find(isBrain);
+    const active = stub.created.find(
+      (w) => w.opts.transparent === true &&
+        w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+    );
+    assert.ok(brain && active, "brain and an active overlay exist");
+    active.sent.length = 0;
+    // The brain drains two window commands before the active overlay has sent pet-ready
+    // (its onWindowCommand listener is not mounted yet). Both must survive, in order.
+    stub.ipcHandlers["crew-companion:window-command"]({ sender: brain.webContents }, "panel");
+    stub.ipcHandlers["crew-companion:window-command"]({ sender: brain.webContents }, "gallery");
+    assert.ok(
+      !active.sent.some((m) => m.ch === "crew-companion:window-command"),
+      "the commands are held, not sent to the still-loading overlay",
+    );
+    // The active overlay finishes mounting and reports pet-ready — both held commands
+    // must now be delivered, in the order they arrived.
+    stub.ipcHandlers["crew-companion:pet-ready"]({ sender: active.webContents });
+    const delivered = active.sent
+      .filter((m) => m.ch === "crew-companion:window-command")
+      .map((m) => m.args[0]);
+    assert.deepStrictEqual(delivered, ["panel", "gallery"], "both held commands delivered in order");
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("unplugging the active display re-elects a surviving overlay as active", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // overlays for displays 1 and 2; one is active
+    // Overlays are transparent full-screen windows; the hidden brain is not.
+    const overlaysCreated = stub.created.filter((w) => w.opts.transparent === true);
+    // Find the overlay currently drawing the avatar (told set-active(true) on reveal).
+    const activeWin = overlaysCreated.find((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+    );
+    assert.ok(activeWin, "an overlay is active after open");
+    const survivor = overlaysCreated.find((w) => w !== activeWin);
+    survivor.sent.length = 0;
+    // Unplug the active display: its overlay closes. A survivor must become active so
+    // the avatar and every relayed bubble still land on a live screen.
+    activeWin.destroyed = true;
+    if (activeWin._events.closed) activeWin._events.closed();
+    const reactivated = survivor.sent.some(
+      (m) => m.ch === "crew-companion:set-active" && m.args[0] === true,
+    );
+    assert.ok(reactivated, "a surviving overlay is re-elected active");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a window command queued for a still-loading active overlay drains to a re-elected survivor", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // overlays for displays 1 and 2; one active
+    overlay.registerOverlayIpc();
+    const isBrain = (w) =>
+      w.opts.transparent !== true &&
+      w.sent.some((m) => m.ch === "crew-companion:set-owner" && m.args[0] === true);
+    const brain = stub.created.find(isBrain);
+    const overlaysCreated = stub.created.filter((w) => w.opts.transparent === true);
+    const activeWin = overlaysCreated.find((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+    );
+    const survivor = overlaysCreated.find((w) => w !== activeWin);
+    assert.ok(brain && activeWin && survivor, "brain, active, and survivor overlays exist");
+    // The survivor has finished mounting (pet-ready → ready); the active overlay has
+    // NOT, so a window command for it must queue rather than deliver.
+    stub.ipcHandlers["crew-companion:pet-ready"]({ sender: survivor.webContents });
+    survivor.sent.length = 0;
+    stub.ipcHandlers["crew-companion:window-command"]({ sender: brain.webContents }, "panel");
+    assert.ok(
+      !survivor.sent.some((m) => m.ch === "crew-companion:window-command"),
+      "the command is held while the active overlay is still loading",
+    );
+    // The active display is unplugged: its overlay closes and the ready survivor is
+    // re-elected active. The queued command must drain to it, not stay stranded.
+    activeWin.destroyed = true;
+    if (activeWin._events.closed) activeWin._events.closed();
+    const delivered = survivor.sent
+      .filter((m) => m.ch === "crew-companion:window-command")
+      .map((m) => m.args[0]);
+    assert.deepStrictEqual(delivered, ["panel"], "queued command drains to the re-elected survivor");
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("adding a display preserves the active overlay instead of re-electing it", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    const overlaysBefore = stub.created.filter((w) => w.opts.transparent === true);
+    const activeWin = overlaysBefore.find((w) =>
+      w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+    );
+    assert.ok(activeWin, "an overlay is active after open");
+    activeWin.sent.length = 0;
+    // Hot-plug a monitor and re-run openPetWindow — exactly what the display-added
+    // listener does. The already-active overlay must stay active (no set-active(true)
+    // churn, no deactivation), and the new display's overlay must open inactive.
+    stub.addDisplay({ id: 3, bounds: { x: 3360, y: 0, width: 1280, height: 720 } });
+    overlay.openPetWindow();
+    const stillActive = !activeWin.sent.some(
+      (m) => m.ch === "crew-companion:set-active" && m.args[0] === false,
+    );
+    assert.ok(stillActive, "the active overlay was not deactivated by the display add");
+    const newOverlay = stub.created.find(
+      (w) => w.opts.transparent === true && w.opts.x === 3360,
+    );
+    assert.ok(newOverlay, "an overlay opened on the new display");
+    const newIsInactive = newOverlay.sent.some(
+      (m) => m.ch === "crew-companion:set-active" && m.args[0] === false,
+    );
+    assert.ok(newIsInactive, "the new display's overlay opened inactive");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("dragging the avatar across the boundary hands it off — still exactly one avatar", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // cursor at (0,0) -> active display 1
+    const [winA, winB] = stub.created;
+
+    // A drag begins on display 1; then the cursor moves onto display 2 and one tick runs.
+    overlay.startDragPolling(10, 10);
+    stub.setCursor(2000, 500); // inside display 2's bounds
+    overlay.dragPollOnce();
+
+    // The avatar handed off: display 1 told inactive, display 2 told active — so it
+    // lives on exactly one screen, the one the cursor dragged it to.
+    assert.ok(
+      winA.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === false),
+      "old display told inactive on crossing",
+    );
+    assert.ok(
+      winB.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === true),
+      "new display told active on crossing",
+    );
+
+    // Ending the drag restores click-through on every overlay (the hitbox poll makes
+    // the active one interactive again once the renderer reports a real rect).
+    overlay.stopDragPolling();
+    assert.deepStrictEqual(winA.ignoreMouse, { ignore: true, opts: { forward: true } });
+    assert.deepStrictEqual(winB.ignoreMouse, { ignore: true, opts: { forward: true } });
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a readiness reply DURING a drag carries the drag state, not a bare activation", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // active = display 1
+    const [, winB] = stub.created;
+    overlay.registerOverlayIpc();
+
+    // Drag the avatar onto display 2, so display 2 is now the active one and a drag
+    // is in progress. Target winB's own webContents so the reply is unambiguous
+    // regardless of the hidden brain window's creation order.
+    overlay.startDragPolling(10, 10);
+    stub.setCursor(2000, 500);
+    overlay.dragPollOnce();
+    winB.sent.length = 0;
+
+    // A slow renderer only now finishes mounting and sends pet-ready. The reply must
+    // NOT be a bare set-active(true): that would make the renderer activate at-rest
+    // and clear the carried bubble. It must carry isDragging=true so the renderer
+    // adopts the in-flight drag and keeps the reminder.
+    stub.ipcHandlers["crew-companion:pet-ready"]({ sender: winB.webContents });
+    const reply = winB.sent.find(
+      (m) => m.ch === "crew-companion:set-active" && m.args[0] === true,
+    );
+    assert.ok(reply, "readiness during a drag re-activates the requesting overlay");
+    assert.strictEqual(reply.args[3], true, "the reply carries isDragging=true");
+    assert.strictEqual(typeof reply.args[1], "number", "and the live drag x");
+    assert.strictEqual(typeof reply.args[2], "number", "and the live drag y");
+
+    overlay.stopDragPolling();
+    overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a drag over a display with NO overlay streams to the active overlay, not fs", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow(); // overlays for displays 1 and 2
+    // A monitor hot-plugged after enable: present to the OS but with no overlay in
+    // the map (nothing opens one for it).
+    stub.addDisplay({ id: 3, bounds: { x: 3360, y: 0, width: 1280, height: 720 } });
+
+    overlay.startDragPolling(10, 10);
+    for (const w of stub.created) w.sent.length = 0;
+    stub.setCursor(3800, 300); // inside display 3, which has no overlay
+    overlay.dragPollOnce();
+
+    // No hand-off to a non-existent overlay, and the active overlay keeps getting a
+    // clamped drag-update (the avatar tracks the cursor on its own display) instead
+    // of the loop no-oping and hammering savePetPos on the main thread.
+    assert.ok(
+      !stub.created.some((w) =>
+        w.sent.some((m) => m.ch === "crew-companion:set-active" && m.args[0] === false),
+      ),
+      "no overlay is deactivated for a display that has no overlay",
+    );
+    assert.ok(
+      stub.created.some((w) =>
+        w.sent.some((m) => m.ch === "crew-companion:drag-update"),
+      ),
+      "the active overlay still receives a clamped drag-update",
+    );
+
+    overlay.stopDragPolling();
+    overlay.stopHitboxPoll();
   } finally {
     stub.restore();
   }

--- a/website/electron/crew-companion/test/petTransfer.test.js
+++ b/website/electron/crew-companion/test/petTransfer.test.js
@@ -1,0 +1,113 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("path");
+const os = require("os");
+const Module = require("module");
+
+// Load petOverlay.js with a fake `electron` whose screen exposes a configurable
+// display arrangement. findDisplayAtPoint / findNearestDisplay / clampLocal read
+// screen directly (verbatim from the reference), so the stub is how we drive them.
+function loadWithDisplays(displays) {
+  const electron = {
+    app: { getPath: () => os.tmpdir(), on() {} },
+    BrowserWindow: class {},
+    ipcMain: { on() {}, handle() {} },
+    screen: {
+      getPrimaryDisplay: () => displays[0],
+      getAllDisplays: () => displays,
+      getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+      on() {},
+      removeListener() {},
+    },
+  };
+  const modPath = path.join(__dirname, "..", "petOverlay.js");
+  delete require.cache[require.resolve(modPath)];
+  const orig = Module._load;
+  Module._load = (request, parent, isMain) =>
+    request === "electron" ? electron : orig(request, parent, isMain);
+  try {
+    return require(modPath);
+  } finally {
+    Module._load = orig;
+  }
+}
+
+// A: primary at origin; B: to its right. Gaps exist at x<0 and x>=3360.
+const A = {
+  id: 1,
+  bounds: { x: 0, y: 0, width: 1440, height: 900 },
+  workArea: { x: 0, y: 25, width: 1440, height: 875 },
+};
+const B = {
+  id: 2,
+  bounds: { x: 1440, y: 0, width: 1920, height: 1080 },
+  workArea: { x: 1440, y: 0, width: 1920, height: 1040 },
+};
+
+test("findDisplayAtPoint returns the display whose bounds contain the point", () => {
+  const m = loadWithDisplays([A, B]);
+  assert.strictEqual(m._findDisplayAtPoint(700, 400).id, 1, "inside A");
+  assert.strictEqual(m._findDisplayAtPoint(2000, 500).id, 2, "inside B");
+  assert.strictEqual(m._findDisplayAtPoint(1440, 0).id, 2, "B's left edge is inclusive");
+  assert.strictEqual(m._findDisplayAtPoint(1439, 0).id, 1, "one px left is still A");
+});
+
+test("findDisplayAtPoint returns null when no display contains the point", () => {
+  const m = loadWithDisplays([A, B]);
+  assert.strictEqual(m._findDisplayAtPoint(-50, 400), null, "gap left of A");
+  assert.strictEqual(m._findDisplayAtPoint(5000, 400), null, "gap right of B");
+});
+
+test("findNearestDisplay picks the closest display for a gap point", () => {
+  const m = loadWithDisplays([A, B]);
+  assert.strictEqual(m._findNearestDisplay(-100, 400).id, 1, "left of A -> A");
+  assert.strictEqual(m._findNearestDisplay(5000, 500).id, 2, "right of B -> B");
+  assert.strictEqual(m._findNearestDisplay(1450, 4000).id, 2, "below B, inside its x -> B");
+});
+
+test("transfer decision: cross-boundary triggers a handoff, same display does not", () => {
+  const m = loadWithDisplays([A, B]);
+  const activeDisplayId = 1; // avatar currently on A
+  // Cursor over B -> target B -> id differs -> transfer.
+  const overB = m._findDisplayAtPoint(2000, 500) || m._findNearestDisplay(2000, 500);
+  assert.notStrictEqual(overB.id, activeDisplayId, "over B while active A -> transfer");
+  // Cursor still over A -> target A -> id matches -> no transfer.
+  const overA = m._findDisplayAtPoint(700, 400) || m._findNearestDisplay(700, 400);
+  assert.strictEqual(overA.id, activeDisplayId, "over A while active A -> no transfer");
+  // Cursor in a gap -> nearest-display fallback still yields a valid target (never null).
+  const inGap = m._findDisplayAtPoint(-100, 400) || m._findNearestDisplay(-100, 400);
+  assert.strictEqual(inGap.id, 1, "gap resolves to nearest (A), never null");
+});
+
+test("clampLocal lets the avatar hang half off left/right but not top/bottom", () => {
+  const m = loadWithDisplays([A, B]);
+  const bounds = { width: 1000, height: 800 };
+  assert.strictEqual(m._clampLocal(-500, 100, bounds).x, -m.PET_W / 2, "half off the left");
+  assert.strictEqual(m._clampLocal(5000, 100, bounds).x, 1000 - m.PET_W / 2, "half off the right");
+  assert.strictEqual(m._clampLocal(0, -300, bounds).y, 0, "never off the top");
+  assert.strictEqual(m._clampLocal(0, 5000, bounds).y, 800 - m.PET_H, "fully on-screen at the bottom");
+  assert.deepStrictEqual(m._clampLocal(400, 300, bounds), { x: 400, y: 300 }, "inside is untouched");
+});
+
+test("single-display arrangement: every point resolves to the one display", () => {
+  const m = loadWithDisplays([A]);
+  assert.strictEqual(m._findDisplayAtPoint(700, 400).id, 1, "inside the only display");
+  assert.strictEqual(m._findNearestDisplay(-999, -999).id, 1, "off-screen still -> the only display");
+});
+
+test("main's PET box stays in sync with the renderer's exported sprite size", () => {
+  const m = loadWithDisplays([A, B]);
+  // The renderer owns the sprite size (src/apps/crew-companion/constants.ts); main
+  // duplicates it across the process boundary for edge-clamp and hand-off math.
+  // Assert cross-file equality so a change on one side that is not mirrored fails
+  // HERE instead of silently mispositioning the avatar at runtime.
+  const src = fs.readFileSync(
+    path.join(__dirname, "..", "..", "..", "src", "apps", "crew-companion", "constants.ts"),
+    "utf-8",
+  );
+  const rW = Number((src.match(/export const PET_W\s*=\s*(\d+)/) || [])[1]);
+  const rH = Number((src.match(/export const PET_H\s*=\s*(\d+)/) || [])[1]);
+  assert.strictEqual(m.PET_W, rW, "main PET_W must equal the renderer's PET_W");
+  assert.strictEqual(m.PET_H, rH, "main PET_H must equal the renderer's PET_H");
+});

--- a/website/src/apps/crew-companion/pet.tsx
+++ b/website/src/apps/crew-companion/pet.tsx
@@ -31,7 +31,7 @@ import { PENDING_PATH, PRESENCE_PATH } from './constants'
 import { nudgeTextFor } from './nudgeKeys'
 import { PetAvatar, type PetState } from './PetAvatar'
 import { usePlayfulMotion } from './usePlayfulMotion'
-import { petBridge } from './petBridge'
+import { petBridge, hasCompanionBridge } from './petBridge'
 import { watchSessions } from './sessionWatch'
 import { randomCelebrateProp, type GhostAccessory } from './ghostAccessories'
 
@@ -219,6 +219,39 @@ function Companion() {
   /** Where the press began, for the tap-vs-drag test in onClick. */
   const clickDownPt = useRef<{ x: number; y: number } | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
+  // Which display draws the companion. The main process elects ONE active overlay
+  // and tells every other it is inactive, so only one ghost is ever shown. Starts
+  // FALSE and waits for set-active(true): openPetWindow always elects exactly one
+  // active display and re-sends the flag after load, so a secondary monitor never
+  // briefly flashes the pet before its set-active(false) arrives (the very
+  // one-ghost-per-screen regression this change removes).
+  // A plain browser has no preload bridge and no main process to elect an active
+  // overlay or an owner, so the lone page defaults to BOTH (view + producer);
+  // otherwise it waits for main to assign the roles.
+  const [isActive, setIsActive] = useState(() => !hasCompanionBridge())
+  // Mirror isActive into a ref so the mount-armed pending poll reads the CURRENT
+  // value without re-arming: only the active overlay may drain the shared reminder
+  // cursor, or an inactive one would advance it past a fire it never shows.
+  const isActiveRef = useRef(isActive)
+  isActiveRef.current = isActive
+  // The notification OWNER role, set by the main process (the hidden brain window is
+  // the only owner). Only the owner runs the WebSocket + reminder poll + slot
+  // machine. Decoupled from isActive so the avatar-drawing overlay and the producer
+  // are independent; in a plain browser the lone page is both.
+  const [isOwner, setIsOwner] = useState(() => !hasCompanionBridge())
+  const isOwnerRef = useRef(isOwner)
+  isOwnerRef.current = isOwner
+  // Owner → main: report the single resolved bubble (or null). The owner does NOT
+  // render its own bubble; main relays it to whichever overlay is active, which sets
+  // `bubble` from the render-bubble push. One producer, one source of truth.
+  const emitBubble = useCallback((next: Bubble | null) => {
+    // Report the producer's recovery state (slot snapshot + local sequence) with the
+    // render bubble: a crash-replaced brain reloads with slotRef=null and localSeqRef
+    // reset to 0, so main hands both back to rehydrate the live slot AND continue the
+    // negative local sequence — a reset sequence would reuse a seq and make the active
+    // overlay's React key collide, retaining a stale dismissal timer.
+    petBridge.reportBubbleState?.(next, slotRef.current, localSeqRef.current)
+  }, [])
   // Peek/dock state the drag hook drives when the companion is left at a screen edge.
   // Centralised in useEdgeHide so `setIsPeeking` updates `isPeekingRef` SYNCHRONOUSLY
   // — useDrag reads that ref inside its mouse handlers, so a render-lagged ref (the
@@ -238,7 +271,7 @@ function Companion() {
    */
   const { mood, setMood, clearPersistentMood } = useMood()
 
-  const { pos, setPos, onMouseDown, dragging, posReady, isDragging } = useDrag(
+  const { pos, setPos, onMouseDown, dragging, dragPollingStarted, posReady, isDragging } = useDrag(
     {
       x: Math.max(0, window.innerWidth - PET_PX - 28),
       y: Math.max(0, window.innerHeight - PET_PX - 96),
@@ -256,6 +289,61 @@ function Companion() {
     getGrip: () => dragGrip({}),
     },
   )
+
+  // The main process elects the active overlay. On a live drag hand-off onto this
+  // display it also passes the local landing point and that the gesture is still
+  // held, so we adopt the drag in flight instead of the pet popping in at rest.
+  useEffect(() => {
+    const off = petBridge.onSetActive?.((active, x, y, isDragging) => {
+      // DEACTIVATION must land synchronously (not wait for the line-217 render
+      // mirror): a poll awaiting /pending on this overlay when it is handed off has
+      // to see the inactive state at its post-await gate, or the now-hidden overlay
+      // would commit the shared cursor past a reminder it never showed and the newly
+      // active display would skip it (data loss). Activation stays render-driven —
+      // its backlog drain is timing-sensitive and must not run a render early.
+      if (!active) isActiveRef.current = false
+      setIsActive(active)
+      if (active) {
+        if (isDragging && typeof x === 'number' && typeof y === 'number') {
+          // Adopt the drag main is already polling: mark polling started so this
+          // overlay does not fire a SECOND dragStart, and take the entry point. The
+          // bubble is NOT touched here — main pushes the owner's current bubble via
+          // render-bubble on activation, so there is nothing to carry or clear.
+          dragging.current = true
+          dragPollingStarted.current = true
+          setPos({ x, y })
+        }
+      } else {
+        // Handed off to another display: drop our local drag state so useDrag's 2s
+        // stuck-timer (or a stray mouseup) can't fire a late dragEnd or save stale
+        // coordinates for a drag this overlay no longer owns.
+        dragging.current = false
+        dragPollingStarted.current = false
+      }
+    })
+    // Our listener is attached now — tell main we're ready so it (re)sends this
+    // overlay's active state. The main-process initial send may have fired before
+    // this effect mounted (e.g. a slow theme load), which would otherwise leave the
+    // active overlay hidden forever.
+    petBridge.petReady?.()
+    return off
+  }, [dragging, dragPollingStarted, setPos])
+
+  // At drag-start the main process broadcasts onDragListenMouseUp; while it holds we
+  // watch for the mouseup and report it back, so a drag that ends over this overlay
+  // is caught even though the gesture began on another display.
+  useEffect(() => {
+    let onUp: (() => void) | null = null
+    const detach = () => {
+      if (onUp) { window.removeEventListener('mouseup', onUp); onUp = null }
+    }
+    const off = petBridge.onDragListenMouseUp?.(() => {
+      detach()
+      onUp = () => { petBridge.dragMouseUp?.(); detach() }
+      window.addEventListener('mouseup', onUp)
+    })
+    return () => { off?.(); detach() }
+  }, [])
 
   /**
    * Playful idle motion — the ported `usePlayfulMotion` hook. ONE rAF loop mutates
@@ -393,7 +481,6 @@ function Companion() {
    * cannot be dismissed.
    */
   const cursorRef = useRef(readStoredCursor())
-  const dismissRef = useRef<number | null>(null)
   /**
    * The live "tell me when sessions are done" preference.
    *
@@ -507,24 +594,13 @@ function Companion() {
 
 
   const dismiss = useCallback(() => {
-    if (dismissRef.current !== null) {
-      window.clearTimeout(dismissRef.current)
-      dismissRef.current = null
-    }
-    /**
-     * Dismissing frees the slot — for STICKY bubbles too.
-     *
-     * A sticky bubble has no ✕ and never auto-expires, but the whole bubble is a
-     * dismiss target, so the user can still acknowledge one. Holding the slot after
-     * that was a real bug: the bubble left the screen while the slot stayed taken for
-     * up to STICKY_HOLD_MS, silently swallowing every notification that followed.
-     *
-     * A deliberate dismissal IS the acknowledgement the hold was waiting for, so it
-     * releases the slot rather than leaving the 90s cap to do it.
-     */
-    slotRef.current = null
+    // The ✕ (and a tap on a sticky bubble) lives on the ACTIVE overlay, but the slot
+    // is owned by the owner overlay, so route the dismissal to it through main. Clear
+    // the local view optimistically so the bubble leaves at once rather than after
+    // the round-trip; main will push the owner's resulting null shortly after.
     setBubble(null)
     setPlacement(null)
+    petBridge.bubbleAction?.('dismiss')
   }, [])
 
   /**
@@ -618,7 +694,76 @@ function Companion() {
     }, CELEBRATE_MS + CELEBRATE_PROP_HOLD_MS)
   }, [])
 
-  useEffect(() => watchSessions({
+  // Owner role: the main process elects exactly one owner overlay to run production.
+  useEffect(() => petBridge.onSetOwner?.(setIsOwner) ?? undefined, [])
+
+  // Rehydrate the slot after a brain crash: main replays the last reported slot to the
+  // replacement owner on pet-ready, before it resumes producing, so a live bubble's
+  // count/timestamp survive the restart and its resolution still clears the right slot.
+  useEffect(
+    () =>
+      petBridge.onRehydrateSlot?.((recovery) => {
+        const r = (recovery ?? {}) as { slot?: PendingBubble | null; seq?: number }
+        slotRef.current = r.slot ?? null
+        // Continue the negative local sequence where the crashed brain left off, so a
+        // freshly-reloaded producer never reissues a seq the active overlay still keys.
+        if (typeof r.seq === 'number') localSeqRef.current = r.seq
+      }) ?? undefined,
+    [],
+  )
+
+  // Window commands (Open panel / Change avatar) are drained from /pending by the
+  // owner (the hidden brain) but relayed here so the ACTIVE overlay opens them at
+  // the avatar's real screen position; main sends only to the active overlay.
+  useEffect(
+    () =>
+      petBridge.onWindowCommand?.((cmd) => {
+        if (cmd === 'panel') openPanelRef.current()
+        else if (cmd === 'gallery') window.crewCompanion?.galleryOpen?.()
+      }) ?? undefined,
+    [],
+  )
+
+  // Owner: a bubble action performed on the ACTIVE overlay, relayed here by main. A
+  // dismiss frees the slot (the resolve path is the socket's onApprovalResolved).
+  useEffect(
+    () =>
+      petBridge.onBubbleAction?.((action) => {
+        if (action === 'dismiss') {
+          slotRef.current = null
+          emitBubble(null)
+        }
+      }) ?? undefined,
+    [emitBubble],
+  )
+
+  // Display: render whatever the owner (the hidden brain window, relayed by main)
+  // pushes. The avatar's reaction plays HERE — on the active overlay that draws the
+  // avatar, not on the hidden owner — but ONLY when main flags this as a freshly
+  // reported bubble. A re-push on activation or a display hand-off arrives with
+  // playReaction=false, so the reaction is never replayed for a bubble the
+  // previously-active overlay already reacted to.
+  useEffect(
+    () =>
+      petBridge.onRenderBubble?.((b, playReaction) => {
+        const next = b as Bubble | null
+        setBubble(next)
+        if (!next) { setPlacement(null); return }
+        if (!playReaction) return
+        const k = next.kind
+        if (k === 'session-error') { react('error', 2_000); setMood('scared') }
+        else if (k === 'approval' || k === 'session-input') { bumpReaction(); setMood('curious') }
+        else if (k === 'break' || k === 'break-breathe' || k === 'reminder') { /* ambient: no reaction */ }
+        else { react('done', 2_400); setMood('happy'); celebrateWithProp() }
+      }) ?? undefined,
+    [react, setMood, bumpReaction, celebrateWithProp],
+  )
+
+  useEffect(() => {
+    // Only the elected owner runs the WebSocket producer; every other overlay is a
+    // pure view fed by the render-bubble push above.
+    if (!isOwner) return
+    return watchSessions({
     isSilent: () => sessionAlertsRef.current === false,
     // The backend rang: drain now rather than at the next tick of the poll.
     onFireQueued: () => pollNowRef.current?.(),
@@ -659,7 +804,7 @@ function Companion() {
       // Local, negative sequence numbers: these bubbles have no backend fire behind
       // them, and a positive number could collide with a real fire's seq.
       localSeqRef.current -= 1
-      setBubble({
+      emitBubble({
         seq: localSeqRef.current,
         kind: result.pending?.kind ?? kind,
         text: result.show,
@@ -668,14 +813,9 @@ function Companion() {
         // lead somewhere, so it leads to the most recent one.
         slot,
       })
-      if (failed) {
-        react('error', 2_000)
-        setMood('scared')
-      } else {
-        react('done', 2_400)
-        setMood('happy')
-        celebrateWithProp()
-      }
+      // The avatar's hop + mood play on the ACTIVE overlay when this bubble is pushed
+      // to it (see onRenderBubble), keyed on its kind — not here, because the owner
+      // may be a hidden, non-active overlay.
     },
     /*
      * A tool is BLOCKED on your OK — raise the sticky approval bubble.
@@ -718,7 +858,7 @@ function Companion() {
       // Local, negative sequence: no backend fire sits behind this bubble, and a
       // positive number could collide with a real fire's seq.
       localSeqRef.current -= 1
-      setBubble({
+      emitBubble({
         seq: localSeqRef.current,
         kind: result.pending?.kind ?? kind,
         text: result.show,
@@ -727,9 +867,6 @@ function Companion() {
         // carries '' here and is surfaced on the dashboard's own approvals feed.
         slot,
       })
-      // Curious, not alarmed: activeAnimFor turns a curious mood into the head-cock.
-      bumpReaction()
-      setMood('curious')
     },
     /*
      * Blocked work answered elsewhere frees the slot at once.
@@ -739,10 +876,15 @@ function Companion() {
      * something already decided.
      */
     onApprovalResolved: () => {
-      if (slotRef.current?.sticky) slotRef.current = null
-      setBubble((b) => (b && isSticky(b.kind) ? null : b))
+      // Only a sticky approval is cleared by an external resolve; a routine bubble
+      // holding the slot is left alone.
+      if (slotRef.current?.sticky) {
+        slotRef.current = null
+        emitBubble(null)
+      }
     },
-  }), [react, setMood, celebrateWithProp, bumpReaction])
+    })
+  }, [emitBubble, isOwner])
 
   /** Presence: silence is read as "nobody is there", so this must not stop. */  useEffect(() => {
     void post(PRESENCE_PATH)
@@ -755,6 +897,10 @@ function Companion() {
     let stopped = false
 
     const poll = async () => {
+      // Only the notification OWNER drains reminders — there is exactly one, so no
+      // other overlay can advance the shared cursor concurrently. A non-owner resumes
+      // draining if it is later elected owner.
+      if (!isOwnerRef.current) return
       try {
         const since = cursorRef.current
         const r = await fetch(`${PENDING_PATH}?since=${since}`, {
@@ -782,6 +928,17 @@ function Companion() {
           if (stopped) return
         }
 
+        // Commit-safety invariant: act on this response ONLY if this overlay is STILL
+        // the owner and the stored cursor has not moved past what we fetched from. A
+        // single owner means no concurrent poll can advance it, but a reload can leave
+        // our in-memory cursor behind the stored one; bail FORWARD-only, so a failed
+        // localStorage write (stored cursor LOWER than ours) does not deadlock
+        // delivery — proceeding re-attempts the write.
+        if (!isOwnerRef.current || readStoredCursor() > since) return
+
+        // Window commands the dashboard page recorded (Open panel / Change
+        // avatar). The page has no bridge of its own, so it enqueues the intent
+
         // Window commands the dashboard page recorded (Open panel / Change
         // avatar). The page has no bridge of its own, so it enqueues the intent
         // in the backend and this overlay — which does hold the bridge — carries
@@ -791,8 +948,10 @@ function Companion() {
           if (f.kind !== 'command') continue
           const ts = Date.parse(f.at)
           if (Number.isFinite(ts) && Date.now() - ts > COMMAND_FRESH_MS) continue
-          if (f.text === 'panel') openPanelRef.current()
-          else if (f.text === 'gallery') window.crewCompanion?.galleryOpen?.()
+          // The poll runs on the OWNER (the hidden brain window), but a window
+          // command must open next to the AVATAR, so relay it to the active overlay
+          // to execute with its own on-screen position rather than the brain's.
+          petBridge.reportWindowCommand?.(f.text)
         }
 
         /*
@@ -870,7 +1029,7 @@ function Companion() {
           if (held?.sticky && now - held.at < STICKY_HOLD_MS) return
           commitCursor(latest.seq)
           slotRef.current = { text, sticky: false, count: 1, at: now, kind }
-          setBubble({ seq: latest.seq, kind, text })
+          emitBubble({ seq: latest.seq, kind, text })
           return
         }
 
@@ -885,32 +1044,9 @@ function Companion() {
         commitCursor(latest.seq)
         slotRef.current = result.pending
         const shownKind = result.pending?.kind ?? kind
-        setBubble({ seq: latest.seq, kind: shownKind, text: result.show })
-        // A finish is a celebration; a failure or something blocked is a shake. Both
-        // settle back to idle so the companion does not sit in a reaction.
-        // The body reacts AND the mood changes, because the mood is what the eyes
-        // read — a body nod alone left the face blank, which is why the companion
-        // looked unmoved by its own notifications. Transient, so it auto-resets.
-        if (shownKind === 'session-error') {
-          react('error', 2_000)
-          setMood('scared')
-        } else if (shownKind === 'approval' || shownKind === 'session-input') {
-          /*
-           * Waiting on YOU is not a failure.
-           *
-           * These three kinds used to share the alarmed error shake, which made
-           * "something broke" and "I need your OK" look identical. The source cocks
-           * the head instead — curious, not alarmed — and the mood is what drives it,
-           * so no `react` here: `activeAnimFor` turns a curious mood into the head-cock.
-           */
-          bumpReaction()
-          setMood('curious')
-        } else {
-          react('done', 2_400)
-          setMood('happy')
-          // Every finish gets the flourish, not just the ones arriving over the socket.
-          celebrateWithProp()
-        }
+        emitBubble({ seq: latest.seq, kind: shownKind, text: result.show })
+        // The avatar's reaction plays on the ACTIVE overlay when this bubble is
+        // pushed to it (see onRenderBubble), keyed on the bubble's kind.
       } catch {
         /* keep polling */
       }
@@ -926,6 +1062,18 @@ function Companion() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: starts poll loop once, deps are stable refs/callbacks
   }, [])
+
+  // When this overlay becomes the notification owner, drain any reminders that queued
+  // before it took over right away, instead of waiting up to a full poll interval.
+  useEffect(() => {
+    if (isOwner) {
+      // Refresh from the stored cursor before draining: a freshly elected owner (or a
+      // reload) may hold a stale in-memory cursor that would re-show an already-shown
+      // reminder.
+      cursorRef.current = readStoredCursor()
+      pollNowRef.current?.()
+    }
+  }, [isOwner])
 
 
   // ── Local aliveness ─────────────────────────────────────────────────────
@@ -947,8 +1095,10 @@ function Companion() {
       setIsPeeking(false)
       setHideEdge(null)
     }
-    // Persist through the same petX/petY config path a drag uses.
-    petBridge.savePosition?.(finalPos.x, finalPos.y)
+    // Persist through the same petX/petY config path a drag uses — but only while
+    // active. A hop begun before a hand-off can end after deactivation (which sets
+    // isActiveRef synchronously); saving then would overwrite the new owner's spot.
+    if (isActiveRef.current) petBridge.savePosition?.(finalPos.x, finalPos.y)
   }, [setHideEdge, setIsPeeking])
 
   const { isWalking, walkDir, walkTilt, cancelWalk, walkPath } =
@@ -963,8 +1113,10 @@ function Companion() {
    */
   const reducedMotion =
     window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  // Only the active overlay owns the avatar; an inactive view must stay still, or
+  // its idle hop would call savePosition and clobber the active display's position.
   const settled =
-    posReady && !dragging.current && !isWalking && !isPeeking &&
+    isActive && posReady && !dragging.current && !isWalking && !isPeeking &&
     menuAt === null && !reducedMotion
 
   // Built-in ghost: small in-place hop / brief mood flicker.
@@ -1047,7 +1199,7 @@ function Companion() {
   // menu reports its own rect separately (PetContextMenu → petBridge.setMenuHitbox).
   // `placement` is null until the bubble is measured, so the bubble rect is reported
   // once it lands.
-  useMouseForward({ pos, bubbleRect: placement?.rect ?? null, dragging })
+  useMouseForward({ pos, bubbleRect: placement?.rect ?? null, dragging, isActive })
 
   // Playful motion runs only when the companion is settled — not while it is being
   // dragged, walking, or docked at an edge. Set every render so the rAF loop sees
@@ -1082,7 +1234,7 @@ function Companion() {
 
   return (
     <div className="cc-pet-layer">
-      {menuAt ? (
+      {isActive && menuAt ? (
         <div className="cc-menu-host">
           <PetContextMenu
             x={menuAt.x}
@@ -1093,7 +1245,7 @@ function Companion() {
         </div>
       ) : null}
 
-      {bubble ? (
+      {isActive && bubble ? (
         <div
           ref={bubbleHostRef}
           className="cc-bubble-host"
@@ -1134,6 +1286,7 @@ function Companion() {
       ) : null}
 
       {/* The only element that accepts input; everything else is click-through. */}
+      {isActive ? (
       <div
         className="cc-pet"
         onMouseDown={(e) => {
@@ -1253,6 +1406,7 @@ function Companion() {
           />
         </div>
       </div>
+      ) : null}
     </div>
   )
 }

--- a/website/src/apps/crew-companion/petBridge.ts
+++ b/website/src/apps/crew-companion/petBridge.ts
@@ -47,11 +47,48 @@ type Preload = {
   galleryOpen?(): void
   galleryClose?(): void
   turnOff?(): void
+
+  // ── Single-active-overlay + cross-display drag hand-off ─────────────────────
+  // The main process picks ONE active display and drives these; every other
+  // overlay is told inactive so only one companion is ever drawn.
+  onSetActive?(cb: (active: boolean, x?: number, y?: number, isDragging?: boolean) => void): () => void
+  dragStart?(offsetX: number, offsetY: number): void
+  dragEnd?(): void
+  dragMouseUp?(): void
+  onDragUpdate?(cb: (x: number, y: number) => void): () => void
+  onDragEnded?(cb: (x: number, y: number) => void): () => void
+  onDragListenMouseUp?(cb: () => void): () => void
+  petReady?(): void
+  onSetOwner?(cb: (isOwner: boolean) => void): () => void
+  reportBubbleState?(bubble: unknown, slot?: unknown, seq?: unknown): void
+  onRenderBubble?(cb: (bubble: unknown, playReaction?: boolean) => void): () => void
+  bubbleAction?(action: unknown): void
+  onBubbleAction?(cb: (action: unknown) => void): () => void
+  reportWindowCommand?(cmd: unknown): void
+  onWindowCommand?(cb: (cmd: unknown) => void): () => void
+  onRehydrateSlot?(cb: (slot: unknown) => void): () => void
 }
 
 function preload(): Preload | undefined {
   return (window as unknown as { crewCompanion?: Preload }).crewCompanion
 }
+
+/**
+ * True when the Electron preload bridge is present — i.e. this page is an overlay or
+ * the brain window, driven by main. False in a plain browser tab, where the lone page
+ * must be both the view and the producer (no main to tell it its role).
+ */
+export function hasCompanionBridge(): boolean {
+  return preload() !== undefined
+}
+
+// Plain-browser fallback state: with no preload there is no main process to relay the
+// producer's bubble to the view, or a user action back to the producer. These hold
+// the in-page callbacks so reportBubbleState/bubbleAction can echo directly, the same
+// round-trip main performs between the brain window and the active overlay.
+let localRenderBubble: ((b: unknown, playReaction?: boolean) => void) | null = null
+let localBubbleAction: ((a: unknown) => void) | null = null
+let localWindowCommand: ((cmd: unknown) => void) | null = null
 
 /** The detail payload, named so call sites need no indexed-access type. */
 /**
@@ -93,10 +130,25 @@ export interface PackDetail {
 export interface PetBridge {
   getWindowPosition?: () => Promise<{ x: number; y: number } | null>
   savePosition?: (x: number, y: number) => void
+  /** Main -> overlay: this display is (in)active; x,y,isDragging ride a live hand-off. */
+  onSetActive?: (cb: (active: boolean, x?: number, y?: number, isDragging?: boolean) => void) => () => void
   dragStart?: (offsetX: number, offsetY: number) => void
   dragEnd?: () => void
+  /** Renderer -> main: the drag's mouseup fired on this overlay. */
+  dragMouseUp?: () => void
   onDragUpdate?: (cb: (x: number, y: number) => void) => (() => void) | undefined
   onDragEnded?: (cb: (x: number, y: number) => void) => (() => void) | undefined
+  /** Main -> overlay at drag-start: attach a window mouseup that calls dragMouseUp. */
+  onDragListenMouseUp?: (cb: () => void) => () => void
+  petReady?: () => void
+  onSetOwner?: (cb: (isOwner: boolean) => void) => () => void
+  reportBubbleState?: (bubble: unknown, slot?: unknown, seq?: unknown) => void
+  onRenderBubble?: (cb: (bubble: unknown, playReaction?: boolean) => void) => () => void
+  bubbleAction?: (action: unknown) => void
+  onBubbleAction?: (cb: (action: unknown) => void) => () => void
+  reportWindowCommand?: (cmd: unknown) => void
+  onWindowCommand?: (cb: (cmd: unknown) => void) => () => void
+  onRehydrateSlot?: (cb: (slot: unknown) => void) => () => void
   /**
    * Report the companion's and bubble's hitboxes to the main process.
    *
@@ -453,21 +505,81 @@ export const petBridge: PetBridge = {
   },
 
   /**
-   * Cross-display drag hooks.
+   * Single-active-overlay + cross-display drag hand-off.
    *
-   * In the desktop app the main process polled the cursor so a drag could carry the
-   * pet onto another monitor. Here each display has its own overlay, so a drag is
-   * handled entirely within the one the pointer is in — these stay undefined and the
-   * hook's optional calls (`api?.dragStart?.()`) simply do nothing, which is the
-   * single-display path it already supports.
-   *
-   * Left named and documented rather than deleted so the gap is visible: without
-   * them, dragging the companion to a second monitor stops at the screen edge.
+   * The main process now picks ONE active display and drives these, so only that
+   * overlay draws a companion and a drag can carry the pet onto another monitor.
+   * Each delegates to the preload bridge; subscribes hand back its unsubscribe, or a
+   * no-op when the page is open in an ordinary browser with no bridge.
    */
-  dragStart: undefined,
-  dragEnd: undefined,
-  onDragUpdate: undefined,
-  onDragEnded: undefined,
+  onSetActive(cb) {
+    return preload()?.onSetActive?.(cb) ?? (() => {})
+  },
+  dragStart(offsetX, offsetY) {
+    preload()?.dragStart?.(offsetX, offsetY)
+  },
+  dragEnd() {
+    preload()?.dragEnd?.()
+  },
+  dragMouseUp() {
+    preload()?.dragMouseUp?.()
+  },
+  onDragUpdate(cb) {
+    return preload()?.onDragUpdate?.(cb) ?? (() => {})
+  },
+  onDragEnded(cb) {
+    return preload()?.onDragEnded?.(cb) ?? (() => {})
+  },
+  onDragListenMouseUp(cb) {
+    return preload()?.onDragListenMouseUp?.(cb) ?? (() => {})
+  },
+  petReady() {
+    preload()?.petReady?.()
+  },
+  onSetOwner(cb) {
+    return preload()?.onSetOwner?.(cb) ?? (() => {})
+  },
+  reportBubbleState(bubble, slot, seq) {
+    const p = preload()
+    if (p) { p.reportBubbleState?.(bubble, slot, seq); return }
+    // No main to relay through: echo the producer's bubble straight to the view
+    // in-page (the plain-browser dev path), so it renders and reacts.
+    localRenderBubble?.(bubble, true)
+  },
+  onRenderBubble(cb) {
+    const p = preload()
+    if (p) return p.onRenderBubble?.(cb) ?? (() => {})
+    localRenderBubble = cb
+    return () => { if (localRenderBubble === cb) localRenderBubble = null }
+  },
+  bubbleAction(action) {
+    const p = preload()
+    if (p) { p.bubbleAction?.(action); return }
+    localBubbleAction?.(action)
+  },
+  onBubbleAction(cb) {
+    const p = preload()
+    if (p) return p.onBubbleAction?.(cb) ?? (() => {})
+    localBubbleAction = cb
+    return () => { if (localBubbleAction === cb) localBubbleAction = null }
+  },
+  reportWindowCommand(cmd) {
+    const p = preload()
+    if (p) { p.reportWindowCommand?.(cmd); return }
+    // No main to relay through (plain-browser dev path): run it in-page.
+    localWindowCommand?.(cmd)
+  },
+  onWindowCommand(cb) {
+    const p = preload()
+    if (p) return p.onWindowCommand?.(cb) ?? (() => {})
+    localWindowCommand = cb
+    return () => { if (localWindowCommand === cb) localWindowCommand = null }
+  },
+  onRehydrateSlot(cb) {
+    // Only meaningful with a main process (brain restart). The plain-browser page
+    // never crash-restarts a separate producer, so there is nothing to rehydrate.
+    return preload()?.onRehydrateSlot?.(cb) ?? (() => {})
+  },
 
   // Walk commands are renderer-driven for now (the wander calls walkPath directly),
   // so the main process emits none of these yet. Left undefined and documented, like

--- a/website/src/apps/crew-companion/sessionWatch.ts
+++ b/website/src/apps/crew-companion/sessionWatch.ts
@@ -149,6 +149,20 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
    */
   const stoppedSlots = new Set<string>()
 
+  /*
+   * Slots we have already raised the pending-approval bubble for.
+   *
+   * The `approval` frame is a point event with no replay, so one broadcast while the
+   * owner is between sockets (a crash-replaced brain reconnecting) is lost. The `slots`
+   * frame, by contrast, carries each slot's live `pending_approval` and arrives on
+   * every connect — so a missed approval is RECOVERABLE by reconciling from it. This
+   * set dedupes the two sources: the live frame marks the slot here, so the slots
+   * reconcile never double-raises it, and a slot whose `pending_approval` goes false is
+   * cleared so a later approval on it raises again. (A completion `chat_done` has no
+   * such persistent flag, so its own gap is not recoverable this way.)
+   */
+  const surfacedApprovals = new Set<string>()
+
   let socket: WebSocket | null = null
   let stopped = false
   let retryMs = RECONNECT_MIN_MS
@@ -240,7 +254,7 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
         // running is an ASSUMED start: we joined mid-turn.
         const list = Array.isArray(data) ? data : (data.slots as unknown[]) ?? []
         for (const entry of list) {
-          const s = entry as { key?: unknown; running?: unknown; title?: unknown; stopping?: unknown }
+          const s = entry as { key?: unknown; running?: unknown; title?: unknown; stopping?: unknown; pending_approval?: unknown }
           if (typeof s.key !== 'string') continue
           if (typeof s.title === 'string') titles.set(s.key, s.title)
           if (s.running === true) markStart(s.key, true)
@@ -254,6 +268,21 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
            * ending was chosen, not earned.
            */
           if (s.stopping === true) stoppedSlots.add(s.key)
+          /*
+           * Recover a pending approval whose live `approval` frame was lost while the
+           * owner was between sockets (brain restart). `pending_approval` is persistent
+           * backend state, so the first `slots` frame after reconnect still shows it;
+           * raise it once, deduped against the live path via surfacedApprovals, and
+           * clear the mark when it goes false so a future approval re-raises.
+           */
+          if (s.pending_approval === true) {
+            if (!surfacedApprovals.has(s.key)) {
+              surfacedApprovals.add(s.key)
+              opts.onApproval?.({ slot: s.key, title: titles.get(s.key) ?? '' })
+            }
+          } else if (s.pending_approval === false) {
+            surfacedApprovals.delete(s.key)
+          }
         }
         break
       }
@@ -275,6 +304,7 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
         // waiting — the title comes from the same table `onDone` reads, since the
         // frame itself has no human name.
         if (typeof data.slot === 'string') {
+          surfacedApprovals.add(data.slot)
           opts.onApproval?.({ slot: data.slot, title: titles.get(data.slot) ?? '' })
         }
         break
@@ -348,7 +378,18 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
     ws.onopen = () => { retryMs = RECONNECT_MIN_MS }
     ws.onmessage = (ev) => handle(String(ev.data))
     // Both paths reconnect: a gateway restart closes cleanly, a network drop errors.
-    ws.onclose = () => { socket = null; failInFlight(); schedule() }
+    ws.onclose = () => {
+      socket = null
+      // Drop the approval dedupe set: across a reconnect it can no longer be trusted
+      // (an approval may have resolved and a NEW one gone pending on the same slot
+      // while we were disconnected, with no intervening pending_approval:false frame
+      // to clear the mark). The first slots frame after reconnect re-derives it from
+      // live pending_approval; a still-pending approval's re-raise is absorbed by the
+      // sticky-hold guard in onApproval.
+      surfacedApprovals.clear()
+      failInFlight()
+      schedule()
+    }
     ws.onerror = () => { try { ws.close() } catch { /* already closing */ } }
   }
 

--- a/website/src/apps/crew-companion/useMouseForward.ts
+++ b/website/src/apps/crew-companion/useMouseForward.ts
@@ -10,11 +10,13 @@
  * make it to the main process and back before the window accepted input, so a
  * fast click landed while the window was still click-through.
  *
- * Adapted to this build's single-display-per-overlay model:
- *   - There is no `set-active` handshake here (each overlay renders the companion
- *     independently and the main process never transfers a pet between displays),
- *     so the source's `isActiveRef` gating is dropped — this overlay always
- *     describes its own companion.
+ * Adapted to this build's single-active-overlay model:
+ *   - The main process picks ONE active display and signals each overlay
+ *     (onSetActive), so only the active overlay describes a companion. When
+ *     inactive this hook clears its hitbox once (updateHitbox(null, null)) and goes
+ *     silent, so a background display never claims cursor input — that is the
+ *     `isActive` gating restored here, which the earlier single-display port had
+ *     dropped.
  *   - The source SKIPS sending while dragging because its main process runs a
  *     separate drag poll that owns ignore-mouse during a drag. This build has no
  *     such poll, so we do the opposite and keep sending: the companion's rect
@@ -37,18 +39,33 @@ export interface UseMouseForwardParams {
   bubbleRect: Rect | null
   /** useDrag's dragging flag — a ref, so no re-render when it flips. */
   dragging: MutableRefObject<boolean>
+  /** False on a background display: this overlay draws no companion, so send nothing. */
+  isActive: boolean
 }
 
-export function useMouseForward({ pos, bubbleRect, dragging }: UseMouseForwardParams): void {
+export function useMouseForward({ pos, bubbleRect, dragging, isActive }: UseMouseForwardParams): void {
   // Last rects sent, so an unchanged frame does not flood IPC.
   const lastPet = useRef('')
   const lastBubble = useRef('')
+  // True once we have cleared our hitbox for the current inactive spell, so an
+  // inactive overlay sends updateHitbox(null, null) exactly once and nothing after.
+  const clearedInactive = useRef(false)
 
   // Forces a re-send while a bubble is visible, guarding against a hitbox the
   // main process may have dropped across a sleep/wake.
   const [tick, setTick] = useState(0)
 
   useEffect(() => {
+    if (!isActive) {
+      if (!clearedInactive.current) {
+        clearedInactive.current = true
+        lastPet.current = ''
+        lastBubble.current = ''
+        petBridge.updateHitbox?.(null, null)
+      }
+      return
+    }
+    clearedInactive.current = false
     const pet = petHitbox(pos)
     const bubble = bubbleHitbox(bubbleRect)
     const petKey = `${pet.x},${pet.y},${tick}`
@@ -57,7 +74,7 @@ export function useMouseForward({ pos, bubbleRect, dragging }: UseMouseForwardPa
     lastPet.current = petKey
     lastBubble.current = bubbleKey
     petBridge.updateHitbox?.(pet, bubble)
-  }, [pos, bubbleRect, tick])
+  }, [pos, bubbleRect, tick, isActive])
 
   // Re-assert the hitbox every couple of seconds while a bubble is up.
   useEffect(() => {
@@ -70,6 +87,8 @@ export function useMouseForward({ pos, bubbleRect, dragging }: UseMouseForwardPa
   // re-send so the companion becomes clickable again immediately. Runs after the
   // React commit (rAF) so it reads the settled post-drag position.
   useEffect(() => {
+    // Inactive overlay stays silent — see the header note.
+    if (!isActive) return
     const onUp = () => {
       requestAnimationFrame(() => {
         if (dragging.current) return
@@ -80,5 +99,5 @@ export function useMouseForward({ pos, bubbleRect, dragging }: UseMouseForwardPa
     }
     window.addEventListener('mouseup', onUp)
     return () => window.removeEventListener('mouseup', onUp)
-  }, [pos, bubbleRect, dragging])
+  }, [pos, bubbleRect, dragging, isActive])
 }

--- a/website/src/test/CrewCompanionHitbox.test.ts
+++ b/website/src/test/CrewCompanionHitbox.test.ts
@@ -121,14 +121,14 @@ describe('useMouseForward — reports the companion and bubble rects', () => {
   const dragging = { current: false } as MutableRefObject<boolean>
 
   it('reports the companion box, and no bubble, at rest', () => {
-    renderHook(() => useMouseForward({ pos: { x: 100, y: 120 }, bubbleRect: null, dragging }))
+    renderHook(() => useMouseForward({ pos: { x: 100, y: 120 }, bubbleRect: null, dragging, isActive: true }))
     expect(update).toHaveBeenCalledWith({ x: 100, y: 120, w: PET_W, h: PET_H }, null)
   })
 
   it('reports the bubble rect once a bubble is showing', () => {
     const { rerender } = renderHook(
       ({ bubbleRect }: { bubbleRect: Rect | null }) =>
-        useMouseForward({ pos: { x: 100, y: 120 }, bubbleRect, dragging }),
+        useMouseForward({ pos: { x: 100, y: 120 }, bubbleRect, dragging, isActive: true }),
       { initialProps: { bubbleRect: null as Rect | null } },
     )
     update.mockClear()
@@ -137,5 +137,13 @@ describe('useMouseForward — reports the companion and bubble rects', () => {
       { x: 100, y: 120, w: PET_W, h: PET_H },
       { x: 60, y: 20, w: 240, h: 70 + BUBBLE_HIT_PAD },
     )
+  })
+
+  it('an inactive overlay clears its hitbox once and sends nothing at rest', () => {
+    renderHook(() => useMouseForward({ pos: { x: 100, y: 120 }, bubbleRect: null, dragging, isActive: false }))
+    // The one send is the null clear, so the main process stops treating this
+    // background display as interactive.
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledWith(null, null)
   })
 })

--- a/website/src/test/CrewCompanionPet.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPet.coverage.test.tsx
@@ -14,7 +14,7 @@
  * session socket drives.
  */
 import { describe, it, expect, vi, beforeEach, afterEach, onTestFinished } from 'vitest'
-import { waitFor, fireEvent } from '@testing-library/react'
+import { waitFor, fireEvent, act } from '@testing-library/react'
 
 import { PENDING_PATH, PRESENCE_PATH } from '../apps/crew-companion/constants'
 import type { SessionWatchOptions } from '../apps/crew-companion/sessionWatch'
@@ -47,8 +47,52 @@ const bridge = {
   updateHitbox: vi.fn(),
   setMenuHitbox: vi.fn(),
   contextMenuAction: vi.fn(),
+  // Single-active-overlay model: the pet renders only once main tells it it is the
+  // active display. Simulate the active overlay so these render assertions hold
+  // (a background overlay would receive false and draw nothing).
+  onSetActive: vi.fn((cb: (active: boolean, x?: number, y?: number, isDragging?: boolean) => void) => {
+    setActiveCb = cb
+    cb(true)
+    return () => {}
+  }),
+  // Single-owner model: the test overlay is BOTH the notification owner (runs the
+  // producer) and the active display (draws). The relay loop main performs in
+  // production is simulated here: reportBubbleState (owner → main) is looped straight
+  // into the onRenderBubble listener (main → active), and bubbleAction (active → main)
+  // into the onBubbleAction listener (main → owner).
+  onSetOwner: vi.fn((cb: (isOwner: boolean) => void) => {
+    cb(true)
+    return () => {}
+  }),
+  reportBubbleState: vi.fn((b: unknown) => { renderBubbleCb?.(b, true) }),
+  onRenderBubble: vi.fn((cb: (b: unknown, playReaction?: boolean) => void) => {
+    renderBubbleCb = cb
+    return () => {}
+  }),
+  // Main → replacement brain after a crash: rehydrate the live slot.
+  onRehydrateSlot: vi.fn((cb: (slot: unknown) => void) => {
+    rehydrateSlotCb = cb
+    return () => {}
+  }),
+  bubbleAction: vi.fn((a: unknown) => { bubbleActionCb?.(a) }),
+  onBubbleAction: vi.fn((cb: (a: unknown) => void) => {
+    bubbleActionCb = cb
+    return () => {}
+  }),
+  // Window command (owner → main → active), looped straight to the listener.
+  reportWindowCommand: vi.fn((cmd: unknown) => { windowCommandCb?.(cmd) }),
+  onWindowCommand: vi.fn((cb: (cmd: unknown) => void) => {
+    windowCommandCb = cb
+    return () => {}
+  }),
+  onDragListenMouseUp: vi.fn(() => () => {}),
+  onDragUpdate: vi.fn(() => () => {}),
+  onDragEnded: vi.fn(() => () => {}),
+  dragStart: vi.fn(),
+  dragEnd: vi.fn(),
+  dragMouseUp: vi.fn(),
 }
-vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: bridge }))
+vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: bridge, hasCompanionBridge: () => true }))
 // Both harnesses re-import the entry per test with `vi.resetModules()`, and the
 // entry boots through `../i18n/all` — so without this every test would re-fetch the
 // twelve non-English catalogs, 434 ms each. They pin `mc-lang` to `en` and assert
@@ -64,6 +108,13 @@ vi.mock('../i18n/all', async () => await import('../i18n/index'))
 
 /** The gateway socket is replaced by a handle on the callbacks the overlay passes. */
 let watch: SessionWatchOptions | null = null
+/** Relay callbacks the renderer registers, so a single-overlay test can stand in for
+ * the main-process relay loop (owner reports → active renders; action → owner). */
+let renderBubbleCb: ((b: unknown, playReaction?: boolean) => void) | null = null
+let setActiveCb: ((active: boolean, x?: number, y?: number, isDragging?: boolean) => void) | null = null
+let bubbleActionCb: ((a: unknown) => void) | null = null
+let windowCommandCb: ((cmd: unknown) => void) | null = null
+let rehydrateSlotCb: ((slot: unknown) => void) | null = null
 vi.mock('../apps/crew-companion/sessionWatch', () => ({
   watchSessions: (opts: SessionWatchOptions) => {
     watch = opts
@@ -211,6 +262,11 @@ function tapPet(at = { x: 340, y: 240 }): void {
 beforeEach(() => {
   calls = []
   watch = null
+  renderBubbleCb = null
+  setActiveCb = null
+  bubbleActionCb = null
+  windowCommandCb = null
+  rehydrateSlotCb = null
   panelClosedCbs = []
   galleryOpenedCbs = []
   galleryClosedCbs = []
@@ -793,6 +849,29 @@ describe('the active appearance pack', () => {
   })
 })
 
+describe('the single notification owner drives the bubble', () => {
+  it('renders a produced reminder through the owner → main → active relay', async () => {
+    queue([fire({ seq: 4, kind: 'reminder', text: 'stretch' })])
+    await mountPet()
+    // No shared store and no per-overlay copy: the owner runs the poll, reports the
+    // resolved bubble to main, and main relays it to the active overlay's render push.
+    await waitFor(() => expect(bubbleText()).toBe('stretch'))
+    expect(bridge.reportBubbleState).toHaveBeenCalled()
+    expect(bridge.onRenderBubble).toHaveBeenCalled()
+  })
+
+  it('rehydrates the slot after a brain restart so a live count survives', async () => {
+    await mountPet()
+    await waitFor(() => expect(bridge.onRehydrateSlot).toHaveBeenCalled())
+    // Main hands the replacement brain the live slot (one completion already collapsed)
+    // on pet-ready. Without rehydration slotRef would be null and the next completion
+    // would start a fresh count instead of collapsing onto the one that survived.
+    rehydrateSlotCb!({ slot: { text: 'one', sticky: false, count: 1, at: Date.now(), kind: 'session-done' }, seq: -1 })
+    watch!.onDone({ slot: 'b', title: 'two', elapsedMs: 1, failed: false })
+    await waitFor(() => expect(bubbleText()).toBe('2 jobs finished'))
+  })
+})
+
 describe('fires that arrive through /pending rather than the socket', () => {
   it('celebrates a completion that came off the fire queue', async () => {
     queue([fire({ seq: 1, kind: 'session-done', text: 'built the thing' })])
@@ -942,5 +1021,20 @@ describe('dragging the companion', () => {
     fireEvent.mouseMove(window, { clientX: 420, clientY: 300 })
     fireEvent.mouseUp(window)
     await waitFor(() => expect(bridge.savePosition).toHaveBeenCalled())
+  })
+
+  it('does not persist position after this display is handed off mid-drag', async () => {
+    await mountPet()
+    await waitFor(() => expect(petEl().style.opacity).toBe('1'))
+    const pet = petEl()
+    fireEvent.mouseDown(pet, { clientX: 340, clientY: 240, button: 0 })
+    fireEvent.mouseMove(window, { clientX: 420, clientY: 300 })
+    const before = bridge.savePosition.mock.calls.length
+    // Main elects another display: this overlay goes inactive while the gesture is
+    // still held. An inactive view no longer owns the avatar's position, so a later
+    // commit here must not overwrite the new owner's saved spot.
+    act(() => setActiveCb!(false))
+    fireEvent.mouseUp(window)
+    expect(bridge.savePosition.mock.calls.length).toBe(before)
   })
 })

--- a/website/src/test/CrewCompanionSessionWatch.test.ts
+++ b/website/src/test/CrewCompanionSessionWatch.test.ts
@@ -29,6 +29,7 @@ function fakeSocket() {
 
 interface Harness {
   done: SessionDone[]
+  approvals: { slot: string; title: string }[]
   send: (type: string, data: unknown) => void
   stop: () => void
   socket: ReturnType<typeof fakeSocket>
@@ -39,16 +40,19 @@ interface Harness {
 function harness(): Harness {
   const socket = fakeSocket()
   const done: SessionDone[] = []
+  const approvals: { slot: string; title: string }[] = []
   let t = 1_000_000
   let silent = false
   const stop = watchSessions({
     onDone: (d) => done.push(d),
+    onApproval: (a) => approvals.push(a),
     isSilent: () => silent,
     now: () => t,
     connect: () => socket as unknown as WebSocket,
   })
   return {
     done,
+    approvals,
     socket,
     stop,
     send: (type, data) => socket.onmessage?.({ data: JSON.stringify({ type, data }) }),
@@ -457,5 +461,49 @@ describe('session completion → bubble', () => {
     h.socket.close()
     expect(spy).not.toHaveBeenCalled()
     spy.mockRestore()
+  })
+})
+
+describe('pending-approval recovery across a brain restart', () => {
+  it('recovers a pending approval from the slots frame when its live approval frame was missed', () => {
+    /*
+     * The `approval` frame is push-only with no replay, so one broadcast while the
+     * owner is between sockets (a crash-replaced brain reconnecting) is lost. But
+     * `pending_approval` is persistent backend state carried on every `slots` frame,
+     * so the first frame after reconnect still shows it — recover it there.
+     */
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toEqual([{ slot: 'chat-1', title: 'Deploy' }])
+    // A later frame with the SAME pending approval must not raise it a second time.
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toHaveLength(1)
+    // Once it clears and a fresh approval appears, it raises again.
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: false }] })
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toHaveLength(2)
+  })
+
+  it('does not double-raise when the live approval frame and the slots reconcile both carry it', () => {
+    const h = harness()
+    h.send('approval', { slot: 'chat-1' })
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toHaveLength(1)
+  })
+
+  it('re-surfaces a still-pending approval after a reconnect clears the dedupe set', () => {
+    /*
+     * The dedupe mark normally clears on a `pending_approval:false` frame. A reconnect
+     * can strand it: an approval resolves and a NEW one goes pending on the same slot
+     * while disconnected, with no false frame between. Clearing the set on disconnect
+     * lets the first post-reconnect frame re-derive truth, so the new approval is not
+     * suppressed as a duplicate of the resolved one.
+     */
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toHaveLength(1)
+    h.socket.close() // disconnect clears the dedupe set
+    h.send('slots', { slots: [{ key: 'chat-1', title: 'Deploy', pending_approval: true }] })
+    expect(h.approvals).toHaveLength(2)
   })
 })

--- a/website/src/test/PetBridgeCoverage.test.tsx
+++ b/website/src/test/PetBridgeCoverage.test.tsx
@@ -851,14 +851,28 @@ describe('contextMenuAction', () => {
   })
 })
 
-describe('cross-display hooks are deliberately absent', () => {
-  // Left undefined and documented rather than deleted, so the ported hooks'
-  // `api?.on*?.()` guards resolve to no-ops on a single display.
-  it('drag and walk hooks are undefined so the hooks degrade to no-ops', () => {
-    expect(petBridge.dragStart).toBeUndefined()
-    expect(petBridge.dragEnd).toBeUndefined()
-    expect(petBridge.onDragUpdate).toBeUndefined()
-    expect(petBridge.onDragEnded).toBeUndefined()
+describe('cross-display drag hooks delegate to the preload bridge', () => {
+  // The main process now elects one active overlay and carries a drag between
+  // displays, so these are live delegates. With no bridge in this environment they
+  // must degrade safely: sends are no-ops and subscribes hand back a no-op remover.
+  it('drag sends are safe no-ops and subscribes return a remover without a bridge', () => {
+    expect(petBridge.dragStart).toBeInstanceOf(Function)
+    expect(petBridge.dragEnd).toBeInstanceOf(Function)
+    expect(petBridge.dragMouseUp).toBeInstanceOf(Function)
+    expect(() => petBridge.dragStart?.(1, 2)).not.toThrow()
+    expect(() => petBridge.dragEnd?.()).not.toThrow()
+    expect(() => petBridge.dragMouseUp?.()).not.toThrow()
+    expect(petBridge.onSetActive?.(() => {})).toBeInstanceOf(Function)
+    expect(petBridge.onDragUpdate?.(() => {})).toBeInstanceOf(Function)
+    expect(petBridge.onDragEnded?.(() => {})).toBeInstanceOf(Function)
+    expect(petBridge.onDragListenMouseUp?.(() => {})).toBeInstanceOf(Function)
+  })
+})
+
+describe('walk hooks are deliberately absent', () => {
+  // Left undefined and documented rather than deleted, so useWalking's
+  // `api?.on*?.()` guards resolve to no-ops until the main process drives them.
+  it('walk hooks are undefined so the hook degrades to no-ops', () => {
     expect(petBridge.onWalk).toBeUndefined()
     expect(petBridge.onWalkPath).toBeUndefined()
     expect(petBridge.onWalkCancel).toBeUndefined()


### PR DESCRIPTION
## Problem / Motivation

Crew Companion opened a transparent overlay on **every** display, and each overlay's renderer drew the pet independently. On a machine with more than one monitor this meant one companion **per screen** — the user sees two (or more) ghosts, one on the laptop display and one on the external monitor. Reported on a clean, single-stable install with two displays.

## Why it matters

The companion is meant to be a single presence that lives on your screen. Duplicating it across every monitor is confusing and reads as a bug, and it undermines the whole point of the feature. It gets worse the more displays you attach.

## What changed (motivation → approach → change)

- **Symptom:** one companion per monitor on a multi-display setup.
- **Root cause:** `openPetWindow` opens one full-screen overlay per display, and the renderer drew the sprite unconditionally. The original desktop pet kept a *single* active-display model (only one overlay ever shows the pet, and it transfers across displays when dragged); that gating was dropped when the companion was ported into KiroCrew, so every overlay rendered its own pet — and, separately, every overlay ran its own notification producer (the dashboard WebSocket + reminder poll + bubble state machine), so the per-screen copies could disagree.
- **Change (single active display):** the main process elects **one** active display and sends a per-overlay `crew-companion:set-active` signal; only the active overlay's renderer draws the pet (an `isActive` gate). To move the avatar to another monitor you **drag it across the screen boundary** — the main process follows the global cursor *during a drag* (`startDragPolling` → `transferActiveToDisplay`) and hands the avatar to the display it crosses into, persisting the landing position. It does **not** follow the cursor at rest.
- **Change (one notification producer, decoupled from the avatar):** notification production is owned by a single dedicated **hidden "brain" window**, created when the companion is enabled and destroyed when it is disabled. It loads the same `pet.html` as an overlay (so it inherits the gateway session), is never shown and never made active, and runs the *only* WebSocket + reminder poll + bubble slot machine (`isOwner=true` / `isActive=false` → produce-only). It reports the single resolved bubble to main (`crew-companion:bubble-state`); main caches it and relays it to whichever overlay is drawing the avatar (`crew-companion:render-bubble`), with a `playReaction` flag that is true only for a **freshly reported** bubble so a re-push on activation or a display hand-off does not replay the avatar's reaction. A user action on the bubble (dismiss) happens on the active overlay and is routed back to the brain (`crew-companion:bubble-action`). Because the producer's lifetime is the companion's — not any display's — there is no producer hand-off, so a completion/approval/reminder cannot be lost or duplicated when a monitor is unplugged, an overlay reloads, or the avatar is dragged. In a plain browser (no preload bridge) the lone page is both producer and view, relayed in-page, preserving the documented dev path.
- **Change (multi-monitor robustness):** the overlay `closed` handler re-elects a surviving overlay as **active** when the display hosting the avatar goes away (otherwise the avatar would be drawn on a gone display and every bubble shown nowhere); `screen` `display-removed` / `display-added` listeners reconcile the overlay set; `openPetWindow` preserves an already-valid active display across re-invocation so hot-plugging a monitor never silently moves "active"; and a crashed brain window is destroyed and recreated so production self-heals.
- **Change (dead code removed):** the persisted at-rest position record is `{displayId}` only — the renderer owns the on-screen coordinates via `savePosition`/`getWindowPosition`.

## Tests

Automated, all green (**57** electron main-process + **1000** renderer vitest):

- **`website/electron/crew-companion/test/petOverlay.test.js`**: exactly **one** overlay is told to render (`set-active(true)`) and every other is explicitly inactive; the notification **owner is a single hidden brain window**, not a visible overlay; **unplugging the active display re-elects a surviving overlay as active**; **adding a display preserves the active overlay** (no churn, new overlay opens inactive); the end-to-end cross-boundary drag hand-off; the `pet-ready` handshake (including that a readiness reply during a drag carries the drag state); and a transfer to a display with no live overlay is a no-op.
- **`website/electron/crew-companion/test/petTransfer.test.js`**: the pure geometry (`findDisplayAtPoint` / `findNearestDisplay` / `clampLocal`), the transfer **decision**, single-display resolution, and a **cross-file guard** that the main process's `PET_W`/`PET_H` equals the renderer's exported sprite constant.
- **`website/src/test/CrewCompanionPet.coverage.test.tsx`**: the single-owner render loop — the owner produces, main relays, the active overlay renders and reacts (mocked as an in-page relay); reminder/approval/completion behavior, the sticky-slot state machine, dismiss routing, and hostile-`localStorage` cursor handling.
- **`petHitbox.test.js`** and **`PetBridgeCoverage.test.tsx`**: stubs extended to the new Electron / bridge surface (`set-active`, `set-owner`, `render-bubble`/`bubble-state`/`bubble-action`, drag IPC, `did-finish-load` handshake, display-topology listeners).

## Manual verification

The single-active election, the cross-display hand-off, the brain-window relay, active re-election on unplug, and display-add preservation are exercised directly by the unit tests above (not just asserted in prose). The one thing unit tests can't stand in for is eyeballing it on a **real two-monitor desktop** — that final check is best done on hardware with two displays. Single-display behavior is unchanged: the sole display is always elected active and receives `set-active(true)`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only visible change is in the Crew Companion **desktop overlay** — a separate Electron window that renders `pet.html`, not a dashboard page — so the dashboard's browser screenshot tooling cannot render it. The meaningful delta (one companion across monitors instead of one-per-monitor, dragging it across the boundary, and the bubble riding along) is a **multi-monitor desktop behavior** a single-display CI browser can't reproduce. It is covered by the unit tests named above. Happy to attach a two-monitor screen recording if a reviewer wants one.

## Related Issues

no linked issue: reported informally as a teammate bug report; no tracked issue was filed.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`feat: ...`)
