### PR TITLE
fix(cron): tell a scoped-empty cron_list apart from an empty registry

### DIFF
--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -958,7 +958,12 @@ def _list_tools() -> list[dict[str, Any]]:
                 'full last_error/last_result). Pass ids=["<job_id>", ...] '
                 "to fetch full bodies for only those jobs (drill-in "
                 "pattern after a compact list). ids takes precedence over "
-                "verbose."
+                "verbose. SCOPED TO THE CALLING SESSION: only jobs this "
+                "session owns are listed, so an empty result means none are "
+                "owned HERE, not that none are scheduled. Jobs owned by "
+                "another session, or created without one (the CLI, the "
+                "onboarding importer), are managed with `kirocrew cron list` "
+                "or on the dashboard Schedule page."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1671,6 +1676,34 @@ def _check_cron_job_ownership(svc: "CronService", job_id: str) -> str | None:
     return None
 
 
+#: The answer when rows exist but none are in the caller's scope, kept DISTINCT
+#: from the store-is-empty ``"No cron jobs."``.
+#:
+#: One string served both states until #6447, and a filtered result reading
+#: "nothing is scheduled" is actively misleading: an operator whose 15 jobs were
+#: all enabled and running on schedule read it and concluded this server was
+#: pointed at a different store. The scoping decision was legible only in the SEL
+#: row that records it (``kept=0 withheld=N``), and an audit log is the right
+#: place to keep that record, not the only place to explain it.
+#:
+#: ``dashboard/handlers/cron.py`` already documents the invariant this sentence
+#: states -- "cron_list only shows a session its own jobs, so a job whose key is
+#: empty ... [is] manageable only from this page or the CLI". The knowledge was
+#: written down; the message a caller actually sees just did not carry it.
+#:
+#: Deliberately WITHOUT a count of what was withheld. :data:`_UNOWNED` exists
+#: because an identified session is not necessarily the operator, and "N jobs
+#: exist that you may not see" discloses the admin surface's volume to exactly
+#: that principal. Naming the two surfaces that CAN reach those rows discloses
+#: nothing further: both already require the operator's own machine.
+_SCOPED_EMPTY = (
+    "No cron jobs owned by this session. Jobs owned by another session, or "
+    "created without one (the CLI and the onboarding importer), are outside "
+    "this session's scope and are not listed here. Manage those with "
+    "`kirocrew cron list` or on the dashboard Schedule page."
+)
+
+
 def _owned_by(jobs: list[CronJob], session_key: str) -> list[CronJob]:
     """The jobs *session_key* may reach -- for reading and for writing alike.
 
@@ -1709,7 +1742,9 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             session_key = _authz_session_key()
             jobs = _audit_list_scope(_owned_by(jobs, session_key), jobs, session_key)
             if not jobs:
-                return "No cron jobs."
+                # NOT the store-empty string above: rows exist, they are just out
+                # of scope. See _SCOPED_EMPTY for why the two must differ.
+                return _SCOPED_EMPTY
         # Drill-in: ids filter forces full bodies for matching jobs only.
         if ids_filter:
             id_set = set(ids_filter)

--- a/test/test_mcp_cron_caller_identity.py
+++ b/test/test_mcp_cron_caller_identity.py
@@ -417,3 +417,67 @@ def test_remove_all_never_sweeps_an_ownerless_row() -> None:
     after = CronService(base_dir=mcp_cron.config_dir())
     assert after.get_job(kept.id) is not None
     assert after.get_job(mine) is None
+
+
+# --- 6: the scoping decision has to be legible in the ANSWER ----------------
+
+
+def test_a_scoped_empty_list_does_not_read_as_an_empty_registry() -> None:
+    """The distinction the whole of #6447 is about.
+
+    Bob owns nothing, Alice owns a job. Bob's answer must not be the string a
+    caller gets when the registry is genuinely empty, because that reads as
+    "nothing is scheduled" and sends the reader looking for a broken store. The
+    inequality below is the actual invariant; the wording can change freely
+    underneath it.
+    """
+    _as_session("dashboard:alice")
+    _add_job(f"alice-{uuid.uuid4().hex[:8]}")
+
+    _as_session("dashboard:bob")
+    out = _call_tool_inner("cron_list", {})
+
+    assert out != "No cron jobs."
+    assert out == mcp_cron._SCOPED_EMPTY
+    # It has to leave the reader somewhere to go, or it only relabels the dead end.
+    assert "cron list" in out and "Schedule page" in out
+
+
+def test_a_genuinely_empty_registry_still_says_so() -> None:
+    """The other half of the same invariant: two states, two strings.
+
+    Without this, collapsing both branches back onto one message would still pass
+    the test above.
+    """
+    _as_session("dashboard:alice")
+    assert _call_tool_inner("cron_list", {}) == "No cron jobs."
+
+
+def test_an_unidentified_caller_is_told_its_scope_is_empty_not_the_store() -> None:
+    """The branch where the MOST is withheld gets the clearest answer.
+
+    ``caller=None`` on a pooled connection withholds every row, so this caller is
+    the one most likely to misread an empty list as an empty registry.
+    """
+    _as_session("dashboard:owner")
+    _add_job(f"owned-{uuid.uuid4().hex[:8]}")
+
+    set_current_caller(None)
+    out = _call_tool_inner("cron_list", {})
+
+    assert out == mcp_cron._SCOPED_EMPTY
+    assert out != "No cron jobs."
+
+
+def test_the_tool_description_warns_that_the_list_is_scoped() -> None:
+    """A caller should not have to hit the empty case to learn the rule.
+
+    The message fixes the symptom after the fact; the description is what stops a
+    caller concluding "no scheduled work exists" from a filtered result it never
+    knew was filtered.
+    """
+    spec = next(t for t in mcp_cron._list_tools() if t["name"] == "cron_list")
+    desc = spec["description"]
+
+    assert "SCOPED TO THE CALLING SESSION" in desc
+    assert "not that none are scheduled" in desc


### PR DESCRIPTION
## 1. What is the problem?

`cron_list` returned the same string, `No cron jobs.`, for two materially different facts:

1. the registry is empty, and
2. the registry holds N jobs and the ownership filter kept none of them.

The filter itself is correct and deliberate: `_owned_by()` keeps only rows whose `session_key` equals the caller's, ownerless rows are outside every MCP session's scope, and an unidentifiable caller gets nothing rather than everything. Only the *reporting* of the scoped-empty case was wrong - it fell through to the store-is-empty message. The tool description ("List scheduled cron jobs") did not mention session scoping either, so a caller had nothing telling it the result had been filtered.

## 2. Why this issue matters to the user

Observed on a live gateway with 15 enabled jobs, every one of them running on schedule (`last_status: ok`, each interval job within 1x its period). `cron_list` from a chat session answered `No cron jobs.`

Both readings the operator could form from that output were wrong, and neither was falsifiable from the output: that the MCP server was pointed at a different store, or that the registry had never loaded. Recovering the truth took reading the module source and then the audit trail, where the answer did exist:

```
operation=cron_list  tool_kind=authz  outcome=denied
  resources='session=dashboard:chat-<n> kept=0 withheld=15'
```

Two consequences worth separating:

- A user-facing scoping decision was legible only in the SEL log. The audit row is the right place to keep the *record*; it should not be the only place that carries the *explanation*.
- The symptom leads a reader straight to #4663 (cron service not hydrating from `crons.json`), which is a different bug. `withheld=15` proves `list_jobs()` returned all 15 rows, so the store was read correctly and hydration is not implicated. Anyone hitting this would otherwise spend their time on a non-cause.

Worth noting how avoidable this was: `dashboard/handlers/cron.py` already documents the exact invariant the message failed to convey - "cron_list only shows a session its own jobs, so a job whose key is empty ... [is] manageable only from this page or the CLI". The knowledge was written down. The message a caller actually sees just did not carry it.

## 3. How our fix solves it

Chain from symptom to root cause:

- symptom: `No cron jobs.` while 15 jobs exist and are running
- because: the scoped-empty branch returns the store-empty message
- because: that branch was written when the filter was a no-op for gateway callers, so scoped-empty could not occur in practice
- root cause: one string serving two states, with no scoping statement in the tool description to make the filter visible before a caller trips over it

The fix addresses both halves:

- The scoped-empty branch returns its own message (`_SCOPED_EMPTY`), which says the rows are out of this session's scope and names the two surfaces that can reach them - `kirocrew cron list` and the dashboard Schedule page. Verified against the code, not assumed: the CLI drives `CronService` directly and the dashboard `GET /api/crons` handler lists all rows with no session filter.
- The `cron_list` description states the scoping, so a caller knows the result is filtered without having to hit the empty case to find out.

Deliberately **without a count** of the withheld rows. A count would have shortened the original diagnosis, but `_UNOWNED` exists precisely because an identified session is not necessarily the operator - an allowlisted Slack or Telegram participant gets a session of its own - and "N jobs exist that you may not see" discloses the admin surface's volume to exactly that principal. The wording alone removes the ambiguity that produced this report. Naming the two recovery surfaces discloses nothing further, since both already require the operator's own machine.

Behaviour otherwise unchanged: no row becomes visible that was not visible before, and `_audit_list_scope` still records the decision exactly as it did.

## 4. What tests we did

Four new tests in `test/test_mcp_cron_caller_identity.py`, the module that owns cron authorization:

- a scoped-empty result is not the store-empty string, is `_SCOPED_EMPTY`, and names both recovery surfaces (the inequality is the real invariant; the wording can change under it)
- a genuinely empty registry still returns `No cron jobs.`, so the two states stay distinguishable
- the unidentifiable-caller branch, where the most is withheld, also gets the scoped answer
- the tool description carries the scoping statement

Gates on the changed files: `isort` clean, `flake8` clean, `mypy` clean. Targeted suites green - `test_mcp_cron_caller_identity.py`, `test_mcp_cron_list_compact.py`, `test_cron_session_scope.py`: 59 passed.

Mutation-verified by reverting only the source file to the base commit and re-running the new tests: 3 of the 4 go red with the intended reasons (`assert 'No cron jobs.' != 'No cron jobs.'`; the description assertion; `_SCOPED_EMPTY` absent). The fourth, `test_a_genuinely_empty_registry_still_says_so`, correctly passes on both sides - it pins behaviour that must NOT change.

Also confirmed the existing equality assertions in `test_mcp_cron_list_compact.py::TestCronListEmpty` are untouched: those seed no jobs, so they exercise the store-empty branch, not the scoped one.

## 5. Any other suggestions on the work

One observation found while verifying the message, deliberately NOT changed here: `KIROCREW_CLI` is read at `_caller_is_cli()` and set nowhere in shipped code (only in tests, a spec doc, and a pod e2e script), so the CLI admin bypass on this surface never fires in production. That is consistent rather than broken - the CLI drives `CronService` directly and never routes through this server - but it does mean the bypass is vestigial for the MCP path, and the docstrings describing it read as if it were live. Worth a separate look, not a change on a message fix.

Closes #6447
