### PR TITLE
fix: keep session read cursors exact with a durable prefix count (#2474)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -1085,7 +1085,6 @@ test/test_session_more_coverage.py
 test/test_session_mtime_ordering.py
 test/test_session_pid_sig.py
 test/test_session_pool.py
-test/test_session_restore.py
 test/test_session_rss.py
 test/test_session_sharing.py
 test/test_session_spend_identity.py

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -146,6 +146,16 @@ no longer destroy older turns.
   into the frozen prefix (`_disk_older_count += …`) only for messages actually
   persisted (`min(excess, _disk_window_len)`); an unpersisted overflow is logged
   rather than silently counted as on-disk.
+- **`slot._disk_older_durable_count`**: the durable-only position base — how
+  many non-transient rows (`state._TRANSIENT_ROLES`) have left the window off
+  the front. Maintained at every site that sets or advances
+  `_disk_older_count` (restore/resume/rehydrate/channel rebuild recompute it
+  from disk; the trim path advances it by the durable rows in the WHOLE
+  evicted slice, unpersisted overflow included — it is a position base with no
+  disk contract, so an uncounted lost row would silently shift every later
+  position). It exists for absolute message positions
+  (`session_control.read_messages`), never for save-model arithmetic — the
+  save's frozen-prefix contract stays on `_disk_older_count`.
 - **Single-file only**: the save touches `_path(history_key)` and never reads or
   writes sibling files. `tab_id` is 1:1 with a file (fork creates a fresh slot
   with its own file), so chaining is untouched and legacy no-tab_id sessions are

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -146,12 +146,15 @@ shape:
 window. A slot retains only its most recent messages in memory and credits each
 trimmed row to a frozen-prefix counter, so a length-derived cursor would freeze
 at the retention cap — and a poller on a long session would silently stop seeing
-replies, on exactly the sessions that need it most. A `since` read on a session
-whose rows have aged out is refused with `cursor_unavailable` (409) rather than
-fast-forwarded onto newer rows as if they were the ones asked for: the position
-is no longer exact, so answering it would be a guess dressed as an answer. The
-caller falls back to a tail read, which is why `next_since` is omitted in that
-case — its absence IS the signal that cursors are not available.
+replies, on exactly the sessions that need it most. Positions are based on the
+**durable-only** frozen-prefix counter (`_disk_older_durable_count`), which
+counts only trimmed rows a durable read returns — never the all-rows
+`_disk_older_count`, which also counts transient rows and would shift every
+position as soon as one was trimmed. A trimmed session therefore keeps an exact
+cursor: `next_since` is returned as usual. The one trim-related refusal left is
+a `since` **below** the trimmed prefix (409 `cursor_unavailable`): those rows
+exist only on disk now, and starting the read at the window instead would
+silently skip everything in between. The caller falls back to a tail read.
 
 `running` is what makes the loop terminable: `running: false` with an empty
 window means the target finished and went idle, which is different from "nothing

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -57,10 +57,11 @@ import asyncio
 import logging
 import time
 import weakref
+from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.channel_folders import lookup_channel_folder
-from kiro_crew.dashboard.state import _normalize_slot_key
+from kiro_crew.dashboard.state import _normalize_slot_key, durable_row_count
 from kiro_crew.history import carry_provenance, is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
@@ -371,7 +372,13 @@ def _rebuild_window(slot: "_ChatSlot", messages: list[dict[str, Any]]) -> None:
     """
     slot.messages.clear()
     slot._pending.clear()
-    slot._disk_older_count = max(0, len(messages) - _RESTORE_WINDOW)
+    older_cut = max(0, len(messages) - _RESTORE_WINDOW)
+    slot._disk_older_count = older_cut
+    # Durable-only view of the same prefix (transient-role lines excluded),
+    # recomputed from the transcript on every rebuild — the base absolute
+    # message positions are built over. ``islice`` avoids copying the whole
+    # prefix. See _ChatSlot.__init__.
+    slot._disk_older_durable_count = durable_row_count(islice(messages, older_cut))
     for msg in messages[-_RESTORE_WINDOW:]:
         role = msg.get("role", "assistant")
         cls = msg.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")

--- a/src/kiro_crew/dashboard/chat_backfill.py
+++ b/src/kiro_crew/dashboard/chat_backfill.py
@@ -178,6 +178,11 @@ def select_backfill_messages(
     rows = [row for row in slot.messages if _is_conversational(row)]
     prefix: list[dict[str, Any]] = []
     if include_first_turn:
+        # Deliberately the all-rows counter: it slices the DISK read below
+        # (``_transcript_prefix`` takes ``chained[:disk_older]``), so the count
+        # whose units are on-disk lines is the correct one. The durable-only
+        # ``_disk_older_durable_count`` measures positions over durable rows,
+        # a different unit.
         disk_older = getattr(slot, "_disk_older_count", 0) or 0
         if disk_older > 0:
             prefix = _transcript_prefix(state, slot, disk_older)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
+from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -82,6 +83,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
     _normalize_slot_key,
+    durable_row_count,
     is_stop_event_row,
     is_turn_interrupted,
     parse_cls_meta,
@@ -4897,6 +4899,11 @@ async def _reconcile_slot_window(state: DashboardState, slot: "_ChatSlot") -> No
     if getattr(slot, "_dirty_flag", False):
         return
     history_key = slot_history_key(slot)
+    # Deliberately ``_disk_older_count``, NOT ``_disk_older_durable_count``:
+    # this reconciliation reasons about the on-disk FILE LAYOUT (how many disk
+    # lines the slot represents), so the all-rows counter is the one whose
+    # units match. The durable counter exists for absolute message positions
+    # (session_control.read_messages), a different measurement.
     represented = (getattr(slot, "_disk_older_count", 0) or 0) + len(slot.messages)
     try:
         disk_msgs = await asyncio.to_thread(
@@ -5418,6 +5425,10 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     messages = all_messages[-max_resume:] if disk_total > max_resume else all_messages
     # Stable count of messages older than what we loaded into memory
     slot._disk_older_count = max(0, disk_total - len(messages))
+    # Durable-only view of the same prefix, recomputed from the on-disk rows —
+    # the base absolute message positions are built over. ``islice`` avoids
+    # copying the whole prefix on the event loop. See _ChatSlot.__init__.
+    slot._disk_older_durable_count = durable_row_count(islice(all_messages, slot._disk_older_count))
     for m in messages:
         role = m.get("role", "assistant")
         cls = "msg msg-u" if role == "user" else "msg msg-a"

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -13,6 +13,7 @@ import time
 import uuid
 from collections import OrderedDict, deque
 from collections.abc import Iterator, Mapping
+from itertools import islice
 
 from kiro_crew import model_registry
 from kiro_crew.agent import kiro_agents_dir_path
@@ -28,10 +29,12 @@ from kiro_crew.dashboard.chat_utils import (
     slot_transcript_key,
 )
 from kiro_crew.dashboard.state import (
+    _TRANSIENT_ROLES,
     DashboardState,
     _ChatSlot,
     _normalize_slot_key,
     _note_authorized_elsewhere,
+    durable_row_count,
     row_mid,
 )
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
@@ -958,7 +961,14 @@ def _rehydrate_slot_from_history(
         # Only the recent window is loaded into memory; older on-disk lines become
         # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
         # therefore count those older lines so the save model preserves them.
-        slot._disk_older_count = max(0, len(messages) - 500)
+        older_cut = max(0, len(messages) - 500)
+        slot._disk_older_count = older_cut
+        # Recomputed from the on-disk rows on every load (never trusted from any
+        # stored value): the durable-only view of the same prefix, which is what
+        # absolute message positions are built over. See _ChatSlot.__init__.
+        # ``islice``, not ``messages[:older_cut]`` — this can run on the event
+        # loop for a large transcript, and a slice would copy the whole prefix.
+        slot._disk_older_durable_count = durable_row_count(islice(messages, older_cut))
         for m in messages[-500:]:
             role = m.get("role", "assistant")
             cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
@@ -1362,7 +1372,12 @@ def _apply_recent_session(
         # _rehydrate_slot_from_history.
         update_metadata_off_loop(conv_log, key, {"tab_id": tab_id})
     slot._tab_id = tab_id
-    slot._disk_older_count = max(0, len(messages) - 500)
+    older_cut = max(0, len(messages) - 500)
+    slot._disk_older_count = older_cut
+    # Durable-only view of the same prefix, recomputed from disk on every load —
+    # see the equivalent line (and the islice rationale) in
+    # _rehydrate_slot_from_history.
+    slot._disk_older_durable_count = durable_row_count(islice(messages, older_cut))
     for m in messages[-500:]:
         role = m.get("role", "assistant")
         cls = m.get("cls") or ("msg msg-u" if role == "user" else "msg msg-a")
@@ -1816,7 +1831,9 @@ def _build_message_entry_uncached(m: dict) -> dict | None:
 # Transient/streaming roles that are never persisted (mirrors
 # ``_build_message_entry``). A window-region disk line carrying one of these is
 # not a real message and is never treated as a cross-process append to preserve.
-_TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
+# Canonically defined in ``state`` (imported above) so the trim path that must
+# count durable rows shares the same set; re-exported here unchanged for this
+# module's historical readers (session_control, chat_handlers).
 
 
 def _foreign_tail_ts(foreign_lines: list[str]) -> str | None:

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -127,6 +127,10 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
         # by slot._disk_older_count. Validate inputs against the chained
         # length so error messages match what the user sees, and translate
         # back to a slot.messages-relative index for the truncation below.
+        # Deliberately the all-rows counter: the frontend's index space is the
+        # chained DISK read plus the raw window, so on-disk-line units are the
+        # ones that line up (the durable-only counter measures a different,
+        # role-filtered space).
         disk_older = getattr(slot, "_disk_older_count", 0)
         chained_len = disk_older + len(msgs)
 

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -1317,12 +1317,22 @@ def read_messages(
 
     # Indexes are ABSOLUTE positions in the session, not offsets into the live
     # window. A slot keeps only the most recent ``_MAX_SLOT_MESSAGES`` in memory
-    # and credits each trimmed row to ``_disk_older_count``, so window length
+    # and credits each trimmed row to a frozen-prefix counter, so window length
     # stops growing once trimming starts. A cursor derived from that length
     # would freeze at the cap and never see another reply; adding the
     # frozen-prefix count makes it monotonic for the session's whole life.
     raw_window = list(slot.messages)
-    base = int(getattr(slot, "_disk_older_count", 0) or 0)
+    # The DURABLE frozen-prefix counter, never ``_disk_older_count``: that one
+    # counts every trimmed row, transient ones included, while the positions
+    # below are built over the durable rows the filter keeps. Basing on the
+    # all-rows counter shifted every position as soon as a transient row was
+    # trimmed, and a ``since`` read then served a durable message the caller
+    # already had. ``_disk_older_durable_count`` counts exactly the rows the
+    # ``TRANSIENT_ROLES`` filter below would have kept, so the two spaces agree
+    # for the session's whole life. Defensive ``getattr`` matches how the
+    # existing code reads ``_disk_older_count``: a slot restored by an older
+    # build simply has no trimmed prefix yet.
+    base = int(getattr(slot, "_disk_older_durable_count", 0) or 0)
     # Stop the cursor before the streaming tail (see ``TRANSIENT_ROLES``): those
     # rows are deleted when the segment flushes, so a cursor past them would sit
     # beyond the list that replaces them and never return the finished reply.
@@ -1332,40 +1342,28 @@ def read_messages(
     if since is not None:
         if since < 0:
             raise SessionControlError("since must be >= 0", code="invalid_since")
-        if base:
-            # ``_disk_older_count`` counts every trimmed row, transient ones
-            # included (persistence writes them and only skips them when reading
-            # back), while the positions above are built over DURABLE rows only.
-            # The two agree until a transient row is trimmed into the frozen
-            # prefix — then `base` advances with no durable row behind it, every
-            # position shifts, and a `since` read serves a durable message the
-            # caller already had.
-            #
-            # An exact cursor needs a durable-only prefix count, which does not
-            # exist yet and cannot be added from here: ``_disk_older_count`` has a
-            # contract with the save model (it is the frozen prefix saves must not
-            # rewrite) and is read by backfill, rewind and channel slots. So this
-            # refuses loudly instead of quietly duplicating. Tail reads (no
-            # ``since``) still work, and the window is 10,000 rows, so only a very
-            # long-lived session reaches this at all. Tracked for the real fix.
+        if since < base:
+            # The cursor points into the trimmed prefix: those rows exist only
+            # on disk now, and this read serves the in-memory window. Starting
+            # at ``base`` instead would silently skip every row in
+            # ``[since, base)`` — a poller that lagged a whole window behind
+            # would lose messages with nothing in the response saying so. The
+            # refusal is loud and the tail-read fallback recovers, exactly like
+            # the past-the-end case below.
             raise SessionControlError(
-                "this session is long enough that older messages have been "
-                "trimmed, and cursor positions are no longer exact — read without "
-                "`since` to get the latest messages",
+                "this session is long enough that the messages at your cursor "
+                "have been trimmed from memory — read without `since` to get "
+                "the latest messages",
                 status=409,
                 code="cursor_unavailable",
             )
-        # `base` is 0 from here on — the guard above refused every trimmed
-        # session — so the absolute position and the window offset coincide.
-        #
         # A cursor PAST the end is the remaining inexact case, and it is not the
         # same as a stale one: rewind and regenerate shrink a transcript, so
         # `total` can move backwards under a caller that is still holding the old
         # position. Clamping it to `total` would start the read at the end and
         # silently skip every replacement row written below the old cursor, with
-        # nothing in the response saying so. That is the failure the trimmed-session
-        # guard above refuses loudly rather than answer approximately, so this
-        # refuses the same way. Reads without `since` are unaffected.
+        # nothing in the response saying so. So this refuses loudly rather than
+        # answer approximately. Reads without `since` are unaffected.
         if since > total:
             raise SessionControlError(
                 "this session is shorter than your cursor — it was rewound or "
@@ -1375,13 +1373,16 @@ def read_messages(
                 code="cursor_unavailable",
             )
         start = since
-        offset = start
+        # Positions are absolute; the window slice below is offset-relative, so
+        # subtract the durable prefix that is no longer in memory.
+        offset = start - base
     else:
-        # A tail read is still served on a trimmed session (only `since` reads are
-        # refused), so the two spaces come apart here: slice the in-memory window
-        # by OFFSET, but report the index in ABSOLUTE terms so the number still
-        # means "position in the session". Conflating them returned an empty
-        # window, because `total` counts the frozen prefix the list does not hold.
+        # A tail read never refuses (only a `since` below the trimmed prefix or
+        # past the end is), and the two spaces come apart here: slice the
+        # in-memory window by OFFSET, but report the index in ABSOLUTE terms so
+        # the number still means "position in the session". Conflating them
+        # returned an empty window, because `total` counts the frozen prefix
+        # the list does not hold.
         offset = max(0, durable_end - limit)
         start = base + offset
     window = messages[offset:][:limit]
@@ -1434,13 +1435,11 @@ def read_messages(
         # `total` stays in the response as the backlog depth — the difference
         # from `next_since` is how far behind the caller still is.
         #
-        # Omitted once rows have been trimmed, because positions stop being exact
-        # there (see the `cursor_unavailable` refusal above). Handing back a
-        # cursor that the next call would reject is worse than saying it is gone,
-        # so its ABSENCE is the signal: a caller with no `next_since` falls back
-        # to tail reads. No separate flag says the same thing -- two encodings of
-        # one fact can disagree, and the reader already has to handle the absent
-        # key.
-        **({"next_since": start + len(out)} if not base else {}),
+        # Returned on trimmed sessions too: positions are based on the
+        # durable-only prefix counter, so they stay exact after rows age into
+        # the frozen prefix. The refusals above cover the cases that genuinely
+        # cannot be exact (a cursor under the trimmed prefix, or past the end of
+        # a rewound transcript).
+        "next_since": start + len(out),
         "messages": out,
     }

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -17,7 +17,7 @@ import threading
 import time
 import traceback
 import uuid
-from collections.abc import Coroutine, Iterator
+from collections.abc import Coroutine, Iterable, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, TypeVar
@@ -1966,9 +1966,29 @@ def stuck_turn_notice(parked_secs: float) -> str:
 
 _MAX_SLOT_MESSAGES = 10000  # Keep all messages — virtual scrolling handles performance
 
+#: Transient/streaming roles that are never persisted by the save path
+#: (``chat_persistence._build_message_entry`` returns ``None`` for them) and are
+#: skipped by durable readers. Defined here — beside the trim path that must
+#: count the durable rows it folds into the frozen prefix — and re-exported by
+#: ``chat_persistence`` as ``_TRANSIENT_ROLES`` for its readers, so there is one
+#: definition rather than two that can drift.
+_TRANSIENT_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
+
+
+def durable_row_count(rows: Iterable[dict]) -> int:
+    """How many of *rows* a durable read returns: everything non-transient.
+
+    The one shared counting rule for the durable-only frozen-prefix counter
+    (``_disk_older_durable_count``): every site that sets or advances it counts
+    with this, so the restore paths, the channel restore and the trim path can
+    never disagree about which rows are durable.
+    """
+    return sum(1 for m in rows if m.get("role") not in _TRANSIENT_ROLES)
+
+
 #: Roles that exist only on the wire: appended so a reader/flush can see them,
 #: never broadcast as a `chat_message` and never persisted (the mirror of
-#: ``chat_persistence._TRANSIENT_ROLES`` minus the rows that ARE broadcast).
+#: ``_TRANSIENT_ROLES`` above minus the rows that ARE broadcast).
 #: They get no ``meta.mid`` — see ``_ChatSlot.append``.
 _WIRE_ONLY_ROLES = frozenset({"chunk", "done", "streaming"})
 
@@ -2772,6 +2792,7 @@ class _ChatSlot:
         "_tab_id",
         "_channel_window_mtime",
         "_disk_older_count",
+        "_disk_older_durable_count",
         "_disk_window_len",
         "_disk_tail_ts",
         "_frozen_prefix_cache",
@@ -3211,6 +3232,17 @@ class _ChatSlot:
         self._disk_older_count: int = (
             0  # count of disk messages OLDER than in-memory window (stable, set at restore/resume)
         )
+        # Durable-only frozen-prefix counter: how many durable rows (role not
+        # in ``_TRANSIENT_ROLES``) have LEFT the in-memory window off the front.
+        # Absolute message positions (``session_control.read_messages``) are
+        # built over durable rows, so they base on THIS counter;
+        # ``_disk_older_count`` keeps its save-model contract (the frozen
+        # prefix saves must not rewrite) untouched. The two also draw the
+        # unpersisted-overflow line differently — see the trim path below.
+        # Maintained at every site that sets or advances ``_disk_older_count``,
+        # always via :func:`durable_row_count`. Never persisted — every restore
+        # path recomputes it from the messages on disk.
+        self._disk_older_durable_count: int = 0
         # Count of in-memory window messages the LAST save persisted to disk
         # (the on-disk window region). Trimming may only fold a leading window
         # message into the frozen prefix once it is known to be on disk; this
@@ -3613,15 +3645,29 @@ class _ChatSlot:
         # Trim old messages to bound memory usage
         if len(self.messages) > _MAX_SLOT_MESSAGES:
             excess = len(self.messages) - _MAX_SLOT_MESSAGES
-            del self.messages[:excess]
-            self._resumed_count = max(0, self._resumed_count - excess)
             # A trimmed leading window message may only join the frozen prefix
             # once it is actually on disk. Credit _disk_older_count only
             # for the persisted portion; the unpersisted overflow (should not
             # happen between 5s flushes) is logged rather than silently counted
             # as on-disk, which would have stranded those turns.
             persisted_trim = min(excess, self._disk_window_len)
+            # The durable counter counts the WHOLE evicted slice, including the
+            # unpersisted overflow the disk counter excludes. The two draw
+            # different lines because they answer different questions:
+            # ``_disk_older_count`` claims on-disk lines (its save contract), so
+            # counting a row that never reached disk would corrupt the frozen
+            # prefix. ``_disk_older_durable_count`` is a POSITION base with no
+            # disk contract — if a durable row leaves the window uncounted,
+            # every later absolute position shifts down and a poller's cursor
+            # silently skips rows. Counting the lost rows instead makes a cursor
+            # that pointed at them refuse loudly (``since < base``), which is
+            # the recoverable outcome. Counted BEFORE the ``del`` below —
+            # afterwards the slice is gone.
+            durable_trim = durable_row_count(self.messages[:excess])
+            del self.messages[:excess]
+            self._resumed_count = max(0, self._resumed_count - excess)
             self._disk_older_count += persisted_trim
+            self._disk_older_durable_count += durable_trim
             self._disk_window_len = max(0, self._disk_window_len - excess)
             if persisted_trim < excess:
                 logger.warning(

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -932,9 +932,10 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             # position either re-reads without `since` -- taking the tail, which
             # silently skips everything older than the last `limit` rows once the
             # target answers in a burst -- or keeps reusing a cursor from before,
-            # re-reading rows it has already seen. `next_since` is absent only when
-            # rows have been trimmed and positions stopped being exact, which is
-            # the one case a cursor must not be invented for.
+            # re-reading rows it has already seen. The server now returns
+            # `next_since` on trimmed sessions too (positions are based on a
+            # durable-only prefix count), so its absence is only a defensive
+            # possibility here, not a live server state.
             empty_lines = [head_line, "No messages in that window yet."]
             if "next_since" in resp:
                 empty_lines.append(
@@ -956,8 +957,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             )
             if "next_since" in resp
             else (
-                "This session is long enough that older messages have been trimmed, so "
-                "cursor positions are no longer exact and `since` reads are refused. "
+                "No cursor came back with this read. "
                 "Read again without `since` to get the latest messages."
             )
         )

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -121,6 +121,69 @@ class TestChatSlot:
         assert slot.messages[0]["content"] == "msg 50"
         assert slot.messages[-1]["content"] == f"msg {count - 1}"
 
+    def test_trim_advances_the_durable_counter_by_durable_rows_only(self):
+        """Transient rows folded into the frozen prefix advance ONLY the all-rows counter.
+
+        ``_disk_older_count`` credits every persisted trimmed row (its contract
+        with the save model), while ``_disk_older_durable_count`` counts only
+        the rows a durable read returns — the base absolute message positions
+        are built over. Counting them together is the cursor-skew defect.
+
+        Mutation guards: advancing the durable counter by ``persisted_trim``
+        re-introduces the skew; counting the slice AFTER the ``del`` counts the
+        wrong (surviving) rows — the leading transient rows here make both
+        mutants visibly wrong.
+        """
+        slot = _ChatSlot("s1")
+        # The five oldest window rows: 2 transient, 3 durable.
+        slot.append("permission", "approve?", "")
+        slot.append("queued", "queued prompt", "")
+        for i in range(3):
+            slot.append("user", f"old {i}")
+        for i in range(_MAX_SLOT_MESSAGES - 5):
+            slot.append("user", f"fill {i}")
+        # Pretend the whole window was flushed, as a 5s save would have.
+        slot._disk_window_len = len(slot.messages)
+        assert slot._disk_older_count == 0
+        assert slot._disk_older_durable_count == 0
+
+        # Cross the cap by 5: the trimmed slice is exactly the 5 rows above.
+        for i in range(5):
+            slot.append("user", f"new {i}")
+
+        assert slot._disk_older_count == 5, "all persisted trimmed rows are credited"
+        assert (
+            slot._disk_older_durable_count == 3
+        ), "only the durable trimmed rows advance the durable counter"
+
+    def test_trim_counts_evicted_durable_rows_even_when_unpersisted(self):
+        """Durable rows lost to the unpersisted overflow still advance the durable counter.
+
+        ``_disk_older_count`` excludes the overflow (its save contract: it
+        claims on-disk lines, and these rows never reached disk). The durable
+        counter is a POSITION base with no disk contract: if evicted durable
+        rows were uncounted, every later absolute position would shift down and
+        a poller's ``since`` guard would pass while rows were silently skipped
+        — the silent failure the deleted blanket refusal used to make loud.
+        Counting them makes such a cursor refuse loudly (``since < base``).
+
+        Mutation guard: restricting the durable count to the persisted slice
+        (``messages[:persisted_trim]``) yields 2 here instead of 5.
+        """
+        slot = _ChatSlot("s1")
+        for i in range(_MAX_SLOT_MESSAGES):
+            slot.append("user", f"old {i}")
+        # Only the first 2 window rows ever reached disk.
+        slot._disk_window_len = 2
+
+        for i in range(5):
+            slot.append("user", f"new {i}")
+
+        assert slot._disk_older_count == 2, "the disk counter keeps its persisted-only contract"
+        assert (
+            slot._disk_older_durable_count == 5
+        ), "every evicted durable row advances the position base"
+
     def test_to_dict(self):
         slot = _ChatSlot("s1", title="Test Chat", mode="orchestrator")
         slot.append("user", "hi")

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1433,7 +1433,12 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         assert "since=7" in out, "an empty window must still carry next_since"
 
     def test_a_trimmed_transcript_invents_no_cursor_on_an_empty_window(self):
-        """`next_since` is absent exactly when positions stopped being exact."""
+        """The renderer never invents a cursor the response did not carry.
+
+        The live server now returns `next_since` on trimmed sessions too, so
+        this pins the renderer's defensive behaviour for a cursor-less
+        response shape, whatever produces one.
+        """
         with patch(
             "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
         ), patch(

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -1140,63 +1140,132 @@ def test_the_read_cursor_is_absolute_across_a_trimmed_window(tmp_path):
     """Window length freezes at the retention cap; `total` and the indexes must not.
 
     Mutation guard: deriving `total` from `len(slot.messages)` makes it freeze at
-    the cap, so a caller can no longer tell how much history exists.
+    the cap, so a caller can no longer tell how much history exists. Basing it on
+    `_disk_older_count` instead of the durable counter shifts every position by
+    the transient rows that were trimmed (here: 20), which this pins.
     """
     state = _make_state(tmp_path)
     caller = _slot(state, "chat-1")
     target = _peer_target(state, "chat-2", caller)
     for i in range(3):
         target.append("assistant", f"live {i}", "msg msg-a")
-    # Stand in for the trim: 5,000 rows already aged into the frozen prefix.
+    # Stand in for the trim: 5,000 rows aged into the frozen prefix, of which
+    # 20 were transient (never returned by a durable read).
     target._disk_older_count = 5000
+    target._disk_older_durable_count = 4980
 
     out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
 
-    assert out["total"] == 5003, "total must count the frozen prefix, not just the window"
-    assert [m["index"] for m in out["messages"]] == [5000, 5001, 5002]
-    # No cursor is offered once trimming has started, because positions built on
-    # `_disk_older_count` (which counts transient rows) cannot line up with
-    # durable-only indexes. Handing back a cursor the next call would reject is
-    # worse than admitting it is gone, and the ABSENCE of `next_since` is the
-    # whole signal -- no separate flag restates it.
-    assert "next_since" not in out
-    assert "cursor_exact" not in out, "absence of next_since is the only signal"
+    assert out["total"] == 4983, "total must count the DURABLE frozen prefix + the window"
+    assert [m["index"] for m in out["messages"]] == [4980, 4981, 4982]
+    # Positions are durable-only on both sides of the trim boundary, so the
+    # cursor stays exact and is still offered on a trimmed session.
+    assert out["next_since"] == 4983
+    assert "cursor_exact" not in out, "an exact cursor needs no caveat"
 
 
-def test_cursor_pagination_is_refused_once_rows_have_been_trimmed(tmp_path):
-    """A `since` read on a trimmed session must fail loudly, not duplicate a row.
+def test_cursor_pagination_stays_exact_once_rows_have_been_trimmed(tmp_path):
+    """Two consecutive `since` pages on a trimmed session never overlap.
 
-    `_disk_older_count` counts every trimmed row including transient ones, while
-    positions here are durable-only. Once a transient row is trimmed into the
-    frozen prefix the two disagree, every position shifts, and a `since` read
-    serves a durable message the caller already had.
+    This is the regression the durable counter exists for: `_disk_older_count`
+    counts every trimmed row including transient ones, so basing positions on it
+    advances the base with no durable row behind it — every position shifts and
+    a `since` read serves a durable message the caller already had. Basing on
+    the durable-only counter keeps the two spaces aligned.
 
-    Mutation guard: dropping the refusal silently returns the shifted window.
+    Mutation guard: swapping the base back to `_disk_older_count` makes the
+    second page re-serve the first page's rows (an overlap this asserts away);
+    on the pre-fix code the first `since` read raised `cursor_unavailable`.
     """
     state = _make_state(tmp_path)
     caller = _slot(state, "chat-1")
     target = _peer_target(state, "chat-2", caller)
-    for i in range(3):
+    for i in range(4):
         target.append("assistant", f"live {i}", "msg msg-a")
+    # A trim that folded transient rows into the frozen prefix: the all-rows
+    # counter and the durable counter disagree by 20.
     target._disk_older_count = 5000
+    target._disk_older_durable_count = 4980
+
+    first = sc.read_messages(
+        state, caller_session_key=_key(caller), target="chat-2", since=4980, limit=2
+    )
+    assert [m["content"] for m in first["messages"]] == ["live 0", "live 1"]
+    assert first["next_since"] == 4982
+
+    second = sc.read_messages(
+        state,
+        caller_session_key=_key(caller),
+        target="chat-2",
+        since=first["next_since"],
+        limit=2,
+    )
+    assert [m["content"] for m in second["messages"]] == ["live 2", "live 3"]
+
+    served_once = {m["index"] for m in first["messages"]}
+    assert served_once.isdisjoint(
+        {m["index"] for m in second["messages"]}
+    ), "consecutive since pages must never re-serve a row"
+
+
+def test_a_since_read_on_a_trimmed_session_returns_a_cursor_not_a_409(tmp_path):
+    """A trimmed session answers `since` reads exactly instead of refusing.
+
+    The old behaviour raised 409 `cursor_unavailable` for ANY `since` read once
+    the frozen-prefix base was non-zero, and withheld `next_since`, so pollers
+    on exactly the long-lived sessions worth polling fell back to inexact tail
+    reads forever. With a durable-only base the positions are exact again.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("assistant", "the reply", "msg msg-a")
+    target._disk_older_count = 100
+    target._disk_older_durable_count = 90
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=90)
+
+    assert [m["content"] for m in out["messages"]] == ["the reply"]
+    assert out["next_since"] == 91
+    assert out["total"] == 91
+
+
+def test_a_cursor_under_the_trimmed_prefix_is_refused_not_skipped_over(tmp_path):
+    """A `since` below the durable base cannot be served from memory.
+
+    The rows in ``[since, base)`` exist only on disk; starting the read at the
+    window instead would silently skip them, which is the same silent-gap
+    failure the past-the-end refusal exists for. Refusing loudly sends the
+    caller to a tail read.
+
+    Mutation guard: clamping the offset to 0 returns the window as if it were
+    the rows asked for.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("assistant", "newest", "msg msg-a")
+    target._disk_older_count = 100
+    target._disk_older_durable_count = 90
 
     with pytest.raises(sc.SessionControlError) as exc:
-        sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=5000)
+        sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=50)
     assert exc.value.code == "cursor_unavailable"
     assert exc.value.status == 409
 
     # The tail read is the documented fallback and still works.
     tail = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
-    assert [m["content"] for m in tail["messages"]] == ["live 0", "live 1", "live 2"]
+    assert [m["content"] for m in tail["messages"]] == ["newest"]
 
 
 def test_an_untrimmed_session_still_reports_a_gap_free_cursor(tmp_path):
     """With nothing trimmed the cursor is exact, which is the common case.
 
-    The old version of this test asserted a `trimmed` gap report on a session
-    whose rows HAD aged out — that path is now refused outright (see
-    `cursor_unavailable`), because the gap count was derived from the same mixed
-    counter that made the positions wrong.
+    An even older version of this test asserted a `trimmed` gap report on a
+    session whose rows HAD aged out — that gap count was derived from the mixed
+    all-rows counter that made the positions wrong. Positions are now based on
+    the durable-only prefix counter, so trimmed sessions get exact cursors too
+    (see the trimmed-window tests above) and no gap report exists on any path.
     """
     state = _make_state(tmp_path)
     caller = _slot(state, "chat-1")

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -82,7 +82,12 @@ class TestRestoreRecentSessions:
                 {"role": "user", "content": "hello", "ts": "2026-03-23T10:00:00"},
                 {"role": "assistant", "content": "hi there", "ts": "2026-03-23T10:00:01"},
             ],
-            meta={"title": "Test Chat", "agent": "kirocrew", "workspace": "myws", "mode": "orchestrator"},
+            meta={
+                "title": "Test Chat",
+                "agent": "kirocrew",
+                "workspace": "myws",
+                "mode": "orchestrator",
+            },
         )
         # Touch the file to make it recent
         path = tmp_path / "dashboard_chat1.jsonl"
@@ -222,6 +227,62 @@ class TestRestoreRecentSessions:
         assert len(slot.messages) == 500
         assert slot.messages[0]["content"] == "msg 100"
         assert slot._disk_older_count == 100  # 600 total - 500 loaded = 100 older on disk
+
+    def test_restore_computes_the_durable_prefix_count_from_disk(self, tmp_path, monkeypatch):
+        """A trimmed prefix holding transient-role lines splits the two counters.
+
+        ``_disk_older_count`` counts every on-disk line older than the window
+        (the frozen prefix the save model preserves); the durable counter must
+        count only the rows a durable read returns, and must be RECOMPUTED from
+        the messages on disk — a slot restored by an older build has no durable
+        counter persisted anywhere to trust.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        messages = [
+            {"role": "user", "content": f"msg {i}", "ts": f"2026-03-23T10:{i:04d}"}
+            for i in range(600)
+        ]
+        # 10 transient-role lines inside the trimmed prefix (a legacy or foreign
+        # writer put them on disk; the save path itself never does).
+        for i in range(10):
+            messages[i * 5] = {
+                "role": "permission",
+                "content": "approve?",
+                "ts": messages[i * 5]["ts"],
+            }
+        _write_session(tmp_path, "dashboard_big", messages)
+        (tmp_path / "dashboard_big.jsonl").touch()
+
+        state = _make_state(tmp_path)
+        assert restore_recent_sessions(state, window_minutes=60) == 1
+        slot = state._slots["big"]
+        assert slot._disk_older_count == 100
+        assert (
+            slot._disk_older_durable_count == 90
+        ), "the 10 transient prefix lines must not count as durable"
+
+    def test_channel_rebuild_window_computes_the_durable_prefix_count(self, tmp_path, monkeypatch):
+        """The channel restore path draws the same durable/all-rows line."""
+        from kiro_crew.dashboard import channel_slots
+        from kiro_crew.dashboard.channel_slots import _rebuild_window
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("slack_1.1", linked_session_key="slack:1.1")
+        n = channel_slots._RESTORE_WINDOW
+        messages = [
+            {"role": "user", "content": f"msg {i}", "ts": f"2026-03-23T10:{i:04d}"}
+            for i in range(n + 40)
+        ]
+        # 7 transient lines inside the 40-row trimmed prefix.
+        for i in range(7):
+            messages[i * 3] = {"role": "queued", "content": "q", "ts": messages[i * 3]["ts"]}
+
+        _rebuild_window(slot, messages)
+
+        assert slot._disk_older_count == 40
+        assert slot._disk_older_durable_count == 33
+        assert len(slot.messages) == n
 
     def test_restores_multiple_sessions(self, tmp_path, monkeypatch):
         """Multiple recent dashboard sessions are all restored."""
@@ -1064,9 +1125,9 @@ class TestAsyncRehydrateSlotFromHistory:
         slot = await rehydrate_slot_from_history_async(state, "racy")
 
         assert slot is state._slots["racy"]
-        assert [m["content"] for m in slot.messages] == ["from the other task"], (
-            "the snapshot was applied on top of a concurrently created slot"
-        )
+        assert [m["content"] for m in slot.messages] == [
+            "from the other task"
+        ], "the snapshot was applied on top of a concurrently created slot"
 
 
 class TestPartialRehydrateRollsBack:
@@ -1090,8 +1151,12 @@ class TestPartialRehydrateRollsBack:
         from kiro_crew.dashboard.chat import _rehydrate_slot_from_history
 
         state = _make_state(tmp_path)
-        _write_session(tmp_path, "dashboard_doomed", [{"role": "user", "content": "hi"}],
-                       meta={"title": "T", "memory_mode": "ephemeral"})
+        _write_session(
+            tmp_path,
+            "dashboard_doomed",
+            [{"role": "user", "content": "hi"}],
+            meta={"title": "T", "memory_mode": "ephemeral"},
+        )
         # Fail inside the population, after the slot is registered.
         monkeypatch.setattr(chat_persistence, "redact_credentials", self._boom)
 
@@ -1112,8 +1177,12 @@ class TestPartialRehydrateRollsBack:
         from kiro_crew.dashboard import chat_persistence
 
         state = _make_state(tmp_path)
-        _write_session(tmp_path, "dashboard_doomed-async", [{"role": "user", "content": "hi"}],
-                       meta={"title": "T", "memory_mode": "ephemeral"})
+        _write_session(
+            tmp_path,
+            "dashboard_doomed-async",
+            [{"role": "user", "content": "hi"}],
+            meta={"title": "T", "memory_mode": "ephemeral"},
+        )
         monkeypatch.setattr(chat_persistence, "redact_credentials", self._boom)
 
         with pytest.raises(RuntimeError):
@@ -1140,16 +1209,20 @@ class TestPartialRehydrateRollsBack:
 
         state = _make_state(tmp_path)
         state._restricted_keys.add("dashboard:keeper")
-        _write_session(tmp_path, "dashboard_keeper", [{"role": "user", "content": "hi"}],
-                       meta={"title": "T", "memory_mode": "ephemeral"})
+        _write_session(
+            tmp_path,
+            "dashboard_keeper",
+            [{"role": "user", "content": "hi"}],
+            meta={"title": "T", "memory_mode": "ephemeral"},
+        )
         monkeypatch.setattr(chat_persistence, "redact_credentials", self._boom)
 
         with pytest.raises(RuntimeError):
             _rehydrate_slot_from_history(state, "keeper")
 
-        assert "dashboard:keeper" in state._restricted_keys, (
-            "rollback discarded a restricted key it did not add"
-        )
+        assert (
+            "dashboard:keeper" in state._restricted_keys
+        ), "rollback discarded a restricted key it did not add"
 
     def test_the_rollback_lives_in_the_callee_not_the_caller(self):
         """Source guard: the rollback belongs at the creation site so EVERY caller
@@ -1274,9 +1347,7 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         )
 
     @pytest.mark.asyncio
-    async def test_a_skipped_session_never_pays_for_its_transcript(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_skipped_session_never_pays_for_its_transcript(self, tmp_path, monkeypatch):
         """The filters run BETWEEN the two reads, on the cheap one.
 
         Reading a multi-megabyte transcript and then discarding it because the
@@ -1314,14 +1385,12 @@ class TestAsyncRestoreRecentSessionsOffLoop:
 
         assert await restore_recent_sessions_async(state, window_minutes=60) == 1
         assert set(state._slots) == {"keep"}
-        assert not any("shut" in k for k in walked), (
-            f"read the transcript of a session it then skipped: {walked}"
-        )
+        assert not any(
+            "shut" in k for k in walked
+        ), f"read the transcript of a session it then skipped: {walked}"
 
     @pytest.mark.asyncio
-    async def test_the_restoring_guard_is_released_even_on_failure(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_the_restoring_guard_is_released_even_on_failure(self, tmp_path, monkeypatch):
         """A stuck flag silently disables open-tab persistence for the process."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
@@ -1335,9 +1404,7 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         assert state.restoring_open_slots is False
 
     @pytest.mark.asyncio
-    async def test_a_channel_born_session_is_left_to_the_reconciler(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_channel_born_session_is_left_to_the_reconciler(self, tmp_path, monkeypatch):
         """Non-dashboard keys stay out of this path — the reconciler owns them."""
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         from kiro_crew.dashboard.chat_persistence import restore_recent_sessions_async
@@ -1408,9 +1475,7 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         ], "the transcript was replayed onto a live slot — duplicated history"
 
     @pytest.mark.asyncio
-    async def test_a_tab_closed_during_the_read_is_not_resurrected(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_tab_closed_during_the_read_is_not_resurrected(self, tmp_path, monkeypatch):
         """✕ clicked mid-read must win over the metadata snapshot.
 
         The close pops the slot and records a tombstone synchronously, but
@@ -1445,9 +1510,7 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         assert "dismissed" not in state._slots, "resurrected a tab the user closed"
 
     @pytest.mark.asyncio
-    async def test_an_older_tombstone_does_not_block_a_reopened_tab(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_an_older_tombstone_does_not_block_a_reopened_tab(self, tmp_path, monkeypatch):
         """Only a close DURING the read is the race; older tombstones are inert.
 
         Without the ``>= started`` comparison the guard would make a reopened tab
@@ -1473,9 +1536,7 @@ class TestAsyncRestoreRecentSessionsOffLoop:
         assert "reopened" in state._slots
 
     @pytest.mark.asyncio
-    async def test_a_session_deleted_during_the_read_is_not_restored(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_a_session_deleted_during_the_read_is_not_restored(self, tmp_path, monkeypatch):
         """Third post-hop window: permanent deletion during the offloaded read.
 
         ``delete_session`` leaves no tombstone, so a slot published from content
@@ -1510,9 +1571,9 @@ class TestAsyncRestoreRecentSessionsOffLoop:
             "restored a slot for a permanently deleted session; its flush would "
             "rewrite the deleted transcript"
         )
-        assert not (tmp_path / "dashboard_doomed.jsonl").exists(), (
-            "the deleted transcript came back"
-        )
+        assert not (
+            tmp_path / "dashboard_doomed.jsonl"
+        ).exists(), "the deleted transcript came back"
 
     @pytest.mark.asyncio
     async def test_an_intact_session_is_not_refused_by_the_deletion_guard(
@@ -1584,6 +1645,6 @@ class TestAsyncRestoreRecentSessionsOffLoop:
             "built a phantom slot for a deleted session; its flush would "
             f"recreate the transcript (slots: {sorted(state._slots)})"
         )
-        assert not (tmp_path / "dashboard_vanished.jsonl").exists(), (
-            "the deleted transcript came back"
-        )
+        assert not (
+            tmp_path / "dashboard_vanished.jsonl"
+        ).exists(), "the deleted transcript came back"


### PR DESCRIPTION
## Summary

Fixes #2474: absolute message cursors in `session_control.read_messages` skewed once rows were trimmed, because `slot._disk_older_count` counts every trimmed row (transient roles included) while positions are built over durable rows only. The code coped by refusing every `since` read on a trimmed session with `409 cursor_unavailable` and withholding `next_since` — so pollers on exactly the long-lived sessions worth polling fell back to inexact tail reads forever.

This adds a parallel **durable-only position base**, `_disk_older_durable_count`:

- Maintained at **every** site that sets or advances `_disk_older_count`: slot `__init__` + the window trim (`state.py`), both persistence restore paths (`chat_persistence.py`), the channel window rebuild (`channel_slots.py`), and the slot-resume handler (`chat_handlers.py`) — always through one shared counting rule, `state.durable_row_count`.
- **Recomputed from the on-disk rows on every restore**, never trusted from a stored value (a slot restored by an older build simply has no trimmed prefix yet; consumers read it with a defensive `getattr`).
- The trim path counts the **whole evicted slice, unpersisted overflow included**. This deliberately differs from `_disk_older_count`, which excludes the overflow because it claims on-disk lines. The durable counter is a position base with no disk contract: leaving a lost durable row uncounted would shift every later position down and let a poller's cursor skip rows *silently*. Counting it makes such a cursor refuse *loudly* (`since < base`). This line was drawn by a pre-push reviewer finding (see below).
- `_disk_older_count` itself is untouched: its save-model contract (the frozen prefix saves never rewrite) and its disk-layout readers keep their meaning, now with explicit "deliberately the all-rows counter" comments at the reconcile, backfill and rewind sites.

`read_messages` now bases positions on the durable counter: the blanket trimmed-session refusal is **deleted**, `next_since` is **always returned**, and a trimmed session pages exactly. Two genuinely-inexact cases still refuse with 409 `cursor_unavailable`: a cursor **below the trimmed prefix**, and the existing **cursor-past-end** case after a rewind/regenerate.

`_TRANSIENT_ROLES` moves to `state.py` (canonical, single definition) and is re-imported by `chat_persistence` for its historical readers; the restore-path counting uses `itertools.islice` to avoid copying the whole frozen prefix on the event loop. Docs (`session-control.md`, `history.md`) updated in the same commit.

## Testing

- New tests (all verified to **fail against main**, and mutation-verified against six mutants: wrong-counter base, count-after-delete, persisted-slice-only durable count, missing offset rebase, clamp-instead-of-refuse, unfiltered restore count):
  - trim with transient rows advances the durable counter by durable rows only while `_disk_older_count` credits all persisted rows;
  - trim counts evicted durable rows even when unpersisted (position base vs disk contract);
  - two consecutive `since` pages on a trimmed session never overlap (the exact regression from the issue);
  - a `since` read on a trimmed session returns `next_since` instead of raising;
  - a cursor under the trimmed prefix refuses loudly; cursor-past-end still refuses (pre-existing test kept);
  - restore and channel-restore compute the durable counter when the trimmed prefix holds transient lines.
- Updated: the two trimmed-session cursor tests in `test_session_control.py` now assert exact-cursor behaviour (not deleted), plus a stale renderer docstring in `test_mcp_dashboard_folders.py`.
- Full local gates green: `isort`, `flake8`, `mypy` (1128 files), black baselined gate (one graduated file pruned), full backend pytest **71457 passed** (2 pre-existing `test_docker_entrypoint.py` failures reproduce identically on pristine main in this environment — env-specific, unrelated).
- Backend-only change; no UI, no screenshots.

## Pre-push review (two model-pinned reviewers)

- **Opus lane: BLOCK → fixed.** HIGH: the durable counter originally excluded the unpersisted trim overflow, silently collapsing positions when `persisted_trim < excess` — fixed by counting the whole evicted slice, pinned by `test_trim_counts_evicted_durable_rows_even_when_unpersisted`, mutation-verified. MEDIUM: prefix-copy on the boot path — fixed with `islice`. LOW: stale comment — fixed.
- **GPT lane: BLOCK, rebutted as out of scope.** Its five findings (rewind index mapping, `_append_unflushed_tail`/slot-detail slices, `next_before` pagination, backfill prefix, reconcile arithmetic) all describe the **pre-existing** skew of `_disk_older_count` itself: the trim credits raw window rows via `_disk_window_len` (which counts the raw window, not the durable rows the save actually wrote), so after a transient row is folded, `_disk_older_count` can overstate the on-disk prefix. That behaviour is byte-identical on `main`, this PR does not touch it, and swapping those disk-slicing sites to the new durable counter would be unit-wrong (it counts evicted window rows — including, after this PR, rows that never reached disk — not disk lines). The real fix for that family is making `_disk_window_len`/`_disk_older_count` durable-accurate at the save boundary, which changes the frozen-prefix save model and deserves its own issue/PR. GPT verified this PR's own surfaces correct: trim counting, offset arithmetic, all six write sites, no import cycle.

## Out of scope / follow-up

Pre-existing `_disk_older_count`-vs-disk-lines drift in the trim path (via raw `_disk_window_len`) affecting disk-layout consumers (`chat_rewind`, `chat_backfill`, slot-detail/`_append_unflushed_tail`, reconcile, `next_before`). Documented at those sites in this PR; needs a dedicated issue on the save-boundary accounting.

Closes #2474
