### PR TITLE
refactor(instances): share the peer-request derivation across the three callers

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -1310,6 +1310,17 @@ port-scoped cookie so it cannot land in the peer's access log, and a `401/403`
 gets exactly one transparent re-mint retry, because a retained credential can go
 stale while the tunnel stays `CONNECTED`.
 
+"Follows the same rules" is now **enforced rather than asserted**: all three
+peer-request methods — `send_session_bundle`, `search_sessions_remote` and
+`proxy_request` — resolve their target and credential through one shared private
+pair, `_peer_target` (connected-only, loopback target, port-scoped cookie name)
+and `_peer_cookie_header` (credential re-read per attempt, sent as a cookie,
+never logged). A fourth caller inherits the invariant instead of copying it.
+What is deliberately *not* shared is each method's error contract: the
+`proxy_`/`transfer_`/`search_` code families belong to three separate route
+contracts, so the helper reports a neutral reason and each caller names its own
+code as a literal — a drift test asserts the three stay distinct.
+
 Each peer request runs under `DEFAULT_SEARCH_PROXY_TIMEOUT_SECS` (6s) — sized
 between the token probe (2s, a bare ping, which would produce false
 "unreachable" verdicts on a loaded peer doing real scan work) and the transfer

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -260,6 +260,33 @@ class ProxyRequestError(Exception):
         self.http_status = http_status
 
 
+class _PeerUnavailable(Exception):
+    """A request to a connected peer could not be attempted at all.
+
+    Raised by :meth:`SshTunnelManager._peer_target` and
+    :meth:`SshTunnelManager._peer_cookie_header` so the three public callers can
+    share how a peer target is *resolved* without sharing their error contracts:
+    each maps ``kind`` onto its own machine-readable code. Those codes are
+    deliberately NOT derived from ``kind`` here — the ``proxy_``/``transfer_``/
+    ``search_`` families belong to three separate route contracts pinned by
+    ``test_error_code_contract.py``, and a reader grepping for one of them must
+    land on the site that returns it.
+
+    ``kind`` is ``"not_connected"`` or ``"no_credential"``; ``message`` is the
+    caller-facing text, identical across the three families.
+    """
+
+    _MESSAGES = {
+        "not_connected": "instance is not connected",
+        "no_credential": "no live credential for this instance; reconnect it",
+    }
+
+    def __init__(self, kind: str) -> None:
+        super().__init__(kind)
+        self.kind = kind
+        self.message = self._MESSAGES[kind]
+
+
 class TunnelState(enum.Enum):
     """Per-instance tunnel states."""
 
@@ -2089,6 +2116,54 @@ class SshTunnelManager:
             )
             return False
 
+    def _peer_target(self, instance_id: str, path: str) -> tuple[str, str]:
+        """Resolve ``(url, cookie_name)`` for one request to a CONNECTED peer.
+
+        Owns the three rules that every peer request shares and that all of them
+        depend on for correctness, so they are stated once instead of per caller:
+
+        * the request is only ever attempted against a ``CONNECTED`` tunnel —
+          none of these methods opens one, so a disconnected peer is a refusal,
+          not a reconnect;
+        * the target is always the loopback end of the already-open forward,
+          never a peer-supplied host;
+        * the cookie name is **port-scoped**. The dashboard keys its cookie on
+          the port the CLIENT connected to (``token_auth._cookie_port_from_host``),
+          not on the peer's own listen port, so two remotes both serving 7777
+          through different forwards do not collide on one cookie. A bare
+          ``mc_token`` is never read and would 403 every call.
+
+        Raises :class:`_PeerUnavailable` instead of returning an error, because
+        the callers' failure shapes differ (an exception for ``proxy_request``,
+        an ``(ok, payload)`` tuple for the other two).
+        """
+        st = self.status(instance_id)
+        if st is None or st.state is not TunnelState.CONNECTED:
+            raise _PeerUnavailable("not_connected")
+        local_port = st.local_port
+        if local_port <= 0:
+            raise _PeerUnavailable("no_credential")
+        url = f"http://{_LOOPBACK}:{int(local_port)}/{path.lstrip('/')}"
+        return url, f"mc_token_{int(local_port)}"
+
+    def _peer_cookie_header(self, instance_id: str, cookie_name: str) -> dict[str, str]:
+        """Build the ``Cookie`` header carrying this peer's credential.
+
+        Must be re-read per attempt, not hoisted out of a retry loop: a re-mint
+        replaces the credential mid-call and the retry exists to use the fresh
+        one.
+
+        **The token never leaves this object.** It travels as a cookie rather
+        than a query parameter so it cannot land in the peer's HTTP access log,
+        it is never logged here, and issuing the request from the manager is what
+        keeps ``connect``/``refresh-token`` the only two routes where a minted
+        token crosses the API boundary (instances.md §14.4).
+        """
+        token = self._tokens.get(instance_id, "")
+        if not token:
+            raise _PeerUnavailable("no_credential")
+        return {"Cookie": f"{cookie_name}={token}"}
+
     @contextlib.asynccontextmanager
     async def proxy_request(
         self,
@@ -2099,7 +2174,6 @@ class SshTunnelManager:
         params: "dict[str, str] | None" = None,
         data: bytes | None = None,
         content_type: str = "",
-        timeout: "aiohttp.ClientTimeout | None" = None,
     ):
         """Open *path* on a connected peer's gateway; yield the live response.
 
@@ -2113,43 +2187,36 @@ class SshTunnelManager:
         Yields the **un-buffered** ``aiohttp.ClientResponse`` so the caller can
         pump a streaming body (a proxied chat turn streams SSE for minutes);
         the response and its session are closed when the context exits. The
-        default timeout is connect+read-idle, not total, for the same reason.
+        timeout is connect+read-idle rather than total for the same reason: a
+        total cap would sever a long turn mid-stream. It is fixed here rather
+        than offered as a parameter — the policy is a property of what this
+        method is for, not a per-call choice.
 
         Failures raise :class:`ProxyRequestError` with a machine-readable
         ``code`` and a suggested ``http_status``, so the route handler can
         translate without string-matching.
         """
-        st = self.status(instance_id)
-        if st is None or st.state is not TunnelState.CONNECTED:
-            raise ProxyRequestError(
-                "proxy_peer_not_connected", "instance is not connected", http_status=503
-            )
-        local_port = st.local_port
-        if local_port <= 0:
-            raise ProxyRequestError(
-                "proxy_no_credential",
-                "no live credential for this instance; reconnect it",
-                http_status=503,
-            )
-        url = f"http://{_LOOPBACK}:{int(local_port)}/{path.lstrip('/')}"
-        # Port-scoped cookie name, for the same reason as send_session_bundle:
-        # the peer keys its cookie on the port the CLIENT connected to.
-        cookie_name = f"mc_token_{int(local_port)}"
-        tmo = timeout or aiohttp.ClientTimeout(
+
+        def _unavailable(exc: _PeerUnavailable) -> ProxyRequestError:
+            if exc.kind == "not_connected":
+                return ProxyRequestError("proxy_peer_not_connected", exc.message, http_status=503)
+            return ProxyRequestError("proxy_no_credential", exc.message, http_status=503)
+
+        try:
+            url, cookie_name = self._peer_target(instance_id, path)
+        except _PeerUnavailable as e:
+            raise _unavailable(e) from None
+        tmo = aiohttp.ClientTimeout(
             total=None,
             sock_connect=_PROXY_CONNECT_TIMEOUT,
             sock_read=_PROXY_READ_IDLE_TIMEOUT,
         )
         reminted = False
         while True:
-            token = self._tokens.get(instance_id, "")
-            if not token:
-                raise ProxyRequestError(
-                    "proxy_no_credential",
-                    "no live credential for this instance; reconnect it",
-                    http_status=503,
-                )
-            headers = {"Cookie": f"{cookie_name}={token}"}
+            try:
+                headers = self._peer_cookie_header(instance_id, cookie_name)
+            except _PeerUnavailable as e:
+                raise _unavailable(e) from None
             if content_type:
                 headers["Content-Type"] = content_type
             session = aiohttp.ClientSession(timeout=tmo)
@@ -2210,34 +2277,20 @@ class SshTunnelManager:
         Runs entirely over the already-open forward — **no SSH spawn**, same as
         :meth:`token_validates`.
 
-        **The token never leaves this object.** The request is issued here rather
-        than in the API layer specifically so that ``connect`` and
-        ``refresh-token`` remain the only two routes where a minted token crosses
-        the API boundary (instances.md §6). A transfer needs the credential but
-        the browser does not, so handing it out would widen that boundary for no
-        reason. It is sent as a cookie rather than a query parameter so it cannot
-        land in the peer's HTTP access log, and it is never logged here.
+        **The token never leaves this object** — see
+        :meth:`_peer_cookie_header`, which owns that rule for every peer request.
         """
-        st = self.status(instance_id)
-        if st is None or st.state is not TunnelState.CONNECTED:
+        try:
+            url, cookie_name = self._peer_target(instance_id, "/api/chat/slots/import")
+        except _PeerUnavailable as e:
             return False, {
-                "error": "instance is not connected",
-                "code": "transfer_peer_not_connected",
+                "error": e.message,
+                "code": (
+                    "transfer_peer_not_connected"
+                    if e.kind == "not_connected"
+                    else "transfer_no_credential"
+                ),
             }
-        local_port = st.local_port
-        if local_port <= 0:
-            return False, {
-                "error": "no live credential for this instance; reconnect it",
-                "code": "transfer_no_credential",
-            }
-        url = f"http://{_LOOPBACK}:{int(local_port)}/api/chat/slots/import"
-        # The dashboard cookie is keyed by the port the CLIENT connects to, taken
-        # from the Host header (token_auth._cookie_port_from_host) — not by the
-        # peer's own listen port, so two remotes both serving 7777 through
-        # different forwards do not collide on one cookie. We connect to
-        # 127.0.0.1:<local_port>, so that is the name the peer will look for; a
-        # bare ``mc_token`` is never read and would 403 every transfer.
-        cookie_name = f"mc_token_{int(local_port)}"
         timeout = aiohttp.ClientTimeout(total=_TRANSFER_TIMEOUT)
         # Two INDEPENDENT one-shot retries, tracked by flag rather than by loop
         # index so neither consumes the other's budget:
@@ -2251,17 +2304,13 @@ class SshTunnelManager:
         reminted = False
         downgraded = False
         for _attempt in range(3):
-            token = self._tokens.get(instance_id, "")
-            if not token:
-                return False, {
-                    "error": "no live credential for this instance; reconnect it",
-                    "code": "transfer_no_credential",
-                }
+            try:
+                headers = self._peer_cookie_header(instance_id, cookie_name)
+            except _PeerUnavailable as e:
+                return False, {"error": e.message, "code": "transfer_no_credential"}
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
-                    async with session.post(
-                        url, json=bundle, headers={"Cookie": f"{cookie_name}={token}"}
-                    ) as resp:
+                    async with session.post(url, json=bundle, headers=headers) as resp:
                         try:
                             payload = await resp.json()
                         except Exception:
@@ -2360,44 +2409,35 @@ class SshTunnelManager:
         from an unreachable peer.
 
         Runs entirely over the already-open forward — **no SSH spawn** — and
-        follows :meth:`send_session_bundle`'s credential rules: **the token
-        never leaves this object** (``connect``/``refresh-token`` stay the only
-        routes where one crosses the API boundary), it travels as the
-        port-scoped cookie so it cannot land in the peer's access log, and a
+        follows the shared credential rules in :meth:`_peer_cookie_header`: the
+        token never leaves this object and travels as the port-scoped cookie. A
         401/403 gets exactly one transparent re-mint retry — a retained
         credential can go stale while the tunnel stays CONNECTED.
         """
-        st = self.status(instance_id)
-        if st is None or st.state is not TunnelState.CONNECTED:
+        try:
+            url, cookie_name = self._peer_target(instance_id, "/api/sessions/search")
+        except _PeerUnavailable as e:
             return False, {
-                "error": "instance is not connected",
-                "code": "search_peer_not_connected",
+                "error": e.message,
+                "code": (
+                    "search_peer_not_connected"
+                    if e.kind == "not_connected"
+                    else "search_no_credential"
+                ),
             }
-        local_port = st.local_port
-        if local_port <= 0:
-            return False, {
-                "error": "no live credential for this instance; reconnect it",
-                "code": "search_no_credential",
-            }
-        url = f"http://{_LOOPBACK}:{int(local_port)}/api/sessions/search"
-        # Port-scoped cookie name, for the same reason as send_session_bundle:
-        # the peer keys its cookie on the port the CLIENT connected to.
-        cookie_name = f"mc_token_{int(local_port)}"
         timeout = aiohttp.ClientTimeout(total=_SEARCH_PROXY_TIMEOUT)
         reminted = False
         for _attempt in range(2):
-            token = self._tokens.get(instance_id, "")
-            if not token:
-                return False, {
-                    "error": "no live credential for this instance; reconnect it",
-                    "code": "search_no_credential",
-                }
+            try:
+                headers = self._peer_cookie_header(instance_id, cookie_name)
+            except _PeerUnavailable as e:
+                return False, {"error": e.message, "code": "search_no_credential"}
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     async with session.get(
                         url,
                         params={"q": query, "limit": str(int(limit))},
-                        headers={"Cookie": f"{cookie_name}={token}"},
+                        headers=headers,
                         # The tunnel endpoint is the ONLY legitimate target. A
                         # compromised peer answering 30x would otherwise make
                         # aiohttp fetch an attacker-chosen URL FROM THE HUB

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -6023,6 +6023,127 @@ class TestProxyRequest:
         assert ei.value.http_status == 502
 
 
+class TestPeerRequestSharedDance:
+    """The derivation shared by the three peer-request methods.
+
+    `proxy_request`, `send_session_bundle` and `search_sessions_remote` each
+    make an authenticated call to a CONNECTED peer over the open forward. The
+    part that is identical — connected-only, loopback target, port-scoped cookie
+    name, credential read per attempt — lives in `_peer_target` /
+    `_peer_cookie_header` so it is stated once. What is NOT shared is each
+    method's error contract, and that is what these tests pin.
+    """
+
+    def _mgr(self, tmp_path):
+        from kiro_crew.instances.registry import InstancesRegistry
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        reg = InstancesRegistry(path=tmp_path / "instances.json")
+
+        async def ok_mint(host, **kwargs):
+            return "SECRET_TOK"
+
+        return reg, SshTunnelManager(
+            reg, base_port=53700, mint_token=ok_mint, tunnel_factory=_FakeTunnel
+        )
+
+    @pytest.mark.asyncio
+    async def test_peer_target_is_the_single_source_of_the_port_scoped_cookie(self, tmp_path):
+        """One derivation, not three: loopback URL + `mc_token_{port}`.
+
+        The port scope is load-bearing — the peer keys its cookie on the port the
+        CLIENT connected to, so two remotes both serving 7777 through different
+        forwards must not collide, and a bare `mc_token` would 403 every call.
+        """
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        st = await mgr.connect("cd-1")
+
+        url, cookie_name = mgr._peer_target("cd-1", "/api/chat/slots")
+        assert url == f"http://127.0.0.1:{st.local_port}/api/chat/slots"
+        assert cookie_name == f"mc_token_{st.local_port}"
+        # Leading slash is optional — callers pass both spellings.
+        assert mgr._peer_target("cd-1", "api/chat/slots")[0] == url
+
+    def test_peer_cookie_header_refuses_when_no_credential(self, tmp_path):
+        from kiro_crew.instances.ssh_tunnel_manager import _PeerUnavailable
+
+        _reg, mgr = self._mgr(tmp_path)
+        with pytest.raises(_PeerUnavailable) as ei:
+            mgr._peer_cookie_header("cd-1", "mc_token_1")
+        assert ei.value.kind == "no_credential"
+
+    @pytest.mark.asyncio
+    async def test_each_caller_keeps_its_own_not_connected_code(self, tmp_path):
+        """The shared helper must NOT flatten the three error families.
+
+        `proxy_*`, `transfer_*` and `search_*` belong to three separate route
+        contracts pinned by test_error_code_contract.py. Deriving them from the
+        helper's `kind` would be tidier and wrong — this is the drift guard that
+        catches it, and it is the reason the codes are literals at each site.
+        """
+        from kiro_crew.instances.ssh_tunnel_manager import ProxyRequestError
+
+        _reg, mgr = self._mgr(tmp_path)
+
+        with pytest.raises(ProxyRequestError) as ei:
+            async with mgr.proxy_request("nope", "GET", "api/chat"):
+                pass
+        assert ei.value.code == "proxy_peer_not_connected"
+
+        ok, payload = await mgr.send_session_bundle("nope", {"bundle_version": 2})
+        assert (ok, payload["code"]) == (False, "transfer_peer_not_connected")
+
+        ok, payload = await mgr.search_sessions_remote("nope", "q", 10)
+        assert (ok, payload["code"]) == (False, "search_peer_not_connected")
+
+    @pytest.mark.asyncio
+    async def test_each_caller_keeps_its_own_no_credential_code(self, tmp_path):
+        """Same split for the missing-credential condition, on a LIVE tunnel."""
+        from kiro_crew.instances.ssh_tunnel_manager import ProxyRequestError
+
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(name="CD", ssh_host="cd-1-alias", instance_id="cd-1")
+        await mgr.connect("cd-1")
+        mgr._tokens.pop("cd-1", None)  # connected, but the credential is gone
+
+        with pytest.raises(ProxyRequestError) as ei:
+            async with mgr.proxy_request("cd-1", "GET", "api/chat"):
+                pass
+        assert ei.value.code == "proxy_no_credential"
+        assert ei.value.http_status == 503
+
+        ok, payload = await mgr.send_session_bundle("cd-1", {"bundle_version": 2})
+        assert (ok, payload["code"]) == (False, "transfer_no_credential")
+
+        ok, payload = await mgr.search_sessions_remote("cd-1", "q", 10)
+        assert (ok, payload["code"]) == (False, "search_no_credential")
+
+    def test_proxy_request_exposes_no_timeout_override(self):
+        """The timeout policy is a property of the method, not a per-call choice.
+
+        It is connect+read-idle rather than total because a proxied chat turn
+        streams for minutes and a total cap would sever it. Nothing ever passed
+        the old override, so the parameter only invited a caller to break that
+        for itself; this pins the subtraction.
+        """
+        import inspect
+
+        from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager
+
+        params = inspect.signature(SshTunnelManager.proxy_request).parameters
+        assert "timeout" not in params
+        assert set(params) == {
+            "self",
+            "instance_id",
+            "method",
+            "path",
+            "params",
+            "data",
+            "content_type",
+        }
+
+
 class TestProxyHandlerPolicy:
     """api_instances_proxy — the policy gates in front of the carrier.
 


### PR DESCRIPTION
Two follow-ups to #6211, done together because the shared helper is what retires the unused override — splitting them would mean two PRs editing the same span.

## The duplication (#6456)

`proxy_request`, `send_session_bundle` and `search_sessions_remote` each hand-rolled the same sequence to reach a connected peer:

| step | before | after |
|---|---|---|
| require `CONNECTED` | 3 copies | `_peer_target` |
| refuse `local_port <= 0` | 3 copies | `_peer_target` |
| build the loopback URL | 3 copies | `_peer_target` |
| derive `mc_token_{port}` | 3 copies (+3 copies of the comment explaining why) | `_peer_target` |
| re-read the credential per attempt | 3 copies | `_peer_cookie_header` |

This is not ordinary duplication — the duplicated logic *is* the credential invariant. The cookie is port-scoped so two remotes both serving 7777 through different forwards cannot collide on one cookie; the token travels as a cookie so it cannot land in the peer's access log. A fourth caller now inherits that instead of copying whichever version it found first.

## What is deliberately NOT shared

A full request-lifecycle helper would need callbacks, and would be worse than the duplication it removed. `proxy_request` yields a live streaming response with a manually managed session; the other two buffer inside `async with` and have bespoke body handling (a version-downgrade retry; a byte-capped accumulate). So this PR shares the *derivation* and leaves alone:

- **The three retry budgets.** A `while True` streaming call, a 2-attempt search, and a 3-attempt transfer carrying a second independent one-shot downgrade budget. Unifying these would mean restructuring all three loop shapes — real behaviour risk for no gain.
- **The three error-code families.** `proxy_*` / `transfer_*` / `search_*` belong to separate route contracts pinned by `test_error_code_contract.py`. The helper raises a private `_PeerUnavailable` carrying a neutral `kind`, and each caller maps it to its own code **as a literal** — deriving `f"{prefix}_{kind}"` would be tidier and wrong, because someone grepping `search_no_credential` must land on the site that returns it.

`test_each_caller_keeps_its_own_not_connected_code` is the drift guard for exactly that. **Revert-checked**: flattening the search family to `f"peer_{e.kind}"` makes it fail with `assert (False, 'peer_not_connected') == (False, 'search_peer_not_connected')`.

## The unused override (#6455)

`proxy_request` took `timeout: aiohttp.ClientTimeout | None = None`, threaded as `tmo = timeout or ...`. Zero callers passed it — the sole caller `api_instances_proxy` passes `params`/`data`/`content_type`, and no test passed it either. The policy it would override is deliberately unusual (connect + read-idle rather than the `total=` its two siblings use, because a proxied chat turn streams for minutes and a total cap would sever it mid-stream). That reasoning belongs in the method, not in a parameter a caller could override without knowing it. Now constructed unconditionally, with the signature pinned by a test.

## Verification

- 430 passed across `test_instances.py`, `test_instances_search_federation.py`, `test_session_transfer.py`, `test_error_code_contract.py`.
- The one failure, `TestForwarderPidHints::test_connect_persists_forwarder_identity`, is **pre-existing on clean `main`** — re-verified this run by stashing the diff and reproducing it.
- black / isort / flake8 / mypy clean; black baseline scanner passes in scope.
- Behaviour-identical by intent: no error code, HTTP status, response shape, timeout value or retry budget changes.

Spec §15.1 records that "follows the same credential rules" is now enforced structurally rather than asserted in prose.

Fixes #6455
Fixes #6456
