### PR TITLE
test(semgrep): pin the ContextVar token-reset ban in test/ (#6440)

### DIFF
--- a/semgrep-tests/contextvar-token-reset.py
+++ b/semgrep-tests/contextvar-token-reset.py
@@ -1,0 +1,38 @@
+# Fixtures for semgrep/contextvar-token-reset.yaml, exercised by
+# `semgrep --test` in the SAST job. `ruleid:` asserts the NEXT line MUST
+# match; `ok:` asserts it must NOT.
+
+from contextvars import ContextVar
+
+_MY_VAR: ContextVar[float | None] = ContextVar("my_var", default=None)
+
+
+def bad_token_reset():
+    """Token-based reset is context-bound and leaks under xdist."""
+    # ruleid: kirocrew.contextvar-token-reset
+    token = _MY_VAR.set(42.0)
+    # do work ...
+    _MY_VAR.reset(token)
+
+
+def good_value_restore():
+    """Value-based restore works across context boundaries."""
+    previous = _MY_VAR.get()
+    _MY_VAR.set(42.0)
+    # do work ...
+    # ok: kirocrew.contextvar-token-reset
+    _MY_VAR.set(previous)
+
+
+class SessionManager:
+    """Unrelated .reset() calls must not be flagged."""
+
+    def reset(self, key: str) -> None:
+        pass
+
+
+def good_session_manager_reset():
+    """A non-ContextVar .reset() call should not match."""
+    mgr = SessionManager()
+    # ok: kirocrew.contextvar-token-reset
+    mgr.reset("session_id")

--- a/semgrep/contextvar-token-reset.yaml
+++ b/semgrep/contextvar-token-reset.yaml
@@ -1,0 +1,44 @@
+rules:
+  # ─── ContextVar: Token-based reset is context-bound ────────────────
+  # ContextVar.reset(token) is bound to the Context object the token was
+  # created in. Under pytest-xdist each worker shares the main-thread
+  # Context across tests, so a token obtained in one test and reset in
+  # another (or after an asyncio task boundary) raises ValueError and can
+  # take down the whole worker. Use value-based restore instead:
+  #   previous = var.get()
+  #   var.set(new_value)
+  #   ...
+  #   var.set(previous)
+
+  - id: kirocrew.contextvar-token-reset
+    patterns:
+      - pattern: |
+          $TOKEN = $VAR.set(...)
+          ...
+          $VAR.reset($TOKEN)
+    # Scoped to test/** on purpose. In production code a synchronous
+    # `token = var.set(...)` / `try: yield / finally: var.reset(token)` inside
+    # one contextmanager frame is the CANONICAL use of a token and is strictly
+    # better than value-based restore (only reset() can restore "unset").
+    # The hazard this rule catches is the test-suite shape: a token taken in
+    # one test and reset after an asyncio task boundary, where pytest-xdist
+    # shares the worker's main-thread Context across tests.
+    paths:
+      include:
+        - test/**
+    message: >
+      ContextVar token-based reset ($VAR.reset($TOKEN)) is bound to the
+      Context the token was created in. In a test this leaks: pytest-xdist
+      shares the worker's main-thread Context across tests, so a token taken
+      here and reset after an asyncio task boundary raises ValueError and can
+      take the worker down. Use value-based restore instead: save the previous
+      value with .get() before setting, and restore with .set(previous) in a
+      finally block.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      category: correctness
+      subcategory: concurrency
+      cwe: "CWE-362: Concurrent Execution using Shared Resource with Improper Synchronization"
+      references:
+        - https://docs.python.org/3/library/contextvars.html#contextvars.Token.old_value


### PR DESCRIPTION
## What

Adds a semgrep rule that bans ContextVar **token-based** reset in `test/**`.

## Why this PR shrank

The `_TURN_DEADLINE` fix itself **already landed on main as #6454** (`24cb5e76c`) — value-based restore across `test_dashboard_approval_window.py` plus an autouse isolation fixture, and an equivalent `_bounded_turn` restore-by-value test. That was the conflict: this branch and #6454 rewrote the same lines. All duplicate test-file changes are dropped; the test file is now byte-identical to main.

What is left is the part #6454 did not carry: the **regression guard**.

## The rule

`kirocrew.contextvar-token-reset` flags `tok = var.set(...)` … `var.reset(tok)`.

A `Token` is bound to the `Context` it was created in. pytest-xdist shares the worker's main-thread `Context` across tests, so a token taken in one test and reset after an asyncio task boundary raises `ValueError` and can take the whole worker down — exactly #6440.

**Scoped to `test/**` deliberately.** In production code the same shape inside one synchronous contextmanager frame is the *canonical* use of a token and is strictly better than value-based restore, because only `reset()` can restore "unset". The two such sites (`src/kiro_crew/apps/manager.py:498`, `src/kiro_crew/history.py:425`) are correct and are not flagged — an earlier revision of this rule included `src/kiro_crew/**` and would have turned both into landmines for unrelated PRs.

## Verification

- `semgrep --test --config semgrep/ semgrep-tests/` → **11/11 pass** (semgrep 1.78.0, the pinned CI image version).
- Repo-wide scan with the rule: **0 hits** on the current tree.
- Non-vacuous: re-introducing the #6440 pattern in `test_dashboard_approval_window.py` produces exactly 1 hit at that line; reverted.
