### PR TITLE
fix(ci): dedupe capture-aws-control server, unbreak jscpd gate on main

### DIFF
--- a/website/scripts/capture-aws-control.mjs
+++ b/website/scripts/capture-aws-control.mjs
@@ -14,37 +14,11 @@
  * Usage: node scripts/capture-aws-control.mjs <outDir>
  */
 import { chromium } from 'playwright'
-import { mkdirSync, readFileSync, statSync } from 'node:fs'
-import { createServer } from 'node:http'
-import { extname, join, resolve, sep } from 'node:path'
+import { mkdirSync } from 'node:fs'
+import { serveDist } from './lib/serve-dist.mjs'
 
 const OUT = process.argv[2] || '/tmp/aws-control-shots'
-const PORT = 6813
-const DIST = new URL('../dist', import.meta.url).pathname
 mkdirSync(OUT, { recursive: true })
-
-const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.png': 'image/png', '.woff2': 'font/woff2', '.json': 'application/json' }
-const isFile = (p) => { try { return statSync(p).isFile() } catch { return false } }
-const server = createServer((req, res) => {
-  const path = decodeURIComponent(new URL(req.url, 'http://x').pathname)
-  if (path === '/logo.png') {
-    res.writeHead(200, { 'content-type': 'image/png' })
-    res.end(readFileSync(join(DIST, 'icon-192.png')))
-    return
-  }
-  let file = resolve(DIST, '.' + path)
-  if (!file.startsWith(resolve(DIST) + sep) && file !== resolve(DIST)) {
-    res.writeHead(403); res.end(); return
-  }
-  if (path === '/' || !isFile(file)) file = join(DIST, 'index.html') // SPA fallback
-  try {
-    const body = readFileSync(file)
-    res.writeHead(200, { 'content-type': MIME[extname(file)] || 'application/octet-stream' })
-    res.end(body)
-  } catch {
-    res.writeHead(404); res.end()
-  }
-})
 
 // ---- fixtures -------------------------------------------------------------
 // Three accounts so the list reads as a list, with one degraded key so the
@@ -139,7 +113,7 @@ async function answer(route) {
 }
 
 // ---- run ------------------------------------------------------------------
-await new Promise((r) => server.listen(PORT, '127.0.0.1', r))
+const { srv: server, base } = await serveDist()
 const browser = await chromium.launch()
 const page = await browser.newPage({ viewport: { width: 1280, height: 900 }, deviceScaleFactor: 2 })
 await page.route('**/api/**', answer)
@@ -152,7 +126,7 @@ await page.addInitScript(() => {
   localStorage.setItem('mc-theme-mode', 'dark')
 })
 
-await page.goto(`http://127.0.0.1:${PORT}/aws-control`, { waitUntil: 'domcontentloaded' })
+await page.goto(`${base}/aws-control`, { waitUntil: 'domcontentloaded' })
 await page.waitForTimeout(1200)
 await page.screenshot({ path: `${OUT}/home.png`, fullPage: false })
 console.log('shot home')


### PR DESCRIPTION
## Problem / Motivation

The `Copy/paste detection` step (`npx jscpd .`, threshold 0%) in Frontend Lint & Type Check fails on **every branch cut from current main**: `ERROR: jscpd found too many duplicates (0.01%) over threshold (0%)`. Reproduced on a pristine `origin/main` worktree with the pinned jscpd — this is main's own breakage, not any PR's.

## Why it matters

Every open PR red-lights on a gate its diff cannot influence; contributors burn CI rounds triaging a failure that is inherited. (Hit live while babysitting #6428.)

## What changed (motivation → approach → change)

`capture-aws-control.mjs` (landed recently) hand-rolled the same 17-line static-file server that `capture-hero-art-proxy.mjs` carries, pushing repo-wide duplication from one tolerated clone (rounds to 0%) to two (0.01% > 0%). The repo already has the shared harness helper for exactly this: `scripts/lib/serve-dist.mjs`. The fix deletes the hand-rolled server from `capture-aws-control.mjs` and uses `serveDist()` (ephemeral port instead of hardcoded 6813, same SPA-fallback + `/logo.png` behavior — the helper is the canonical implementation the other harnesses use).

## Tests

`jscpd` on this branch: back to 1 clone / exit 0 (the pre-existing queue-edit/upload-error pair, which rounds to 0% and passes). N/A for unit tests — capture harness script, not shipped code.

## Manual verification

Ran the fixed script end-to-end against a built dist (`node scripts/capture-aws-control.mjs /tmp/aws-verify`): server starts on an ephemeral port, SPA loads, `home.png` and `account.png` captured. `node --check` clean.

<!-- no-visual-delta -->
**Why no screenshot:** capture-harness plumbing only; no shipped UI renders differently.

## Related Issues

no linked issue: found while babysitting #6428; fixed directly as a main-unblocker.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — N/A, harness script
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
