### PR TITLE
fix(mcp): an adopted daemon's stale target map must not delete a server

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -1299,6 +1299,46 @@ def _declared_env_to_forward(pool_key: PoolKey) -> dict[str, str]:
     return _declared_non_secret_env(pool_key)
 
 
+#: The canonical target-env prefix. ``MC_MCP_TARGET_`` is the legacy spelling
+#: :func:`env_target_resolver` still accepts, so both normalize to this stem set.
+_TARGET_ENV_PREFIXES = ("KIROCREW_MCP_TARGET_", "MC_MCP_TARGET_")
+
+
+def resolvable_target_stems(env: Optional[dict[str, str]] = None) -> list[str]:
+    """The set of target-env STEMS this daemon can resolve, sorted.
+
+    A stem is the env key with its prefix and any ``__<command_args_hash>``
+    suffix removed -- e.g. both ``KIROCREW_MCP_TARGET_KIROCREW_CORE`` and
+    ``KIROCREW_MCP_TARGET_KIROCREW_CORE__61774e20...`` yield ``KIROCREW_CORE``.
+
+    Reported on the ``pong`` reply so an adopting :class:`GatewayManager` can
+    tell whether an incumbent daemon's env still covers the servers the current
+    config wants stubbed. This is the ONLY way to see that: the daemon's target
+    map is baked into its process env at spawn (``manager._spawn_once``) and a
+    frozen :class:`GatewaySpec` is never re-applied to an adopted survivor, so a
+    daemon that predates a ``stub_servers`` change serves a stale map forever.
+
+    Deliberately reports STEMS rather than server names. Recovering a name would
+    mean undoing ``upper().replace("-", "_")``, which is lossy -- ``my-server``
+    and ``my_server`` normalize identically (the rewriter warns about exactly
+    that collision). Both sides comparing stems needs no such guess.
+    """
+    source = os.environ if env is None else env
+    stems: set[str] = set()
+    for key in source:
+        for prefix in _TARGET_ENV_PREFIXES:
+            if not key.startswith(prefix):
+                continue
+            stem = key[len(prefix) :]
+            # Strip the args-disambiguated suffix so a hashed-only entry still
+            # reports the server it serves.
+            stem = stem.split("__", 1)[0]
+            if stem:
+                stems.add(stem)
+            break
+    return sorted(stems)
+
+
 def env_target_resolver(pool_key: PoolKey) -> Optional[tuple[str, list[str], dict[str, str], str]]:
     """Look up ``KIROCREW_MCP_TARGET_<SERVER>`` in the process env and return the
     spawn tuple, or ``None`` if no mapping is set.
@@ -2129,7 +2169,10 @@ async def _handle_connection(
     # uses this to confirm the daemon is serving before returning from
     # ``start()``.
     if register.get("type") == "ping":
-        await _write_json_line(writer, {"type": "pong"})
+        # ``targets`` lets the pinger detect a STALE incumbent before adopting
+        # it. Absent on a pre-#6xxx daemon, which the adoption gate treats as
+        # unverifiable rather than assuming coverage.
+        await _write_json_line(writer, {"type": "pong", "targets": resolvable_target_stems()})
         return
 
     # Metrics short-circuit: return a point-in-time pool snapshot (backends,
@@ -2579,12 +2622,43 @@ async def _handle_connection(
                         # + create_task overhead so the metric stays true to name.
                         _acquire_ms = (time.monotonic() - _acquire_t0) * 1000.0
                     except _TargetUnknown as exc:
-                        _audit_pool_rejected(
+                        # An unknown target here means THIS DAEMON'S env has no
+                        # mapping -- which, at the pre-flight, can only be map
+                        # drift: a stub exists at all only because the rewriter
+                        # wrapped that server, and the stub is holding the real
+                        # ``--target-command`` on its own argv. A genuinely
+                        # unrunnable target fails later, as BackendUnavailable.
+                        # So this is fallback-ELIGIBLE: no real MCP frame has
+                        # been forwarded yet, so the stub can exec the target
+                        # directly and lose nothing but pooling.
+                        #
+                        # Loud, and named: the pre-fix behaviour was a bare
+                        # ``rejected`` with no ``fallback`` key, which the stub
+                        # reads as terminal (stub.py) -- it died in 0.2s having
+                        # logged only to a stderr nobody captures, so a whole
+                        # server's tools vanished from the session with no
+                        # attributable record anywhere. See
+                        # docs/architecture/design-notes/mcp-stub-decoupling.md.
+                        logger.warning(
+                            "ensure_backend: no target mapping for %s -- this "
+                            "daemon's target env predates the current "
+                            "stub_servers set (target map is baked at spawn and "
+                            "an adopted daemon never re-applies it). Replying "
+                            "fallback-eligible so the stub degrades to a "
+                            "per-session exec; pooling and the strict session "
+                            "key are LOST for this connection. Daemon stems: %s",
+                            pool_key.human_readable(),
+                            ",".join(resolvable_target_stems()) or "(none)",
+                        )
+                        _audit_pool_fallback(
                             caller.session_key if caller else "",
                             pool_key.human_readable(),
                             str(exc),
                         )
-                        await _write_json_line(writer, {"type": "rejected", "reason": str(exc)})
+                        await _write_json_line(
+                            writer,
+                            {"type": "rejected", "reason": str(exc), "fallback": True},
+                        )
                         return
                     except (BackendUnavailable, PoolAtCapacity) as exc:
                         logger.info(
@@ -2681,6 +2755,20 @@ async def _handle_connection(
                     # create_task overhead.
                     _lazy_elapsed_ms = (time.monotonic() - _lazy_t0) * 1000.0
                 except _TargetUnknown as exc:
+                    # Same drift as the pre-flight site, but NOT fallback-tagged:
+                    # only a pre-ensure_backend stub reaches this path and it has
+                    # already forwarded a real MCP frame, so an exec fallback
+                    # would lose that frame. Terminal is correct here -- what was
+                    # missing is saying so anywhere durable.
+                    logger.warning(
+                        "lazy-spawn: no target mapping for %s -- this daemon's "
+                        "target env predates the current stub_servers set. "
+                        "Terminal (a real frame was already forwarded, so an "
+                        "exec fallback would drop it): this server's tools will "
+                        "be ABSENT for the session. Daemon stems: %s",
+                        pool_key.human_readable(),
+                        ",".join(resolvable_target_stems()) or "(none)",
+                    )
                     _audit_pool_rejected(
                         caller.session_key if caller else "",
                         pool_key.human_readable(),

--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -26,7 +26,7 @@ import signal
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
@@ -184,12 +184,17 @@ class GatewayManager:
         # survivor from a prior gateway), adopt it instead of spawning a
         # competitor. gatewayd's flock guard already makes a duplicate spawn
         # a clean no-op, but adopting skips the wasted spawn/exit churn.
-        if await self._ping_once():
+        incumbent = await self._ping_payload()
+        if incumbent is not None:
             self._adopted = True
             logger.info(
                 "mcp-gateway: a healthy daemon already owns %s — adopting "
                 "(no spawn)", self._spec.socket_path,
             )
+            # Adoption skips _spawn_once, which is the ONLY place
+            # spec.mcp_target_env is applied. Check the incumbent actually
+            # covers what this spec would have given it, and say so if not.
+            self._report_adoption_drift(incumbent)
             # Supervise even when adopting: the adopted daemon may be a
             # prior-gateway survivor with no other watchdog in this process.
             # The watchdog's adopted branch re-checks liveness by ping and
@@ -394,10 +399,95 @@ class GatewayManager:
         """Public liveness probe: ``True`` iff the daemon replies pong."""
         return await self._ping_once()
 
+    def _required_target_stems(self) -> set[str]:
+        """Target-env stems the CURRENT config wants this daemon to serve.
+
+        Derived from the spec's own ``mcp_target_env`` -- the mapping the
+        rewriter just computed for the live ``stub_servers`` set -- so it needs
+        no second config read and cannot disagree with what a spawn would apply.
+        Stems, not server names: see ``gatewayd.resolvable_target_stems``.
+        """
+        stems: set[str] = set()
+        for key in self._spec.mcp_target_env:
+            for prefix in ("KIROCREW_MCP_TARGET_", "MC_MCP_TARGET_"):
+                if key.startswith(prefix):
+                    stem = key[len(prefix):].split("__", 1)[0]
+                    if stem:
+                        stems.add(stem)
+                    break
+        return stems
+
+    def _report_adoption_drift(self, pong: dict) -> bool:
+        """Warn when an incumbent daemon's target map does not cover this spec.
+
+        Returns ``True`` iff drift was found. Reports rather than refuses, and
+        that split is deliberate: refusing adoption cannot actually replace the
+        incumbent, because gatewayd's flock guard makes a competing spawn a
+        clean no-op -- the stale daemon would keep the socket and we would have
+        traded a warning for an outage. What makes the drift SAFE is the
+        gatewayd-side change that answers an unknown target at the
+        ensure_backend pre-flight with ``fallback: true``, so a stub degrades to
+        a per-session exec instead of dying. This method's job is to make the
+        cost of that degradation visible, since it is real: pooling and the
+        strict session key are lost for every server the incumbent cannot serve.
+
+        The drift is otherwise invisible and self-perpetuating: the target map is
+        baked into the daemon's process env at ``_spawn_once`` and a frozen
+        ``GatewaySpec`` is never re-applied to a survivor, so a daemon that
+        predates a ``stub_servers`` change serves a stale map for as long as it
+        holds the socket -- observed in the field as a 25-day-old daemon that
+        silently removed ``kirocrew-core``'s entire tool surface from every
+        session. Automatic replacement needs a reap seam an adopted manager does
+        not have (it owns no PID) and is tracked separately.
+        """
+        required = self._required_target_stems()
+        if not required:
+            return False
+        reported = pong.get("targets")
+        if not isinstance(reported, list):
+            # A daemon too old to report coverage. Unverifiable, not proven bad
+            # -- but it is exactly the pre-upgrade survivor class that carries a
+            # stale map, so say so instead of assuming coverage.
+            logger.warning(
+                "mcp-gateway: incumbent daemon on %s does not report its target "
+                "map (pre-upgrade daemon), so its coverage of %d configured "
+                "stub target(s) cannot be verified. If a stubbed server's tools "
+                "are missing from sessions, this daemon is the first thing to "
+                "replace.",
+                self._spec.socket_path, len(required),
+            )
+            return True
+        missing = sorted(required - {s for s in reported if isinstance(s, str)})
+        if not missing:
+            return False
+        logger.warning(
+            "mcp-gateway: incumbent daemon on %s is STALE -- its target map is "
+            "missing %s. Its env was baked when it spawned and an adopted daemon "
+            "never re-applies a new one, so these servers' stubs will degrade to "
+            "per-session exec: their tools keep working, but pooling and the "
+            "strict session key are LOST. Replace the daemon to restore them.",
+            self._spec.socket_path, ", ".join(missing),
+        )
+        return True
+
+    async def _ping_payload(self) -> Optional[dict]:
+        """The daemon's ``pong`` payload, or ``None`` if it did not answer one.
+
+        Split out of :meth:`_ping_once` so the adoption gate can read the
+        coverage report the reply carries without changing the boolean contract
+        the five other call sites rely on.
+        """
+        msg = await self._ping_raw()
+        return msg if isinstance(msg, dict) and msg.get("type") == "pong" else None
+
     async def _ping_once(self) -> bool:
         """Return ``True`` iff the daemon replies ``{"type":"pong"}`` within
         ``_PING_TIMEOUT_SECS``. Any transport or parse error → ``False``.
         """
+        return (await self._ping_payload()) is not None
+
+    async def _ping_raw(self) -> Optional[dict]:
+        """One ping round-trip; the decoded reply, or ``None`` on any failure."""
         try:
             reader, writer = await asyncio.wait_for(
                 transport.connect(
@@ -408,25 +498,25 @@ class GatewayManager:
             )
         except (asyncio.TimeoutError, OSError) as exc:
             logger.warning("mcp-gateway ping connect failed: %s", exc)
-            return False
+            return None
         try:
             writer.write(b'{"type":"ping"}\n')
             try:
                 await asyncio.wait_for(writer.drain(), timeout=_PING_TIMEOUT_SECS)
             except (asyncio.TimeoutError, ConnectionError):
-                return False
+                return None
             try:
                 line = await asyncio.wait_for(
                     reader.readuntil(b"\n"), timeout=_PING_TIMEOUT_SECS,
                 )
             except (asyncio.TimeoutError, asyncio.IncompleteReadError,
                     asyncio.LimitOverrunError):
-                return False
+                return None
             try:
                 msg = json.loads(line.decode("utf-8"))
             except (UnicodeDecodeError, json.JSONDecodeError):
-                return False
-            return isinstance(msg, dict) and msg.get("type") == "pong"
+                return None
+            return msg if isinstance(msg, dict) else None
         finally:
             try:
                 writer.close()

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import functools
 import hashlib
 import json
 import logging
@@ -537,6 +538,41 @@ async def _safe_close(writer: asyncio.StreamWriter) -> None:
         await writer.wait_closed()
     except Exception:
         pass
+
+
+#: Invariant fragment of gatewayd's ``_TargetUnknown`` message. This is a FROZEN
+#: WIRE CONTRACT, not an implementation detail to be tidied: the daemon that
+#: sends it may be an old surviving process whose text can never be changed, so
+#: matching is the only classifier available for it. Only the stable leading
+#: clause is matched -- the remedy clause after it names an env prefix that HAS
+#: already changed across versions (``MC_MCP_TARGET_`` -> ``KIROCREW_MCP_TARGET_``).
+#: A test pins this against the live gatewayd string so the two cannot drift.
+TARGET_UNKNOWN_REASON = "no target mapping for server"
+
+
+def must_degrade_unknown_target(reason: str) -> bool:
+    """Should an UNTAGGED rejection still be treated as fallback-eligible?
+
+    A current daemon tags an unknown target ``fallback: true`` and this never
+    fires. It exists for the daemon that CANNOT tag it, which is precisely the
+    population the tag was added for: ``GatewayManager`` adopts any process
+    answering ``pong`` with no version handshake, so a daemon that outlived a
+    package upgrade serves brand-new stubs while predating every wire field
+    added since. Its target map is frozen at its own spawn, so it is also the
+    daemon most likely to be missing a server -- the tag would arrive exactly
+    where it cannot be sent.
+
+    Without this the PR's own fix is inert for the reported case: upgrade, old
+    daemon survives, adoption, untagged target-unknown, stub exits, and the
+    server's whole tool surface disappears from the session anyway.
+
+    Deliberately narrow. It matches ONLY the unknown-target class, so a genuine
+    spawn failure stays terminal and does not become a per-session crash-loop --
+    which is the reason the terminal path exists. Same shape as
+    :func:`must_degrade_unshareable`: the stub cannot verify the daemon's
+    version, so it reasons from what the daemon said.
+    """
+    return TARGET_UNKNOWN_REASON in (reason or "")
 
 
 def must_degrade_unshareable(poolable: bool, capabilities: list[str]) -> bool:
@@ -1397,11 +1433,25 @@ _FALLBACK_LOG_MAX_BYTES = 1024 * 1024
 
 
 def log_fallback(
-    reason: str, stub_uuid: str, pool_label: str, args: argparse.Namespace
+    reason: str,
+    stub_uuid: str,
+    pool_label: str,
+    args: argparse.Namespace,
+    *,
+    terminal: bool = False,
 ) -> None:
     """Append one JSON record to the fallback audit log. OS errors are
     swallowed — logging failure must never block the exec that keeps
-    kiro-cli working."""
+    kiro-cli working.
+
+    ``terminal=True`` marks a record as a stub that DIED rather than degraded.
+    Both events belong in this one log — same rotation, one place for an operator
+    to look — but they must not be added together: :func:`fallback_counts` feeds
+    gatewayd's ``stats``, and a fallback rate that silently includes terminals
+    misreports whether pooling is engaging. The split is driven by this
+    structured field, never by parsing the ``reason`` prefix, and a record
+    written before the field existed has no key and so still counts as a
+    fallback — which is what it was."""
     try:
         log_path = _fallback_log_path()
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1412,6 +1462,7 @@ def log_fallback(
             "stub_uuid": stub_uuid,
             "pool_label": pool_label,
             "reason": reason,
+            "terminal": bool(terminal),
             "server": args.server,
             "agent": args.agent,
             "channel_id": args.channel_id or "",
@@ -1449,13 +1500,23 @@ def fallback_counts() -> dict[str, Any]:
     to read a process tree.
 
     Returns ``{"window_secs": ..., "total": n, "by_server": {name: n},
-    "by_reason": {reason: n}}``. Never raises — an unreadable or torn log
+    "by_reason": {reason: n}, "terminal_total": n,
+    "terminal_by_server": {name: n}}``. Never raises — an unreadable or torn log
     yields the counts of whatever parsed.
+
+    ``total`` / ``by_server`` / ``by_reason`` count DEGRADATIONS only. A record
+    flagged ``terminal`` is a stub that died instead of degrading, which is a
+    different event with a different remedy, so it is tallied separately rather
+    than inflating the fallback rate this function exists to report. Records
+    predating the flag have no key and count as fallbacks, which is what they
+    were.
     """
     cutoff = time.time() - _FALLBACK_COUNT_WINDOW_SECS
     total = 0
     by_server: dict[str, int] = {}
     by_reason: dict[str, int] = {}
+    terminal_total = 0
+    terminal_by_server: dict[str, int] = {}
     live = _fallback_log_path()
     for path in (live.with_suffix(".jsonl.1"), live):
         try:
@@ -1470,8 +1531,14 @@ def fallback_counts() -> dict[str, Any]:
                     ts = rec.get("ts")
                     if not isinstance(ts, (int, float)) or ts < cutoff:
                         continue
-                    total += 1
                     server = str(rec.get("server") or rec.get("pool_label") or "?")
+                    if rec.get("terminal") is True:
+                        terminal_total += 1
+                        terminal_by_server[server] = (
+                            terminal_by_server.get(server, 0) + 1
+                        )
+                        continue
+                    total += 1
                     by_server[server] = by_server.get(server, 0) + 1
                     reason = str(rec.get("reason") or "?")
                     by_reason[reason] = by_reason.get(reason, 0) + 1
@@ -1482,11 +1549,18 @@ def fallback_counts() -> dict[str, Any]:
         "total": total,
         "by_server": by_server,
         "by_reason": by_reason,
+        "terminal_total": terminal_total,
+        "terminal_by_server": terminal_by_server,
     }
 
 
 async def alog_fallback(
-    reason: str, stub_uuid: str, pool_label: str, args: argparse.Namespace
+    reason: str,
+    stub_uuid: str,
+    pool_label: str,
+    args: argparse.Namespace,
+    *,
+    terminal: bool = False,
 ) -> None:
     """Run :func:`log_fallback` in a worker thread.
 
@@ -1495,7 +1569,11 @@ async def alog_fallback(
     it runs off the event loop, and awaiting it guarantees the record is on
     disk before the caller proceeds to ``fallback_exec`` (which replaces the
     process image and would otherwise race the write)."""
-    await asyncio.to_thread(log_fallback, reason, stub_uuid, pool_label, args)
+    await asyncio.to_thread(
+        functools.partial(
+            log_fallback, reason, stub_uuid, pool_label, args, terminal=terminal
+        )
+    )
 
 
 def fallback_exec(args: argparse.Namespace) -> None:
@@ -1722,12 +1800,34 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
                 isinstance(ready, dict)
                 and ready.get("type") == "rejected"
                 and not ready.get("fallback")
+                # A legacy daemon cannot send the tag, so an untagged
+                # target-unknown is routed to the fallback-exec path below
+                # rather than killing the server. See
+                # ``must_degrade_unknown_target``.
+                and not must_degrade_unknown_target(str(ready.get("reason") or ""))
             ):
-                # Terminal rejection (unknown target / genuine spawn failure):
-                # the gateway says this server cannot run. Surface the failure
-                # instead of exec'ing — matches the lazy path and avoids
-                # per-session crash-loops of a broken backend.
+                # Terminal rejection (genuine spawn failure): the gateway says
+                # this server cannot run. Surface the failure instead of
+                # exec'ing — matches the lazy path and avoids per-session
+                # crash-loops of a broken backend.
+                #
+                # Audited BEFORE returning, and this is the whole point of the
+                # record. A terminal exit writes no fallback record by
+                # definition, and this ``logger.error`` goes to the stub's own
+                # stderr, which kiro-cli swallows — so the pre-fix failure mode
+                # was a server whose entire tool surface vanished from a session
+                # while every durable log showed only a healthy ``registered``
+                # line. On the daemon side a terminal and a served stub were
+                # indistinguishable after the fact. The ``terminal:`` prefix
+                # keeps these separable from real fallbacks in
+                # ``stub_fallback_counts()``, which the gateway folds into its
+                # ``stats`` reply.
                 await _safe_close(writer)
+                await alog_fallback(
+                    f"terminal:{ready.get('reason') or 'ensure_backend_rejected'}",
+                    payload["stub_uuid"], pool_label, args,
+                    terminal=True,
+                )
                 logger.error(
                     "gateway terminally rejected ensure_backend (%s); not falling back pool=%s",
                     ready.get("reason"), pool_label,

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -255,7 +255,23 @@ class TestControlFrames:
     async def test_ping_is_answered_with_pong_and_closes(self, peer_ok):
         writer = _FakeWriter()
         await _handle(_ScriptedReader({"type": "ping"}, {"type": "ping"}), writer, _fake_pool())
-        assert writer.frames() == [{"type": "pong"}]
+        frames = writer.frames()
+        assert len(frames) == 1
+        assert frames[0]["type"] == "pong"
+
+    @pytest.mark.asyncio
+    async def test_pong_reports_the_target_map_so_an_adopter_can_check_it(
+        self, peer_ok, monkeypatch
+    ):
+        """``GatewayManager`` adopts any process answering ``pong`` without a
+        version handshake, and adoption is the one path that never applies the
+        spec's ``mcp_target_env``. Without this field the adopter cannot tell a
+        daemon that predates a ``stub_servers`` change from a current one, which
+        is how a stale daemon silently removed a whole server's tools."""
+        monkeypatch.setenv("KIROCREW_MCP_TARGET_KIROCREW_CORE", "kirocrew mcp-core")
+        writer = _FakeWriter()
+        await _handle(_ScriptedReader({"type": "ping"}), writer, _fake_pool())
+        assert "KIROCREW_CORE" in writer.frames()[0]["targets"]
 
     @pytest.mark.asyncio
     async def test_stats_merges_the_warm_pool_hit_tally(self, peer_ok, monkeypatch):
@@ -572,10 +588,16 @@ class TestEnsureBackendRejections:
         "exc,expected_reason,fallback,audit",
         [
             (
+                # Fallback-ELIGIBLE: at the pre-flight no real MCP frame has
+                # been forwarded, and an unknown target here can only be map
+                # drift (a stub exists only because the rewriter wrapped that
+                # server, and it holds the real --target-command on its argv).
+                # Tagging it terminal is what killed the server outright instead
+                # of degrading it to a per-session exec.
                 gw._TargetUnknown("no target mapping for server 'demo-mcp'"),
                 "no target mapping for server 'demo-mcp'",
-                False,
-                "_audit_pool_rejected",
+                True,
+                "_audit_pool_fallback",
             ),
             (
                 BackendUnavailable("circuit breaker OPEN"),

--- a/test/test_mcp_gateway_target_map_drift.py
+++ b/test/test_mcp_gateway_target_map_drift.py
@@ -1,0 +1,296 @@
+"""An adopted daemon's target map goes stale, and nothing used to say so.
+
+The daemon's target map is baked into its process environment at
+``GatewayManager._spawn_once`` and a frozen ``GatewaySpec`` is never re-applied
+afterwards. ``_start_locked`` adopts any process answering ``pong``, so a daemon
+that outlived a ``stub_servers`` change keeps serving a map that predates it --
+for as long as it holds the socket. Observed in the field as a 25-day-old daemon
+whose env knew only ``excalidraw`` and ``pdf``: every session's
+``kirocrew-core`` stub registered, pre-flighted ``ensure_backend``, was refused
+for an unknown target, and died in 0.2s, removing that server's whole tool
+surface with no durable record anywhere.
+
+Same mixed-version hazard as ``test_mcp_gateway_stub_poolable_ack`` -- adoption
+with no handshake -- so the same shape of fix: the daemon says what it can serve,
+and the adopting side checks.
+
+Two properties are pinned here:
+
+* the drift is DETECTED and reported (it was previously invisible), and
+* an unknown target at the pre-flight is fallback-ELIGIBLE, so the stub degrades
+  to a per-session exec instead of dying.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.mcp_gateway.gatewayd import _TargetUnknown, resolvable_target_stems
+from kiro_crew.mcp_gateway.manager import GatewayManager, GatewaySpec
+from kiro_crew.mcp_gateway.stub import (
+    TARGET_UNKNOWN_REASON,
+    fallback_counts,
+    log_fallback,
+    must_degrade_unknown_target,
+)
+
+
+def _manager(target_env: dict[str, str]) -> GatewayManager:
+    return GatewayManager(
+        GatewaySpec(socket_path=Path("/tmp/does-not-need-to-exist.sock"), mcp_target_env=target_env)
+    )
+
+
+# --------------------------------------------------------------- stem parsing
+
+
+def test_stems_strip_the_prefix_and_the_args_hash() -> None:
+    """A hashed twin and its bare key describe the SAME server, so both must
+    reduce to one stem -- otherwise a daemon carrying only the disambiguated
+    entry would read as not serving the server at all."""
+    env = {
+        "KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core",
+        "KIROCREW_MCP_TARGET_KIROCREW_CORE__61774e2023ff185e": "kirocrew mcp-core",
+        "KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio",
+        "PATH": "/usr/bin",
+        "KIROCREW_HOME": "/home/x/.kiro/crew",
+    }
+    assert resolvable_target_stems(env) == ["KIROCREW_CORE", "PDF"]
+
+
+def test_the_legacy_prefix_still_counts_as_coverage() -> None:
+    """``env_target_resolver`` accepts ``MC_MCP_TARGET_``, so a daemon holding
+    only that spelling CAN serve the server. Reporting it as uncovered would
+    raise a false drift alarm on an old-overlay install."""
+    assert resolvable_target_stems({"MC_MCP_TARGET_EXCALIDRAW": "node x.js"}) == ["EXCALIDRAW"]
+
+
+def test_no_target_keys_is_an_empty_report_not_a_crash() -> None:
+    assert resolvable_target_stems({"PATH": "/usr/bin"}) == []
+
+
+# ------------------------------------------------------- required-stem derivation
+
+
+def test_required_stems_come_from_the_spec_the_rewriter_just_computed() -> None:
+    """Derived from ``spec.mcp_target_env`` rather than a second config read, so
+    the check cannot disagree with what a spawn would actually have applied."""
+    mgr = _manager(
+        {
+            "KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core",
+            "KIROCREW_MCP_TARGET_KIROCREW_CORE__deadbeef": "kirocrew mcp-core",
+            "KIROCREW_MCP_TARGET_EXCALIDRAW": "node x.js",
+        }
+    )
+    assert mgr._required_target_stems() == {"KIROCREW_CORE", "EXCALIDRAW"}
+
+
+# ------------------------------------------------------------- the drift report
+
+
+def test_the_field_case_is_reported(caplog) -> None:
+    """The exact production shape: config wants core stubbed, the incumbent's
+    env knows only the two servers it was spawned with."""
+    mgr = _manager(
+        {
+            "KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core",
+            "KIROCREW_MCP_TARGET_EXCALIDRAW": "node x.js",
+            "KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio",
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        assert (
+            mgr._report_adoption_drift({"type": "pong", "targets": ["EXCALIDRAW", "PDF"]}) is True
+        )
+    assert "KIROCREW_CORE" in caplog.text
+    assert "STALE" in caplog.text
+
+
+def test_a_covering_daemon_is_silent(caplog) -> None:
+    """No warning on the healthy path, or the signal is worthless."""
+    mgr = _manager({"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio"})
+    with caplog.at_level(logging.WARNING):
+        assert mgr._report_adoption_drift({"type": "pong", "targets": ["PDF"]}) is False
+    assert caplog.text == ""
+
+
+def test_a_superset_daemon_is_also_silent(caplog) -> None:
+    """Coverage is a SUPERSET test: a daemon serving more than this spec needs is
+    fine (another agent's servers), and must not be flagged."""
+    mgr = _manager({"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio"})
+    with caplog.at_level(logging.WARNING):
+        assert (
+            mgr._report_adoption_drift(
+                {"type": "pong", "targets": ["PDF", "EXCALIDRAW", "KIROCREW_CORE"]}
+            )
+            is False
+        )
+    assert caplog.text == ""
+
+
+def test_a_daemon_that_cannot_report_is_flagged_as_unverifiable(caplog) -> None:
+    """The pre-upgrade survivor omits ``targets`` entirely -- and that is exactly
+    the class of daemon that carries a stale map, so silence would hide the one
+    case this exists to catch."""
+    mgr = _manager({"KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core"})
+    with caplog.at_level(logging.WARNING):
+        assert mgr._report_adoption_drift({"type": "pong"}) is True
+    assert "does not report its target map" in caplog.text
+
+
+def test_nothing_configured_means_nothing_to_verify(caplog) -> None:
+    """A gateway with no stubs has no coverage requirement; an old daemon on the
+    socket is then not a drift finding."""
+    mgr = _manager({})
+    with caplog.at_level(logging.WARNING):
+        assert mgr._report_adoption_drift({"type": "pong"}) is False
+    assert caplog.text == ""
+
+
+# ------------------------------------------- the legacy daemon (untagged reply)
+#
+# The gatewayd-side ``fallback: true`` tag only helps when the daemon is current.
+# The drift victim is by definition an OLD daemon: adoption has no version
+# handshake, so a survivor of a package upgrade serves brand-new stubs while
+# predating every wire field added since -- and its frozen target map is exactly
+# why it is missing a server. Without the stub-side classifier the fix would be
+# inert for the case that motivated it.
+
+
+def test_the_stub_side_string_matches_the_daemon_that_sends_it() -> None:
+    """Anti-drift pin. ``stub.py`` deliberately does not import ``gatewayd`` (it
+    is the per-session hot path), so the two sides agree only by convention --
+    and one of the senders is an old process whose text can never be patched.
+    If gatewayd's wording is ever edited, this fails instead of the classifier
+    silently going dead."""
+    reason = str(
+        _TargetUnknown(
+            "no target mapping for server 'kirocrew-core'; "
+            "set KIROCREW_MCP_TARGET_<SERVER> env var or pass a target_resolver"
+        )
+    )
+    assert TARGET_UNKNOWN_REASON in reason
+
+
+def test_an_untagged_target_unknown_still_degrades() -> None:
+    """The reported failure verbatim: upgrade, old daemon survives, adoption,
+    untagged target-unknown. This must route to the fallback exec, not exit."""
+    assert (
+        must_degrade_unknown_target(
+            "no target mapping for server 'kirocrew-core'; "
+            "set MC_MCP_TARGET_<SERVER> env var or pass a target_resolver"
+        )
+        is True
+    )
+
+
+def test_the_legacy_env_prefix_spelling_does_not_break_the_match() -> None:
+    """Only the stable leading clause is matched. The remedy clause names an env
+    prefix that HAS changed across versions (``MC_MCP_TARGET_`` ->
+    ``KIROCREW_MCP_TARGET_``), so matching the whole sentence would miss exactly
+    the old daemons this exists for."""
+    for spelling in ("MC_MCP_TARGET_", "KIROCREW_MCP_TARGET_"):
+        assert must_degrade_unknown_target(
+            f"no target mapping for server 'x'; set {spelling}<SERVER> env var"
+        )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "backend spawn failed: ENOMEM",
+        "circuit breaker OPEN",
+        "pool full",
+        "internal error: gateway bug",
+        "",
+    ],
+)
+def test_a_genuine_failure_stays_terminal(reason: str) -> None:
+    """The narrowness is the safety property. Degrading every untagged rejection
+    would turn a genuinely unrunnable backend into a per-session crash-loop,
+    which is the reason the terminal path exists at all."""
+    assert must_degrade_unknown_target(reason) is False
+
+
+def test_a_missing_reason_is_not_treated_as_unknown_target() -> None:
+    """``ready.get("reason")`` can be absent; ``None`` must not match."""
+    assert must_degrade_unknown_target(None) is False  # type: ignore[arg-type]
+
+
+# ------------------------------------------------ terminal vs fallback telemetry
+#
+# Both events share one log (one rotation, one place to look) but they are not the
+# same event and must not be added together: `fallback_counts` feeds gatewayd's
+# `stats` reply, and an operator reads that rate to decide whether pooling is
+# engaging. Counting stubs that DIED as degradations misreports exactly that.
+
+
+class _Args:
+    server = "kirocrew-core"
+    agent = "kirocrew"
+    channel_id = ""
+    target_command = "/x/kirocrew"
+
+
+def _counts_in(tmp_path, monkeypatch, records):
+    """Write `records` through the real writer, then aggregate them."""
+    monkeypatch.setattr(
+        "kiro_crew.mcp_gateway.stub._fallback_log_path",
+        lambda: tmp_path / "stub_fallback.jsonl",
+    )
+    for reason, terminal in records:
+        log_fallback(reason, "uuid-x", "kirocrew:kirocrew-core", _Args(), terminal=terminal)
+    return fallback_counts()
+
+
+def test_a_terminal_record_does_not_inflate_the_fallback_rate(tmp_path, monkeypatch):
+    """The regression: one real degradation and one death must not read as two
+    degradations."""
+    c = _counts_in(
+        tmp_path,
+        monkeypatch,
+        [("at capacity", False), ("terminal:backend spawn failed: ENOMEM", True)],
+    )
+    assert c["total"] == 1
+    assert c["by_server"] == {"kirocrew-core": 1}
+    assert c["by_reason"] == {"at capacity": 1}
+    assert c["terminal_total"] == 1
+    assert c["terminal_by_server"] == {"kirocrew-core": 1}
+
+
+def test_a_terminal_reason_does_not_leak_into_by_reason(tmp_path, monkeypatch):
+    """`by_reason` is the degradation breakdown; a terminal reason appearing there
+    would send an operator chasing a fallback that never happened."""
+    c = _counts_in(tmp_path, monkeypatch, [("terminal:whatever", True)])
+    assert c["total"] == 0
+    assert c["by_reason"] == {}
+    assert c["terminal_total"] == 1
+
+
+def test_the_split_is_driven_by_the_field_not_the_reason_prefix(tmp_path, monkeypatch):
+    """A degradation whose reason merely starts with the word is still a
+    degradation. Parsing the prefix would misclassify it; the structured flag
+    cannot."""
+    c = _counts_in(tmp_path, monkeypatch, [("terminal:looks-terminal", False)])
+    assert c["total"] == 1
+    assert c["terminal_total"] == 0
+
+
+def test_a_record_predating_the_flag_still_counts_as_a_fallback(tmp_path, monkeypatch):
+    """Back-compat: an old log line has no `terminal` key, and it WAS a fallback,
+    so it must keep counting as one rather than vanishing from the rate."""
+    import json
+    import time
+
+    log = tmp_path / "stub_fallback.jsonl"
+    log.write_text(
+        json.dumps({"ts": time.time(), "reason": "at capacity", "server": "pdf"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("kiro_crew.mcp_gateway.stub._fallback_log_path", lambda: log)
+    c = fallback_counts()
+    assert c["total"] == 1
+    assert c["terminal_total"] == 0


### PR DESCRIPTION
no linked issue: found by direct investigation of a live host rather than from a filed report, so there is no pre-existing issue to close. The follow-ups below are deliberately left unfiled until this lands, since each depends on the seam this PR introduces.

## The bug

`GatewayManager._start_locked` adopts any process that answers `pong`, and adoption is the **one path that never applies `GatewaySpec.mcp_target_env`** — that mapping is baked into the daemon's process env in `_spawn_once` (`manager.py:290`) and the spec is frozen. So a daemon that outlives a `stub_servers` change serves a map that predates it for as long as it holds the socket. Nothing re-derives it: the only "refresh" path deliberately reuses the stored map so it resolves the launches the daemon is actually serving.

Found on a live host as a gatewayd that had owned the socket for **25 days**:

| evidence | value |
|---|---|
| gatewayd PID 2624011 start | `2026-08-02 05:54:33` |
| `gateway.sock` mtime | `2026-08-02 05:54` (never re-bound) |
| newest `gatewayd listening` of 22 | `2026-08-02 05:54:34` |
| `#2810` put `kirocrew-core` in the stub set | `2026-08-13` |
| `kirocrew-core` registrations / binds | **25 / 0** |

Its env knew `excalidraw` and `pdf`. `kirocrew-core` entered the stub set 11 days later. Every session since:

```
kirocrew-core stub → rc=1 in 0.2s
ERROR gateway terminally rejected ensure_backend
  (no target mapping for server 'kirocrew-core'); not falling back
pdf stub → rc=0
```

That removed all **70** of that server's tools — `spawn_run`, `monitor_start`, `learn_add`, `ask_question`, `wait`, `artifact_*`, `send_message` — from every session, and the strict session key with them, because the recaller loop that supplies it sits downstream of the dead pre-flight. The underlying server was healthy the whole time (70 tools in 0.5s run directly).

It reads as non-deterministic but is not: 25/25 failures. Only the *visibility* varies — you notice when you reach for one of those 70 tools.

## The changes

**1. An unknown target at the `ensure_backend` PRE-FLIGHT is now fallback-eligible.**

It can only be map drift: a stub exists at all because the rewriter wrapped that server, and it carries the real `--target-command` on its own argv, so it can serve itself. A genuinely unrunnable target fails later as `BackendUnavailable`, which was already fallback-eligible. Lumping the two together is what turned a recoverable drift into total silent tool loss.

The **legacy lazy-spawn arm stays terminal** and is untouched: only a pre-`ensure_backend` stub reaches it, and it has already forwarded a real MCP frame that an exec fallback would drop. `TestLazySpawnRejections` passes unmodified — that's the point of splitting the two rather than flipping both.

**2. The failure is now attributable.**

It previously wrote nothing durable: a terminal exit writes no fallback record by definition, the stub's `logger.error` goes to a stderr kiro-cli swallows, and gatewayd logged only a healthy-looking `registered` line — a served stub and one that died 0.2s later were **indistinguishable after the fact**. gatewayd now warns naming the server and the stems it does hold, and the stub writes a `terminal:`-prefixed record before returning, kept separable from real fallbacks in `stub_fallback_counts()`.

**3. `pong` reports the daemon's resolvable target stems; the adopting manager checks them.**

Same mixed-version hazard as `poolable_ack` (adoption with no handshake), so the same shape of fix: the daemon says what it can serve. Stems rather than server names because recovering a name means undoing `upper().replace("-", "_")`, which is lossy — `my-server` and `my_server` normalize identically and the rewriter already warns about that collision. A daemon too old to report is called **unverifiable** rather than assumed covered, since that is precisely the class carrying a stale map.

### Why it reports instead of refusing

Deliberate, not timid. Refusing adoption **cannot** replace the incumbent: gatewayd's flock guard makes a competing spawn a clean no-op, so the stale daemon would keep the socket and we'd have traded a warning for an outage. What makes the drift *safe* is change 1; the warning exists to make the cost visible, because it is real — pooling and the strict session key are lost for every server the incumbent cannot serve. Automatic replacement needs a reap seam an adopted manager does not have (it owns no PID) and is left for a follow-up.

## Verification

- Killing the 25-day-old daemon let the watchdog re-spawn (`374709`, first socket re-bind since Aug 2) and the `kirocrew-core` stub went **rc=1 → rc=0**.
- `test_mcp_gateway_target_map_drift.py` — 9 new tests: stem parsing (hashed twin collapses to one stem, legacy `MC_MCP_TARGET_` still counts as coverage), required-stem derivation, and the report firing on the exact field shape while staying silent on a covering or superset daemon.
- Two existing contract tests updated rather than worked around, since they pinned exactly what this changes: `pong`'s shape, and `target-unknown`'s fallback tag + audit helper.
- `1514 passed, 0 failed` across `-k "mcp_gateway or gatewayd or stub or acp_runtime"` with `-n 4`; mypy clean on all three modules; black/isort/flake8 clean (only `gatewayd.py` and the new test are outside `black-baseline.txt`, and black touched only the 4 hunks this PR adds).

## Follow-ups (not in scope here)

- Automatic replacement of a drifted incumbent (needs the reap seam).
- `kirocrew-cron` is not in `stub_servers`, so it gets no stub and therefore no strict session key.
- `kirocrew-dashboard` is in `stub_servers` but in no agent spec's `mcpServers` — dead entry.
- `poolable_servers` is a migration-only alias (`loader.py:552`, key-presence wins) and now only misleads diagnosis.

