### PR TITLE
fix(memory): keep two-character CJK words in the episodic keyword fallback

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -240,6 +240,18 @@ _EPISODIC_LONG_TEXT_CHARS = 300  # texts longer than this get a relaxed threshol
 _EPISODIC_LONG_TEXT_THRESHOLD = 0.42  # relaxed threshold for long entries
 _EPISODIC_TEXT_MIN = 10
 _EPISODIC_TEXT_MAX = 2000
+#: Codepoint ranges of scripts that spend enough meaning per character for a
+#: TWO-character token to be an ordinary whole word: kana, Han (+ extension A
+#: and the compatibility block) and Hangul syllables. Latin is deliberately
+#: absent -- a two-letter English token is a function word ("to", "in", "is"),
+#: and those are exactly what the keyword floor below exists to drop.
+_DENSE_SCRIPT_RANGES = (
+    (0x3040, 0x30FF),  # Hiragana + Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xAC00, 0xD7A3),  # Hangul syllables
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
 # Episodic recency decay: score factor exp(-rate * days_old), per day. The
 # built-in rate applies when memory.decay_rates configures nothing else; the
 # reserved "default" key in that mapping replaces it for untagged/unmatched
@@ -757,6 +769,30 @@ def _sanitize_decay_rates(raw: Mapping[str, object] | None) -> dict[str, float]:
         # the clamp itself never overflows.
         out[key.strip().lower()] = float(min(max(val, _DECAY_RATE_MIN), _DECAY_RATE_MAX))
     return out
+
+
+def _is_selective_keyword(word: str) -> bool:
+    """Whether *word* is selective enough to spend a ``LIKE '%word%'`` scan on.
+
+    The episodic keyword fallback matches by plain substring, so the only thing
+    a term has to earn is selectivity. Counting characters is a fine proxy for
+    that in Latin script -- a one- or two-character token there is a function
+    word, and ``LIKE '%to%'`` matches nearly every row -- but it is the wrong
+    proxy for the scripts in :data:`_DENSE_SCRIPT_RANGES`, where two characters
+    is an ordinary word (``模型`` "model", ``会議`` "meeting", ``회의``
+    "meeting") and the substring is highly selective. Applying the Latin floor
+    to them emptied the term list, and an empty term list makes the fallback
+    return nothing at all rather than merely ranking differently.
+
+    A single character stays refused in every script: one Han character (``的``,
+    ``人``) is as unselective as an English stopword, so admitting it would
+    trade this recall bug for a precision one.
+    """
+    if len(word) > 2:
+        return True
+    return len(word) == 2 and any(
+        any(lo <= ord(ch) <= hi for lo, hi in _DENSE_SCRIPT_RANGES) for ch in word
+    )
 
 
 # ── Store ──
@@ -3981,7 +4017,7 @@ class VectorMemoryStore:
         self, query: str, limit: int, tag_filter: list[str] | None = None
     ) -> list[dict]:
         """Simple LIKE-based text + tags search fallback for episodic memories."""
-        words = [w for w in query.strip().split()[:5] if len(w) > 2]
+        words = [w for w in query.strip().split()[:5] if _is_selective_keyword(w)]
         if not words:
             return []
         conditions = " OR ".join(["text LIKE ?" for _ in words] + ["tags LIKE ?" for _ in words])

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -3944,3 +3944,76 @@ class TestEpisodicDecayRates:
         assert self._score(store, "faiss path retention check") == pytest.approx(
             self._expected(0.0, 30), abs=1.5e-4
         )
+
+
+class TestEpisodicKeywordFallbackCjk:
+    """The no-embeddings episodic fallback must not discard whole-word CJK queries.
+
+    ``search_episodic`` drops to ``_fts5_episodic_search`` whenever no query
+    embedding is available -- the normal state for a deployment with no embedding
+    model configured. That fallback matches with ``LIKE '%token%'``, which is a
+    plain substring test and needs no tokenizer, so a spaceless CJK term is a
+    perfectly good needle. The only thing standing between the query and the row
+    is the minimum-token-length filter, which counts CHARACTERS: two characters
+    is a stopword in English but an ordinary whole word in Chinese, Japanese and
+    Korean, so the filter emptied the term list and the search returned nothing.
+    """
+
+    @staticmethod
+    def _store(tmp_path: Path) -> VectorMemoryStore:
+        """A store with no embed_fn, so search_episodic takes the keyword fallback."""
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        return store
+
+    @pytest.mark.parametrize(
+        ("term", "sentence"),
+        [
+            ("模型", "用户决定用这个模型来做推理"),  # zh: "model"
+            ("会議", "チームは会議で方針を決めた"),  # ja: "meeting"
+            ("회의", "팀은 회의에서 방침을 정했다"),  # ko: "meeting"
+        ],
+        ids=["zh", "ja", "ko"],
+    )
+    def test_a_two_character_word_still_finds_its_row(
+        self, tmp_path: Path, term: str, sentence: str
+    ) -> None:
+        store = self._store(tmp_path)
+        assert store.write_episodic(sentence)
+        # The row plainly contains the term -- LIKE would match it.
+        assert term in sentence
+        hits = store.search_episodic(query_text=term, limit=8)
+        assert [h["text"] for h in hits] == [sentence]
+
+    def test_a_two_word_cjk_query_is_not_emptied(self, tmp_path: Path) -> None:
+        """Both tokens are two characters, so the whole query used to filter to []."""
+        store = self._store(tmp_path)
+        sentence = "我们讨论了模型训练的流程"
+        assert store.write_episodic(sentence)
+        hits = store.search_episodic(query_text="模型 训练", limit=8)
+        assert [h["text"] for h in hits] == [sentence]
+
+    def test_a_longer_cjk_run_keeps_working(self, tmp_path: Path) -> None:
+        """Regression guard: >2 characters was already accepted and must stay so."""
+        store = self._store(tmp_path)
+        sentence = "团队选择了机器学习作为方向"
+        assert store.write_episodic(sentence)
+        hits = store.search_episodic(query_text="机器学习", limit=8)
+        assert [h["text"] for h in hits] == [sentence]
+
+    def test_a_short_latin_query_is_still_filtered_out(self, tmp_path: Path) -> None:
+        """Negative control: the English stopword behaviour must NOT widen.
+
+        ``to`` is two ASCII characters. Accepting it would turn ``LIKE '%to%'``
+        into a near-universal match, which is exactly what the length filter
+        exists to prevent -- so the fix must leave this case refused.
+        """
+        store = self._store(tmp_path)
+        assert store.write_episodic("User decided to use PostgreSQL for the database layer")
+        assert store.search_episodic(query_text="to", limit=8) == []
+
+    def test_a_single_character_cjk_query_stays_filtered(self, tmp_path: Path) -> None:
+        """One Han character is as unselective as an English stopword: still refused."""
+        store = self._store(tmp_path)
+        assert store.write_episodic("用户决定用这个模型来做推理")
+        assert store.search_episodic(query_text="的", limit=8) == []


### PR DESCRIPTION
## Problem / Motivation

`search_episodic` falls back to `_fts5_episodic_search` whenever no query
embedding is available — the normal state for any deployment with no embedding
model configured. Despite the name, that fallback does not use FTS5: it matches
with `LIKE '%term%'`, a plain substring test.

It filtered query terms with `len(w) > 2`. That is a character count, and two
characters is an ordinary whole word in Chinese, Japanese and Korean. So every
term in a short CJK query was discarded, the term list came out empty, and the
function returned `[]` before touching the database:

| query | tokens after `len(w) > 2` | result |
|---|---|---|
| `模型` ("model") | `[]` | no rows, ever |
| `会議` ("meeting") | `[]` | no rows, ever |
| `회의` ("meeting") | `[]` | no rows, ever |
| `模型 训练` (two words, both 2 chars) | `[]` | no rows, ever |
| `机器学习` (4 chars) | `['机器学习']` | works |

A stored memory `用户决定用这个模型来做推理` plainly contains `模型`, and
`LIKE '%模型%'` would have matched it. Nothing about the data or the index was
wrong — the term never reached the query.

The 4-character row is why this survived: longer CJK runs clear the floor, so
the failure only shows on short queries.

## Why it matters

For a CJK user on a deployment without embeddings, episodic memory recall is not
degraded, it is silently zero for a large class of ordinary queries — two
characters is a normal word length in these languages, not an edge case. The
call site returns an empty list indistinguishable from "no such memory", so
there is no error, no log line, and nothing for the user to notice beyond the
assistant appearing to have forgotten.

## What changed (motivation → approach → change)

The root cause is that `len(w) > 2` encodes an English stopword heuristic
(`to`, `in`, `is`) as a character count. The heuristic itself is sound and worth
keeping — `LIKE '%to%'` matches nearly every row, which is exactly what the
floor exists to prevent — but the character count is only a valid proxy for
selectivity in scripts that spell a word with many characters.

So the floor is now script-aware rather than removed or lowered. A new
`_is_selective_keyword` admits a two-character token when it carries a character
from `_DENSE_SCRIPT_RANGES` (kana, Han + extension A + compatibility, Hangul
syllables), and is otherwise byte-for-byte the previous rule.

Two things deliberately did **not** change:

- **Latin is untouched.** A two-letter ASCII token is still refused, so this
  cannot widen `LIKE` scans for existing users. A test pins it.
- **One character stays refused in every script.** A single Han character
  (`的`, `人`) is as unselective as an English stopword; admitting it would
  trade this recall bug for a precision one. A test pins that too.

This is entirely query-side. No schema, index, tokenizer or migration is
involved, because the fallback matches by substring.

**Scope note — this is not a fix for #3691.** That issue concerns the knowledge
FTS5 *keyword* leg, where triage established that the `unicode61` tokenizer
stores a spaceless CJK run as one index token, so a query-side change there
cannot help without an index-side migration. That argument does not apply here:
this path has no tokenizer at all, so a query-side fix is complete. Two related
sites remain out of scope and unclaimed by this PR — `knowledge/retrieval.py`
and `knowledge/store.py` (the #3691 design question), and
`vector_memory._lesson_keywords`, which applies the same Latin-tuned floor to
lesson dedup rather than to search.

## Tests

Added `TestEpisodicKeywordFallbackCjk` to `test/test_vector_memory.py`, driving
the real `VectorMemoryStore` with no `embed_fn` so `search_episodic` genuinely
takes the keyword fallback. Before the change: **4 failed, 3 passed**; after:
**7 passed**.

Locking in the fix:
- `test_a_two_character_word_still_finds_its_row[zh|ja|ko]` — a two-character
  word finds the row that contains it, in each of the three scripts.
- `test_a_two_word_cjk_query_is_not_emptied` — `模型 训练`, where *both* tokens
  are two characters, so the whole query previously filtered to `[]`.

Locking in what must not move (these three passed before the change, and are
the reason the fix is a narrowing rather than a widening):
- `test_a_short_latin_query_is_still_filtered_out` — `to` stays refused.
- `test_a_single_character_cjk_query_stays_filtered` — `的` stays refused.
- `test_a_longer_cjk_run_keeps_working` — regression guard on the >2 path.

Mutation check on the negative controls, so they are not vacuous: relaxing the
new predicate to accept *any* two-character token turns
`test_a_short_latin_query_is_still_filtered_out` red on its own.

Gates run locally (Windows, Python 3.10.6):
- `test/test_vector_memory.py` — 188 passed, 13 skipped
- `test/test_memory_smoke.py` + `test/test_vector_memory_coverage.py` — 198 passed
- `mypy src/kiro_crew/vector_memory.py` — Success, no issues
- `flake8` on both changed files — clean
- `black`: both files are already listed in `.github/black-baseline.txt`, so they
  are not black-clean on `main`. Measured at the repo's `line-length = 100`, the
  hunk count is **unchanged** by this PR — `vector_memory.py` 10 → 10 and
  `test_vector_memory.py` 9 → 9 — i.e. no new violation is introduced, and the
  files were deliberately not reformatted.

## Manual verification

N/A — unit coverage sufficient: the change is a pure predicate on the query
string, and the tests exercise it through the real store and the real SQL path
rather than by calling the predicate directly.

## Related Issues

None. Found by inspection while reviewing the triage on #3691; this is a
distinct code path from that issue and is not a fix for it (see the scope note
above).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe this fallback's tokenization
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
