### PR TITLE
test: fix _TURN_DEADLINE leak across approval-window tests (#6440)

### DIFF
--- a/test/test_dashboard_approval_window.py
+++ b/test/test_dashboard_approval_window.py
@@ -17,6 +17,7 @@ import asyncio
 import inspect
 import logging
 import re
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -51,6 +52,52 @@ def cfg(monkeypatch: pytest.MonkeyPatch):
         )
 
     return _apply
+
+
+@pytest.fixture(autouse=True)
+def _isolate_turn_deadline():
+    """Give every test a clean ``_TURN_DEADLINE`` and put the outside value back.
+
+    Residue travels through the main-thread context: an un-reset ``set()`` made
+    there is inherited by every later test in the worker, because each async
+    test's task context is copied from it (an async test's own writes die with
+    its task copy — a leak seen at test start was already in the parent
+    context). Baselining to ``None`` here is what makes this module's
+    ``get() is None`` assertions deterministic under any ordering; restoring
+    the snapshot afterwards keeps the fixture honest about state it did not
+    create. Deliberately a sync fixture: an async one would run inside a copied
+    task context and its writes would be discarded with it.
+
+    Save/restore is by VALUE, not ``reset(token)``, mirroring
+    ``turn_dispatch._bounded_turn``: test and shutdown harnesses may resume
+    finalization in a copied Context (notably Windows xdist); ``reset(token)``
+    then raises and can take down the whole worker because tokens are
+    context-bound. The sites below follow the same pattern for the same reason.
+    """
+    prev = td._TURN_DEADLINE.get()
+    td._TURN_DEADLINE.set(None)
+    try:
+        yield
+    finally:
+        td._TURN_DEADLINE.set(prev)
+
+
+def test_token_based_restore_stays_banned_in_this_module() -> None:
+    """No test here may restore ``_TURN_DEADLINE`` through a ContextVar token.
+
+    The isolation fixture above masks exactly the failure it fixes: with every
+    test baselined to ``None``, the ``get() is None`` assertions can no longer
+    catch a reintroduced token-based restore — the pattern that leaves the var
+    set (or kills the worker) when finalization resumes in a copied Context,
+    per the rationale at turn_dispatch.py:350-356. Pin the ban at the source
+    level instead of relying on convention.
+    """
+    src = inspect.getsource(sys.modules[__name__])
+    needle = "_TURN_DEADLINE" + ".reset("
+    assert needle not in src, (
+        "restore _TURN_DEADLINE by value (set the captured previous value), "
+        "never through a ContextVar token"
+    )
 
 
 class TestDefaultsAreShort:
@@ -139,11 +186,12 @@ class TestPerSlotWindowIsAlsoBudgetBounded:
         cfg(window=600, turn=7200)
         loop = asyncio.get_running_loop()
         state = SimpleNamespace(approval_timeout_for=lambda _s: 7200.0)
-        token = td._TURN_DEADLINE.set(loop.time() + 300.0)
+        prev = td._TURN_DEADLINE.get()
+        td._TURN_DEADLINE.set(loop.time() + 300.0)
         try:
             got = self._window(state, object())
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(prev)
         assert got == pytest.approx(300.0 - APPROVAL_TURN_MARGIN_SECS, abs=1.0)
 
     @pytest.mark.asyncio
@@ -153,11 +201,12 @@ class TestPerSlotWindowIsAlsoBudgetBounded:
         cfg(window=600, turn=7200)
         loop = asyncio.get_running_loop()
         state = SimpleNamespace(approval_timeout_for=lambda _s: 180.0)
-        token = td._TURN_DEADLINE.set(loop.time() + 5.0)
+        prev = td._TURN_DEADLINE.get()
+        td._TURN_DEADLINE.set(loop.time() + 5.0)
         try:
             assert self._window(state, object()) == 0.0
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(prev)
 
 
 class TestStallSignalReachesTheLoop:
@@ -341,11 +390,12 @@ class TestArmTimeBudget:
         cfg(window=600, turn=7200)
         loop = asyncio.get_running_loop()
         # 300s left of a 2h turn: a 600s window would outlive it.
-        token = td._TURN_DEADLINE.set(loop.time() + 300.0)
+        prev = td._TURN_DEADLINE.get()
+        td._TURN_DEADLINE.set(loop.time() + 300.0)
         try:
             got = td.tool_approval_timeout_secs()
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(prev)
         assert got == pytest.approx(300.0 - APPROVAL_TURN_MARGIN_SECS, abs=1.0)
 
     @pytest.mark.asyncio
@@ -353,21 +403,23 @@ class TestArmTimeBudget:
         """Under the margin there is no window that can both wait and report."""
         cfg(window=600, turn=7200)
         loop = asyncio.get_running_loop()
-        token = td._TURN_DEADLINE.set(loop.time() + 5.0)
+        prev = td._TURN_DEADLINE.get()
+        td._TURN_DEADLINE.set(loop.time() + 5.0)
         try:
             assert td.tool_approval_timeout_secs() == 0.0
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(prev)
 
     @pytest.mark.asyncio
     async def test_early_prompt_keeps_the_configured_window(self, cfg) -> None:
         cfg(window=600, turn=7200)
         loop = asyncio.get_running_loop()
-        token = td._TURN_DEADLINE.set(loop.time() + 7200.0)
+        prev = td._TURN_DEADLINE.get()
+        td._TURN_DEADLINE.set(loop.time() + 7200.0)
         try:
             assert td.tool_approval_timeout_secs() == 600.0
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(prev)
 
     def test_absent_deadline_falls_back_to_the_ceiling_bound(self, cfg) -> None:
         """Paths that don't go through _bounded_turn must still get a window."""
@@ -406,6 +458,30 @@ class TestArmTimeBudget:
         with pytest.raises(ValueError):
             await td._bounded_turn(_boom(), 120.0)
         assert td._TURN_DEADLINE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_bounded_turn_restores_the_previous_deadline_by_value(self) -> None:
+        """A non-None prior deadline comes back after the turn — not None.
+
+        Pins the restore-by-value contract documented in ``_bounded_turn``
+        (turn_dispatch.py): the finally writes back the CAPTURED previous
+        value. No other test armed a non-None prior value, so the two
+        ``get() is None`` neighbours above only ever exercised the None case —
+        which is how a residue inherited from another test's context read as
+        this module's product bug (#6440).
+        """
+        prev = td._TURN_DEADLINE.get()
+        armed = asyncio.get_running_loop().time() + 999.0
+        td._TURN_DEADLINE.set(armed)
+        try:
+
+            async def _turn() -> str:
+                return "done"
+
+            assert await td._bounded_turn(_turn(), 120.0) == "done"
+            assert td._TURN_DEADLINE.get() == armed
+        finally:
+            td._TURN_DEADLINE.set(prev)
 
 
 class TestNoBudgetCard:


### PR DESCRIPTION
## Problem / Motivation

`test/test_dashboard_approval_window.py::TestArmTimeBudget::test_bounded_turn_publishes_then_clears_the_deadline` fails intermittently in CI (seen on Backend Tests 3.10 shard 2) on `assert td._TURN_DEADLINE.get() is None`, observing a residual `7715.530793947`. It passes 5/5 locally without random ordering.

Closes #6440

## Why it matters

A flaky required-check test reds unrelated PRs' CI and burns reruns for every contributor. This one also *looks* like a product bug in `_bounded_turn` (deadline not cleared), inviting a "fix" to product code that is behaving exactly to its documented contract.

## What changed (motivation → approach → change)

**Symptom → root cause.** The residual is a value `_bounded_turn` correctly RESTORED, not one it leaked: `turn_dispatch.py:331` captures `previous_deadline` before publishing and the `finally` writes it back. So `_TURN_DEADLINE` was already non-None when the failing test started — residue from outside the test. `7715.53 − 7200.0 = 515.53`, a plausible `loop.time()`; the only `+7200.0` publisher in the tree is a sibling in the same class.

**Propagation channel (empirically established, identical under pytest-asyncio 0.20.3 = the CI pin, and 1.4.0).** A `set()` without restore made in the **main-thread context** is inherited by every later test in the worker (each async test's task context is copied from it). An async test's own writes die with its task-context copy. Planting `7715.530793947` in the main context reproduces the CI failure signature exactly. The specific depositing site was not isolated — a failed `reset(token)` inside this module's async tests raises visibly rather than leaking silently — but containment is total regardless, because `_TURN_DEADLINE` is exercised only in `turn_dispatch.py` and this file.

**Change (test-only; `turn_dispatch.py` untouched — its restore-by-value is deliberate, see its :350-356 rationale and PR #4274 / issue #2851):**
1. A sync `autouse` fixture baselines `_TURN_DEADLINE` to `None` before each test in this module and restores the outer value by value afterwards. Sync deliberately: an async fixture would run in a discarded task-context copy and heal nothing. Local to this file per testing-conventions (the var's entire blast radius is this module + `turn_dispatch.py`).
2. All five test-side `set(...)`/`reset(token)` sites converted to the product's restore-by-value pattern, removing this module's exposure to the context-bound-token hazard (rationale mirrored once, in the fixture docstring).
3. The three `get() is None` assertions kept untouched — the fixture makes them deterministic instead of ordering-dependent.

## Tests

- `test_bounded_turn_restores_the_previous_deadline_by_value` (new): pins `_bounded_turn`'s restore-by-value contract — a non-None prior deadline comes back, not `None`. Previously uncovered; its absence is what let the over-strict-looking `is None` assertion read as a product bug.
- `test_token_based_restore_stays_banned_in_this_module` (new): source-level guard — the fixture now masks the failure mode the `is None` assertions used to surface, so a reintroduced token-based restore is caught at review time instead of as a rare CI flake.
- Existing 37 tests in the module: unchanged behavior, now ordering-independent.

## Manual verification

- Pre-fix reproduction: planting `7715.530793947` in the main-thread context makes `TestArmTimeBudget` fail with the exact CI signature (`assert 7715.530793947 is None`); post-fix the same plant is green.
- Adverse ordering: green with the planted residue across `pytest-randomly` seeds (1, 42, 7715, 20260828, 999983, 11, 6440, 777) at `-n 0`, seeds (5, 6440, 314159) under xdist, and an explicit worst-case order (`+7200` publisher immediately before the `is None` asserters).
- Both pytest-asyncio pins: 0.20.3 (CI dev-group pin) and 1.4.0 (setup.cfg extras resolution).
- Full suite: failure set byte-identical to a clean-main control run on the same host (81 failed + 2 errors, all environmental: `AF_UNIX path too long` class); zero regressions, my module fully green in both runs.

## Screenshots / video

N/A — test-only change, no UI surface.
