### PR TITLE
fix: anchor alloc-watch stack trim on V8 and skip browsers (#6427)

### DIFF
--- a/website/electron/big-alloc-log.js
+++ b/website/electron/big-alloc-log.js
@@ -135,8 +135,12 @@ function createBigAllocLog({ capacity = DEFAULT_CAPACITY, now } = {}) {
 
     /** Drains the buffer into log lines: summary first, then each event oldest to
      *  newest. Returns [] when nothing was buffered, so a crash with no large
-     *  allocations adds no noise — itself a signal that points away from a
-     *  binary-buffer OOM. */
+     *  allocations adds no noise. An empty flush rules out only large
+     *  JS-constructed buffers in the main frame — the renderer's watcher sees JS
+     *  constructor calls at or above its threshold in the top-level document,
+     *  not host-API backing stores, cumulative sub-threshold buffers,
+     *  resizable-ArrayBuffer growth, or allocations made off the main frame
+     *  (workers, subframes, WASM memory). */
     flush() {
       if (entries.length === 0) return [];
       const lines = [renderSummary(entries), ...entries.map(renderEvent)];

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -2368,8 +2368,12 @@ function createWindow() {
     for (const line of pierrePerfLog.flush()) glog(line);
     // Then the large-allocation history: on a cage OOM the last entries name the
     // binary buffer that pierre-perf's near-empty heap numbers cannot. Also
-    // unconditional, also empty-is-informative (no large allocation in the
-    // lead-up points away from a binary-buffer OOM).
+    // unconditional. An empty flush rules out only LARGE JS-CONSTRUCTED buffers
+    // IN THE MAIN FRAME: the watcher sees JS constructor calls at or above its
+    // threshold in the top-level document, so a cage exhausted by host-API
+    // backing stores, cumulative sub-threshold buffers, a grown resizable
+    // ArrayBuffer, or allocations made off the main frame (workers, subframes,
+    // WASM memory) flushes empty too.
     for (const line of bigAllocLog.flush()) glog(line);
     rendererRecovery.handleGone(details || {});
   });

--- a/website/src/lib/allocWatch.test.ts
+++ b/website/src/lib/allocWatch.test.ts
@@ -17,23 +17,23 @@ function freshScope(): Scope {
   return { ArrayBuffer, Uint8Array, Float64Array } as Scope
 }
 
+// Small threshold so tiny allocations trip it deterministically.
+const TEST_MIN_BYTES = 1024
+
 beforeEach(() => {
   reporter = vi.fn()
   ;(window as unknown as { electronAPI?: unknown }).electronAPI = { reportBigAlloc: reporter }
-  // Small threshold so tiny allocations trip it deterministically.
-  ;(globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number }).__KIROCREW_BIG_ALLOC_BYTES__ = 1024
   scope = freshScope()
 })
 
 afterEach(() => {
   uninstallAllocWatch()
   delete (window as unknown as { electronAPI?: unknown }).electronAPI
-  delete (globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number }).__KIROCREW_BIG_ALLOC_BYTES__
 })
 
 describe('installAllocWatch', () => {
   it('reports an ArrayBuffer allocation at or above the threshold', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     new scope.ArrayBuffer(2048)
     expect(reporter).toHaveBeenCalledTimes(1)
     const ev = reporter.mock.calls[0][0]
@@ -42,17 +42,60 @@ describe('installAllocWatch', () => {
     expect(ev.outcome).toBe('requested')
     expect(typeof ev.stack).toBe('string')
     // Its own frames are stripped, so the site is the caller, not the watcher.
-    expect(ev.stack).not.toMatch(/allocWatch/)
+    expect(ev.stack).not.toMatch(/allocWatch\.ts/)
+  })
+
+  it('leads the reported stack with the caller, not watcher machinery', () => {
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
+    function allocSiteForStackTest(): ArrayBuffer {
+      return new scope.ArrayBuffer(2048)
+    }
+    allocSiteForStackTest()
+    const ev = reporter.mock.calls[0][0]
+    // The trim is anchored on the construct trap by FUNCTION REFERENCE
+    // (Error.captureStackTrace), so it holds even when a minifier renames every
+    // identifier in the watcher module: the first frame is the allocation site.
+    const firstFrame = String(ev.stack).split(' <- ')[0]
+    expect(firstFrame).toContain('allocSiteForStackTest')
   })
 
   it('does not report allocations below the threshold', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     new scope.ArrayBuffer(512)
     expect(reporter).not.toHaveBeenCalled()
   })
 
-  it('sizes typed arrays by element count times BYTES_PER_ELEMENT', () => {
+  it('uses the 64 MiB default threshold when no minBytes option is passed', () => {
+    // Allocation-free stub: requestedBytes reads only args[0] and
+    // BYTES_PER_ELEMENT, so the boundary is provable without materializing two
+    // real 64 MiB backing stores inside a cage-sensitive test runner.
+    function ArrayBufferStub(this: unknown, _n: number) {}
+    scope.ArrayBuffer = ArrayBufferStub as unknown as typeof ArrayBuffer
     installAllocWatch(scope)
+    new (scope.ArrayBuffer as typeof ArrayBuffer)(DEFAULT_MIN_BYTES - 1)
+    expect(reporter).not.toHaveBeenCalled()
+    new (scope.ArrayBuffer as typeof ArrayBuffer)(DEFAULT_MIN_BYTES)
+    expect(reporter).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a non-positive minBytes option and keeps the default', () => {
+    installAllocWatch(scope, { minBytes: -1 })
+    new scope.ArrayBuffer(2048)
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('ignores a non-finite minBytes option and keeps the default', () => {
+    // Infinity would silently disable all reporting; it must fall back to the
+    // default threshold instead. Stubbed for the same reason as above.
+    function ArrayBufferStub(this: unknown, _n: number) {}
+    scope.ArrayBuffer = ArrayBufferStub as unknown as typeof ArrayBuffer
+    installAllocWatch(scope, { minBytes: Infinity })
+    new (scope.ArrayBuffer as typeof ArrayBuffer)(DEFAULT_MIN_BYTES)
+    expect(reporter).toHaveBeenCalledTimes(1)
+  })
+
+  it('sizes typed arrays by element count times BYTES_PER_ELEMENT', () => {
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     new scope.Float64Array(300) // 300 * 8 = 2400 bytes >= 1024
     expect(reporter).toHaveBeenCalledTimes(1)
     const ev = reporter.mock.calls[0][0]
@@ -62,13 +105,13 @@ describe('installAllocWatch', () => {
 
   it('ignores a typed array constructed as a view over an existing buffer', () => {
     const buf = new ArrayBuffer(4096) // real global, pre-install
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     new scope.Uint8Array(buf) // first arg is a buffer, not a length: no fresh allocation
     expect(reporter).not.toHaveBeenCalled()
   })
 
   it('reports a failed allocation and rethrows', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     expect(() => new scope.ArrayBuffer(Number.MAX_SAFE_INTEGER)).toThrow()
     // one "requested" before, one "failed" after
     expect(reporter).toHaveBeenCalledTimes(2)
@@ -79,29 +122,40 @@ describe('installAllocWatch', () => {
   })
 
   it('preserves instanceof for wrapped constructors', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     const ab = new scope.ArrayBuffer(8)
     expect(ab instanceof ArrayBuffer).toBe(true)
     const ta = new scope.Uint8Array(8)
     expect(ta instanceof Uint8Array).toBe(true)
   })
 
-  it('no-ops when electronAPI is absent (does not throw)', () => {
+  it('returns early when electronAPI is absent, leaving constructors pristine', () => {
     delete (window as unknown as { electronAPI?: unknown }).electronAPI
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
+    // A plain-browser dashboard can never report, so it must not pay for (or
+    // carry the identity caveats of) patched constructors.
+    expect(scope.ArrayBuffer).toBe(ArrayBuffer)
+    expect(scope.Uint8Array).toBe(Uint8Array)
     expect(() => new scope.ArrayBuffer(2048)).not.toThrow()
     expect(reporter).not.toHaveBeenCalled()
   })
 
+  it('returns early when electronAPI exists without reportBigAlloc', () => {
+    ;(window as unknown as { electronAPI?: unknown }).electronAPI = {}
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
+    expect(scope.ArrayBuffer).toBe(ArrayBuffer)
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
   it('is idempotent: a second install does not double-wrap', () => {
-    installAllocWatch(scope)
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     new scope.ArrayBuffer(2048)
     expect(reporter).toHaveBeenCalledTimes(1)
   })
 
   it('uninstall restores the original constructors', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     uninstallAllocWatch()
     expect(scope.ArrayBuffer).toBe(ArrayBuffer)
     new scope.ArrayBuffer(2048)
@@ -109,7 +163,7 @@ describe('installAllocWatch', () => {
   })
 
   it('caps reports per session to bound IPC against a runaway allocator', () => {
-    installAllocWatch(scope)
+    installAllocWatch(scope, { minBytes: TEST_MIN_BYTES })
     for (let i = 0; i < 4100; i++) new scope.ArrayBuffer(2048)
     // MAX_REPORTS_PER_SESSION is 4096; anything past it is dropped.
     expect(reporter).toHaveBeenCalledTimes(4096)

--- a/website/src/lib/allocWatch.ts
+++ b/website/src/lib/allocWatch.ts
@@ -57,8 +57,8 @@ export interface BigAllocEvent {
 
 /** Default threshold: 64 MiB. Large enough that a normal session never trips it
  *  (icons, avatars, ordinary payloads are kilobytes), small enough to catch the
- *  binary buffers that pressure a 4 GB cage. Overridable at runtime via
- *  `globalThis.__KIROCREW_BIG_ALLOC_BYTES__` for tuning without a rebuild. */
+ *  binary buffers that pressure a 4 GB cage. Overridable per install via the
+ *  `minBytes` option — tests pass a tiny value to trip it deterministically. */
 export const DEFAULT_MIN_BYTES = 64 * 1024 * 1024
 
 /** Bounds IPC even if something allocates large buffers in a loop. The main-side
@@ -99,12 +99,7 @@ interface Patched {
 
 let installed: Patched[] | null = null
 let reportCount = 0
-
-function minBytes(): number {
-  const override = (globalThis as unknown as { __KIROCREW_BIG_ALLOC_BYTES__?: number })
-    .__KIROCREW_BIG_ALLOC_BYTES__
-  return typeof override === 'number' && override > 0 ? override : DEFAULT_MIN_BYTES
-}
+let activeMinBytes = DEFAULT_MIN_BYTES
 
 /** Best-effort requested size from the constructor arguments. A typed array or
  *  buffer constructed OVER an existing buffer (first arg not a number) allocates
@@ -117,16 +112,37 @@ function requestedBytes(Ctor: unknown, args: unknown[]): number {
 }
 
 /** Captures the caller stack, dropping this module's own frames so the first
- *  reported frame is the real allocation site. Bounded to keep the log line
- *  readable; preload re-caps as the trust boundary. */
-function captureStack(): string {
-  const raw = new Error().stack || ''
-  const lines = raw.split('\n')
-  // Drop the "Error" header and any frame mentioning this module.
-  const frames = lines
-    .slice(1)
-    .filter((l) => !/allocWatch/.test(l))
-    .map((l) => l.trim())
+ *  reported frame is the real allocation site. Anchored on the construct trap
+ *  via `Error.captureStackTrace` (the renderer is V8, as is vitest's Node), so
+ *  the watcher's frames are excluded by FUNCTION REFERENCE and the trim survives
+ *  esbuild renaming this module's identifiers in the minified prod build — a
+ *  name-based filter would leak the watcher's own frames exactly where the cage
+ *  OOM report matters most. Captured into a plain holder so V8 walks the stack
+ *  ONCE — `new Error()` would capture eagerly only for `captureStackTrace` to
+ *  discard and re-capture, doubling the cost at the moment the renderer may be
+ *  about to die. Bounded to keep the log line readable; preload re-caps as the
+ *  trust boundary. */
+function captureStack(skip: (...a: never[]) => unknown): string {
+  const capture = (Error as unknown as {
+    captureStackTrace?: (holder: object, above?: unknown) => void
+  }).captureStackTrace
+  const holder: { stack?: string } = {}
+  let lines: string[]
+  if (typeof capture === 'function') {
+    capture(holder, skip)
+    // Drop the "Error" header V8 prepends even for a plain holder.
+    lines = (holder.stack || '').split('\n').slice(1)
+  } else {
+    // Non-V8 fallback (unreached today: renderer and vitest are both V8). No
+    // reference anchoring exists here, so drop this frame and the trap's by
+    // POSITION — deterministic and minifier-proof — after tolerating an
+    // Error-style header line, leaving the caller first on the known engines.
+    // Error.name carries the header token without a string literal, matching
+    // the WATCHED_CTORS convention (the i18n source-string gate flags literals).
+    const raw = (new Error().stack || '').split('\n')
+    lines = (raw[0] && raw[0].startsWith(Error.name) ? raw.slice(1) : raw).slice(2)
+  }
+  const frames = lines.map((l) => l.trim())
   return frames.slice(0, 8).join(' <- ')
 }
 
@@ -147,33 +163,62 @@ function send(ev: BigAllocEvent): void {
 
 function wrap(name: string, Original: unknown): unknown {
   if (typeof Original !== 'function') return Original
-  return new Proxy(Original as new (...a: unknown[]) => unknown, {
-    construct(target, args, newTarget) {
-      const bytes = requestedBytes(target, args)
-      if (bytes >= minBytes()) {
-        const stack = captureStack()
-        // Report BEFORE constructing: a cage OOM aborts the process instead of
-        // throwing, so this may be the last thing this renderer does.
-        send({ kind: name, bytes, outcome: 'requested', stack })
-        try {
-          return Reflect.construct(target, args, newTarget)
-        } catch (e) {
-          send({ kind: name, bytes, outcome: 'failed', stack, error: String(e) })
-          throw e
-        }
+  // The trap is a named reference so captureStack can anchor the stack trim on
+  // it — everything from the trap upward is watcher machinery.
+  const constructTrap: NonNullable<
+    ProxyHandler<new (...a: unknown[]) => unknown>['construct']
+  > = (target, args, newTarget) => {
+    const bytes = requestedBytes(target, args)
+    if (bytes >= activeMinBytes) {
+      const stack = captureStack(constructTrap)
+      // Report BEFORE constructing: a cage OOM aborts the process instead of
+      // throwing, so this may be the last thing this renderer does.
+      send({ kind: name, bytes, outcome: 'requested', stack })
+      try {
+        return Reflect.construct(target, args, newTarget)
+      } catch (e) {
+        send({ kind: name, bytes, outcome: 'failed', stack, error: String(e) })
+        throw e
       }
-      return Reflect.construct(target, args, newTarget)
-    },
+    }
+    return Reflect.construct(target, args, newTarget)
+  }
+  return new Proxy(Original as new (...a: unknown[]) => unknown, {
+    construct: constructTrap,
   })
+}
+
+/** Options for {@link installAllocWatch}. */
+export interface AllocWatchOptions {
+  /** Report threshold in bytes. Defaults to {@link DEFAULT_MIN_BYTES}; tests
+   *  pass a tiny value so small allocations trip it deterministically. Read
+   *  only by the first effective install — a later call is a no-op and its
+   *  options are ignored. Non-finite or non-positive values fall back to the
+   *  default (`Infinity` would silently disable all reporting). */
+  minBytes?: number
 }
 
 /**
  * Patches the buffer-allocating globals. Idempotent — a second call is a no-op.
- * Safe to call in any renderer: it only reports when `electronAPI.reportBigAlloc`
- * exists, so a plain-browser dashboard patches the constructors but sends nothing.
+ * Returns without patching when `electronAPI.reportBigAlloc` is absent: a
+ * plain-browser dashboard has no main process to report to, so it keeps its
+ * pristine constructors instead of paying for a watcher that can never speak.
  */
-export function installAllocWatch(scope: Record<string, unknown> = globalThis as unknown as Record<string, unknown>): void {
+export function installAllocWatch(
+  scope: Record<string, unknown> = globalThis as unknown as Record<string, unknown>,
+  options: AllocWatchOptions = {}
+): void {
   if (installed) return
+  const api = (window as unknown as {
+    electronAPI?: { reportBigAlloc?: (e: BigAllocEvent) => void }
+  }).electronAPI
+  if (typeof api?.reportBigAlloc !== 'function') return
+  activeMinBytes =
+    typeof options.minBytes === 'number' &&
+    Number.isFinite(options.minBytes) &&
+    options.minBytes > 0
+      ? options.minBytes
+      : DEFAULT_MIN_BYTES
   const patched: Patched[] = []
   for (const Ctor of WATCHED_CTORS) {
     const name = Ctor.name
@@ -185,10 +230,11 @@ export function installAllocWatch(scope: Record<string, unknown> = globalThis as
   installed = patched
 }
 
-/** Test seam: restores the original globals and resets the session counter. */
+/** Test seam: restores the original globals and resets the session state. */
 export function uninstallAllocWatch(): void {
   if (!installed) return
   for (const p of installed) p.target[p.name] = p.original
   installed = null
   reportCount = 0
+  activeMinBytes = DEFAULT_MIN_BYTES
 }


### PR DESCRIPTION
## Summary

Implements the four advisory refinements deferred from merged PR #6402 (tracked in #6427) on the big-alloc watcher, plus the verification the issue asked for on the fifth suggestion.

1. **Minification-proof stack trim** — `captureStack()` filtered frames by the literal string `allocWatch`, which esbuild renames in the minified prod build, so the reported `from=` led with the watcher's own frames exactly where the cage-OOM report matters most. The trim is now anchored on the construct trap by **function reference** via `Error.captureStackTrace` (the renderer is V8), immune to identifier renaming. The stack is captured **once** into a plain holder (`new Error()` would eagerly capture a stack only for `captureStackTrace` to discard and replace — doubled cost at the moment the renderer may be about to die). A test pins the first reported frame as the caller.
2. **Honest "empty flush" comments** — the claim that an empty flush "points away from a binary-buffer OOM" over-reached: the watcher sees only JS constructor calls at or above its threshold **in the main frame**. The comments in `electron/main.js` and `electron/big-alloc-log.js` now enumerate what stays invisible: host-API backing stores, cumulative sub-threshold buffers, resizable-ArrayBuffer growth, and allocations off the main frame (workers, subframes, WASM memory). Comments/docs in-repo only — the merged PR #6402 body is not touched.
3. **Delete the speculative global** — `__KIROCREW_BIG_ALLOC_BYTES__` had zero non-test consumers. Replaced by a `minBytes` option on `installAllocWatch` that the tests pass. Non-finite or non-positive values fall back to the default (`Infinity` would silently disable all reporting; pinned by test).
4. **Plain browsers keep pristine constructors** — `installAllocWatch` now returns early when `electronAPI.reportBigAlloc` is absent, so a plain-browser dashboard no longer pays for (or carries the `x.constructor === ArrayBuffer` identity caveat of) patched constructors that can never report. Pinned by tests. Electron is unaffected: `preload.js` exposes `electronAPI` synchronously before any page script runs, so the API is always present when `main.tsx` installs the watcher.

### Fifth suggestion: verified redundant, SKIPPED

The issue asked to verify whether an `app.getAppMetrics()` snapshot on crash flush is redundant with the existing crash-moment snapshot from PR #4849 before adding it. Verified: `electron/main.js`'s `render-process-gone` handler already routes through `createRendererRecovery({ describeProcesses: () => { const metrics = app.getAppMetrics() ... } })`, which logs process count, total CPU, total working set, and the worst offender at the moment of death — the same flush moment. Adding another snapshot would duplicate it, so it was skipped.

## Testing

- `npx tsc -b` — clean
- `npx vitest run` — full suite green (25293 passed; 16 allocWatch tests including 4 new pins: caller-first stack frame, plain-browser early return x2, finite/positive `minBytes` fallback x2, default-threshold boundary via allocation-free stub)
- `npm run test:electron` — 1348 pass; 2 unrelated files red under full-suite load, both pass in isolation and the electron diff here is comments-only
- eslint clean on changed TS files

No user-visible UI change — no screenshots (diagnostics code + comments only).

## Pre-push adversarial review

Two blind model-pinned reviewers on the staged diff:
- GPT lane (gpt-5.6-sol, codex-review.yml contract): **PASS**, 0 findings
- Opus lane (claude-opus-5, claude-review.yml + AUTOSDE contract): **PASS**, 0 blocking, 5 advisories — **all adopted**: off-main-frame gap added to the empty-flush comments, default-threshold boundary test made allocation-free (was materializing 2x64 MiB real backing stores in a cage-sensitive runner), single stack capture on the hot path, non-V8 fallback made positionally correct instead of overclaimed, `Number.isFinite` guard + first-install-only doc on `minBytes`.

Closes #6427
