### PR TITLE
feat: add glance to the app registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "glance",
+    "gitUrl": "https://github.com/rubencu/kirocrew-glance",
+    "repo": "https://github.com/rubencu/kirocrew-glance",
+    "branch": "main"
+  },
+  {
     "name": "launchdarkly",
     "gitUrl": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",
     "repo": "https://github.com/launchdarkly-labs/launchdarkly-kiro-crew-app",


### PR DESCRIPTION
## Problem / Motivation

Glance (https://github.com/rubencu/kirocrew-glance) is a KiroCrew app for people running many agent sessions at once: a curator cron triages everything in flight every 15 minutes and writes a short prioritized brief, and the UI is a single screen — live blockers (questions, approvals, option gates) answerable inline, the brief with one-click delegation back to an agent, and one free-text line. Today it can only be installed by cloning the repo manually; it is not discoverable in the Apps → Discover page.

## Why it matters

Users who would benefit most from Glance (anyone juggling several concurrent sessions) have no way to find it. A registry listing makes it a one-click install and lets the app's own `app.json` drive its store metadata from then on.

## What changed (motivation → approach → change)

Goal: make Glance installable from the store. Approach: follow the existing third-party listing pattern (launchdarkly, todo-ledger, todo-txt) — the registry holds only name + clone coordinates, and all display information is fetched from the app's own `app.json`, so future app releases need no registry edits. Change: one new entry in `src/kiro_crew/apps/app-registry.json` (name `glance`, gitUrl/repo `https://github.com/rubencu/kirocrew-glance`, branch `main`), placed alphabetically.

## Tests

N/A — data-only registry entry; no code paths change. The registry JSON parses cleanly (`python3 -m json.tool`).

## Manual verification

- Installed the app from this exact gitUrl/branch via `kirocrew app install` and enabled it; the curator cron registers and the `/glance` UI route mounts and renders.
- The app repo has its own CI (unit tests + SSR render smoke) gating every merge to `main`.

## Related Issues

N/A

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality (N/A — data-only entry)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff