### PR TITLE
fix(ci): dedupe the split-pane chat harness page wiring

### DIFF
--- a/website/scripts/capture-chatpane-queue-edit.mjs
+++ b/website/scripts/capture-chatpane-queue-edit.mjs
@@ -19,6 +19,7 @@
  * Usage: node scripts/capture-chatpane-queue-edit.mjs <baseUrl> <outDir>
  */
 import { chromium } from 'playwright'
+import { prepareSplitChatPage } from './lib/prepare-split-chat-page.mjs'
 import { mkdirSync } from 'node:fs'
 
 const BASE = process.argv[2] || 'http://127.0.0.1:3000'
@@ -92,32 +93,14 @@ const FIXTURES = {
 }
 
 async function preparePage(context) {
-  const page = await context.newPage()
-  await page.routeWebSocket(/\/api\/ws/, () => {})
-  await page.route(url => url.pathname.startsWith('/api/'), async route => {
-    const path = new URL(route.request().url()).pathname
-    if (path in FIXTURES) return json(route, FIXTURES[path])
-    // Queue mutations (PATCH edit, DELETE cancel, reorder) get a plain ack —
-    // answering them with a slot-detail body would feed the client a bogus
-    // shape at exactly the moment this capture exercises the edit path.
-    if (route.request().method() !== 'GET') return json(route, { ok: true })
-    const slotMatch = path.match(/^\/api\/chat\/slots\/([^/]+)/)
-    if (slotMatch) return json(route, decodeURIComponent(slotMatch[1]) === 'pane-b' ? detailB : detailA)
-    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
-    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
-    return json(route, objectish ? {} : [])
+  // Queue mutations (PATCH edit, DELETE cancel, reorder) ride the shared
+  // helper's plain-ack branch — answering them with a slot-detail body would
+  // feed the client a bogus shape at exactly the moment this capture
+  // exercises the edit path. Readiness is gated by the Pencil waitFor in
+  // main(), not a fixed sleep.
+  return prepareSplitChatPage(context, {
+    base: BASE, fixtures: FIXTURES, detailA, detailB, splitLayouts, json,
   })
-  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 200)))
-  await page.addInitScript((layouts) => {
-    localStorage.setItem('mc-theme', 'dark')
-    localStorage.setItem('mc-onboarded', '1')
-    localStorage.setItem('mc-active-slot', 'pane-a')
-    localStorage.setItem('mc-split-layouts', layouts)
-  }, JSON.stringify(splitLayouts))
-  await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' })
-  // Readiness is gated by the Pencil waitFor in main(), not a fixed sleep —
-  // fixed sleeps are the usual source of harness flake on a loaded runner.
-  return page
 }
 
 async function main() {

--- a/website/scripts/capture-chatpane-upload-error.mjs
+++ b/website/scripts/capture-chatpane-upload-error.mjs
@@ -30,6 +30,7 @@
  * Usage: node scripts/capture-chatpane-upload-error.mjs [outDir]
  */
 import { chromium } from 'playwright'
+import { prepareSplitChatPage } from './lib/prepare-split-chat-page.mjs'
 import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -99,32 +100,17 @@ const FIXTURES = {
 }
 
 async function preparePage(context) {
-  const page = await context.newPage()
-  await page.routeWebSocket(/\/api\/ws/, () => {})
-  await page.route(url => url.pathname.startsWith('/api/'), async route => {
-    const path = new URL(route.request().url()).pathname
+  return prepareSplitChatPage(context, {
+    base, fixtures: FIXTURES, detailA, detailB, splitLayouts, json,
     // THE POINT OF THIS HARNESS: the server refuses the upload with a non-2xx
     // carrying an `error`. api.uploadFiles turns that into a RESOLVED
     // { paths: [], error } -- never a throw -- which is exactly the shape that
     // used to vanish in this pane.
-    if (path === '/api/upload/file') return json(route, { error: REFUSAL }, 400)
-    if (path in FIXTURES) return json(route, FIXTURES[path])
-    if (route.request().method() !== 'GET') return json(route, { ok: true })
-    const slotMatch = path.match(/^\/api\/chat\/slots\/([^/]+)/)
-    if (slotMatch) return json(route, decodeURIComponent(slotMatch[1]) === 'pane-b' ? detailB : detailA)
-    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
-    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
-    return json(route, objectish ? {} : [])
+    pre: async (path, route) => {
+      if (path === '/api/upload/file') { await json(route, { error: REFUSAL }, 400); return true }
+      return false
+    },
   })
-  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 200)))
-  await page.addInitScript((layouts) => {
-    localStorage.setItem('mc-theme', 'dark')
-    localStorage.setItem('mc-onboarded', '1')
-    localStorage.setItem('mc-active-slot', 'pane-a')
-    localStorage.setItem('mc-split-layouts', layouts)
-  }, JSON.stringify(splitLayouts))
-  await page.goto(base + '/', { waitUntil: 'domcontentloaded' })
-  return page
 }
 
 const { srv, base } = await serveDist()

--- a/website/scripts/lib/prepare-split-chat-page.mjs
+++ b/website/scripts/lib/prepare-split-chat-page.mjs
@@ -1,0 +1,45 @@
+/**
+ * Shared page wiring for the split-pane chat capture harnesses: route every
+ * /api/** call to the harness's FIXTURES map with the pane-detail fallback,
+ * silence the websocket, seed the persisted split layout, and open the app.
+ *
+ * Extracted from capture-chatpane-queue-edit.mjs when
+ * capture-chatpane-upload-error.mjs shipped the identical stanza (the jscpd
+ * gate runs at 0% duplication over scripts/).
+ *
+ * @param context Playwright browser context
+ * @param opts.base         app origin to open
+ * @param opts.fixtures     path -> body map answered first (after `pre`)
+ * @param opts.detailA      slot-detail body for every pane but pane-b
+ * @param opts.detailB      slot-detail body for pane-b
+ * @param opts.splitLayouts mc-split-layouts object to persist
+ * @param opts.json         the harness's json(route, body[, status]) responder
+ * @param opts.pre          optional (path, route) handler tried FIRST, for
+ *                          harness-specific intercepts (e.g. a 400 upload)
+ */
+export async function prepareSplitChatPage(context, { base, fixtures, detailA, detailB, splitLayouts, json, pre = null }) {
+  const page = await context.newPage()
+  await page.routeWebSocket(/\/api\/ws/, () => {})
+  await page.route(url => url.pathname.startsWith('/api/'), async route => {
+    const path = new URL(route.request().url()).pathname
+    if (pre && (await pre(path, route))) return
+    if (path in fixtures) return json(route, fixtures[path])
+    // Mutations (PATCH/POST/DELETE) get a plain ack -- answering them with a
+    // slot-detail body would feed the client a bogus shape mid-interaction.
+    if (route.request().method() !== 'GET') return json(route, { ok: true })
+    const slotMatch = path.match(/^\/api\/chat\/slots\/([^/]+)/)
+    if (slotMatch) return json(route, decodeURIComponent(slotMatch[1]) === 'pane-b' ? detailB : detailA)
+    if (path.startsWith('/api/instances')) return json(route, { instances: [], active: '' })
+    const objectish = /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
+    return json(route, objectish ? {} : [])
+  })
+  page.on('pageerror', err => console.log('PAGEERROR:', String(err).slice(0, 200)))
+  await page.addInitScript((layouts) => {
+    localStorage.setItem('mc-theme', 'dark')
+    localStorage.setItem('mc-onboarded', '1')
+    localStorage.setItem('mc-active-slot', 'pane-a')
+    localStorage.setItem('mc-split-layouts', layouts)
+  }, JSON.stringify(splitLayouts))
+  await page.goto(base + '/', { waitUntil: 'domcontentloaded' })
+  return page
+}


### PR DESCRIPTION
## Summary

Repo-wide jscpd is red on every merge ref: `capture-chatpane-queue-edit.mjs` and `capture-chatpane-upload-error.mjs` carry the same 14-line `preparePage` stanza (route fallback, websocket silence, split-layout seed, app open). This is the sibling of #6434, which cleared the other clone pair (aws-control / hero-art-proxy) via `serveDist`.

Extracts the stanza into `scripts/lib/prepare-split-chat-page.mjs` with a `pre` hook carrying the upload harness's 400 intercept.

- `npx jscpd .` in `website/`: **0 clones** (was 1 pair)
- `node --check` on all three files: clean
- Behavior-preserving: the upload harness reaches the same state before and after (verified by running both versions locally — it progresses to the 2-pane split identically; its banner-wait failure is pre-existing on main in this environment, unrelated to the dedupe)

Unblocks the Frontend Lint & Type Check job for every open frontend PR (first observed on #6419's merge ref).