### PR TITLE
test(session-storage): scope the forged-iterdir patch to the trash root

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -894,9 +894,22 @@ class TestTrashBatchNamesAreLogSafe:
             "missing": None,
             "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0),
         }
+
+        # Forge ONLY the trash root's own enumeration, via a Path subclass whose
+        # `iterdir` yields the double. Patching `session_storage.Path.iterdir`
+        # (i.e. `pathlib.Path.iterdir`) globally leaks across the xdist worker:
+        # a sibling test in the same process that legitimately iterates a real
+        # directory then reaches the unpatched `_summarize_manifest`, which does
+        # `<_ForgedDir> / MANIFEST_NAME` and raises TypeError (refs #6425).
+        class _ForgedRoot(type(session_storage.trash_root())):
+            def iterdir(self):  # type: ignore[override]
+                return iter([_ForgedDir()])
+
+        forged_root = _ForgedRoot(session_storage.trash_root())
+
         for label, parsed in manifests.items():
             caplog.clear()
-            monkeypatch.setattr(session_storage.Path, "iterdir", lambda self: iter([_ForgedDir()]))
+            monkeypatch.setattr(session_storage, "trash_root", lambda: forged_root)
             monkeypatch.setattr(
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )


### PR DESCRIPTION
## Problem / Motivation

`test/test_session_storage.py::TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem` is failing on `main`'s own CI (`Backend Tests (Windows) (3)`, `(3.10, 3)`, `(3.12, 3)` all at once, on multiple consecutive `main` runs), which wedges `Coverage Gate` + `PR Readiness` and turns `main` red. Every PR built on the affected tip inherits the failure, so the fork PR queue is blocked. Tracked in #6425.

```
TypeError: unsupported operand type(s) for /: '_ForgedDir' and 'str'
  src/kiro_crew/session_storage.py:1432: in _summarize_manifest
    with (batch / MANIFEST_NAME).open(encoding="utf-8") as handle:
```

## Why it matters

`main` red = no fork PR can reach green CI, and the Stage-2 AI review lanes never dispatch (they only run after CI succeeds). This unblocks the whole queue.

## What changed (motivation → approach → change)

Root cause: the test patched `session_storage.Path.iterdir` — and `session_storage.Path` **is** `pathlib.Path` — so it replaced `pathlib.Path.iterdir` **globally for the process**. Under the sharded CI invocation (`-n --dist loadgroup`) this test shares a worker with other files; a sibling test that then iterates a real directory and reaches the *unpatched* `_summarize_manifest` received the name-only `_ForgedDir` double and hit `<_ForgedDir> / MANIFEST_NAME` → the `TypeError` at line 1432. This is why it passed in isolation and single-process but failed on three shards at once.

Proven with a minimal probe: the old global patch makes a subsequent real `Path.iterdir()` + `cand / MANIFEST_NAME` raise the exact `TypeError`; the new instance-scoped forger leaves a sibling real `Path.iterdir()` returning a real `PosixPath`.

Fix: forge only the trash root's **own** enumeration — a `Path` subclass whose `iterdir` yields the double, with `session_storage.trash_root` patched to return it — leaving `pathlib.Path.iterdir` untouched. No sibling test in the worker can inherit the forgery. The behaviour under test (both log sites escape the agent-controlled batch name) is unchanged.

## Tests

`test/test_session_storage.py` passes 154/154 under the sharded invocation `-n --dist loadgroup` (previously the target test failed there); the `TestTrashBatchNamesAreLogSafe` class still asserts both the missing-manifest and batch-id-disagreement log sites escape the forged newline on every platform. Non-baselined file kept black-clean.

## Related Issues

Fixes #6425
