### PR TITLE
fix(account): use accent-fg token on usage percentage badge

### DIFF
--- a/website/src/components/KiroAccountModal.tsx
+++ b/website/src/components/KiroAccountModal.tsx
@@ -253,7 +253,7 @@ function CreditUsage({ usage }: { usage: KiroAccountUsage }) {
         <div className="mb-2 flex items-baseline gap-2">
           <span className="text-2xl font-bold text-text">{fmtNumber(usage.used)}</span>
           <span className="text-sm text-muted">/ {fmtNumber(usage.limit)} {i18nT('app.credits')}</span>
-          <span className="ml-auto rounded-md bg-accent px-2 py-0.5 text-[12px] font-medium text-white">
+          <span className="ml-auto rounded-md bg-accent px-2 py-0.5 text-[12px] font-medium text-accent-fg">
             {fmtPercent(pct / 100)}
           </span>
         </div>


### PR DESCRIPTION
## Problem / Motivation

The credit usage percentage badge in the Kiro account modal is barely legible on themes with a light accent color. On Tokyo Nights dark (`--accent:#9fc1ff`), the badge renders white text on a light-blue pill.

## Why it matters

Any user on a light-accent theme (Tokyo Nights, Dracula, Catppuccin, Monokai, Kiro dark itself — all define `--accent-fg:#000`) gets an unreadable usage percentage in the account modal, one of the few places to check remaining credits.

## What changed (motivation → approach → change)

Symptom: white-on-light-blue badge text. Root cause: the badge hardcoded `text-white` on `bg-accent` instead of the semantic foreground token. Every other accent badge in the codebase (App.tsx count badges, ChatInput.tsx pills, ChatSidebar.tsx create button, etc.) pairs `bg-accent` with `text-accent-fg`, which each theme sets to black or white to match its accent. This was the one stray hardcode — the fix is the one-line swap to `text-accent-fg`.

## Tests

- All 11 existing `KiroAccountModal` tests pass (identity, plan, remaining credits, progressbar semantics, overage rows).
- `tsc --noEmit` clean.
- No new test added: per-theme computed-style coverage for this pattern already lives in `AgentsPage.meterLabels.test.tsx`-style checks; the change makes the badge consistent with the pattern they lock in.

## Manual verification

Verified `[data-theme="tokyonight-dark"]` defines `--accent:#9fc1ff` / `--accent-fg:#000`, so the badge now renders black-on-light-blue. Screenshot of the fixed badge to follow if maintainers want it.

## Related Issues

None filed — reported directly from a Tokyo Nights user session.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
