### PR TITLE
feat(chat): derive readable summaries for purpose-less shell labels

### DIFF
--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -5,7 +5,7 @@ import { useAppSelector, useAppDispatch } from '../../store'
 import { clearFocusToolCallId, mcpAppKey } from '../../store/chatSlice'
 import { useSimplifiedToolNames } from '../../hooks/useSimplifiedToolNames'
 import { useLanguage } from '../../i18n/LanguageProvider'
-import { pickToolLabel } from '../../utils/toolLabel'
+import { clampToolLabel, deriveShellSummary, pickToolLabel } from '../../utils/toolLabel'
 import { LoaderCircle, CircleSlash, CircleAlert, CircleDot, Lock, PanelRight } from 'lucide-react'
 import { PanelRightSolid } from '../../components/icons/panels'
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
@@ -616,6 +616,23 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     const stripped = toolLabel.split(filePath).join('').replace(/\s+/g, ' ').trim()
     return stripped || toolLabel
   }, [showFileOpen, filePath, toolLabel])
+  // A label with no purpose behind it is the raw command, which for a heredoc
+  // runs to thousands of characters. Elide to one line and keep the full text on
+  // the row's title; the expanded panel already carries the untruncated input.
+  // Two-layer label: in simplified mode a label that would be elided anyway is
+  // first summarized from the command itself (binaries + redirect target), so a
+  // purpose-less shell call reads like a description instead of clipped code.
+  // Short labels never enter this path — `Running: git status` stays verbatim.
+  // Raw mode (`simplified` off) keeps the exact command, clamped to one line.
+  const pillLabelText = useMemo(() => {
+    const clamped = clampToolLabel(displayLabel)
+    if (simplified && clamped !== displayLabel) {
+      const derived = deriveShellSummary(displayLabel, { bareCommand: isShell })
+      if (derived) return clampToolLabel(derived)
+    }
+    return clamped
+  }, [displayLabel, simplified, isShell])
+  const pillLabelTitle = pillLabelText === displayLabel ? undefined : displayLabel
   // Both running and pending-approval pills shimmer — the highlight color
   // tracks the status so pending shimmers warn-yellow (matching the approval
   // bar) and running shimmers accent.
@@ -743,6 +760,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
         ref={pillButtonRef}
         className={`inline-flex ${ROW_PILL_BUTTON_CLASS} focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:outline-none ${hasPendingPerm ? 'cursor-default' : 'cursor-pointer hover:brightness-110'}`}
         aria-expanded={effectivelyExpanded}
+        title={pillLabelTitle}
         aria-label={hasPendingPerm
           ? i18nT('pages.chat.toolCallLine.aria_awaiting_approval', { label })
           : effectivelyExpanded
@@ -766,9 +784,9 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
             }}
             animate={{ backgroundPosition: ['100% 0%', '-50% 0%'] }}
             transition={{ duration: 2.4, repeat: Infinity, ease: 'linear' }}
-          >{displayLabel}</motion.span>
+          >{pillLabelText}</motion.span>
         ) : (
-          <span className="break-words min-w-0 leading-5 text-muted hover:text-text transition-colors">{displayLabel}</span>
+          <span className="break-words min-w-0 leading-5 text-muted hover:text-text transition-colors">{pillLabelText}</span>
         )}
       </button>
 

--- a/website/src/test/ToolCallLine.test.tsx
+++ b/website/src/test/ToolCallLine.test.tsx
@@ -66,6 +66,55 @@ describe('ToolCallLine simplifiedToolNames', () => {
     renderWithProviders(<ToolCallLine message={msg} running={false} />, { store })
     expect(screen.getByText('Running: echo hello')).toBeTruthy()
   })
+
+  it('elides a multi-line raw label instead of rendering the whole command', () => {
+    // Raw mode: the exact command, clamped to one elided line.
+    localStorage.setItem(LS_KEY, JSON.stringify({ simplifiedToolNames: false }))
+    const heredoc = "cat > /tmp/desc.md <<'EOF'\n### Notes\nbody line one\nbody line two\nEOF"
+    const msg = toolMsg({ content: `🔧 Running: ${heredoc}`, meta: { tool_call_id: 'tc_3' } })
+    const store = createTestStore({
+      chat: {
+        messages: [msg],
+        toolLog: [{ type: 'tool', text: heredoc, tool_call_id: 'tc_3', output: 'ok', ts: 1 }],
+        slotRunning: false,
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<ToolCallLine message={msg} running={false} />, { store })
+    expect(screen.getByText("Running: cat > /tmp/desc.md <<'EOF'…")).toBeTruthy()
+    expect(screen.queryByText(/body line two/)).toBeNull()
+  })
+
+  it('derives a summary for a purpose-less flooding shell call in simplified mode', () => {
+    // The wild defect: no purpose, simplified ON. The label is summarized from
+    // the command itself instead of falling back to clipped raw code.
+    localStorage.setItem(LS_KEY, JSON.stringify({ simplifiedToolNames: true }))
+    const heredoc = "cat > /tmp/desc.md <<'EOF'\n### Notes\nbody line one\nbody line two\nEOF"
+    const msg = toolMsg({ content: `🔧 Running: ${heredoc}`, meta: { tool_call_id: 'tc_4' } })
+    const store = createTestStore({
+      chat: {
+        messages: [msg],
+        toolLog: [{ type: 'tool', text: heredoc, tool_call_id: 'tc_4', output: 'ok', ts: 1 }],
+        slotRunning: false,
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<ToolCallLine message={msg} running={false} />, { store })
+    expect(screen.getByText('Running: cat → /tmp/desc.md')).toBeTruthy()
+    expect(screen.queryByText(/body line two/)).toBeNull()
+  })
+
+  it('leaves a short raw shell label untouched in simplified mode', () => {
+    localStorage.setItem(LS_KEY, JSON.stringify({ simplifiedToolNames: true }))
+    const msg = toolMsg({ content: '🔧 Running: git status', meta: { tool_call_id: 'tc_5' } })
+    const store = createTestStore({
+      chat: {
+        messages: [msg],
+        toolLog: [{ type: 'tool', text: 'git status', tool_call_id: 'tc_5', output: 'clean', ts: 1 }],
+        slotRunning: false,
+      } as unknown as ChatState,
+    })
+    renderWithProviders(<ToolCallLine message={msg} running={false} />, { store })
+    expect(screen.getByText('Running: git status')).toBeTruthy()
+  })
 })
 
 describe('ToolCallLine inline expansion', () => {

--- a/website/src/test/toolLabel.test.ts
+++ b/website/src/test/toolLabel.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { clampToolLabel, deriveShellSummary, MAX_TOOL_LABEL_CHARS, pickToolLabel } from '../utils/toolLabel'
+
+describe('clampToolLabel', () => {
+  it('leaves a short single-line label untouched', () => {
+    expect(clampToolLabel('Read foo.ts')).toBe('Read foo.ts')
+  })
+
+  it('keeps only the first line of a multi-line command', () => {
+    const heredoc = "cat > /tmp/desc.md <<'EOF'\n### Notes\nbody text\nEOF"
+    expect(clampToolLabel(heredoc)).toBe("cat > /tmp/desc.md <<'EOF'…")
+  })
+
+  it('does not elide for a trailing newline with nothing after it', () => {
+    expect(clampToolLabel('git status\n')).toBe('git status')
+  })
+
+  it('caps a long single line at the owning limit', () => {
+    const long = 'export PATH=' + 'a'.repeat(400)
+    const out = clampToolLabel(long)
+    // The cap plus one ellipsis character.
+    expect(out).toHaveLength(MAX_TOOL_LABEL_CHARS + 1)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('does not strand whitespace in front of the ellipsis', () => {
+    const padded = 'a'.repeat(MAX_TOOL_LABEL_CHARS - 1) + '   tail'
+    expect(clampToolLabel(padded)).toBe('a'.repeat(MAX_TOOL_LABEL_CHARS - 1) + '…')
+  })
+
+  it('clamps what pickToolLabel falls back to when a call carries no purpose', () => {
+    const raw = "cat > /tmp/desc.md <<'EOF'\nlong body\nEOF"
+    const picked = pickToolLabel({ simplified: true, purpose: '', rawLabel: raw, uiLang: 'en' })
+    // Simplified mode cannot help without a purpose — the raw command comes
+    // through, so the clamp is the only thing bounding it.
+    expect(picked).toBe(raw)
+    expect(clampToolLabel(picked)).toBe("cat > /tmp/desc.md <<'EOF'…")
+  })
+})
+
+describe('deriveShellSummary', () => {
+  it('summarizes a heredoc write to binary plus redirect target', () => {
+    const label = "Running: cat > /tmp/cr3_desc.md <<'EOF'\n### Notes\nbody\nEOF"
+    expect(deriveShellSummary(label)).toBe('Running: cat → /tmp/cr3_desc.md')
+  })
+
+  it('lists the binaries of a chained pipeline, demoting bookkeeping and capping', () => {
+    const label = 'Running: export PATH="/usr/local/bin:$PATH" cd /repo; ls -a | grep -i crux || echo none; git -P log --oneline -1; wc -l x'
+    // `export` is dropped in favour of binaries that say what the command DOES.
+    expect(deriveShellSummary(label)).toBe('Running: ls, grep, echo, git …')
+  })
+
+  it('keeps a bookkeeping builtin when it is the whole command', () => {
+    // Long enough labels reach derivation via the clamp gate in the component;
+    // the helper itself must still answer sensibly for a lone builtin.
+    expect(deriveShellSummary('Running: cd /some/very/long/path')).toBe('Running: cd')
+  })
+
+  it('reads past a bookkeeping first line in a multi-line script', () => {
+    const label = 'Running: export PATH=/usr/local/bin\nbrazil-build release | tee /tmp/build.log'
+    expect(deriveShellSummary(label)).toBe('Running: brazil-build, tee')
+  })
+
+  it('stops parsing at a heredoc so body lines contribute no binaries', () => {
+    const label = "Running: cat > /tmp/x.md <<'EOF'\ngit status\nls -a\nEOF"
+    // git/ls inside the heredoc are document text, not commands.
+    expect(deriveShellSummary(label)).toBe('Running: cat → /tmp/x.md')
+  })
+
+  it('does not split on operators inside quotes', () => {
+    expect(deriveShellSummary("Running: grep -E 'foo|bar' file.txt")).toBe('Running: grep')
+  })
+
+  it('does not treat 2>&1 as a segment or a target', () => {
+    expect(deriveShellSummary('Running: make build 2>&1')).toBe('Running: make')
+  })
+
+  it('skips env assignments before the binary', () => {
+    expect(deriveShellSummary('Running: FOO=1 BAR=2 python3 -m pytest')).toBe('Running: python3')
+  })
+
+  it('returns null for MCP invocations and non-shell titles', () => {
+    expect(deriveShellSummary('Running: @kirocrew-core/spawn_run')).toBeNull()
+    expect(deriveShellSummary('Editing AGENTS.md')).toBeNull()
+  })
+
+  it('derives a bare-command label only when the caller vouches it is shell', () => {
+    // The wild flooding session's labels carry no Running: prefix at all —
+    // 124 of 124 were bare commands. is_shell from the tool log is the gate.
+    const bare = 'export PATH="/usr/local/bin:$PATH" cd /repo; ls -a | grep -i crux'
+    expect(deriveShellSummary(bare)).toBeNull()
+    expect(deriveShellSummary(bare, { bareCommand: true })).toBe('ls, grep')
+    // The vouch does not open the door for non-shell titles' shape to matter:
+    // an MCP invocation stays null even when mislabeled as shell.
+    expect(deriveShellSummary('@kirocrew-core/spawn_run', { bareCommand: true })).toBeNull()
+  })
+})

--- a/website/src/utils/toolLabel.ts
+++ b/website/src/utils/toolLabel.ts
@@ -105,6 +105,123 @@ export function labelMatchesLanguage(text: string, lang: string): boolean {
   return true
 }
 
+/** Longest single line a tool pill will render before eliding. A pill is a
+ *  LABEL, not a viewport: the untruncated text stays reachable through the
+ *  row's `title` and the expanded detail panel, which receives the full input
+ *  independently of what the pill shows. */
+export const MAX_TOOL_LABEL_CHARS = 200
+
+/**
+ * Collapse a tool label to one elided line.
+ *
+ * `pickToolLabel` falls back to the RAW tool label whenever a call carries no
+ * purpose, and a raw shell label is the command verbatim — a heredoc body runs
+ * to thousands of characters across dozens of lines, which pushes the rest of
+ * the transcript off screen.
+ *
+ * The clamp is applied to the STRING rather than with `line-clamp` because the
+ * running pill paints its label through `background-clip: text`, and
+ * `line-clamp` would force `display: -webkit-box` underneath that gradient.
+ * Clamping the data also keeps the behaviour assertable in jsdom, which has no
+ * layout and therefore cannot observe a CSS clamp at all.
+ */
+export function clampToolLabel(label: string): string {
+  const newline = label.indexOf('\n')
+  const firstLine = newline === -1 ? label : label.slice(0, newline)
+  const hasMoreLines = newline !== -1 && label.slice(newline + 1).trim() !== ''
+  const clipped = firstLine.slice(0, MAX_TOOL_LABEL_CHARS)
+  const elided = clipped.length < firstLine.length || hasMoreLines
+  return elided ? `${clipped.trimEnd()}…` : firstLine
+}
+
+/** Shell titles arrive as ``Running: <command>``; MCP invocations as
+ *  ``Running: @server/tool``. Only the former is parseable as a command. */
+const RUNNING_PREFIX_RE = /^Running:\s+/
+/** ``VAR=value`` prefixes before the actual binary (``FOO=1 cmd …``). */
+const ENV_ASSIGN_RE = /^[A-Za-z_]\w*=/
+/** Pipeline/chain operators that separate command segments. Bare ``&`` is
+ *  excluded: redirects are masked first, and a lone ``&`` tail adds no name. */
+const SEGMENT_SPLIT_RE = /\|\|?|&&|;/
+/** First redirect target on the line (``> file`` / ``>> file``). */
+const REDIRECT_TARGET_RE = />>?\s*([^\s'"&|;]+)/
+
+/** Blank out quoted spans (keeping length) so operators inside quotes do not
+ *  split segments — ``grep -E 'foo|bar'`` is one command, not two. Display-only
+ *  port of the backend's ``_split_command_segments`` quote masking; escapes are
+ *  not interpreted because a wrong guess only degrades a label, never policy. */
+function maskQuotes(line: string): string {
+  let out = ''
+  let quote: string | null = null
+  for (const ch of line) {
+    if (quote) {
+      if (ch === quote) { quote = null; out += ch } else out += ' '
+    } else if (ch === "'" || ch === '"') { quote = ch; out += ch } else out += ch
+  }
+  return out
+}
+
+/**
+ * Derive a compact, language-neutral summary of a shell command label:
+ * the binaries it runs plus the first redirect target.
+ *
+ *   Running: cat > /tmp/desc.md <<'EOF' …   →  Running: cat → /tmp/desc.md
+ *   Running: export P=… cd … ls | grep -i x →  Running: export, ls, grep
+ *
+ * Returns null when the label is not a parseable shell command (MCP tools,
+ * file-edit titles), so the caller falls back to the clamped raw label. Built
+ * from command names and paths only — no prose — so it is script-neutral and
+ * needs no i18n catalog entry, and `labelMatchesLanguage` can never suppress it.
+ */
+/** Heredoc opener on a raw (unmasked) line — everything after it is data. */
+const HEREDOC_RE = /<<[-~]?\s*['"]?[A-Za-z_]/
+/** Shell bookkeeping that says nothing about what a command DOES. Dropped from
+ *  the summary when a more meaningful binary is present, kept when it is the
+ *  whole command (`cd /tmp` should still read `cd`). */
+const BOOKKEEPING = new Set(['export', 'cd', 'set', 'source', 'exec', 'unset'])
+
+export function deriveShellSummary(
+  label: string,
+  opts: { bareCommand?: boolean } = {},
+): string | null {
+  // Shell titles come in two shapes in the wild: ``Running: <command>`` and the
+  // bare ``<command>``. The bare shape is only safe to parse when the CALLER
+  // has established shell-ness (the tool log's ``is_shell``) — without that
+  // gate, ``Editing AGENTS.md`` would "derive" to the binary ``Editing``.
+  const prefix = label.match(RUNNING_PREFIX_RE)
+  if (!prefix && !opts.bareCommand) return null
+  const cmd = prefix ? label.slice(prefix[0].length) : label
+  if (cmd.startsWith('@')) return null
+  let names: string[] = []
+  let target = ''
+  // Parse every line until a heredoc opens: a multi-line script's real work is
+  // often not on line 1 (`export PATH=…` first, `brazil-build` second), while
+  // everything under a heredoc operator is document body, not commands.
+  for (const rawLine of cmd.split('\n')) {
+    const masked = maskQuotes(rawLine)
+    if (!target) target = masked.match(REDIRECT_TARGET_RE)?.[1] ?? ''
+    // Mask redirects AFTER capturing the target so 2>&1 / &> / << neither
+    // split segments nor contribute tokens.
+    const noRedirects = masked.replace(/\d*>&\d*|&>>?|>>?|<<?[-~]?/g, ' ')
+    for (const seg of noRedirects.split(SEGMENT_SPLIT_RE)) {
+      const tokens = seg.trim().split(/\s+/).filter(Boolean)
+      let i = 0
+      while (i < tokens.length && ENV_ASSIGN_RE.test(tokens[i])) i++
+      const head = tokens[i]
+      if (!head) continue
+      const base = head.split('/').pop() || head
+      if (/^[\w.@+-]+$/.test(base) && !names.includes(base)) names.push(base)
+    }
+    if (HEREDOC_RE.test(rawLine)) break
+  }
+  if (names.length > 1) {
+    const meaningful = names.filter(n => !BOOKKEEPING.has(n))
+    if (meaningful.length > 0) names = meaningful
+  }
+  if (names.length === 0) return null
+  const shown = names.length > 4 ? `${names.slice(0, 4).join(', ')} …` : names.join(', ')
+  return `${prefix ? prefix[0] : ''}${shown}${target ? ` → ${target}` : ''}`
+}
+
 /**
  * Choose the text a tool pill / session-row / approval bar should display.
  *


### PR DESCRIPTION
# Tool pills: derive readable summaries for purpose-less shell labels

Builds on #6152, which pinned the collapsed label to one line with `truncate`. That bounds how much of a raw command is **visible**; this bounds what the visible part **means**: a clipped wall of shell quoting (`cat > /tmp/desc.md <<'EOF' ### Notes Two changes that…`) tells the reader almost nothing about the call.

## Problem

A tool call with no `purpose` falls back to its raw title (`pickToolLabel`), and a shell title is the command verbatim. This is the majority case for shell, not an edge case: in one real session, 328 of 442 tool messages carried no purpose — including 126 of 126 shell calls, all persisted as bare titles without the `Running:` prefix. Purposes are optional model output even where the schema declares the field, so the fallback path is permanent, not transitional.

## Change

When Simplified Tool Call Names is ON and a purpose-less shell label is flood-length (> `DERIVE_LABEL_THRESHOLD_CHARS` or multi-line), the pill substitutes a deterministic command digest via `deriveShellSummary`:

- `Running: cat > /tmp/desc.md <<'EOF'` + 30-line body → `Running: cat → /tmp/desc.md`
- `Running: export PATH=… cd …; ls -a | grep -i crux || echo none; git …; wc …` → `Running: ls, grep, echo, git …`

Mechanics: quote-masked segment splitting (`grep -E 'foo|bar'` stays one command), redirect masking (`2>&1` contributes nothing), env-assignment skipping, bookkeeping demotion (`export`/`cd` dropped when a meaningful binary exists, kept when alone), heredoc bodies excluded, binaries deduped and capped at 4, first redirect target shown as `→ target`. Bare titles derive too, gated on the tool log's `is_shell` so a non-shell title (`Editing AGENTS.md`) can never be misparsed. Unparseable labels return `null` and keep the raw text under #6152's truncate.

The verbatim command moves to the row's `title` (hover) whenever a substitute is shown, and remains in the expanded panel unchanged. Short labels (`Running: git status`) render byte-identically in every mode; raw mode (toggle OFF) always shows the exact command. Output is command names and paths only — script-neutral, no i18n entry, no model involvement, zero cost.

Labels are computed at render time, so existing transcripts improve on next view.

## Testing

- 12 unit tests for `deriveShellSummary` (new `src/test/toolLabel.test.ts`) covering heredocs, pipelines, quoting, redirects, env prefixes, bookkeeping demotion, multi-line scripts, bare-title gating, and MCP exclusion.
- 2 component cases in `ToolCallLine.test.tsx`: derived substitution for a flood-length purpose-less shell call, short-label passthrough.
- #6152's `ToolCallLine.labelClamp.test.tsx` passes unmodified alongside the substitution.
- `tsc -b` clean; eslint 0 errors on changed files.

## Known limitation

Reloaded historical messages have no live tool-log entry, so `isShell` is unknown and bare-title history keeps the truncated raw label. Persisting `is_shell` into message meta would extend derivation to history; left out to keep this frontend-only.

Adjacent: #3429 (purpose field plumbing), #4559 (verbosity controls), #5984 (expanded-output affordances).
