### PR TITLE
fix(crew-companion): turn the companion off instantly, not on the next reconcile tick

### DIFF
--- a/website/electron/crew-companion/index.js
+++ b/website/electron/crew-companion/index.js
@@ -392,6 +392,21 @@ function initCrewCompanion(deps) {
   ipcMain.handle("crew-companion:open-session", (_event, slotKey) =>
     openDashboardSession(typeof slotKey === "string" ? slotKey : ""));
 
+  // "Turn off companion" (the pet's context menu) disables the app over HTTP — which
+  // updates the dashboard's Apps page too — and then asks us to close the overlay AT
+  // ONCE, so it does not linger until the next reconcile tick. The renderer only
+  // sends this after the disable POST succeeds, so the app is already disabled by
+  // the time we close and the reconcile then keeps it closed. (A reconcile tick
+  // that was already in flight and read "enabled" just before the disable landed
+  // could reopen the overlay for a single tick; it self-heals on the next tick.)
+  ipcMain.on("crew-companion:turn-off", () => {
+    closePanelWindow();
+    closeGalleryWindow();
+    closePetWindow();
+    log("crew-companion: turned off by user — overlays closed immediately");
+  });
+
+
   if (timer) clearInterval(timer);
   timer = setInterval(() => void reconcileOnce(), TICK_MS);
   // A background poll must never be the reason a process cannot exit. Electron's

--- a/website/electron/crew-companion/pet-preload.js
+++ b/website/electron/crew-companion/pet-preload.js
@@ -160,6 +160,15 @@ contextBridge.exposeInMainWorld("crewCompanion", {
   },
 
   /**
+   * "Turn off companion": close the overlay immediately. The renderer sends this
+   * only after the disable POST succeeds, so the app is already disabled and the
+   * reconcile loop will not reopen the overlay.
+   */
+  turnOff() {
+    ipcRenderer.send("crew-companion:turn-off");
+  },
+
+  /**
    * The avatar gallery window opened / closed.
    *
    * The overlay has no other signal — the gallery is its own window — and it needs

--- a/website/electron/crew-companion/test/petOverlay.test.js
+++ b/website/electron/crew-companion/test/petOverlay.test.js
@@ -840,3 +840,25 @@ test("a ROUTED approval is still refused on the splash it cannot deliver to", ()
     stub.restore();
   }
 });
+
+test("the turn-off IPC closes every overlay immediately", () => {
+  const stub = stubElectron();
+  try {
+    const { overlay, index } = loadModules();
+    overlay.setOverlayTarget("http://localhost:5476", "cred");
+    overlay.openPetWindow();
+    assert.ok(overlay.petWindowCount() > 0, "overlays are open first");
+    index.initCrewCompanion({
+      backendUrl: "http://127.0.0.1:9",
+      fetchLocalToken: async () => "cred",
+      glog: () => {},
+    });
+    // The renderer sends this after its disable POST succeeds. It must close the
+    // overlay at once, not leave it until the next ~5s reconcile tick.
+    stub.ipcHandlers["crew-companion:turn-off"]();
+    assert.strictEqual(overlay.petWindowCount(), 0, "overlay closed immediately on turn-off");
+    index.shutdownCrewCompanion();
+  } finally {
+    stub.restore();
+  }
+});

--- a/website/src/apps/crew-companion/petBridge.ts
+++ b/website/src/apps/crew-companion/petBridge.ts
@@ -46,6 +46,7 @@ type Preload = {
   openExternal?(url: string): void
   galleryOpen?(): void
   galleryClose?(): void
+  turnOff?(): void
 }
 
 function preload(): Preload | undefined {
@@ -873,16 +874,23 @@ export const petBridge: PetBridge = {
 
   contextMenuAction(action) {
     if (action === 'quit') {
-      // The desktop app quit its own process. Here the companion IS an app, so the
-      // equivalent is disabling it: the overlay goes, the reminders stay, and the
-      // user can bring it back from the Apps page. Quitting Kiro Crew itself would
-      // close the dashboard too, which is not what "dismiss the companion" means.
-      void fetch('/api/apps/crew-companion/disable', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-      }).catch(() => {})
+      // "Turn off companion" = disable the app (over HTTP, which also updates the
+      // dashboard's Apps page via the gateway's teardown), then close the overlay
+      // the instant that succeeds — not on the main process's next ~5s reconcile
+      // tick. Gate the close on success: a failed disable leaves the companion
+      // visible (better than vanishing with nothing actually turned off), and the
+      // reconcile loop remains the backstop.
+      void (async () => {
+        const ok = await fetch('/api/apps/crew-companion/disable', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        })
+          .then((r) => r.ok)
+          .catch(() => false)
+        if (ok) preload()?.turnOff?.()
+      })()
       return
     }
     if (action === 'gallery') {

--- a/website/src/test/PetBridgeCoverage.test.tsx
+++ b/website/src/test/PetBridgeCoverage.test.tsx
@@ -102,6 +102,7 @@ interface PreloadStub {
   openExternal: ReturnType<typeof vi.fn>
   updateHitbox: ReturnType<typeof vi.fn>
   setMenuHitbox: ReturnType<typeof vi.fn>
+  turnOff: ReturnType<typeof vi.fn>
 }
 
 /** Install the preload bridge the desktop windows have and a browser tab does not. */
@@ -115,6 +116,7 @@ function stubPreload(offBridge = vi.fn()): PreloadStub {
     openExternal: vi.fn(),
     updateHitbox: vi.fn(),
     setMenuHitbox: vi.fn(),
+    turnOff: vi.fn(),
   }
   ;(window as unknown as { crewCompanion?: unknown }).crewCompanion = bridge
   return bridge
@@ -812,22 +814,27 @@ describe('window-level bridge calls', () => {
 })
 
 describe('contextMenuAction', () => {
-  it('"quit" disables the app instead of quitting Kiro Crew itself', async () => {
+  it('"quit" disables the app and then closes the overlay at once', async () => {
     const { calls } = stubFetchAll({ ok: true })
     const bridge = stubPreload()
     petBridge.contextMenuAction!('quit')
-    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
     expect(calls[0].url).toBe('/api/apps/crew-companion/disable')
     expect(calls[0].method).toBe('POST')
     // Disabling is a gateway call, not a window-level one.
     expect(bridge.contextMenuAction).not.toHaveBeenCalled()
+    // On success the overlay is closed immediately, not left for the reconcile tick.
+    expect(bridge.turnOff).toHaveBeenCalledOnce()
   })
 
-  it('a failed disable request is swallowed', async () => {
+  it('a failed disable leaves the companion up instead of closing it', async () => {
+    const bridge = stubPreload()
     stubFetchAll({ fails: true })
     expect(() => petBridge.contextMenuAction!('quit')).not.toThrow()
-    await Promise.resolve()
-    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    // The disable failed, so the overlay must NOT be closed — better a companion
+    // that stays than one that vanishes with nothing actually turned off.
+    expect(bridge.turnOff).not.toHaveBeenCalled()
   })
 
   it('"gallery" opens the gallery window', () => {


### PR DESCRIPTION
## Problem / Motivation

Right-clicking the companion → **"Turn off companion"** feels like it does nothing. The avatar keeps sitting there for several seconds after the click, so users conclude it's broken.

## Why it matters

"Turn off companion" is the one way to dismiss the pet from the pet itself. If clicking it appears to do nothing, the companion feels un-closable.

## What changed (motivation → approach → change)

- **Symptom:** clicking "Turn off companion" leaves the avatar on screen for up to ~5 seconds, with no feedback.
- **Root cause:** the menu action POSTed `/api/apps/crew-companion/disable` and returned. The overlay only closed when the desktop shell's **reconcile loop** next ran (a ~5s tick) and noticed the app was disabled.
- **Change:** the renderer now `await`s the disable POST — which is also what signals the dashboard (the gateway's teardown fires `notify_app_disabled`, so the Apps page updates) — and, **on success**, sends a new `crew-companion:turn-off` IPC that closes the overlay **immediately** (main calls `closePetWindow` / `closePanelWindow` / `closeGalleryWindow`). Because the app is already disabled by then, the reconcile loop keeps it closed (an in-flight tick that read "enabled" just before the disable landed could reopen it for a single tick — self-healing on the next). On a **failed** disable the companion stays visible — that *is* the failure signal (better than vanishing with nothing actually turned off). Note: there is deliberately **no** console log on failure — the repo's `no-console` lint budget disallows it (adding one fails Frontend Lint); the visible companion is the signal, and the ~5s reconcile remains the backstop.

## Tests

- `website/electron/crew-companion/test/petOverlay.test.js` — new test: firing the `crew-companion:turn-off` IPC closes every overlay at once. Full electron suite green (23 tests).
- `website/src/test/PetBridgeCoverage.test.tsx` — updated the two `contextMenuAction('quit')` tests: on a successful disable the bridge's `turnOff` is called (overlay closes immediately); on a failed disable `turnOff` is **not** called (companion stays up) and nothing throws. PetBridge suite green.

## Manual verification

On macOS with the companion enabled: right-click → "Turn off companion" → the avatar disappears immediately (not after a pause), and the companion shows as disabled on the dashboard's Apps page. Re-enable from the Apps page brings it back.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** this is a timing/behaviour change to the desktop overlay and its IPC — there is no rendered change to any dashboard page for the browser screenshot tooling to capture (the affected surface is a desktop Electron overlay). Covered by the unit tests above.

## Related Issues

no linked issue: reported informally while testing the companion.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`fix: ...`)
