### PR TITLE
fix(test): read setup.cfg as UTF-8 so the deps gate runs on a CJK locale

### DIFF
--- a/test/test_pip_deps_consistency.py
+++ b/test/test_pip_deps_consistency.py
@@ -86,10 +86,30 @@ def _setup_cfg_path() -> pathlib.Path:
     return pathlib.Path(__file__).resolve().parent.parent / "setup.cfg"
 
 
+def _is_unpinned_read(line: str) -> bool:
+    """Whether *line* reads ``setup.cfg`` without pinning an explicit encoding."""
+    return ".read(" in line and "_setup_cfg_path()" in line and "encoding=" not in line
+
+
+def _read_setup_cfg() -> configparser.ConfigParser:
+    """Parse ``setup.cfg`` as UTF-8, whatever the host's locale codepage is.
+
+    ``ConfigParser.read`` without ``encoding=`` opens the file with
+    ``locale.getpreferredencoding()``. ``setup.cfg`` is UTF-8 and its comments
+    carry non-ASCII text, so on a Windows host whose ANSI codepage is a
+    double-byte one (cp932/cp936/cp950) the decode raises
+    ``UnicodeDecodeError`` and this build gate cannot run at all. Pinning the
+    encoding to UTF-8 matches how the file is written and how
+    ``test_coverage_omit_contract.py`` already reads it.
+    """
+    cfg = configparser.ConfigParser()
+    cfg.read(_setup_cfg_path(), encoding="utf-8")
+    return cfg
+
+
 def _parse_install_requires() -> set[str]:
     """Parse setup.cfg and return the set of declared import root names."""
-    cfg = configparser.ConfigParser()
-    cfg.read(_setup_cfg_path())
+    cfg = _read_setup_cfg()
     raw = cfg.get("options", "install_requires", fallback="")
     declared: set[str] = set()
     for line in raw.strip().splitlines():
@@ -145,8 +165,7 @@ def _is_in_try_except_importerror(node: ast.stmt, tree: ast.Module) -> bool:
 
 def test_otlp_extra_declares_exact_http_exporter_version():
     """The documented kirocrew[otlp] install path must remain usable."""
-    cfg = configparser.ConfigParser()
-    cfg.read(_setup_cfg_path())
+    cfg = _read_setup_cfg()
     requirements = [
         line.strip()
         for line in cfg.get("options.extras_require", "otlp").splitlines()
@@ -190,8 +209,7 @@ def test_pyproject_declares_optional_dependencies_dynamic():
 
 def test_declared_extras_match_setup_cfg():
     """Every setup.cfg extra stays reachable; guards the dynamic wiring above."""
-    cfg = configparser.ConfigParser()
-    cfg.read(_setup_cfg_path())
+    cfg = _read_setup_cfg()
     assert cfg.has_section("options.extras_require")
     extras = set(cfg.options("options.extras_require"))
     # These three are referenced by docs, CI, and the Makefile; losing any of
@@ -204,8 +222,7 @@ def test_declared_extras_match_setup_cfg():
 
 
 def _extra_requirements(extra: str) -> list[str]:
-    cfg = configparser.ConfigParser()
-    cfg.read(_setup_cfg_path())
+    cfg = _read_setup_cfg()
     return [
         line.strip()
         for line in cfg.get("options.extras_require", extra).splitlines()
@@ -236,8 +253,7 @@ def test_python_requires_agrees_between_pyproject_and_setup_cfg():
     bound in setup.cfg is dead config that advertises support for interpreters
     the package cannot actually run on.
     """
-    cfg = configparser.ConfigParser()
-    cfg.read(_setup_cfg_path())
+    cfg = _read_setup_cfg()
     cfg_req = cfg.get("options", "python_requires", fallback="").strip()
 
     proj_req = ""
@@ -411,3 +427,51 @@ def test_noop_recorder_when_otel_missing(monkeypatch):
         sys.modules.pop("kiro_crew.metrics.provider", None)
         # Re-import cleanly
         importlib.import_module("kiro_crew.metrics.provider")
+
+
+# --- setup.cfg decoding: this gate must run on a non-UTF-8 locale host ---
+
+
+def test_setup_cfg_is_read_as_utf8_not_locale_default() -> None:
+    """The parse survives ``setup.cfg``'s non-ASCII bytes and keeps them intact.
+
+    ``setup.cfg`` is UTF-8 and its comments contain non-ASCII characters, so a
+    locale-default read is a decode error on a double-byte codepage and silent
+    mojibake on a single-byte one. Reading the raw bytes here rather than
+    trusting the host keeps the assertion meaningful on a UTF-8 CI runner too:
+    it pins that the file really does carry the bytes that make the encoding
+    argument necessary, so this test cannot quietly go vacuous if the comments
+    are ever rewritten to pure ASCII.
+    """
+    raw = _setup_cfg_path().read_bytes()
+    assert any(b > 0x7F for b in raw), "setup.cfg no longer has non-ASCII bytes"
+
+    # The decode must not depend on the host codepage.
+    cfg = _read_setup_cfg()
+    assert cfg.has_section("options")
+    assert cfg.get("options", "install_requires", fallback="")
+
+
+def test_every_setup_cfg_read_in_this_module_pins_the_encoding() -> None:
+    """Ratchet: no call site may fall back to the locale codepage again.
+
+    The behavioural test above only fails on a host whose preferred encoding
+    cannot decode UTF-8 -- it passes either way on a UTF-8 runner, which is
+    what CI uses. This static check is what actually holds the seam closed
+    there, so a future ``ConfigParser().read(path)`` cannot reintroduce the
+    crash for developers on cp932/cp936/cp950 machines.
+    """
+    source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    offenders = [
+        (n, line.strip())
+        for n, line in enumerate(source.splitlines(), 1)
+        if _is_unpinned_read(line)
+    ]
+    assert not offenders, f"setup.cfg read without an explicit encoding: {offenders}"
+
+    # Self-check: the scan must be able to see a violation at all, otherwise a
+    # renamed helper would turn this ratchet into a permanent green no-op. The
+    # probe is assembled from fragments so that this line is not itself an
+    # offender the scan above would report.
+    probe = "cfg." + "read(" + "_setup_cfg_path())"
+    assert _is_unpinned_read(probe), "the ratchet's own scan no longer detects a violation"


### PR DESCRIPTION
## Problem / Motivation

`test/test_pip_deps_consistency.py` is a build gate — it fails the build when a
module-level third-party import in core `kiro_crew` source is not declared in
`setup.cfg [options] install_requires`.

It parsed that file with `configparser.ConfigParser().read(path)` at five call
sites, with no `encoding=`. `ConfigParser.read` without an encoding opens the
file using `locale.getpreferredencoding()`, i.e. the host's ANSI codepage.

`setup.cfg` is UTF-8 and carries **48 non-ASCII bytes** in its comments (em
dashes, plus a CJK character). On a Windows host whose codepage is a
double-byte one — cp932 (ja), cp936 (zh-CN), cp950 (zh-TW) — that decode fails
outright:

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 502:
  illegal multibyte sequence
  .../lib/configparser.py:1021
```

Measured on a cp950 host, running the file on current `main`:

| | `main` | this branch |
|---|---|---|
| `test/test_pip_deps_consistency.py` | **4 failed**, 2 passed, 1 skipped | **8 passed**, 1 skipped |

The four do not fail an assertion — they error inside `configparser` before
asserting anything, so the gate does not run at all.

## Why it matters

The gate exists to stop a dependency reaching a release declared only in a dev
environment (the PyYAML and opentelemetry gaps are named in the module
docstring). On a CJK-locale Windows machine it cannot execute, so a contributor
developing there gets an error that looks like a broken checkout rather than a
gate result, and loses the check locally. It is also latent mojibake rather than
a crash on single-byte codepages such as cp1252, where every byte decodes to
*something*.

CI runs UTF-8, so this never shows up there — which is precisely why it has
survived.

## What changed (motivation → approach → change)

The root cause is that the encoding of `setup.cfg` is a fixed property of the
file (it is written as UTF-8) but was being inferred from the host at read time.

The five call sites were byte-for-byte identical, so rather than repeat the
keyword five times they now go through one `_read_setup_cfg()` helper that pins
`encoding="utf-8"`. That matches the file's existing `_setup_cfg_path()` helper
idiom, and matches how `test/test_coverage_omit_contract.py:109` already reads
the same file — this PR brings the outlier into line with the precedent that is
already in the tree.

Nothing about what the gate asserts changes; only how the bytes are decoded.

**Deliberately out of scope:** `test/test_ci_surface_tests.py:135` has the same
bare read. That file is being changed by open PR #5884, so folding it in here
would conflict; it is left for that PR or a follow-up.

## Tests

Two new tests, covering the two different hosts this has to hold on.

- `test_setup_cfg_is_read_as_utf8_not_locale_default` — the behavioural one.
  It first asserts from the **raw bytes** that `setup.cfg` still contains
  non-ASCII, so the test cannot quietly go vacuous if those comments are ever
  rewritten to pure ASCII, then parses through the helper and checks the
  sections come back. On a cp950 host this is red before the change and green
  after; on a UTF-8 runner it passes either way.
- `test_every_setup_cfg_read_in_this_module_pins_the_encoding` — the ratchet,
  and the one that actually holds the seam on CI, where the behavioural test
  cannot discriminate. It scans this module's own source for a `setup.cfg` read
  with no explicit encoding. It carries a self-check asserting its own predicate
  still matches a known-bad line (assembled from fragments so the check is not
  itself reported as an offender), so a renamed helper cannot turn it into a
  permanent green no-op.

Evidence:
- Red-before / green-after, same command, same cp950 host: `main` **4 failed,
  2 passed, 1 skipped** → branch **8 passed, 1 skipped**.
- Mutation check on the ratchet, run on a UTF-8 host where the behavioural test
  stays green: dropping the `encoding="utf-8"` kwarg turns
  `test_every_setup_cfg_read_in_this_module_pins_the_encoding` red on its own.

Gates (Windows, Python 3.10.6): `flake8` clean, `isort --check-only` clean,
`black --check --line-length 100` reports the file unchanged — it is **not** in
`.github/black-baseline.txt`, so it is held to black-clean and stays so.

## Manual verification

N/A — unit coverage sufficient: the failure is a decode of a file already in the
repo, and it is reproduced by running the suite itself on a non-UTF-8-codepage
host, which is what the measured before/after above is.

## Related Issues

None — found while running the suite on a cp950 Windows host.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc describes this gate's file decoding
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
