### PR TITLE
fix: repr co-tenant names in reclaim refusal text (#6430)

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -935,7 +935,11 @@ def reclaim_block_reason() -> str:
         if _norm(kiro_home()) == home / KIRO_BASE_DIR_NAME:
             _protected, refusals = cotenant_sids()
             if refusals:
-                listed = "; ".join(f"{name} — {why}" for name, why in refusals[:3])
+                # !r, not plain interpolation: the directory name is
+                # agent-influenced and passes no identifier gate, so a newline
+                # or ANSI payload in it would forge a second record the moment
+                # a caller logs this text (the #6281/#6371 forgery class).
+                listed = "; ".join(f"{name!r} — {why}" for name, why in refusals[:3])
                 return (
                     f"{len(refusals)} other instance(s) sharing this kiro-cli session "
                     f"store make reclaiming unsafe ({listed}). Evict them with "
@@ -1578,9 +1582,13 @@ def _move_to_trash_locked(
     cotenant_now, refusals = cotenant_sids()
     if refusals:
         name, why = refusals[0]
+        # name!r, not plain interpolation: the directory name is agent-influenced
+        # and passes no identifier gate, so a newline or ANSI payload in it would
+        # forge a second record the moment a caller logs str(exc) (the
+        # #6281/#6371 forgery class).
         raise SessionStorageError(
             f"{len(refusals)} instance(s) sharing this session store make reclaiming "
-            f"unsafe ({name} — {why}); nothing was moved"
+            f"unsafe ({name!r} — {why}); nothing was moved"
         )
     live_sids = live_sids | cotenant_now
 

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2122,6 +2122,64 @@ class TestCotenantNamesAreLogSafe:
             assert all("\n" not in message for message in rendered)
 
 
+class TestCotenantRefusalTextIsForgeSafe:
+    """The raw co-tenant name also exits ``cotenant_sids`` inside the refusals
+    tuples and is interpolated into two downstream refusal-text surfaces. Neither
+    is a log line today, but one caller-side ``logger.warning(str(exc))`` away
+    from re-opening the #6281/#6371 forgery class — so both must carry the name
+    repr'd, exactly like the log sites ``TestCotenantNamesAreLogSafe`` pins
+    (refs #6430).
+    """
+
+    _FORGED = "wt-evil\nWARNING forged: reclaim authorized by operator\x1b[31m"
+    _REFUSALS = ((_FORGED, "its session map could not be parsed"),)
+
+    def test_reclaim_block_reason_escapes_the_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The listed refusals in the block reason render one-line and escaped.
+
+        Injected at the ``cotenant_sids`` seam rather than through the pod root:
+        Windows refuses a newline in a real directory name, and what is under
+        test is the CONSUMER's rendering, not discovery.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+
+        reason = session_storage.reclaim_block_reason()
+
+        assert "make reclaiming unsafe" in reason
+        assert repr(self._FORGED) in reason
+        # One line, no raw control bytes: the injected second record and the
+        # ANSI payload both survive only inside the repr's escapes.
+        assert "\n" not in reason
+        assert "\x1b" not in reason
+
+    def test_move_to_trash_refusal_error_escapes_the_name(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``SessionStorageError`` raised at the move renders one-line and
+        escaped, so a caller logging ``str(exc)`` cannot be used to forge a
+        second record.
+        """
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
+        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+
+        with pytest.raises(SessionStorageError, match="make reclaiming unsafe") as excinfo:
+            session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+        text = str(excinfo.value)
+        assert repr(self._FORGED) in text
+        assert "\n" not in text
+        assert "\x1b" not in text
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+
 class TestBuckets:
     def test_split_on_the_documented_edges(self, stores: tuple[Path, Path]) -> None:
         _, kiro_home = stores


### PR DESCRIPTION
# fix: repr co-tenant names in reclaim refusal text

Closes #6430

## Summary

PR #6391 (issue #6371) escaped the co-tenant directory name at the `cotenant_sids()` log sites (`%r` on both `logger.warning` calls), but the raw name still exits that function inside the refusals tuples and was interpolated **unescaped** into two downstream refusal-text surfaces:

1. `reclaim_block_reason()` — the `listed` string built from refusal names
2. `_move_to_trash_locked()` — the `SessionStorageError` message interpolating `refusals[0]`

Neither is a log line on today's main (consumers are a JSON body and a React text node), but the class is one caller-side `logger.warning(str(exc))` away from re-opening the #6281/#6371/#6344 log-forgery pattern.

## Fix

Escape at the **two consumer sites** with `!r` (option 2 from the issue), matching the `%r` convention #6391 established, so the escaping stays consistent across the class. Building the refusals tuple is left untouched — no copy-level change to how names are collected.

- The escape happens at message-construction time, so `str(exc)` and the `StorageReport.reclaim_blocked_reason` field are already-safe strings; a downstream logger cannot re-introduce the raw bytes.
- `repr()` escapes on `str.isprintable()`, so beyond the tested `\n` + ANSI it also covers `\r`, NEL, `U+2028`/`U+2029`, and bidi overrides.
- The `why` half of each tuple is a module-local literal and needs no escape.

## Consumer sweep

`cotenant_sids()` has exactly three call sites, all in `session_storage.py`: one discards the refusals tuple entirely; the other two are the sites fixed here. Nothing outside the module imports the function or the tuple — no fourth unescaped consumer exists.

## Tests

New `TestCotenantRefusalTextIsForgeSafe` (mirrors the existing `TestCotenantNamesAreLogSafe` from #6391): a forged name carrying a newline + ANSI payload, injected at the `cotenant_sids` seam (Windows refuses a newline in a real directory name, and the consumer's rendering is what is under test), asserting BOTH surfaces render one line, control-byte-free, with the name repr'd.

## Verification

- `pytest test/test_session_storage.py test/test_session_storage_api.py` — 209 passed
- Full backend suite — 71296 passed; the 104 failures are the documented host-env set (xdist budget, AF_UNIX path length, host-isolation floor), none in session_storage
- `isort` / `flake8` / `mypy` / diff-scoped black gate — clean

## Pre-push adversarial review

- Rounds: 1 (dual blind, cross-model)
- GPT lane: PASS, zero findings
- Opus lane: PASS, 3 non-blocking advisories, all noise or pre-existing (refusals[0]-vs-count asymmetry predates this diff; repr quote-style is cosmetic and tests are immune; the React text-node consumer auto-escapes independently of this fix)
- Verdict: CLEAN

No UI change — no screenshots.
