### PR TITLE
fix(crew-companion): keep the app in the Dock when the companion opens

### DIFF
--- a/website/electron/crew-companion/galleryWindow.js
+++ b/website/electron/crew-companion/galleryWindow.js
@@ -16,6 +16,7 @@
 const path = require("path");
 const { BrowserWindow, ipcMain, shell } = require("electron");
 const { companionPageUrl } = require("./pageUrl");
+const { assertHostStaysInDock } = require("./petOverlay");
 
 /** Transparent gutter for the card's own shadow. */
 const GALLERY_PAD = 24;
@@ -72,6 +73,7 @@ function openGalleryWindow() {
     // Already open — bring it forward rather than opening a second copy.
     galleryWin.show();
     galleryWin.focus();
+    assertHostStaysInDock();
     if (onOpened) onOpened();
     return galleryWin;
   }
@@ -98,7 +100,10 @@ function openGalleryWindow() {
 
   galleryWin.loadURL(companionPageUrl(baseUrl, "gallery.html", credential));
   galleryWin.once("ready-to-show", () => {
-    if (galleryWin && !galleryWin.isDestroyed()) galleryWin.show();
+    if (galleryWin && !galleryWin.isDestroyed()) {
+      galleryWin.show();
+      assertHostStaysInDock();
+    }
     if (onOpened) onOpened();
   });
   galleryWin.setAlwaysOnTop(true, "modal-panel");

--- a/website/electron/crew-companion/panelWindow.js
+++ b/website/electron/crew-companion/panelWindow.js
@@ -24,7 +24,7 @@
 const path = require("path");
 const { BrowserWindow, ipcMain, screen } = require("electron");
 const { companionPageUrl } = require("./pageUrl");
-const { isPetWindow } = require("./petOverlay");
+const { isPetWindow, assertHostStaysInDock } = require("./petOverlay");
 
 /** True when the window belongs to the companion (an overlay, or the gallery). */
 function isCompanionWindow(win) {
@@ -102,6 +102,7 @@ function openPanelWindow(petRect) {
     panelWin.setBounds(bounds);
     panelWin.showInactive();
     panelWin.focus();
+    assertHostStaysInDock();
     panelWin.webContents.send("crew-companion:panel-opened", placement.side);
     return panelWin;
   }
@@ -138,6 +139,7 @@ function openPanelWindow(petRect) {
       panelWin.show();
       panelWin.focus();
       panelWin.webContents.send("crew-companion:panel-opened", placement.side);
+      assertHostStaysInDock();
     }
   });
 

--- a/website/electron/crew-companion/petOverlay.js
+++ b/website/electron/crew-companion/petOverlay.js
@@ -15,7 +15,7 @@
  */
 
 const path = require("path");
-const { BrowserWindow, screen, ipcMain } = require("electron");
+const { app, BrowserWindow, screen, ipcMain } = require("electron");
 const { companionPageUrl } = require("./pageUrl");
 
 /** @type {Map<number, Electron.BrowserWindow>} display id -> overlay */
@@ -49,6 +49,26 @@ function setOverlayLogger(fn) {
 function setOverlayTarget(url, token) {
   baseUrl = url || "";
   credential = token || "";
+}
+
+/**
+ * Keep the HOST app in the Dock (macOS).
+ *
+ * macOS flips a window-owning app to the accessory activation policy — which drops
+ * its Dock icon — when it shows a window shaped like this overlay (frameless,
+ * transparent, always-on-top). Re-assert "regular" and the Dock icon right after
+ * showing, so opening the companion never makes Kiro Crew vanish from the Dock.
+ * Mirrors Mochi's assertHostStaysInDock (mochi/petOverlays.js), which carries the
+ * same note; the crew-companion overlay was missing it.
+ */
+function assertHostStaysInDock() {
+  if (process.platform !== "darwin") return;
+  try {
+    app.setActivationPolicy?.("regular");
+    app.dock?.show?.();
+  } catch {
+    /* older Electron / already regular */
+  }
 }
 
 function createOverlayFor(display) {
@@ -111,7 +131,11 @@ function createOverlayFor(display) {
 
   win.loadURL(companionPageUrl(baseUrl, "pet.html", credential));
   win.once("ready-to-show", () => {
-    if (!win.isDestroyed()) win.showInactive();
+    if (win.isDestroyed()) return;
+    win.showInactive();
+    // Showing this accessory-shaped window demotes the app to a Dock-less accessory
+    // on macOS; put the host back in the Dock (see assertHostStaysInDock).
+    assertHostStaysInDock();
   });
   win.on("closed", () => {
     for (const [id, w] of overlays) if (w === win) overlays.delete(id);
@@ -296,6 +320,7 @@ function registerOverlayIpc() {
 }
 
 module.exports = {
+  assertHostStaysInDock,
   broadcastToPets,
   isPetWindow,
   openPetWindow,

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -41,7 +41,13 @@ function stubElectron() {
     destroy() { this.destroyed = true; }
   }
 
+  const dockCalls = { setActivationPolicy: [], dockShow: 0 };
+
   const electron = {
+    app: {
+      setActivationPolicy: (p) => dockCalls.setActivationPolicy.push(p),
+      dock: { show: () => { dockCalls.dockShow += 1; } },
+    },
     BrowserWindow: FakeWindow,
     screen: {
       getAllDisplays: () => [
@@ -65,6 +71,7 @@ function stubElectron() {
   return {
     created,
     ipcHandlers,
+    dockCalls,
     restore() {
       Module._resolveFilename = realResolve;
       delete require.cache.electron;
@@ -386,6 +393,31 @@ test("the overlay registers the cursor-hitbox channels the renderer reports to",
     );
 
     overlay.stopHitboxPoll();
+  } finally {
+    stub.restore();
+  }
+});
+
+test("showing an overlay re-asserts the host's Dock presence on macOS", () => {
+  // macOS-only behaviour: assertHostStaysInDock no-ops off darwin, so there is
+  // nothing to assert there.
+  if (process.platform !== "darwin") return;
+  const stub = stubElectron();
+  try {
+    const { overlay } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "");
+    overlay.openPetWindow();
+    // Fire the ready-to-show that real Electron fires once the page is ready.
+    stub.created[0]._events["ready-to-show"]();
+
+    // Showing the accessory-shaped overlay demotes the app to a Dock-less
+    // accessory; the overlay must put the host straight back in the Dock, or
+    // opening the companion makes Kiro Crew's Dock icon disappear.
+    assert.ok(
+      stub.dockCalls.setActivationPolicy.includes("regular"),
+      "activation policy re-asserted to regular after showing the overlay",
+    );
+    assert.ok(stub.dockCalls.dockShow >= 1, "app.dock.show() called after showing the overlay");
   } finally {
     stub.restore();
   }


### PR DESCRIPTION
## Problem / Motivation

On macOS, opening Crew Companion makes the **KiroCrew Dock icon disappear**. The app looks like it vanished. Reported on the current stable release (v0.4.0).

## Why it matters

The Dock icon vanishing reads as "the app crashed / quit" — the user loses their handle on the running app just by showing the companion. It's a confusing, broken-feeling regression for anyone who turns the companion on.

## What changed (motivation → approach → change)

- **Symptom:** the KiroCrew Dock icon disappears when the companion overlay appears.
- **Root cause:** macOS demotes a window-owning app to the **accessory** activation policy — which removes its Dock icon — when the app shows a window shaped like the companion overlay (frameless, transparent, always-on-top). Nothing hides the icon explicitly; it's an implicit macOS side effect of showing that window. Mochi already knows this and re-asserts the Dock presence after showing its overlay (`assertHostStaysInDock` → `setActivationPolicy("regular")` + `app.dock.show()`), with a comment spelling out the exact reason. The crew-companion overlay was ported without that step.
- **Change:** add `assertHostStaysInDock()` (`setActivationPolicy("regular")` + `app.dock.show()`, macOS-only, no-op elsewhere) and call it at **every** companion-window reveal so the Dock icon survives all of them, not just the overlay: after the overlay `showInactive()` in `petOverlay.js`, and at the panel and gallery show-sites (`panelWindow.js` re-place + ready-to-show; `galleryWindow.js` re-open + first-show). Mochi calls the helper once because it ships only the overlay; Crew Companion also opens a panel and a gallery of the same accessory shape, and one of those reveals (`galleryWindow.js` first-show) shows the window **without** focusing it, so macOS activation would not restore the policy there on its own — hence the re-assertion is load-bearing, not a stylistic echo of Mochi.

## Tests

- `website/electron/crew-companion/test/petOverlay.test.js` — new test fires the overlay's `ready-to-show` and asserts the app re-asserts `setActivationPolicy("regular")` and calls `app.dock.show()` after showing (macOS-gated; the behaviour no-ops off darwin). Stub extended with an `app` recorder. Full electron crew-companion suite green (23 tests).

## Manual verification

On macOS: open Crew Companion and confirm the KiroCrew Dock icon stays put (before this change it disappears the moment the companion overlay shows). No effect on Linux/Windows — the re-assertion is guarded on `process.platform === "darwin"`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** this is a macOS Dock/activation-policy behaviour on the desktop shell (`website/electron/`), not a browser-dashboard surface — there is nothing the dashboard's screenshot tooling can render, and the effect (a Dock icon staying vs disappearing) is not reproducible in a headless CI browser. Covered by the unit test above.

## Related Issues

no linked issue: reported informally as a teammate bug report on stable v0.4.0.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`fix: ...`)

