### PR TITLE
refactor(chat): share one reasoning-burst predicate between wrap gate and fold

### DIFF
--- a/website/src/app-sdk/messageRenderers.tsx
+++ b/website/src/app-sdk/messageRenderers.tsx
@@ -28,6 +28,7 @@ import NudgeCard from '../pages/chat/NudgeCard'
 import NoticeCard from '../pages/chat/NoticeCard'
 import { ErrorCard } from '../pages/chat/ErrorCard'
 import { isSubagentCompletionMessage } from '../pages/chat/subagentCompletion'
+import { REASONING_ROLES } from '../pages/chat/groupDisplayItems'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import MessageErrorBoundary from '../components/MessageErrorBoundary'
 import PastedChip from '../components/PastedChip'
@@ -341,7 +342,10 @@ export const defaultMessageRenderers: readonly MessageRenderer[] = [
     // permission message is displayed by the group's own summary UI, and
     // system/done/queued carry state rather than something to read here.
     id: 'undrawn',
-    roles: ['thinking', 'system', 'done', 'queued'],
+    // Reasoning roles derive from the shared classification (see
+    // pages/chat/groupDisplayItems.ts) so this default cannot drift from the
+    // surfaces that DO draw them; the lifecycle roles are local to this entry.
+    roles: [...REASONING_ROLES, 'system', 'done', 'queued'],
     render: () => null,
   },
   {
@@ -399,7 +403,7 @@ export function resolveRenderer(
  * is not an extension point today — see the limitation note in
  * docs/app-kit/api-reference.md.
  */
-export const GROUPED_ROLES: readonly string[] = Object.freeze(['thinking', 'permission'])
+export const GROUPED_ROLES: readonly string[] = Object.freeze([...REASONING_ROLES, 'permission'])
 
 /**
  * Host entries sit between the SHAPE-matched defaults and the role-keyed ones.

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -154,7 +154,7 @@ import SubagentProgressBar from './chat/SubagentProgressBar'
 import TaskProgressBar from './chat/TaskProgressBar'
 import SidePanel, { CHAT_PANE_MIN_W, sidePanelFillWidth } from './chat/SidePanel'
 import { useSidePanelDock } from '../hooks/useSidePanelDock'
-import { groupDisplayItems, applyRunningState } from './chat/groupDisplayItems'
+import { groupDisplayItems, applyRunningState, hasReasoningContent, isReasoningRole } from './chat/groupDisplayItems'
 import { setSessionPreviewPending, normalizeUrl, PREVIEW_EXPAND_EVENT, PREVIEW_SNIP_EVENT } from '../components/WebPreviewPanel'
 import { detectPreviewUrl, previewFeedDecision } from '../utils/detectPreviewUrl'
 import { fileLandingSlot } from '../utils/uploadRouting'
@@ -6275,7 +6275,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // Key identity rules (clientTs preference + streaming→assistant role
     // normalization) live in messageRowKey — see its doc comment.
     const key = messageRowKey(m, i)
-    if (m.role === 'thinking') return m.content ? <ThinkingBlock key={key} content={m.content} disclosureKey={key} /> : null
+    // Shared with the wrap gate and fold — see hasReasoningContent in
+    // groupDisplayItems.ts for why there is ONE definition of this condition.
+    if (hasReasoningContent(m)) return <ThinkingBlock key={key} content={m.content} disclosureKey={key} />
+    if (isReasoningRole(m)) return null
     if (m.role === 'tool') {
       // Skip ✅/🚫 completion messages — completion shown via CircleCheckBig icon
       if (!m.content.startsWith('🔧')) return null

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -7,6 +7,7 @@ import { isWorkflowRunTool } from './WorkflowRunCard'
 import { isSpawnRunTool } from './SubagentRunCard'
 import { isWorkflowCompletionMessage } from './WorkflowCompletionCard'
 import { isSubagentCompletionMessage } from './subagentCompletion'
+import { isReasoningBurst } from './groupDisplayItems'
 import { isDiffToolMessage } from './toolDiff'
 import { OPTION_MARKER_RE } from '../../app-sdk/protocol/optionMarker'
 import { i18nT } from '../../i18n/t'
@@ -202,19 +203,20 @@ function findConclusionIdx(items: TurnItem[]): number {
  */
 function mergeTurnThinking(items: TurnItem[]): TurnItem[] {
   const thinkingPositions: number[] = []
+  const bursts: Extract<TurnItem, { kind: 'single' }>[] = []
   for (let i = 0; i < items.length; i++) {
     const it = items[i]
-    if (it.kind === 'single' && it.msg.role === 'thinking' && it.msg.content) thinkingPositions.push(i)
+    // Shared with the wrap gate that routes multi-burst batches here — see
+    // isReasoningBurst in groupDisplayItems.ts for why there is ONE definition.
+    if (isReasoningBurst(it)) { thinkingPositions.push(i); bursts.push(it) }
   }
   if (thinkingPositions.length === 0) return items
   // A single burst already at the top is the settled, correct shape (the live
   // path and a 1:1 reload both produce it) — leave it, so a plain reasoning
   // turn is not needlessly rewritten.
   if (thinkingPositions.length === 1 && thinkingPositions[0] === 0) return items
-  const first = items[thinkingPositions[0]] as Extract<TurnItem, { kind: 'single' }>
-  const merged = thinkingPositions
-    .map(p => (items[p] as Extract<TurnItem, { kind: 'single' }>).msg.content)
-    .join('\n\n')
+  const first = bursts[0]
+  const merged = bursts.map(b => b.msg.content).join('\n\n')
   const mergedItem: TurnItem = { kind: 'single', msg: { ...first.msg, content: merged }, idx: first.idx }
   const drop = new Set(thinkingPositions)
   // Hoist the merged reasoning to the turn top; every other item keeps its order.

--- a/website/src/pages/chat/groupDisplayItems.ts
+++ b/website/src/pages/chat/groupDisplayItems.ts
@@ -9,6 +9,45 @@ import { isSubagentCompletionMessage } from './subagentCompletion'
 export const GROUPABLE = new Set(['permission'])
 
 /**
+ * The reasoning roles, and what "content-bearing reasoning" means. These are
+ * THE single definition of the classification, shared by every display-layer
+ * site that acts on it:
+ *
+ *  - the wrap gate below (`contentThinkingCount` via `isReasoningBurst`, which
+ *    decides when a batch is routed into a {kind:'turn'} wrapper),
+ *  - the per-turn fold that gate feeds (`mergeTurnThinking` in TurnBlock.tsx,
+ *    which folds a turn's bursts into one hoisted row),
+ *  - ChatPage's `renderMessage` (content-bearing → ThinkingBlock, empty
+ *    placeholder → nothing, via `hasReasoningContent` + `isReasoningRole`),
+ *  - the shared-transcript registry entry (`transcriptRenderers.tsx`, whose
+ *    `roles` key and render guard both derive from here).
+ *
+ * These sites used to keep hand-written copies of the same condition; any
+ * future refinement (a new reasoning role, a whitespace guard, a meta flag)
+ * must happen HERE so the wrap threshold, the fold, and the row renderers can
+ * never drift apart — that drift is exactly how the duplicate
+ * "Thought process" rows of #6376 would regrow. (The store's burst-lifecycle
+ * mechanics in chatSlice are a different concern — they manage streaming
+ * placeholders, not display classification — and deliberately stay separate.)
+ */
+export const REASONING_ROLES = ['thinking'] as const
+
+const REASONING_ROLE_SET: ReadonlySet<string> = new Set(REASONING_ROLES)
+
+/** Is this message a reasoning trace (regardless of whether it has content)?
+ *  Structurally typed so raw-snapshot (wire-shape) surfaces can reuse it. */
+export const isReasoningRole = (msg: { role: string }): boolean =>
+  REASONING_ROLE_SET.has(msg.role)
+
+/** A content-bearing reasoning message; empty placeholders render nothing and never count. */
+export const hasReasoningContent = (msg: { role: string; content: string }): boolean =>
+  isReasoningRole(msg) && !!msg.content
+
+/** Item-level form of {@link hasReasoningContent} for TurnItem scans. */
+export const isReasoningBurst = (t: TurnItem): t is Extract<TurnItem, { kind: 'single' }> =>
+  t.kind === 'single' && hasReasoningContent(t.msg)
+
+/**
  * Roles that OPEN a turn, and are therefore the rows a reader can be anchored to.
  *
  * `nudge` and `subagent` are machine-injected but they ARE the thing that started
@@ -100,7 +139,7 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
   // a separate predicate. Empty placeholder bursts do not count (they render
   // nothing, and mergeTurnThinking ignores them too).
   const contentThinkingCount = (items: TurnItem[]) =>
-    items.reduce((n, t) => n + (t.kind === 'single' && t.msg.role === 'thinking' && t.msg.content ? 1 : 0), 0)
+    items.reduce((n, t) => n + (isReasoningBurst(t) ? 1 : 0), 0)
   const flushTurn = (items: TurnItem[], complete: boolean) => {
     if ((hasWorkingSteps(items) && items.length > 2) || contentThinkingCount(items) >= 2) {
       turns.push({ kind: 'turn', items, complete })

--- a/website/src/pages/chat/transcriptRenderers.tsx
+++ b/website/src/pages/chat/transcriptRenderers.tsx
@@ -30,6 +30,7 @@ import SubagentRunCard, { extractSpawnRunLaunch, isSpawnRunTool } from './Subage
 import WorkflowCompletionCard, { isWorkflowCompletionMessage } from './WorkflowCompletionCard'
 import SubagentCompletionCard from './SubagentCompletionCard'
 import { isSubagentCompletionMessage, type ParsedSubagentCompletion } from './subagentCompletion'
+import { REASONING_ROLES, hasReasoningContent } from './groupDisplayItems'
 import { FileCard } from '../../components/FileCard'
 import type { MessageRenderer, MessageRenderContext } from '../../app-sdk/messageRenderers'
 import type { ChatMessage } from '../../types'
@@ -172,8 +173,11 @@ export function createTranscriptRenderers(
       // surface renders it. Opting a grouped role out of the group is not an
       // extension point yet — tracked in #2940.
       id: 'thinking_block',
-      roles: ['thinking'],
-      render: (m, ctx) => (m.content ? ctx.row(<ThinkingBlock content={m.content} disclosureKey={ctx.key} />) : null),
+      // Both the role key and the content guard derive from the shared
+      // reasoning predicate (see groupDisplayItems.ts) so this surface can
+      // never drift from ChatPage's renderer or the gate→fold pipeline.
+      roles: [...REASONING_ROLES],
+      render: (m, ctx) => (hasReasoningContent(m) ? ctx.row(<ThinkingBlock content={m.content} disclosureKey={ctx.key} />) : null),
     },
     {
       // Replaces the default's null with the player / download card.

--- a/website/src/test/chatRolesParity.contract.test.ts
+++ b/website/src/test/chatRolesParity.contract.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { defaultMessageRenderers } from '../app-sdk/messageRenderers'
+import { REASONING_ROLES } from '../pages/chat/groupDisplayItems'
 
 /**
  * Roles ChatPage handles that are deliberately NOT a registry row. Each entry
@@ -55,6 +56,26 @@ function chatPageRoleLiterals(): Set<string> {
   // `messages[i].role === 'x'` (and their !== variants — a negative dispatch
   // still means the code KNOWS the role).
   for (const m of src.matchAll(/\.role\s*[!=]==\s*'([a-z_]+)'/g)) roles.add(m[1])
+  // Reasoning rows dispatch through the shared predicate (isReasoningRole /
+  // hasReasoningContent from pages/chat/groupDisplayItems — the #6406
+  // single-definition consolidation) rather than a role literal. Credit the
+  // shared list's roles ONLY when ChatPage imports BOTH predicates from the
+  // shared module AND both dispatch statements are present. This is a textual
+  // check, not an AST binding check: a comment spelling the exact dispatch
+  // shape could keep the credit alive — accepted, because the companion
+  // predicate-idiom guard below and the reasoningBurst structural scan bound
+  // what ChatPage can contain, and losing either import drops the credit
+  // (the orphan check then reddens). If the dispatch shape is refactored,
+  // update these patterns.
+  const importsShared =
+    /import \{[^}]*\bhasReasoningContent\b[^}]*\} from '\.\/chat\/groupDisplayItems'/.test(src) &&
+    /import \{[^}]*\bisReasoningRole\b[^}]*\} from '\.\/chat\/groupDisplayItems'/.test(src)
+  const dispatchesReasoning =
+    /hasReasoningContent\(\w+\)\)\s*return\s*<ThinkingBlock/.test(src) &&
+    /isReasoningRole\(\w+\)\)\s*return\s*null/.test(src)
+  if (importsShared && dispatchesReasoning) {
+    for (const role of REASONING_ROLES) roles.add(role)
+  }
   return roles
 }
 
@@ -106,14 +127,24 @@ describe('chat role parity (ChatPage renderMessage vs app-sdk registry)', () => 
 
   it('fails closed: every role dispatch in ChatPage uses the shape the extractor parses', () => {
     const src = readFileSync(resolve(__dirname, '../pages/ChatPage.tsx'), 'utf8')
-    // The extractor only understands `<expr>.role ===/!== '<literal>'`. Any
-    // other dispatch idiom — switch(m.role), a lookup map, comparison against
-    // a variable — would be invisible to the parity checks above, so its mere
-    // presence fails this contract. If you add one, extend the extractor in
-    // this file to parse it rather than allowlisting it here.
+    // The extractor understands two idioms: `<expr>.role ===/!== '<literal>'`
+    // and the shared reasoning predicates credited above. Any other dispatch
+    // idiom — switch(m.role), a lookup map, comparison against a variable —
+    // would be invisible to the parity checks above, so its mere presence
+    // fails this contract. If you add one, extend the extractor in this file
+    // to parse it rather than allowlisting it here.
     const comparisons = [...src.matchAll(/\.role\s*[!=]==\s*(\S)/g)]
     const nonLiteral = comparisons.filter(m => m[1] !== "'")
     expect(nonLiteral.map(m => m[0])).toEqual([])
     expect([...src.matchAll(/switch\s*\([^)]*\.role/g)].map(m => m[0])).toEqual([])
+    // Predicate-shaped role dispatch (the #6406 idiom): only the two shared
+    // reasoning predicates are parsed. A future is<X>Role(...) / has<X>Content(...)
+    // helper called in ChatPage is a role dispatch the extractor cannot see,
+    // so its presence fails here until the extractor learns it.
+    const predicateCalls = [...src.matchAll(/\b(is[A-Z]\w*Role|has[A-Z]\w*Content)\s*\(/g)].map(m => m[1])
+    const unknownPredicates = predicateCalls.filter(
+      name => name !== 'isReasoningRole' && name !== 'hasReasoningContent',
+    )
+    expect(unknownPredicates).toEqual([])
   })
 })

--- a/website/src/test/reasoningBurst.contract.test.tsx
+++ b/website/src/test/reasoningBurst.contract.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Gate→fold contract for the shared reasoning-burst predicate (#6406).
+ *
+ * groupDisplayItems' wrap gate (contentThinkingCount) routes multi-burst
+ * reasoning batches into a {kind:'turn'} wrapper for the ONE purpose of
+ * feeding TurnBlock's mergeTurnThinking fold. The gate, the fold, ChatPage's
+ * renderMessage, and the shared-transcript registry entry all derive from a
+ * single definition (REASONING_ROLES / isReasoningRole / hasReasoningContent /
+ * isReasoningBurst). Two layers pin the contract:
+ *
+ * 1. Behavioral: grouping output rendered straight through TurnBlock must show
+ *    exactly one thinking row, so a SEMANTICALLY divergent fork (the gate
+ *    wrapping batches the fold no longer merges, regrowing the duplicate
+ *    "Thought process" rows of #6376) fails here rather than passing each
+ *    side's isolated tests.
+ * 2. Structural: a re-inlined copy of the condition anywhere in the display
+ *    layer would keep the behavioral tests green today and only diverge later,
+ *    so a source scan asserts no chat-surface file re-spells the role
+ *    predicate. (The scan matches the literal `role === 'thinking'` spellings;
+ *    an exotic re-spelling can evade any regex — the honest floor is that the
+ *    common forms fail loudly. ChatPage's real renderMessage path is covered
+ *    by ChatPageCoverage.test.tsx.)
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFile, readdir } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import TurnBlock from '../pages/chat/TurnBlock'
+import {
+  groupDisplayItems,
+  isReasoningBurst,
+  isReasoningRole,
+  hasReasoningContent,
+  REASONING_ROLES,
+} from '../pages/chat/groupDisplayItems'
+import type { ChatMessage } from '../types'
+import type { DisplayItem, TurnItem } from '../pages/chat/types'
+
+const PAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'pages')
+const CHAT_DIR = join(PAGES_DIR, 'chat')
+
+const msg = (role: string, content = ''): ChatMessage =>
+  ({ role, content, cls: '' } as ChatMessage)
+
+// Content-bearing bursts render like ChatPage's renderMessage (same shared
+// predicate). Empty placeholders — which every real surface renders as
+// NOTHING — get a visible marker here on purpose: it lets the assertions
+// observe TurnBlock's post-fold item stream (that the fold left the
+// placeholder in place rather than deleting or hoisting it), which a null
+// render would hide.
+const renderItem = (it: TurnItem, i: number) => {
+  if (it.kind !== 'single') return <div data-testid={`row-${i}`} data-role="group">group</div>
+  const role = isReasoningRole(it.msg) && !hasReasoningContent(it.msg)
+    ? 'thinking-placeholder'
+    : it.msg.role
+  return (
+    <div data-testid={`row-${i}`} data-role={role}>
+      {it.msg.content}
+    </div>
+  )
+}
+
+const findTurn = (turns: DisplayItem[]): Extract<DisplayItem, { kind: 'turn' }> => {
+  const turn = turns.find((t): t is Extract<DisplayItem, { kind: 'turn' }> => t.kind === 'turn')
+  expect(turn).toBeDefined()
+  return turn!
+}
+
+describe('reasoning-burst gate→fold contract (#6406)', () => {
+  it('a reasoning-only multi-burst batch renders exactly ONE thinking row through TurnBlock', () => {
+    // The exact #6376 shape: a trailing turn that has only emitted reasoning.
+    // The gate must wrap it, and the fold the gate feeds must merge it — the
+    // contract holds only when both sides agree on what a burst is.
+    const { turns } = groupDisplayItems([
+      msg('thinking', 'burst 1'),
+      msg('thinking', 'burst 2'),
+      msg('thinking', 'burst 3'),
+    ])
+    const turn = findTurn(turns)
+    const { container } = render(<TurnBlock turn={turn} renderItem={renderItem} />)
+    const thinkingRows = container.querySelectorAll('[data-role="thinking"]')
+    expect(thinkingRows).toHaveLength(1)
+    // The fold concatenates burst content, so the one row carries all of it.
+    expect(thinkingRows[0].textContent).toContain('burst 1')
+    expect(thinkingRows[0].textContent).toContain('burst 3')
+  })
+
+  it('empty placeholder bursts neither trip the gate nor count as bursts', () => {
+    // One real burst + empties: the gate must NOT wrap (nothing to dedup). If
+    // a future predicate fork made the gate count empties while the fold
+    // ignores them, this batch would wrap despite having one real burst.
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('thinking', 'one real'),
+      msg('thinking', ''),
+      msg('thinking', ''),
+    ])
+    expect(turns.some(t => t.kind === 'turn')).toBe(false)
+  })
+
+  it('mixed batch: real bursts fold to one hoisted row, the empty placeholder stays in place below it', () => {
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('thinking', 'plan A'),
+      msg('tool', 'tool step'),
+      msg('thinking', ''),
+      msg('thinking', 'plan B'),
+      msg('assistant', 'answer'),
+    ])
+    const turn = findTurn(turns)
+    const { container } = render(<TurnBlock turn={turn} renderItem={renderItem} />)
+    // Exactly one merged (content-bearing) thinking row survives the fold…
+    expect(container.querySelectorAll('[data-role="thinking"]')).toHaveLength(1)
+    // …and the empty placeholder survives IN the rendered stream (the fold
+    // leaves it in place, it is neither merged nor dropped), positioned after
+    // the hoisted merged row. Asserted on the rendered output, not on the
+    // pre-fold turn.items, so a fold that deleted or moved it fails here.
+    const rows = [...container.querySelectorAll('[data-role]')].map(el => el.getAttribute('data-role'))
+    expect(rows.filter(r => r === 'thinking-placeholder')).toHaveLength(1)
+    expect(rows.indexOf('thinking')).toBeLessThan(rows.indexOf('thinking-placeholder'))
+    // The answer is still rendered (the fold is a hoist, not a filter).
+    expect(screen.getByText('answer')).toBeInTheDocument()
+  })
+
+  it('the shared predicates classify the enumerated shapes', () => {
+    // Direct predicate pins: content-bearing thinking counts (whitespace-only
+    // is content-bearing today — refining that is legal, but it must happen in
+    // the shared predicate so gate, fold, and renderers move together), empty
+    // and non-thinking shapes do not.
+    const single = (role: string, content: string): TurnItem =>
+      ({ kind: 'single', msg: msg(role, content), idx: 0 })
+    expect(isReasoningBurst(single('thinking', 'text'))).toBe(true)
+    expect(isReasoningBurst(single('thinking', '  '))).toBe(true)
+    expect(isReasoningBurst(single('thinking', ''))).toBe(false)
+    expect(isReasoningBurst(single('assistant', 'text'))).toBe(false)
+    expect(isReasoningBurst({ kind: 'group', msgs: [msg('thinking', 'text')], startIdx: 0 })).toBe(false)
+    expect(hasReasoningContent(msg('thinking', 'text'))).toBe(true)
+    expect(hasReasoningContent(msg('thinking', ''))).toBe(false)
+    expect(isReasoningRole(msg('thinking', ''))).toBe(true)
+    expect(isReasoningRole(msg('assistant', 'x'))).toBe(false)
+    expect(REASONING_ROLES).toContain('thinking')
+  })
+
+  it('no display-layer file re-spells the reasoning-role predicate (structural pin)', async () => {
+    // A byte-identical re-inline in any consumer would keep every behavioral
+    // test above green and only drift later — the regression #6406 exists to
+    // prevent. Scan the directories where the chat transcript is rendered
+    // (pages/chat/ and app-sdk/ recursively, plus ChatPage.tsx — classification
+    // CONSUMERS elsewhere, e.g. utils/pinnedPrompt.ts, import from the shared
+    // module and are covered by their own contracts) for the predicate's
+    // common spellings — === and !== comparisons and hardcoded role-list
+    // membership; the single definition site is the REASONING_ROLES list,
+    // which is not spelled as a role comparison at all. (chatSlice's
+    // burst-lifecycle checks are store mechanics, not display classification,
+    // and live outside this scope. An exotic re-spelling can evade any regex —
+    // the honest floor is that the common forms fail loudly.)
+    const respell = /\brole\s*[!=]==\s*['"]thinking['"]|roles:\s*\[\s*['"]thinking['"]/
+    const walk = async (dir: string): Promise<string[]> => {
+      const out: string[] = []
+      for (const e of await readdir(dir, { withFileTypes: true })) {
+        const p = join(dir, e.name)
+        if (e.isDirectory()) {
+          if (e.name === '__mocks__' || e.name === '__fixtures__') continue
+          out.push(...await walk(p))
+        } else if (/\.tsx?$/.test(e.name) && !/\.(test|spec)\./.test(e.name)) {
+          out.push(p)
+        }
+      }
+      return out
+    }
+    const files = [
+      ...await walk(CHAT_DIR),
+      ...await walk(join(PAGES_DIR, '..', 'app-sdk')),
+      join(PAGES_DIR, 'ChatPage.tsx'),
+    ]
+    expect(files.length).toBeGreaterThan(10) // the walk really found the display layer
+    for (const file of files) {
+      const src = await readFile(file, 'utf8')
+      expect(
+        src.match(respell),
+        `${file} re-spells the reasoning predicate — use isReasoningRole/hasReasoningContent/REASONING_ROLES from groupDisplayItems`,
+      ).toBeNull()
+    }
+    // The consumers import the shared forms instead, and the definition site
+    // exists (its MEMBERS are deliberately not pinned — growing the list is
+    // the exact change the shared definition exists to make safe).
+    const turnBlock = await readFile(join(CHAT_DIR, 'TurnBlock.tsx'), 'utf8')
+    expect(turnBlock).toMatch(/import \{ isReasoningBurst \} from '\.\/groupDisplayItems'/)
+    const groupSrc = await readFile(join(CHAT_DIR, 'groupDisplayItems.ts'), 'utf8')
+    expect(groupSrc).toMatch(/export const REASONING_ROLES = \[/)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #6406.

PR #6389 (fix for #6376) left the "content-bearing reasoning burst" condition spelled by hand at multiple display-layer sites: the wrap gate (`contentThinkingCount` in `groupDisplayItems.ts`), the fold it feeds (`mergeTurnThinking` in `TurnBlock.tsx`), ChatPage's `renderMessage`, the shared-transcript registry entry (`transcriptRenderers.tsx`), and the app-sdk default registry's `undrawn` / `GROUPED_ROLES` lists. If any copy drifted (a new reasoning role, a whitespace guard, a meta flag), the wrap threshold would silently diverge from the fold and the duplicate "Thought process" rows of #6376 would regrow while each side's isolated tests stayed green.

This consolidates all of them onto one definition in `groupDisplayItems.ts` — **zero behavior change**:

- `REASONING_ROLES` (the role list), `isReasoningRole`, `hasReasoningContent` (message-level, structurally typed so wire-shape consumers can reuse it), and `isReasoningBurst` (TurnItem type guard).
- `contentThinkingCount`, `mergeTurnThinking` (casts removed — the guard's narrowing is carried through), ChatPage's `renderMessage`, `transcriptRenderers`' thinking entry (role key AND render guard), and `messageRenderers`' `undrawn`/`GROUPED_ROLES` all derive from it. Membership and order preserved everywhere.
- All new import edges (`TurnBlock`/`ChatPage`/`transcriptRenderers`/`messageRenderers` → `groupDisplayItems`) are cycle-free: `groupDisplayItems`'s only value import is `subagentCompletion`, which was already an app-sdk dependency; no back edge exists.

Two contract layers pin it:

- **Behavioral** (`reasoningBurst.contract.test.tsx`): groupDisplayItems output rendered straight through TurnBlock shows exactly one thinking row for a multi-burst batch (the #6376 shape), placeholder handling asserted on the rendered post-fold stream, plus direct predicate pins (including whitespace-only content, which is content-bearing today).
- **Structural**: a recursive source scan over `pages/chat/` + `app-sdk/` + `ChatPage.tsx` fails on any re-spelling of the predicate (`===`/`!==`/hardcoded role-list forms). The `chatRolesParity` extractor was extended to credit `REASONING_ROLES` only when ChatPage imports both shared predicates and both dispatch statements are present, and its fails-closed guard now also reds on any unknown `is*Role(`/`has*Content(` predicate call in ChatPage.

Pure refactor + tests; no UI pixel change, so no screenshots are required.

`no linked issue: N/A — Closes #6406 above.`

## Pre-push adversarial review

4 rounds, two blind model-pinned reviewers per round (GPT `gpt-5.6-sol` mirroring codex-review, Opus `claude-opus-5` mirroring claude-review), fresh context each round:

- **R1** (8 fixed): third predicate copy in ChatPage; byte-identical re-inline invisible to behavioral tests (→ structural scan); type-guard narrowing discarded in `mergeTurnThinking`; fabricated group shape in a test; emoji glyph in a fixture; whitespace coverage; test title/assertion mismatch. Out-of-scope "reverts" both lanes flagged were a stale shared-mirror `main` ref (diff regenerated single-commit; branch rebased).
- **R2** (8 fixed): fourth copy in `transcriptRenderers.tsx`; ChatPage fall-through role guard breaking on the exact refinement the doc invites (→ `isReasoningRole`); scan scope/spelling tolerance; post-fold placement asserted pre-fold; `chatRolesParity` extractor taught the predicate-dispatch idiom (the one full-suite red this change surfaced).
- **R3** (fixed): fifth/sixth copies in app-sdk `messageRenderers` (`undrawn`, `GROUPED_ROLES`); extractor over-credit on textual presence; `!==` scan gap; exact-member pin contradicting the invited change; `Set`-based role check.
- **R4**: Opus **PASS** (verified: no drift on any input incl. order-sensitive registry lists, no module-init hazard, no cycles, zero-match scan claim, no AUTOSDE engagement). Remaining findings tightened or dispositioned below.

**Documented trade-offs (accepted, with rationale):**
1. The parity extractor's dispatch check is textual (regex over raw source), not AST-binding: a comment spelling the exact dispatch shape could retain credit. Bounded by the predicate-idiom guard + structural scan + both-imports requirement; an AST parser inside a test file is disproportionate to the residual risk.
2. `app-sdk/messageRenderers` takes a value dependency on `pages/chat/groupDisplayItems` for a constant. app-sdk already imports nine `pages/chat` modules; the cycle-proof home is the chat-core extraction already planned in the parity test's own docblock, out of scope here.

## Testing

- `npx tsc -b` clean.
- `npx vitest run` full suite green: 25259 passed / 1 expected fail / 3 skipped (final full run had 6 files hit forks-worker startup timeouts under host load — all 6 pass in isolation, zero test failures).
- Targeted: `reasoningBurst.contract.test.tsx`, `chatRolesParity.contract.test.ts`, `groupDisplayItems.test.ts`, `TurnBlock.test.tsx`, `ChatMessageList.test.tsx`, `ChatPageCoverage.test.tsx` all green.
