### PR TITLE
fix(sel): stop recording the caller's session key as the audit tool_kind

### DIFF
--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -617,11 +617,19 @@ def call_tool_with_logging(
     try:
         args = validate_fn(name, raw_args)
     except ValidationError as e:
+        # No ``tool_kind``: it is a CLASSIFICATION of the invocation -- callers
+        # that write their own rows pass things like "authz" -- and this wrapper
+        # has no per-tool taxonomy to supply. It used to pass ``session_key``,
+        # which is both wrong and redundant, since ``caller_identity`` on the same
+        # record already carries it. The effect was that every row written through
+        # here, across all five MCP servers, held a high-cardinality session key
+        # where a kind belongs, which made the field useless to filter or
+        # aggregate on while still looking populated (#6448). The parameter
+        # defaults to "", and an honestly empty kind beats a false one.
         sel().log_tool_invocation(
             session_key=session_key,
             source="mcp",
             tool_name=name,
-            tool_kind=session_key,
             outcome="failed",
             downstream_service=downstream_service,
             error=str(e),
@@ -646,7 +654,7 @@ def call_tool_with_logging(
         session_key=session_key,
         source="mcp",
         tool_name=name,
-        tool_kind=session_key,
+        # No ``tool_kind`` -- see the ValidationError path above.
         outcome=outcome,
         downstream_service=downstream_service,
         resources=resources,

--- a/test/test_mcp_shared.py
+++ b/test/test_mcp_shared.py
@@ -535,6 +535,70 @@ class TestCallToolWithLoggingRedaction:
         assert "slug" in captured.get("resources", "")
 
 
+class TestCallToolWithLoggingKind:
+    """``tool_kind`` classifies the invocation; it must not hold the caller.
+
+    The wrapper passed ``session_key`` as ``tool_kind``, so every row it wrote --
+    the bulk of the agent tool surface, across all five MCP servers -- carried a
+    high-cardinality session key where a kind belongs, sitting in the same file as
+    correctly-kinded rows written directly by callers. The field looked populated
+    and trustworthy while carrying no kind at all.
+    """
+
+    _CALLER = "dashboard:chat-7"
+
+    def _capture(self, *, raises: bool = False) -> dict:
+        from kiro_crew.mcp_shared import call_tool_with_logging
+        from kiro_crew.validation import ValidationError
+
+        captured: dict = {}
+
+        class _FakeSel:
+            def log_tool_invocation(self, **kw):
+                captured.update(kw)
+
+        def _validate(_name, raw):
+            if raises:
+                raise ValidationError("slug", "bad arg")
+            return raw
+
+        def _inner(_name, _args):
+            return "ok"
+
+        with patch("kiro_crew.mcp_shared.sel", return_value=_FakeSel()):
+            call_tool_with_logging(
+                "artifact_list",
+                {"slug": "doc"},
+                _validate,
+                _inner,
+                session_key=self._CALLER,
+                downstream_service="kirocrew-core",
+            )
+        assert captured, "the wrapper wrote no audit row at all"
+        return captured
+
+    def test_the_success_row_does_not_put_the_caller_in_tool_kind(self):
+        captured = self._capture()
+        assert captured.get("tool_kind", "") != self._CALLER
+
+    def test_the_validation_failure_row_does_not_either(self):
+        """The other call site. It was the same copy of the same wrong variable,
+        so fixing only the success path would leave every rejected call mislabeled.
+        """
+        captured = self._capture(raises=True)
+        assert captured["outcome"] == "failed"
+        assert captured.get("tool_kind", "") != self._CALLER
+
+    @pytest.mark.parametrize("raises", [False, True])
+    def test_the_caller_is_still_recorded_on_both_paths(self, raises):
+        """Guards the obvious wrong fix: dropping the caller instead of the kind.
+
+        ``session_key`` is what SEL stores as ``caller_identity``, and it is the
+        field the ownership and attribution questions are answered from.
+        """
+        assert self._capture(raises=raises)["session_key"] == self._CALLER
+
+
 # --- run_mcp_stdio_loop busy-queue behavior ----------------------------------
 #
 # A tools/call arriving while a worker is busy used to be silently dropped:


### PR DESCRIPTION
## 1. What is the problem?

`call_tool_with_logging` in `src/kiro_crew/mcp_shared.py` passed the caller's session key as the audit record's `tool_kind`, at both of its SEL call sites - the `ValidationError` path and the success path:

```python
sel().log_tool_invocation(
    session_key=session_key,
    source="mcp",
    tool_name=name,
    tool_kind=session_key,     # a session key, not a kind
    ...
)
```

`tool_kind` is a classification of the invocation; the surrounding code uses it that way (`"authz"` for an authorization decision, `"search"` and `"execute"` on rows written elsewhere). The session key is already carried by `caller_identity` on the same record, so the field was simultaneously wrong and redundant.

Two rows from a single `cron_list` call, side by side in `security_events.jsonl`:

```
operation=cron_list  tool_kind=authz                outcome=denied
operation=cron_list  tool_kind=dashboard:chat-<n>   outcome=completed
```

## 2. Why this issue matters to the user

Blast radius is every MCP tool in every server that routes through the shared wrapper - `mcp_core`, `mcp_cron`, `mcp_dashboard`, `mcp_computer`, and the mochi app server - which is the bulk of the agent tool surface. So most `tool_invocation` rows on the trail carried a corrupted kind.

- `tool_kind` could not be used to filter or aggregate the trail. "Show me every execute-kind invocation" was unanswerable, because the field held a high-cardinality session key.
- The failure was silent and looked like success. Correctly-kinded rows written directly by callers sit in the same file, so the column appeared populated and trustworthy; nothing signalled that most rows never had a kind.
- It degraded the audit trail for exactly the review task it exists to serve. Integrity was never affected - the HMAC chain covers the bytes actually written, so no existing chain is invalidated by this change.

## 3. How our fix solves it

Chain from symptom to root cause:

- symptom: most `tool_invocation` rows carry a session key where a kind belongs
- because: the shared wrapper hardcodes `tool_kind=session_key` at both call sites
- because: `log_tool_invocation` takes `session_key` and `tool_kind` as adjacent keyword strings with `tool_kind` defaulting to `""`, so passing the wrong one is accepted silently
- root cause: a copy of the wrong variable into an adjacent same-typed optional field, with nothing at the call site asserting that a kind is a kind

Both sites now omit the argument, which already defaults to empty. No per-tool taxonomy is invented here: the wrapper has none to draw on, and an honestly empty kind beats a false one. Nothing else about the record changes - `caller_identity`, `operation`, `outcome`, `resources` and the redaction of serialized args are all as before.

## 4. What tests we did

New `TestCallToolWithLoggingKind` class in `test/test_mcp_shared.py`:

- the success-path row does not carry the caller's session key in `tool_kind`
- the validation-failure-path row does not either (it was the same copy of the same wrong variable, so fixing one path would have left every rejected call mislabeled)
- parametrized over both paths: `session_key` is still recorded, which guards the obvious wrong fix of dropping the caller instead of the kind
- the helper asserts a row was written at all, so a wrapper that silently stopped auditing could not pass by writing nothing

Gates on the changed files: `isort` clean, `flake8` clean, `mypy` clean. Suites green for the wrapper and for two servers that route through it - `test_mcp_shared.py`, `test_mcp_cron_caller_identity.py`, `test_mochi_mcp_server.py`: 98 passed.

Mutation-verified by reverting only the source file to the base commit and re-running the new class: both kind assertions go red with the intended reason (`assert 'dashboard:chat-7' != 'dashboard:chat-7'`). The two caller-identity assertions correctly pass on both sides - they pin behaviour that must NOT change.

## 5. Any other suggestions on the work

If a real per-tool taxonomy is wanted, the natural shape is a kind supplied by each server at its own `call_tool_with_logging` call site (five sites), so the classification comes from somewhere that knows the tool. That is a separate change from removing a wrong value, and it should not gate this fix: the field is more useful empty than false in the meantime.

Closes #6448
